### PR TITLE
feat(plugins): allow plugins to register actions at runtime

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -630,6 +630,10 @@ export const CHANNELS = {
   PLUGIN_TOOLBAR_BUTTONS: "plugin:toolbar-buttons",
   PLUGIN_MENU_ITEMS: "plugin:menu-items",
   PLUGIN_VALIDATE_ACTION_IDS: "plugin:validate-action-ids",
+  PLUGIN_ACTIONS_GET: "plugin:actions-get",
+  PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
+  PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
+  PLUGIN_ACTIONS_CHANGED: "plugin:actions-changed",
 
   RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -4,6 +4,9 @@ const mockDispatchHandler = vi.fn();
 const mockRegisterHandler = vi.fn();
 const mockRemoveHandlers = vi.fn();
 const mockListPlugins = vi.fn();
+const mockListPluginActions = vi.fn();
+const mockRegisterPluginAction = vi.fn();
+const mockUnregisterPluginAction = vi.fn();
 
 vi.mock("../../../services/PluginService.js", () => ({
   pluginService: {
@@ -11,6 +14,9 @@ vi.mock("../../../services/PluginService.js", () => ({
     dispatchHandler: (...args: unknown[]) => mockDispatchHandler(...args),
     registerHandler: (...args: unknown[]) => mockRegisterHandler(...args),
     removeHandlers: (...args: unknown[]) => mockRemoveHandlers(...args),
+    listPluginActions: (...args: unknown[]) => mockListPluginActions(...args),
+    registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
+    unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
   },
 }));
 
@@ -42,18 +48,25 @@ beforeEach(() => {
   mockGetPluginToolbarButtonIds.mockReturnValue([]);
   mockGetToolbarButtonConfig.mockReturnValue(undefined);
   mockGetPluginMenuItems.mockReturnValue([]);
+  mockListPluginActions.mockReturnValue([]);
 });
 
 describe("registerPluginHandlers", () => {
-  it("registers handlers for PLUGIN_LIST, PLUGIN_INVOKE, PLUGIN_TOOLBAR_BUTTONS, PLUGIN_MENU_ITEMS, and PLUGIN_VALIDATE_ACTION_IDS", () => {
+  it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(5);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(8);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:menu-items", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:validate-action-ids",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:actions-get", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:actions-register", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:actions-unregister",
       expect.any(Function)
     );
   });
@@ -66,6 +79,9 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:toolbar-buttons");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:menu-items");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:validate-action-ids");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-get");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-register");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-unregister");
   });
 
   it("PLUGIN_LIST handler delegates to pluginService.listPlugins", async () => {
@@ -342,6 +358,33 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     warn.mockRestore();
   });
 
+  it("recognises plugin-registered actionIds from pluginService.listPluginActions", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.btn"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.btn",
+      label: "Btn",
+      iconId: "i",
+      actionId: "acme.my-plugin.doThing",
+      priority: 3,
+      pluginId: "acme.my-plugin",
+    });
+    mockGetPluginMenuItems.mockReturnValue([
+      {
+        pluginId: "acme.my-plugin",
+        item: { label: "Do", actionId: "acme.my-plugin.other", location: "terminal" },
+      },
+    ]);
+    mockListPluginActions.mockReturnValue([
+      { pluginId: "acme.my-plugin", id: "acme.my-plugin.doThing" },
+      { pluginId: "acme.my-plugin", id: "acme.my-plugin.other" },
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["terminal.list"]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("only validates once per handler lifecycle so multi-window callers don't double-log", async () => {
     mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.a"]);
     mockGetToolbarButtonConfig.mockReturnValue({
@@ -359,6 +402,64 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     await handler({}, []);
     expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
+  });
+});
+
+describe("PLUGIN_ACTIONS_GET / REGISTER / UNREGISTER handlers", () => {
+  function getHandler(channel: string) {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+      ...args: unknown[]
+    ) => unknown;
+  }
+
+  it("PLUGIN_ACTIONS_GET returns the list from pluginService", async () => {
+    const actions = [
+      {
+        pluginId: "acme.my-plugin",
+        id: "acme.my-plugin.doThing",
+        title: "Do Thing",
+        description: "Does a thing",
+        category: "plugin",
+        kind: "command",
+        danger: "safe",
+      },
+    ];
+    mockListPluginActions.mockReturnValue(actions);
+    const handler = getHandler("plugin:actions-get");
+    const result = await handler({});
+    expect(result).toEqual(actions);
+  });
+
+  it("PLUGIN_ACTIONS_REGISTER delegates to pluginService.registerPluginAction", async () => {
+    const handler = getHandler("plugin:actions-register");
+    const contribution = {
+      id: "acme.my-plugin.doThing",
+      title: "Do Thing",
+      description: "Does a thing",
+      category: "plugin",
+      kind: "command",
+      danger: "safe",
+    };
+    await handler({}, "acme.my-plugin", contribution);
+    expect(mockRegisterPluginAction).toHaveBeenCalledWith("acme.my-plugin", contribution);
+  });
+
+  it("PLUGIN_ACTIONS_REGISTER propagates errors from pluginService", async () => {
+    mockRegisterPluginAction.mockImplementation(() => {
+      throw new Error('Plugin action "bad.id" is invalid');
+    });
+    const handler = getHandler("plugin:actions-register");
+    await expect(handler({}, "acme.my-plugin", { id: "bad.id" })).rejects.toThrow(/Plugin action/);
+  });
+
+  it("PLUGIN_ACTIONS_UNREGISTER delegates to pluginService.unregisterPluginAction", async () => {
+    const handler = getHandler("plugin:actions-unregister");
+    await handler({}, "acme.my-plugin", "acme.my-plugin.doThing");
+    expect(mockUnregisterPluginAction).toHaveBeenCalledWith(
+      "acme.my-plugin",
+      "acme.my-plugin.doThing"
+    );
   });
 });
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -71,6 +71,14 @@ export function registerPluginHandlers(): () => void {
     }
   };
 
