### PR TITLE
chore(ipc,store): delete handler shims and version Zustand persist stores

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -67,10 +67,10 @@ const registerMocks = vi.hoisted(() => ({
   registerPerfHandlers: vi.fn(),
 }));
 
-vi.mock("../handlers/worktree.js", () => ({
+vi.mock("../handlers/worktree/index.js", () => ({
   registerWorktreeHandlers: registerMocks.registerWorktreeHandlers,
 }));
-vi.mock("../handlers/terminal.js", () => ({
+vi.mock("../handlers/terminal/index.js", () => ({
   registerTerminalHandlers: registerMocks.registerTerminalHandlers,
 }));
 vi.mock("../handlers/files.js", () => ({
@@ -94,7 +94,7 @@ vi.mock("../handlers/editorConfig.js", () => ({
 vi.mock("../handlers/agentCli.js", () => ({
   registerAgentCliHandlers: registerMocks.registerAgentCliHandlers,
 }));
-vi.mock("../handlers/projectCrud.js", () => ({
+vi.mock("../handlers/projectCrud/index.js", () => ({
   registerProjectCrudHandlers: registerMocks.registerProjectCrudHandlers,
 }));
 vi.mock("../handlers/projectRecipes.js", () => ({

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1,12 +1,12 @@
 import type { HandlerDependencies } from "./types.js";
-import { registerWorktreeHandlers } from "./handlers/worktree.js";
-import { registerTerminalHandlers } from "./handlers/terminal.js";
+import { registerWorktreeHandlers } from "./handlers/worktree/index.js";
+import { registerTerminalHandlers } from "./handlers/terminal/index.js";
 import { registerCopyTreeHandlers } from "./handlers/copyTree.js";
 import { registerAiHandlers } from "./handlers/ai.js";
 import { registerSystemShellHandlers } from "./handlers/systemShell.js";
 import { registerEditorConfigHandlers } from "./handlers/editorConfig.js";
 import { registerAgentCliHandlers } from "./handlers/agentCli.js";
-import { registerProjectCrudHandlers } from "./handlers/projectCrud.js";
+import { registerProjectCrudHandlers } from "./handlers/projectCrud/index.js";
 import { registerProjectRecipesHandlers } from "./handlers/projectRecipes.js";
 import { registerProjectPresetsHandlers } from "./handlers/projectPresets.js";
 import { registerGlobalRecipesHandlers } from "./handlers/globalRecipes.js";

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -88,7 +88,7 @@ vi.mock("../../../window/portDistribution.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 
 function makePtyClient(overrides: Record<string, unknown> = {}) {

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -44,7 +44,7 @@ vi.mock("../../../services/ProjectSwitchService.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 
 describe("project:close handler", () => {

--- a/electron/ipc/handlers/__tests__/project.openDialog.test.ts
+++ b/electron/ipc/handlers/__tests__/project.openDialog.test.ts
@@ -58,7 +58,7 @@ vi.mock("../../../window/portDistribution.js", () => ({
 
 import { ipcMain, dialog } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 
 function getHandler(channel: string): (...args: unknown[]) => unknown {

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -40,7 +40,7 @@ vi.mock("../../../services/ProjectSwitchService.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 
 function getHandler(channel: string) {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -61,7 +61,7 @@ vi.mock("../../../window/portDistribution.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
 import type {
   WindowRegistry,

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -105,7 +105,7 @@ vi.mock("../../../utils/logger.js", () => ({
   logError: vi.fn(),
 }));
 
-import { registerWorktreeHandlers } from "../worktree.js";
+import { registerWorktreeHandlers } from "../worktree/index.js";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 

--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -89,7 +89,7 @@ vi.mock("../../../services/SoundService.js", () => ({
 }));
 
 import { CHANNELS } from "../../channels.js";
-import { registerWorktreeHandlers } from "../worktree.js";
+import { registerWorktreeHandlers } from "../worktree/index.js";
 
 function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
   const call = (ipcMainMock.handle as Mock).mock.calls.find(

--- a/electron/ipc/handlers/projectCrud.ts
+++ b/electron/ipc/handlers/projectCrud.ts
@@ -1,8 +1,0 @@
-/**
- * Project CRUD handlers — re-exports from the modular projectCrud handlers.
- *
- * @deprecated Import directly from './projectCrud/index.js' for new code.
- * This file is kept for backward compatibility with existing imports.
- */
-
-export { registerProjectCrudHandlers, getProjectStatsService } from "./projectCrud/index.js";

--- a/electron/ipc/handlers/terminal.ts
+++ b/electron/ipc/handlers/terminal.ts
@@ -1,8 +1,0 @@
-/**
- * Terminal handlers - Re-exports from the modular terminal handlers.
- *
- * @deprecated Import directly from './terminal/index.js' for new code.
- * This file is kept for backward compatibility with existing imports.
- */
-
-export { registerTerminalHandlers } from "./terminal/index.js";

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -1,8 +1,0 @@
-/**
- * Worktree handlers - Re-exports from the modular worktree handlers.
- *
- * @deprecated Import directly from './worktree/index.js' for new code.
- * This file is kept for backward compatibility with existing imports.
- */
-
-export { registerWorktreeHandlers } from "./worktree/index.js";

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -65,7 +65,7 @@ import {
   setupWindowFocusThrottle,
   registerWindowForFocusThrottle,
 } from "./window/powerMonitor.js";
-import { getProjectStatsService } from "./ipc/handlers/projectCrud.js";
+import { getProjectStatsService } from "./ipc/handlers/projectCrud/index.js";
 import { isSmokeTest } from "./setup/environment.js";
 import { store } from "./store.js";
 import {

--- a/src/store/__tests__/agentPreferencesStore.test.ts
+++ b/src/store/__tests__/agentPreferencesStore.test.ts
@@ -75,7 +75,11 @@ describe("agentPreferencesStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as { version: number };
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { defaultAgent?: string };
+    };
     expect(parsed.version).toBe(0);
+    expect(parsed.state.defaultAgent).toBe("gemini");
   });
 });

--- a/src/store/__tests__/agentPreferencesStore.test.ts
+++ b/src/store/__tests__/agentPreferencesStore.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("agentPreferencesStore persistence migration", () => {
+  const STORAGE_KEY = "daintree-agent-preferences";
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rehydrates a legacy unversioned blob with a valid defaultAgent", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { defaultAgent: "claude" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useAgentPreferencesStore: store } = await import("../agentPreferencesStore");
+
+    expect(store.getState().defaultAgent).toBe("claude");
+  });
+
+  it("preserves an explicit undefined defaultAgent from a legacy blob", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {},
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useAgentPreferencesStore: store } = await import("../agentPreferencesStore");
+
+    expect(store.getState().defaultAgent).toBeUndefined();
+  });
+
+  it("writes version: 0 on the next persist after rehydration", async () => {
+    const legacyBlob = JSON.stringify({ state: { defaultAgent: "claude" } });
+    const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useAgentPreferencesStore: store } = await import("../agentPreferencesStore");
+    store.getState().setDefaultAgent("gemini");
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as { version: number };
+    expect(parsed.version).toBe(0);
+  });
+});

--- a/src/store/__tests__/commandHistoryStore.test.ts
+++ b/src/store/__tests__/commandHistoryStore.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useCommandHistoryStore } from "../commandHistoryStore";
+import { useCommandHistoryStore, type PromptHistoryEntry } from "../commandHistoryStore";
 
 describe("commandHistoryStore", () => {
   beforeEach(() => {
@@ -178,7 +178,12 @@ describe("commandHistoryStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as { version: number };
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { history: Record<string, PromptHistoryEntry[]> };
+    };
     expect(parsed.version).toBe(0);
+    expect(parsed.state.history["proj1"]!.some((e) => e.prompt === "old")).toBe(true);
+    expect(parsed.state.history["proj1"]!.some((e) => e.prompt === "new")).toBe(true);
   });
 });

--- a/src/store/__tests__/commandHistoryStore.test.ts
+++ b/src/store/__tests__/commandHistoryStore.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCommandHistoryStore } from "../commandHistoryStore";
 
 describe("commandHistoryStore", () => {
@@ -91,5 +92,93 @@ describe("commandHistoryStore", () => {
     store.recordPrompt("proj1", "test", undefined);
     const entries = useCommandHistoryStore.getState().getProjectHistory("proj1");
     expect(entries[0]!.agentId).toBeNull();
+  });
+});
+
+describe("commandHistoryStore persistence migration", () => {
+  const STORAGE_KEY = "daintree-command-history";
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rehydrates a legacy unversioned blob without discarding history", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        history: {
+          proj1: [
+            {
+              id: "legacy-1",
+              prompt: "legacy prompt",
+              agentId: "claude",
+              addedAt: 1_700_000_000_000,
+            },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useCommandHistoryStore: store } = await import("../commandHistoryStore");
+
+    const entries = store.getState().getProjectHistory("proj1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.prompt).toBe("legacy prompt");
+    expect(entries[0]!.agentId).toBe("claude");
+  });
+
+  it("writes version: 0 on the next persist after rehydration", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        history: {
+          proj1: [{ id: "legacy-1", prompt: "old", agentId: null, addedAt: 1_700_000_000_000 }],
+        },
+      },
+    });
+    const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useCommandHistoryStore: store } = await import("../commandHistoryStore");
+    store.getState().recordPrompt("proj1", "new", null);
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as { version: number };
+    expect(parsed.version).toBe(0);
   });
 });

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -98,7 +98,12 @@ describe("helpPanelStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as { version: number };
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { width: number; preferredAgentId: string | null };
+    };
     expect(parsed.version).toBe(0);
+    expect(parsed.state.width).toBe(450);
+    expect(parsed.state.preferredAgentId).toBe("gemini");
   });
 });

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HELP_PANEL_DEFAULT_WIDTH,
+  HELP_PANEL_MAX_WIDTH,
+  HELP_PANEL_MIN_WIDTH,
+} from "../helpPanelStore";
+
+describe("helpPanelStore persistence migration", () => {
+  const STORAGE_KEY = "help-panel-storage";
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rehydrates a legacy unversioned blob and preserves in-range width", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        width: 500,
+        preferredAgentId: "claude",
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().width).toBe(500);
+    expect(store.getState().preferredAgentId).toBe("claude");
+  });
+
+  it("clamps out-of-range legacy width via the existing merge callback", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        width: HELP_PANEL_MAX_WIDTH + 1000,
+        preferredAgentId: null,
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().width).toBe(HELP_PANEL_MAX_WIDTH);
+  });
+
+  it("falls back to defaults when nothing is persisted", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().width).toBe(HELP_PANEL_DEFAULT_WIDTH);
+    expect(store.getState().width).toBeGreaterThanOrEqual(HELP_PANEL_MIN_WIDTH);
+  });
+
+  it("writes version: 0 on the next persist after rehydration", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().setWidth(450);
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as { version: number };
+    expect(parsed.version).toBe(0);
+  });
+});

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -372,7 +372,11 @@ describe("portalStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as { version: number };
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { width: number };
+    };
     expect(parsed.version).toBe(0);
+    expect(parsed.state.width).toBe(620);
   });
 });

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -274,3 +274,105 @@ describe("portalStore", () => {
     });
   });
 });
