### PR TITLE
fix(settings): hide presets header divider when list is empty

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -647,7 +647,7 @@ export function AgentSettings({
                   className="rounded-[var(--radius-lg)] border border-daintree-border bg-surface p-4 space-y-4"
                 >
                   {/* Header: title + Add button */}
-                  <div className="pb-3 border-b border-daintree-border">
+                  <div className={`pb-3${allPresets.length > 0 ? " border-b border-daintree-border" : ""}`}>
                     <div className="flex items-center justify-between">
                       <div>
                         <label className="text-sm font-medium text-daintree-text">

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -647,7 +647,9 @@ export function AgentSettings({
                   className="rounded-[var(--radius-lg)] border border-daintree-border bg-surface p-4 space-y-4"
                 >
                   {/* Header: title + Add button */}
-                  <div className={`pb-3${allPresets.length > 0 ? " border-b border-daintree-border" : ""}`}>
+                  <div
+                    className={`pb-3${allPresets.length > 0 ? " border-b border-daintree-border" : ""}`}
+                  >
                     <div className="flex items-center justify-between">
                       <div>
                         <label className="text-sm font-medium text-daintree-text">


### PR DESCRIPTION
## Summary

- The border-b on the Presets section header was unconditional, so it showed a divider line below the "Add" button even when there were no presets beneath it.
- Fixed by making the `border-b` class conditional on `presets.length > 0`, so the divider only renders when there's actually content below it.

Resolves #5640

## Changes

- `src/components/Settings/AgentSettings.tsx`: conditional `border-b` class on the presets header row based on whether any presets exist.

## Testing

The change is a single conditional class toggle on a rendered element. No logic paths were added or removed, so there's nothing meaningful to unit test here — visual verification is the right check for a CSS visibility fix. Confirmed the divider disappears with an empty preset list and appears correctly when presets are present.