### PR TITLE
fix(plugin): reject duplicate plugin names at load time

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -119,6 +119,13 @@ export class PluginService {
 
     const manifest = parseResult.data;
 
+    if (this.plugins.has(manifest.name)) {
+      console.error(
+        `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName} — rejecting`
+      );
+      return null;
+    }
+
     const requiredRange = manifest.engines?.daintree;
     if (requiredRange) {
       if (!semver.satisfies(this.appVersion, requiredRange, { includePrerelease: true })) {
@@ -198,12 +205,6 @@ export class PluginService {
     // plugin as loaded. Without this, `hasPlugin(pluginId)` returns false
     // inside the plugin's own init, and registerHandler/registerPluginAction
     // throw "Unknown plugin" even for a correctly loaded plugin.
-    if (this.plugins.has(manifest.name)) {
-      console.warn(
-        `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName}, tearing down previous instance`
-      );
-      this.unloadPlugin(manifest.name);
-    }
     this.plugins.set(manifest.name, plugin);
 
     if (plugin.resolvedMain) {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -446,16 +446,32 @@ describe("PluginService", () => {
     expect(service.listPlugins()).toEqual([]);
   });
 
-  it("warns on duplicate plugin names and keeps the last one", async () => {
-    await writePlugin("dir-a", { name: "acme.same-name", version: "1.0.0", description: "first" });
-    await writePlugin("dir-b", { name: "acme.same-name", version: "2.0.0", description: "second" });
+  it("rejects duplicate plugin names with error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await writePlugin("dir-a", {
+        name: "acme.same-name",
+        version: "1.0.0",
+        description: "first",
+      });
+      await writePlugin("dir-b", {
+        name: "acme.same-name",
+        version: "2.0.0",
+        description: "second",
+      });
 
-    const service = new PluginService(tmpDir);
-    await service.initialize();
+      const service = new PluginService(tmpDir);
+      await service.initialize();
 
-    const plugins = service.listPlugins();
-    expect(plugins).toHaveLength(1);
-    expect(plugins[0].manifest.name).toBe("acme.same-name");
+      const plugins = service.listPlugins();
+      expect(plugins).toHaveLength(1);
+      expect(plugins[0].manifest.description).toBe("first");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate plugin name "acme.same-name" in dir-b')
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("allows retry after non-ENOENT initialize failure", async () => {


### PR DESCRIPTION
## Summary
- Moved duplicate name check before registering contributions (panels, toolbar buttons, menu items)
- Returns `null` and logs error instead of tearing down the previous plugin instance
- Updated test to verify rejection behaviour rather than teardown behaviour
- Fixes a bug where duplicate-named plugins would end up registered but with no visible contributions

Resolves #5612

## Changes
- `PluginService.loadPlugin`: Check for duplicate names before calling `registerPanelKind`, `registerToolbarButton`, `registerPluginMenuItem`
- `PluginService.loadPlugin`: Log error and return `null` when duplicate detected
- `PluginService.test`: Replaced "tears down previous instance" test with "rejects second plugin with duplicate name" test

## Testing
- Unit test verifies duplicate plugin name rejection
- Manual testing confirmed plugin loads fail gracefully with error log when duplicate name detected