+
+describe("portalStore persistence migration", () => {
+  const STORAGE_KEY = "portal-storage";
+
+  function installLocalStorageWith(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    const mock = {
+      getItem: (key: string) => backing.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        backing.set(key, value);
+      },
+      removeItem: (key: string) => {
+        backing.delete(key);
+      },
+      clear: () => {
+        backing.clear();
+      },
+    } as unknown as Storage;
+    (globalThis as unknown as { localStorage: Storage }).localStorage = mock;
+    window.localStorage = mock;
+    return backing;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rehydrates a legacy unversioned blob and keeps user links", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        width: 600,
+        links: [
+          {
+            id: "user-1",
+            type: "user",
+            title: "Custom",
+            url: "https://example.com",
+            icon: "globe",
+            enabled: true,
+            order: 0,
+          },
+        ],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: legacyBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    const userLinks = store.getState().links.filter((l) => l.type === "user");
+    expect(userLinks).toHaveLength(1);
+    expect(userLinks[0]!.id).toBe("user-1");
+    expect(store.getState().width).toBe(600);
+  });
+
+  it("still runs the discovered→system merge migration after version check", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        links: [
+          {
+            id: "discovered-foo",
+            type: "discovered",
+            title: "Foo",
+            url: "https://foo.test",
+            icon: "globe",
+            enabled: true,
+          },
+        ],
+      },
+    });
+    installLocalStorageWith({ [STORAGE_KEY]: legacyBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+
+    const migrated = store.getState().links.find((l) => l.id === "system-foo");
+    expect(migrated).toBeDefined();
+    expect(migrated!.type).toBe("system");
+    expect(store.getState().links.some((l) => l.id === "discovered-foo")).toBe(false);
+  });
+
+  it("writes version: 0 on the next persist after rehydration", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        width: 600,
+        links: [],
+      },
+    });
+    const backing = installLocalStorageWith({ [STORAGE_KEY]: legacyBlob });
+
+    const { usePortalStore: store } = await import("../portalStore");
+    store.getState().setWidth(620);
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as { version: number };
+    expect(parsed.version).toBe(0);
+  });
+});

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -334,8 +334,13 @@ describe("urlHistoryStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as { version: number };
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { entries: Record<string, UrlHistoryEntry[]> };
+    };
     expect(parsed.version).toBe(0);
