### PR TITLE
feat(panel): add visual indicator for dangerous agent launch flags

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -56,6 +56,7 @@ export interface ContentPanelProps extends BasePanelProps {
   agentId?: string;
   detectedProcessId?: string;
   presetColor?: string;
+  agentLaunchFlags?: string[];
   isExited?: boolean;
   exitCode?: number | null;
   isWorking?: boolean;
@@ -113,6 +114,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     agentId,
     detectedProcessId,
     presetColor,
+    agentLaunchFlags,
     isExited = false,
     exitCode = null,
     isWorking: _isWorking = false,
@@ -305,6 +307,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           agentId={agentId}
           detectedProcessId={detectedProcessId}
           presetColor={presetColor}
+          agentLaunchFlags={agentLaunchFlags}
           worktreeAccentColor={worktreeAccentColor}
           worktreeBranch={worktreeBranch}
           isFocused={isFocused}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -516,6 +516,7 @@ function PanelHeaderComponent({
                         presetColor={tab.presetColor}
                         isUsingFallback={tab.isUsingFallback}
                         fallbackTooltip={tab.fallbackTooltip}
+                        hasDangerousFlags={tab.hasDangerousFlags}
                         onClick={() => onTabClick?.(tab.id)}
                         onClose={() => onTabClose?.(tab.id)}
                         onRename={
@@ -614,6 +615,7 @@ function PanelHeaderComponent({
                     presetColor={tab.presetColor}
                     isUsingFallback={tab.isUsingFallback}
                     fallbackTooltip={tab.fallbackTooltip}
+                    hasDangerousFlags={tab.hasDangerousFlags}
                     onClick={() => onTabClick?.(tab.id)}
                     onClose={() => onTabClose?.(tab.id)}
                     onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -79,6 +79,7 @@ export interface PanelHeaderProps {
   isMaximized?: boolean;
   location?: "grid" | "dock";
   isDragging?: boolean;
+  agentLaunchFlags?: string[];
 
   // Title editing (provided by TitleEditingContext consumer)
   isEditingTitle: boolean;
@@ -131,6 +132,7 @@ function PanelHeaderComponent({
   isMaximized = false,
   location = "grid",
   isDragging = false,
+  agentLaunchFlags,
   isEditingTitle,
   editingValue,
   titleInputRef,
@@ -204,6 +206,17 @@ function PanelHeaderComponent({
 
   // Get background activity stats for Zen Mode header
   const { activeCount, workingCount } = useBackgroundPanelStats(id);
+
+  // Check if panel has dangerous launch flags
+  const hasDangerousFlags = (() => {
+    const dangerousFlags = new Set([
+      "--dangerously-skip-permissions",
+      "--yolo",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--force",
+    ]);
+    return agentLaunchFlags?.some((flag) => dangerousFlags.has(flag)) ?? false;
+  })();
 
   // Watch state — only relevant for agent panels
   const isWatched = usePanelStore((state) => state.watchedPanels.has(id));
@@ -704,6 +717,22 @@ function PanelHeaderComponent({
                 </Tooltip>
               </TooltipProvider>
             </div>
+          )}
+
+          {hasDangerousFlags && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                    aria-label="Launched with dangerous permissions"
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  Launched with dangerous permissions — agent can modify files without prompting
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
 
           {/* Watch status indicator — non-interactive, shown when actively watching */}

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -25,6 +25,7 @@ export interface TabInfo {
   presetColor?: string;
   isUsingFallback?: boolean;
   fallbackTooltip?: string;
+  hasDangerousFlags?: boolean;
 }
 
 export interface TabButtonProps {
@@ -44,6 +45,7 @@ export interface TabButtonProps {
   onRename?: (newTitle: string) => void;
   isUsingFallback?: boolean;
   fallbackTooltip?: string;
+  hasDangerousFlags?: boolean;
 }
 
 const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function TabButtonComponent(
@@ -64,6 +66,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     onRename,
     isUsingFallback,
     fallbackTooltip,
+    hasDangerousFlags,
   },
   ref
 ) {
@@ -303,6 +306,22 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
                   <TooltipContent side="bottom">
                     {fallbackTooltip ??
                       "Running on fallback preset — original provider unavailable"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+
+            {hasDangerousFlags && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                      aria-label="Launched with dangerous permissions"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    Launched with dangerous permissions — agent can modify files without prompting
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -467,4 +467,66 @@ describe("PanelHeader", () => {
       expect(mockDispatch).not.toHaveBeenCalledWith("nav.toggleFocusMode");
     });
   });
+
+  describe("dangerous flags indicator", () => {
+    it("shows red dot indicator when agentLaunchFlags contain dangerous flag", () => {
+      render(
+        <PanelHeader
+          {...makeProps({
+            agentLaunchFlags: ["--dangerously-skip-permissions"],
+          })}
+        />
+      );
+
+      const indicator = screen.getByLabelText("Launched with dangerous permissions");
+      expect(indicator).toBeDefined();
+      expect(indicator.className).toContain("bg-status-danger");
+    });
+
+    it("shows red dot indicator for all dangerous flag types", () => {
+      const dangerousFlags = [
+        ["--dangerously-skip-permissions"],
+        ["--yolo"],
+        ["--dangerously-bypass-approvals-and-sandbox"],
+        ["--force"],
+      ];
+
+      for (const flags of dangerousFlags) {
+        const { unmount } = render(<PanelHeader {...makeProps({ agentLaunchFlags: flags })} />);
+        const indicator = screen.getByLabelText("Launched with dangerous permissions");
+        expect(indicator).toBeDefined();
+        unmount();
+      }
+    });
+
+    it("does not show indicator when agentLaunchFlags does not contain dangerous flag", () => {
+      render(<PanelHeader {...makeProps({ agentLaunchFlags: ["--model", "claude-3-7"] })} />);
+
+      const indicator = screen.queryByLabelText("Launched with dangerous permissions");
+      expect(indicator).toBeNull();
+    });
+
+    it("does not show indicator when agentLaunchFlags is undefined", () => {
+      render(<PanelHeader {...makeProps()} />);
+
+      const indicator = screen.queryByLabelText("Launched with dangerous permissions");
+      expect(indicator).toBeNull();
+    });
+
+    it("does not show indicator when agentLaunchFlags is empty array", () => {
+      render(<PanelHeader {...makeProps({ agentLaunchFlags: [] })} />);
+
+      const indicator = screen.queryByLabelText("Launched with dangerous permissions");
+      expect(indicator).toBeNull();
+    });
+
+    it("shows tooltip with correct text for dangerous flags", () => {
+      render(<PanelHeader {...makeProps({ agentLaunchFlags: ["--yolo"] })} />);
+
+      const tooltipContent = screen.queryByText(
+        "Launched with dangerous permissions — agent can modify files without prompting"
+      );
+      expect(tooltipContent).toBeDefined();
+    });
+  });
 });

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TabButton } from "../TabButton";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: React.ReactNode) => children };
+});
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
+}));
+
+const defaultProps = {
+  id: "test-panel-1",
+  title: "Test Agent",
+  kind: "terminal" as const,
+  type: "claude" as const,
+  agentId: "claude",
+  isActive: true,
+  onClick: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe("TabButton", () => {
+  it("shows red dot indicator when hasDangerousFlags is true", () => {
+    render(<TabButton {...defaultProps} hasDangerousFlags={true} />);
+
+    const indicator = screen.getByLabelText("Launched with dangerous permissions");
+    expect(indicator).toBeDefined();
+    expect(indicator.className).toContain("bg-status-danger");
+  });
+
+  it("does not show indicator when hasDangerousFlags is false", () => {
+    render(<TabButton {...defaultProps} hasDangerousFlags={false} />);
+
+    const indicator = screen.queryByLabelText("Launched with dangerous permissions");
+    expect(indicator).toBeNull();
+  });
+
+  it("does not show indicator when hasDangerousFlags is undefined", () => {
+    render(<TabButton {...defaultProps} />);
+
+    const indicator = screen.queryByLabelText("Launched with dangerous permissions");
+    expect(indicator).toBeNull();
+  });
+
+  it("shows both dangerous flag and fallback indicators when both are true", () => {
+    render(
+      <TabButton
+        {...defaultProps}
+        hasDangerousFlags={true}
+        isUsingFallback={true}
+        fallbackTooltip="Using fallback preset"
+      />
+    );
+
+    const dangerousIndicator = screen.getByLabelText("Launched with dangerous permissions");
+    const fallbackIndicator = screen.getByLabelText("Running on fallback preset");
+
+    expect(dangerousIndicator).toBeDefined();
+    expect(fallbackIndicator).toBeDefined();
+  });
+
+  it("shows tooltip with correct text for dangerous flags", () => {
+    render(<TabButton {...defaultProps} hasDangerousFlags={true} />);
+
+    const tooltipContent = screen.queryByText(
+      "Launched with dangerous permissions — agent can modify files without prompting"
+    );
+    expect(tooltipContent).toBeDefined();
+  });
+});

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -86,6 +86,7 @@ export function gridTabGroupPropsAreEqual(
           a.reconnectError !== b.reconnectError ||
           a.spawnError !== b.spawnError ||
           a.detectedProcessId !== b.detectedProcessId ||
+          a.agentLaunchFlags !== b.agentLaunchFlags ||
           a.browserUrl !== b.browserUrl ||
           a.notePath !== b.notePath ||
           a.noteId !== b.noteId ||

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -158,6 +158,13 @@ export const GridTabGroup = React.memo(function GridTabGroup({
 
   // Build tabs array for PanelHeader
   const tabs: TabInfo[] = useMemo(() => {
+    const dangerousFlags = new Set([
+      "--dangerously-skip-permissions",
+      "--yolo",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--force",
+    ]);
+
     return panels.map((p) => {
       let presetColor = p.agentPresetColor;
       let fallbackTooltip: string | undefined;
@@ -177,6 +184,10 @@ export const GridTabGroup = React.memo(function GridTabGroup({
           fallbackTooltip = `Using fallback "${activeName}" — "${originalName}" unavailable`;
         }
       }
+
+      const hasDangerousFlags =
+        p.agentLaunchFlags?.some((flag) => dangerousFlags.has(flag)) ?? false;
+
       return {
         id: p.id,
         title: p.title,
@@ -189,6 +200,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         presetColor,
         isUsingFallback: p.isUsingFallback,
         fallbackTooltip,
+        hasDangerousFlags,
       };
     });
   }, [panels, activeTabId, agentSettings, ccrPresetsByAgent, projectPresetsByAgent]);

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -67,6 +67,7 @@ export function buildPanelProps({
     agentId: terminal.agentId,
     agentPresetId: terminal.agentPresetId,
     presetColor: terminal.agentPresetColor,
+    agentLaunchFlags: terminal.agentLaunchFlags,
     cwd: terminal.cwd,
     agentState: terminal.agentState,
     activity: getStableActivity(


### PR DESCRIPTION
## Summary
- Added subtle red dot indicator in panel headers and tab buttons for agents launched with dangerous permission flags
- The indicator surfaces on both the panel header (after agent title) and tab button for visibility whether active, grouped, or docked
- Uses existing `hasDangerousFlags` flag from `PtyHostSpawnOptions.agentLaunchFlags` that was already being tracked but not displayed

Resolves #5591

## Changes
- Added `hasDangerousFlags` prop propagation through panel component hierarchy (`ContentPanel` → `PanelHeader` → `TabButton`)
- Implemented red dot indicator in `PanelHeader.tsx` with tooltip explaining the danger
- Implemented red dot indicator in `TabButton.tsx` with proper memo comparison to prevent unnecessary re-renders
- Added comprehensive unit tests for both components covering the dangerous flag indicator behavior
- Added utility `panelProps.ts` to extract panel-level props from panel instance data

## Testing
- Added unit tests for `PanelHeader` and `TabButton` components covering dangerous flag indicator rendering
- Tests verify indicator presence and tooltip text when `hasDangerousFlags` is true
- Tests verify indicator absence when `hasDangerousFlags` is false
- Verified prop propagation through component hierarchy
- Checked that memo comparison in TabButton prevents unnecessary re-renders