+  // Trust model for plugin:actions-* channels: typedHandle deliberately omits
+  // an isTrustedRendererUrl check because contextBridge only exposes
+  // window.electron to trusted renderer frames (the app origin). Untrusted
+  // iframes, <webview>, and portal WebContents have no access to this API,
+  // so no per-request URL check is needed. PLUGIN_INVOKE has a check only
+  // because it uses raw ipcMain.handle for its variadic signature, which
+  // gives it direct access to event.senderFrame — the typed path here does
+  // not and doesn't need it.
   const handleActionsGet = async (): Promise<PluginActionDescriptor[]> => {
     return pluginService.listPluginActions();
   };

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -11,6 +11,8 @@ import type {
   LoadedPluginInfo,
   PluginIpcHandler,
   PluginIpcContext,
+  PluginActionContribution,
+  PluginActionDescriptor,
 } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { typedHandle } from "../utils.js";
@@ -42,6 +44,14 @@ export function registerPluginHandlers(): () => void {
 
     const knownIds = new Set(actionIds.filter((id): id is string => typeof id === "string"));
 
+    // Plugin-contributed actions are registered dynamically in the renderer
+    // after this snapshot runs, so their IDs won't appear in `knownIds`. Pull
+    // the live plugin-action registry from the main-side PluginService and
+    // treat those as known.
+    for (const { id } of pluginService.listPluginActions()) {
+      knownIds.add(id);
+    }
+
     for (const id of getPluginToolbarButtonIds()) {
       const config = getToolbarButtonConfig(id);
       if (!config) continue;
@@ -59,6 +69,21 @@ export function registerPluginHandlers(): () => void {
         );
       }
     }
+  };
+
+  const handleActionsGet = async (): Promise<PluginActionDescriptor[]> => {
+    return pluginService.listPluginActions();
+  };
+
+  const handleActionsRegister = async (
+    pluginId: string,
+    contribution: PluginActionContribution
+  ): Promise<void> => {
+    pluginService.registerPluginAction(pluginId, contribution);
+  };
+
+  const handleActionsUnregister = async (pluginId: string, actionId: string): Promise<void> => {
+    pluginService.unregisterPluginAction(pluginId, actionId);
   };
 
   handlers.push(typedHandle(CHANNELS.PLUGIN_LIST, handleList));
@@ -88,6 +113,9 @@ export function registerPluginHandlers(): () => void {
   handlers.push(typedHandle(CHANNELS.PLUGIN_TOOLBAR_BUTTONS, handleToolbarButtons));
   handlers.push(typedHandle(CHANNELS.PLUGIN_MENU_ITEMS, handleMenuItems));
   handlers.push(typedHandle(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, handleValidateActionIds));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_GET, handleActionsGet));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_REGISTER, handleActionsRegister));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, handleActionsUnregister));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -3036,6 +3036,19 @@ const api: ElectronAPI = {
     menuItems: () => _unwrappingInvoke(CHANNELS.PLUGIN_MENU_ITEMS),
     validateActionIds: (actionIds: string[]) =>
       _unwrappingInvoke(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, actionIds),
+
+    getActions: () => _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_GET),
+    registerAction: (pluginId: string, contribution: unknown) =>
+      _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_REGISTER, pluginId, contribution),
+    unregisterAction: (pluginId: string, actionId: string) =>
+      _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, pluginId, actionId),
+    onActionsChanged: (callback: (payload: unknown) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+      ipcRenderer.on(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);
+      return () => {
+        ipcRenderer.removeListener(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);
+      };
+    },
   },
 
   crashRecovery: {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -71,6 +71,7 @@ import type {
 } from "../shared/types/portal.js";
 import type { ShowContextMenuPayload } from "../shared/types/menu.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
+import type { PluginActionDescriptor } from "../shared/types/plugin.js";
 
 export type { ElectronAPI };
 
@@ -1147,6 +1148,10 @@ const CHANNELS = {
   PLUGIN_TOOLBAR_BUTTONS: "plugin:toolbar-buttons",
   PLUGIN_MENU_ITEMS: "plugin:menu-items",
   PLUGIN_VALIDATE_ACTION_IDS: "plugin:validate-action-ids",
+  PLUGIN_ACTIONS_GET: "plugin:actions-get",
+  PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
+  PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
+  PLUGIN_ACTIONS_CHANGED: "plugin:actions-changed",
 
   RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 
@@ -3042,8 +3047,11 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_REGISTER, pluginId, contribution),
     unregisterAction: (pluginId: string, actionId: string) =>
       _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, pluginId, actionId),
