### PR TITLE
feat(fleet): arm all agents matching active worktree filter

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -301,6 +301,7 @@ export type BuiltInActionId =
   | "fleet.scope.exit"
   | "fleet.dryRun"
   | "fleet.retryFailed"
+  | "fleet.armMatchingFilter"
   | "terminal.focusFleetComposer";
 
 export type ActionId = BuiltInActionId | (string & {});

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1002,7 +1002,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                Arm all eligible agents in these {filteredWorktrees.length} worktrees
+                Arm all eligible agents in the {filteredWorktrees.length} worktrees visible below
               </TooltipContent>
             </Tooltip>
           </div>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -980,6 +980,34 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         {/* Inline search bar — only when there are non-main worktrees */}
         {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
 
+        {/* Arm all agents matching the active filter — only when a filter narrows the list */}
+        {hasNonMainWorktrees && hasFilters && filteredWorktrees.length > 0 && (
+          <div className="shrink-0 px-4 py-1.5 border-b border-divider">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() =>
+                    actionService.dispatch(
+                      "fleet.armMatchingFilter",
+                      { worktreeIds: filteredWorktrees.map((w) => w.id) },
+                      { source: "user" }
+                    )
+                  }
+                  className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
+                  aria-label={`Arm ${filteredWorktrees.length} matching worktrees`}
+                >
+                  <BroadcastTerminalIcon className="w-3 h-3" />
+                  Arm {filteredWorktrees.length} matching
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Arm all eligible agents in these {filteredWorktrees.length} worktrees
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+
         {/* Main worktree — visible unless excluded by text search */}
         {mainMatchesQuery && (
           <div

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -291,6 +291,17 @@ describe("fleet.armMatchingFilter", () => {
     expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
   });
 
+  it("preserves prior armed set when filtered worktrees contain no eligible agents", async () => {
+    // Matches the sidebar case where the filter matches worktrees that
+    // happen to have no arm-eligible agent terminals — the button must
+    // not silently clear the user's selection.
+    seedPanels([makeAgent("a1", { worktreeId: "wt-1" })]);
+    useFleetArmingStore.getState().armIds(["a1"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-9"] });
+    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+  });
+
   it("replaces any prior armed set that falls outside the filter", async () => {
     seedPanels([
       makeAgent("a1", { worktreeId: "wt-1" }),

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -266,6 +266,43 @@ describe("fleet actions — threshold confirmation", () => {
   });
 });
 
+describe("fleet.armMatchingFilter", () => {
+  beforeEach(() => {
+    resetStores();
+    vi.clearAllMocks();
+  });
+
+  it("arms only eligible agents in the provided worktree ids", async () => {
+    seedPanels([
+      makeAgent("a1", { worktreeId: "wt-1" }),
+      makeAgent("a2", { worktreeId: "wt-2" }),
+      makeAgent("a3", { worktreeId: "wt-3" }),
+    ]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1", "wt-3"] });
+    expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a3"]);
+  });
+
+  it("is a no-op when worktreeIds is empty (does not clobber existing armed set)", async () => {
+    seedPanels([makeAgent("a1"), makeAgent("a2")]);
+    useFleetArmingStore.getState().armIds(["a1"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.armMatchingFilter", { worktreeIds: [] });
+    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+  });
+
+  it("replaces any prior armed set that falls outside the filter", async () => {
+    seedPanels([
+      makeAgent("a1", { worktreeId: "wt-1" }),
+      makeAgent("a2", { worktreeId: "wt-2" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a2"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1"] });
+    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+  });
+});
+
 describe("fleet scope actions — flag gating", () => {
   beforeEach(async () => {
     resetStores();

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -303,10 +303,7 @@ describe("fleet.armMatchingFilter", () => {
   });
 
   it("replaces any prior armed set that falls outside the filter", async () => {
-    seedPanels([
-      makeAgent("a1", { worktreeId: "wt-1" }),
-      makeAgent("a2", { worktreeId: "wt-2" }),
-    ]);
+    seedPanels([makeAgent("a1", { worktreeId: "wt-1" }), makeAgent("a2", { worktreeId: "wt-2" })]);
     useFleetArmingStore.getState().armIds(["a2"]);
     const registry = await buildRegistry();
     await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1"] });

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -310,7 +310,6 @@ export function registerFleetActions(actions: ActionRegistry): void {
     argsSchema: z.object({ worktreeIds: z.array(z.string()) }),
     run: async (args: unknown) => {
       const worktreeIds = (args as { worktreeIds?: string[] } | undefined)?.worktreeIds ?? [];
-      if (worktreeIds.length === 0) return;
       useFleetArmingStore.getState().armMatchingFilter(worktreeIds);
     },
   }));

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -298,6 +298,23 @@ export function registerFleetActions(actions: ActionRegistry): void {
     },
   }));
 
+  actions.set("fleet.armMatchingFilter", () => ({
+    id: "fleet.armMatchingFilter",
+    title: "Fleet: Arm Agents Matching Filter",
+    description:
+      "Arm all eligible agent terminals whose worktree is in the provided set — drives the sidebar 'Arm N matching' affordance",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ worktreeIds: z.array(z.string()) }),
+    run: async (args: unknown) => {
+      const worktreeIds = (args as { worktreeIds?: string[] } | undefined)?.worktreeIds ?? [];
+      if (worktreeIds.length === 0) return;
+      useFleetArmingStore.getState().armMatchingFilter(worktreeIds);
+    },
+  }));
+
   actions.set("fleet.retryFailed", () => ({
     id: "fleet.retryFailed",
     title: "Fleet: Retry Failed",

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -255,6 +255,68 @@ describe("fleetArmingStore", () => {
     });
   });
 
+  describe("armMatchingFilter", () => {
+    it("arms eligible agents only in the matching worktree set", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+        makeAgentTerminal("a3", { worktreeId: "wt-3" }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1", "wt-3"]);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a3"]);
+    });
+
+    it("skips ineligible panels even when worktree matches", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-1", location: "trash" }),
+        makeAgentTerminal("a3", { worktreeId: "wt-1", location: "background" }),
+        makeAgentTerminal("a4", { worktreeId: "wt-1", hasPty: false }),
+        makeAgentTerminal("a5", {
+          worktreeId: "wt-1",
+          kind: "terminal",
+          agentId: undefined,
+        }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
+    it("empty worktreeIds arms nothing and clears any prior armed set", () => {
+      seedPanels([makeAgentTerminal("a1"), makeAgentTerminal("a2")]);
+      useFleetArmingStore.getState().armIds(["a1", "a2"]);
+      useFleetArmingStore.getState().armMatchingFilter([]);
+      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    });
+
+    it("no eligible agents in matching worktrees leaves armed set empty", () => {
+      seedPanels([makeAgentTerminal("a1", { worktreeId: "wt-1" })]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-9"]);
+      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    });
+
+    it("replaces the existing armed set rather than merging", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+      ]);
+      useFleetArmingStore.getState().armIds(["a2"]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
+    it("is idempotent — calling twice with the same ids produces the same set", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-1" }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      const first = [...useFleetArmingStore.getState().armOrder];
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect(useFleetArmingStore.getState().armOrder).toEqual(first);
+    });
+  });
+
   describe("clear", () => {
     it("resets to empty state", () => {
       useFleetArmingStore.getState().armId("a");

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -282,14 +282,25 @@ describe("fleetArmingStore", () => {
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
     });
 
-    it("empty worktreeIds arms nothing and clears any prior armed set", () => {
+    it("empty worktreeIds is a no-op and preserves any prior armed set", () => {
       seedPanels([makeAgentTerminal("a1"), makeAgentTerminal("a2")]);
       useFleetArmingStore.getState().armIds(["a1", "a2"]);
       useFleetArmingStore.getState().armMatchingFilter([]);
-      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
     });
 
-    it("no eligible agents in matching worktrees leaves armed set empty", () => {
+    it("no eligible agents in matching worktrees preserves any prior armed set", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+      ]);
+      useFleetArmingStore.getState().armIds(["a1", "a2"]);
+      // wt-9 has no panels — the button must not clobber the user's selection
+      useFleetArmingStore.getState().armMatchingFilter(["wt-9"]);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
+    });
+
+    it("no eligible agents and no prior selection leaves armed set empty", () => {
       seedPanels([makeAgentTerminal("a1", { worktreeId: "wt-1" })]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-9"]);
       expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
@@ -305,15 +316,45 @@ describe("fleetArmingStore", () => {
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
     });
 
-    it("is idempotent — calling twice with the same ids produces the same set", () => {
+    it("preserves panel iteration order, not worktreeIds input order", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+        makeAgentTerminal("a3", { worktreeId: "wt-1" }),
+      ]);
+      // Input worktree order is wt-2 then wt-1, but panel order is a1,a2,a3.
+      // The armed list should follow panel order so badge numbers match
+      // the sidebar's rendered sequence.
+      useFleetArmingStore.getState().armMatchingFilter(["wt-2", "wt-1"]);
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a1", "a2", "a3"]);
+      expect(s.lastArmedId).toBe("a3");
+    });
+
+    it("duplicate worktreeIds do not duplicate armed terminals", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-1" }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1", "wt-1", "wt-1"]);
+      expect(useFleetArmingStore.getState().armOrder).toEqual(["a1", "a2"]);
+    });
+
+    it("is fully idempotent — repeated calls preserve armOrder, armOrderById, and lastArmedId", () => {
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),
         makeAgentTerminal("a2", { worktreeId: "wt-1" }),
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
-      const first = [...useFleetArmingStore.getState().armOrder];
+      const first = useFleetArmingStore.getState();
+      const firstOrder = [...first.armOrder];
+      const firstById = { ...first.armOrderById };
+      const firstLast = first.lastArmedId;
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
-      expect(useFleetArmingStore.getState().armOrder).toEqual(first);
+      const second = useFleetArmingStore.getState();
+      expect(second.armOrder).toEqual(firstOrder);
+      expect(second.armOrderById).toEqual(firstById);
+      expect(second.lastArmedId).toBe(firstLast);
     });
   });
 

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -212,6 +212,7 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
   },
 
   armMatchingFilter: (worktreeIds) => {
+    if (worktreeIds.length === 0) return;
     const worktreeIdSet = new Set(worktreeIds);
     const state = usePanelStore.getState();
     const ids: string[] = [];
@@ -221,6 +222,11 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
       if (!t.worktreeId || !worktreeIdSet.has(t.worktreeId)) continue;
       ids.push(id);
     }
+    // No eligible agents — leave the existing armed set alone rather than
+    // silently clearing it. The button is still visible whenever any
+    // worktrees match the filter; clicking it must not destroy the user's
+    // prior selection when the filtered subset has no arm-eligible agents.
+    if (ids.length === 0) return;
     get().armIds(ids);
   },
 

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -22,6 +22,7 @@ interface FleetArmingState {
   extendTo: (id: string, orderedEligibleIds: string[]) => void;
   armByState: (state: FleetArmStatePreset, scope: FleetArmScope, extend: boolean) => void;
   armAll: (scope: FleetArmScope) => void;
+  armMatchingFilter: (worktreeIds: string[]) => void;
   clear: () => void;
   prune: (validIds: Set<string>) => void;
 }
@@ -207,6 +208,19 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
 
   armAll: (scope) => {
     const ids = collectEligibleIds(scope, getActiveWorktreeId());
+    get().armIds(ids);
+  },
+
+  armMatchingFilter: (worktreeIds) => {
+    const worktreeIdSet = new Set(worktreeIds);
+    const state = usePanelStore.getState();
+    const ids: string[] = [];
+    for (const id of state.panelIds) {
+      const t = state.panelsById[id];
+      if (!isFleetArmEligible(t)) continue;
+      if (!t.worktreeId || !worktreeIdSet.has(t.worktreeId)) continue;
+      ids.push(id);
+    }
     get().armIds(ids);
   },
 


### PR DESCRIPTION
## Summary

- Adds a `fleet.armMatchingFilter` action that collects eligible agents from the current filtered worktree set and arms them in one shot
- Exposes an inline \"Arm N matching\" button in the sidebar, gated on an active filter with at least one visible worktree
- Store method short-circuits when the filtered set is empty or has no eligible agents, preserving any prior armed selection rather than clobbering it

Resolves #5681

## Changes

- `shared/types/actions.ts` — new `fleet.armMatchingFilter` action ID
- `src/services/actions/definitions/fleetActions.ts` — action definition wired to `armMatchingFilter`
- `src/store/fleetArmingStore.ts` — `armMatchingFilter(worktreeIds)` store method with no-op guard
- `src/components/Sidebar/SidebarContent.tsx` — \"Arm N matching\" button rendered when `hasFilters && filteredWorktrees.length > 0`
- Tests covering the store method (empty input, no eligible agents, partial eligibility, full arm) and action dispatch

## Testing

68 unit tests pass. Covered: store method guards (empty array, no eligible agents), partial eligibility, successful arm, and action dispatch routing to `armMatchingFilter`.