### PR TITLE
feat(settings): add Import .env paste flow to env var editor

### DIFF
--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Eye, EyeOff, Plus, RotateCcw, X } from "lucide-react";
+import { Eye, EyeOff, Plus, RotateCcw, Upload, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { looksLikeSecret } from "@/utils/secretDetection";
 import { isSensitiveEnvKey } from "../../../shared/utils/envVars";
+import { ImportEnvDialog } from "./ImportEnvDialog";
 
 /**
  * Inline env var CRUD editor with validation and optional inheritance.
@@ -174,6 +175,7 @@ export function EnvVarEditor({
   const [revealedRows, setRevealedRows] = useState<Set<string>>(() => new Set());
   // When non-null, the focus-recovery effect focuses the key input for that rowId.
   const [pendingFocusKey, setPendingFocusKey] = useState<string | null>(null);
+  const [isImportOpen, setIsImportOpen] = useState(false);
   const lastEnvRef = useRef<Record<string, string>>(env);
   const lastInheritedRef = useRef<Record<string, string> | undefined>(inheritedEnv);
   const lastContextKeyRef = useRef<string | undefined>(contextKey);
@@ -386,6 +388,20 @@ export function EnvVarEditor({
     else keyInputRefs.current.delete(rowId);
   }, []);
 
+  const handleImportConfirm = useCallback(
+    (mergedEnv: Record<string, string>) => {
+      // Imports always commit the merged map directly — the parent re-seeds
+      // `rows` through the reseed effect when its source-of-truth env changes.
+      // We update `lastEnvRef` so the reseed effect treats this as a committed
+      // change rather than an external reset that would stomp in-progress edits.
+      lastEnvRef.current = mergedEnv;
+      setRows(envToDraft(mergedEnv));
+      setTouchedKeys({});
+      onChange(mergedEnv);
+    },
+    [onChange]
+  );
+
   const duplicateKeys = findDuplicateKeys(rows);
   const isEmpty = rows.length === 0;
 
@@ -409,15 +425,26 @@ export function EnvVarEditor({
       </div>
       {/* Body */}
       {isEmpty ? (
-        <button
-          type="button"
-          onClick={handleAdd}
-          className="w-full flex items-center justify-center gap-1.5 py-4 text-[12px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 m-2 rounded-[var(--radius-sm)]"
-          data-testid="env-editor-add"
-        >
-          <Plus size={12} aria-hidden="true" />
-          <span>Add your first variable</span>
-        </button>
+        <div className="m-2 flex flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="w-full flex items-center justify-center gap-1.5 py-4 text-[12px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 rounded-[var(--radius-sm)]"
+            data-testid="env-editor-add"
+          >
+            <Plus size={12} aria-hidden="true" />
+            <span>Add your first variable</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsImportOpen(true)}
+            className="w-full flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors rounded-[var(--radius-sm)]"
+            data-testid="env-editor-import"
+          >
+            <Upload size={12} aria-hidden="true" />
+            <span>Import .env</span>
+          </button>
+        </div>
       ) : (
         <div className="divide-y divide-daintree-border">
           {rows.map((row) => {
@@ -609,16 +636,33 @@ export function EnvVarEditor({
       )}
       {/* Add row (only when non-empty — empty state has its own affordance) */}
       {!isEmpty && (
-        <button
-          type="button"
-          onClick={handleAdd}
-          className="w-full flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors border-t border-daintree-border"
-          data-testid="env-editor-add"
-        >
-          <Plus size={12} aria-hidden="true" />
-          <span>Add variable</span>
-        </button>
+        <div className="grid grid-cols-2 divide-x divide-daintree-border border-t border-daintree-border">
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors"
+            data-testid="env-editor-add"
+          >
+            <Plus size={12} aria-hidden="true" />
+            <span>Add variable</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setIsImportOpen(true)}
+            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors"
+            data-testid="env-editor-import"
+          >
+            <Upload size={12} aria-hidden="true" />
+            <span>Import .env</span>
+          </button>
+        </div>
       )}
+      <ImportEnvDialog
+        isOpen={isImportOpen}
+        onClose={() => setIsImportOpen(false)}
+        env={env}
+        onImport={handleImportConfirm}
+      />
     </div>
   );
 }

--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -390,14 +390,14 @@ export function EnvVarEditor({
 
   const handleImportConfirm = useCallback(
     (mergedEnv: Record<string, string>) => {
-      // Imports always commit the merged map directly — the parent re-seeds
-      // `rows` through the reseed effect when its source-of-truth env changes.
-      // We update `lastEnvRef` so the reseed effect treats this as a committed
-      // change rather than an external reset that would stomp in-progress edits.
+      // Imports commit the merged map as the new source of truth. Bump the
+      // parent first, then sync local draft + lastEnvRef so the reseed effect
+      // sees the prop and ref already aligned (no stomp on the optimistic
+      // rows) and so a thrown onChange leaves local state untouched.
+      onChange(mergedEnv);
       lastEnvRef.current = mergedEnv;
       setRows(envToDraft(mergedEnv));
       setTouchedKeys({});
-      onChange(mergedEnv);
     },
     [onChange]
   );

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { parseEnvPaste, type ParseEnvResult } from "@/utils/parseEnvPaste";
+
+type ConflictResolution = "keep" | "overwrite";
+type Step = "paste" | "conflicts";
+
+interface Conflict {
+  key: string;
+  oldValue: string;
+  newValue: string;
+}
+
+interface ImportEnvDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  env: Record<string, string>;
+  onImport: (merged: Record<string, string>) => void;
+}
+
+function collapsePairs(result: ParseEnvResult): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const p of result.pairs) out[p.key] = p.value; // later duplicates win
+  return out;
+}
+
+function findConflicts(env: Record<string, string>, incoming: Record<string, string>): Conflict[] {
+  const out: Conflict[] = [];
+  for (const [key, newValue] of Object.entries(incoming)) {
+    if (Object.prototype.hasOwnProperty.call(env, key) && env[key] !== newValue) {
+      out.push({ key, oldValue: env[key] ?? "", newValue });
+    }
+  }
+  return out;
+}
+
+function buildMerged(
+  env: Record<string, string>,
+  incoming: Record<string, string>,
+  mode: ConflictResolution
+): Record<string, string> {
+  if (mode === "overwrite") {
+    return { ...env, ...incoming };
+  }
+  // keep existing — only add keys not present.
+  const merged = { ...env };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (!Object.prototype.hasOwnProperty.call(merged, key)) merged[key] = value;
+  }
+  return merged;
+}
+
+export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDialogProps) {
+  const [pastedText, setPastedText] = useState("");
+  const [step, setStep] = useState<Step>("paste");
+  const [conflictResolution, setConflictResolution] = useState<ConflictResolution>("keep");
+
+  // Single reset effect keyed on [isOpen] — avoids the split-effect trap from #4958.
+  useEffect(() => {
+    if (isOpen) {
+      setPastedText("");
+      setStep("paste");
+      setConflictResolution("keep");
+    }
+  }, [isOpen]);
+
+  const parsed = useMemo(() => parseEnvPaste(pastedText), [pastedText]);
+  const incoming = useMemo(() => collapsePairs(parsed), [parsed]);
+  const conflicts = useMemo(() => findConflicts(env, incoming), [env, incoming]);
+
+  const incomingCount = Object.keys(incoming).length;
+  const newCount = incomingCount - conflicts.length;
+  const hasErrors = parsed.errors.length > 0;
+  const canProceed = !hasErrors && incomingCount > 0;
+
+  const handleImport = (mode: ConflictResolution) => {
+    onImport(buildMerged(env, incoming, mode));
+    onClose();
+  };
+
+  const handlePrimary = () => {
+    if (!canProceed) return;
+    if (step === "paste") {
+      if (conflicts.length > 0) {
+        setStep("conflicts");
+        return;
+      }
+      handleImport("overwrite");
+      return;
+    }
+    handleImport(conflictResolution);
+  };
+
+  const primaryLabel =
+    step === "conflicts"
+      ? conflictResolution === "keep"
+        ? "Import, keep existing"
+        : "Import, overwrite conflicts"
+      : conflicts.length > 0
+        ? `Review ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
+        : incomingCount > 0
+          ? `Import ${incomingCount} variable${incomingCount === 1 ? "" : "s"}`
+          : "Import";
+
+  const secondaryLabel = step === "conflicts" ? "Back" : "Cancel";
+  const handleSecondary = () => {
+    if (step === "conflicts") {
+      setStep("paste");
+      return;
+    }
+    onClose();
+  };
+
+  return (
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="md"
+      zIndex="nested"
+      data-testid="import-env-dialog"
+    >
+      <AppDialog.Header>
+        <AppDialog.Title>Import .env</AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body className="space-y-3">
+        {step === "paste" ? (
+          <>
+            <AppDialog.Description>
+              Paste the contents of a .env file. Keys must match{" "}
+              <code className="text-[11px]">[A-Z_][A-Z0-9_]*</code>. Quoted values, comments, and
+              <code className="text-[11px]"> export</code> prefixes are supported.
+            </AppDialog.Description>
+            <textarea
+              value={pastedText}
+              onChange={(e) => setPastedText(e.target.value)}
+              placeholder={'FOO=bar\nexport BAZ="hello world"\n# comments supported'}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 outline-none focus:ring-2 focus:ring-daintree-accent/40 text-daintree-text"
+              aria-label="Paste .env content"
+              data-testid="import-env-textarea"
+            />
+            {hasErrors && (
+              <div
+                className="rounded-[var(--radius-md)] border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-500"
+                data-testid="import-env-errors"
+              >
+                <div className="flex items-center gap-1.5 font-medium mb-1">
+                  <AlertTriangle size={12} aria-hidden="true" />
+                  <span>
+                    {parsed.errors.length} parse error
+                    {parsed.errors.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <ul className="space-y-0.5 font-mono text-[11px]">
+                  {parsed.errors.map((e) => (
+                    <li key={`${e.line}-${e.raw}`}>
+                      <span className="text-amber-500/70">Line {e.line}:</span> {e.reason}
+                      {e.raw.trim() !== "" && (
+                        <span className="text-daintree-text/50"> — {e.raw}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {!hasErrors && incomingCount > 0 && (
+              <p className="text-[11px] text-daintree-text/50" data-testid="import-env-summary">
+                {incomingCount} variable{incomingCount === 1 ? "" : "s"} detected
+                {conflicts.length > 0
+                  ? ` · ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
+                  : ""}
+                {newCount > 0 && conflicts.length > 0 ? ` · ${newCount} new` : ""}
+              </p>
+            )}
+          </>
+        ) : (
+          <>
+            <AppDialog.Description>
+              {conflicts.length} key{conflicts.length === 1 ? "" : "s"} already exist
+              {conflicts.length === 1 ? "s" : ""}. Choose how to merge.
+            </AppDialog.Description>
+            <fieldset className="space-y-2">
+              <legend className="sr-only">Conflict resolution</legend>
+              <ConflictOption
+                checked={conflictResolution === "keep"}
+                onChange={() => setConflictResolution("keep")}
+                label="Keep existing"
+                description="Only add new keys — leave colliding values untouched."
+                testId="import-env-mode-keep"
+              />
+              <ConflictOption
+                checked={conflictResolution === "overwrite"}
+                onChange={() => setConflictResolution("overwrite")}
+                label="Overwrite conflicts"
+                description="Replace colliding values with the pasted ones."
+                testId="import-env-mode-overwrite"
+              />
+            </fieldset>
+            <div
+              className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden"
+              data-testid="import-env-conflict-list"
+            >
+              <div className="bg-daintree-bg/40 px-3 py-1.5 text-[10px] uppercase tracking-wide text-daintree-text/50 border-b border-daintree-border">
+                Conflicts ({conflicts.length})
+              </div>
+              <ul className="max-h-48 overflow-y-auto divide-y divide-daintree-border/60">
+                {conflicts.map((c) => (
+                  <li key={c.key} className="px-3 py-1.5 font-mono text-[11px]">
+                    <div className="text-daintree-text/80">{c.key}</div>
+                    <div className="text-daintree-text/50">
+                      <span className="line-through">{c.oldValue || "(empty)"}</span>
+                      <span className="mx-1.5">→</span>
+                      <span className="text-daintree-accent">{c.newValue || "(empty)"}</span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </AppDialog.Body>
+
+      <AppDialog.Footer
+        secondaryAction={{ label: secondaryLabel, onClick: handleSecondary }}
+        primaryAction={{
+          label: primaryLabel,
+          onClick: handlePrimary,
+          disabled: !canProceed,
+        }}
+      />
+    </AppDialog>
+  );
+}
+
+function ConflictOption({
+  checked,
+  onChange,
+  label,
+  description,
+  testId,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  description: string;
+  testId: string;
+}) {
+  return (
+    <label className="flex items-start gap-3 cursor-pointer group">
+      <input
+        type="radio"
+        name="import-env-conflict-mode"
+        checked={checked}
+        onChange={onChange}
+        className="mt-0.5 shrink-0 accent-daintree-accent"
+        data-testid={testId}
+      />
+      <div>
+        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-accent transition-colors">
+          {label}
+        </span>
+        <p className="text-xs text-daintree-text/40">{description}</p>
+      </div>
+    </label>
+  );
+}

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -73,6 +73,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
   const newCount = incomingCount - conflicts.length;
   const hasErrors = parsed.errors.length > 0;
   const canProceed = !hasErrors && incomingCount > 0;
+  const duplicateInPasteCount = parsed.pairs.length - incomingCount;
 
   const handleImport = (mode: ConflictResolution) => {
     onImport(buildMerged(env, incoming, mode));
@@ -130,8 +131,8 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
           <>
             <AppDialog.Description>
               Paste the contents of a .env file. Keys must match{" "}
-              <code className="text-[11px]">[A-Z_][A-Z0-9_]*</code>. Quoted values, comments, and
-              <code className="text-[11px]"> export</code> prefixes are supported.
+              <code className="text-[11px]">[A-Za-z_][A-Za-z0-9_]*</code>. Quoted values, comments,
+              and <code className="text-[11px]">export</code> prefixes are supported.
             </AppDialog.Description>
             <textarea
               value={pastedText}
@@ -175,6 +176,9 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                   ? ` · ${conflicts.length} conflict${conflicts.length === 1 ? "" : "s"}`
                   : ""}
                 {newCount > 0 && conflicts.length > 0 ? ` · ${newCount} new` : ""}
+                {duplicateInPasteCount > 0
+                  ? ` · ${duplicateInPasteCount} duplicate key${duplicateInPasteCount === 1 ? "" : "s"} in paste (last value kept)`
+                  : ""}
               </p>
             )}
           </>