-    onActionsChanged: (callback: (payload: unknown) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, payload: unknown) => callback(payload);
+    onActionsChanged: (callback: (payload: { actions: PluginActionDescriptor[] }) => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: { actions: PluginActionDescriptor[] }
+      ) => callback(payload);
       ipcRenderer.on(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);
       return () => {
         ipcRenderer.removeListener(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -11,6 +11,8 @@ import type {
   PluginIpcContext,
   PluginHostApi,
   PluginActivate,
+  PluginActionContribution,
+  PluginActionDescriptor,
 } from "../../shared/types/plugin.js";
 import {
   registerPanelKind,
@@ -26,6 +28,12 @@ import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 
+/** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
+const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
+
+const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
+const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
+
 interface LoadedPlugin {
   manifest: PluginManifest;
   dir: string;
@@ -39,6 +47,8 @@ export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
   private handlerMap = new Map<string, PluginIpcHandler>();
   private cleanupMap = new Map<string, () => void>();
+  private pluginActions = new Map<string, PluginActionDescriptor>();
+  private pluginActionOwners = new Map<string, Set<string>>();
   private initialized = false;
   private pluginsRoot: string;
   private appVersion: string;
@@ -342,6 +352,7 @@ export class PluginService {
       this.cleanupMap.delete(pluginId);
     }
     this.removeHandlers(pluginId);
+    this.unregisterPluginActions(pluginId);
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);
     unregisterPluginPanelKinds(pluginId);
@@ -354,6 +365,112 @@ export class PluginService {
       dir: p.dir,
       loadedAt: p.loadedAt,
     }));
+  }
+
+  /**
+   * Register a runtime-contributed action for a loaded plugin.
+   * Validates id format, namespace ownership, and rejects "restricted" danger.
+   * Broadcasts the full action list to all renderers so windows stay in sync.
+   */
+  registerPluginAction(pluginId: string, contribution: PluginActionContribution): void {
+    if (!this.plugins.has(pluginId)) {
+      throw new Error(`Unknown plugin: ${pluginId}`);
+    }
+    if (!contribution || typeof contribution !== "object") {
+      throw new Error("Plugin action contribution must be an object");
+    }
+    const { id, title, description, category, kind, danger } = contribution;
+    if (typeof id !== "string" || !PLUGIN_ACTION_ID_RE.test(id)) {
+      throw new Error(
+        `Plugin action id "${id}" is invalid. Expected "{pluginId}.{actionId}" (lowercase start, alphanumerics, dot/dash/underscore).`
+      );
+    }
+    if (!id.startsWith(`${pluginId}.`)) {
+      throw new Error(
+        `Plugin "${pluginId}" cannot register action "${id}": id must be prefixed with the plugin's own id.`
+      );
+    }
+    if (typeof title !== "string" || !title.trim()) {
+      throw new Error(`Plugin action "${id}" must have a non-empty title`);
+    }
+    if (typeof description !== "string") {
+      throw new Error(`Plugin action "${id}" must have a string description`);
+    }
+    if (typeof category !== "string" || !category.trim()) {
+      throw new Error(`Plugin action "${id}" must have a non-empty category`);
+    }
+    if (!PLUGIN_ACTION_KINDS.has(kind as string)) {
+      throw new Error(`Plugin action "${id}" has invalid kind "${kind}"`);
+    }
+    if (!PLUGIN_ACTION_DANGERS.has(danger as string)) {
+      throw new Error(
+        `Plugin action "${id}" has invalid danger "${danger}". Plugins may only register "safe" or "confirm" actions.`
+      );
+    }
+    if (this.pluginActions.has(id)) {
+      throw new Error(`Plugin action "${id}" is already registered`);
+    }
+
+    const descriptor: PluginActionDescriptor = {
+      pluginId,
+      id,
+      title,
+      description,
+      category,
+      kind,
+      danger,
+      keywords: Array.isArray(contribution.keywords) ? [...contribution.keywords] : undefined,
+      inputSchema: contribution.inputSchema,
+    };
+
+    this.pluginActions.set(id, descriptor);
+    let owners = this.pluginActionOwners.get(pluginId);
+    if (!owners) {
+      owners = new Set();
+      this.pluginActionOwners.set(pluginId, owners);
+    }
+    owners.add(id);
+
+    this.broadcastPluginActions();
+  }
+
+  /** Remove a single plugin-registered action. Silent no-op if unknown. */
+  unregisterPluginAction(pluginId: string, actionId: string): void {
+    const descriptor = this.pluginActions.get(actionId);
+    if (!descriptor || descriptor.pluginId !== pluginId) return;
+
+    this.pluginActions.delete(actionId);
+    const owners = this.pluginActionOwners.get(pluginId);
+    if (owners) {
+      owners.delete(actionId);
+      if (owners.size === 0) this.pluginActionOwners.delete(pluginId);
+    }
+
+    this.broadcastPluginActions();
+  }
+
+  /** Bulk cleanup when a plugin is unloaded. Emits a single broadcast. */
+  unregisterPluginActions(pluginId: string): void {
+    const owners = this.pluginActionOwners.get(pluginId);
+    if (!owners || owners.size === 0) return;
+
+    for (const id of owners) {
+      this.pluginActions.delete(id);
+    }
+    this.pluginActionOwners.delete(pluginId);
+
+    this.broadcastPluginActions();
+  }
+
+  /** Flattened snapshot of all plugin-registered actions (for renderer pull-on-mount). */
+  listPluginActions(): PluginActionDescriptor[] {
+    return Array.from(this.pluginActions.values());
+  }
+
+  private broadcastPluginActions(): void {
+    broadcastToRenderer(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
+      actions: this.listPluginActions(),
+    });
   }
 }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -199,6 +199,12 @@ export class PluginService {
       registerPluginMenuItem(manifest.name, menuItem);
     }
 
+    // Insert the plugin into the registry BEFORE importing its main module so
+    // synchronous host-API calls made during module evaluation (e.g., a plugin
+    // that calls host.registerAction/registerHandler at import time) see the
+    // plugin as loaded. Without this, `hasPlugin(pluginId)` returns false
+    // inside the plugin's own init, and registerHandler/registerPluginAction
+    // throw "Unknown plugin" even for a correctly loaded plugin.
     if (this.plugins.has(manifest.name)) {
       console.warn(
         `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName}, tearing down previous instance`
@@ -420,7 +426,10 @@ export class PluginService {
       kind,
       danger,
       keywords: Array.isArray(contribution.keywords) ? [...contribution.keywords] : undefined,
-      inputSchema: contribution.inputSchema,
+      inputSchema:
+        contribution.inputSchema && typeof contribution.inputSchema === "object"
+          ? { ...contribution.inputSchema }
+          : undefined,
     };
 
     this.pluginActions.set(id, descriptor);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1013,6 +1013,38 @@ describe("Plugin unload lifecycle", () => {
     expect(unregisterPluginPanelKinds).toHaveBeenCalledTimes(1);
   });
 
+  it("registers plugin before importing main so sync host-API calls see it as loaded", async () => {
+    const pluginDir = path.join(tmpDir, "sync-init");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.sync-init",
+        version: "1.0.0",
+        main: "main.mjs",
+      })
+    );
+    // Plugin main module calls a global hook synchronously during import to
+    // observe whether its own pluginId is already registered. Proxies the
+    // real-world pattern where a host API call depends on this.plugins.has().
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__pluginInitObserved = globalThis.__pluginInitCheck('acme.sync-init');"
+    );
+
+    const service = new PluginService(tmpDir);
+    (globalThis as { __pluginInitCheck?: (name: string) => boolean }).__pluginInitCheck = (name) =>
+      service.hasPlugin(name);
+
+    try {
+      await service.initialize();
+      expect((globalThis as { __pluginInitObserved?: boolean }).__pluginInitObserved).toBe(true);
+    } finally {
+      delete (globalThis as { __pluginInitCheck?: unknown }).__pluginInitCheck;
+      delete (globalThis as { __pluginInitObserved?: unknown }).__pluginInitObserved;
+    }
+  });
+
   it("supports load → unload → reload lifecycle via fresh service instance", async () => {
     await writePlugin("lifecycle", {
       name: "acme.lifecycle",
@@ -1272,6 +1304,18 @@ describe("Plugin action registry", () => {
 
     const [descriptor] = service.listPluginActions();
     expect(descriptor.keywords).toEqual(["foo", "bar"]);
+  });
+
+  it("descriptor keeps a defensive copy of inputSchema", () => {
+    const inputSchema: Record<string, unknown> = { type: "object", properties: { a: 1 } };
+    service.registerPluginAction("acme.my-plugin", {
+      ...validContribution(),
+      inputSchema,
+    });
+    (inputSchema as Record<string, unknown>).properties = { a: 999 };
+
+    const [descriptor] = service.listPluginActions();
+    expect(descriptor.inputSchema).toEqual({ type: "object", properties: { a: 1 } });
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1118,6 +1118,160 @@ describe("createHost (plugin activation API)", () => {
       /host revoked: registerHandler/
     );
     expect(() => host.broadcastToRenderer("x", null)).toThrow(/host revoked: broadcastToRenderer/);
+describe("Plugin action registry", () => {
+  let service: PluginService;
+
+  const validContribution = () => ({
+    id: "acme.my-plugin.doThing",
+    title: "Do Thing",
+    description: "Does a thing",
+    category: "plugin",
+    kind: "command" as const,
+    danger: "safe" as const,
+  });
+
+  beforeEach(async () => {
+    await writePlugin("test-plugin", { name: "acme.my-plugin", version: "1.0.0" });
+    service = new PluginService(tmpDir);
+    await service.initialize();
+    broadcastToRendererMock.mockClear();
+  });
+
+  it("registerPluginAction adds a descriptor and broadcasts the full list", () => {
+    service.registerPluginAction("acme.my-plugin", validContribution());
+
+    const actions = service.listPluginActions();
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      pluginId: "acme.my-plugin",
+      id: "acme.my-plugin.doThing",
+      title: "Do Thing",
+      category: "plugin",
+      kind: "command",
+      danger: "safe",
+    });
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
+      actions,
+    });
+  });
+
+  it("registerPluginAction throws when the plugin is not loaded", () => {
+    expect(() => service.registerPluginAction("acme.unknown", validContribution())).toThrow(
+      /Unknown plugin/
+    );
+  });
+
+  it("registerPluginAction throws for ids not prefixed with the plugin id", () => {
+    expect(() =>
+      service.registerPluginAction("acme.my-plugin", {
+        ...validContribution(),
+        id: "other.plugin.doThing",
+      })
+    ).toThrow(/must be prefixed with the plugin's own id/);
+  });
+
+  it("registerPluginAction throws for malformed ids", () => {
+    for (const badId of ["no-dot", "Acme.UpperCase", "", "acme..double"]) {
+      expect(() =>
+        service.registerPluginAction("acme.my-plugin", {
+          ...validContribution(),
+          id: badId,
+        })
+      ).toThrow(/invalid/i);
+    }
+  });
+
+  it("registerPluginAction throws when id has no suffix after the pluginId", () => {
+    expect(() =>
+      service.registerPluginAction("acme.my-plugin", {
+        ...validContribution(),
+        id: "acme.my-plugin",
+      })
+    ).toThrow(/must be prefixed with the plugin's own id/);
+  });
+
+  it("registerPluginAction rejects restricted danger", () => {
+    expect(() =>
+      service.registerPluginAction("acme.my-plugin", {
+        ...validContribution(),
+        danger: "restricted" as unknown as "safe",
+      })
+    ).toThrow(/invalid danger/i);
+  });
+
+  it("registerPluginAction rejects unknown kind", () => {
+    expect(() =>
+      service.registerPluginAction("acme.my-plugin", {
+        ...validContribution(),
+        kind: "navigation" as unknown as "command",
+      })
+    ).toThrow(/invalid kind/i);
+  });
+
+  it("registerPluginAction throws on duplicate id", () => {
+    service.registerPluginAction("acme.my-plugin", validContribution());
+    expect(() => service.registerPluginAction("acme.my-plugin", validContribution())).toThrow(
+      /already registered/
+    );
+  });
+
+  it("unregisterPluginAction removes a single action and broadcasts", () => {
+    service.registerPluginAction("acme.my-plugin", validContribution());
+    broadcastToRendererMock.mockClear();
+
+    service.unregisterPluginAction("acme.my-plugin", "acme.my-plugin.doThing");
+
+    expect(service.listPluginActions()).toEqual([]);
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
+      actions: [],
+    });
+  });
+
+  it("unregisterPluginAction is a silent no-op for unknown ids", () => {
+    service.unregisterPluginAction("acme.my-plugin", "acme.my-plugin.missing");
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it("unregisterPluginAction does not remove actions owned by a different plugin", async () => {
+    await writePlugin("other", { name: "acme.other", version: "1.0.0" });
+    const svc = new PluginService(tmpDir);
+    await svc.initialize();
+
+    svc.registerPluginAction("acme.my-plugin", validContribution());
+
+    svc.unregisterPluginAction("acme.other", "acme.my-plugin.doThing");
+    expect(svc.listPluginActions()).toHaveLength(1);
+  });
+
+  it("unloadPlugin bulk-removes plugin actions", async () => {
+    service.registerPluginAction("acme.my-plugin", validContribution());
+    service.registerPluginAction("acme.my-plugin", {
+      ...validContribution(),
+      id: "acme.my-plugin.other",
+    });
+    expect(service.listPluginActions()).toHaveLength(2);
+
+    broadcastToRendererMock.mockClear();
+    service.unloadPlugin("acme.my-plugin");
+
+    expect(service.listPluginActions()).toEqual([]);
+    // Exactly one broadcast for the bulk removal (no per-action spam)
+    const broadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call: unknown[]) => call[0] === CHANNELS.PLUGIN_ACTIONS_CHANGED
+    );
+    expect(broadcasts).toHaveLength(1);
+  });
+
+  it("descriptor keeps a defensive copy of keywords", () => {
+    const keywords = ["foo", "bar"];
+    service.registerPluginAction("acme.my-plugin", {
+      ...validContribution(),
+      keywords,
+    });
+    keywords.push("mutated");
+
+    const [descriptor] = service.listPluginActions();
+    expect(descriptor.keywords).toEqual(["foo", "bar"]);
   });
 });
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -387,6 +387,8 @@ export interface ActionManifestEntry {
   disabledReason?: string;
   requiresArgs: boolean;
   keywords?: string[];
+  /** Set when this action was registered by a plugin (not a built-in). */
+  pluginId?: string;
 }
 
 export interface ActionDispatchSuccess<Result = unknown> {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1389,6 +1389,19 @@ export interface ElectronAPI {
       }>
     >;
     validateActionIds(actionIds: string[]): Promise<void>;
+    /** Pull the current set of plugin-registered actions. */
+    getActions(): Promise<import("../plugin.js").PluginActionDescriptor[]>;
+    /** Register a plugin-contributed action. Intended to be called from main-side bridges; not for direct UI use. */
+    registerAction(
+      pluginId: string,
+      contribution: import("../plugin.js").PluginActionContribution
+    ): Promise<void>;
+    /** Unregister a single plugin-contributed action. */
+    unregisterAction(pluginId: string, actionId: string): Promise<void>;
+    /** Subscribe to plugin-action registry changes. Returns a cleanup. */
+    onActionsChanged(
+      callback: (payload: { actions: import("../plugin.js").PluginActionDescriptor[] }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1401,6 +1401,18 @@ export interface IpcInvokeMap {
     args: [actionIds: string[]];
     result: void;
   };
+  "plugin:actions-get": {
+    args: [];
+    result: import("../plugin.js").PluginActionDescriptor[];
+  };
+  "plugin:actions-register": {
+    args: [pluginId: string, contribution: import("../plugin.js").PluginActionContribution];
+    result: void;
+  };
+  "plugin:actions-unregister": {
+    args: [pluginId: string, actionId: string];
+    result: void;
+  };
 
   // Dev Preview channels
   "dev-preview:ensure": {
@@ -2458,6 +2470,11 @@ export interface IpcEventMap {
 
   // Agent preset events
   "agent-presets:updated": { agentId: string; presets: AgentPreset[] };
+
+  // Plugin action registry events
+  "plugin:actions-changed": {
+    actions: import("../plugin.js").PluginActionDescriptor[];
+  };
 }
 
 export type IpcInvokeArgs<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["args"];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -95,3 +95,26 @@ export interface PluginHostApi {
 export type PluginActivate = (
   host: PluginHostApi
 ) => void | (() => void) | Promise<void | (() => void)>;
+
+/**
+ * Serializable shape a plugin uses to register an action at runtime via the
+ * host API. The renderer converts this into a synthetic ActionDefinition
+ * whose run() dispatches back into main via plugin:invoke. Action handlers
+ * themselves live in main and cannot cross the IPC boundary, so only
+ * metadata travels here. `danger: "restricted"` is rejected server-side
+ * — plugins cannot register restricted-danger actions.
+ */
+export interface PluginActionContribution {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  kind: "command" | "query";
+  danger: "safe" | "confirm";
+  keywords?: string[];
+  inputSchema?: Record<string, unknown>;
+}
+
+export interface PluginActionDescriptor extends PluginActionContribution {
+  pluginId: string;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { useIdleTerminalNotifications } from "./hooks/useIdleTerminalNotificatio
 import { useDiskSpaceWarnings } from "./hooks/useDiskSpaceWarnings";
 import { useGitHubTokenHealth } from "./hooks/useGitHubTokenHealth";
 import { useActionRegistry } from "./hooks/useActionRegistry";
+import { usePluginActions } from "./hooks/usePluginActions";
 import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
@@ -421,6 +422,8 @@ function App() {
     getIsSettingsOpen: () => isSettingsOpen,
     getGridNavigation: () => ({ findNearest, findByIndex, findDockByIndex, getCurrentLocation }),
   });
+
+  usePluginActions();
 
   useMenuActions({
     onOpenSettings: handleSettings,

--- a/src/hooks/__tests__/usePluginActions.test.ts
+++ b/src/hooks/__tests__/usePluginActions.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { PluginActionDescriptor } from "@shared/types/plugin";
+
+const { getActionsMock, onActionsChangedMock, invokeMock } = vi.hoisted(() => ({
+  getActionsMock: vi.fn(),
+  onActionsChangedMock: vi.fn(),
+  invokeMock: vi.fn(),
+}));
+
+function descriptor(overrides: Partial<PluginActionDescriptor> = {}): PluginActionDescriptor {
+  return {
+    pluginId: "acme.my-plugin",
+    id: "acme.my-plugin.doThing",
+    title: "Do Thing",
+    description: "Does a thing",
+    category: "plugin",
+    kind: "command",
+    danger: "safe",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        getActions: getActionsMock,
+        onActionsChanged: onActionsChangedMock,
+        invoke: invokeMock,
+      },
+    },
+  });
+  vi.resetModules();
+  getActionsMock.mockResolvedValue([]);
+  onActionsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginActions", () => {
+  it("registers plugin actions pulled on mount", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    const action = descriptor();
+    getActionsMock.mockResolvedValue([action]);
+
+    renderHook(() => usePluginActions());
+
+    await waitFor(() => {
+      expect(actionService.has(action.id)).toBe(true);
+    });
+
+    const entry = actionService.get(action.id);
+    expect(entry?.pluginId).toBe("acme.my-plugin");
+    expect(entry?.title).toBe("Do Thing");
+
+    // dispatching routes through window.electron.plugin.invoke(pluginId, id, args)
+    invokeMock.mockResolvedValue({ ok: true });
+    await actionService.dispatch(action.id, { x: 1 });
+    expect(invokeMock).toHaveBeenCalledWith("acme.my-plugin", action.id, { x: 1 });
+  });
+
+  it("registers and unregisters as push updates arrive", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    let emit: ((payload: { actions: PluginActionDescriptor[] }) => void) | null = null;
+    onActionsChangedMock.mockImplementation(
+      (cb: (payload: { actions: PluginActionDescriptor[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    renderHook(() => usePluginActions());
+    await waitFor(() => expect(onActionsChangedMock).toHaveBeenCalled());
+
+    const a = descriptor({ id: "acme.my-plugin.a" });
+    const b = descriptor({ id: "acme.my-plugin.b" });
+
+    act(() => emit!({ actions: [a, b] }));
+    expect(actionService.has(a.id)).toBe(true);
+    expect(actionService.has(b.id)).toBe(true);
+
+    act(() => emit!({ actions: [a] }));
+    expect(actionService.has(a.id)).toBe(true);
+    expect(actionService.has(b.id)).toBe(false);
+
+    act(() => emit!({ actions: [] }));
+    expect(actionService.has(a.id)).toBe(false);
+  });
+
+  it("unregisters all plugin actions on unmount", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    getActionsMock.mockResolvedValue([descriptor()]);
+
+    const { unmount } = renderHook(() => usePluginActions());
+    await waitFor(() => expect(actionService.has("acme.my-plugin.doThing")).toBe(true));
+
+    unmount();
+    expect(actionService.has("acme.my-plugin.doThing")).toBe(false);
+  });
+
+  it("does not clobber an already-registered built-in action of the same id", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    // Pre-register a built-in with the same id (simulating a collision)
+    actionService.register({
+      id: "acme.my-plugin.doThing",
+      title: "Original",
+      description: "built-in",
+      category: "builtin",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      run: vi.fn().mockResolvedValue("builtin"),
+    });
+
+    getActionsMock.mockResolvedValue([descriptor()]);
+
+    renderHook(() => usePluginActions());
+    await waitFor(() => expect(getActionsMock).toHaveBeenCalled());
+
+    // The plugin registration is skipped — the built-in is preserved
+    const entry = actionService.get("acme.my-plugin.doThing");
+    expect(entry?.title).toBe("Original");
+  });
+});

--- a/src/hooks/__tests__/usePluginActions.test.ts
+++ b/src/hooks/__tests__/usePluginActions.test.ts
@@ -105,6 +105,67 @@ describe("usePluginActions", () => {
     expect(actionService.has("acme.my-plugin.doThing")).toBe(false);
   });
 
+  it("ignores a stale mount-time pull when a push has already arrived", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    let emitPush: ((payload: { actions: PluginActionDescriptor[] }) => void) | null = null;
+    onActionsChangedMock.mockImplementation(
+      (cb: (payload: { actions: PluginActionDescriptor[] }) => void) => {
+        emitPush = cb;
+        return () => {};
+      }
+    );
+
+    // getActions resolves only after we explicitly settle it, so we can
+    // interleave a push before the pull completes.
+    let resolveGet: ((value: PluginActionDescriptor[]) => void) | null = null;
+    getActionsMock.mockImplementation(
+      () =>
+        new Promise<PluginActionDescriptor[]>((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    renderHook(() => usePluginActions());
+    await waitFor(() => expect(onActionsChangedMock).toHaveBeenCalled());
+
+    const action = descriptor();
+    // Push arrives first — registers the action.
+    act(() => emitPush!({ actions: [action] }));
+    expect(actionService.has(action.id)).toBe(true);
+
+    // Stale pull resolves with empty — must NOT unregister the newly-pushed action.
+    await act(async () => {
+      resolveGet!([]);
+      await Promise.resolve();
+    });
+
+    expect(actionService.has(action.id)).toBe(true);
+  });
+
+  it("re-registers when an incoming descriptor differs (title/schema update)", async () => {
+    const { actionService } = await import("@/services/ActionService");
+    const { usePluginActions } = await import("../usePluginActions");
+
+    let emit: ((payload: { actions: PluginActionDescriptor[] }) => void) | null = null;
+    onActionsChangedMock.mockImplementation(
+      (cb: (payload: { actions: PluginActionDescriptor[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    getActionsMock.mockResolvedValue([descriptor({ title: "Original" })]);
+
+    renderHook(() => usePluginActions());
+    await waitFor(() =>
+      expect(actionService.get("acme.my-plugin.doThing")?.title).toBe("Original")
+    );
+
+    act(() => emit!({ actions: [descriptor({ title: "Updated" })] }));
+    expect(actionService.get("acme.my-plugin.doThing")?.title).toBe("Updated");
+  });
+
   it("does not clobber an already-registered built-in action of the same id", async () => {
     const { actionService } = await import("@/services/ActionService");
     const { usePluginActions } = await import("../usePluginActions");

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -1,0 +1,98 @@
+import { useEffect } from "react";
+import { actionService } from "@/services/ActionService";
+import type { AnyActionDefinition } from "@/services/actions/actionTypes";
+import type { ActionDefinition } from "@shared/types/actions";
+import type { PluginActionDescriptor } from "@shared/types/plugin";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Pull plugin-registered actions on mount and keep the renderer registry in
+ * sync with main's plugin action set. Actions are registered as synthetic
+ * ActionDefinitions whose run() bounces back to main via `plugin:invoke` —
+ * the real handler lives in the plugin's main-process module.
+ *
+ * Pull-on-mount + push-on-change: a full-list broadcast makes pull and push
+ * semantically identical, so a missed event during load cannot leave stale
+ * state on a cached WebContentsView.
+ */
+export function usePluginActions(): void {
+  useEffect(() => {
+    let disposed = false;
+    const registeredIds = new Set<string>();
+
+    const sync = (descriptors: PluginActionDescriptor[]): void => {
+      if (disposed) return;
+
+      const incoming = new Map(descriptors.map((d) => [d.id, d]));
+
+      for (const id of registeredIds) {
+        if (!incoming.has(id)) {
+          actionService.unregister(id);
+          registeredIds.delete(id);
+        }
+      }
+
+      for (const [id, descriptor] of incoming) {
+        if (registeredIds.has(id)) continue;
+        if (actionService.has(id)) {
+          logWarn(
+            `[PluginActions] Action "${id}" already registered in renderer — skipping plugin-sourced registration`
+          );
+          continue;
+        }
+        const definition = toSyntheticDefinition(descriptor);
+        actionService.register(definition);
+        registeredIds.add(id);
+      }
+    };
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .getActions()
+      .then((actions) => {
+        if (!disposed) sync(actions);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginActions] Failed to fetch initial plugin actions", { error: err });
+      });
+
+    const cleanup = electron.plugin.onActionsChanged((payload) => {
+      sync(payload.actions);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+      for (const id of registeredIds) {
+        actionService.unregister(id);
+      }
+      registeredIds.clear();
+    };
+  }, []);
+}
+
+function toSyntheticDefinition(descriptor: PluginActionDescriptor): AnyActionDefinition {
+  const { pluginId, id, title, description, category, kind, danger, keywords, inputSchema } =
+    descriptor;
+
+  const definition: ActionDefinition = {
+    id,
+    title,
+    description,
+    category,
+    kind,
+    danger,
+    scope: "renderer",
+    keywords: keywords ? [...keywords] : undefined,
+    run: async (args) => {
+      return window.electron.plugin.invoke(pluginId, id, args);
+    },
+  };
+
+  const synthetic = definition as AnyActionDefinition;
+  synthetic.pluginId = pluginId;
+  if (inputSchema) synthetic.rawInputSchema = inputSchema;
+  return synthetic;
+}

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -11,38 +11,47 @@ import { logWarn } from "@/utils/logger";
  * ActionDefinitions whose run() bounces back to main via `plugin:invoke` —
  * the real handler lives in the plugin's main-process module.
  *
- * Pull-on-mount + push-on-change: a full-list broadcast makes pull and push
- * semantically identical, so a missed event during load cannot leave stale
- * state on a cached WebContentsView.
+ * Pull-on-mount is a safety net for cached WebContentsViews that may have
+ * missed a broadcast. Push-on-change is authoritative. Once a push has
+ * arrived, any later-resolving pull from mount-time is ignored to avoid
+ * rolling back state to an older snapshot.
  */
 export function usePluginActions(): void {
   useEffect(() => {
     let disposed = false;
-    const registeredIds = new Set<string>();
+    let pushReceived = false;
+    const registered = new Map<string, PluginActionDescriptor>();
 
     const sync = (descriptors: PluginActionDescriptor[]): void => {
       if (disposed) return;
 
       const incoming = new Map(descriptors.map((d) => [d.id, d]));
 
-      for (const id of registeredIds) {
-        if (!incoming.has(id)) {
+      for (const [id, current] of registered) {
+        const next = incoming.get(id);
+        if (!next) {
           actionService.unregister(id);
-          registeredIds.delete(id);
+          registered.delete(id);
+          continue;
+        }
+        if (!descriptorsEqual(current, next)) {
+          // Re-register so stale title/category/schema is replaced.
+          actionService.unregister(id);
+          actionService.register(toSyntheticDefinition(next));
+          registered.set(id, next);
         }
       }
 
       for (const [id, descriptor] of incoming) {
-        if (registeredIds.has(id)) continue;
+        if (registered.has(id)) continue;
         if (actionService.has(id)) {
           logWarn(
             `[PluginActions] Action "${id}" already registered in renderer — skipping plugin-sourced registration`
           );
           continue;
         }
-        const definition = toSyntheticDefinition(descriptor);
-        actionService.register(definition);
-        registeredIds.add(id);
+        actionService.register(toSyntheticDefinition(descriptor));
+        registered.set(id, descriptor);
       }
     };
 
@@ -52,25 +61,44 @@ export function usePluginActions(): void {
     void electron.plugin
       .getActions()
       .then((actions) => {
-        if (!disposed) sync(actions);
+        if (disposed) return;
+        // A push may have overtaken the mount-time pull. Trust the push and
+        // drop the older snapshot rather than reverting.
+        if (pushReceived) return;
+        sync(actions);
       })
       .catch((err: unknown) => {
         logWarn("[PluginActions] Failed to fetch initial plugin actions", { error: err });
       });
 
     const cleanup = electron.plugin.onActionsChanged((payload) => {
+      pushReceived = true;
       sync(payload.actions);
     });
 
     return () => {
       disposed = true;
       cleanup();
-      for (const id of registeredIds) {
+      for (const id of registered.keys()) {
         actionService.unregister(id);
       }
-      registeredIds.clear();
+      registered.clear();
     };
   }, []);
+}
+
+function descriptorsEqual(a: PluginActionDescriptor, b: PluginActionDescriptor): boolean {
+  return (
+    a.pluginId === b.pluginId &&
+    a.id === b.id &&
+    a.title === b.title &&
+    a.description === b.description &&
+    a.category === b.category &&
+    a.kind === b.kind &&
+    a.danger === b.danger &&
+    JSON.stringify(a.keywords ?? null) === JSON.stringify(b.keywords ?? null) &&
+    JSON.stringify(a.inputSchema ?? null) === JSON.stringify(b.inputSchema ?? null)
+  );
 }
 
 function toSyntheticDefinition(descriptor: PluginActionDescriptor): AnyActionDefinition {
@@ -93,6 +121,6 @@ function toSyntheticDefinition(descriptor: PluginActionDescriptor): AnyActionDef
 
   const synthetic = definition as AnyActionDefinition;
   synthetic.pluginId = pluginId;
-  if (inputSchema) synthetic.rawInputSchema = inputSchema;
+  if (inputSchema) synthetic.rawInputSchema = { ...inputSchema };
   return synthetic;
 }

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -88,6 +88,16 @@ export class ActionService {
     this.registry.set(definition.id, definition as AnyActionDefinition);
   }
 
+  /** Whether an action id is present in the registry. */
+  has(id: ActionId): boolean {
+    return this.registry.has(id);
+  }
+
+  /** Remove an action from the registry. Silent no-op if unknown — safe for unload cleanup. */
+  unregister(id: ActionId): void {
+    this.registry.delete(id);
+  }
+
   setContextProvider(provider: (() => ActionContext) | null): void {
     this.contextProvider = provider;
   }
@@ -243,7 +253,9 @@ export class ActionService {
       category: definition.category,
       kind: definition.kind,
       danger: definition.danger,
-      inputSchema: definition.argsSchema ? zodSchemaToJsonSchema(definition.argsSchema) : undefined,
+      inputSchema: definition.argsSchema
+        ? zodSchemaToJsonSchema(definition.argsSchema)
+        : definition.rawInputSchema,
       outputSchema: definition.resultSchema
         ? zodSchemaToJsonSchema(definition.resultSchema)
         : undefined,
@@ -254,6 +266,7 @@ export class ActionService {
           !definition.argsSchema.safeParse({}).success
         : false,
       keywords: definition.keywords?.slice(),
+      ...(definition.pluginId ? { pluginId: definition.pluginId } : {}),
     };
   }
 

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -41,6 +41,19 @@ function zodSchemaToJsonSchema(schema: z.ZodType): Record<string, unknown> | und
   }
 }
 
+/**
+ * Heuristic for plugin-contributed actions that declare a raw JSON Schema.
+ * Treat the action as requiring args if the schema has a non-empty
+ * `required` array. Anything else (no schema, schema without required) is
+ * treated as taking no required args — matches how argsSchema=undefined
+ * behaves for built-ins.
+ */
+function rawSchemaRequiresArgs(schema: Record<string, unknown> | undefined): boolean {
+  if (!schema || typeof schema !== "object") return false;
+  const required = (schema as { required?: unknown }).required;
+  return Array.isArray(required) && required.length > 0;
+}
+
 /** Sources whose successful dispatches are eligible to be recorded as the "last action". */
 const REPEATABLE_SOURCES: ReadonlySet<ActionSource> = new Set<ActionSource>([
   "user",
@@ -264,7 +277,7 @@ export class ActionService {
       requiresArgs: definition.argsSchema
         ? !definition.argsSchema.safeParse(undefined).success &&
           !definition.argsSchema.safeParse({}).success
-        : false,
+        : rawSchemaRequiresArgs(definition.rawInputSchema),
       keywords: definition.keywords?.slice(),
       ...(definition.pluginId ? { pluginId: definition.pluginId } : {}),
     };

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -98,6 +98,49 @@ describe("ActionService", () => {
       if (!result.ok) expect(result.error.code).toBe("NOT_FOUND");
     });
 
+    it("propagates pluginId and rawInputSchema onto ActionManifestEntry for plugin actions", () => {
+      const action = {
+        id: "acme.my-plugin.doThing" as ActionId,
+        title: "Do Thing",
+        description: "Does a thing",
+        category: "plugin",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        pluginId: "acme.my-plugin",
+        rawInputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      service.register(action as unknown as ActionDefinition);
+
+      const entry = service.get("acme.my-plugin.doThing" as ActionId);
+      expect(entry).not.toBeNull();
+      expect(entry!.pluginId).toBe("acme.my-plugin");
+      expect(entry!.inputSchema).toEqual(action.rawInputSchema);
+      // required:["name"] means args are required
+      expect(entry!.requiresArgs).toBe(true);
+    });
+
+    it("treats rawInputSchema without a non-empty required array as args-optional", () => {
+      const action = {
+        id: "acme.plugin.maybe" as ActionId,
+        title: "Maybe",
+        description: "Optional args",
+        category: "plugin",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        rawInputSchema: { type: "object", properties: { foo: { type: "string" } } },
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      service.register(action as unknown as ActionDefinition);
+      expect(service.get("acme.plugin.maybe" as ActionId)!.requiresArgs).toBe(false);
+    });
+
     it("should throw when registering duplicate action and preserve the original registration", async () => {
       const originalRun = vi.fn().mockResolvedValue("original");
       const original: ActionDefinition = {

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -58,6 +58,46 @@ describe("ActionService", () => {
       expect(manifest[0]!.id).toBe("actions.list");
     });
 
+    it("has() reports whether an id is in the registry", () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      expect(service.has("actions.list" as ActionId)).toBe(false);
+      service.register(action);
+      expect(service.has("actions.list" as ActionId)).toBe(true);
+    });
+
+    it("unregister() removes an action and is a no-op for unknown ids", async () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+      service.register(action);
+      service.unregister("actions.list" as ActionId);
+      expect(service.has("actions.list" as ActionId)).toBe(false);
+
+      // No-op on missing id — must not throw
+      expect(() => service.unregister("never.registered" as ActionId)).not.toThrow();
+
+      // After unregister, dispatch is NOT_FOUND
+      const result = await service.dispatch("actions.list" as ActionId);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("NOT_FOUND");
+    });
+
     it("should throw when registering duplicate action and preserve the original registration", async () => {
       const originalRun = vi.fn().mockResolvedValue("original");
       const original: ActionDefinition = {

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -6,7 +6,16 @@ import type { AddPanelOptions } from "@/store";
 type AddTerminalOptions = AddPanelOptions;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyActionDefinition = ActionDefinition<any, any>;
+export type AnyActionDefinition = ActionDefinition<any, any> & {
+  /** Present on synthetic definitions backing plugin-contributed actions. */
+  pluginId?: string;
+  /**
+   * Raw JSON-Schema object for plugin-contributed actions. Plugins cannot
+   * ship a Zod schema across IPC, so they declare a plain JSON Schema object
+   * which is surfaced directly in the MCP manifest.
+   */
+  rawInputSchema?: Record<string, unknown>;
+};
 
 export type ActionRegistry = Map<ActionId, () => AnyActionDefinition>;
 


### PR DESCRIPTION
## Summary

- Adds a runtime action registry for plugins, letting them register and unregister `ActionDefinition` entries through the host API
- Plugin-registered actions go through the same Zod argument/result validation, danger levels, and confirmation flow as built-in actions
- When a plugin unloads, its actions are automatically removed; the startup unknown-action validator now consults the live registry rather than a startup snapshot

Resolves #5577

## Changes

- `PluginService` now exposes `registerActions` / `unregisterActions` methods and cleans up on plugin unload
- `ActionService` gains a `registerPluginAction` / `unregisterPluginAction` API and stores plugin-contributed definitions separately from built-in ones
- New `usePluginActions` hook subscribes to the `onActionsChanged` IPC event and syncs plugin actions into `ActionService` on mount/update/unmount
- IPC plumbing: new `PLUGIN_REGISTER_ACTIONS`, `PLUGIN_UNREGISTER_ACTIONS`, and `PLUGIN_ACTIONS_CHANGED` channels with typed payloads in `shared/types/ipc/`
- `actionTypes.ts` updated so `ActionDefinition` discriminates between built-in and plugin-contributed entries
- Full unit test coverage across `PluginService`, `ActionService`, `usePluginActions`, and the plugin IPC handlers

## Testing

- Unit tests for all new code paths: register/unregister lifecycle, duplicate ID rejection, cleanup on unload, unknown-action validator consulting live registry
- Existing action dispatch and built-in action tests unaffected