### PR TITLE
feat(theme-browser): hide Portal and block its toggle while browser is open

### DIFF
--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -15,6 +15,7 @@ import {
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { useOverlayClaim } from "@/hooks";
 
 const PANEL_WIDTH = 380;
 
@@ -89,6 +90,8 @@ function ThemeRow({
 }
 
 export function ThemeBrowser() {
+  useOverlayClaim("theme-browser", true);
+
   const close = useThemeBrowserStore((s) => s.close);
   const selectedSchemeId = useAppThemeStore((s) => s.selectedSchemeId);
   const customSchemes = useAppThemeStore((s) => s.customSchemes);

--- a/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
+++ b/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
@@ -4,6 +4,8 @@ import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { useThemeBrowserStore } from "@/store/themeBrowserStore";
+import { useUIStore } from "@/store/uiStore";
+import { usePortalStore } from "@/store/portalStore";
 import { _resetForTests } from "@/lib/escapeStack";
 import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
 
@@ -47,6 +49,8 @@ describe("ThemeBrowser", () => {
       previewSchemeId: null,
     });
     useThemeBrowserStore.setState({ isOpen: true });
+    useUIStore.setState({ overlayClaims: new Set<string>() });
+    usePortalStore.setState({ isOpen: false });
   });
 
   afterEach(() => {
@@ -54,6 +58,7 @@ describe("ThemeBrowser", () => {
     _resetForTests();
     useAppThemeStore.setState({ previewSchemeId: null });
     useThemeBrowserStore.setState({ isOpen: false });
+    useUIStore.setState({ overlayClaims: new Set<string>() });
   });
 
   it("clicking a theme row sets previewSchemeId instantly (no debounce)", () => {
@@ -189,5 +194,28 @@ describe("ThemeBrowser", () => {
     for (const option of options) {
       expect(option.textContent?.toLowerCase()).toContain(target.name.toLowerCase());
     }
+  });
+
+  it("registers a 'theme-browser' overlay claim while mounted", () => {
+    render(<Harness />);
+    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(true);
+  });
+
+  it("releases the 'theme-browser' overlay claim on unmount", () => {
+    const { unmount } = render(<Harness />);
+    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(true);
+
+    unmount();
+
+    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(false);
+  });
+
+  it("portal toggle is a no-op while the browser is mounted", () => {
+    render(<Harness />);
+    expect(usePortalStore.getState().isOpen).toBe(false);
+
+    usePortalStore.getState().toggle();
+
+    expect(usePortalStore.getState().isOpen).toBe(false);
   });
 });

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -245,6 +245,7 @@ const { registerPanelActions } = await import("../definitions/panelActions");
 const { registerWorktreeActions } = await import("../definitions/worktreeActions");
 const { usePanelStore } = await import("../../../store/panelStore");
 const { usePortalStore } = await import("../../../store/portalStore");
+const { useUIStore } = await import("../../../store/uiStore");
 const { useWorktreeSelectionStore } = await import("../../../store/worktreeStore");
 const { useWorktreeFilterStore } = await import("../../../store/worktreeFilterStore");
 const worktreeViewStore = mocks.worktreeViewStore;
@@ -333,6 +334,8 @@ beforeEach(() => {
     links: [],
     defaultNewTabUrl: null,
   });
+
+  useUIStore.setState({ overlayClaims: new Set<string>() });
 
   useWorktreeSelectionStore.setState({
     activeWorktreeId: null,
@@ -705,6 +708,27 @@ describe("panel action hardening", () => {
 
     expect(usePortalStore.getState().tabs).toEqual([]);
     expect(usePortalStore.getState().createdTabs.size).toBe(0);
+  });
+
+  it("portal.openUrl is a no-op while an overlay claim is active", async () => {
+    const actions = buildRegistry(registerPanelActions);
+    const openUrl = actions.get("portal.openUrl")!();
+
+    useUIStore.setState({ overlayClaims: new Set(["theme-browser"]) });
+    usePortalStore.setState({
+      isOpen: false,
+      activeTabId: null,
+      tabs: [],
+      createdTabs: new Set<string>(),
+    });
+
+    await openUrl.run({ url: "https://example.com/blocked", title: "Blocked" }, {} as never);
+
+    const state = usePortalStore.getState();
+    expect(state.isOpen).toBe(false);
+    expect(state.tabs).toEqual([]);
+    expect(mocks.portal.create).not.toHaveBeenCalled();
+    expect(mocks.portal.show).not.toHaveBeenCalled();
   });
 
   it("reuses the active blank tab when opening a foreground URL", async () => {

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -7,6 +7,7 @@ import { getPortalPlaceholderBounds } from "@/lib/portalBounds";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { usePortalStore } from "@/store/portalStore";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { useUIStore } from "@/store/uiStore";
 
 export function registerPanelActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   // Query action: list all panels with metadata
@@ -541,6 +542,12 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
         }
         return;
       }
+
+      // Suppress foreground portal reveal while another surface owns the
+      // viewport (e.g. theme browser). Mirrors portalStore.toggle()'s guard —
+      // without it, setOpen(true) would flip isOpen unconditionally and the
+      // portal would pop into view the moment the overlay closed.
+      if (useUIStore.getState().overlayClaims.size > 0) return;
 
       // Ensure portal is visible before activating a tab
       if (!state.isOpen) {


### PR DESCRIPTION
## Summary

- ThemeBrowser registers an overlay claim on mount/unmount via `useOverlayClaim("theme-browser", true)`, giving Portal auto-hide for free through the existing `overlayCount` mechanism in `PortalVisibilityController`.
- The `portal.openUrl` action now checks `overlayCount > 0` before setting `isOpen = true` on the foreground path, so an agent-triggered open during theme browsing can't sneak the Portal into view when the overlay eventually closes.
- Tests cover claim lifecycle (mount/unmount), Portal toggle being a no-op while the browser is open, and the agent-triggered `openUrl` guard.

Resolves #5586

## Changes

- `ThemeBrowser.tsx` — added `useOverlayClaim("theme-browser", true)` hook call
- `panelActions.ts` — added `overlayCount > 0` guard to the `portal.openUrl` foreground path
- `ThemeBrowser.test.tsx` — 3 new tests: overlay claim on mount, claim released on unmount, portal toggle no-op while browser open
- `actionDefinitions.adversarial.test.ts` — 1 new test: `portal.openUrl` is a no-op while an overlay is active

## Testing

Unit tests all pass (ThemeBrowser 12, portalStore 16, adversarial 34+). Typecheck, lint, and format clean. Edge cases from the issue spec verified: keyboard shortcut for Portal while browser is open produces no visible change or store desync; overlay claim properly suppresses Portal visibility through the existing `PortalVisibilityController` path.