+    expect(parsed.state.entries["proj1"]!.some((e) => e.url === "http://a.test/")).toBe(true);
+    expect(parsed.state.entries["proj1"]!.some((e) => e.url === "http://b.test/")).toBe(true);
   });
 });
 

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
 import { useUrlHistoryStore, frecencyScore, getFrecencySuggestions } from "../urlHistoryStore";
 import type { UrlHistoryEntry } from "@shared/types/browser";
 
@@ -245,6 +246,96 @@ describe("getFrecencySuggestions", () => {
   it("limits results to specified count", () => {
     const results = getFrecencySuggestions(entries, "localhost", 2);
     expect(results).toHaveLength(2);
+  });
+});
+
+describe("urlHistoryStore persistence migration", () => {
+  const STORAGE_KEY = "daintree-url-history";
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+
+  function installLocalStorage(initial: Record<string, string>): Map<string, string> {
+    const backing = new Map<string, string>(Object.entries(initial));
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("rehydrates a legacy unversioned blob without discarding entries", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            {
+              url: "http://localhost:3000/",
+              title: "Legacy",
+              visitCount: 3,
+              lastVisitAt: 1_700_000_000_000,
+            },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+
+    const entries = store.getState().entries["proj1"];
+    expect(entries).toHaveLength(1);
+    expect(entries![0]!.url).toBe("http://localhost:3000/");
+    expect(entries![0]!.visitCount).toBe(3);
+  });
+
+  it("writes version: 0 on the next persist after rehydration", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            { url: "http://a.test/", title: "A", visitCount: 1, lastVisitAt: 1_700_000_000_000 },
+          ],
+        },
+      },
+    });
+    const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    store.getState().recordVisit("proj1", "http://b.test/", "B");
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as { version: number };
+    expect(parsed.version).toBe(0);
   });
 });
 

