### PR TITLE
feat(fleet): add discoverable selection menu to broadcast bar

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -248,6 +248,13 @@ export function FleetArmingRibbon(): ReactElement | null {
     return () => window.removeEventListener("keydown", handler, true);
   }, [armedCount]);
 
+  // "Match active filter" maps the sidebar's quick-state filter (which is
+  // worktree-chip-state driven) to an agent-state preset 1:1 by name. In
+  // edge cases a worktree's chip state can differ from an individual
+  // agent's state (e.g. a worktree in "cleanup" with a still-waiting
+  // agent), so "finished" here arms agents in terminal states, not every
+  // agent under a "finished"-chip worktree. Acceptable — the menu arms
+  // by agent state throughout.
   const filterPreset: FleetArmStatePreset | null =
     quickStateFilter === "all" ? null : (quickStateFilter as FleetArmStatePreset);
   const filterLabel = filterPreset

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
-import { X } from "lucide-react";
+import { MoreHorizontal, X } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { useEscapeStack } from "@/hooks";
 import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
+import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
@@ -14,6 +15,14 @@ import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { FleetComposer } from "./FleetComposer";
 
 interface PresetOption {
@@ -111,7 +120,9 @@ export function FleetArmingRibbon(): ReactElement | null {
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
   const clear = useFleetArmingStore((s) => s.clear);
   const armByState = useFleetArmingStore((s) => s.armByState);
+  const armAll = useFleetArmingStore((s) => s.armAll);
   const counts = useArmedCounts();
+  const quickStateFilter = useWorktreeFilterStore((s) => s.quickStateFilter);
   const pending = useFleetPendingActionStore((s) => s.pending);
   const clearPending = useFleetPendingActionStore((s) => s.clear);
 
@@ -237,7 +248,106 @@ export function FleetArmingRibbon(): ReactElement | null {
     return () => window.removeEventListener("keydown", handler, true);
   }, [armedCount]);
 
-  if (armedCount === 0) return null;
+  const filterPreset: FleetArmStatePreset | null =
+    quickStateFilter === "all" ? null : (quickStateFilter as FleetArmStatePreset);
+  const filterLabel = filterPreset
+    ? filterPreset === "working"
+      ? "Working"
+      : filterPreset === "waiting"
+        ? "Waiting"
+        : "Finished"
+    : null;
+
+  const selectionMenuItems = (
+    <>
+      <DropdownMenuLabel>Select by state</DropdownMenuLabel>
+      <DropdownMenuItem
+        onSelect={() => {
+          armByState("waiting", "current", false);
+        }}
+      >
+        All waiting — this worktree
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => {
+          armByState("waiting", "all", false);
+        }}
+      >
+        All waiting — all worktrees
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => {
+          armByState("working", "current", false);
+        }}
+      >
+        All working — this worktree
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => {
+          armByState("working", "all", false);
+        }}
+      >
+        All working — all worktrees
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        onSelect={() => {
+          armAll("current");
+        }}
+      >
+        All in this worktree
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        disabled={filterPreset === null}
+        onSelect={() => {
+          if (filterPreset === null) return;
+          armByState(filterPreset, "current", false);
+        }}
+      >
+        {filterLabel ? `Match active filter (${filterLabel})` : "Match active filter"}
+      </DropdownMenuItem>
+      {armedCount > 0 ? (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            destructive
+            onSelect={() => {
+              clear();
+            }}
+          >
+            Clear selection
+          </DropdownMenuItem>
+        </>
+      ) : null}
+    </>
+  );
+
+  if (armedCount === 0) {
+    return (
+      <div
+        className="flex items-center gap-1.5 border-b border-transparent px-3 py-1 text-[11px] text-daintree-text/40"
+        data-testid="fleet-arming-ribbon-discovery"
+      >
+        <span>Broadcast</span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Open broadcast selection menu"
+              className="rounded p-0.5 text-daintree-text/60 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+              data-testid="fleet-selection-menu-trigger"
+            >
+              <MoreHorizontal className="h-3.5 w-3.5" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" sideOffset={4}>
+            {selectionMenuItems}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    );
+  }
 
   if (pending !== null) {
     const message = buildConfirmMessage(
@@ -322,6 +432,21 @@ export function FleetArmingRibbon(): ReactElement | null {
             open={popoverOpen}
             onOpenChange={setPopoverOpen}
           />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Open selection menu"
+                className="rounded p-1 text-daintree-text/60 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+                data-testid="fleet-selection-menu-trigger"
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" sideOffset={4}>
+              {selectionMenuItems}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <div className="flex items-center gap-1" role="toolbar" aria-label="Arm by state">
             {PRESETS.map((preset) => (
               <button

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -17,12 +17,48 @@ vi.mock("framer-motion", () => ({
   useReducedMotion: () => false,
 }));
 
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="fleet-selection-menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+    destructive,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    disabled?: boolean;
+    destructive?: boolean;
+  }) => (
+    <div
+      role="menuitem"
+      data-disabled={disabled ? "true" : undefined}
+      data-destructive={destructive ? "true" : undefined}
+      onClick={(e) => {
+        if (disabled) return;
+        onSelect?.(e as unknown as Event);
+      }}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+}));
+
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { dispatchEscape, _resetForTests as resetEscapeStack } from "@/lib/escapeStack";
 import type { TerminalInstance } from "@shared/types";
@@ -38,6 +74,7 @@ function resetStores() {
   useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", isFleetScopeActive: false });
+  useWorktreeFilterStore.setState({ quickStateFilter: "all" });
   useAnnouncerStore.setState({ polite: null, assertive: null });
   resetEscapeStack();
 }
@@ -75,9 +112,18 @@ describe("FleetArmingRibbon", () => {
     resetStores();
   });
 
-  it("renders nothing when nothing is armed", () => {
-    const { container } = render(<FleetArmingRibbon />);
-    expect(container.firstChild).toBeNull();
+  it("does not render the armed ribbon when nothing is armed", () => {
+    render(<FleetArmingRibbon />);
+    expect(screen.queryByTestId("fleet-arming-ribbon")).toBeNull();
+  });
+
+  it("renders a discovery affordance with the selection menu when nothing is armed", () => {
+    render(<FleetArmingRibbon />);
+    expect(screen.getByTestId("fleet-arming-ribbon-discovery")).toBeTruthy();
+    expect(screen.getByTestId("fleet-selection-menu-trigger")).toBeTruthy();
+    // Menu content is rendered by the mocked DropdownMenuContent — reachable
+    // even without clicking the trigger, which is the expected mock behavior.
+    expect(screen.getByTestId("fleet-selection-menu")).toBeTruthy();
   });
 
   it("renders armed count when armed", () => {
@@ -306,6 +352,117 @@ describe("FleetArmingRibbon", () => {
       render(<FleetArmingRibbon />);
       expect(screen.queryAllByTestId("fleet-composer")).toHaveLength(1);
       expect(screen.queryByTestId("fleet-arming-ribbon")).toBeTruthy();
+    });
+  });
+
+  describe("Selection menu", () => {
+    function findMenuItem(label: RegExp | string): HTMLElement {
+      const items = screen.getAllByRole("menuitem");
+      for (const el of items) {
+        const text = el.textContent ?? "";
+        if (typeof label === "string" ? text.includes(label) : label.test(text)) {
+          return el;
+        }
+      }
+      throw new Error(`menu item not found for ${label.toString()}`);
+    }
+
+    it("renders the trigger on the armed ribbon", () => {
+      seed([makeAgent("t1", "working")]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-selection-menu-trigger")).toBeTruthy();
+    });
+
+    it("'All waiting — this worktree' arms waiting agents in the current worktree", () => {
+      seed([
+        makeAgent("t1", "working"),
+        makeAgent("t2", "waiting"),
+        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+      ]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/All waiting — this worktree/));
+      const armed = useFleetArmingStore.getState().armedIds;
+      expect([...armed]).toEqual(["t2"]);
+    });
+
+    it("'All waiting — all worktrees' arms waiting agents across every worktree", () => {
+      seed([
+        makeAgent("t1", "working"),
+        makeAgent("t2", "waiting"),
+        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+      ]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/All waiting — all worktrees/));
+      const armed = useFleetArmingStore.getState().armedIds;
+      expect([...armed].sort()).toEqual(["t2", "t3"]);
+    });
+
+    it("'All working — this worktree' arms working agents in the current worktree", () => {
+      seed([makeAgent("t1", "working"), makeAgent("t2", "waiting")]);
+      useFleetArmingStore.getState().armIds(["t2"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/All working — this worktree/));
+      const armed = useFleetArmingStore.getState().armedIds;
+      expect([...armed]).toEqual(["t1"]);
+    });
+
+    it("'All in this worktree' arms every eligible agent in the current worktree", () => {
+      seed([
+        makeAgent("t1", "working"),
+        makeAgent("t2", "waiting"),
+        makeAgent("t3", "completed"),
+        { ...makeAgent("t4", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+      ]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/All in this worktree/));
+      const armed = useFleetArmingStore.getState().armedIds;
+      expect([...armed].sort()).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("disables 'Match active filter' when quickStateFilter is 'all'", () => {
+      useFleetArmingStore.getState().armIds(["t1"]);
+      useWorktreeFilterStore.setState({ quickStateFilter: "all" });
+      render(<FleetArmingRibbon />);
+      const item = findMenuItem(/Match active filter/);
+      expect(item.getAttribute("data-disabled")).toBe("true");
+      // Disabled item should not mutate the armed set.
+      fireEvent.click(item);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["t1"]);
+    });
+
+    it("'Match active filter' uses the current filter preset at current scope", () => {
+      seed([
+        makeAgent("t1", "working"),
+        makeAgent("t2", "waiting"),
+        { ...makeAgent("t3", "waiting"), worktreeId: "wt-2" } as TerminalInstance,
+      ]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      useWorktreeFilterStore.setState({ quickStateFilter: "waiting" });
+      render(<FleetArmingRibbon />);
+      const item = findMenuItem(/Match active filter \(Waiting\)/);
+      expect(item.getAttribute("data-disabled")).toBeNull();
+      fireEvent.click(item);
+      const armed = useFleetArmingStore.getState().armedIds;
+      // Scope is 'current' — cross-worktree waiting agents are not armed.
+      expect([...armed]).toEqual(["t2"]);
+    });
+
+    it("'Clear selection' clears the armed set", () => {
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/Clear selection/));
+      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    });
+
+    it("omits 'Clear selection' from the discovery menu when nothing is armed", () => {
+      render(<FleetArmingRibbon />);
+      const items = screen.getAllByRole("menuitem");
+      const labels = items.map((el) => el.textContent ?? "");
+      expect(labels.every((label) => !/Clear selection/.test(label))).toBe(true);
     });
   });
 });

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -464,5 +464,25 @@ describe("FleetArmingRibbon", () => {
       const labels = items.map((el) => el.textContent ?? "");
       expect(labels.every((label) => !/Clear selection/.test(label))).toBe(true);
     });
+
+    it("selecting from the discovery menu swaps into the armed ribbon", () => {
+      seed([makeAgent("t1", "waiting")]);
+      render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-arming-ribbon-discovery")).toBeTruthy();
+      act(() => {
+        fireEvent.click(findMenuItem(/All waiting — this worktree/));
+      });
+      expect(screen.queryByTestId("fleet-arming-ribbon-discovery")).toBeNull();
+      expect(screen.getByTestId("fleet-arming-ribbon")).toBeTruthy();
+    });
+
+    it("'All working' arms agents in 'running' state alongside 'working'", () => {
+      seed([makeAgent("t1", "working"), makeAgent("t2", "running")]);
+      useFleetArmingStore.getState().armIds(["t1"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/All working — this worktree/));
+      const armed = useFleetArmingStore.getState().armedIds;
+      expect([...armed].sort()).toEqual(["t1", "t2"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `⋯` dropdown menu to `FleetArmingRibbon` (armed state) exposing named selection commands: select by state (waiting/working) scoped to current worktree or all worktrees, select all in this worktree, match active filter, and clear selection.
- Adds a compact "Broadcast ⋯" discovery affordance when `armedCount === 0`, so the selection commands are reachable before any agent is armed. Addresses the open question in the issue about first-time discoverability.
- Backed by direct `fleetArmingStore` calls against the existing `armByState`/`armAll` API with `current`/`all` scope support. No new action IDs needed.

Resolves #5680

## Changes

- `FleetArmingRibbon.tsx`: `⋯` DropdownMenu trigger on the armed ribbon + pre-armed "Broadcast ⋯" discovery button. `Match active filter` item reads `useWorktreeFilterStore` and is disabled when `quickStateFilter === "all"`.
- `FleetArmingRibbon.test.tsx`: `vi.mock` for dropdown-menu (pass-through pattern), `quickStateFilter` reset in `resetStores`, and a Selection menu describe block with 10 tests covering trigger visibility, each state×scope path, disabled/enabled match-filter, clear, discovery-to-armed transition, and running-state handling.

## Testing

Unit tests cover all menu paths. Run `npx vitest run src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx` to verify locally.