### PR TITLE
fix(settings): revert hover-to-preview behaviour in app theme picker

### DIFF
--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -97,8 +97,6 @@ describe("AppThemePicker shuffle button", () => {
       addCustomScheme: vi.fn(),
       accentColorOverride: null,
       setAccentColorOverride: vi.fn(),
-      previewSchemeId: null,
-      setPreviewSchemeId: vi.fn(),
     });
   });
 
@@ -188,8 +186,6 @@ describe("AppThemePicker image loading attributes", () => {
       addCustomScheme: vi.fn(),
       accentColorOverride: null,
       setAccentColorOverride: vi.fn(),
-      previewSchemeId: null,
-      setPreviewSchemeId: vi.fn(),
     });
   });
 
@@ -253,5 +249,52 @@ describe("AppThemePicker Change theme button", () => {
   it("hides the Change theme button when onClose is not provided", () => {
     render(<AppThemePicker />);
     expect(screen.queryByRole("button", { name: /change theme/i })).toBeNull();
+  });
+});
+
+describe("AppThemePicker hover/focus preview regression", () => {
+  beforeEach(() => {
+    Object.assign(storeState, {
+      selectedSchemeId: "theme-a",
+      customSchemes: [],
+      recentSchemeIds: [],
+      followSystem: false,
+      preferredDarkSchemeId: "theme-a",
+      preferredLightSchemeId: "theme-a",
+      setSelectedSchemeId: vi.fn(),
+      commitSchemeSelection: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
+      injectTheme: vi.fn(),
+      setFollowSystem: vi.fn(),
+      setPreferredDarkSchemeId: vi.fn(),
+      setPreferredLightSchemeId: vi.fn(),
+      setRecentSchemeIds: vi.fn(),
+      addCustomScheme: vi.fn(),
+      accentColorOverride: null,
+      setAccentColorOverride: vi.fn(),
+    });
+  });
+
+  it("hovering a theme row does not change the applied theme", () => {
+    const injectTheme = vi.fn();
+    storeState.injectTheme = injectTheme;
+
+    render(<AppThemePicker />);
+    const rows = screen.getAllByRole("option");
+    fireEvent.pointerEnter(rows[1]!);
+    expect(injectTheme).not.toHaveBeenCalled();
+  });
+
+  it("keyboard focus on a theme row does not preview or commit", () => {
+    const injectTheme = vi.fn();
+    const commitSchemeSelection = vi.fn();
+    storeState.injectTheme = injectTheme;
+    storeState.commitSchemeSelection = commitSchemeSelection;
+
+    render(<AppThemePicker />);
+    const rows = screen.getAllByRole("option");
+    fireEvent.focus(rows[1]!);
+    expect(injectTheme).not.toHaveBeenCalled();
+    expect(commitSchemeSelection).not.toHaveBeenCalled();
   });
 });

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -14,7 +14,6 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
       preferredLightSchemeId: "bondi",
       recentSchemeIds: [],
       accentColorOverride: null,
-      previewSchemeId: null,
     });
   });
 
@@ -143,84 +142,6 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
     expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
       "#abcdef"
     );