--- a/src/store/agentPreferencesStore.ts
+++ b/src/store/agentPreferencesStore.ts
@@ -35,6 +35,8 @@ export const useAgentPreferencesStore = create<AgentPreferencesState>()(
     {
       name: "daintree-agent-preferences",
       storage: createSafeJSONStorage(),
+      version: 0,
+      migrate: (persistedState) => persistedState as AgentPreferencesState,
       merge: (persistedState, currentState) => {
         const persisted = persistedState as Partial<AgentPreferencesState> | null;
 

--- a/src/store/commandHistoryStore.ts
+++ b/src/store/commandHistoryStore.ts
@@ -90,6 +90,8 @@ export const useCommandHistoryStore = create<CommandHistoryState>()(
     {
       name: "daintree-command-history",
       storage: createSafeJSONStorage(),
+      version: 0,
+      migrate: (persistedState) => persistedState as CommandHistoryState,
       partialize: (state) => ({ history: state.history }),
     }
   )

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -55,6 +55,8 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     {
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
+      version: 0,
+      migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -409,6 +409,8 @@ const portalStoreCreator: StateCreator<
 > = persist(createPortalStore, {
   name: "portal-storage",
   storage: createSafeJSONStorage(),
+  version: 0,
+  migrate: (persistedState) => persistedState as PortalState & PortalActions,
   partialize: (state) => ({
     links: state.links,
     width: state.width,

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -121,6 +121,8 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
     {
       name: "daintree-url-history",
       storage: createSafeJSONStorage(),
+      version: 0,
+      migrate: (persistedState) => persistedState as UrlHistoryState,
       partialize: (state) => ({ entries: state.entries }),
     }
   )


### PR DESCRIPTION
## Summary

- Deleted three deprecated IPC handler re-export shims (`worktree.ts`, `terminal.ts`, `projectCrud.ts`) and updated all import sites to point directly at the submodule entry points. All seven affected test files and `handlers.ts`/`main.ts` are updated.
- Added `version: 0` and a passthrough `migrate` callback to five Zustand persist stores (`agentPreferencesStore`, `commandHistoryStore`, `helpPanelStore`, `portalStore`, `urlHistoryStore`) that previously had no version field. Establishes a clean baseline so future schema changes can introduce numbered migrations without silent data corruption.
- Added fixture-based migration tests for all five stores, verifying that legacy unversioned blobs rehydrate intact and the first persist after rehydration writes `version: 0` with the partialized state preserved.

Resolves #5685

## Changes

- Deleted: `electron/ipc/handlers/worktree.ts`, `terminal.ts`, `projectCrud.ts`
- Updated: `electron/ipc/handlers.ts`, `electron/main.ts`, `electron/ipc/__tests__/handlers.registry.test.ts`
- Updated: 7 handler test files to import directly from submodule paths
- Updated: `src/store/agentPreferencesStore.ts`, `commandHistoryStore.ts`, `helpPanelStore.ts`, `portalStore.ts`, `urlHistoryStore.ts` (added `version: 0` + `migrate`)
- Added: migration tests in `src/store/__tests__/` for all five stores

## Testing

Unit tests cover the migration path for each store. The handler test suite verifies all IPC handlers remain registered after the import redirects. `npm run check` passes cleanly.