--- a/src/components/Settings/__tests__/EnvVarEditor.test.tsx
+++ b/src/components/Settings/__tests__/EnvVarEditor.test.tsx
@@ -718,6 +718,41 @@ describe("EnvVarEditor", () => {
       expect(screen.getByTestId("env-editor-warning-secret")).toBeTruthy();
     });
 
+    it("same-value paste is NOT flagged as a conflict", () => {
+      renderEditor({ FOO: "bar" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "FOO=bar\nBAZ=baz" },
+      });
+
+      const primary = screen.getByTestId("app-dialog-primary") as HTMLButtonElement;
+      // No conflict — primary should be direct Import, not Review.
+      expect(primary.textContent).toMatch(/Import/);
+      expect(primary.textContent).not.toMatch(/conflict/i);
+      fireEvent.click(primary);
+
+      expect(onChange).toHaveBeenLastCalledWith({ FOO: "bar", BAZ: "baz" });
+    });
+
+    it("duplicate keys within the paste collapse with last-value-wins", () => {
+      renderEditor({ API_KEY: "old" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "API_KEY=one\nAPI_KEY=two" },
+      });
+
+      // Summary should note the collapsed duplicate.
+      expect(screen.getByTestId("import-env-summary").textContent).toMatch(/duplicate key/i);
+
+      // Advance to conflict step and overwrite.
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+      fireEvent.click(screen.getByTestId("import-env-mode-overwrite"));
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      // Last-value-wins → "two", not "one".
+      expect(onChange).toHaveBeenLastCalledWith({ API_KEY: "two" });
+    });
+
     it("Back button from conflict step returns to paste step preserving text", () => {
       renderEditor({ FOO: "old" });
       fireEvent.click(screen.getByTestId("env-editor-import"));

--- a/src/components/Settings/__tests__/EnvVarEditor.test.tsx
+++ b/src/components/Settings/__tests__/EnvVarEditor.test.tsx
@@ -11,8 +11,9 @@
  *  - Removing a row commits the updated env immediately.
  *  - Renaming a key commits only when the new name is non-empty and unique.
  */
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { EnvVarEditor } from "../EnvVarEditor";
 
 vi.mock("lucide-react", () => ({
@@ -21,7 +22,66 @@ vi.mock("lucide-react", () => ({
   EyeOff: () => <span data-testid="eye-off-icon" />,
   Plus: () => <span data-testid="plus-icon" />,
   RotateCcw: () => <span data-testid="rotate-ccw-icon" />,
+  Upload: () => <span data-testid="upload-icon" />,
+  AlertTriangle: () => <span data-testid="alert-triangle-icon" />,
 }));
+
+interface DialogAction {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({
+    children,
+    isOpen,
+    "data-testid": testId,
+  }: {
+    children: React.ReactNode;
+    isOpen: boolean;
+    onClose?: () => void;
+    size?: string;
+    zIndex?: string;
+    "data-testid"?: string;
+  }) => (isOpen ? <div data-testid={testId ?? "app-dialog"}>{children}</div> : null);
+  Dialog.Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Title = ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>;
+  Dialog.CloseButton = () => <button type="button" aria-label="Close dialog" />;
+  Dialog.Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Description = ({ children }: { children: React.ReactNode }) => <p>{children}</p>;
+  Dialog.Footer = ({
+    primaryAction,
+    secondaryAction,
+  }: {
+    primaryAction?: DialogAction;
+    secondaryAction?: DialogAction;
+  }) => (
+    <div>
+      {secondaryAction && (
+        <button
+          type="button"
+          onClick={secondaryAction.onClick}
+          disabled={secondaryAction.disabled}
+          data-testid="app-dialog-secondary"
+        >
+          {secondaryAction.label}
+        </button>
+      )}
+      {primaryAction && (
+        <button
+          type="button"
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled}
+          data-testid="app-dialog-primary"
+        >
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+  return { AppDialog: Dialog };
+});
 
 describe("EnvVarEditor", () => {
   let onChange: ReturnType<typeof vi.fn<(env: Record<string, string>) => void>>;
@@ -501,6 +561,179 @@ describe("EnvVarEditor", () => {
       expect(onChange.mock.calls.length).toBe(commitsBeforeRerender);
       const valueInput = getAllByTestId("env-editor-value")[0] as HTMLInputElement;
       expect(valueInput.disabled).toBe(false); // still an override, not reseeded back to inherited
+    });
+  });
+
+  describe("Import .env flow", () => {
+    it("renders Import button in the empty state", () => {
+      renderEditor({});
+      expect(screen.getByTestId("env-editor-import")).toBeTruthy();
+    });
+
+    it("renders Import button in the non-empty toolbar", () => {
+      renderEditor({ FOO: "bar" });
+      expect(screen.getByTestId("env-editor-import")).toBeTruthy();
+    });
+
+    it("clicking Import opens the dialog", () => {
+      renderEditor({ FOO: "bar" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      expect(screen.getByTestId("import-env-dialog")).toBeTruthy();
+      expect(screen.getByTestId("import-env-textarea")).toBeTruthy();
+    });
+
+    it("parse errors block the confirm button and surface the error block", () => {
+      renderEditor({});
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      const textarea = screen.getByTestId("import-env-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "NOT_A_PAIR" } });
+
+      expect(screen.getByTestId("import-env-errors")).toBeTruthy();
+      const primary = screen.getByTestId("app-dialog-primary") as HTMLButtonElement;
+      expect(primary.disabled).toBe(true);
+    });
+
+    it("no-conflict import merges additively and calls onChange", () => {
+      renderEditor({ EXISTING: "keep" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      const textarea = screen.getByTestId("import-env-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "NEW_ONE=1\nNEW_TWO=2" } });
+
+      const primary = screen.getByTestId("app-dialog-primary") as HTMLButtonElement;
+      expect(primary.disabled).toBe(false);
+      expect(primary.textContent).toMatch(/Import 2/);
+      fireEvent.click(primary);
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        EXISTING: "keep",
+        NEW_ONE: "1",
+        NEW_TWO: "2",
+      });
+      // Dialog closes after import
+      expect(screen.queryByTestId("import-env-dialog")).toBeNull();
+    });
+
+    it("conflicting import advances to conflict step and 'keep existing' preserves old values", () => {
+      renderEditor({ EXISTING: "old", OTHER: "untouched" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "EXISTING=new\nBRAND_NEW=fresh" },
+      });
+
+      const primary = screen.getByTestId("app-dialog-primary") as HTMLButtonElement;
+      expect(primary.textContent).toMatch(/Review 1 conflict/);
+      fireEvent.click(primary);
+
+      // Now on the conflict step — "keep" is the default.
+      expect(screen.getByTestId("import-env-conflict-list")).toBeTruthy();
+      const confirm = screen.getByTestId("app-dialog-primary") as HTMLButtonElement;
+      expect(confirm.textContent).toMatch(/Import, keep existing/);
+      fireEvent.click(confirm);
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        EXISTING: "old",
+        OTHER: "untouched",
+        BRAND_NEW: "fresh",
+      });
+    });
+
+    it("'overwrite conflicts' replaces colliding values", () => {
+      renderEditor({ EXISTING: "old" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "EXISTING=new" },
+      });
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      // Switch to overwrite mode.
+      fireEvent.click(screen.getByTestId("import-env-mode-overwrite"));
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      expect(onChange).toHaveBeenLastCalledWith({ EXISTING: "new" });
+    });
+
+    it("imported rows appear in the editor after merge (controlled parent)", () => {
+      function Controlled() {
+        const [env, setEnv] = useState<Record<string, string>>({});
+        return (
+          <EnvVarEditor
+            env={env}
+            onChange={(next) => {
+              onChange(next);
+              setEnv(next);
+            }}
+          />
+        );
+      }
+      const { getAllByTestId } = render(<Controlled />);
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: 'FOO=bar\nBAZ="hello world"' },
+      });
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      const keyInputs = getAllByTestId("env-editor-key") as HTMLInputElement[];
+      expect(keyInputs.map((el) => el.value).sort()).toEqual(["BAZ", "FOO"]);
+      const valueInputs = getAllByTestId("env-editor-value") as HTMLInputElement[];
+      expect(valueInputs.some((el) => el.value === "hello world")).toBe(true);
+    });
+
+    it("closing and reopening the dialog clears the textarea", () => {
+      renderEditor({});
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      const first = screen.getByTestId("import-env-textarea") as HTMLTextAreaElement;
+      fireEvent.change(first, { target: { value: "FOO=bar" } });
+      expect(first.value).toBe("FOO=bar");
+
+      // Cancel closes the dialog.
+      fireEvent.click(screen.getByTestId("app-dialog-secondary"));
+      expect(screen.queryByTestId("import-env-dialog")).toBeNull();
+
+      // Reopening yields a fresh empty textarea.
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      const second = screen.getByTestId("import-env-textarea") as HTMLTextAreaElement;
+      expect(second.value).toBe("");
+    });
+
+    it("imported value that looks like a secret triggers the row warning (controlled parent)", () => {
+      function Controlled() {
+        const [env, setEnv] = useState<Record<string, string>>({});
+        return (
+          <EnvVarEditor
+            env={env}
+            onChange={(next) => {
+              onChange(next);
+              setEnv(next);
+            }}
+          />
+        );
+      }
+      render(<Controlled />);
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz123456" },
+      });
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      expect(screen.getByTestId("env-editor-warning-secret")).toBeTruthy();
+    });
+
+    it("Back button from conflict step returns to paste step preserving text", () => {
+      renderEditor({ FOO: "old" });
+      fireEvent.click(screen.getByTestId("env-editor-import"));
+      fireEvent.change(screen.getByTestId("import-env-textarea"), {
+        target: { value: "FOO=new" },
+      });
+      fireEvent.click(screen.getByTestId("app-dialog-primary"));
+
+      // On conflict step — secondary is "Back".
+      const back = screen.getByTestId("app-dialog-secondary") as HTMLButtonElement;
+      expect(back.textContent).toBe("Back");
+      fireEvent.click(back);
+
+      // Paste step with retained text.
+      const textarea = screen.getByTestId("import-env-textarea") as HTMLTextAreaElement;
+      expect(textarea.value).toBe("FOO=new");
     });
   });
 });

