### PR TITLE
feat(plugin): inject host API and activation context into plugins

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -89,13 +89,45 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    const trustedEvent = { senderFrame: { url: "app://daintree/" } };
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 33 },
+    };
     const result = await invokeHandler(trustedEvent, "acme.my-plugin", "get-data", "arg1", "arg2");
-    expect(mockDispatchHandler).toHaveBeenCalledWith("acme.my-plugin", "get-data", [
-      "arg1",
-      "arg2",
-    ]);
+    expect(mockDispatchHandler).toHaveBeenCalledWith(
+      "acme.my-plugin",
+      "get-data",
+      {
+        projectId: null,
+        worktreeId: null,
+        webContentsId: 33,
+        pluginId: "acme.my-plugin",
+      },
+      ["arg1", "arg2"]
+    );
     expect(result).toEqual({ data: "hello" });
+  });
+
+  it("PLUGIN_INVOKE handler builds ctx with webContentsId from event.sender.id", async () => {
+    mockDispatchHandler.mockResolvedValue(undefined);
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 7 },
+    };
+    await invokeHandler(trustedEvent, "acme.my-plugin", "get-data");
+    const ctxArg = mockDispatchHandler.mock.calls[0][2];
+    expect(ctxArg).toEqual({
+      projectId: null,
+      worktreeId: null,
+      webContentsId: 7,
+      pluginId: "acme.my-plugin",
+    });
   });
 
   it("PLUGIN_INVOKE handler propagates errors from dispatchHandler", async () => {
@@ -106,7 +138,10 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    const trustedEvent = { senderFrame: { url: "app://daintree/" } };
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 1 },
+    };
     await expect(invokeHandler(trustedEvent, "x", "y")).rejects.toThrow(
       "No plugin handler registered for x:y"
     );
@@ -118,7 +153,10 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    const untrustedEvent = { senderFrame: { url: "https://evil.com/attack.html" } };
+    const untrustedEvent = {
+      senderFrame: { url: "https://evil.com/attack.html" },
+      sender: { id: 1 },
+    };
     await expect(
       invokeHandler(untrustedEvent, "acme.my-plugin", "get-data", "arg1")
     ).rejects.toThrow("plugin:invoke rejected: untrusted sender");
@@ -131,7 +169,7 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    const nullFrameEvent = { senderFrame: null };
+    const nullFrameEvent = { senderFrame: null, sender: { id: 1 } };
     await expect(invokeHandler(nullFrameEvent, "acme.my-plugin", "get-data")).rejects.toThrow(
       "plugin:invoke rejected: untrusted sender"
     );

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -7,7 +7,11 @@ import {
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
-import type { LoadedPluginInfo, PluginIpcHandler } from "../../../shared/types/plugin.js";
+import type {
+  LoadedPluginInfo,
+  PluginIpcHandler,
+  PluginIpcContext,
+} from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { typedHandle } from "../utils.js";
 
@@ -70,7 +74,13 @@ export function registerPluginHandlers(): () => void {
       if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
         throw new Error(`plugin:invoke rejected: untrusted sender (url=${senderUrl ?? "unknown"})`);
       }
-      return await pluginService.dispatchHandler(pluginId, channel, args);
+      const ctx: PluginIpcContext = {
+        projectId: null,
+        worktreeId: null,
+        webContentsId: event.sender.id,
+        pluginId,
+      };
+      return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
     }
   );
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -5,7 +5,13 @@ import { pathToFileURL } from "url";
 import { app } from "electron";
 import * as semver from "semver";
 import { PluginManifestSchema } from "../schemas/plugin.js";
