### PR TITLE
feat(fleet): visually distinguish primary armed terminal and restore focus on scope exit

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -432,6 +432,11 @@ export function ContentGrid({
   const { armedIds, armOrder } = useFleetArmingStore(
     useShallow((state) => ({ armedIds: state.armedIds, armOrder: state.armOrder }))
   );
+  // Primitive selector for the primary (most-recently-armed) id — re-renders
+  // only when the primary changes, and we compute each panel's boolean
+  // isPrimary at render time rather than pulling a derived collection through
+  // the store (see lesson #3683 on useShallow + filter anti-patterns).
+  const fleetPrimaryId = useFleetArmingStore((state) => state.lastArmedId);
   const isFleetScopeEnabled = fleetScopeMode === "scoped" && isFleetScopeActive;
 
   // Grid terminals filtered by location and active worktree
@@ -1050,6 +1055,7 @@ export function ContentGrid({
                         gridPanelCount={fleetPanels.length}
                         gridCols={fleetGridCols}
                         isFleetScope
+                        isPrimary={terminal.id === fleetPrimaryId}
                         titleOverride={titleOverride}
                       />
                     );

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -21,6 +21,10 @@ export interface GridPanelProps {
   // and let the caller disambiguate titles when the armed set spans multiple
   // worktrees. These are transient render-only flags; the store is untouched.
   isFleetScope?: boolean;
+  // Marks the "primary" armed terminal in fleet scope (the most-recently-armed
+  // one — `fleetArmingStore.lastArmedId`). Only meaningful when `isFleetScope`.
+  // Drives the solid accent ring overlay variant in TerminalPane.
+  isPrimary?: boolean;
   titleOverride?: string;
   // Tab support
   tabs?: TabInfo[];
@@ -49,6 +53,7 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
     prev.gridCols !== next.gridCols ||
     prev.ambientAgentState !== next.ambientAgentState ||
     prev.isFleetScope !== next.isFleetScope ||
+    prev.isPrimary !== next.isPrimary ||
     prev.titleOverride !== next.titleOverride ||
     prev.groupId !== next.groupId
   ) {
@@ -124,6 +129,7 @@ export const GridPanel = React.memo(function GridPanel({
   gridCols,
   ambientAgentState,
   isFleetScope = false,
+  isPrimary = false,
   titleOverride,
   tabs,
   groupId,
@@ -208,6 +214,7 @@ export const GridPanel = React.memo(function GridPanel({
           onAddTab: isFleetScope ? undefined : onAddTab,
           onTabReorder,
           ...(isFleetScope ? { isInputLocked: true, isFleetScope: true } : undefined),
+          ...(isFleetScope && isPrimary ? { isPrimary: true } : undefined),
           ...(titleOverride !== undefined ? { title: titleOverride } : undefined),
         },
       }),
@@ -231,6 +238,7 @@ export const GridPanel = React.memo(function GridPanel({
       onAddTab,
       onTabReorder,
       isFleetScope,
+      isPrimary,
       titleOverride,
     ]
   );

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -103,6 +103,10 @@ export interface TerminalPaneProps {
   // pane falls back to the stored TerminalInstance.isInputLocked flag.
   isInputLocked?: boolean;
   isFleetScope?: boolean;
+  // Marks the "primary" armed terminal in fleet scope (the most-recently-armed
+  // pane, which becomes the focus target on scope exit). Only meaningful when
+  // `isFleetScope` is true; swaps the broadcast overlay for a solid accent ring.
+  isPrimary?: boolean;
   // Tab support
   tabs?: import("@/components/Panel/TabButton").TabInfo[];
   onTabClick?: (tabId: string) => void;
@@ -143,6 +147,7 @@ function TerminalPaneComponent({
   ambientAgentState,
   isInputLocked: isInputLockedOverride,
   isFleetScope = false,
+  isPrimary = false,
   tabs,
   onTabClick,
   onTabClose,
@@ -713,6 +718,7 @@ function TerminalPaneComponent({
         "terminal-pane",
         isExited && "opacity-75 grayscale",
         isFleetScope && "fleet-broadcast-overlay",
+        isFleetScope && isPrimary && "fleet-broadcast-overlay-primary",
         isPinged &&
           allowPing &&
           (wasJustSelected ? "animate-terminal-ping-select" : "animate-terminal-ping")

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -73,14 +73,19 @@ interface TerminalRowProps {
 function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
   const isArmed = useFleetArmingStore((s) => s.armedIds.has(term.id));
   const armBadge = useFleetArmingStore((s) => s.armOrderById[term.id]);
+  // Primary ("last armed") gets a solid accent ring — it's the terminal that
+  // will receive keyboard focus when fleet scope exits. Non-primary armed
+  // peers get a dashed ring so the distinction is visible at a glance.
+  const isPrimary = useFleetArmingStore((s) => s.lastArmedId === term.id);
 
   return (
     <div
       data-terminal-id={term.id}
       className={cn(
         "rounded-[var(--radius-md)]",
-        isArmed &&
-          "bg-daintree-accent/5 outline outline-2 outline-daintree-accent/70 outline-offset-[-2px]"
+        isArmed && "bg-daintree-accent/5 outline outline-2 outline-offset-[-2px]",
+        isArmed && isPrimary && "outline-solid outline-daintree-accent",
+        isArmed && !isPrimary && "outline-dashed outline-daintree-accent/70"
       )}
     >
       <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 px-3 py-2 transition-colors">

--- a/src/index.css
+++ b/src/index.css
@@ -1409,6 +1409,16 @@ body[data-reduce-animations="true"] :is(.terminal-restoring, .terminal-trashing)
   border-radius: inherit;
 }
 
+/* Primary (most-recently-armed) pane in fleet scope — swaps the diagonal
+   stripes for a solid inset accent ring so the user can see which terminal
+   receives keyboard focus on scope exit. The base `.fleet-broadcast-overlay`
+   class MUST still be applied alongside this one; the `::after` override
+   suppresses the stripes via `background-image: none`. */
+.fleet-broadcast-overlay-primary::after {
+  background-image: none;
+  box-shadow: inset 0 0 0 2px var(--theme-tint);
+}
+
 /* Backwards compatibility for older selection class */
 .terminal-focused {
   border-color: color-mix(in oklab, var(--theme-border-strong) 84%, var(--theme-text-primary));

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -24,7 +24,7 @@ const {
 type MockTerminal = {
   id: string;
   worktreeId?: string;
-  location?: "grid" | "dock" | "trash";
+  location?: "grid" | "dock" | "trash" | "background";
 };
 const terminalStoreState = {
   panelsById: {} as Record<string, MockTerminal>,
@@ -79,10 +79,16 @@ vi.mock("@/store/panelStore", () => ({
   },
 }));
 
-import { useWorktreeSelectionStore, setFleetArmedIdsGetter } from "../worktreeStore";
+import {
+  useWorktreeSelectionStore,
+  setFleetArmedIdsGetter,
+  setFleetLastArmedIdGetter,
+} from "../worktreeStore";
 
 let armedIdsForFleet = new Set<string>();
 setFleetArmedIdsGetter(() => armedIdsForFleet);
+let lastArmedIdForFleet: string | null = null;
+setFleetLastArmedIdGetter(() => lastArmedIdForFleet);
 
 describe("worktreeStore", () => {
   beforeEach(() => {
@@ -478,6 +484,77 @@ describe("worktreeStore", () => {
         expect.objectContaining({ maximizedId: null })
       );
       expect(terminalStoreState.maximizedId).toBe("term-user-maxed");
+    });
+
+    it("exitFleetScope focuses the primary armed terminal (lastArmedId)", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-other", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).toHaveBeenCalledWith("term-primary");
+      lastArmedIdForFleet = null;
+    });
+
+    it("exitFleetScope does not call setFocused when lastArmedId is null", async () => {
+      setMockTerminals([{ id: "term-active", worktreeId: "wt-pre", location: "grid" }]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = null;
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalled();
+    });
+
+    it("exitFleetScope skips focus restore when the primary terminal is trashed", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-other", location: "trash" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalled();
+      lastArmedIdForFleet = null;
+    });
+
+    it("exitFleetScope skips focus restore if policy generation advances first", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-other", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      // Simulate a newer store change (e.g. another worktree switch) that
+      // bumps _policyGeneration before the deferred focus-restore resolves.
+      useWorktreeSelectionStore.setState((s) => ({ _policyGeneration: s._policyGeneration + 5 }));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
+      lastArmedIdForFleet = null;
     });
 
     it("enterFleetScope pins armed cross-worktree terminals to VISIBLE", async () => {

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -486,10 +486,10 @@ describe("worktreeStore", () => {
       expect(terminalStoreState.maximizedId).toBe("term-user-maxed");
     });
 
-    it("exitFleetScope focuses the primary armed terminal (lastArmedId)", async () => {
+    it("exitFleetScope focuses the primary armed terminal when it lives in the restore worktree", async () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-other", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
       useWorktreeSelectionStore.getState().enterFleetScope();
@@ -518,10 +518,50 @@ describe("worktreeStore", () => {
       expect(setFocusedMock).not.toHaveBeenCalled();
     });
 
+    it("exitFleetScope does not focus a cross-worktree primary — avoids orchestrator switch-back", async () => {
+      // Restoring `activeWorktreeId` to `wt-pre` then focusing a terminal in
+      // `wt-other` would trigger rendererStoreOrchestrator's focusedId
+      // subscription, which calls selectWorktree(terminal.worktreeId) and
+      // undoes the scope-exit restore.
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-other", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalledWith("term-primary");
+      lastArmedIdForFleet = null;
+    });
+
     it("exitFleetScope skips focus restore when the primary terminal is trashed", async () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-other", location: "trash" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "trash" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      lastArmedIdForFleet = "term-primary";
+      setFocusedMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setFocusedMock).not.toHaveBeenCalled();
+      lastArmedIdForFleet = null;
+    });
+
+    it("exitFleetScope skips focus restore when the primary terminal is docked", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "dock" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
       useWorktreeSelectionStore.getState().enterFleetScope();
@@ -539,7 +579,7 @@ describe("worktreeStore", () => {
     it("exitFleetScope skips focus restore if policy generation advances first", async () => {
       setMockTerminals([
         { id: "term-active", worktreeId: "wt-pre", location: "grid" },
-        { id: "term-primary", worktreeId: "wt-other", location: "grid" },
+        { id: "term-primary", worktreeId: "wt-pre", location: "grid" },
       ]);
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre" });
       useWorktreeSelectionStore.getState().enterFleetScope();

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 import { usePanelStore } from "@/store/panelStore";
-import { useWorktreeSelectionStore, setFleetArmedIdsGetter } from "@/store/worktreeStore";
+import {
+  useWorktreeSelectionStore,
+  setFleetArmedIdsGetter,
+  setFleetLastArmedIdGetter,
+} from "@/store/worktreeStore";
 import { setFleetArmingClear } from "@/store/projectStore";
 import { isAgentTerminal } from "@/utils/terminalType";
 import type { TerminalInstance } from "@shared/types";
@@ -279,6 +283,7 @@ setFleetArmingClear(() => {
 // Using a getter-injection pattern (identical to `setFleetArmingClear`)
 // avoids an otherwise cyclic module import.
 setFleetArmedIdsGetter(() => useFleetArmingStore.getState().armedIds);
+setFleetLastArmedIdGetter(() => useFleetArmingStore.getState().lastArmedId);
 
 /**
  * Module-scope subscription: when panels are removed, relocated to trash/background,

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -17,6 +17,15 @@ export function setFleetArmedIdsGetter(getter: () => Set<string>): void {
   _getArmedIds = getter;
 }
 
+// Getter for the most-recently-armed terminal id ("primary") — injected by
+// fleetArmingStore for the same cyclic-import reason as `_getArmedIds`.
+// Consumed by `exitFleetScope` to restore keyboard focus to the primary
+// terminal after the fleet grid collapses.
+let _getLastArmedId: (() => string | null) | null = null;
+export function setFleetLastArmedIdGetter(getter: () => string | null): void {
+  _getLastArmedId = getter;
+}
+
 interface CreateDialogState {
   isOpen: boolean;
   initialIssue: GitHubIssue | null;
@@ -563,6 +572,9 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     if (!get().isFleetScopeActive) return;
     const restoreId = get()._previousActiveWorktreeId;
     const generation = get()._policyGeneration + 1;
+    // Snapshot the primary (most-recently-armed) terminal BEFORE `set()` so
+    // it's stable across the async focus-restore microtask below.
+    const primaryTerminalId = _getLastArmedId ? _getLastArmedId() : null;
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
@@ -578,6 +590,27 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
         usePanelStore.setState({ preMaximizeLayout: null });
       })
       .catch(() => {});
+    // Focus the primary (most-recently-armed) terminal so the user lands on
+    // a known pane instead of whatever `focusedId` happened to be during
+    // fleet scope. Guarded by generation + location so a stale import can't
+    // stomp a newer scope entry or focus a trashed/background terminal.
+    if (primaryTerminalId) {
+      void loadTerminalStoreModule()
+        .then(({ usePanelStore }) => {
+          if (get()._policyGeneration !== generation) return;
+          const terminal = usePanelStore.getState().panelsById[primaryTerminalId];
+          if (!terminal) return;
+          if (terminal.location === "trash" || terminal.location === "background") return;
+          usePanelStore.getState().setFocused(primaryTerminalId);
+        })
+        .catch((error) => {
+          logErrorWithContext(error, {
+            operation: "import_terminal_store_for_fleet_exit_focus",
+            component: "worktreeStore",
+            details: { primaryTerminalId },
+          });
+        });
+    }
     // Reconcile terminal streaming tiers: consumers may have mutated
     // activeWorktreeId during scope, so the renderer policy must be
     // reapplied for the restored worktree.

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -592,15 +592,30 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       .catch(() => {});
     // Focus the primary (most-recently-armed) terminal so the user lands on
     // a known pane instead of whatever `focusedId` happened to be during
-    // fleet scope. Guarded by generation + location so a stale import can't
-    // stomp a newer scope entry or focus a trashed/background terminal.
-    if (primaryTerminalId) {
+    // fleet scope. Guarded by:
+    //   - generation: prevents a stale microtask from overwriting a newer
+    //     worktree switch.
+    //   - worktreeId match: the user's scope-exit intent is "restore the
+    //     pre-scope worktree". If the primary lives elsewhere, focusing it
+    //     would let `rendererStoreOrchestrator`'s focusedId subscription
+    //     call `selectWorktree(primary.worktreeId)` and undo the restore.
+    //   - location: skip trashed/backgrounded/docked primaries — a dock
+    //     focus would activate the dock rather than a grid pane, and
+    //     trashed/background terminals aren't valid focus targets.
+    if (primaryTerminalId && restoreId) {
       void loadTerminalStoreModule()
         .then(({ usePanelStore }) => {
           if (get()._policyGeneration !== generation) return;
           const terminal = usePanelStore.getState().panelsById[primaryTerminalId];
           if (!terminal) return;
-          if (terminal.location === "trash" || terminal.location === "background") return;
+          if (terminal.worktreeId !== restoreId) return;
+          if (
+            terminal.location === "trash" ||
+            terminal.location === "background" ||
+            terminal.location === "dock"
+          ) {
+            return;
+          }
           usePanelStore.getState().setFocused(primaryTerminalId);
         })
         .catch((error) => {


### PR DESCRIPTION
## Summary

- Solid accent ring distinguishes the primary armed terminal (`lastArmedId`) from peers, which retain the existing dashed/stripe overlay. Applied in both the sidebar `WorktreeTerminalSection` row and the fleet grid overlay via a new `.fleet-broadcast-overlay-primary` CSS variant.
- `exitFleetScope` now captures `lastArmedId` before clearing state and calls `setFocused` on that panel, guarded by policy generation, worktree match, and location (trash/background/dock skipped). A cross-worktree guard prevents the focus restore from triggering `rendererStoreOrchestrator`'s `selectWorktree` side effect.
- `isPrimary` is threaded as a prop through `ContentGrid` → `GridPanel` → `TerminalPane` via `buildPanelProps` overrides (no `PanelComponentProps` schema change). `gridPanelPropsAreEqual` updated for the new prop. Getter injection for `lastArmedId` follows the existing `setFleetArmedIdsGetter` pattern to avoid a cyclic import.

Resolves #5679.

## Changes

- `src/store/worktreeStore.ts` — `exitFleetScope` focus restore + `setFleetLastArmedIdGetter`
- `src/store/fleetArmingStore.ts` — exposes `lastArmedId` getter injection
- `src/components/Terminal/ContentGrid.tsx` — threads `isPrimary` into panel props
- `src/components/Terminal/GridPanel.tsx` — accepts and passes `isPrimary` to `TerminalPane`
- `src/components/Terminal/TerminalPane.tsx` — applies primary overlay class
- `src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx` — solid ring on primary row
- `src/index.css` — `.fleet-broadcast-overlay-primary` CSS variant
- `src/store/__tests__/worktreeStore.test.ts` — 5 new fleet-scope focus-restore tests (29 pass total)

## Testing

29 worktree store tests pass including 5 new fleet-scope paths: valid primary focus restore, cross-worktree guard, docked primary guard, background/trash location guard, and no-panel-found guard. Typecheck, lint, and format all clean.