### PR TITLE
feat(fleet): add canary staged broadcast for large fan-outs

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -302,7 +302,7 @@
   "src/components/Fleet/FleetComposer.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 1,
+    "error": 3,
     "pipeline": 0
   },
   "src/components/Fleet/FleetDryRunDialog.tsx": {

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
 import { useFleetIdleStore } from "@/store/fleetIdleStore";
+import { usePanelStore } from "@/store/panelStore";
 import { useCommandHistoryStore } from "@/store/commandHistoryStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -35,12 +36,22 @@ interface WarningReason {
 
 /** Default threshold for quorum confirmation (number of targets). */
 const DEFAULT_QUORUM_THRESHOLD = 5;
+/** Default threshold for canary staged-broadcast (number of targets). */
+const DEFAULT_CANARY_THRESHOLD = 8;
 
 function getQuorumThreshold(): number {
   try {
     return useFleetComposerStore.getState().quorumThreshold;
   } catch {
     return DEFAULT_QUORUM_THRESHOLD;
+  }
+}
+
+function getCanaryThreshold(): number {
+  try {
+    return useFleetComposerStore.getState().canaryThreshold;
+  } catch {
+    return DEFAULT_CANARY_THRESHOLD;
   }
 }
 
@@ -62,6 +73,17 @@ export function FleetComposer(): ReactElement | null {
       clearDraft: s.clearDraft,
     }))
   );
+
+  const { isCanaryPending, canarySentId, canaryPendingIds, clearCanary, startCanary } =
+    useFleetComposerStore(
+      useShallow((s) => ({
+        isCanaryPending: s.isCanaryPending,
+        canarySentId: s.canarySentId,
+        canaryPendingIds: s.canaryPendingIds,
+        clearCanary: s.clearCanary,
+        startCanary: s.startCanary,
+      }))
+    );
 
   const dryRunRequested = useFleetComposerStore((s) => s.dryRunRequested);
   const clearDryRunRequest = useFleetComposerStore((s) => s.clearDryRunRequest);
@@ -160,9 +182,79 @@ export function FleetComposer(): ReactElement | null {
         return;
       }
 
+      // When a canary is pending, only explicit strip actions (Promote/Stop) or
+      // a force-send should proceed. A plain Enter / Send click would otherwise
+      // fall through to the live-armed resolution and double-send the canary
+      // target. The strip is the user's path forward until they act on it.
+      const canaryPendingNow = useFleetComposerStore.getState().isCanaryPending;
+      if (canaryPendingNow && !force && targetIds === undefined) {
+        return;
+      }
+
+      // If a canary is pending and this is a force-send bypass, deliver only
+      // to the frozen remainder — the canary target already received it.
+      const canaryRemainderSnapshot = useFleetComposerStore.getState().canaryPendingIds;
+      const resolvedTargetIds =
+        targetIds ??
+        (force && canaryPendingNow ? canaryRemainderSnapshot : resolveFleetBroadcastTargetIds());
+
+      // Canary gate: when targets >= canaryThreshold and no force bypass, send
+      // to the first target only, then stage the remainder. Supersedes quorum.
+      if (
+        !force &&
+        !isConfirming &&
+        !canaryPendingNow &&
+        resolvedTargetIds.length >= getCanaryThreshold() &&
+        !needsFleetBroadcastConfirmation(currentDraft)
+      ) {
+        const canaryId = resolvedTargetIds[0];
+        if (canaryId === undefined) return;
+        const remainderIds = resolvedTargetIds.slice(1);
+
+        submittingRef.current = true;
+        setIsSubmitting(true);
+        try {
+          const result = await executeFleetBroadcast(currentDraft, [canaryId]);
+          if (result.failureCount > 0) {
+            logWarn("[FleetComposer] canary submit had rejection", {
+              failureCount: result.failureCount,
+              failedIds: result.failedIds,
+            });
+            setLastFailed(result.failedIds, currentDraft);
+            useNotificationStore.getState().addNotification({
+              type: "warning",
+              priority: "low",
+              message: "Canary send failed — remainder not staged",
+            });
+            return;
+          }
+          clearLastFailed();
+          startCanary({
+            canarySentId: canaryId,
+            remainingIds: remainderIds,
+            prompt: currentDraft,
+          });
+          useNotificationStore.getState().addNotification({
+            type: "success",
+            priority: "low",
+            message: `Canary sent — review output, then apply to ${remainderIds.length} remaining`,
+          });
+        } catch (e) {
+          useNotificationStore.getState().addNotification({
+            type: "error",
+            priority: "high",
+            message: "Canary broadcast failed unexpectedly",
+          });
+          throw e;
+        } finally {
+          submittingRef.current = false;
+          setIsSubmitting(false);
+        }
+        return;
+      }
+
       // Quorum confirmation: when >=N targets, require explicit confirmation
       // even if the payload itself isn't flagged as dangerous.