--- a/src/utils/__tests__/parseEnvPaste.test.ts
+++ b/src/utils/__tests__/parseEnvPaste.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { parseEnvPaste } from "../parseEnvPaste";
+
+describe("parseEnvPaste", () => {
+  it("returns empty result for empty input", () => {
+    const result = parseEnvPaste("");
+    expect(result.pairs).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("parses a simple KEY=VALUE", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=bar");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("parses multiple lines", () => {
+    const { pairs, errors } = parseEnvPaste("A=1\nB=2\nC=3");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "A", value: "1" },
+      { key: "B", value: "2" },
+      { key: "C", value: "3" },
+    ]);
+  });
+
+  it("normalizes CRLF to LF", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=bar\r\nBAZ=qux\r\n");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("strips UTF-8 BOM from start of input", () => {
+    const { pairs, errors } = parseEnvPaste("\uFEFFFOO=bar");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("skips blank and whitespace-only lines", () => {
+    const { pairs, errors } = parseEnvPaste("\nFOO=bar\n   \n\nBAZ=qux\n");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("skips # comment lines", () => {
+    const { pairs, errors } = parseEnvPaste("# comment\nFOO=bar\n  # indented comment\nBAZ=qux");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("accepts export prefix", () => {
+    const { pairs, errors } = parseEnvPaste("export FOO=bar\nexport BAZ=qux");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+  });
+
+  it("splits on the first '=' only", () => {
+    const { pairs, errors } = parseEnvPaste("URL=https://example.com/?q=1&r=2");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "URL", value: "https://example.com/?q=1&r=2" }]);
+  });
+
+  it("strips double quotes and processes escape sequences", () => {
+    const { pairs, errors } = parseEnvPaste(
+      'FOO="hello\\nworld"\nBAR="tab\\there"\nBAZ="back\\\\slash"'
+    );
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "hello\nworld" },
+      { key: "BAR", value: "tab\there" },
+      { key: "BAZ", value: "back\\slash" },
+    ]);
+  });
+
+  it("preserves escaped double quote inside double-quoted values", () => {
+    const { pairs, errors } = parseEnvPaste('MSG="she said \\"hi\\""');
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "MSG", value: 'she said "hi"' }]);
+  });
+
+  it("treats single-quoted values as literal (no escape processing)", () => {
+    const { pairs, errors } = parseEnvPaste("FOO='hello\\nworld'");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "hello\\nworld" }]);
+  });
+
+  it("strips inline comment when # is preceded by whitespace", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=bar # trailing comment");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("does NOT strip # when not preceded by whitespace", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=bar#notcomment");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar#notcomment" }]);
+  });
+
+  it("does not strip inline comment from quoted values", () => {
+    const { pairs, errors } = parseEnvPaste('FOO="bar # not a comment"');
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar # not a comment" }]);
+  });
+
+  it("allows empty value", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "" }]);
+  });
+
+  it("surfaces lines with no '=' as parse errors", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=bar\nNOT_A_PAIR\nBAZ=qux");
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.line).toBe(2);
+    expect(errors[0]!.raw).toBe("NOT_A_PAIR");
+  });
+
+  it("surfaces invalid keys as parse errors", () => {
+    const { pairs, errors } = parseEnvPaste("1INVALID=bad\nFOO-BAR=bad\nGOOD=ok");
+    expect(pairs).toEqual([{ key: "GOOD", value: "ok" }]);
+    expect(errors).toHaveLength(2);
+    expect(errors.map((e) => e.line)).toEqual([1, 2]);
+  });
+
+  it("surfaces empty key after export prefix as parse error", () => {
+    const { pairs, errors } = parseEnvPaste("export =value");
+    expect(pairs).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.line).toBe(1);
+  });
+
+  it("surfaces unterminated double quote as parse error", () => {
+    const { pairs, errors } = parseEnvPaste('FOO="unterminated');
+    expect(pairs).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.reason).toMatch(/unterminated/i);
+  });
+
+  it("surfaces unterminated single quote as parse error", () => {
+    const { pairs, errors } = parseEnvPaste("FOO='unterminated");
+    expect(pairs).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+
+  it("uses absolute line numbers (not skipping blanks/comments)", () => {
+    const input = ["# header", "", "FOO=bar", "", "NOT_A_PAIR", "BAZ=qux"].join("\n");
+    const { pairs, errors } = parseEnvPaste(input);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "bar" },
+      { key: "BAZ", value: "qux" },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.line).toBe(5);
+  });
+
+  it("keeps duplicate keys in pairs list (UI resolves the merge strategy)", () => {
+    const { pairs, errors } = parseEnvPaste("FOO=one\nFOO=two");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "FOO", value: "one" },
+      { key: "FOO", value: "two" },
+    ]);
+  });
+
+  it("handles whitespace around key and value", () => {
+    const { pairs, errors } = parseEnvPaste("  FOO = bar  ");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("returns zero pairs for comment-only input", () => {
+    const { pairs, errors } = parseEnvPaste("# just a comment\n# and another");
+    expect(pairs).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/utils/__tests__/parseEnvPaste.test.ts
+++ b/src/utils/__tests__/parseEnvPaste.test.ts
@@ -189,4 +189,41 @@ describe("parseEnvPaste", () => {
     expect(pairs).toEqual([]);
     expect(errors).toEqual([]);
   });
+
+  it("preserves unknown escape sequences (backslash stays)", () => {
+    const { pairs, errors } = parseEnvPaste('RAW="keep \\q as-is"\nP="C:\\foo\\bar"');
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "RAW", value: "keep \\q as-is" },
+      { key: "P", value: "C:\\foo\\bar" },
+    ]);
+  });
+
+  it("allows trailing comment after a double-quoted value", () => {
+    const { pairs, errors } = parseEnvPaste('FOO="bar" # from staging');
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("allows trailing comment after a single-quoted value", () => {
+    const { pairs, errors } = parseEnvPaste("FOO='bar' # note");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([{ key: "FOO", value: "bar" }]);
+  });
+
+  it("rejects unquoted text after a closing quote", () => {
+    const { pairs, errors } = parseEnvPaste('FOO="bar" trailing');
+    expect(pairs).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.reason).toMatch(/after closing quote/i);
+  });
+
+  it("accepts lowercase and mixed-case keys", () => {
+    const { pairs, errors } = parseEnvPaste("node_env=production\nMixedCase=ok");
+    expect(errors).toEqual([]);
+    expect(pairs).toEqual([
+      { key: "node_env", value: "production" },
+      { key: "MixedCase", value: "ok" },
+    ]);
+  });
 });