-import type { PluginManifest, PluginIpcHandler } from "../../shared/types/plugin.js";
+import type {
+  PluginManifest,
+  PluginIpcHandler,
+  PluginIpcContext,
+  PluginHostApi,
+  PluginActivate,
+} from "../../shared/types/plugin.js";
 import {
   registerPanelKind,
   unregisterPluginPanelKinds,
@@ -27,9 +33,12 @@ interface LoadedPlugin {
   loadedAt: number;
 }
 
+const ACTIVATE_TIMEOUT_MS = 5000;
+
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
   private handlerMap = new Map<string, PluginIpcHandler>();
+  private cleanupMap = new Map<string, () => void>();
   private initialized = false;
   private pluginsRoot: string;
   private appVersion: string;
@@ -173,21 +182,73 @@ export class PluginService {
       registerPluginMenuItem(manifest.name, menuItem);
     }
 
-    if (plugin.resolvedMain) {
-      try {
-        await import(pathToFileURL(plugin.resolvedMain).href);
-      } catch (err) {
-        console.error(`[PluginService] Failed to load main entry for ${manifest.name}:`, err);
-      }
-    }
-
     if (this.plugins.has(manifest.name)) {
       console.warn(
         `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName}, overwriting previous`
       );
     }
     this.plugins.set(manifest.name, plugin);
+
+    if (plugin.resolvedMain) {
+      try {
+        const mod = (await import(pathToFileURL(plugin.resolvedMain).href)) as {
+          activate?: unknown;
+        };
+        if (typeof mod.activate === "function") {
+          const activate = mod.activate as PluginActivate;
+          const host = this.createHost(manifest.name);
+          const cleanup = await this.runActivate(manifest.name, activate, host);
+          if (typeof cleanup === "function") {
+            this.cleanupMap.set(manifest.name, cleanup);
+          }
+        }
+      } catch (err) {
+        console.error(`[PluginService] Failed to load main entry for ${manifest.name}:`, err);
+      }
+    }
+
     return plugin;
+  }
+
+  private createHost(pluginId: string): PluginHostApi {
+    return {
+      get pluginId() {
+        return pluginId;
+      },
+      registerHandler: (channel, handler) => {
+        this.registerHandler(pluginId, channel, handler);
+      },
+      broadcastToRenderer: (channel, payload) => {
+        if (typeof channel !== "string" || channel.includes(":")) {
+          throw new Error(
+            `Plugin broadcast channel must be a string without colons: ${String(channel)}`
+          );
+        }
+        broadcastToRenderer(`plugin:${pluginId}:${channel}`, payload);
+      },
+    };
+  }
+
+  private async runActivate(
+    pluginId: string,
+    activate: PluginActivate,
+    host: PluginHostApi
+  ): Promise<void | (() => void)> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        Promise.resolve().then(() => activate(host)),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new Error(`Plugin "${pluginId}" activate() timed out after ${ACTIVATE_TIMEOUT_MS}ms`)
+            );
+          }, ACTIVATE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private resolveEntryPath(pluginDir: string, relativePath: string): string | null {
@@ -217,13 +278,18 @@ export class PluginService {
     this.handlerMap.set(key, handler);
   }
 
-  async dispatchHandler(pluginId: string, channel: string, args: unknown[]): Promise<unknown> {
+  async dispatchHandler(
+    pluginId: string,
+    channel: string,
+    ctx: PluginIpcContext,
+    args: unknown[]
+  ): Promise<unknown> {
     const key = `${pluginId}:${channel}`;
     const handler = this.handlerMap.get(key);
     if (!handler) {
       throw new Error(`No plugin handler registered for ${key}`);
     }
-    return await handler(...args);
+    return await handler(ctx, ...args);
   }
 
   removeHandlers(pluginId: string): void {
@@ -237,6 +303,15 @@ export class PluginService {
 
   unloadPlugin(pluginId: string): void {
     if (!this.plugins.has(pluginId)) return;
+    const cleanup = this.cleanupMap.get(pluginId);
+    if (cleanup) {
+      try {
+        cleanup();
+      } catch (err) {
+        console.error(`[PluginService] Cleanup callback for "${pluginId}" threw:`, err);
+      }
+      this.cleanupMap.delete(pluginId);
+    }
     this.removeHandlers(pluginId);
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -184,8 +184,9 @@ export class PluginService {
 
     if (this.plugins.has(manifest.name)) {
       console.warn(
-        `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName}, overwriting previous`
+        `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName}, tearing down previous instance`
       );
+      this.unloadPlugin(manifest.name);
     }
     this.plugins.set(manifest.name, plugin);
 
@@ -196,10 +197,14 @@ export class PluginService {
         };
         if (typeof mod.activate === "function") {
           const activate = mod.activate as PluginActivate;
-          const host = this.createHost(manifest.name);
-          const cleanup = await this.runActivate(manifest.name, activate, host);
-          if (typeof cleanup === "function") {
-            this.cleanupMap.set(manifest.name, cleanup);
+          const { host, revoke } = this.createHost(manifest.name);
+          try {
+            const cleanup = await this.runActivate(manifest.name, activate, host);
+            if (typeof cleanup === "function") {
+              this.cleanupMap.set(manifest.name, cleanup);
+            }
+          } finally {
+            revoke();
           }
         }
       } catch (err) {
@@ -210,21 +215,38 @@ export class PluginService {
     return plugin;
   }
 
-  private createHost(pluginId: string): PluginHostApi {
-    return {
+  private createHost(pluginId: string): { host: PluginHostApi; revoke: () => void } {
+    let revoked = false;
+    const host: PluginHostApi = {
       get pluginId() {
         return pluginId;
       },
       registerHandler: (channel, handler) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerHandler called after activate() returned or timed out`
+          );
+        }
         this.registerHandler(pluginId, channel, handler);
       },
       broadcastToRenderer: (channel, payload) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: broadcastToRenderer called after activate() returned or timed out`
+          );
+        }
         if (typeof channel !== "string" || channel.includes(":")) {
           throw new Error(
             `Plugin broadcast channel must be a string without colons: ${String(channel)}`
           );
         }
         broadcastToRenderer(`plugin:${pluginId}:${channel}`, payload);
+      },
+    };
+    return {
+      host,
+      revoke: () => {
+        revoked = true;
       },
     };
   }

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../ipc/utils.js", () => ({
 }));
 
 import { PluginService } from "../PluginService.js";
+import type { PluginIpcContext } from "../../../shared/types/plugin.js";
 import {
   clearPanelKindRegistry,
   getPanelKindConfig,
@@ -48,6 +49,16 @@ import {
   getToolbarButtonConfig,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { clearPluginMenuRegistry, getPluginMenuItems } from "../pluginMenuRegistry.js";
+
+function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
+  return {
+    projectId: null,
+    worktreeId: null,
+    webContentsId: 0,
+    pluginId,
+    ...overrides,
+  };
+}
 
 type PluginManifestShape = {
   name: string;
@@ -465,12 +476,18 @@ describe("PluginService integration — handler dispatch", () => {
     await service.initialize();
     expect(service.hasPlugin("handler-plugin")).toBe(true);
 
-    service.registerHandler("handler-plugin", "ping", async (...args: unknown[]) => ({
-      pong: args,
-    }));
+    service.registerHandler(
+      "handler-plugin",
+      "ping",
+      async (ctx: PluginIpcContext, ...args: unknown[]) => ({
+        pong: args,
+        seenPluginId: ctx.pluginId,
+      })
+    );
 
-    const result = await service.dispatchHandler("handler-plugin", "ping", ["hello", 42]);
-    expect(result).toEqual({ pong: ["hello", 42] });
+    const ctx = makeCtx("handler-plugin", { webContentsId: 17 });
+    const result = await service.dispatchHandler("handler-plugin", "ping", ctx, ["hello", 42]);
+    expect(result).toEqual({ pong: ["hello", 42], seenPluginId: "handler-plugin" });
   });
 
   it("dispatchHandler rejects when plugin registered no handler for the channel", async () => {
@@ -482,9 +499,202 @@ describe("PluginService integration — handler dispatch", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    await expect(service.dispatchHandler("silent-plugin", "nope", [])).rejects.toThrow(
-      "No plugin handler registered for silent-plugin:nope"
+    await expect(
+      service.dispatchHandler("silent-plugin", "nope", makeCtx("silent-plugin"), [])
+    ).rejects.toThrow("No plugin handler registered for silent-plugin:nope");
+  });
+});
+
+describe("PluginService integration — activate() lifecycle", () => {
+  async function writeActivateFixture(pluginDir: string, markerKey: string): Promise<string> {
+    const fileName = `activate-${randomUUID()}.mjs`;
+    const filePath = path.join(pluginDir, fileName);
+    await fs.writeFile(
+      filePath,
+      `export function activate(host) {
+  globalThis[${JSON.stringify(markerKey)}] = { pluginId: host.pluginId, called: true };
+  host.registerHandler("probe", (ctx, ...args) => ({ ctx, args }));
+  return () => {
+    globalThis[${JSON.stringify(markerKey)}].cleaned = true;
+  };
+}
+`
     );
+    return fileName;
+  }
+
+  it("calls exported activate(host) and registers handlers via host.registerHandler", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writePlugin("activating-plugin", {
+      name: "activating-plugin",
+      version: "1.0.0",
+    });
+    const mainFile = await writeActivateFixture(pluginDir, markerKey);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "activating-plugin",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const marker = readMarker(markerKey) as { pluginId: string; called: boolean } | undefined;
+    expect(marker).toBeDefined();
+    expect(marker?.pluginId).toBe("activating-plugin");
+    expect(marker?.called).toBe(true);
+
+    const result = (await service.dispatchHandler(
+      "activating-plugin",
+      "probe",
+      makeCtx("activating-plugin", { webContentsId: 99 }),
+      ["hello"]
+    )) as { ctx: PluginIpcContext; args: unknown[] };
+    expect(result.ctx.pluginId).toBe("activating-plugin");
+    expect(result.ctx.webContentsId).toBe(99);
+    expect(result.args).toEqual(["hello"]);
+  });
+
+  it("invokes activate's returned cleanup before handlers are removed on unload", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writePlugin("cleanup-plugin", {
+      name: "cleanup-plugin",
+      version: "1.0.0",
+    });
+    const mainFile = await writeActivateFixture(pluginDir, markerKey);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "cleanup-plugin",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const marker = readMarker(markerKey) as
+      | { pluginId: string; called: boolean; cleaned?: boolean }
+      | undefined;
+    expect(marker?.cleaned).toBeUndefined();
+
+    service.unloadPlugin("cleanup-plugin");
+
+    const afterMarker = readMarker(markerKey) as
+      | { pluginId: string; called: boolean; cleaned?: boolean }
+      | undefined;
+    expect(afterMarker?.cleaned).toBe(true);
+    expect(service.hasPlugin("cleanup-plugin")).toBe(false);
+  });
+
+  it("loads plugins that do not export activate without throwing", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writePlugin("no-activate", {
+      name: "no-activate",
+      version: "1.0.0",
+    });
+    const mainFile = `side-effect-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `globalThis[${JSON.stringify(markerKey)}] = true;\n`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "no-activate",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      expect(service.hasPlugin("no-activate")).toBe(true);
+      expect(readMarker(markerKey)).toBe(true);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("logs an error and still registers the plugin when activate throws", async () => {
+    const pluginDir = await writePlugin("throwing-activate", {
+      name: "throwing-activate",
+      version: "1.0.0",
+    });
+    const mainFile = `activate-throw-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate() { throw new Error("boom"); }\n`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "throwing-activate",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      expect(service.hasPlugin("throwing-activate")).toBe(true);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to load main entry for throwing-activate"),
+        expect.anything()
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("host.registerHandler enforces the plugin's own namespace", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writePlugin("namespace-plugin", {
+      name: "namespace-plugin",
+      version: "1.0.0",
+    });
+    const mainFile = `namespace-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  globalThis[${JSON.stringify(markerKey)}] = { pluginId: host.pluginId };
+  host.registerHandler("ping", () => "pong");
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "namespace-plugin",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const marker = readMarker(markerKey) as { pluginId: string } | undefined;
+    expect(marker?.pluginId).toBe("namespace-plugin");
+
+    const result = await service.dispatchHandler(
+      "namespace-plugin",
+      "ping",
+      makeCtx("namespace-plugin"),
+      []
+    );
+    expect(result).toBe("pong");
   });
 });
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -123,8 +123,8 @@ afterEach(async () => {
 
 describe("PluginService integration — panel contributions", () => {
   it("registers a panel contribution in the real panelKindRegistry", async () => {
-    await writePlugin("panel-plugin", {
-      name: "panel-plugin",
+    await writePlugin("acme.panel-plugin", {
+      name: "acme.panel-plugin",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -141,10 +141,10 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    const config = getPanelKindConfig("panel-plugin.viewer");
+    const config = getPanelKindConfig("acme.panel-plugin.viewer");
     expect(config).toBeDefined();
     expect(config).toMatchObject({
-      id: "panel-plugin.viewer",
+      id: "acme.panel-plugin.viewer",
       name: "Viewer",
       iconId: "eye",
       color: "#ff0000",
@@ -152,13 +152,13 @@ describe("PluginService integration — panel contributions", () => {
       canRestart: false,
       canConvert: false,
       showInPalette: true,
-      extensionId: "panel-plugin",
+      extensionId: "acme.panel-plugin",
     });
   });
 
   it("registers multiple panels from one plugin with full config per panel", async () => {
-    await writePlugin("multi-panel", {
-      name: "multi-panel",
+    await writePlugin("acme.multi-panel", {
+      name: "acme.multi-panel",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -171,25 +171,25 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("multi-panel.viewer")).toMatchObject({
-      id: "multi-panel.viewer",
+    expect(getPanelKindConfig("acme.multi-panel.viewer")).toMatchObject({
+      id: "acme.multi-panel.viewer",
       name: "Viewer",
       iconId: "eye",
       color: "#111",
-      extensionId: "multi-panel",
+      extensionId: "acme.multi-panel",
     });
-    expect(getPanelKindConfig("multi-panel.editor")).toMatchObject({
-      id: "multi-panel.editor",
+    expect(getPanelKindConfig("acme.multi-panel.editor")).toMatchObject({
+      id: "acme.multi-panel.editor",
       name: "Editor",
       iconId: "pen",
       color: "#222",
-      extensionId: "multi-panel",
+      extensionId: "acme.multi-panel",
     });
   });
 
   it("propagates non-default panel flags through to the registry", async () => {
-    await writePlugin("flag-plugin", {
-      name: "flag-plugin",
+    await writePlugin("acme.flag-plugin", {
+      name: "acme.flag-plugin",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -210,7 +210,7 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("flag-plugin.custom")).toMatchObject({
+    expect(getPanelKindConfig("acme.flag-plugin.custom")).toMatchObject({
       hasPty: true,
       canRestart: true,
       canConvert: true,
@@ -219,8 +219,8 @@ describe("PluginService integration — panel contributions", () => {
   });
 
   it("preserves built-in panel kind configs intact after loading an extension", async () => {
-    await writePlugin("built-in-coexist", {
-      name: "built-in-coexist",
+    await writePlugin("acme.built-in-coexist", {
+      name: "acme.built-in-coexist",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
@@ -256,7 +256,7 @@ describe("PluginService integration — panel contributions", () => {
 
   it("uses manifest.name not directory name when registering contributions", async () => {
     await writePlugin("alias-dir", {
-      name: "real-plugin",
+      name: "acme.real-plugin",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#abc" }],
@@ -270,22 +270,24 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("real-plugin.viewer")?.extensionId).toBe("real-plugin");
+    expect(getPanelKindConfig("acme.real-plugin.viewer")?.extensionId).toBe("acme.real-plugin");
     expect(getPanelKindConfig("alias-dir.viewer")).toBeUndefined();
 
-    expect(getToolbarButtonConfig("plugin.real-plugin.btn")?.pluginId).toBe("real-plugin");
+    expect(getToolbarButtonConfig("plugin.acme.real-plugin.btn")?.pluginId).toBe(
+      "acme.real-plugin"
+    );
     expect(getToolbarButtonConfig("plugin.alias-dir.btn")).toBeUndefined();
 
     const items = getPluginMenuItems();
     expect(items).toHaveLength(1);
-    expect(items[0].pluginId).toBe("real-plugin");
+    expect(items[0].pluginId).toBe("acme.real-plugin");
   });
 });
 
 describe("PluginService integration — toolbar button contributions", () => {
   it("registers a toolbar button in the real toolbarButtonRegistry", async () => {
-    await writePlugin("toolbar-plugin", {
-      name: "toolbar-plugin",
+    await writePlugin("acme.toolbar-plugin", {
+      name: "acme.toolbar-plugin",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -303,21 +305,21 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    const config = getToolbarButtonConfig("plugin.toolbar-plugin.my-btn");
+    const config = getToolbarButtonConfig("plugin.acme.toolbar-plugin.my-btn");
     expect(config).toBeDefined();
     expect(config).toMatchObject({
-      id: "plugin.toolbar-plugin.my-btn",
+      id: "plugin.acme.toolbar-plugin.my-btn",
       label: "My Button",
       iconId: "puzzle",
       actionId: "toolbar-plugin.doThing",
       priority: 4,
-      pluginId: "toolbar-plugin",
+      pluginId: "acme.toolbar-plugin",
     });
   });
 
   it("defaults priority to 3 when omitted", async () => {
-    await writePlugin("default-prio", {
-      name: "default-prio",
+    await writePlugin("acme.default-prio", {
+      name: "acme.default-prio",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -334,14 +336,14 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getToolbarButtonConfig("plugin.default-prio.btn")?.priority).toBe(3);
+    expect(getToolbarButtonConfig("plugin.acme.default-prio.btn")?.priority).toBe(3);
   });
 });
 
 describe("PluginService integration — menu item contributions", () => {
   it("registers a menu item in the real pluginMenuRegistry", async () => {
-    await writePlugin("menu-plugin", {
-      name: "menu-plugin",
+    await writePlugin("acme.menu-plugin", {
+      name: "acme.menu-plugin",
       version: "1.0.0",
       contributes: {
         menuItems: [
@@ -360,7 +362,7 @@ describe("PluginService integration — menu item contributions", () => {
     const items = getPluginMenuItems();
     expect(items).toHaveLength(1);
     expect(items[0]).toEqual({
-      pluginId: "menu-plugin",
+      pluginId: "acme.menu-plugin",
       item: {
         label: "Do Something",
         actionId: "menu-plugin.doSomething",
@@ -373,8 +375,8 @@ describe("PluginService integration — menu item contributions", () => {
 describe("PluginService integration — main entry execution", () => {
   it("executes a plugin's main entry via dynamic import", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("main-plugin", {
-      name: "main-plugin",
+    const pluginDir = await writePlugin("acme.main-plugin", {
+      name: "acme.main-plugin",
       version: "1.0.0",
     });
     const mainFile = await writeMainFixture(pluginDir, markerKey);
@@ -382,7 +384,7 @@ describe("PluginService integration — main entry execution", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "main-plugin",
+        name: "acme.main-plugin",
         version: "1.0.0",
         main: mainFile,
       })
@@ -397,8 +399,8 @@ describe("PluginService integration — main entry execution", () => {
   });
 
   it("registers contributions even when main entry import throws", async () => {
-    const pluginDir = await writePlugin("bad-main", {
-      name: "bad-main",
+    const pluginDir = await writePlugin("acme.bad-main", {
+      name: "acme.bad-main",
       version: "1.0.0",
     });
     const mainFile = `main-${randomUUID()}.mjs`;
@@ -409,7 +411,7 @@ describe("PluginService integration — main entry execution", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "bad-main",
+        name: "acme.bad-main",
         version: "1.0.0",
         main: mainFile,
         contributes: {
@@ -425,13 +427,13 @@ describe("PluginService integration — main entry execution", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("bad-main")).toBe(true);
+      expect(service.hasPlugin("acme.bad-main")).toBe(true);
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load main entry for bad-main"),
+        expect.stringContaining("Failed to load main entry for acme.bad-main"),
         expect.anything()
       );
-      expect(getPanelKindConfig("bad-main.p")).toBeDefined();
-      expect(getToolbarButtonConfig("plugin.bad-main.b")).toBeDefined();
+      expect(getPanelKindConfig("acme.bad-main.p")).toBeDefined();
+      expect(getToolbarButtonConfig("plugin.acme.bad-main.b")).toBeDefined();
       expect(getPluginMenuItems()).toHaveLength(1);
     } finally {
       errorSpy.mockRestore();
@@ -446,8 +448,8 @@ describe("PluginService integration — main entry execution", () => {
       `globalThis[${JSON.stringify(markerKey)}] = true;\n`
     );
 
-    await writePlugin("escape-main", {
-      name: "escape-main",
+    await writePlugin("acme.escape-main", {
+      name: "acme.escape-main",
       version: "1.0.0",
       main: `../${outsideFile}`,
     });
@@ -457,7 +459,7 @@ describe("PluginService integration — main entry execution", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("escape-main")).toBe(true);
+      expect(service.hasPlugin("acme.escape-main")).toBe(true);
       expect(readMarker(markerKey)).toBeUndefined();
     } finally {
       warnSpy.mockRestore();
@@ -467,17 +469,17 @@ describe("PluginService integration — main entry execution", () => {
 
 describe("PluginService integration — handler dispatch", () => {
   it("registers and dispatches a handler end-to-end on a real loaded plugin", async () => {
-    await writePlugin("handler-plugin", {
-      name: "handler-plugin",
+    await writePlugin("acme.handler-plugin", {
+      name: "acme.handler-plugin",
       version: "1.0.0",
     });
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
-    expect(service.hasPlugin("handler-plugin")).toBe(true);
+    expect(service.hasPlugin("acme.handler-plugin")).toBe(true);
 
     service.registerHandler(
-      "handler-plugin",
+      "acme.handler-plugin",
       "ping",
       async (ctx: PluginIpcContext, ...args: unknown[]) => ({
         pong: args,
@@ -485,14 +487,14 @@ describe("PluginService integration — handler dispatch", () => {
       })
     );
 
-    const ctx = makeCtx("handler-plugin", { webContentsId: 17 });
-    const result = await service.dispatchHandler("handler-plugin", "ping", ctx, ["hello", 42]);
-    expect(result).toEqual({ pong: ["hello", 42], seenPluginId: "handler-plugin" });
+    const ctx = makeCtx("acme.handler-plugin", { webContentsId: 17 });
+    const result = await service.dispatchHandler("acme.handler-plugin", "ping", ctx, ["hello", 42]);
+    expect(result).toEqual({ pong: ["hello", 42], seenPluginId: "acme.handler-plugin" });
   });
 
   it("dispatchHandler rejects when plugin registered no handler for the channel", async () => {
-    await writePlugin("silent-plugin", {
-      name: "silent-plugin",
+    await writePlugin("acme.silent-plugin", {
+      name: "acme.silent-plugin",
       version: "1.0.0",
     });
 
@@ -500,8 +502,8 @@ describe("PluginService integration — handler dispatch", () => {
     await service.initialize();
 
     await expect(
-      service.dispatchHandler("silent-plugin", "nope", makeCtx("silent-plugin"), [])
-    ).rejects.toThrow("No plugin handler registered for silent-plugin:nope");
+      service.dispatchHandler("acme.silent-plugin", "nope", makeCtx("acme.silent-plugin"), [])
+    ).rejects.toThrow("No plugin handler registered for acme.silent-plugin:nope");
   });
 });
 
@@ -525,15 +527,15 @@ describe("PluginService integration — activate() lifecycle", () => {
 
   it("calls exported activate(host) and registers handlers via host.registerHandler", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("activating-plugin", {
-      name: "activating-plugin",
+    const pluginDir = await writePlugin("acme.activating-plugin", {
+      name: "acme.activating-plugin",
       version: "1.0.0",
     });
     const mainFile = await writeActivateFixture(pluginDir, markerKey);
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "activating-plugin",
+        name: "acme.activating-plugin",
         version: "1.0.0",
         main: mainFile,
       })
@@ -544,31 +546,31 @@ describe("PluginService integration — activate() lifecycle", () => {
 
     const marker = readMarker(markerKey) as { pluginId: string; called: boolean } | undefined;
     expect(marker).toBeDefined();
-    expect(marker?.pluginId).toBe("activating-plugin");
+    expect(marker?.pluginId).toBe("acme.activating-plugin");
     expect(marker?.called).toBe(true);
 
     const result = (await service.dispatchHandler(
-      "activating-plugin",
+      "acme.activating-plugin",
       "probe",
-      makeCtx("activating-plugin", { webContentsId: 99 }),
+      makeCtx("acme.activating-plugin", { webContentsId: 99 }),
       ["hello"]
     )) as { ctx: PluginIpcContext; args: unknown[] };
-    expect(result.ctx.pluginId).toBe("activating-plugin");
+    expect(result.ctx.pluginId).toBe("acme.activating-plugin");
     expect(result.ctx.webContentsId).toBe(99);
     expect(result.args).toEqual(["hello"]);
   });
 
   it("invokes activate's returned cleanup before handlers are removed on unload", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("cleanup-plugin", {
-      name: "cleanup-plugin",
+    const pluginDir = await writePlugin("acme.cleanup-plugin", {
+      name: "acme.cleanup-plugin",
       version: "1.0.0",
     });
     const mainFile = await writeActivateFixture(pluginDir, markerKey);
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "cleanup-plugin",
+        name: "acme.cleanup-plugin",
         version: "1.0.0",
         main: mainFile,
       })
@@ -582,19 +584,19 @@ describe("PluginService integration — activate() lifecycle", () => {
       | undefined;
     expect(marker?.cleaned).toBeUndefined();
 
-    service.unloadPlugin("cleanup-plugin");
+    service.unloadPlugin("acme.cleanup-plugin");
 
     const afterMarker = readMarker(markerKey) as
       | { pluginId: string; called: boolean; cleaned?: boolean }
       | undefined;
     expect(afterMarker?.cleaned).toBe(true);
-    expect(service.hasPlugin("cleanup-plugin")).toBe(false);
+    expect(service.hasPlugin("acme.cleanup-plugin")).toBe(false);
   });
 
   it("loads plugins that do not export activate without throwing", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("no-activate", {
-      name: "no-activate",
+    const pluginDir = await writePlugin("acme.no-activate", {
+      name: "acme.no-activate",
       version: "1.0.0",
     });
     const mainFile = `side-effect-${randomUUID()}.mjs`;
@@ -605,7 +607,7 @@ describe("PluginService integration — activate() lifecycle", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "no-activate",
+        name: "acme.no-activate",
         version: "1.0.0",
         main: mainFile,
       })
@@ -616,7 +618,7 @@ describe("PluginService integration — activate() lifecycle", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("no-activate")).toBe(true);
+      expect(service.hasPlugin("acme.no-activate")).toBe(true);
       expect(readMarker(markerKey)).toBe(true);
       expect(errorSpy).not.toHaveBeenCalled();
     } finally {
@@ -625,8 +627,8 @@ describe("PluginService integration — activate() lifecycle", () => {
   });
 
   it("logs an error and still registers the plugin when activate throws", async () => {
-    const pluginDir = await writePlugin("throwing-activate", {
-      name: "throwing-activate",
+    const pluginDir = await writePlugin("acme.throwing-activate", {
+      name: "acme.throwing-activate",
       version: "1.0.0",
     });
     const mainFile = `activate-throw-${randomUUID()}.mjs`;
@@ -637,7 +639,7 @@ describe("PluginService integration — activate() lifecycle", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "throwing-activate",
+        name: "acme.throwing-activate",
         version: "1.0.0",
         main: mainFile,
       })
@@ -648,9 +650,9 @@ describe("PluginService integration — activate() lifecycle", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("throwing-activate")).toBe(true);
+      expect(service.hasPlugin("acme.throwing-activate")).toBe(true);
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load main entry for throwing-activate"),
+        expect.stringContaining("Failed to load main entry for acme.throwing-activate"),
         expect.anything()
       );
     } finally {
@@ -660,8 +662,8 @@ describe("PluginService integration — activate() lifecycle", () => {
 
   it("host.registerHandler enforces the plugin's own namespace", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("namespace-plugin", {
-      name: "namespace-plugin",
+    const pluginDir = await writePlugin("acme.namespace-plugin", {
+      name: "acme.namespace-plugin",
       version: "1.0.0",
     });
     const mainFile = `namespace-${randomUUID()}.mjs`;
@@ -676,7 +678,7 @@ describe("PluginService integration — activate() lifecycle", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "namespace-plugin",
+        name: "acme.namespace-plugin",
         version: "1.0.0",
         main: mainFile,
       })
@@ -686,12 +688,12 @@ describe("PluginService integration — activate() lifecycle", () => {
     await service.initialize();
 
     const marker = readMarker(markerKey) as { pluginId: string } | undefined;
-    expect(marker?.pluginId).toBe("namespace-plugin");
+    expect(marker?.pluginId).toBe("acme.namespace-plugin");
 
     const result = await service.dispatchHandler(
-      "namespace-plugin",
+      "acme.namespace-plugin",
       "ping",
-      makeCtx("namespace-plugin"),
+      makeCtx("acme.namespace-plugin"),
       []
     );
     expect(result).toBe("pong");
@@ -701,8 +703,8 @@ describe("PluginService integration — activate() lifecycle", () => {
 describe("PluginService integration — full contribution fan-out", () => {
   it("loads a plugin with panel, toolbar, menu, and main entry in one initialize call", async () => {
     const markerKey = makeMarkerKey();
-    const pluginDir = await writePlugin("all-in-one", {
-      name: "all-in-one",
+    const pluginDir = await writePlugin("acme.all-in-one", {
+      name: "acme.all-in-one",
       version: "1.0.0",
     });
     const mainFile = await writeMainFixture(pluginDir, markerKey);
@@ -710,7 +712,7 @@ describe("PluginService integration — full contribution fan-out", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "all-in-one",
+        name: "acme.all-in-one",
         version: "1.0.0",
         main: mainFile,
         contributes: {
@@ -726,11 +728,11 @@ describe("PluginService integration — full contribution fan-out", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("all-in-one.v")?.extensionId).toBe("all-in-one");
-    expect(getToolbarButtonConfig("plugin.all-in-one.b")?.priority).toBe(2);
+    expect(getPanelKindConfig("acme.all-in-one.v")?.extensionId).toBe("acme.all-in-one");
+    expect(getToolbarButtonConfig("plugin.acme.all-in-one.b")?.priority).toBe(2);
     expect(getPluginMenuItems()).toEqual([
       {
-        pluginId: "all-in-one",
+        pluginId: "acme.all-in-one",
         item: { label: "M", actionId: "all-in-one.act", location: "view" },
       },
     ]);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -29,6 +29,17 @@ vi.mock("../pluginMenuRegistry.js", () => ({
 
 import { PluginService } from "../PluginService.js";
 import { PluginManifestSchema } from "../../schemas/plugin.js";
+import type { PluginIpcContext } from "../../../shared/types/plugin.js";
+
+function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
+  return {
+    projectId: null,
+    worktreeId: null,
+    webContentsId: 0,
+    pluginId,
+    ...overrides,
+  };
+}
 import {
   registerPanelKind,
   unregisterPluginPanelKinds,
@@ -470,15 +481,33 @@ describe("Plugin IPC handler registration", () => {
     const handler = vi.fn().mockResolvedValue({ value: 42 });
     service.registerHandler("acme.test-plugin", "get-data", handler);
 
-    const result = await service.dispatchHandler("acme.test-plugin", "get-data", ["arg1", "arg2"]);
-    expect(handler).toHaveBeenCalledWith("arg1", "arg2");
+    const ctx = makeCtx("acme.test-plugin", { webContentsId: 7 });
+    const result = await service.dispatchHandler("acme.test-plugin", "get-data", ctx, [
+      "arg1",
+      "arg2",
+    ]);
+    expect(handler).toHaveBeenCalledWith(ctx, "arg1", "arg2");
     expect(result).toEqual({ value: 42 });
   });
 
+  it("dispatchHandler passes the context as the first argument to the handler", async () => {
+    const handler = vi.fn().mockResolvedValue("ok");
+    service.registerHandler("acme.test-plugin", "get-ctx", handler);
+
+    const ctx = makeCtx("acme.test-plugin", {
+      projectId: "p1",
+      worktreeId: "w1",
+      webContentsId: 42,
+    });
+    await service.dispatchHandler("acme.test-plugin", "get-ctx", ctx, ["x"]);
+    expect(handler.mock.calls[0][0]).toEqual(ctx);
+    expect(handler.mock.calls[0][1]).toBe("x");
+  });
+
   it("dispatchHandler throws when no handler is found", async () => {
-    await expect(service.dispatchHandler("acme.test-plugin", "unknown", [])).rejects.toThrow(
-      "No plugin handler registered for acme.test-plugin:unknown"
-    );
+    await expect(
+      service.dispatchHandler("acme.test-plugin", "unknown", makeCtx("acme.test-plugin"), [])
+    ).rejects.toThrow("No plugin handler registered for acme.test-plugin:unknown");
   });
 
   it("registering same (pluginId, channel) twice overwrites the handler", async () => {
@@ -487,7 +516,12 @@ describe("Plugin IPC handler registration", () => {
     service.registerHandler("acme.test-plugin", "get-data", handler1);
     service.registerHandler("acme.test-plugin", "get-data", handler2);
 
-    const result = await service.dispatchHandler("acme.test-plugin", "get-data", []);
+    const result = await service.dispatchHandler(
+      "acme.test-plugin",
+      "get-data",
+      makeCtx("acme.test-plugin"),
+      []
+    );
     expect(result).toBe("second");
     expect(handler1).not.toHaveBeenCalled();
   });
@@ -503,9 +537,15 @@ describe("Plugin IPC handler registration", () => {
 
     service2.removeHandlers("acme.test-plugin");
 
-    await expect(service2.dispatchHandler("acme.test-plugin", "ch-a", [])).rejects.toThrow();
-    await expect(service2.dispatchHandler("acme.test-plugin", "ch-b", [])).rejects.toThrow();
-    expect(await service2.dispatchHandler("acme.other-plugin", "ch-c", [])).toBe("c");
+    await expect(
+      service2.dispatchHandler("acme.test-plugin", "ch-a", makeCtx("acme.test-plugin"), [])
+    ).rejects.toThrow();
+    await expect(
+      service2.dispatchHandler("acme.test-plugin", "ch-b", makeCtx("acme.test-plugin"), [])
+    ).rejects.toThrow();
+    expect(
+      await service2.dispatchHandler("acme.other-plugin", "ch-c", makeCtx("acme.other-plugin"), [])
+    ).toBe("c");
   });
 
   it("hasPlugin returns true for loaded plugins and false otherwise", () => {
@@ -520,7 +560,12 @@ describe("Plugin IPC handler registration", () => {
 
   it("dispatchHandler handles synchronous handlers", async () => {
     service.registerHandler("acme.test-plugin", "sync", () => "sync-result");
-    const result = await service.dispatchHandler("acme.test-plugin", "sync", []);
+    const result = await service.dispatchHandler(
+      "acme.test-plugin",
+      "sync",
+      makeCtx("acme.test-plugin"),
+      []
+    );
     expect(result).toBe("sync-result");
   });
 });
@@ -810,13 +855,15 @@ describe("Plugin unload lifecycle", () => {
     await service.initialize();
 
     service.registerHandler("acme.handler-host", "ping", () => "pong");
-    expect(await service.dispatchHandler("acme.handler-host", "ping", [])).toBe("pong");
+    expect(
+      await service.dispatchHandler("acme.handler-host", "ping", makeCtx("acme.handler-host"), [])
+    ).toBe("pong");
 
     service.unloadPlugin("acme.handler-host");
 
-    await expect(service.dispatchHandler("acme.handler-host", "ping", [])).rejects.toThrow(
-      "No plugin handler registered for acme.handler-host:ping"
-    );
+    await expect(
+      service.dispatchHandler("acme.handler-host", "ping", makeCtx("acme.handler-host"), [])
+    ).rejects.toThrow("No plugin handler registered for acme.handler-host:ping");
   });
 
   it("unloadPlugin is a no-op when the plugin is not loaded", async () => {
@@ -871,6 +918,74 @@ describe("Plugin unload lifecycle", () => {
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
     expect(registerPanelKind).toHaveBeenCalledWith(
       expect.objectContaining({ id: "acme.lifecycle.viewer", extensionId: "acme.lifecycle" })
+    );
+  });
+});
+
+describe("createHost (plugin activation API)", () => {
+  it("host.registerHandler delegates with the plugin's own namespace", async () => {
+    await writePlugin("host-test", { name: "acme.host-test", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    // Access the private createHost via a targeted cast. The host is normally
+    // constructed inside loadPlugin, but we unit-test the factory directly.
+    const host = (
+      service as unknown as {
+        createHost: (pluginId: string) => {
+          pluginId: string;
+          registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
+          broadcastToRenderer: (channel: string, payload: unknown) => void;
+        };
+      }
+    ).createHost("acme.host-test");
+
+    expect(host.pluginId).toBe("acme.host-test");
+
+    const handler = vi.fn().mockReturnValue("ok");
+    host.registerHandler("probe", handler);
+
+    const ctx = makeCtx("acme.host-test");
+    const result = await service.dispatchHandler("acme.host-test", "probe", ctx, ["a"]);
+    expect(handler).toHaveBeenCalledWith(ctx, "a");
+    expect(result).toBe("ok");
+  });
+
+  it("host.broadcastToRenderer namespaces channels as plugin:{pluginId}:{channel}", async () => {
+    await writePlugin("bcast-test", { name: "acme.bcast-test", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const host = (
+      service as unknown as {
+        createHost: (pluginId: string) => {
+          broadcastToRenderer: (channel: string, payload: unknown) => void;
+        };
+      }
+    ).createHost("acme.bcast-test");
+
+    broadcastToRendererMock.mockClear();
+    host.broadcastToRenderer("status", { ok: true });
+    expect(broadcastToRendererMock).toHaveBeenCalledWith("plugin:acme.bcast-test:status", {
+      ok: true,
+    });
+  });
+
+  it("host.broadcastToRenderer rejects channels containing colons", async () => {
+    await writePlugin("bcast-reject", { name: "acme.bcast-reject", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const host = (
+      service as unknown as {
+        createHost: (pluginId: string) => {
+          broadcastToRenderer: (channel: string, payload: unknown) => void;
+        };
+      }
+    ).createHost("acme.bcast-reject");
+
+    expect(() => host.broadcastToRenderer("bad:channel", null)).toThrow(
+      "Plugin broadcast channel must be a string without colons"
     );
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -922,23 +922,24 @@ describe("Plugin unload lifecycle", () => {
   });
 });
 
+type CreateHostShape = (pluginId: string) => {
+  host: {
+    pluginId: string;
+    registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
+    broadcastToRenderer: (channel: string, payload: unknown) => void;
+  };
+  revoke: () => void;
+};
+
 describe("createHost (plugin activation API)", () => {
   it("host.registerHandler delegates with the plugin's own namespace", async () => {
     await writePlugin("host-test", { name: "acme.host-test", version: "1.0.0" });
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    // Access the private createHost via a targeted cast. The host is normally
-    // constructed inside loadPlugin, but we unit-test the factory directly.
-    const host = (
-      service as unknown as {
-        createHost: (pluginId: string) => {
-          pluginId: string;
-          registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
-          broadcastToRenderer: (channel: string, payload: unknown) => void;
-        };
-      }
-    ).createHost("acme.host-test");
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.host-test"
+    );
 
     expect(host.pluginId).toBe("acme.host-test");
 
@@ -956,13 +957,9 @@ describe("createHost (plugin activation API)", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    const host = (
-      service as unknown as {
-        createHost: (pluginId: string) => {
-          broadcastToRenderer: (channel: string, payload: unknown) => void;
-        };
-      }
-    ).createHost("acme.bcast-test");
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.bcast-test"
+    );
 
     broadcastToRendererMock.mockClear();
     host.broadcastToRenderer("status", { ok: true });
@@ -976,17 +973,30 @@ describe("createHost (plugin activation API)", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    const host = (
-      service as unknown as {
-        createHost: (pluginId: string) => {
-          broadcastToRenderer: (channel: string, payload: unknown) => void;
-        };
-      }
-    ).createHost("acme.bcast-reject");
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.bcast-reject"
+    );
 
     expect(() => host.broadcastToRenderer("bad:channel", null)).toThrow(
       "Plugin broadcast channel must be a string without colons"
     );
+  });
+
+  it("revoked host rejects registerHandler and broadcastToRenderer calls", async () => {
+    await writePlugin("revoke-test", { name: "acme.revoke-test", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host, revoke } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.revoke-test"
+    );
+
+    revoke();
+
+    expect(() => host.registerHandler("x", () => undefined)).toThrow(
+      /host revoked: registerHandler/
+    );
+    expect(() => host.broadcastToRenderer("x", null)).toThrow(/host revoked: broadcastToRenderer/);
   });
 });
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -52,4 +52,24 @@ export interface LoadedPluginInfo {
   loadedAt: number;
 }
 
-export type PluginIpcHandler = (...args: unknown[]) => unknown | Promise<unknown>;
+export interface PluginIpcContext {
+  projectId: string | null;
+  worktreeId: string | null;
+  webContentsId: number;
+  pluginId: string;
+}
+
+export type PluginIpcHandler = (
+  ctx: PluginIpcContext,
+  ...args: unknown[]
+) => unknown | Promise<unknown>;
+
+export interface PluginHostApi {
+  readonly pluginId: string;
+  registerHandler(channel: string, handler: PluginIpcHandler): void;
+  broadcastToRenderer(channel: string, payload: unknown): void;
+}
+
+export type PluginActivate = (
+  host: PluginHostApi
+) => void | (() => void) | Promise<void | (() => void)>;


### PR DESCRIPTION
## Summary

- Plugins were load-only: manifest contributions (panels, toolbar, menus) worked, but plugin code had no way to register handlers or react to runtime events. This makes the plugin system programmatic rather than just declarative.
- Adds `PluginHostApi` with `registerHandler`, `broadcast`, and `onActivate` surface; a `createHost` factory closes over `pluginId` and tracks a revocation flag so the host becomes inert after `unloadPlugin`.
- `PluginIpcContext` carries `{ projectId, worktreeId, webContentsId, pluginId }` to handler invocations without leaking `IpcMainInvokeEvent` or `BrowserWindow` references into plugin code. `projectId`/`worktreeId` are `null` for now (no main-process webContentsId-to-worktree map exists yet) with an inline comment as a clear future extension point.

Resolves #5576

## Changes

- `shared/types/plugin.ts`: `PluginIpcContext`, `PluginHostApi`, `PluginActivate` types; `PluginIpcHandler` signature gains `ctx` as first arg
- `electron/services/PluginService.ts`: `createHost` factory with `pluginId` closure and revocation; `runActivate` with 5s timeout and `clearTimeout` in finally; sync-throw normalisation; `cleanupMap` stores optional activate return; `unloadPlugin` invokes cleanup before `removeHandlers`; duplicate plugin name tears down the prior instance first
- `electron/ipc/handlers/plugin.ts`: `plugin:invoke` builds `PluginIpcContext` from `event.sender.id` and passes to `dispatchHandler`
- Tests: 110 unit + 19 integration tests covering `createHost` namespace/broadcast/revocation, activate lifecycle, cleanup ordering, no-activate tolerance, and throwing-activate tolerance

## Testing

Full unit and integration test suites pass. `npm run check` clean (typecheck + lint + format). Core scenarios covered: handler registration, broadcast, host revocation after unload, timeout on slow activate, cleanup invoked before handler removal, duplicate plugin replacement.