### PR TITLE
fix(plugins): add unsandboxed warning and remove deprecated renderer field

### DIFF
--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -47,7 +47,6 @@ export const PluginManifestSchema = z.object({
   displayName: z.string().optional(),
   description: z.string().optional(),
   main: z.string().optional(),
-  renderer: z.string().optional(),
   engines: z
     .object({
       daintree: z

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -119,12 +119,6 @@ export class PluginService {
       );
     }
 
-    if (manifest.renderer) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}" uses deprecated 'renderer' field. This field is no longer supported and will be ignored. Daintree plugins use main process entry points only; renderer-side plugins are not supported.`
-      );
-    }
-
     const plugin: LoadedPlugin = {
       manifest,
       dir: pluginDir,
@@ -172,6 +166,10 @@ export class PluginService {
     for (const menuItem of manifest.contributes.menuItems) {
       registerPluginMenuItem(manifest.name, menuItem);
     }
+
+    console.warn(
+      `[PluginService] DANGER_UNSANDBOXED: Plugin "${manifest.name}" loaded with full Node.js access. Only install plugins you trust.`
+    );
 
     if (plugin.resolvedMain) {
       try {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -113,7 +113,7 @@ afterEach(async () => {
 describe("PluginService integration — panel contributions", () => {
   it("registers a panel contribution in the real panelKindRegistry", async () => {
     await writePlugin("panel-plugin", {
-      name: "panel-plugin",
+      name: "acme.panel-plugin",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -130,10 +130,10 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    const config = getPanelKindConfig("panel-plugin.viewer");
+    const config = getPanelKindConfig("acme.panel-plugin.viewer");
     expect(config).toBeDefined();
     expect(config).toMatchObject({
-      id: "panel-plugin.viewer",
+      id: "acme.panel-plugin.viewer",
       name: "Viewer",
       iconId: "eye",
       color: "#ff0000",
@@ -141,13 +141,13 @@ describe("PluginService integration — panel contributions", () => {
       canRestart: false,
       canConvert: false,
       showInPalette: true,
-      extensionId: "panel-plugin",
+      extensionId: "acme.panel-plugin",
     });
   });
 
   it("registers multiple panels from one plugin with full config per panel", async () => {
     await writePlugin("multi-panel", {
-      name: "multi-panel",
+      name: "acme.multi-panel",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -160,25 +160,25 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("multi-panel.viewer")).toMatchObject({
-      id: "multi-panel.viewer",
+    expect(getPanelKindConfig("acme.multi-panel.viewer")).toMatchObject({
+      id: "acme.multi-panel.viewer",
       name: "Viewer",
       iconId: "eye",
       color: "#111",
-      extensionId: "multi-panel",
+      extensionId: "acme.multi-panel",
     });
-    expect(getPanelKindConfig("multi-panel.editor")).toMatchObject({
-      id: "multi-panel.editor",
+    expect(getPanelKindConfig("acme.multi-panel.editor")).toMatchObject({
+      id: "acme.multi-panel.editor",
       name: "Editor",
       iconId: "pen",
       color: "#222",
-      extensionId: "multi-panel",
+      extensionId: "acme.multi-panel",
     });
   });
 
   it("propagates non-default panel flags through to the registry", async () => {
     await writePlugin("flag-plugin", {
-      name: "flag-plugin",
+      name: "acme.flag-plugin",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -199,7 +199,7 @@ describe("PluginService integration — panel contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("flag-plugin.custom")).toMatchObject({
+    expect(getPanelKindConfig("acme.flag-plugin.custom")).toMatchObject({
       hasPty: true,
       canRestart: true,
       canConvert: true,
@@ -209,7 +209,7 @@ describe("PluginService integration — panel contributions", () => {
 
   it("preserves built-in panel kind configs intact after loading an extension", async () => {
     await writePlugin("built-in-coexist", {
-      name: "built-in-coexist",
+      name: "acme.built-in-coexist",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
@@ -245,36 +245,38 @@ describe("PluginService integration — panel contributions", () => {
 
   it("uses manifest.name not directory name when registering contributions", async () => {
     await writePlugin("alias-dir", {
-      name: "real-plugin",
+      name: "acme.real-plugin",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#abc" }],
         toolbarButtons: [
-          { id: "btn", label: "B", iconId: "i", actionId: "real-plugin.act", priority: 2 },
+          { id: "btn", label: "B", iconId: "i", actionId: "acme.real-plugin.act", priority: 2 },
         ],
-        menuItems: [{ label: "M", actionId: "real-plugin.act", location: "view" }],
+        menuItems: [{ label: "M", actionId: "acme.real-plugin.act", location: "view" }],
       },
     });
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("real-plugin.viewer")?.extensionId).toBe("real-plugin");
+    expect(getPanelKindConfig("acme.real-plugin.viewer")?.extensionId).toBe("acme.real-plugin");
     expect(getPanelKindConfig("alias-dir.viewer")).toBeUndefined();
 
-    expect(getToolbarButtonConfig("plugin.real-plugin.btn")?.pluginId).toBe("real-plugin");
+    expect(getToolbarButtonConfig("plugin.acme.real-plugin.btn")?.pluginId).toBe(
+      "acme.real-plugin"
+    );
     expect(getToolbarButtonConfig("plugin.alias-dir.btn")).toBeUndefined();
 
     const items = getPluginMenuItems();
     expect(items).toHaveLength(1);
-    expect(items[0].pluginId).toBe("real-plugin");
+    expect(items[0].pluginId).toBe("acme.real-plugin");
   });
 });
 
 describe("PluginService integration — toolbar button contributions", () => {
   it("registers a toolbar button in the real toolbarButtonRegistry", async () => {
     await writePlugin("toolbar-plugin", {
-      name: "toolbar-plugin",
+      name: "acme.toolbar-plugin",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -282,7 +284,7 @@ describe("PluginService integration — toolbar button contributions", () => {
             id: "my-btn",
             label: "My Button",
             iconId: "puzzle",
-            actionId: "toolbar-plugin.doThing",
+            actionId: "acme.toolbar-plugin.doThing",
             priority: 4,
           },
         ],
@@ -292,21 +294,21 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    const config = getToolbarButtonConfig("plugin.toolbar-plugin.my-btn");
+    const config = getToolbarButtonConfig("plugin.acme.toolbar-plugin.my-btn");
     expect(config).toBeDefined();
     expect(config).toMatchObject({
-      id: "plugin.toolbar-plugin.my-btn",
+      id: "plugin.acme.toolbar-plugin.my-btn",
       label: "My Button",
       iconId: "puzzle",
-      actionId: "toolbar-plugin.doThing",
+      actionId: "acme.toolbar-plugin.doThing",
       priority: 4,
-      pluginId: "toolbar-plugin",
+      pluginId: "acme.toolbar-plugin",
     });
   });
 
   it("defaults priority to 3 when omitted", async () => {
     await writePlugin("default-prio", {
-      name: "default-prio",
+      name: "acme.default-prio",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -314,7 +316,7 @@ describe("PluginService integration — toolbar button contributions", () => {
             id: "btn",
             label: "Btn",
             iconId: "icon",
-            actionId: "default-prio.action",
+            actionId: "acme.default-prio.action",
           },
         ],
       },
@@ -323,20 +325,20 @@ describe("PluginService integration — toolbar button contributions", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getToolbarButtonConfig("plugin.default-prio.btn")?.priority).toBe(3);
+    expect(getToolbarButtonConfig("plugin.acme.default-prio.btn")?.priority).toBe(3);
   });
 });
 
 describe("PluginService integration — menu item contributions", () => {
   it("registers a menu item in the real pluginMenuRegistry", async () => {
     await writePlugin("menu-plugin", {
-      name: "menu-plugin",
+      name: "acme.menu-plugin",
       version: "1.0.0",
       contributes: {
         menuItems: [
           {
             label: "Do Something",
-            actionId: "menu-plugin.doSomething",
+            actionId: "acme.menu-plugin.doSomething",
             location: "terminal",
           },
         ],
@@ -349,10 +351,10 @@ describe("PluginService integration — menu item contributions", () => {
     const items = getPluginMenuItems();
     expect(items).toHaveLength(1);
     expect(items[0]).toEqual({
-      pluginId: "menu-plugin",
+      pluginId: "acme.menu-plugin",
       item: {
         label: "Do Something",
-        actionId: "menu-plugin.doSomething",
+        actionId: "acme.menu-plugin.doSomething",
         location: "terminal",
       },
     });
@@ -363,7 +365,7 @@ describe("PluginService integration — main entry execution", () => {
   it("executes a plugin's main entry via dynamic import", async () => {
     const markerKey = makeMarkerKey();
     const pluginDir = await writePlugin("main-plugin", {
-      name: "main-plugin",
+      name: "acme.main-plugin",
       version: "1.0.0",
     });
     const mainFile = await writeMainFixture(pluginDir, markerKey);
@@ -371,7 +373,7 @@ describe("PluginService integration — main entry execution", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "main-plugin",
+        name: "acme.main-plugin",
         version: "1.0.0",
         main: mainFile,
       })
@@ -387,7 +389,7 @@ describe("PluginService integration — main entry execution", () => {
 
   it("registers contributions even when main entry import throws", async () => {
     const pluginDir = await writePlugin("bad-main", {
-      name: "bad-main",
+      name: "acme.bad-main",
       version: "1.0.0",
     });
     const mainFile = `main-${randomUUID()}.mjs`;
@@ -398,13 +400,13 @@ describe("PluginService integration — main entry execution", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "bad-main",
+        name: "acme.bad-main",
         version: "1.0.0",
         main: mainFile,
         contributes: {
           panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
-          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "bad-main.a" }],
-          menuItems: [{ label: "M", actionId: "bad-main.a", location: "view" }],
+          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "acme.bad-main.a" }],
+          menuItems: [{ label: "M", actionId: "acme.bad-main.a", location: "view" }],
         },
       })
     );
@@ -414,13 +416,13 @@ describe("PluginService integration — main entry execution", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("bad-main")).toBe(true);
+      expect(service.hasPlugin("acme.bad-main")).toBe(true);
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load main entry for bad-main"),
+        expect.stringContaining("Failed to load main entry for acme.bad-main"),
         expect.anything()
       );
-      expect(getPanelKindConfig("bad-main.p")).toBeDefined();
-      expect(getToolbarButtonConfig("plugin.bad-main.b")).toBeDefined();
+      expect(getPanelKindConfig("acme.bad-main.p")).toBeDefined();
+      expect(getToolbarButtonConfig("plugin.acme.bad-main.b")).toBeDefined();
       expect(getPluginMenuItems()).toHaveLength(1);
     } finally {
       errorSpy.mockRestore();
@@ -436,7 +438,7 @@ describe("PluginService integration — main entry execution", () => {
     );
 
     await writePlugin("escape-main", {
-      name: "escape-main",
+      name: "acme.escape-main",
       version: "1.0.0",
       main: `../${outsideFile}`,
     });
@@ -446,7 +448,7 @@ describe("PluginService integration — main entry execution", () => {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
 
-      expect(service.hasPlugin("escape-main")).toBe(true);
+      expect(service.hasPlugin("acme.escape-main")).toBe(true);
       expect(readMarker(markerKey)).toBeUndefined();
     } finally {
       warnSpy.mockRestore();
@@ -455,35 +457,66 @@ describe("PluginService integration — main entry execution", () => {
 });
 
 describe("PluginService integration — handler dispatch", () => {
+  it("logs unsandboxed warning before main entry side-effects execute", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writePlugin("warn-order", {
+      name: "acme.warn-order",
+      version: "1.0.0",
+    });
+    const mainFile = await writeMainFixture(pluginDir, markerKey);
+
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.warn-order",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      expect(readMarker(markerKey)).toBe(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        `[PluginService] DANGER_UNSANDBOXED: Plugin "acme.warn-order" loaded with full Node.js access. Only install plugins you trust.`
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("registers and dispatches a handler end-to-end on a real loaded plugin", async () => {
     await writePlugin("handler-plugin", {
-      name: "handler-plugin",
+      name: "acme.handler-plugin",
       version: "1.0.0",
     });
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
-    expect(service.hasPlugin("handler-plugin")).toBe(true);
+    expect(service.hasPlugin("acme.handler-plugin")).toBe(true);
 
-    service.registerHandler("handler-plugin", "ping", async (...args: unknown[]) => ({
+    service.registerHandler("acme.handler-plugin", "ping", async (...args: unknown[]) => ({
       pong: args,
     }));
 
-    const result = await service.dispatchHandler("handler-plugin", "ping", ["hello", 42]);
+    const result = await service.dispatchHandler("acme.handler-plugin", "ping", ["hello", 42]);
     expect(result).toEqual({ pong: ["hello", 42] });
   });
 
   it("dispatchHandler rejects when plugin registered no handler for the channel", async () => {
     await writePlugin("silent-plugin", {
-      name: "silent-plugin",
+      name: "acme.silent-plugin",
       version: "1.0.0",
     });
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    await expect(service.dispatchHandler("silent-plugin", "nope", [])).rejects.toThrow(
-      "No plugin handler registered for silent-plugin:nope"
+    await expect(service.dispatchHandler("acme.silent-plugin", "nope", [])).rejects.toThrow(
+      "No plugin handler registered for acme.silent-plugin:nope"
     );
   });
 });
@@ -492,7 +525,7 @@ describe("PluginService integration — full contribution fan-out", () => {
   it("loads a plugin with panel, toolbar, menu, and main entry in one initialize call", async () => {
     const markerKey = makeMarkerKey();
     const pluginDir = await writePlugin("all-in-one", {
-      name: "all-in-one",
+      name: "acme.all-in-one",
       version: "1.0.0",
     });
     const mainFile = await writeMainFixture(pluginDir, markerKey);
@@ -500,15 +533,15 @@ describe("PluginService integration — full contribution fan-out", () => {
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({
-        name: "all-in-one",
+        name: "acme.all-in-one",
         version: "1.0.0",
         main: mainFile,
         contributes: {
           panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
           toolbarButtons: [
-            { id: "b", label: "B", iconId: "i", actionId: "all-in-one.act", priority: 2 },
+            { id: "b", label: "B", iconId: "i", actionId: "acme.all-in-one.act", priority: 2 },
           ],
-          menuItems: [{ label: "M", actionId: "all-in-one.act", location: "view" }],
+          menuItems: [{ label: "M", actionId: "acme.all-in-one.act", location: "view" }],
         },
       })
     );
@@ -516,12 +549,12 @@ describe("PluginService integration — full contribution fan-out", () => {
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
 
-    expect(getPanelKindConfig("all-in-one.v")?.extensionId).toBe("all-in-one");
-    expect(getToolbarButtonConfig("plugin.all-in-one.b")?.priority).toBe(2);
+    expect(getPanelKindConfig("acme.all-in-one.v")?.extensionId).toBe("acme.all-in-one");
+    expect(getToolbarButtonConfig("plugin.acme.all-in-one.b")?.priority).toBe(2);
     expect(getPluginMenuItems()).toEqual([
       {
-        pluginId: "all-in-one",
-        item: { label: "M", actionId: "all-in-one.act", location: "view" },
+        pluginId: "acme.all-in-one",
+        item: { label: "M", actionId: "acme.all-in-one.act", location: "view" },
       },
     ]);
     expect(readMarker(markerKey)).toBe(1);

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -459,11 +459,22 @@ describe("PluginService integration — main entry execution", () => {
 describe("PluginService integration — handler dispatch", () => {
   it("logs unsandboxed warning before main entry side-effects execute", async () => {
     const markerKey = makeMarkerKey();
+    const timeline: string[] = [];
     const pluginDir = await writePlugin("warn-order", {
       name: "acme.warn-order",
       version: "1.0.0",
     });
     const mainFile = await writeMainFixture(pluginDir, markerKey);
+
+    // Rewrite fixture to push to timeline instead of just incrementing a counter
+    const mainFilePath = path.join(pluginDir, mainFile);
+    const timelineKey = markerKey + "_timeline";
+    await fs.writeFile(
+      mainFilePath,
+      `globalThis[${JSON.stringify(markerKey)}] = (globalThis[${JSON.stringify(markerKey)}] ?? 0) + 1;\n` +
+        `globalThis[${JSON.stringify(timelineKey)}] = globalThis[${JSON.stringify(timelineKey)}] || [];\n` +
+        `globalThis[${JSON.stringify(timelineKey)}].push("import");\n`
+    );
 
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
@@ -474,7 +485,11 @@ describe("PluginService integration — handler dispatch", () => {
       })
     );
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation((msg: string) => {
+      if (typeof msg === "string" && msg.includes("DANGER_UNSANDBOXED")) {
+        timeline.push("warn");
+      }
+    });
     try {
       const service = new PluginService(tmpDir, "0.0.0");
       await service.initialize();
@@ -483,6 +498,16 @@ describe("PluginService integration — handler dispatch", () => {
       expect(warnSpy).toHaveBeenCalledWith(
         `[PluginService] DANGER_UNSANDBOXED: Plugin "acme.warn-order" loaded with full Node.js access. Only install plugins you trust.`
       );
+
+      const importTimeline = (globalThis as Record<string, unknown>)[timelineKey] as
+        | string[]
+        | undefined;
+      const fullTimeline = [...timeline, ...(importTimeline ?? [])];
+      const warnIdx = fullTimeline.indexOf("warn");
+      const importIdx = fullTimeline.indexOf("import");
+      expect(warnIdx).toBeGreaterThanOrEqual(0);
+      expect(importIdx).toBeGreaterThanOrEqual(0);
+      expect(warnIdx).toBeLessThan(importIdx);
     } finally {
       warnSpy.mockRestore();
     }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -875,7 +875,7 @@ describe("Plugin unload lifecycle", () => {
   });
 });
 
-describe("deprecated renderer field", () => {
+describe("unsandboxed warning", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -886,11 +886,11 @@ describe("deprecated renderer field", () => {
     warnSpy.mockRestore();
   });
 
-  it("warns when plugin manifest contains renderer field", async () => {
-    await writePlugin("renderer-deprecated", {
-      name: "acme.renderer-deprecated",
+  it("warns when a plugin with main is loaded", async () => {
+    await writePlugin("unsandboxed-main", {
+      name: "acme.unsandboxed-main",
       version: "1.0.0",
-      renderer: "dist/renderer.js",
+      main: "dist/main.js",
       engines: { daintree: "*" },
     });
 
@@ -899,13 +899,13 @@ describe("deprecated renderer field", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      `[PluginService] Plugin "acme.renderer-deprecated" uses deprecated 'renderer' field. This field is no longer supported and will be ignored. Daintree plugins use main process entry points only; renderer-side plugins are not supported.`
+      `[PluginService] DANGER_UNSANDBOXED: Plugin "acme.unsandboxed-main" loaded with full Node.js access. Only install plugins you trust.`
     );
   });
 
-  it("does not warn when plugin manifest lacks renderer field", async () => {
-    await writePlugin("no-renderer", {
-      name: "acme.no-renderer",
+  it("warns when a plugin without main is loaded", async () => {
+    await writePlugin("unsandboxed-no-main", {
+      name: "acme.unsandboxed-no-main",
       version: "1.0.0",
       engines: { daintree: "*" },
     });
@@ -914,30 +914,15 @@ describe("deprecated renderer field", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[PluginService] DANGER_UNSANDBOXED: Plugin "acme.unsandboxed-no-main" loaded with full Node.js access. Only install plugins you trust.`
+    );
   });
 
-  it("does not include resolvedRenderer in listPlugins output", async () => {
-    await writePlugin("renderer-test", {
-      name: "acme.renderer-test",
+  it("does not warn for incompatible plugins that fail the engines.daintree gate", async () => {
+    await writePlugin("incompatible-unsandboxed", {
+      name: "acme.incompatible-unsandboxed",
       version: "1.0.0",
-      renderer: "dist/renderer.js",
-      engines: { daintree: "*" },
-    });
-
-    const service = new PluginService(tmpDir);
-    await service.initialize();
-
-    const plugins = service.listPlugins();
-    expect(plugins).toHaveLength(1);
-    expect(Object.keys(plugins[0])).not.toContain("resolvedRenderer");
-  });
-
-  it("does not warn for incompatible plugins that fail compatibility gate", async () => {
-    await writePlugin("incompatible-with-renderer", {
-      name: "acme.incompatible-with-renderer",
-      version: "1.0.0",
-      renderer: "dist/renderer.js",
       engines: { daintree: "^1.0.0" },
     });
 
@@ -945,28 +930,42 @@ describe("deprecated renderer field", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toEqual([]);
-    expect(warnSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("uses deprecated 'renderer' field")
+    const unsandboxedWarns = warnSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("DANGER_UNSANDBOXED")
     );
+    expect(unsandboxedWarns).toHaveLength(0);
   });
 
-  it("warns once per load attempt even with both main and renderer", async () => {
-    await writePlugin("both-entries", {
-      name: "acme.both-entries",
+  it("does not warn about deprecated renderer field", async () => {
+    await writePlugin("no-renderer-warn", {
+      name: "acme.no-renderer-warn",
       version: "1.0.0",
-      main: "dist/main.js",
-      renderer: "dist/renderer.js",
       engines: { daintree: "*" },
     });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    expect(service.listPlugins()).toHaveLength(1);
     const rendererWarns = warnSpy.mock.calls.filter(
       (call: unknown[]) =>
-        typeof call[0] === "string" && call[0].includes("uses deprecated 'renderer' field")
+        typeof call[0] === "string" && call[0].includes("deprecated 'renderer' field")
     );
-    expect(rendererWarns).toHaveLength(1);
+    expect(rendererWarns).toHaveLength(0);
+  });
+
+  it("warns exactly once per loaded plugin", async () => {
+    await writePlugin("single-warn", {
+      name: "acme.single-warn",
+      version: "1.0.0",
+      engines: { daintree: "*" },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const unsandboxedWarns = warnSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("DANGER_UNSANDBOXED")
+    );
+    expect(unsandboxedWarns).toHaveLength(1);
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -968,4 +968,19 @@ describe("unsandboxed warning", () => {
     );
     expect(unsandboxedWarns).toHaveLength(1);
   });
+
+  it("silently strips renderer field from legacy manifests", async () => {
+    await writePlugin("legacy-renderer", {
+      name: "acme.legacy-renderer",
+      version: "1.0.0",
+      renderer: "dist/renderer.js",
+      engines: { daintree: "*" },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+    expect("renderer" in service.listPlugins()[0].manifest).toBe(false);
+  });
 });

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -32,10 +32,6 @@ export interface PluginManifest {
   displayName?: string;
   description?: string;
   main?: string;
-  /**
-   * @deprecated Use main instead. Renderer entry points are no longer supported.
-   */
-  renderer?: string;
   engines?: {
     daintree?: string;
   };


### PR DESCRIPTION
## Summary
- Adds a clear warning when plugins load that they run unsandboxed with full Node.js access
- Removes the deprecated `renderer` field from plugin manifest schema and types
- Strengthens test coverage for both warnings and schema validation

Resolves #5582

## Changes
- **PluginService.ts**: Added `DANGER_UNSANDBOXED` warning at plugin load, removed deprecated `renderer` field warning and validation
- **plugin.ts schema**: Removed `renderer` field from Zod schema
- **plugin.ts types**: Removed `renderer` field from `PluginManifest` type
- **PluginService.test.ts**: Updated tests to verify unsandboxed warning appears, removed renderer field tests
- **PluginService.integration.test.ts**: Added comprehensive integration tests for plugin loading warnings and schema stripping

## Testing
- Updated unit tests verify the unsandboxed warning logs with correct plugin name
- Integration tests confirm the warning appears during actual plugin loading
- Schema validation tests ensure `renderer` field is stripped and doesn't cause validation errors
- All existing plugin tests pass with updated expectations