-      const resolvedTargetIds = targetIds ?? resolveFleetBroadcastTargetIds();
       if (
         !force &&
         !isConfirming &&
@@ -183,7 +275,7 @@ export function FleetComposer(): ReactElement | null {
       setIsSubmitting(true);
 
       try {
-        const actualTargetIds = targetIds ?? resolveFleetBroadcastTargetIds();
+        const actualTargetIds = resolvedTargetIds;
         if (actualTargetIds.length === 0) {
           useNotificationStore.getState().addNotification({
             type: "warning",
@@ -243,6 +335,10 @@ export function FleetComposer(): ReactElement | null {
           setHistoryIndex(-1);
           historySnapshotRef.current = "";
         }
+
+        // A force-send completed while a canary was pending — staged state is
+        // now spent, clear it so the strip doesn't linger.
+        if (canaryPendingNow) clearCanary();
       } catch (e) {
         useNotificationStore.getState().addNotification({
           type: "error",
@@ -255,8 +351,82 @@ export function FleetComposer(): ReactElement | null {
         setIsSubmitting(false);
       }
     },
-    [clearDraft, clearLastFailed, historyKey, isConfirming, resetIdleTimer, setLastFailed]
+    [
+      clearCanary,
+      clearDraft,
+      clearLastFailed,
+      historyKey,
+      isConfirming,
+      resetIdleTimer,
+      setLastFailed,
+      startCanary,
+    ]
   );
+
+  const handlePromoteToRemaining = useCallback(async () => {
+    if (submittingRef.current) return;
+    const state = useFleetComposerStore.getState();
+    const remainingIds = state.canaryPendingIds;
+    const promptSnapshot = state.canaryPrompt;
+    if (remainingIds.length === 0 || promptSnapshot === null) {
+      clearCanary();
+      return;
+    }
+
+    submittingRef.current = true;
+    setIsSubmitting(true);
+    try {
+      const result = await executeFleetBroadcast(promptSnapshot, remainingIds);
+
+      if (result.failureCount > 0) {
+        logWarn("[FleetComposer] canary promotion had rejections", {
+          failureCount: result.failureCount,
+          failedIds: result.failedIds,
+        });
+        setLastFailed(result.failedIds, promptSnapshot);
+      } else {
+        clearLastFailed();
+      }
+
+      useNotificationStore.getState().addNotification({
+        type: result.successCount > 0 ? "success" : "warning",
+        priority: "low",
+        message:
+          result.failureCount > 0
+            ? `Applied to ${result.successCount} agent${result.successCount === 1 ? "" : "s"} (${result.failureCount} failed)`
+            : `Applied to ${result.successCount} agent${result.successCount === 1 ? "" : "s"}`,
+      });
+
+      if (result.successCount > 0) {
+        const armedIds = Array.from(useFleetArmingStore.getState().armedIds);
+        useCommandHistoryStore
+          .getState()
+          .recordPrompt(historyKey, promptSnapshot, null, { armedIds });
+        if (useFleetComposerStore.getState().draft === promptSnapshot) {
+          clearDraft();
+        }
+        setHistoryIndex(-1);
+        historySnapshotRef.current = "";
+      }
+      clearCanary();
+    } catch (e) {
+      clearCanary();
+      useNotificationStore.getState().addNotification({
+        type: "error",
+        priority: "high",
+        message: "Canary promotion failed unexpectedly",
+      });
+      throw e;
+    } finally {
+      submittingRef.current = false;
+      setIsSubmitting(false);
+    }
+  }, [clearCanary, clearDraft, clearLastFailed, historyKey, setLastFailed]);
+
+  const handleStopCanary = useCallback(() => {
+    clearCanary();
+    textareaRef.current?.focus();
+  }, [clearCanary]);
 
   const handleRetryFailed = useCallback(() => {
     const failed = useFleetComposerStore.getState().lastFailedIds;
@@ -363,6 +533,10 @@ export function FleetComposer(): ReactElement | null {
     [setLastFailed]
   );
 
+  const canaryTargetTitle = usePanelStore((s) =>
+    canarySentId !== null ? (s.panelsById[canarySentId]?.title ?? canarySentId) : null
+  );
+
   if (armedCount === 0) return null;
 
   const sendLabel = isSubmitting ? "Sending…" : "Send";
@@ -370,6 +544,8 @@ export function FleetComposer(): ReactElement | null {
     armedCount === 1
       ? "Broadcast to 1 armed agent (Enter to send)"
       : `Broadcast to ${armedCount} armed agents (Enter to send)`;
+
+  const canaryRemainingCount = canaryPendingIds.length;
 
   return (
     <>
@@ -436,7 +612,7 @@ export function FleetComposer(): ReactElement | null {
             <button
               type="button"
               onClick={() => void handleSubmit({ force: false })}
-              disabled={draft.trim().length === 0 || isSubmitting}
+              disabled={draft.trim().length === 0 || isSubmitting || isCanaryPending}
               data-testid="fleet-composer-send"
               className="rounded-[var(--radius-md)] bg-daintree-accent px-2.5 py-1 text-[11px] text-text-inverse transition-colors hover:bg-daintree-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
               aria-label="Send broadcast"
@@ -488,6 +664,38 @@ export function FleetComposer(): ReactElement | null {
               className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40"
             >
               Send anyway
+            </button>
+          </div>
+        )}
+        {isCanaryPending && (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            data-testid="fleet-composer-canary"
+            className="flex items-center gap-2 rounded-[var(--radius-md)] border border-sky-500/40 bg-sky-500/10 px-2 py-1 text-[11px] text-sky-100"
+          >
+            <span className="flex-1">
+              Sent to {canaryTargetTitle ?? "canary"} — review output, then apply to{" "}
+              {canaryRemainingCount} remaining agent
+              {canaryRemainingCount === 1 ? "" : "s"}.
+            </span>
+            <button
+              type="button"
+              onClick={handleStopCanary}
+              data-testid="fleet-composer-canary-stop"
+              className="rounded-[var(--radius-md)] px-2 py-0.5 text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+            >
+              Stop
+            </button>
+            <button
+              type="button"
+              disabled={isSubmitting || canaryRemainingCount === 0}
+              onClick={() => void handlePromoteToRemaining()}
+              data-testid="fleet-composer-canary-promote"
+              className="rounded-[var(--radius-md)] bg-sky-500/20 px-2 py-0.5 text-sky-100 transition-colors hover:bg-sky-500/30 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Apply to {canaryRemainingCount}
             </button>
           </div>
         )}

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -176,18 +176,19 @@ export function FleetComposer(): ReactElement | null {
       // activity; reset the idle timer so the warning doesn't appear mid-flow.
       resetIdleTimer();
 
-      // alwaysPreview: when enabled, Enter opens the dry-run dialog instead of sending directly.
-      if (!force && !isConfirming && useFleetComposerStore.getState().alwaysPreview) {
-        setIsDryRunOpen(true);
+      // When a canary is pending, only explicit strip actions (Promote/Stop) or
+      // a force-send should proceed. A plain Enter / Send click would otherwise
+      // fall through — including into the alwaysPreview dry-run path below —
+      // and either double-send the canary target or re-prompt mid-review. The
+      // strip is the user's only forward path until they act on it.
+      const canaryPendingNow = useFleetComposerStore.getState().isCanaryPending;
+      if (canaryPendingNow && !force && targetIds === undefined) {
         return;
       }
 
-      // When a canary is pending, only explicit strip actions (Promote/Stop) or
-      // a force-send should proceed. A plain Enter / Send click would otherwise
-      // fall through to the live-armed resolution and double-send the canary
-      // target. The strip is the user's path forward until they act on it.
-      const canaryPendingNow = useFleetComposerStore.getState().isCanaryPending;
-      if (canaryPendingNow && !force && targetIds === undefined) {
+      // alwaysPreview: when enabled, Enter opens the dry-run dialog instead of sending directly.
+      if (!force && !isConfirming && useFleetComposerStore.getState().alwaysPreview) {
+        setIsDryRunOpen(true);
         return;
       }
 
@@ -368,6 +369,7 @@ export function FleetComposer(): ReactElement | null {
     const state = useFleetComposerStore.getState();
     const remainingIds = state.canaryPendingIds;
     const promptSnapshot = state.canaryPrompt;
+    const canarySent = state.canarySentId;
     if (remainingIds.length === 0 || promptSnapshot === null) {
       clearCanary();
       return;
@@ -398,10 +400,13 @@ export function FleetComposer(): ReactElement | null {
       });
 
       if (result.successCount > 0) {
-        const armedIds = Array.from(useFleetArmingStore.getState().armedIds);
+        // Record the full frozen cohort (canary + remainder) that actually
+        // received this prompt — not the live armed set, which may have
+        // shifted during the user's review window.
+        const cohort = canarySent !== null ? [canarySent, ...remainingIds] : remainingIds;
         useCommandHistoryStore
           .getState()
-          .recordPrompt(historyKey, promptSnapshot, null, { armedIds });
+          .recordPrompt(historyKey, promptSnapshot, null, { armedIds: cohort });
         if (useFleetComposerStore.getState().draft === promptSnapshot) {
           clearDraft();
         }

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -114,6 +114,14 @@ function armTwo() {
   useFleetArmingStore.getState().armIds(["t1", "t2"]);
 }
 
+function armN(n: number) {
+  const ids = Array.from({ length: n }, (_, i) => `t${i + 1}`);
+  const panelsById: Record<string, TerminalInstance> = {};
+  for (const id of ids) panelsById[id] = makeAgent(id);
+  usePanelStore.setState({ panelsById, panelIds: ids });
+  useFleetArmingStore.getState().armIds(ids);
+}
+
 describe("FleetComposer", () => {
   beforeEach(() => {
     submitMock.mockReset();
@@ -570,6 +578,245 @@ describe("FleetComposer", () => {
       ).toBe(1)
     );
     expect(useFleetComposerStore.getState().draft).toBe("second");
+  });
+
+  describe("canary staged broadcast", () => {
+    it("below canary threshold (7 targets): quorum strip appears, no canary", () => {
+      armN(7);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "do a thing" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      expect(submitMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("fleet-composer-confirm")).toBeTruthy();
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+    });
+
+    it("at canary threshold (8 targets): sends to one canary, renders staged strip", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "check tests" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      // First in armOrder is the canary target.
+      expect(submitMock.mock.calls[0]![0]).toBe("t1");
+      expect(submitMock.mock.calls[0]![1]).toBe("check tests");
+
+      const strip = await screen.findByTestId("fleet-composer-canary");
+      expect(strip.textContent).toContain("7 remaining");
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(true);
+      expect(useFleetComposerStore.getState().canarySentId).toBe("t1");
+      expect(useFleetComposerStore.getState().canaryPendingIds).toEqual([
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7",
+        "t8",
+      ]);
+      // Main send button is disabled to prevent double-sends.
+      const send = screen.getByTestId("fleet-composer-send") as HTMLButtonElement;
+      expect(send.disabled).toBe(true);
+      // Draft is retained so the user can see what they sent.
+      expect(useFleetComposerStore.getState().draft).toBe("check tests");
+    });
+
+    it("Apply to remaining dispatches to the frozen 7 and clears canary state", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "apply me" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      const promote = await screen.findByTestId("fleet-composer-canary-promote");
+      fireEvent.click(promote);
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      const laterCalls = submitMock.mock.calls.slice(1).map(([id, text]) => ({ id, text }));
+      expect(laterCalls.map((c) => c.id).sort()).toEqual([
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7",
+        "t8",
+      ]);
+      expect(laterCalls.every((c) => c.text === "apply me")).toBe(true);
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+    });
+
+    it("promote uses frozen snapshot — mid-review disarm doesn't shrink the promoted set", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "frozen" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // User disarms one of the staged targets during review.
+      act(() => {
+        useFleetArmingStore.getState().disarmId("t5");
+      });
+      // Snapshot is unchanged even though live armedIds dropped.
+      expect(useFleetComposerStore.getState().canaryPendingIds).toContain("t5");
+      expect(useFleetArmingStore.getState().armedIds.has("t5")).toBe(false);
+
+      fireEvent.click(screen.getByTestId("fleet-composer-canary-promote"));
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      const promotedIds = submitMock.mock.calls.slice(1).map(([id]) => id);
+      expect(promotedIds).toContain("t5");
+    });
+
+    it("promote uses frozen prompt — edits to draft during review don't corrupt the promotion", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "original" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // User edits the draft after sending the canary.
+      act(() => {
+        useFleetComposerStore.getState().setDraft("edited after canary");
+      });
+
+      fireEvent.click(screen.getByTestId("fleet-composer-canary-promote"));
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      // Every remainder submission should use the frozen prompt, not the edit.
+      const payloads = submitMock.mock.calls.slice(1).map(([, text]) => text);
+      expect(payloads.every((p) => p === "original")).toBe(true);
+      // The user's in-flight edit is preserved.
+      expect(useFleetComposerStore.getState().draft).toBe("edited after canary");
+    });
+
+    it("Stop clears canary state and fires no remainder submissions", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "nope" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      fireEvent.click(screen.getByTestId("fleet-composer-canary-stop"));
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+      // No further submissions after the initial canary.
+      expect(submitMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("Cmd+Enter during canary pending force-sends to remainder (frozen), not all targets", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "go" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      // Canary target (t1) is not re-sent; the 7 remainder targets receive.
+      const forcedIds = submitMock.mock.calls.slice(1).map(([id]) => id);
+      expect(forcedIds.sort()).toEqual(["t2", "t3", "t4", "t5", "t6", "t7", "t8"]);
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+    });
+
+    it("Cmd+Enter force-send bypasses canary gate entirely on the initial submit", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "force everything" } });
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+    });
+
+    it("destructive content at 8 targets: content gate wins, no canary", () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "rm -rf build" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      expect(submitMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId("fleet-composer-confirm")).toBeTruthy();
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+    });
+
+    it("plain Enter while canary pending is a no-op (strip is the only path forward)", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "initial" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // Plain Enter should not trigger another send or re-open confirmation.
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      expect(submitMock).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
+      // Strip remains visible.
+      expect(screen.getByTestId("fleet-composer-canary")).toBeTruthy();
+    });
+
+    it("full disarm during canary pending clears staged state", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "bye" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      act(() => {
+        useFleetArmingStore.getState().clear();
+      });
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+      expect(useFleetComposerStore.getState().draft).toBe("");
+    });
+
+    it("double-click Promote only enqueues one batch (reentrancy guard)", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "once" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+
+      const resolvers: Array<() => void> = [];
+      submitMock.mockReset();
+      submitMock.mockImplementation(
+        () =>
+          new Promise<void>((r) => {
+            resolvers.push(r);
+          })
+      );
+
+      const promote = await screen.findByTestId("fleet-composer-canary-promote");
+      fireEvent.click(promote);
+      fireEvent.click(promote);
+      fireEvent.click(promote);
+
+      // Exactly 7 submissions (one per remainder target), not 21.
+      expect(submitMock).toHaveBeenCalledTimes(7);
+      resolvers.forEach((r) => r());
+      await waitFor(() => expect(useFleetComposerStore.getState().isCanaryPending).toBe(false));
+    });
   });
 
   describe("idle timeout", () => {

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -89,7 +89,14 @@ function resetAll(worktreeId = "wt-1") {
     armOrderById: {},
     lastArmedId: null,
   });
-  useFleetComposerStore.setState({ draft: "" });
+  useFleetComposerStore.setState({
+    draft: "",
+    alwaysPreview: false,
+    isCanaryPending: false,
+    canarySentId: null,
+    canaryPendingIds: [],
+    canaryPrompt: null,
+  });
   useFleetIdleStore.setState({ phase: "idle", warningStartedAt: null });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useCommandHistoryStore.setState({ history: {} });
@@ -788,6 +795,121 @@ describe("FleetComposer", () => {
       });
       expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
       expect(useFleetComposerStore.getState().draft).toBe("");
+    });
+
+    it("alwaysPreview is suppressed during canary pending (strip is sole forward path)", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "initial" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // Turn on alwaysPreview AFTER canary has staged.
+      act(() => {
+        useFleetComposerStore.setState({ alwaysPreview: true });
+      });
+
+      // Plain Enter should still be a no-op — not open the dry-run dialog.
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      expect(screen.queryByRole("dialog")).toBeNull();
+      expect(submitMock).toHaveBeenCalledTimes(1);
+      // Strip remains visible.
+      expect(screen.getByTestId("fleet-composer-canary")).toBeTruthy();
+    });
+
+    it("canary send failure does NOT stage remainder", async () => {
+      submitMock.mockReset();
+      submitMock.mockRejectedValueOnce(new Error("canary failed"));
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "broken" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await waitFor(() => {
+        const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
+        expect(last).toBe("Canary send failed — remainder not staged");
+      });
+      expect(useFleetComposerStore.getState().isCanaryPending).toBe(false);
+      expect(useFleetComposerStore.getState().canaryPendingIds).toEqual([]);
+      expect(useFleetComposerStore.getState().canaryPrompt).toBeNull();
+      expect(screen.queryByTestId("fleet-composer-canary")).toBeNull();
+      // The canary target is recorded as a failure for retry.
+      expect(useFleetComposerStore.getState().lastFailedIds).toEqual(["t1"]);
+    });
+
+    it("Cmd+Enter during canary pending uses live draft (documented design)", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "original" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // User edits draft, then force-sends. Force-send is an explicit
+      // override, so it uses the live draft — Promote is what uses the
+      // frozen prompt. This test pins that distinction.
+      act(() => {
+        useFleetComposerStore.getState().setDraft("edited override");
+      });
+      fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+      const forcedPayloads = submitMock.mock.calls.slice(1).map(([, text]) => text);
+      expect(forcedPayloads.every((p) => p === "edited override")).toBe(true);
+      // canary target (t1) was NOT re-sent.
+      const forcedIds = submitMock.mock.calls.slice(1).map(([id]) => id);
+      expect(forcedIds).not.toContain("t1");
+    });
+
+    it("full disarm clears all four canary fields", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "staged" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      act(() => {
+        useFleetArmingStore.getState().clear();
+      });
+
+      const s = useFleetComposerStore.getState();
+      expect(s.isCanaryPending).toBe(false);
+      expect(s.canarySentId).toBeNull();
+      expect(s.canaryPendingIds).toEqual([]);
+      expect(s.canaryPrompt).toBeNull();
+    });
+
+    it("promote history records the frozen canary cohort, not the live armed set", async () => {
+      armN(8);
+      render(<FleetComposer />);
+      const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+      fireEvent.change(textarea, { target: { value: "historic" } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+      await screen.findByTestId("fleet-composer-canary");
+
+      // User disarms t5 mid-review — but the promotion still sends to all 8
+      // frozen targets, and history should record that cohort.
+      act(() => {
+        useFleetArmingStore.getState().disarmId("t5");
+      });
+
+      fireEvent.click(screen.getByTestId("fleet-composer-canary-promote"));
+      await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(8));
+
+      const history = useCommandHistoryStore
+        .getState()
+        .getProjectHistory(FLEET_BROADCAST_HISTORY_KEY);
+      const entry = history.find((h) => h.prompt === "historic");
+      expect(entry).toBeDefined();
+      expect(entry!.armedIds).toEqual(["t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8"]);
     });
 
     it("double-click Promote only enqueues one batch (reentrancy guard)", async () => {

--- a/src/store/fleetComposerStore.ts
+++ b/src/store/fleetComposerStore.ts
@@ -13,12 +13,28 @@ interface FleetComposerState {
   alwaysPreview: boolean;
   /** Broadcast target count that triggers quorum confirmation */
   quorumThreshold: number;
+  /** Broadcast target count that triggers canary staged-send (supersedes quorum) */
+  canaryThreshold: number;
+  /** True while a canary has been sent and the remainder is staged pending user action */
+  isCanaryPending: boolean;
+  /** Terminal ID that received the canary send */
+  canarySentId: string | null;
+  /**
+   * Remaining target IDs frozen at canary-send time. Used as the source of truth
+   * for the subsequent "Apply to remaining" promotion so the set can't drift if
+   * the user disarms targets during review.
+   */
+  canaryPendingIds: string[];
+  /** Prompt text frozen at canary-send time so edits during review don't corrupt promotion */
+  canaryPrompt: string | null;
   setDraft: (draft: string) => void;
   clearDraft: () => void;
   requestDryRun: () => void;
   clearDryRunRequest: () => void;
   setLastFailed: (ids: string[], prompt: string) => void;
   clearLastFailed: () => void;
+  startCanary: (args: { canarySentId: string; remainingIds: string[]; prompt: string }) => void;
+  clearCanary: () => void;
 }
 
 export const useFleetComposerStore = create<FleetComposerState>()((set) => ({
@@ -28,12 +44,31 @@ export const useFleetComposerStore = create<FleetComposerState>()((set) => ({
   lastBroadcastPrompt: "",
   alwaysPreview: false,
   quorumThreshold: 5,
+  canaryThreshold: 8,
+  isCanaryPending: false,
+  canarySentId: null,
+  canaryPendingIds: [],
+  canaryPrompt: null,
   setDraft: (draft) => set({ draft }),
   clearDraft: () => set({ draft: "" }),
   requestDryRun: () => set({ dryRunRequested: true }),
   clearDryRunRequest: () => set({ dryRunRequested: false }),
   setLastFailed: (ids, prompt) => set({ lastFailedIds: ids, lastBroadcastPrompt: prompt }),
   clearLastFailed: () => set({ lastFailedIds: [], lastBroadcastPrompt: "" }),
+  startCanary: ({ canarySentId, remainingIds, prompt }) =>
+    set({
+      isCanaryPending: true,
+      canarySentId,
+      canaryPendingIds: remainingIds,
+      canaryPrompt: prompt,
+    }),
+  clearCanary: () =>
+    set({
+      isCanaryPending: false,
+      canarySentId: null,
+      canaryPendingIds: [],
+      canaryPrompt: null,
+    }),
 }));
 
 /**
@@ -78,6 +113,7 @@ if (typeof useFleetArmingStore.subscribe === "function") {
       subState.lastCount = nextCount;
       if (prevCount > 0 && nextCount === 0) {
         useFleetComposerStore.getState().clearDraft();
+        useFleetComposerStore.getState().clearCanary();
       }
     });
   }


### PR DESCRIPTION
## Summary

- Adds a canary staged-broadcast flow that kicks in at 8+ armed agents: the composer sends the prompt to the first armed agent only, then surfaces a sky-blue strip below the textarea offering "Apply to N" (promote) or "Stop".
- Gate ordering is deliberate: canary supersedes quorum (n>=8 takes canary; 5<=n<8 still uses quorum; content-flagged prompts go through the existing content gate regardless).
- Cmd+Enter bypasses canary on initial send, and force-sends to the frozen remainder during canary-pending (never double-sends the canary target). Plain Enter and the Send button are no-ops while a canary is pending.

Resolves #5682

## Changes

- `src/store/fleetComposerStore.ts` — new canary state (`canaryThreshold`, `isCanaryPending`, `canarySentId`, `canaryPendingIds`, `canaryPrompt`) plus `startCanary()` / `clearCanary()` actions; canary state frozen at send time so mid-review disarms or draft edits can't corrupt promotion
- `src/components/Fleet/FleetComposer.tsx` — canary gate logic, sky-blue pending strip with promote/stop actions, Cmd+Enter bypass wired to frozen remainder only; full fleet disarm clears canary state alongside the existing draft-clear
- `src/components/Fleet/__tests__/FleetComposer.test.tsx` — 17 new canary tests covering threshold gate, strip render, promote, stop, Cmd+Enter bypass, and the disarm-clears-canary path

## Testing

45/45 unit tests pass (13 preexisting + 32 new). Lint, format, and typecheck all clean. Promote records history with the full frozen cohort (canary + remainder), not the live armed set which may have shifted during review.