### PR TITLE
fix(settings): Change theme button now opens the theme browser

### DIFF
--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -252,8 +252,8 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   );
 
   const handleChangeTheme = useCallback(() => {
-    onClose?.();
-  }, [onClose]);
+    window.dispatchEvent(new CustomEvent("daintree:open-theme-browser"));
+  }, []);
 
   return (
     <div className="space-y-3">

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -239,11 +239,22 @@ describe("AppThemePicker Change theme button", () => {
     expect(screen.getByText("Theme A")).toBeTruthy();
   });
 
-  it("calls onClose when the Change theme button is clicked", () => {
+  it("dispatches daintree:open-theme-browser when the Change theme button is clicked", () => {
     const onClose = vi.fn();
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
     render(<AppThemePicker onClose={onClose} />);
     fireEvent.click(screen.getByRole("button", { name: /change theme/i }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+
+    const openEvents = dispatchSpy.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (event): event is CustomEvent =>
+          event instanceof CustomEvent && event.type === "daintree:open-theme-browser"
+      );
+    expect(openEvents).toHaveLength(1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    dispatchSpy.mockRestore();
   });
 
   it("hides the Change theme button when onClose is not provided", () => {


### PR DESCRIPTION
## Summary

- The "Change theme…" button in `AppThemePicker` was calling `onClose()` which closed Settings but never opened the theme browser, leaving the user with nowhere to go.
- Fixed by dispatching the `daintree:open-theme-browser` custom event instead. The existing bridge picks this up and opens the browser panel, so the full Settings-to-browser flow now works correctly.
- Test updated to assert the event is dispatched rather than checking the `onClose` stub.

Resolves #5614

## Changes

- `src/components/Settings/AppThemePicker.tsx`: `handleChangeTheme` now dispatches `daintree:open-theme-browser` instead of calling `onClose`
- `src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx`: test asserts the custom event is dispatched on button click

## Testing

Unit test updated and passing. The button now takes the user to the theme browser rather than silently closing Settings.