-  });
-
-  it("setPreviewSchemeId does not mutate selectedSchemeId or recentSchemeIds", () => {
-    useAppThemeStore.getState().setSelectedSchemeId("daintree");
-    const recentBefore = useAppThemeStore.getState().recentSchemeIds;
-
-    useAppThemeStore.getState().setPreviewSchemeId("bondi");
-    expect(useAppThemeStore.getState().previewSchemeId).toBe("bondi");
-    expect(useAppThemeStore.getState().selectedSchemeId).toBe("daintree");
-    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(recentBefore);
-
-    useAppThemeStore.getState().setPreviewSchemeId(null);
-    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
-  });
-
-  it("removeCustomScheme clears previewSchemeId when it points at the removed id", () => {
-    const customScheme = {
-      id: "custom-preview-target",
-      name: "CustomPreview",
-      type: "dark" as const,
-      builtin: false,
-      tokens: {} as never,
-    };
-    useAppThemeStore.getState().addCustomScheme(customScheme);
-    useAppThemeStore.getState().setPreviewSchemeId("custom-preview-target");
-    expect(useAppThemeStore.getState().previewSchemeId).toBe("custom-preview-target");
-
-    useAppThemeStore.getState().removeCustomScheme("custom-preview-target");
-    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
-  });
-
-  it("removeCustomScheme reverts the DOM to the committed scheme when removing an actively previewed scheme", () => {
-    // Commit to daintree so we have a known baseline for the revert target.
-    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree");
-    const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
-
-    const customScheme = {
-      id: "custom-preview-target",
-      name: "CustomPreview",
-      type: "dark" as const,
-      builtin: false,
-      tokens: {
-        ...daintree.tokens,
-        "accent-primary": "#abcdef",
-      },
-    } as unknown as (typeof BUILT_IN_APP_SCHEMES)[number];
-
-    useAppThemeStore.getState().addCustomScheme(customScheme);
-    useAppThemeStore.getState().setPreviewSchemeId("custom-preview-target");
-    // Simulate the picker having injected the previewed scheme's tokens.
-    useAppThemeStore.getState().injectTheme(customScheme);
-    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
-      "#abcdef"
-    );
-
-    useAppThemeStore.getState().removeCustomScheme("custom-preview-target");
-
-    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
-    expect(useAppThemeStore.getState().selectedSchemeId).toBe("daintree");
-    // DOM should now reflect the committed daintree accent, not the deleted scheme.
-    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
-      daintree.tokens["accent-primary"]
-    );
-  });
-
-  it("removeCustomScheme leaves previewSchemeId alone when unrelated id is removed", () => {
-    const customScheme = {
-      id: "some-custom",
-      name: "Some Custom",
-      type: "dark" as const,
-      builtin: false,
-      tokens: {} as never,
-    };
-    useAppThemeStore.getState().addCustomScheme(customScheme);
-    useAppThemeStore.getState().setPreviewSchemeId("daintree");
-
-    useAppThemeStore.getState().removeCustomScheme("some-custom");
-    expect(useAppThemeStore.getState().previewSchemeId).toBe("daintree");
   });
 
   it("removeCustomScheme strips the removed id from recentSchemeIds", () => {

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -15,15 +15,7 @@ interface AppThemeState {
   preferredLightSchemeId: string;
   recentSchemeIds: string[];
   accentColorOverride: string | null;
-  /**
-   * Ephemeral override used by the picker for live hover/focus preview.
-   * Never persisted. The picker reads this to drive the hero panel image
-   * and aria-live announcement during preview, while calling
-   * `injectSchemeToDOM` imperatively for the CSS variable side-effect.
-   */
-  previewSchemeId: string | null;
   setSelectedSchemeId: (id: string) => void;
-  setPreviewSchemeId: (id: string | null) => void;
   /**
    * Updates Zustand state for a deliberate scheme selection (selectedSchemeId
    * + recentSchemeIds LRU) WITHOUT touching the DOM. The caller is responsible
@@ -50,9 +42,9 @@ interface AppThemeState {
 
 function injectSchemeToDOM(scheme: AppColorScheme): void {
   // Read accent override + CVD from the store on every injection so the
-  // modal-close revert, follow-system switch, unmount cleanup, and hover
-  // preview paths all pick up the current user overrides without each
-  // callsite having to reapply them.
+  // modal-close revert, follow-system switch, and unmount cleanup paths
+  // all pick up the current user overrides without each callsite having
+  // to reapply them.
   const { colorVisionMode, accentColorOverride } = useAppThemeStore.getState();
   const effective = applyAccentOverrideToScheme(scheme, accentColorOverride);
   applyAppThemeToRoot(document.documentElement, effective);
@@ -71,7 +63,6 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   preferredLightSchemeId: "bondi",
   recentSchemeIds: [],
   accentColorOverride: null,
-  previewSchemeId: null,
 
   setSelectedSchemeId: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
@@ -85,8 +76,6 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     }));
     injectSchemeToDOM(scheme);
   },
-
-  setPreviewSchemeId: (id) => set({ previewSchemeId: id }),
 
   commitSchemeSelection: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
@@ -113,24 +102,15 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     })),
 
   removeCustomScheme: (id) => {
-    const prev = useAppThemeStore.getState();
-    const needsFallback = prev.selectedSchemeId === id;
-    const wasPreviewing = prev.previewSchemeId === id;
+    const needsFallback = useAppThemeStore.getState().selectedSchemeId === id;
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: needsFallback ? DEFAULT_APP_SCHEME_ID : state.selectedSchemeId,
-      previewSchemeId: wasPreviewing ? null : state.previewSchemeId,
       recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     }));
     if (needsFallback) {
       const defaultScheme = BUILT_IN_APP_SCHEMES.find((s) => s.id === DEFAULT_APP_SCHEME_ID)!;
       injectSchemeToDOM(defaultScheme);
-    } else if (wasPreviewing) {
-      // Preview was pointing at the deleted scheme — CSS vars on :root still
-      // reflect it. Revert the DOM to the (still-committed) selected scheme
-      // so the app theme doesn't silently get stuck on a deleted theme.
-      const { selectedSchemeId, customSchemes } = useAppThemeStore.getState();
-      injectSchemeToDOM(resolveAppTheme(selectedSchemeId, customSchemes));
     }
   },
 
@@ -151,14 +131,8 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
 
   setAccentColorOverride: (color) => {
     set({ accentColorOverride: color });
-    // Re-inject the currently active scheme so the override (or its removal)
-    // takes effect immediately via the single injectSchemeToDOM pipeline.
-    // When a hover preview is active, the previewed scheme is what's on the
-    // DOM — re-injecting the committed scheme here would flip the DOM off
-    // the preview until the pointer moved.
-    const { selectedSchemeId, previewSchemeId, customSchemes } = useAppThemeStore.getState();
-    const activeId = previewSchemeId ?? selectedSchemeId;
-    const scheme = resolveAppTheme(activeId, customSchemes);
+    const { selectedSchemeId, customSchemes } = useAppThemeStore.getState();
+    const scheme = resolveAppTheme(selectedSchemeId, customSchemes);
     injectSchemeToDOM(scheme);
   },
 }));


### PR DESCRIPTION
## Summary
- Reverts the hover-to-preview behaviour added in #5429 — casual scanning no longer triggers full theme repaints
- Restores clean click-to-commit flow with `runThemeReveal` animation intact
- Closes #5249 as "reverted — superseded by dedicated theme browser redesign"

Resolves #5583.

## Changes
- `AppThemePicker.tsx`: removed `onMouseEnter`, `onMouseLeave`, debounced preview logic, and associated `previewTheme` state
- `appThemeStore.ts`: stripped `previewTheme`, `setPreviewTheme`, `clearPreviewTheme`, and `setTheme` now only commits on click
- Deleted preview‑specific test file (`AppThemePicker.preview.test.tsx`) and trimmed shuffle tests
- Fixed a minor Escape‑handler guard that blocked modal closing when search was empty

## Testing
- Verified clicking a theme row commits immediately, no hover preview
- Confirmed `runThemeReveal` animation triggers on click
- Checked that modal closes with Escape regardless of search state