### PR TITLE
feat(fleet): flip fleetScopeMode default to scoped

### DIFF
--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -339,6 +339,20 @@ describe("fleet scope actions — flag gating", () => {
     expect(state.activeWorktreeId).toBe("wt-1");
   });
 
+  it("fleet.scope.enter is a no-op before hydration resolves", async () => {
+    // With the "scoped" default, an unhydrated store could let a persisted-legacy
+    // user briefly enter scope before hydrate() runs. The isHydrated guard
+    // prevents the stuck isFleetScopeActive state that would follow when late
+    // hydration flips mode back to "legacy".
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.scope.enter");
+    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(false);
+  });
+
   it("flag is read at execution time, not at registration time", async () => {
     const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
     const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -362,7 +362,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      if (useFleetScopeFlagStore.getState().mode !== "scoped") return;
+      const flag = useFleetScopeFlagStore.getState();
+      if (!flag.isHydrated || flag.mode !== "scoped") return;
       useWorktreeSelectionStore.getState().enterFleetScope();
     },
   }));
@@ -377,7 +378,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      if (useFleetScopeFlagStore.getState().mode !== "scoped") return;
+      const flag = useFleetScopeFlagStore.getState();
+      if (!flag.isHydrated || flag.mode !== "scoped") return;
       useWorktreeSelectionStore.getState().exitFleetScope();
     },
   }));

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -22,6 +22,20 @@ describe("fleetScopeFlagStore", () => {
     resetStore();
   });
 
+  describe("initial state", () => {
+    it("defaults to scoped mode, unhydrated, before any user interaction", async () => {
+      // Load the module fresh so we observe the real initial state instead of
+      // whatever resetStore() seeded between tests.
+      vi.resetModules();
+      const { useFleetScopeFlagStore: freshStore } = await import(
+        "../fleetScopeFlagStore"
+      );
+      const state = freshStore.getState();
+      expect(state.mode).toBe("scoped");
+      expect(state.isHydrated).toBe(false);
+    });
+  });
+
   describe("hydrate", () => {
     it("applies persisted 'scoped' value and marks hydrated", () => {
       useFleetScopeFlagStore.getState().hydrate("scoped");
@@ -79,10 +93,22 @@ describe("fleetScopeFlagStore", () => {
       );
     });
 
-    it("is a no-op when mode is unchanged", async () => {
-      useFleetScopeFlagStore.getState().setMode("legacy");
+    it("is a no-op when mode is unchanged (from scoped default)", async () => {
+      useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
+      setStateMock.mockClear();
+      useFleetScopeFlagStore.getState().setMode("scoped");
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("persists when flipping from scoped default to legacy", async () => {
+      useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
+      setStateMock.mockClear();
+      useFleetScopeFlagStore.getState().setMode("legacy");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      await vi.waitFor(() =>
+        expect(setStateMock).toHaveBeenCalledWith({ fleetScopeMode: "legacy" })
+      );
     });
 
     it("marks hydrated so later async hydrate does not clobber", () => {

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -30,24 +30,33 @@ describe("fleetScopeFlagStore", () => {
       expect(state.isHydrated).toBe(true);
     });
 
-    it("falls back to 'legacy' when persisted value is undefined", () => {
+    it("falls back to 'scoped' when persisted value is undefined", () => {
       useFleetScopeFlagStore.getState().hydrate(undefined);
+      const state = useFleetScopeFlagStore.getState();
+      expect(state.mode).toBe("scoped");
+      expect(state.isHydrated).toBe(true);
+    });
+
+    it("preserves explicit 'legacy' opt-in from persisted state", () => {
+      // Soak-period contract: users who previously opted into legacy keep it
+      // until the legacy paths are removed in the follow-up PR.
+      useFleetScopeFlagStore.getState().hydrate("legacy");
       const state = useFleetScopeFlagStore.getState();
       expect(state.mode).toBe("legacy");
       expect(state.isHydrated).toBe(true);
     });
 
-    it("normalizes malformed values to 'legacy'", () => {
-      // Defensive path — legacy persisted values or mid-migration garbage
-      // should not enable scoped mode.
+    it("normalizes malformed values to 'scoped'", () => {
+      // Defensive path — only the exact string "legacy" survives; any other
+      // garbage (wrong case, null, numbers) lands on the new default.
       useFleetScopeFlagStore.getState().hydrate("SCOPED" as never);
-      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
       resetStore();
       useFleetScopeFlagStore.getState().hydrate(null as never);
-      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
       resetStore();
       useFleetScopeFlagStore.getState().hydrate(42 as never);
-      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
     });
 
     it("is idempotent — later hydrate calls cannot clobber user interaction", () => {

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -27,9 +27,7 @@ describe("fleetScopeFlagStore", () => {
       // Load the module fresh so we observe the real initial state instead of
       // whatever resetStore() seeded between tests.
       vi.resetModules();
-      const { useFleetScopeFlagStore: freshStore } = await import(
-        "../fleetScopeFlagStore"
-      );
+      const { useFleetScopeFlagStore: freshStore } = await import("../fleetScopeFlagStore");
       const state = freshStore.getState();
       expect(state.mode).toBe("scoped");
       expect(state.isHydrated).toBe(false);

--- a/src/store/fleetScopeFlagStore.ts
+++ b/src/store/fleetScopeFlagStore.ts
@@ -11,7 +11,7 @@ interface FleetScopeFlagState {
 }
 
 export const useFleetScopeFlagStore = create<FleetScopeFlagState>()((set, get) => ({
-  mode: "legacy",
+  mode: "scoped",
   isHydrated: false,
 
   setMode: (mode) => {
@@ -22,7 +22,7 @@ export const useFleetScopeFlagStore = create<FleetScopeFlagState>()((set, get) =
 
   hydrate: (mode) => {
     if (get().isHydrated) return;
-    set({ mode: mode === "scoped" ? "scoped" : "legacy", isHydrated: true });
+    set({ mode: mode === "legacy" ? "legacy" : "scoped", isHydrated: true });
   },
 }));
 


### PR DESCRIPTION
## Summary

- Flips `fleetScopeMode` default from `"legacy"` to `"scoped"` (step 1 of 2 from #5562's rollout plan)
- Inverts the `hydrate()` fallback from a whitelist to a blacklist so explicit `"legacy"` opt-ins survive the soak period intact
- Adds an `isHydrated` guard to `fleet.scope.enter` / `fleet.scope.exit` to close a pre-hydration race window that the default flip opened

Resolves #5563.

## Changes

- `fleetScopeFlagStore.ts`: default changed to `"scoped"`, hydration logic inverted so `"legacy"` is the explicit opt-out
- `fleetActions.ts`: `fleet.scope.enter` / `fleet.scope.exit` now bail early when store hasn't hydrated yet
- Test coverage added for initial state assertion, the no-op path from the real default, legacy opt-out persistence, and the pre-hydration guard

## Testing

Unit tests cover all four cases: initial state, no-op from default, explicit legacy opt-out, and the pre-hydration guard on enter/exit. Existing tests pass. Legacy code paths are untouched so the default can be rolled back without a code revert if anything surfaces during the soak week.