--- a/src/utils/parseEnvPaste.ts
+++ b/src/utils/parseEnvPaste.ts
@@ -32,7 +32,7 @@ export interface ParseEnvResult {
 const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const EXPORT_RE = /^export\s+/;
 
-function parseDoubleQuoted(body: string): { value: string; ok: boolean } {
+function decodeDoubleQuoted(body: string): string {
   let out = "";
   let i = 0;
   while (i < body.length) {
@@ -56,7 +56,9 @@ function parseDoubleQuoted(body: string): { value: string; ok: boolean } {
           out += '"';
           break;
         default:
-          out += next;
+          // Unknown escape — preserve the backslash so `\q` → `\q`, matching
+          // the way most dotenv parsers (and shell tools) treat the sequence.
+          out += "\\" + next;
           break;
       }
       i += 2;
@@ -65,7 +67,19 @@ function parseDoubleQuoted(body: string): { value: string; ok: boolean } {
     out += ch;
     i += 1;
   }
-  return { value: out, ok: true };
+  return out;
+}
+
+function findUnescapedQuote(body: string, quote: string): number {
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "\\" && quote === '"') {
+      i += 1;
+      continue;
+    }
+    if (ch === quote) return i;
+  }
+  return -1;
 }
 
 function parseValue(raw: string): { value: string; ok: boolean; reason?: string } {
@@ -76,16 +90,19 @@ function parseValue(raw: string): { value: string; ok: boolean; reason?: string 
 
   const first = trimmed[0];
   if (first === '"' || first === "'") {
-    const last = trimmed[trimmed.length - 1];
-    if (trimmed.length < 2 || last !== first) {
+    const rest = trimmed.slice(1);
+    const closeIdx = findUnescapedQuote(rest, first);
+    if (closeIdx === -1) {
       return { value: "", ok: false, reason: "Unterminated quoted value" };
     }
-    const body = trimmed.slice(1, -1);
-    if (first === '"') {
-      const parsed = parseDoubleQuoted(body);
-      return { value: parsed.value, ok: true };
+    const body = rest.slice(0, closeIdx);
+    // Anything after the closing quote must be whitespace or a `# comment`.
+    const tail = rest.slice(closeIdx + 1).trim();
+    if (tail.length > 0 && !tail.startsWith("#")) {
+      return { value: "", ok: false, reason: "Unexpected text after closing quote" };
     }
-    return { value: body, ok: true };
+    const value = first === '"' ? decodeDoubleQuoted(body) : body;
+    return { value, ok: true };
   }
 
   // Unquoted: strip inline comment starting at `#` preceded by whitespace.

--- a/src/utils/parseEnvPaste.ts
+++ b/src/utils/parseEnvPaste.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure parser for pasted dotenv content.
+ *
+ * Supports the canonical subset of the .env format:
+ *  - `KEY=value` and `export KEY=value`
+ *  - `#` comment lines and inline `# comment` after unquoted whitespace
+ *  - `"double quoted"` values with `\n \r \t \\ \"` escape sequences
+ *  - `'single quoted'` values (literal — no escapes)
+ *  - `\r\n` normalization and UTF-8 BOM stripping
+ *
+ * Malformed lines (no `=`, invalid key, unterminated quote) are surfaced as
+ * `{ line, raw }` parse errors so the UI can point the user at the offending
+ * line without hiding data.
+ */
+
+export interface ParsedPair {
+  key: string;
+  value: string;
+}
+
+export interface ParseError {
+  line: number;
+  raw: string;
+  reason: string;
+}
+
+export interface ParseEnvResult {
+  pairs: ParsedPair[];
+  errors: ParseError[];
+}
+
+const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const EXPORT_RE = /^export\s+/;
+
+function parseDoubleQuoted(body: string): { value: string; ok: boolean } {
+  let out = "";
+  let i = 0;
+  while (i < body.length) {
+    const ch = body[i]!;
+    if (ch === "\\" && i + 1 < body.length) {
+      const next = body[i + 1]!;
+      switch (next) {
+        case "n":
+          out += "\n";
+          break;
+        case "r":
+          out += "\r";
+          break;
+        case "t":
+          out += "\t";
+          break;
+        case "\\":
+          out += "\\";
+          break;
+        case '"':
+          out += '"';
+          break;
+        default:
+          out += next;
+          break;
+      }
+      i += 2;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return { value: out, ok: true };
+}
+
+function parseValue(raw: string): { value: string; ok: boolean; reason?: string } {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { value: "", ok: true };
+  }
+
+  const first = trimmed[0];
+  if (first === '"' || first === "'") {
+    const last = trimmed[trimmed.length - 1];
+    if (trimmed.length < 2 || last !== first) {
+      return { value: "", ok: false, reason: "Unterminated quoted value" };
+    }
+    const body = trimmed.slice(1, -1);
+    if (first === '"') {
+      const parsed = parseDoubleQuoted(body);
+      return { value: parsed.value, ok: true };
+    }
+    return { value: body, ok: true };
+  }
+
+  // Unquoted: strip inline comment starting at `#` preceded by whitespace.
+  let end = trimmed.length;
+  for (let i = 0; i < trimmed.length; i++) {
+    if (trimmed[i] === "#" && i > 0 && /\s/.test(trimmed[i - 1]!)) {
+      end = i;
+      break;
+    }
+  }
+  return { value: trimmed.slice(0, end).trim(), ok: true };
+}
+
+export function parseEnvPaste(text: string): ParseEnvResult {
+  const pairs: ParsedPair[] = [];
+  const errors: ParseError[] = [];
+
+  const normalized = text.replace(/^\uFEFF/, "").replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+
+  for (let idx = 0; idx < lines.length; idx++) {
+    const raw = lines[idx]!;
+    const lineNumber = idx + 1;
+    const trimmed = raw.trim();
+
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("#")) continue;
+
+    const withoutExport = trimmed.replace(EXPORT_RE, "");
+    const eqIdx = withoutExport.indexOf("=");
+    if (eqIdx === -1) {
+      errors.push({ line: lineNumber, raw, reason: "Missing '='" });
+      continue;
+    }
+
+    const keyPart = withoutExport.slice(0, eqIdx).trim();
+    const valuePart = withoutExport.slice(eqIdx + 1);
+
+    if (keyPart === "") {
+      errors.push({ line: lineNumber, raw, reason: "Empty key" });
+      continue;
+    }
+    if (!KEY_RE.test(keyPart)) {
+      errors.push({ line: lineNumber, raw, reason: `Invalid key "${keyPart}"` });
+      continue;
+    }
+
+    const parsed = parseValue(valuePart);
+    if (!parsed.ok) {
+      errors.push({ line: lineNumber, raw, reason: parsed.reason ?? "Invalid value" });
+      continue;
+    }
+
+    pairs.push({ key: keyPart, value: parsed.value });
+  }
+
+  return { pairs, errors };
+}


### PR DESCRIPTION
## Summary

- Adds a Vercel-style "Import .env" flow to the env var editor: a button in both the empty state and the non-empty toolbar opens a modal where you can paste raw dotenv content
- Parses standard dotenv syntax (bare values, quoted values, `export` prefix, comments, blank lines) and surfaces parse errors with line numbers before allowing import
- Conflict resolution: non-colliding keys merge additively; collisions prompt a review step with "keep existing" / "overwrite" toggle per conflict

Resolves #5608

## Changes

- `src/utils/parseEnvPaste.ts` — pure dotenv parser with typed error results
- `src/components/Settings/ImportEnvDialog.tsx` — two-step dialog (paste → conflict review) with existing secret-detection warnings applied to imported values
- `src/components/Settings/EnvVarEditor.tsx` — Import button wired into empty state and non-empty toolbar; `handleImportConfirm` merges the result directly
- Tests: 29 parser unit tests + 12 import flow integration tests

## Testing

- 68 tests passing (29 parser, 12 import flow, 27 existing EnvVarEditor)
- Conflict resolution paths tested: additive merge, keep-existing, overwrite
- Secret detection fires on imported values the same way it does on typed values
- Dialog reset on close/reopen verified