### PR TITLE
refactor(preset): unify env editor with inherited global env

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -1033,64 +1033,13 @@ export function AgentSettings({
                         <span className="text-[11px] text-daintree-text/50 font-medium uppercase tracking-wide block">
                           Env overrides
                         </span>
-                        {(() => {
-                          const globalEnv =
-                            (activeEntry.globalEnv as Record<string, string> | undefined) ?? {};
-                          const presetEnv = selectedPreset.env ?? {};
-                          const inheritedEntries = Object.entries(globalEnv).filter(
-                            ([k]) => !(k in presetEnv)
-                          );
-                          if (inheritedEntries.length === 0) return null;
-                          return (
-                            <div
-                              className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden bg-daintree-bg/20"
-                              data-testid="preset-env-inherited-strip"
-                            >
-                              <div className="grid grid-cols-[2fr_3fr_auto] text-[10px] uppercase tracking-wide text-daintree-text/50 bg-daintree-bg/40 border-b border-daintree-border">
-                                <div className="px-2.5 py-1.5">Inherited from global env</div>
-                                <div
-                                  className="px-2.5 py-1.5 border-l border-daintree-border/60"
-                                  aria-hidden="true"
-                                />
-                                <div className="px-2.5 py-1.5 w-[88px]" aria-hidden="true" />
-                              </div>
-                              <div className="divide-y divide-daintree-border">
-                                {inheritedEntries.map(([key, value]) => (
-                                  <div
-                                    key={key}
-                                    className="grid grid-cols-[2fr_3fr_auto] items-center font-mono text-[12px] text-daintree-text/50"
-                                  >
-                                    <span className="px-2.5 py-2 truncate">{key}</span>
-                                    <span className="px-2.5 py-2 border-l border-daintree-border/60 truncate text-daintree-text/40">
-                                      {value}
-                                    </span>
-                                    <div className="flex items-center justify-center w-[88px] border-l border-daintree-border/60">
-                                      <button
-                                        type="button"
-                                        className="text-[10px] px-2 py-1 rounded text-daintree-accent hover:text-daintree-accent/80 hover:bg-daintree-bg/60 transition-colors"
-                                        onClick={() =>
-                                          handleUpdatePreset(selectedPreset.id, {
-                                            env: { ...presetEnv, [key]: value },
-                                          })
-                                        }
-                                        aria-label={`Override ${key} in this preset`}
-                                        data-testid="preset-env-inherited-override"
-                                      >
-                                        + Override
-                                      </button>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          );
-                        })()}
                         <EnvVarEditor
                           env={selectedPreset.env ?? {}}
                           onChange={(env) => handleUpdatePreset(selectedPreset.id, { env })}
                           suggestions={getAgentConfig(activeAgent.id)?.envSuggestions ?? []}
                           datalistId="env-key-suggestions"
                           contextKey={selectedPreset.id}
+                          inheritedEnv={activeEntry.globalEnv as Record<string, string> | undefined}
                           data-testid="preset-env-editor"
                         />
                         {envVarReference}

--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -1,18 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Eye, EyeOff, Plus, X } from "lucide-react";
+import { Eye, EyeOff, Plus, RotateCcw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { looksLikeSecret } from "@/utils/secretDetection";
 import { isSensitiveEnvKey } from "../../../shared/utils/envVars";
 
 /**
- * Inline env var CRUD editor with validation.
+ * Inline env var CRUD editor with validation and optional inheritance.
  *
  * Renders a bordered table surface with flush cells, hairline row dividers,
  * and a flush "Add variable" row — matching the chrome of Vercel/Railway/GitHub
  * Actions env editors. Draft rows are the source of truth during editing — we
  * can't represent an in-progress duplicate key as a JS object, so we keep an
- * array of `{rowId, key, value}` and serialize back to a `Record<string,string>`
- * only when all keys are unique and non-empty.
+ * array of `{rowId, key, value, isInherited}` and serialize back to a
+ * `Record<string, string>` only when all keys are unique and non-empty.
+ *
+ * Inheritance (optional, via `inheritedEnv` prop):
+ *  - Inherited rows render disabled and muted, with a `+ Override` action in
+ *    the actions cell that promotes the row to an editable override seeded
+ *    with the inherited value.
+ *  - Override rows (env entries that shadow an inherited key) get an accent
+ *    left-stripe and a revert (RotateCcw) action that clears the override
+ *    back to inherited.
+ *  - Clearing an override's value on blur also reverts to inherited, so we
+ *    don't silently ship empty-string overrides.
  *
  * Validation surfaces:
  *  - Empty key after trim → red left-stripe on the row + "Key required" inline
@@ -48,12 +58,20 @@ export interface EnvVarEditorProps {
   valuePlaceholder?: string;
   /** Optional data-testid for the whole editor surface. */
   "data-testid"?: string;
+  /**
+   * Optional inherited env vars from a parent scope (e.g. an agent's global
+   * env when editing a preset). Inherited rows render as muted, disabled
+   * entries alongside overrides; absence of the prop disables inheritance
+   * entirely (identical to the original editor behaviour).
+   */
+  inheritedEnv?: Record<string, string>;
 }
 
 interface DraftRow {
   rowId: string;
   key: string;
   value: string;
+  isInherited: boolean;
 }
 
 let rowIdCounter = 0;
@@ -62,18 +80,30 @@ function nextRowId(): string {
   return `row-${rowIdCounter}`;
 }
 
-function envToDraft(env: Record<string, string>): DraftRow[] {
-  return Object.entries(env).map(([key, value]) => ({
-    rowId: nextRowId(),
-    key,
-    value,
-  }));
+function envToDraft(
+  env: Record<string, string>,
+  inheritedEnv?: Record<string, string>
+): DraftRow[] {
+  const rows: DraftRow[] = [];
+  // Preserve insertion order of env entries — these are overrides.
+  for (const [key, value] of Object.entries(env)) {
+    rows.push({ rowId: nextRowId(), key, value, isInherited: false });
+  }
+  if (inheritedEnv) {
+    // Append inherited-only keys in their insertion order.
+    for (const [key, value] of Object.entries(inheritedEnv)) {
+      if (key in env) continue;
+      rows.push({ rowId: nextRowId(), key, value, isInherited: true });
+    }
+  }
+  return rows;
 }
 
 function draftToEnv(rows: DraftRow[]): Record<string, string> {
   const out: Record<string, string> = {};
   const seen = new Set<string>();
   for (const row of rows) {
+    if (row.isInherited) continue;
     const k = row.key.trim();
     if (!k) continue;
     if (seen.has(k)) continue; // drop duplicates — the validation surface warns the user
@@ -83,9 +113,26 @@ function draftToEnv(rows: DraftRow[]): Record<string, string> {
   return out;
 }
 
+function shallowEnvEqual(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return a === undefined && b === undefined;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
 function findDuplicateKeys(rows: DraftRow[]): Set<string> {
   const counts = new Map<string, number>();
   for (const row of rows) {
+    if (row.isInherited) continue;
     const k = row.key.trim();
     if (!k) continue;
     counts.set(k, (counts.get(k) ?? 0) + 1);
@@ -100,6 +147,7 @@ function findDuplicateKeys(rows: DraftRow[]): Set<string> {
 function isValid(rows: DraftRow[]): boolean {
   const seen = new Set<string>();
   for (const row of rows) {
+    if (row.isInherited) continue;
     const k = row.key.trim();
     if (!k) return false;
     if (seen.has(k)) return false;
@@ -116,8 +164,9 @@ export function EnvVarEditor({
   contextKey,
   valuePlaceholder = "value or ${ENV_VAR}",
   "data-testid": dataTestId,
+  inheritedEnv,
 }: EnvVarEditorProps) {
-  const [rows, setRows] = useState<DraftRow[]>(() => envToDraft(env));
+  const [rows, setRows] = useState<DraftRow[]>(() => envToDraft(env, inheritedEnv));
   // Track which keys have been "touched" (blurred or modified after creation) —
   // we suppress the empty-key error for newly added rows until first blur.
   const [touchedKeys, setTouchedKeys] = useState<Record<string, boolean>>({});
@@ -126,45 +175,35 @@ export function EnvVarEditor({
   // When non-null, the focus-recovery effect focuses the key input for that rowId.
   const [pendingFocusKey, setPendingFocusKey] = useState<string | null>(null);
   const lastEnvRef = useRef<Record<string, string>>(env);
+  const lastInheritedRef = useRef<Record<string, string> | undefined>(inheritedEnv);
   const lastContextKeyRef = useRef<string | undefined>(contextKey);
   const keyInputRefs = useRef<Map<string, HTMLInputElement>>(new Map());
 
-  // When the parent's env changes externally (different preset selected,
-  // programmatic reset), reseed the draft rows. We use a shallow compare on
-  // keys+values so typing a value doesn't trigger a reseed.
+  // When the parent's env or inheritedEnv changes externally (different preset
+  // selected, programmatic reset, global env updated), reseed the draft rows.
+  // We use shallow key+value compares so typing a value doesn't trigger a
+  // reseed and new-identity empty objects (`{} !== {}`) don't cause thrash.
   useEffect(() => {
-    const curKeys = Object.keys(env).sort().join("\x00");
-    const curVals = Object.keys(env)
-      .sort()
-      .map((k) => env[k])
-      .join("\x00");
-    const prevKeys = Object.keys(lastEnvRef.current).sort().join("\x00");
-    const prevVals = Object.keys(lastEnvRef.current)
-      .sort()
-      .map((k) => lastEnvRef.current[k])
-      .join("\x00");
+    const envChanged = !shallowEnvEqual(env, lastEnvRef.current);
+    const inheritedChanged = !shallowEnvEqual(inheritedEnv, lastInheritedRef.current);
     const contextChanged = lastContextKeyRef.current !== contextKey;
-    if (contextChanged || curKeys !== prevKeys || curVals !== prevVals) {
-      lastEnvRef.current = env;
-      lastContextKeyRef.current = contextKey;
-      if (contextChanged) {
-        setTouchedKeys({});
-        setRevealedRows(new Set());
-      }
-      // Only reseed if the incoming env is actually different from what our
-      // draft would produce. Otherwise typing triggers a parent update that
-      // would otherwise stomp the user's in-progress edit.
-      const draftAsEnv = draftToEnv(rows);
-      const draftKeys = Object.keys(draftAsEnv).sort().join("\x00");
-      const draftVals = Object.keys(draftAsEnv)
-        .sort()
-        .map((k) => draftAsEnv[k])
-        .join("\x00");
-      if (contextChanged || draftKeys !== curKeys || draftVals !== curVals) {
-        setRows(envToDraft(env));
-      }
+    if (!contextChanged && !envChanged && !inheritedChanged) return;
+
+    lastEnvRef.current = env;
+    lastInheritedRef.current = inheritedEnv;
+    lastContextKeyRef.current = contextKey;
+    if (contextChanged) {
+      setTouchedKeys({});
+      setRevealedRows(new Set());
     }
-  }, [env, contextKey, rows]);
+    // Only reseed if the incoming env+inheritance actually differs from what
+    // our current draft would produce. Otherwise the parent's commit echo
+    // would stomp an in-progress edit.
+    const draftAsEnv = draftToEnv(rows);
+    if (contextChanged || inheritedChanged || !shallowEnvEqual(draftAsEnv, env)) {
+      setRows(envToDraft(env, inheritedEnv));
+    }
+  }, [env, inheritedEnv, contextKey, rows]);
 
   // Focus recovery after adding a row. Narrowly keyed to avoid cross-firing
   // with the reseed effect above.
@@ -182,19 +221,13 @@ export function EnvVarEditor({
     (nextRows: DraftRow[]) => {
       if (isValid(nextRows)) {
         const nextEnv = draftToEnv(nextRows);
-        const prev = lastEnvRef.current;
-        const prevKeys = Object.keys(prev).sort().join("\x00");
-        const nextKeys = Object.keys(nextEnv).sort().join("\x00");
-        const prevVals = Object.keys(prev)
-          .sort()
-          .map((k) => prev[k])
-          .join("\x00");
-        const nextVals = Object.keys(nextEnv)
-          .sort()
-          .map((k) => nextEnv[k])
-          .join("\x00");
-        if (prevKeys !== nextKeys || prevVals !== nextVals) {
-          lastEnvRef.current = nextEnv;
+        // Intentionally do NOT update lastEnvRef here. The ref tracks the last
+        // env *prop* value — if we seed it with our synthesized commit, the
+        // subsequent effect pass will read env (still the stale prop) and
+        // mistake it for an external reset, triggering a reseed that stomps
+        // the in-progress edit. Let the prop echo back from the parent and
+        // update lastEnvRef there.
+        if (!shallowEnvEqual(lastEnvRef.current, nextEnv)) {
           onChange(nextEnv);
         }
       }
@@ -205,12 +238,24 @@ export function EnvVarEditor({
   const handleAdd = useCallback(() => {
     const newRowId = nextRowId();
     setRows((prev) => {
-      // Pick a KEY name that isn't already present.
+      // Pick a KEY name that isn't already present (including inherited keys).
       let candidate = "NEW_VAR";
       let i = 1;
       const present = new Set(prev.map((r) => r.key.trim()));
       while (present.has(candidate)) candidate = `NEW_VAR_${i++}`;
-      return [...prev, { rowId: newRowId, key: candidate, value: "" }];
+      const newRow: DraftRow = {
+        rowId: newRowId,
+        key: candidate,
+        value: "",
+        isInherited: false,
+      };
+      // Insert before the inherited-only tail so new overrides stay grouped
+      // with existing overrides.
+      const firstInheritedIdx = prev.findIndex((r) => r.isInherited);
+      if (firstInheritedIdx === -1) {
+        return [...prev, newRow];
+      }
+      return [...prev.slice(0, firstInheritedIdx), newRow, ...prev.slice(firstInheritedIdx)];
     });
     setPendingFocusKey(newRowId);
   }, []);
@@ -218,6 +263,20 @@ export function EnvVarEditor({
   const handleRemove = useCallback(
     (rowId: string) => {
       setRows((prev) => {
+        const row = prev.find((r) => r.rowId === rowId);
+        if (!row) return prev;
+        const key = row.key.trim();
+        // If this override shadows an inherited key, "removing" means reverting
+        // to the inherited value rather than dropping the row altogether —
+        // the inherited entry would otherwise reappear as a separate row.
+        if (!row.isInherited && inheritedEnv && key in inheritedEnv) {
+          const inheritedValue = inheritedEnv[key]!;
+          const next = prev.map((r) =>
+            r.rowId === rowId ? { ...r, value: inheritedValue, isInherited: true } : r
+          );
+          commitIfValid(next);
+          return next;
+        }
         const next = prev.filter((r) => r.rowId !== rowId);
         commitIfValid(next);
         return next;
@@ -229,7 +288,7 @@ export function EnvVarEditor({
         return next;
       });
     },
-    [commitIfValid]
+    [commitIfValid, inheritedEnv]
   );
 
   const handleKeyChange = useCallback((rowId: string, newKey: string) => {
@@ -239,6 +298,40 @@ export function EnvVarEditor({
   const handleValueChange = useCallback((rowId: string, newValue: string) => {
     setRows((prev) => prev.map((r) => (r.rowId === rowId ? { ...r, value: newValue } : r)));
   }, []);
+
+  const handleOverride = useCallback(
+    (rowId: string) => {
+      setRows((prev) => {
+        const row = prev.find((r) => r.rowId === rowId);
+        if (!row || !row.isInherited) return prev;
+        // Promote the inherited row to an override carrying the current value.
+        // This makes the preset env explicitly include the key, so a later
+        // change to the inherited map does not silently alter this preset.
+        const next = prev.map((r) => (r.rowId === rowId ? { ...r, isInherited: false } : r));
+        commitIfValid(next);
+        return next;
+      });
+    },
+    [commitIfValid]
+  );
+
+  const handleRevert = useCallback(
+    (rowId: string) => {
+      setRows((prev) => {
+        const row = prev.find((r) => r.rowId === rowId);
+        if (!row || row.isInherited) return prev;
+        const key = row.key.trim();
+        if (!inheritedEnv || !(key in inheritedEnv)) return prev;
+        const inheritedValue = inheritedEnv[key]!;
+        const next = prev.map((r) =>
+          r.rowId === rowId ? { ...r, value: inheritedValue, isInherited: true } : r
+        );
+        commitIfValid(next);
+        return next;
+      });
+    },
+    [commitIfValid, inheritedEnv]
+  );
 
   const handleKeyBlur = useCallback(
     (rowId: string) => {
@@ -251,12 +344,33 @@ export function EnvVarEditor({
     [commitIfValid]
   );
 
-  const handleValueBlur = useCallback(() => {
-    setRows((prev) => {
-      commitIfValid(prev);
-      return prev;
-    });
-  }, [commitIfValid]);
+  const handleValueBlur = useCallback(
+    (rowId: string) => {
+      setRows((prev) => {
+        const row = prev.find((r) => r.rowId === rowId);
+        if (!row || row.isInherited) {
+          commitIfValid(prev);
+          return prev;
+        }
+        const key = row.key.trim();
+        // If a user clears an override's value and that key is still inherited,
+        // silently reverting is safer than persisting an empty-string override —
+        // otherwise the preset would ship `KEY=""` which masks the inherited
+        // value instead of falling back to it.
+        if (row.value === "" && inheritedEnv && key in inheritedEnv) {
+          const inheritedValue = inheritedEnv[key]!;
+          const next = prev.map((r) =>
+            r.rowId === rowId ? { ...r, value: inheritedValue, isInherited: true } : r
+          );
+          commitIfValid(next);
+          return next;
+        }
+        commitIfValid(prev);
+        return prev;
+      });
+    },
+    [commitIfValid, inheritedEnv]
+  );
 
   const toggleReveal = useCallback((rowId: string) => {
     setRevealedRows((prev) => {
@@ -309,25 +423,32 @@ export function EnvVarEditor({
           {rows.map((row) => {
             const trimmedKey = row.key.trim();
             const touched = !!touchedKeys[row.rowId];
-            const isEmptyKey = touched && trimmedKey === "";
-            const isDuplicate = trimmedKey !== "" && duplicateKeys.has(trimmedKey);
-            const hasSecretWarning = looksLikeSecret(row.value);
-            const isSecret = isSensitiveEnvKey(row.key) || hasSecretWarning;
+            const isEmptyKey = !row.isInherited && touched && trimmedKey === "";
+            const isDuplicate =
+              !row.isInherited && trimmedKey !== "" && duplicateKeys.has(trimmedKey);
+            const hasSecretWarning = !row.isInherited && looksLikeSecret(row.value);
+            const isSecret = !row.isInherited && (isSensitiveEnvKey(row.key) || hasSecretWarning);
             const isRevealed = revealedRows.has(row.rowId);
             const valueInputType = isSecret && !isRevealed ? "password" : "text";
+            const isOverride =
+              !row.isInherited && !!inheritedEnv && trimmedKey !== "" && trimmedKey in inheritedEnv;
             const stripeClass = isEmptyKey
               ? "before:bg-status-error"
               : isDuplicate || hasSecretWarning
                 ? "before:bg-amber-500/70"
-                : "before:bg-transparent";
+                : isOverride
+                  ? "before:bg-daintree-accent"
+                  : "before:bg-transparent";
             return (
               <div
                 key={row.rowId}
                 className={cn(
                   "relative grid grid-cols-[2fr_3fr_auto] items-stretch group",
                   "before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[2px]",
-                  stripeClass
+                  stripeClass,
+                  row.isInherited && "bg-daintree-bg/20"
                 )}
+                data-testid={row.isInherited ? "env-editor-row-inherited" : "env-editor-row"}
               >
                 {/* Key cell */}
                 <div className="relative">
@@ -337,11 +458,14 @@ export function EnvVarEditor({
                     className={cn(
                       "w-full h-full bg-transparent border-0 outline-none px-2.5 py-2 font-mono text-[12px]",
                       "focus:ring-2 focus:ring-inset focus:ring-daintree-accent/40",
-                      isEmptyKey
-                        ? "text-status-error"
-                        : isDuplicate
-                          ? "text-amber-500"
-                          : "text-daintree-text/80"
+                      "disabled:cursor-default",
+                      row.isInherited
+                        ? "text-daintree-text/40"
+                        : isEmptyKey
+                          ? "text-status-error"
+                          : isDuplicate
+                            ? "text-amber-500"
+                            : "text-daintree-text/80"
                     )}
                     value={row.key}
                     placeholder="KEY"
@@ -349,6 +473,7 @@ export function EnvVarEditor({
                     spellCheck={false}
                     autoCapitalize="off"
                     autoCorrect="off"
+                    disabled={row.isInherited}
                     aria-label={`Env var key for row ${row.rowId}`}
                     aria-invalid={isEmptyKey || isDuplicate ? "true" : undefined}
                     onChange={(e) => handleKeyChange(row.rowId, e.target.value)}
@@ -380,18 +505,24 @@ export function EnvVarEditor({
                   <input
                     type={valueInputType}
                     className={cn(
-                      "w-full h-full bg-transparent border-0 outline-none py-2 font-mono text-[12px] text-daintree-accent/90",
+                      "w-full h-full bg-transparent border-0 outline-none py-2 font-mono text-[12px]",
                       "focus:ring-2 focus:ring-inset focus:ring-daintree-accent/40",
+                      "disabled:cursor-default",
                       isSecret ? "pl-2.5 pr-8" : "px-2.5",
-                      hasSecretWarning && "text-amber-500"
+                      row.isInherited
+                        ? "text-daintree-text/40"
+                        : hasSecretWarning
+                          ? "text-amber-500"
+                          : "text-daintree-accent/90"
                     )}
                     value={row.value}
                     placeholder={valuePlaceholder}
                     spellCheck={false}
                     autoComplete={isSecret ? "new-password" : "off"}
+                    disabled={row.isInherited}
                     aria-label={`Env var value for row ${row.rowId}`}
                     onChange={(e) => handleValueChange(row.rowId, e.target.value)}
-                    onBlur={handleValueBlur}
+                    onBlur={() => handleValueBlur(row.rowId)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.preventDefault();
@@ -435,17 +566,41 @@ export function EnvVarEditor({
                     </p>
                   )}
                 </div>
-                {/* Actions cell */}
+                {/* Actions cell — remove / revert / override by row kind. */}
                 <div className="flex items-center justify-center w-9 border-l border-daintree-border/60">
-                  <button
-                    type="button"
-                    className="p-1 rounded text-daintree-text/30 hover:text-status-error hover:bg-daintree-bg/60 transition-colors"
-                    aria-label={`Remove ${trimmedKey || "empty"} env var`}
-                    onClick={() => handleRemove(row.rowId)}
-                    data-testid="env-editor-remove"
-                  >
-                    <X size={12} aria-hidden="true" />
-                  </button>
+                  {row.isInherited ? (
+                    <button
+                      type="button"
+                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-accent hover:bg-daintree-bg/60 transition-colors"
+                      aria-label={`Override ${trimmedKey} in this preset`}
+                      onClick={() => handleOverride(row.rowId)}
+                      data-testid="env-editor-override"
+                      title="Override this inherited value"
+                    >
+                      <Plus size={12} aria-hidden="true" />
+                    </button>
+                  ) : isOverride ? (
+                    <button
+                      type="button"
+                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-accent hover:bg-daintree-bg/60 transition-colors"
+                      aria-label={`Revert ${trimmedKey} to inherited value`}
+                      onClick={() => handleRevert(row.rowId)}
+                      data-testid="env-editor-revert"
+                      title="Revert to inherited value"
+                    >
+                      <RotateCcw size={12} aria-hidden="true" />
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="p-1 rounded text-daintree-text/30 hover:text-status-error hover:bg-daintree-bg/60 transition-colors"
+                      aria-label={`Remove ${trimmedKey || "empty"} env var`}
+                      onClick={() => handleRemove(row.rowId)}
+                      data-testid="env-editor-remove"
+                    >
+                      <X size={12} aria-hidden="true" />
+                    </button>
+                  )}
                 </div>
               </div>
             );

--- a/src/components/Settings/__tests__/EnvVarEditor.test.tsx
+++ b/src/components/Settings/__tests__/EnvVarEditor.test.tsx
@@ -20,6 +20,7 @@ vi.mock("lucide-react", () => ({
   Eye: () => <span data-testid="eye-icon" />,
   EyeOff: () => <span data-testid="eye-off-icon" />,
   Plus: () => <span data-testid="plus-icon" />,
+  RotateCcw: () => <span data-testid="rotate-ccw-icon" />,
 }));
 
 describe("EnvVarEditor", () => {
@@ -315,5 +316,191 @@ describe("EnvVarEditor", () => {
     const datalist = container.querySelector("datalist#env-key-suggestions-test");
     expect(datalist).toBeTruthy();
     expect(datalist?.querySelectorAll("option").length).toBe(1);
+  });
+
+  describe("inherited env", () => {
+    it("renders inherited-only keys as muted rows with disabled inputs and an Override action", () => {
+      const { getAllByTestId, queryAllByTestId } = render(
+        <EnvVarEditor
+          env={{}}
+          onChange={onChange}
+          inheritedEnv={{ API_KEY: "from-global", NODE_ENV: "dev" }}
+        />
+      );
+
+      const keyInputs = getAllByTestId("env-editor-key") as HTMLInputElement[];
+      const valueInputs = getAllByTestId("env-editor-value") as HTMLInputElement[];
+      expect(keyInputs).toHaveLength(2);
+      expect(keyInputs.every((el) => el.disabled)).toBe(true);
+      expect(valueInputs.every((el) => el.disabled)).toBe(true);
+      expect(getAllByTestId("env-editor-override")).toHaveLength(2);
+      // No remove/revert buttons when all rows are inherited.
+      expect(queryAllByTestId("env-editor-remove")).toHaveLength(0);
+      expect(queryAllByTestId("env-editor-revert")).toHaveLength(0);
+    });
+
+    it("shows overrides first (insertion order), then inherited-only keys (insertion order)", () => {
+      const { getAllByTestId } = render(
+        <EnvVarEditor
+          env={{ ZETA: "z", ALPHA: "a" }}
+          onChange={onChange}
+          inheritedEnv={{ BETA: "b", GAMMA: "g", ZETA: "inherited-z" }}
+        />
+      );
+      const keyInputs = getAllByTestId("env-editor-key") as HTMLInputElement[];
+      // Override rows keep env's insertion order; ZETA is an override of the
+      // inherited ZETA, ALPHA is preset-only. Then inherited-only tail in
+      // inheritedEnv's insertion order: BETA, GAMMA.
+      expect(keyInputs.map((el) => el.value)).toEqual(["ZETA", "ALPHA", "BETA", "GAMMA"]);
+    });
+
+    it("clicking Override promotes an inherited row to an editable override and commits", () => {
+      const { getAllByTestId, queryAllByTestId } = render(
+        <EnvVarEditor env={{}} onChange={onChange} inheritedEnv={{ API_KEY: "from-global" }} />
+      );
+
+      fireEvent.click(getAllByTestId("env-editor-override")[0]!);
+
+      // The row is no longer inherited — value input is editable now.
+      const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
+      expect(valueInput.disabled).toBe(false);
+      // Override got seeded with the inherited value and committed.
+      expect(onChange).toHaveBeenLastCalledWith({ API_KEY: "from-global" });
+      // Action cell now shows Revert (this key is still inherited), not Override.
+      expect(queryAllByTestId("env-editor-override")).toHaveLength(0);
+      expect(queryAllByTestId("env-editor-revert")).toHaveLength(1);
+    });
+
+    it("editing an override's value commits the new value, not the inherited one", () => {
+      const { getAllByTestId } = render(
+        <EnvVarEditor
+          env={{ API_KEY: "preset-val" }}
+          onChange={onChange}
+          inheritedEnv={{ API_KEY: "from-global" }}
+        />
+      );
+      const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
+      expect(valueInput.value).toBe("preset-val");
+      expect(valueInput.disabled).toBe(false);
+
+      fireEvent.change(valueInput, { target: { value: "edited" } });
+      fireEvent.blur(valueInput);
+
+      expect(onChange).toHaveBeenLastCalledWith({ API_KEY: "edited" });
+    });
+
+    it("clicking Revert on an override drops the key and commits without it", () => {
+      const { getAllByTestId } = render(
+        <EnvVarEditor
+          env={{ API_KEY: "preset-val", STAY: "s" }}
+          onChange={onChange}
+          inheritedEnv={{ API_KEY: "from-global" }}
+        />
+      );
+
+      fireEvent.click(getAllByTestId("env-editor-revert")[0]!);
+
+      // Revert falls back to inherited — preset env should no longer carry the key.
+      expect(onChange).toHaveBeenLastCalledWith({ STAY: "s" });
+    });
+
+    it("clearing an override's value on blur reverts to inherited (no empty-string override)", () => {
+      const { getAllByTestId } = render(
+        <EnvVarEditor
+          env={{ API_KEY: "preset-val" }}
+          onChange={onChange}
+          inheritedEnv={{ API_KEY: "from-global" }}
+        />
+      );
+      const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
+
+      fireEvent.change(valueInput, { target: { value: "" } });
+      fireEvent.blur(valueInput);
+
+      // Must revert to inherited — an empty-string override would silently
+      // mask the inherited value.
+      expect(onChange).toHaveBeenLastCalledWith({});
+      for (const call of onChange.mock.calls) {
+        expect(call[0]).not.toMatchObject({ API_KEY: "" });
+      }
+    });
+
+    it("clearing a preset-only (non-inherited) value keeps the empty-string override", () => {
+      const { getAllByTestId } = render(
+        <EnvVarEditor env={{ LOCAL_ONLY: "v" }} onChange={onChange} inheritedEnv={{ OTHER: "x" }} />
+      );
+      const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
+
+      fireEvent.change(valueInput, { target: { value: "" } });
+      fireEvent.blur(valueInput);
+
+      // LOCAL_ONLY has no inherited counterpart — cleared value persists as "".
+      expect(onChange).toHaveBeenLastCalledWith({ LOCAL_ONLY: "" });
+    });
+
+    it("Remove on an override that shadows an inherited key reverts to inherited (preserves row)", () => {
+      const { getAllByTestId, queryAllByTestId } = render(
+        <EnvVarEditor
+          env={{ API_KEY: "preset-val" }}
+          onChange={onChange}
+          inheritedEnv={{ API_KEY: "from-global" }}
+        />
+      );
+
+      // An override that shadows an inherited key renders the Revert action
+      // (not Remove) — there's no X button to click for this row.
+      expect(queryAllByTestId("env-editor-remove")).toHaveLength(0);
+      fireEvent.click(getAllByTestId("env-editor-revert")[0]!);
+      expect(onChange).toHaveBeenLastCalledWith({});
+    });
+
+    it("inherited-only editor with no overrides is not 'empty' (renders inherited rows, not the empty-state CTA)", () => {
+      const { queryByText, getAllByTestId } = render(
+        <EnvVarEditor env={{}} onChange={onChange} inheritedEnv={{ A: "1" }} />
+      );
+      expect(queryByText(/Add your first variable/i)).toBeNull();
+      expect(getAllByTestId("env-editor-key")).toHaveLength(1);
+    });
+
+    it("fully-empty editor (no env, no inherited keys) shows the empty-state CTA", () => {
+      const { getByText } = render(<EnvVarEditor env={{}} onChange={onChange} inheritedEnv={{}} />);
+      expect(getByText(/Add your first variable/i)).toBeTruthy();
+    });
+
+    it("inheritedEnv prop updates trigger a reseed when keys/values differ", () => {
+      const { rerender, getAllByTestId } = render(
+        <EnvVarEditor env={{}} onChange={onChange} inheritedEnv={{ A: "1" }} contextKey="p" />
+      );
+      expect(getAllByTestId("env-editor-key")).toHaveLength(1);
+
+      rerender(
+        <EnvVarEditor
+          env={{}}
+          onChange={onChange}
+          inheritedEnv={{ A: "1", B: "2" }}
+          contextKey="p"
+        />
+      );
+      const keyInputs = getAllByTestId("env-editor-key") as HTMLInputElement[];
+      expect(keyInputs).toHaveLength(2);
+      expect(keyInputs.map((el) => el.value)).toEqual(["A", "B"]);
+    });
+
+    it("a fresh empty-object identity for env/inheritedEnv does NOT trigger a spurious reseed", () => {
+      const { rerender, getAllByTestId } = render(
+        <EnvVarEditor env={{}} onChange={onChange} inheritedEnv={{ A: "1" }} />
+      );
+      fireEvent.click(getAllByTestId("env-editor-override")[0]!);
+      // Onchange fires with the override commit.
+      expect(onChange).toHaveBeenLastCalledWith({ A: "1" });
+      const commitsBeforeRerender = onChange.mock.calls.length;
+
+      // Parent re-renders with the same logical env (now {A:"1"}) but passes a
+      // fresh inherited-env object identity — this must not stomp the override.
+      rerender(<EnvVarEditor env={{ A: "1" }} onChange={onChange} inheritedEnv={{ A: "1" }} />);
+      expect(onChange.mock.calls.length).toBe(commitsBeforeRerender);
+      const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
+      expect(valueInput.disabled).toBe(false); // still an override, not reseeded back to inherited
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Unified the preset env editor into a single table, removing the separate inherited strip
- Inherited global env keys now render as muted rows in the same table with clear visual distinction
- Added explicit override semantics: "Override" button copies inherited key with editable value, "Revert" button clears override back to inherited
- Fixed the empty string override issue by requiring explicit action to drop keys

Resolves #5604

## Changes
- `EnvVarEditor.tsx`: Added `inheritedEnv` prop, visual treatments for inherited rows, revert/override button logic
- `AgentSettings.tsx`: Removed the inherited env strip, passed `inheritedEnv` to the unified editor

## Testing
- Verified inherited keys render with muted styling and "Override" button
- Confirmed overriding creates an editable row with "Revert" button
- Tested that reverting drops the key and falls back to inherited value
- Confirmed emptying a value field no longer creates a silent empty string override