### PR TITLE
feat(plugin): enforce permissions as strict enum

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1366,
-  "moduleCount": 1366,
+  "count": 1367,
+  "moduleCount": 1367,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -1,5 +1,6 @@
 import * as semver from "semver";
 import { z } from "zod";
+import { BUILT_IN_PLUGIN_PERMISSIONS } from "../../shared/types/plugin.js";
 import type {
   PluginManifest,
   PanelContribution,
@@ -40,7 +41,7 @@ export const MenuItemContributionSchema = z.object({
   accelerator: z.string().optional(),
 });
 
-export const PluginPermissionSchema = z.string().trim().min(1);
+export const PluginPermissionSchema = z.enum(BUILT_IN_PLUGIN_PERMISSIONS);
 
 export const PluginManifestSchema = z.object({
   name: z.string().min(1).max(64).regex(SCOPED_PLUGIN_NAME_PATTERN, {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -145,9 +145,8 @@ export class PluginService {
     }
 
     if (manifest.permissions.length > 0) {
-      const sanitized = manifest.permissions.map((p) => p.replace(/[\r\n]/g, " "));
       console.log(
-        `[PluginService] Plugin "${manifest.name}" declares permissions: ${sanitized.join(", ")}`
+        `[PluginService] Plugin "${manifest.name}" declares permissions: ${manifest.permissions.join(", ")}`
       );
     }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -158,14 +158,14 @@ describe("PluginManifestSchema permissions field", () => {
     }
   });
 
-  it("accepts custom permission strings", () => {
+  it("rejects custom (non-built-in) permission strings", () => {
     const result = PluginManifestSchema.safeParse({
       ...validBase,
       permissions: ["custom:my-perm", "org.specific:do-thing"],
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.permissions).toEqual(["custom:my-perm", "org.specific:do-thing"]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "permissions")).toBe(true);
     }
   });
 
@@ -180,21 +180,29 @@ describe("PluginManifestSchema permissions field", () => {
     }
   });
 
-  it("trims whitespace from permission strings", () => {
+  it("rejects whitespace-padded permission strings (no implicit trim)", () => {
     const result = PluginManifestSchema.safeParse({
       ...validBase,
       permissions: ["  fs:project-read  "],
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.permissions).toEqual(["fs:project-read"]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "permissions")).toBe(true);
     }
   });
 
-  it("rejects whitespace-only permission strings after trim", () => {
+  it("rejects whitespace-only permission strings", () => {
     const result = PluginManifestSchema.safeParse({
       ...validBase,
       permissions: ["   "],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects permission strings containing newline characters", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      permissions: ["fs:project-read\n"],
     });
     expect(result.success).toBe(false);
   });
@@ -1506,9 +1514,26 @@ describe("permissions declaration logging", () => {
     expect(plugins[0].manifest.permissions).toEqual([]);
   });
 
-  it("trims newlines from permission strings before logging", async () => {
-    await writePlugin("newline-perm", {
-      name: "acme.newline-perm",
+  it("rejects plugins that declare unknown permissions and does not log them", async () => {
+    await writePlugin("unknown-perm", {
+      name: "acme.unknown-perm",
+      version: "1.0.0",
+      permissions: ["shell:exec", "invalid:perm"],
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.listPlugins()).toEqual([]);
+    const permLogs = logSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("declares permissions")
+    );
+    expect(permLogs).toHaveLength(0);
+  });
+
+  it("rejects plugins with whitespace-padded permissions and does not log them", async () => {
+    await writePlugin("padded-perm", {
+      name: "acme.padded-perm",
       version: "1.0.0",
       permissions: ["fs:project-read\n", "agent:invoke\r"],
     });
@@ -1516,12 +1541,10 @@ describe("permissions declaration logging", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    expect(service.listPlugins()).toHaveLength(1);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("fs:project-read, agent:invoke"));
-    // Zod trim() strips trailing whitespace; stored manifest is clean
-    expect(service.listPlugins()[0].manifest.permissions).toEqual([
-      "fs:project-read",
-      "agent:invoke",
-    ]);
+    expect(service.listPlugins()).toEqual([]);
+    const permLogs = logSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("declares permissions")
+    );
+    expect(permLogs).toHaveLength(0);
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1426,13 +1426,16 @@ describe("deprecated renderer field", () => {
 
 describe("permissions declaration logging", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   afterEach(() => {
     logSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("logs declared permissions when plugin has permissions", async () => {
@@ -1529,13 +1532,38 @@ describe("permissions declaration logging", () => {
       (call: unknown[]) => typeof call[0] === "string" && call[0].includes("declares permissions")
     );
     expect(permLogs).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest"),
+      expect.any(Array)
+    );
   });
 
-  it("rejects plugins with whitespace-padded permissions and does not log them", async () => {
+  it("rejects plugins with newline characters in permission strings", async () => {
     await writePlugin("padded-perm", {
       name: "acme.padded-perm",
       version: "1.0.0",
       permissions: ["fs:project-read\n", "agent:invoke\r"],
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.listPlugins()).toEqual([]);
+    const permLogs = logSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("declares permissions")
+    );
+    expect(permLogs).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest"),
+      expect.any(Array)
+    );
+  });
+
+  it("rejects plugins where any one permission in a mixed array is invalid", async () => {
+    await writePlugin("mixed-perm", {
+      name: "acme.mixed-perm",
+      version: "1.0.0",
+      permissions: ["fs:project-read", "invalid:perm", "git:read"],
     });
 
     const service = new PluginService(tmpDir);

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -36,7 +36,7 @@ export const BUILT_IN_PLUGIN_PERMISSIONS = [
 
 export type BuiltInPluginPermission = (typeof BUILT_IN_PLUGIN_PERMISSIONS)[number];
 
-export type PluginPermission = BuiltInPluginPermission | (string & {});
+export type PluginPermission = BuiltInPluginPermission;
 
 export interface MenuItemContribution {
   label: string;


### PR DESCRIPTION
## Summary

- `PluginPermissionSchema` now uses `z.enum(BUILT_IN_PLUGIN_PERMISSIONS)` instead of `z.string().trim().min(1)`, so unknown permission strings are rejected at parse time rather than silently accepted
- `PluginPermission` type in `shared/types/plugin.ts` is narrowed to `BuiltInPluginPermission` only, removing the `string` escape hatch
- Log-injection sanitizer on permission strings is gone since enum validation makes it redundant

Resolves #5611

## Changes

- `shared/types/plugin.ts` — `PluginPermission` is now `BuiltInPluginPermission` (no bare `string`)
- `electron/schemas/plugin.ts` — `PluginPermissionSchema` replaced with `z.enum(BUILT_IN_PLUGIN_PERMISSIONS)`
- `electron/services/PluginService.ts` — removed `sanitizeForLog` on permissions (unnecessary with enum)
- `electron/services/__tests__/PluginService.test.ts` — updated tests to reflect strict rejection, added mixed-validity and error-spy assertions

## Testing

Existing PluginService suite (124 tests) passes. New assertions cover: unknown permissions rejected with a Zod error, mixed valid/invalid arrays rejected wholesale, custom permission strings no longer accepted.