### PR TITLE
fix(e2e): pass correct argument shape to devPreview.getByWorktree

### DIFF
--- a/e2e/full/core-dev-preview-per-worktree.spec.ts
+++ b/e2e/full/core-dev-preview-per-worktree.spec.ts
@@ -183,11 +183,11 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
 
     // Resolve both sessions through the full IPC stack.
     const mainSession = await window.evaluate(
-      (id: string) => window.electron.devPreview.getByWorktree(id),
+      (id: string) => window.electron.devPreview.getByWorktree({ worktreeId: id }),
       mainWorktreeId
     );
     const featureSession = await window.evaluate(
-      (id: string) => window.electron.devPreview.getByWorktree(id),
+      (id: string) => window.electron.devPreview.getByWorktree({ worktreeId: id }),
       featureWorktreeId
     );
 
@@ -232,7 +232,7 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
 
     // Feature worktree: session gone (null) or explicitly stopped.
     const featureAfter = await window.evaluate(
-      (id: string) => window.electron.devPreview.getByWorktree(id),
+      (id: string) => window.electron.devPreview.getByWorktree({ worktreeId: id }),
       featureWorktreeId
     );
     // stopByPanel deletes the session, so getByWorktree must return null.
@@ -240,7 +240,7 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
 
     // Main worktree: session untouched — still running with the same URL.
     const mainAfter = await window.evaluate(
-      (id: string) => window.electron.devPreview.getByWorktree(id),
+      (id: string) => window.electron.devPreview.getByWorktree({ worktreeId: id }),
       mainWorktreeId
     );
     expect(mainAfter?.status).toBe("running");

--- a/electron/ipc/handlers/__tests__/devPreview.session.test.ts
+++ b/electron/ipc/handlers/__tests__/devPreview.session.test.ts
@@ -597,6 +597,85 @@ describe("dev preview session handlers", () => {
     expect(secondLookup.panelId).toBe(secondRequest.panelId);
   });
 
+  it("returns the session state for a known worktree via get-by-worktree", async () => {
+    const ensureHandler = getRegisteredHandle<
+      [Electron.IpcMainInvokeEvent, Record<string, unknown>],
+      { terminalId: string | null; panelId: string; projectId: string }
+    >(CHANNELS.DEV_PREVIEW_ENSURE);
+    const getByWorktreeHandler = getRegisteredHandle<
+      [Electron.IpcMainInvokeEvent, Record<string, unknown>],
+      { panelId: string; worktreeId: string; status: string; assignedUrl: string | null } | null
+    >(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
+
+    expect(ensureHandler).toBeDefined();
+    expect(getByWorktreeHandler).toBeDefined();
+
+    const ensured = await ensureHandler!({} as Electron.IpcMainInvokeEvent, {
+      panelId: "panel-wt-lookup",
+      projectId: "project-wt-lookup",
+      cwd: "/repo",
+      devCommand: "npm run dev",
+      worktreeId: "wt-lookup",
+    });
+    expect(ensured.terminalId).toBeTruthy();
+
+    scanOutputMock.mockReturnValue({ buffer: "", url: "http://localhost:5174/", error: null });
+    ptyClient.emitData(ensured.terminalId!, "ready");
+
+    await vi.waitFor(async () => {
+      const state = await getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, {
+        worktreeId: "wt-lookup",
+      });
+      expect(state?.status).toBe("running");
+      expect(state?.panelId).toBe("panel-wt-lookup");
+      expect(state?.worktreeId).toBe("wt-lookup");
+      expect(state?.url).toBe("http://localhost:5174/");
+      expect(state?.assignedUrl).toMatch(/^http:\/\/localhost:\d+/);
+    });
+  });
+
+  it("returns null from get-by-worktree for an unknown worktree", async () => {
+    const getByWorktreeHandler = getRegisteredHandle<
+      [Electron.IpcMainInvokeEvent, Record<string, unknown>],
+      unknown
+    >(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
+    expect(getByWorktreeHandler).toBeDefined();
+
+    const state = await getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, {
+      worktreeId: "wt-does-not-exist",
+    });
+    expect(state).toBeNull();
+  });
+
+  it("rejects get-by-worktree calls with missing or malformed request shape", async () => {
+    const getByWorktreeHandler = getRegisteredHandle<
+      [Electron.IpcMainInvokeEvent, unknown],
+      unknown
+    >(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
+    expect(getByWorktreeHandler).toBeDefined();
+
+    // Guards against the regression in #5615: bare string instead of { worktreeId }.
+    await expect(
+      getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, "wt-1" as unknown)
+    ).rejects.toThrow("worktreeId is required");
+
+    await expect(getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, null)).rejects.toThrow(
+      "worktreeId is required"
+    );
+
+    await expect(getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, {})).rejects.toThrow(
+      "worktreeId is required"
+    );
+
+    await expect(
+      getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, { worktreeId: "" })
+    ).rejects.toThrow("worktreeId is required");
+
+    await expect(
+      getByWorktreeHandler!({} as Electron.IpcMainInvokeEvent, { worktreeId: "   " })
+    ).rejects.toThrow("worktreeId is required");
+  });
+
   it("kills active dev preview terminals when handlers are cleaned up", async () => {
     const ensureHandler = getRegisteredHandle<
       [Electron.IpcMainInvokeEvent, Record<string, unknown>],

--- a/electron/ipc/handlers/__tests__/devPreview.session.test.ts
+++ b/electron/ipc/handlers/__tests__/devPreview.session.test.ts
@@ -604,7 +604,13 @@ describe("dev preview session handlers", () => {
     >(CHANNELS.DEV_PREVIEW_ENSURE);
     const getByWorktreeHandler = getRegisteredHandle<
       [Electron.IpcMainInvokeEvent, Record<string, unknown>],
-      { panelId: string; worktreeId: string; status: string; assignedUrl: string | null } | null
+      {
+        panelId: string;
+        worktreeId: string;
+        status: string;
+        url: string | null;
+        assignedUrl: string | null;
+      } | null
     >(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
 
     expect(ensureHandler).toBeDefined();


### PR DESCRIPTION
## Summary

- `e2e/full/core-dev-preview-per-worktree.spec.ts` was passing a bare `worktreeId` string to `devPreview.getByWorktree()` inside `page.evaluate`, bypassing TypeScript's type checker. The IPC handler expects `{ worktreeId: string }`, so every call threw at runtime.
- Wraps the four bare `id` references in the correct object shape so the handler's validation passes.
- Adds a dedicated unit test for the `DEV_PREVIEW_GET_BY_WORKTREE` handler covering the happy path, null return, and the bad-shape guard that was silently failing.

Resolves #5615

## Changes

- `e2e/full/core-dev-preview-per-worktree.spec.ts`: four `getByWorktree(id)` calls updated to `getByWorktree({ worktreeId: id })`
- `electron/ipc/handlers/__tests__/devPreview.session.test.ts`: new test file pinning the handler contract (happy path, null session, bad-shape rejection)
- Handler type corrected to include the `url` field that was missing from the response shape

## Testing

Unit tests cover the handler directly. The E2E spec now passes the correct shape, which will be verified on the next nightly E2E Full run.