### PR TITLE
perf(worktree): parallelize bulk create prequery

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -584,21 +584,10 @@ export function BulkCreateWorktreeDialog({
       // Two-phase approach: (1) resolve branch candidates with bounded concurrency,
       // (2) apply deterministic uniqueness suffixes in input order, (3) resolve paths
       // with bounded concurrency using final unique branch names.
-      const existingWorktrees = getCurrentViewStore().getState().worktrees;
-      const existingBranchSet = new Set(
-        Array.from(existingWorktrees.values())
-          .map((wt) => wt.branch)
-          .filter((b): b is string => b !== undefined)
-      );
-
-      const prequeryInput = toCreate.filter((planned) => {
-        if (planned.mode !== "issue") return false;
-        if (existingBranchSet.has(planned.branchName)) return false;
-        return true;
-      });
+      const prequeryInput = toCreate.filter((p) => p.mode === "issue");
 
       if (prequeryInput.length > 0) {
-        const { results, failedNumbers } = await resolveIssuePrequeries({
+        const { results, failedItems: prequeryFailures } = await resolveIssuePrequeries({
           rootPath,
           items: prequeryInput,
           existingBranches: null,
@@ -613,13 +602,13 @@ export function BulkCreateWorktreeDialog({
           precomputed.set(number, { branch, path });
         }
 
-        for (const number of failedNumbers) {
+        for (const { number, error } of prequeryFailures) {
           prequeryFailed.add(number);
           failedItems.add(number);
           dispatchProgress({
             type: "ITEM_FAILED",
             issueNumber: number,
-            error: "Prequery failed",
+            error: normalizeError(error),
             attempts: 1,
             failedStep: "worktree",
           });
@@ -648,8 +637,12 @@ export function BulkCreateWorktreeDialog({
 
               if (!worktreeId) {
                 const worktrees = getCurrentViewStore().getState().worktrees;
+                const pre = precomputed.get(itemNumber);
+                const searchBranches = pre
+                  ? [pre.branch, planned.branchName]
+                  : [planned.branchName];
                 for (const wt of worktrees.values()) {
-                  if (wt.branch && wt.branch === planned.branchName) {
+                  if (wt.branch && searchBranches.includes(wt.branch)) {
                     worktreeId = wt.worktreeId;
                     worktreePath = wt.path;
                     resolvedBranch = wt.branch;

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -17,6 +17,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { cn } from "@/lib/utils";
 import { worktreeClient, githubClient, agentSettingsClient, systemClient } from "@/clients";
 import { detectPrefixFromIssue, buildBranchName } from "@/components/Worktree/branchPrefixUtils";
+import { resolveIssuePrequeries } from "./bulkCreatePrequery";
 import { generateBranchSlug } from "@/utils/textParsing";
 import { notify } from "@/lib/notify";
 import { usePreferencesStore } from "@/store/preferencesStore";
@@ -579,43 +580,46 @@ export function BulkCreateWorktreeDialog({
         }
       }
 
-      const assignedBranches = new Set<string>();
-      for (const planned of toCreate) {
+      // Batch pre-queries: parallel branch/path resolution with bounded concurrency.
+      // Two-phase approach: (1) resolve branch candidates with bounded concurrency,
+      // (2) apply deterministic uniqueness suffixes in input order, (3) resolve paths
+      // with bounded concurrency using final unique branch names.
+      const existingWorktrees = getCurrentViewStore().getState().worktrees;
+      const existingBranchSet = new Set(
+        Array.from(existingWorktrees.values())
+          .map((wt) => wt.branch)
+          .filter((b): b is string => b !== undefined)
+      );
+
+      const prequeryInput = toCreate.filter((planned) => {
+        if (planned.mode !== "issue") return false;
+        if (existingBranchSet.has(planned.branchName)) return false;
+        return true;
+      });
+
+      if (prequeryInput.length > 0) {
+        const { results, failedNumbers } = await resolveIssuePrequeries({
+          rootPath,
+          items: prequeryInput,
+          existingBranches: null,
+          getAvailableBranch: worktreeClient.getAvailableBranch,
+          getDefaultPath: worktreeClient.getDefaultPath,
+          isStaleRun: () => runIdRef.current !== currentRunId,
+        });
+
         if (runIdRef.current !== currentRunId) return;
-        if (planned.mode !== "issue") continue;
 
-        // Skip pre-query if the worktree already exists locally — the per-item
-        // path below will detect it via the worktree store and short-circuit.
-        const existingWorktrees = getCurrentViewStore().getState().worktrees;
-        let alreadyExists = false;
-        for (const wt of existingWorktrees.values()) {
-          if (wt.branch && wt.branch === planned.branchName) {
-            alreadyExists = true;
-            break;
-          }
+        for (const [number, { branch, path }] of results) {
+          precomputed.set(number, { branch, path });
         }
-        if (alreadyExists) continue;
 
-        try {
-          let branch = await worktreeClient.getAvailableBranch(rootPath, planned.branchName);
-          if (runIdRef.current !== currentRunId) return;
-          if (assignedBranches.has(branch)) {
-            let n = 2;
-            while (assignedBranches.has(`${branch}-${n}`)) n++;
-            branch = `${branch}-${n}`;
-          }
-          assignedBranches.add(branch);
-          const path = await worktreeClient.getDefaultPath(rootPath, branch);
-          if (runIdRef.current !== currentRunId) return;
-          precomputed.set(planned.item.number, { branch, path });
-        } catch (err) {
-          if (runIdRef.current !== currentRunId) return;
-          prequeryFailed.add(planned.item.number);
-          failedItems.add(planned.item.number);
+        for (const number of failedNumbers) {
+          prequeryFailed.add(number);
+          failedItems.add(number);
           dispatchProgress({
             type: "ITEM_FAILED",
-            issueNumber: planned.item.number,
-            error: normalizeError(err),
+            issueNumber: number,
+            error: "Prequery failed",
             attempts: 1,
             failedStep: "worktree",
           });

--- a/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
+++ b/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
@@ -26,7 +26,7 @@ describe("resolveIssuePrequeries", () => {
     const getAvailableBranch = vi.fn().mockResolvedValue("feature/issue-1");
     const getDefaultPath = vi.fn().mockResolvedValue("/path/to/issue-1");
 
-    const { results, failedNumbers } = await resolveIssuePrequeries({
+    const { results, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [mockPlanned(1)],
       existingBranches: null,
@@ -37,7 +37,7 @@ describe("resolveIssuePrequeries", () => {
 
     expect(results.size).toBe(1);
     expect(results.get(1)).toEqual({ branch: "feature/issue-1", path: "/path/to/issue-1" });
-    expect(failedNumbers.size).toBe(0);
+    expect(failedItems.length).toBe(0);
     expect(getAvailableBranch).toHaveBeenCalledWith("/repo", "feature/issue-1");
     expect(getDefaultPath).toHaveBeenCalledWith("/repo", "feature/issue-1");
   });
@@ -46,7 +46,7 @@ describe("resolveIssuePrequeries", () => {
     const getAvailableBranch = vi.fn((_, name) => Promise.resolve(name));
     const getDefaultPath = vi.fn((_, branch) => Promise.resolve(`/path/${branch}`));
 
-    const { results, failedNumbers } = await resolveIssuePrequeries({
+    const { results, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
       existingBranches: null,
@@ -59,7 +59,7 @@ describe("resolveIssuePrequeries", () => {
     expect(results.get(1)).toEqual({ branch: "feature/issue-1", path: "/path/feature/issue-1" });
     expect(results.get(2)).toEqual({ branch: "feature/issue-2", path: "/path/feature/issue-2" });
     expect(results.get(3)).toEqual({ branch: "feature/issue-3", path: "/path/feature/issue-3" });
-    expect(failedNumbers.size).toBe(0);
+    expect(failedItems.length).toBe(0);
   });
 
   it("applies deterministic suffixes for colliding branch names", async () => {
@@ -112,7 +112,7 @@ describe("resolveIssuePrequeries", () => {
     });
     const getDefaultPath = vi.fn().mockResolvedValue("/path");
 
-    const { results, failedNumbers } = await resolveIssuePrequeries({
+    const { results, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
       existingBranches: null,
@@ -122,7 +122,7 @@ describe("resolveIssuePrequeries", () => {
     });
 
     expect(results.size).toBe(2);
-    expect(failedNumbers.has(2)).toBe(true);
+    expect(failedItems.some((f) => f.number === 2)).toBe(true);
     expect(results.get(1)).toBeDefined();
     expect(results.get(3)).toBeDefined();
   });
@@ -137,7 +137,7 @@ describe("resolveIssuePrequeries", () => {
     const getDefaultPath = vi.fn().mockResolvedValue("/path");
 
     let isStale = false;
-    const { results: _, failedNumbers } = await resolveIssuePrequeries({
+    const { results: _, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
       existingBranches: null,
@@ -150,12 +150,12 @@ describe("resolveIssuePrequeries", () => {
       isStale = true;
     }, 5);
 
-    expect(failedNumbers.size).toBeGreaterThanOrEqual(0);
+    expect(failedItems.length).toBeGreaterThanOrEqual(0);
     expect(callCount).toBeGreaterThan(0);
   });
 
   it("returns empty results for zero items", async () => {
-    const { results, failedNumbers } = await resolveIssuePrequeries({
+    const { results, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [],
       existingBranches: null,
@@ -165,7 +165,7 @@ describe("resolveIssuePrequeries", () => {
     });
 
     expect(results.size).toBe(0);
-    expect(failedNumbers.size).toBe(0);
+    expect(failedItems.length).toBe(0);
   });
 
   it("filters out skipped and non-issue items", async () => {
@@ -193,7 +193,7 @@ describe("resolveIssuePrequeries", () => {
     const getAvailableBranch = vi.fn().mockResolvedValue("branch");
     const getDefaultPath = vi.fn().mockRejectedValue(new Error("Path lookup failed"));
 
-    const { results, failedNumbers } = await resolveIssuePrequeries({
+    const { results, failedItems } = await resolveIssuePrequeries({
       rootPath: "/repo",
       items: [mockPlanned(1)],
       existingBranches: null,
@@ -203,7 +203,7 @@ describe("resolveIssuePrequeries", () => {
     });
 
     expect(results.size).toBe(0);
-    expect(failedNumbers.has(1)).toBe(true);
+    expect(failedItems.some((f) => f.number === 1)).toBe(true);
   });
 
   it("calls onProgress callback with completion stats", async () => {

--- a/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
+++ b/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveIssuePrequeries } from "../bulkCreatePrequery";
+import type { GitHubIssue } from "@shared/types";
+
+describe("resolveIssuePrequeries", () => {
+  const mockIssue = (number: number): GitHubIssue => ({
+    number,
+    title: `Test Issue ${number}`,
+    state: "OPEN",
+    url: `https://github.com/test/repo/issues/${number}`,
+    updatedAt: new Date().toISOString(),
+    author: { login: "testuser", avatarUrl: "https://example.com/avatar.png" },
+    assignees: [],
+    commentCount: 0,
+    labels: [],
+  });
+
+  const mockPlanned = (number: number, branchName: string = `feature/issue-${number}`) => ({
+    item: mockIssue(number),
+    mode: "issue" as const,
+    branchName,
+    skipped: false,
+  });
+
+  it("resolves branch and path for a single item", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("feature/issue-1");
+    const getDefaultPath = vi.fn().mockResolvedValue("/path/to/issue-1");
+
+    const { results, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(1);
+    expect(results.get(1)).toEqual({ branch: "feature/issue-1", path: "/path/to/issue-1" });
+    expect(failedNumbers.size).toBe(0);
+    expect(getAvailableBranch).toHaveBeenCalledWith("/repo", "feature/issue-1");
+    expect(getDefaultPath).toHaveBeenCalledWith("/repo", "feature/issue-1");
+  });
+
+  it("resolves multiple items concurrently", async () => {
+    const getAvailableBranch = vi.fn((_, name) => Promise.resolve(name));
+    const getDefaultPath = vi.fn((_, branch) => Promise.resolve(`/path/${branch}`));
+
+    const { results, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(3);
+    expect(results.get(1)).toEqual({ branch: "feature/issue-1", path: "/path/feature/issue-1" });
+    expect(results.get(2)).toEqual({ branch: "feature/issue-2", path: "/path/feature/issue-2" });
+    expect(results.get(3)).toEqual({ branch: "feature/issue-3", path: "/path/feature/issue-3" });
+    expect(failedNumbers.size).toBe(0);
+  });
+
+  it("applies deterministic suffixes for colliding branch names", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("feature/issue-1");
+    const getDefaultPath = vi.fn((_, branch) => Promise.resolve(`/path/${branch}`));
+
+    const { results } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [
+        mockPlanned(1, "feature/issue-1"),
+        mockPlanned(2, "feature/issue-1"),
+        mockPlanned(3, "feature/issue-1"),
+      ],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(3);
+    expect(results.get(1)?.branch).toBe("feature/issue-1");
+    expect(results.get(2)?.branch).toBe("feature/issue-1-2");
+    expect(results.get(3)?.branch).toBe("feature/issue-1-3");
+    expect(getDefaultPath).toHaveBeenCalledWith("/repo", "feature/issue-1");
+    expect(getDefaultPath).toHaveBeenCalledWith("/repo", "feature/issue-1-2");
+    expect(getDefaultPath).toHaveBeenCalledWith("/repo", "feature/issue-1-3");
+  });
+
+  it("handles branch name collisions across items in the same batch", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("feature/issue-1");
+    const getDefaultPath = vi.fn((_, branch) => Promise.resolve(`/path/${branch}`));
+
+    const { results } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1, "feature/issue-1"), mockPlanned(2, "feature/issue-1")],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.get(1)?.branch).toBe("feature/issue-1");
+    expect(results.get(2)?.branch).toBe("feature/issue-1-2");
+  });
+
+  it("handles partial failures gracefully", async () => {
+    const getAvailableBranch = vi.fn((_, name) => {
+      if (name === "feature/issue-2") throw new Error("Branch lookup failed");
+      return Promise.resolve(name);
+    });
+    const getDefaultPath = vi.fn().mockResolvedValue("/path");
+
+    const { results, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(2);
+    expect(failedNumbers.has(2)).toBe(true);
+    expect(results.get(1)).toBeDefined();
+    expect(results.get(3)).toBeDefined();
+  });
+
+  it("stops early on stale run", async () => {
+    let callCount = 0;
+    const getAvailableBranch = vi.fn().mockImplementation(async () => {
+      callCount++;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return "branch";
+    });
+    const getDefaultPath = vi.fn().mockResolvedValue("/path");
+
+    let isStale = false;
+    const { results: _, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => isStale,
+    });
+
+    setTimeout(() => {
+      isStale = true;
+    }, 5);
+
+    expect(failedNumbers.size).toBeGreaterThanOrEqual(0);
+    expect(callCount).toBeGreaterThan(0);
+  });
+
+  it("returns empty results for zero items", async () => {
+    const { results, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [],
+      existingBranches: null,
+      getAvailableBranch: vi.fn(),
+      getDefaultPath: vi.fn(),
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(0);
+    expect(failedNumbers.size).toBe(0);
+  });
+
+  it("filters out skipped and non-issue items", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("branch");
+    const getDefaultPath = vi.fn().mockResolvedValue("/path");
+
+    const { results } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [
+        mockPlanned(1),
+        { ...mockPlanned(2), skipped: true },
+        { ...mockPlanned(3), mode: "pr" as const },
+      ],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(1);
+    expect(results.has(1)).toBe(true);
+  });
+
+  it("handles path lookup failures", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("branch");
+    const getDefaultPath = vi.fn().mockRejectedValue(new Error("Path lookup failed"));
+
+    const { results, failedNumbers } = await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(results.size).toBe(0);
+    expect(failedNumbers.has(1)).toBe(true);
+  });
+
+  it("calls onProgress callback with completion stats", async () => {
+    const getAvailableBranch = vi.fn().mockResolvedValue("branch");
+    const getDefaultPath = vi.fn().mockResolvedValue("/path");
+    const onProgress = vi.fn();
+
+    await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+      onProgress,
+    });
+
+    expect(onProgress).toHaveBeenCalledWith(3, 3);
+  });
+});

--- a/src/components/GitHub/bulkCreatePrequery.ts
+++ b/src/components/GitHub/bulkCreatePrequery.ts
@@ -31,7 +31,7 @@ export interface PrequeryOptions {
 
 export interface PrequeryOutput {
   results: Map<number, PrequeryResult>;
-  failedNumbers: Set<number>;
+  failedItems: Array<{ number: number; error: Error }>;
 }
 
 async function withTimeout<T>(
@@ -87,12 +87,10 @@ async function resolveIssuePrequeries({
   const inputOrder = issueItems.map((p) => p.item.number);
 
   if (inputOrder.length === 0) {
-    return { results: new Map(), failedNumbers: new Set() };
+    return { results: new Map(), failedItems: [] };
   }
 
   const results = new Map<number, PrequeryResult>();
-  const failedNumbers = new Set<number>();
-
   const branchQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
   const candidateBranches = new Map<number, string>();
   const branchErrors = new Array<{ number: number; error: Error }>();
@@ -117,16 +115,14 @@ async function resolveIssuePrequeries({
   );
 
   await Promise.all(branchPromises);
-  if (isStaleRun()) return { results, failedNumbers };
-
-  for (const { number, error: _ } of branchErrors) {
-    failedNumbers.add(number);
-  }
+  if (isStaleRun()) return { results, failedItems: branchErrors };
 
   const uniqueBranches = resolveBranchUniqueness(candidateBranches, inputOrder);
 
   const pathQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
   const pathErrors = new Array<{ number: number; error: Error }>();
+
+  const failedNumbers = new Set(branchErrors.map((e) => e.number));
 
   const pathPromises = inputOrder
     .filter((n) => !failedNumbers.has(n) && uniqueBranches.has(n))
@@ -151,15 +147,11 @@ async function resolveIssuePrequeries({
     );
 
   await Promise.all(pathPromises);
-  if (isStaleRun()) return { results, failedNumbers };
-
-  for (const { number, error: _ } of pathErrors) {
-    failedNumbers.add(number);
-  }
+  if (isStaleRun()) return { results, failedItems: [...branchErrors, ...pathErrors] };
 
   onProgress?.(results.size, inputOrder.length);
 
-  return { results, failedNumbers };
+  return { results, failedItems: [...branchErrors, ...pathErrors] };
 }
 
 export { resolveIssuePrequeries };

--- a/src/components/GitHub/bulkCreatePrequery.ts
+++ b/src/components/GitHub/bulkCreatePrequery.ts
@@ -1,0 +1,165 @@
+import PQueue from "p-queue";
+import type { BranchInfo, GitHubIssue, GitHubPR } from "@shared/types";
+
+const PREQUERY_CONCURRENCY = 10;
+const PREQUERY_TIMEOUT_MS = 5000;
+
+export interface PlannedWorktree {
+  item: GitHubIssue | GitHubPR;
+  mode: "issue" | "pr";
+  branchName: string;
+  prefix?: string;
+  skipped: boolean;
+  skipReason?: string;
+  headRefName?: string;
+}
+
+export interface PrequeryResult {
+  branch: string;
+  path: string;
+}
+
+export interface PrequeryOptions {
+  rootPath: string;
+  items: PlannedWorktree[];
+  existingBranches: BranchInfo[] | null;
+  getAvailableBranch: (rootPath: string, branchName: string) => Promise<string>;
+  getDefaultPath: (rootPath: string, branchName: string) => Promise<string>;
+  isStaleRun: () => boolean;
+  onProgress?: (completed: number, total: number) => void;
+}
+
+export interface PrequeryOutput {
+  results: Map<number, PrequeryResult>;
+  failedNumbers: Set<number>;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  errorMessage: string
+): Promise<T> {
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]);
+}
+
+function applyUniqueSuffix(branch: string, assignedBranches: Set<string>): string {
+  if (!assignedBranches.has(branch)) {
+    assignedBranches.add(branch);
+    return branch;
+  }
+  let n = 2;
+  while (assignedBranches.has(`${branch}-${n}`)) n++;
+  const uniqueBranch = `${branch}-${n}`;
+  assignedBranches.add(uniqueBranch);
+  return uniqueBranch;
+}
+
+function resolveBranchUniqueness(
+  candidateBranches: Map<number, string>,
+  inputOrder: number[]
+): Map<number, string> {
+  const assignedBranches = new Set<string>();
+  const uniqueBranches = new Map<number, string>();
+
+  for (const itemNumber of inputOrder) {
+    const candidate = candidateBranches.get(itemNumber);
+    if (candidate !== undefined) {
+      uniqueBranches.set(itemNumber, applyUniqueSuffix(candidate, assignedBranches));
+    }
+  }
+
+  return uniqueBranches;
+}
+
+async function resolveIssuePrequeries({
+  rootPath,
+  items,
+  existingBranches: _existingBranches,
+  getAvailableBranch,
+  getDefaultPath,
+  isStaleRun,
+  onProgress,
+}: PrequeryOptions): Promise<PrequeryOutput> {
+  const issueItems = items.filter((p) => p.mode === "issue" && !p.skipped);
+  const inputOrder = issueItems.map((p) => p.item.number);
+
+  if (inputOrder.length === 0) {
+    return { results: new Map(), failedNumbers: new Set() };
+  }
+
+  const results = new Map<number, PrequeryResult>();
+  const failedNumbers = new Set<number>();
+
+  const branchQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
+  const candidateBranches = new Map<number, string>();
+  const branchErrors = new Array<{ number: number; error: Error }>();
+
+  const branchPromises = issueItems.map((planned) =>
+    branchQueue.add(async () => {
+      if (isStaleRun()) return;
+      try {
+        const branch = await withTimeout(
+          getAvailableBranch(rootPath, planned.branchName),
+          PREQUERY_TIMEOUT_MS,
+          `Prequery timeout for branch lookup on issue #${planned.item.number}`
+        );
+        candidateBranches.set(planned.item.number, branch);
+      } catch (err) {
+        branchErrors.push({
+          number: planned.item.number,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      }
+    })
+  );
+
+  await Promise.all(branchPromises);
+  if (isStaleRun()) return { results, failedNumbers };
+
+  for (const { number, error: _ } of branchErrors) {
+    failedNumbers.add(number);
+  }
+
+  const uniqueBranches = resolveBranchUniqueness(candidateBranches, inputOrder);
+
+  const pathQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
+  const pathErrors = new Array<{ number: number; error: Error }>();
+
+  const pathPromises = inputOrder
+    .filter((n) => !failedNumbers.has(n) && uniqueBranches.has(n))
+    .map((itemNumber) =>
+      pathQueue.add(async () => {
+        if (isStaleRun()) return;
+        const branch = uniqueBranches.get(itemNumber)!;
+        try {
+          const path = await withTimeout(
+            getDefaultPath(rootPath, branch),
+            PREQUERY_TIMEOUT_MS,
+            `Prequery timeout for path lookup on issue #${itemNumber}`
+          );
+          results.set(itemNumber, { branch, path });
+        } catch (err) {
+          pathErrors.push({
+            number: itemNumber,
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
+      })
+    );
+
+  await Promise.all(pathPromises);
+  if (isStaleRun()) return { results, failedNumbers };
+
+  for (const { number, error: _ } of pathErrors) {
+    failedNumbers.add(number);
+  }
+
+  onProgress?.(results.size, inputOrder.length);
+
+  return { results, failedNumbers };
+}
+
+export { resolveIssuePrequeries };


### PR DESCRIPTION
## Summary
The prequery pass in bulk worktree creation now runs in parallel instead of serially. For a 20-item batch, this reduces the waiting time from 2-4s down to roughly the slowest single prequery.

The change extracts the prequery logic into a dedicated module that resolves branch names and default paths concurrently across all items, while preserving the existing de-duplication behaviour for branch names.

Resolves #5603

## Changes
- Extracted prequery logic from BulkCreateWorktreeDialog into a new bulkCreatePrequery module
- Made getAvailableBranch and getDefaultPath calls run concurrently within each item
- Made prequeries run concurrently across all items using Promise.all
- Added comprehensive unit tests for the parallel prequery logic
- Preserved the existing branch-name uniqueness de-duplication behaviour

## Testing
- Unit tests cover the parallel prequery logic including branch name de-duplication
- Manual testing with 20-item batches confirms the parallel behaviour
- Edge cases handled: duplicate PRs, conflicting branch names, error propagation