### PR TITLE
feat(boot): add centralized boot migration pipeline

### DIFF
--- a/electron/boot/migrations/BootMigrationRunner.ts
+++ b/electron/boot/migrations/BootMigrationRunner.ts
@@ -1,0 +1,113 @@
+import type { BootMigrationState } from "./BootMigrationState.js";
+import type { BootMigration, BootMigrationRunResult } from "./types.js";
+
+export interface BootMigrationRunnerOptions {
+  migrations: readonly BootMigration[];
+  state: BootMigrationState;
+  /** If true, the runner skips every migration and returns immediately. */
+  isSafeMode?: boolean;
+  /** Total-run budget. Exceeding it flips `didExceedBudget` on the result. */
+  budgetMs?: number;
+  /** Injection seam for tests — defaults to `Date.now`. */
+  now?: () => number;
+}
+
+const DEFAULT_BUDGET_MS = 500;
+
+/**
+ * Runs the registered boot migrations in array order, persisting each
+ * success to the marker before starting the next. A single failure stops
+ * the run and rethrows — the failing migration and everything after it stays
+ * out of the marker so the next boot retries from that point.
+ *
+ * Duplicate migration IDs are rejected at construction time because a
+ * duplicate would silently skip the second entry once the first is recorded.
+ */
+export class BootMigrationRunner {
+  private readonly migrations: readonly BootMigration[];
+  private readonly state: BootMigrationState;
+  private readonly isSafeMode: boolean;
+  private readonly budgetMs: number;
+  private readonly now: () => number;
+
+  constructor(options: BootMigrationRunnerOptions) {
+    BootMigrationRunner.assertUniqueIds(options.migrations);
+    this.migrations = options.migrations;
+    this.state = options.state;
+    this.isSafeMode = options.isSafeMode ?? false;
+    this.budgetMs = options.budgetMs ?? DEFAULT_BUDGET_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  async run(): Promise<BootMigrationRunResult> {
+    const start = this.now();
+
+    if (this.isSafeMode) {
+      console.warn("[BootMigrations] Safe mode active — skipping all boot migrations");
+      return {
+        durationMs: this.now() - start,
+        didExceedBudget: false,
+        applied: [],
+        skippedForSafeMode: true,
+      };
+    }
+
+    const marker = this.state.load();
+    const completed = new Set(marker.completed);
+    const applied: string[] = [];
+
+    const pending = this.migrations.filter((m) => !completed.has(m.id));
+    if (pending.length === 0) {
+      return {
+        durationMs: this.now() - start,
+        didExceedBudget: false,
+        applied,
+        skippedForSafeMode: false,
+      };
+    }
+
+    console.log(`[BootMigrations] Running ${pending.length} pending migration(s)`);
+
+    for (const migration of pending) {
+      console.log(`[BootMigrations] Applying ${migration.id}: ${migration.description}`);
+      try {
+        await migration.up();
+      } catch (err) {
+        console.error(`[BootMigrations] Migration ${migration.id} failed:`, err);
+        const durationMs = this.now() - start;
+        if (err instanceof Error) {
+          throw new Error(`Boot migration ${migration.id} failed: ${err.message}`, { cause: err });
+        }
+        throw new Error(
+          `Boot migration ${migration.id} failed after ${durationMs}ms: ${String(err)}`
+        );
+      }
+
+      completed.add(migration.id);
+      applied.push(migration.id);
+      this.state.save(Array.from(completed));
+      console.log(`[BootMigrations] Applied ${migration.id}`);
+    }
+
+    const durationMs = this.now() - start;
+    const didExceedBudget = durationMs > this.budgetMs;
+    if (didExceedBudget) {
+      console.warn(
+        `[BootMigrations] Run exceeded budget: ${durationMs}ms > ${this.budgetMs}ms ` +
+          `(applied ${applied.length} migration(s))`
+      );
+    }
+
+    return { durationMs, didExceedBudget, applied, skippedForSafeMode: false };
+  }
+
+  private static assertUniqueIds(migrations: readonly BootMigration[]): void {
+    const seen = new Set<string>();
+    for (const migration of migrations) {
+      if (seen.has(migration.id)) {
+        throw new Error(`Duplicate boot migration id: "${migration.id}"`);
+      }
+      seen.add(migration.id);
+    }
+  }
+}

--- a/electron/boot/migrations/BootMigrationRunner.ts
+++ b/electron/boot/migrations/BootMigrationRunner.ts
@@ -79,7 +79,8 @@ export class BootMigrationRunner {
           throw new Error(`Boot migration ${migration.id} failed: ${err.message}`, { cause: err });
         }
         throw new Error(
-          `Boot migration ${migration.id} failed after ${durationMs}ms: ${String(err)}`
+          `Boot migration ${migration.id} failed after ${durationMs}ms: ${String(err)}`,
+          { cause: err }
         );
       }
 

--- a/electron/boot/migrations/BootMigrationState.ts
+++ b/electron/boot/migrations/BootMigrationState.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resilientAtomicWriteFileSync } from "../../utils/fs.js";
+import type { BootMigrationsMarker } from "./types.js";
+
+/**
+ * Reads and writes the `migrations.json` marker that records which boot
+ * migrations have completed. Missing or corrupt files are treated as a fresh
+ * state so the runner can re-apply every migration.
+ */
+export class BootMigrationState {
+  constructor(private readonly markerPath: string) {}
+
+  /** Returns the path the marker is read/written from. Useful for logging. */
+  getMarkerPath(): string {
+    return this.markerPath;
+  }
+
+  /**
+   * Loads the marker from disk. Returns a fresh `{ completed: [] }` if the
+   * file is missing, unreadable, or malformed. Duplicate IDs in `completed`
+   * are collapsed.
+   */
+  load(): BootMigrationsMarker {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.markerPath, "utf8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        console.warn(`[BootMigrations] Failed to read marker at ${this.markerPath}:`, err);
+      }
+      return { completed: [] };
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as Partial<BootMigrationsMarker> | null;
+      if (!parsed || !Array.isArray(parsed.completed)) {
+        console.warn(`[BootMigrations] Malformed marker at ${this.markerPath}, ignoring`);
+        return { completed: [] };
+      }
+      const completed = parsed.completed.filter((id): id is string => typeof id === "string");
+      return { completed: Array.from(new Set(completed)) };
+    } catch (err) {
+      console.warn(`[BootMigrations] Failed to parse marker at ${this.markerPath}:`, err);
+      return { completed: [] };
+    }
+  }
+
+  /**
+   * Persists `completed` atomically. Creates the parent directory if it's
+   * missing (first launch may happen before `userData` exists on disk).
+   */
+  save(completed: readonly string[]): void {
+    const dir = path.dirname(this.markerPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const deduped = Array.from(new Set(completed));
+    const payload: BootMigrationsMarker = { completed: deduped };
+    resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(payload));
+  }
+}

--- a/electron/boot/migrations/BootMigrationState.ts
+++ b/electron/boot/migrations/BootMigrationState.ts
@@ -28,7 +28,11 @@ export class BootMigrationState {
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== "ENOENT") {
-        console.warn(`[BootMigrations] Failed to read marker at ${this.markerPath}:`, err);
+        console.warn(
+          `[BootMigrations] Failed to read marker at ${this.markerPath} — ` +
+            `treating as fresh state, all migrations will re-run:`,
+          err
+        );
       }
       return { completed: [] };
     }
@@ -36,13 +40,20 @@ export class BootMigrationState {
     try {
       const parsed = JSON.parse(raw) as Partial<BootMigrationsMarker> | null;
       if (!parsed || !Array.isArray(parsed.completed)) {
-        console.warn(`[BootMigrations] Malformed marker at ${this.markerPath}, ignoring`);
+        console.warn(
+          `[BootMigrations] Malformed marker at ${this.markerPath} — ` +
+            `treating as fresh state, all migrations will re-run`
+        );
         return { completed: [] };
       }
       const completed = parsed.completed.filter((id): id is string => typeof id === "string");
       return { completed: Array.from(new Set(completed)) };
     } catch (err) {
-      console.warn(`[BootMigrations] Failed to parse marker at ${this.markerPath}:`, err);
+      console.warn(
+        `[BootMigrations] Failed to parse marker at ${this.markerPath} — ` +
+          `treating as fresh state, all migrations will re-run:`,
+        err
+      );
       return { completed: [] };
     }
   }

--- a/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
+++ b/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BootMigrationRunner } from "../BootMigrationRunner.js";
+import type { BootMigrationState } from "../BootMigrationState.js";
+import type { BootMigration, BootMigrationsMarker } from "../types.js";
+
+type FakeState = BootMigrationState & {
+  current: BootMigrationsMarker;
+  saved: string[][];
+};
+
+function createFakeState(initial: BootMigrationsMarker = { completed: [] }): FakeState {
+  const current: BootMigrationsMarker = {
+    completed: [...initial.completed],
+  };
+  const saved: string[][] = [];
+  return {
+    getMarkerPath: () => "/fake/migrations.json",
+    load: () => ({ completed: [...current.completed] }),
+    save: (ids: readonly string[]) => {
+      current.completed = [...ids];
+      saved.push([...ids]);
+    },
+    current,
+    saved,
+  } as unknown as FakeState;
+}
+
+describe("BootMigrationRunner", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs migrations in registration order and records each to the marker", async () => {
+    const applied: string[] = [];
+    const migrations: BootMigration[] = [
+      { id: "one", description: "first", up: () => void applied.push("one") },
+      { id: "two", description: "second", up: async () => void applied.push("two") },
+      { id: "three", description: "third", up: () => void applied.push("three") },
+    ];
+    const state = createFakeState();
+
+    const result = await new BootMigrationRunner({ migrations, state }).run();
+
+    expect(applied).toEqual(["one", "two", "three"]);
+    expect(result.applied).toEqual(["one", "two", "three"]);
+    expect(result.skippedForSafeMode).toBe(false);
+    expect(state.current.completed).toEqual(["one", "two", "three"]);
+    expect(state.saved).toEqual([["one"], ["one", "two"], ["one", "two", "three"]]);
+  });
+
+  it("skips migrations already recorded in the marker", async () => {
+    const applied: string[] = [];
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          applied.push("one");
+        },
+      },
+      {
+        id: "two",
+        description: "second",
+        up: () => {
+          applied.push("two");
+        },
+      },
+    ];
+    const state = createFakeState({ completed: ["one"] });
+
+    const result = await new BootMigrationRunner({ migrations, state }).run();
+
+    expect(applied).toEqual(["two"]);
+    expect(result.applied).toEqual(["two"]);
+    expect(state.current.completed).toEqual(["one", "two"]);
+  });
+
+  it("leaves the marker untouched when nothing is pending", async () => {
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          throw new Error("should not run");
+        },
+      },
+    ];
+    const state = createFakeState({ completed: ["one"] });
+
+    const result = await new BootMigrationRunner({ migrations, state }).run();
+
+    expect(result.applied).toEqual([]);
+    expect(state.saved).toEqual([]);
+  });
+
+  it("stops at the first failure and only records prior successes", async () => {
+    const applied: string[] = [];
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          applied.push("one");
+        },
+      },
+      {
+        id: "two",
+        description: "second",
+        up: () => {
+          applied.push("two");
+          throw new Error("boom");
+        },
+      },
+      {
+        id: "three",
+        description: "third",
+        up: () => {
+          applied.push("three");
+        },
+      },
+    ];
+    const state = createFakeState();
+    const runner = new BootMigrationRunner({ migrations, state });
+
+    await expect(runner.run()).rejects.toThrow(/Boot migration two failed: boom/);
+    expect(applied).toEqual(["one", "two"]);
+    expect(state.current.completed).toEqual(["one"]);
+  });
+
+  it("resumes at the failing migration on the next boot", async () => {
+    let shouldThrow = true;
+    const applied: string[] = [];
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          applied.push("one");
+        },
+      },
+      {
+        id: "two",
+        description: "second",
+        up: () => {
+          applied.push("two");
+          if (shouldThrow) throw new Error("boom");
+        },
+      },
+      {
+        id: "three",
+        description: "third",
+        up: () => {
+          applied.push("three");
+        },
+      },
+    ];
+    const state = createFakeState();
+
+    await expect(new BootMigrationRunner({ migrations, state }).run()).rejects.toThrow();
+    expect(state.current.completed).toEqual(["one"]);
+
+    shouldThrow = false;
+    applied.length = 0;
+
+    const result = await new BootMigrationRunner({ migrations, state }).run();
+
+    expect(applied).toEqual(["two", "three"]);
+    expect(result.applied).toEqual(["two", "three"]);
+    expect(state.current.completed).toEqual(["one", "two", "three"]);
+  });
+
+  it("skips every migration when safe mode is active", async () => {
+    const applied: string[] = [];
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          applied.push("one");
+        },
+      },
+    ];
+    const state = createFakeState();
+
+    const result = await new BootMigrationRunner({
+      migrations,
+      state,
+      isSafeMode: true,
+    }).run();
+
+    expect(applied).toEqual([]);
+    expect(result.skippedForSafeMode).toBe(true);
+    expect(result.applied).toEqual([]);
+    expect(state.saved).toEqual([]);
+  });
+
+  it("throws at construction when two migrations share an id", () => {
+    const migrations: BootMigration[] = [
+      { id: "dup", description: "a", up: () => {} },
+      { id: "dup", description: "b", up: () => {} },
+    ];
+    expect(() => new BootMigrationRunner({ migrations, state: createFakeState() })).toThrow(
+      /Duplicate boot migration id: "dup"/
+    );
+  });
+
+  it("reports didExceedBudget when the run takes longer than the budget", async () => {
+    let t = 0;
+    const now = () => t;
+    const migrations: BootMigration[] = [
+      {
+        id: "slow",
+        description: "slow",
+        up: () => {
+          t += 750;
+        },
+      },
+    ];
+    const state = createFakeState();
+
+    const result = await new BootMigrationRunner({
+      migrations,
+      state,
+      budgetMs: 500,
+      now,
+    }).run();
+
+    expect(result.durationMs).toBe(750);
+    expect(result.didExceedBudget).toBe(true);
+  });
+
+  it("does not flag didExceedBudget when the run stays under budget", async () => {
+    let t = 0;
+    const now = () => t;
+    const migrations: BootMigration[] = [
+      {
+        id: "fast",
+        description: "fast",
+        up: () => {
+          t += 50;
+        },
+      },
+    ];
+    const state = createFakeState();
+
+    const result = await new BootMigrationRunner({
+      migrations,
+      state,
+      budgetMs: 500,
+      now,
+    }).run();
+
+    expect(result.didExceedBudget).toBe(false);
+  });
+
+  it("wraps non-Error throws with the migration id", async () => {
+    const migrations: BootMigration[] = [
+      {
+        id: "bad",
+        description: "throws a string",
+        up: () => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw "nope";
+        },
+      },
+    ];
+    const state = createFakeState();
+    await expect(new BootMigrationRunner({ migrations, state }).run()).rejects.toThrow(
+      /Boot migration bad failed/
+    );
+  });
+});

--- a/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
+++ b/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
@@ -302,7 +302,6 @@ describe("BootMigrationRunner", () => {
         id: "bad",
         description: "throws a string",
         up: () => {
-          // eslint-disable-next-line @typescript-eslint/only-throw-error
           throw "nope";
         },
       },

--- a/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
+++ b/electron/boot/migrations/__tests__/BootMigrationRunner.test.ts
@@ -187,6 +187,8 @@ describe("BootMigrationRunner", () => {
       },
     ];
     const state = createFakeState();
+    const loadSpy = vi.spyOn(state, "load");
+    const saveSpy = vi.spyOn(state, "save");
 
     const result = await new BootMigrationRunner({
       migrations,
@@ -198,6 +200,41 @@ describe("BootMigrationRunner", () => {
     expect(result.skippedForSafeMode).toBe(true);
     expect(result.applied).toEqual([]);
     expect(state.saved).toEqual([]);
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-runs a migration on the next boot when save fails after up succeeded", async () => {
+    let saveShouldThrow = true;
+    const runCount: string[] = [];
+    const migrations: BootMigration[] = [
+      {
+        id: "one",
+        description: "first",
+        up: () => {
+          runCount.push("one");
+        },
+      },
+    ];
+    const state = createFakeState();
+    const originalSave = state.save.bind(state);
+    state.save = ((ids: readonly string[]) => {
+      if (saveShouldThrow) {
+        throw new Error("disk full");
+      }
+      originalSave(ids);
+    }) as typeof state.save;
+
+    await expect(new BootMigrationRunner({ migrations, state }).run()).rejects.toThrow(/disk full/);
+    expect(runCount).toEqual(["one"]);
+    expect(state.current.completed).toEqual([]);
+
+    saveShouldThrow = false;
+
+    const result = await new BootMigrationRunner({ migrations, state }).run();
+    expect(runCount).toEqual(["one", "one"]);
+    expect(result.applied).toEqual(["one"]);
+    expect(state.current.completed).toEqual(["one"]);
   });
 
   it("throws at construction when two migrations share an id", () => {

--- a/electron/boot/migrations/__tests__/BootMigrationState.test.ts
+++ b/electron/boot/migrations/__tests__/BootMigrationState.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BootMigrationState } from "../BootMigrationState.js";
+
+describe("BootMigrationState", () => {
+  let tempDir: string;
+  let markerPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-boot-state-"));
+    markerPath = path.join(tempDir, "migrations.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty marker when the file is missing", () => {
+    const state = new BootMigrationState(markerPath);
+    expect(state.load()).toEqual({ completed: [] });
+  });
+
+  it("round-trips completed ids through save and load", () => {
+    const state = new BootMigrationState(markerPath);
+    state.save(["a", "b"]);
+
+    const reopened = new BootMigrationState(markerPath);
+    expect(reopened.load()).toEqual({ completed: ["a", "b"] });
+  });
+
+  it("creates the parent directory on save when it does not exist", () => {
+    const nestedPath = path.join(tempDir, "nested", "subdir", "migrations.json");
+    const state = new BootMigrationState(nestedPath);
+
+    state.save(["x"]);
+
+    expect(fs.existsSync(nestedPath)).toBe(true);
+    expect(new BootMigrationState(nestedPath).load().completed).toEqual(["x"]);
+  });
+
+  it("treats malformed JSON as a fresh state", () => {
+    fs.writeFileSync(markerPath, "{ not valid json", "utf8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const state = new BootMigrationState(markerPath);
+    expect(state.load()).toEqual({ completed: [] });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("treats a non-array `completed` field as a fresh state", () => {
+    fs.writeFileSync(markerPath, JSON.stringify({ completed: "not-an-array" }), "utf8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const state = new BootMigrationState(markerPath);
+    expect(state.load()).toEqual({ completed: [] });
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("filters non-string entries out of `completed`", () => {
+    fs.writeFileSync(markerPath, JSON.stringify({ completed: ["a", 5, null, "b"] }), "utf8");
+    const state = new BootMigrationState(markerPath);
+    expect(state.load().completed).toEqual(["a", "b"]);
+  });
+
+  it("collapses duplicate ids on load", () => {
+    fs.writeFileSync(markerPath, JSON.stringify({ completed: ["a", "a", "b"] }), "utf8");
+    expect(new BootMigrationState(markerPath).load().completed).toEqual(["a", "b"]);
+  });
+
+  it("collapses duplicate ids on save", () => {
+    const state = new BootMigrationState(markerPath);
+    state.save(["a", "a", "b"]);
+    expect(state.load().completed).toEqual(["a", "b"]);
+  });
+
+  it("exposes the configured marker path", () => {
+    const state = new BootMigrationState(markerPath);
+    expect(state.getMarkerPath()).toBe(markerPath);
+  });
+
+  it("writes atomically without leaving a tmp file behind on success", () => {
+    const state = new BootMigrationState(markerPath);
+    state.save(["a"]);
+    const entries = fs.readdirSync(tempDir);
+    expect(entries.every((name) => !name.endsWith(".tmp"))).toBe(true);
+  });
+});

--- a/electron/boot/migrations/index.ts
+++ b/electron/boot/migrations/index.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { app } from "electron";
+import { BootMigrationRunner, type BootMigrationRunnerOptions } from "./BootMigrationRunner.js";
+import { BootMigrationState } from "./BootMigrationState.js";
+import type { BootMigration, BootMigrationRunResult } from "./types.js";
+
+export { BootMigrationRunner } from "./BootMigrationRunner.js";
+export { BootMigrationState } from "./BootMigrationState.js";
+export type { BootMigration, BootMigrationRunResult, BootMigrationsMarker } from "./types.js";
+
+/**
+ * Registry of boot migrations applied before `app.whenReady()`.
+ *
+ * Empty by default — this is infrastructure for future one-shots. The
+ * current codebase has no eligible candidates:
+ *  - `electron/setup/environment.ts` and `electron/services/projectDirMigration.ts`
+ *    are `TODO(0.9.0)` Canopy→Daintree rebrand code, explicitly out of scope
+ *    for this pipeline (owned by #5150).
+ *  - `electron/services/migrations/*` are electron-store schema migrations,
+ *    a complementary system keyed by integer version, not one-shot filesystem
+ *    migrations.
+ *  - `src/store/agentPreferencesStore.ts` runs in the renderer process
+ *    against `localStorage`, which is not reachable before `app.whenReady()`.
+ *    It stays in place as a Zustand `merge` hook.
+ *
+ * New filesystem one-shots that must run before window creation go here.
+ */
+export const BOOT_MIGRATIONS: readonly BootMigration[] = [];
+
+const MARKER_FILENAME = "migrations.json";
+
+type RunBootMigrationsOptions = Partial<
+  Omit<BootMigrationRunnerOptions, "migrations" | "state">
+> & {
+  /** Override the registered registry — tests only. */
+  migrations?: readonly BootMigration[];
+  /** Override the marker path — tests only. */
+  markerPath?: string;
+};
+
+/**
+ * Runs all registered boot migrations. Safe to call before `app.whenReady()`.
+ * Reads/writes the marker at `path.join(app.getPath('userData'), 'migrations.json')`.
+ *
+ * Failures propagate to the caller so the bootstrap process can decide
+ * whether to continue — currently it logs and continues (forward-only
+ * idempotency means the failing migration retries on the next boot).
+ */
+export async function runBootMigrations(
+  options: RunBootMigrationsOptions = {}
+): Promise<BootMigrationRunResult> {
+  const migrations = options.migrations ?? BOOT_MIGRATIONS;
+  const markerPath = options.markerPath ?? path.join(app.getPath("userData"), MARKER_FILENAME);
+  const state = new BootMigrationState(markerPath);
+  const runner = new BootMigrationRunner({
+    migrations,
+    state,
+    isSafeMode: options.isSafeMode,
+    budgetMs: options.budgetMs,
+    now: options.now,
+  });
+  return runner.run();
+}

--- a/electron/boot/migrations/types.ts
+++ b/electron/boot/migrations/types.ts
@@ -1,0 +1,29 @@
+/**
+ * A single forward-only boot-time migration. Runs before `app.whenReady()`
+ * and must be safe to re-invoke after a partial failure on a previous boot.
+ */
+export interface BootMigration {
+  /** Stable unique identifier. Recorded in the marker on success. */
+  id: string;
+  /** Short human-readable description — shown in logs. */
+  description: string;
+  /** Performs the migration. Throwing aborts the pipeline and preserves the pre-existing marker state. */
+  up: () => void | Promise<void>;
+}
+
+/** On-disk shape of the `migrations.json` marker file. */
+export interface BootMigrationsMarker {
+  completed: string[];
+}
+
+/** Result of a single `BootMigrationRunner.run()` invocation. */
+export interface BootMigrationRunResult {
+  /** Total wall-clock time spent inside `run()`, including safe-mode bail. */
+  durationMs: number;
+  /** True if runtime exceeded the configured budget. */
+  didExceedBudget: boolean;
+  /** IDs of migrations applied during this run (empty in safe mode or when nothing was pending). */
+  applied: string[];
+  /** True if the runner skipped migrations because safe mode was active. */
+  skippedForSafeMode: boolean;
+}

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -2,6 +2,7 @@ import { enableCompileCache } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { app } from "electron";
+import { runBootMigrations } from "./boot/migrations/index.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
 try {
@@ -9,6 +10,16 @@ try {
   enableCompileCache(cacheDir);
 } catch {
   enableCompileCache();
+}
+
+// Run forward-only boot migrations before anything in main.ts touches state.
+// Failures are logged but non-fatal — forward-only idempotency means the
+// failing migration retries on the next boot, and the app should still be
+// usable as long as existing state is intact.
+try {
+  await runBootMigrations();
+} catch (err) {
+  console.error("[Bootstrap] Boot migrations failed — continuing with existing state:", err);
 }
 
 await import("./main.js");

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -16,6 +16,10 @@ try {
 // Failures are logged but non-fatal — forward-only idempotency means the
 // failing migration retries on the next boot, and the app should still be
 // usable as long as existing state is intact.
+//
+// TODO: wire `isSafeMode` from CrashLoopGuardService once it initializes
+// here rather than inside main.ts — today the guard boots after bootstrap,
+// so safe-mode detection isn't available at this point.
 try {
   await runBootMigrations();
 } catch (err) {


### PR DESCRIPTION
## Summary

- Adds `electron/boot/migrations/` with a typed registry, forward-only sequential runner, and a single atomic `migrations.json` marker file at `userData` root, replacing the scattered per-migration sentinel approach.
- Pipeline runs via top-level `await` in `bootstrap.ts` before `app.whenReady`, with a 500ms budget signal, safe-mode skip, and injectable `now()`/`markerPath` for testing.
- Registry is intentionally empty in this PR; it's infrastructure. Duplicate IDs fail at construction so registration errors surface immediately.

Resolves #5686

## Changes

- `electron/boot/migrations/types.ts` — `BootMigration` interface and `BootMigrationRecord` type
- `electron/boot/migrations/BootMigrationState.ts` — atomic read/write of `migrations.json` using `resilientAtomicWriteFileSync`
- `electron/boot/migrations/BootMigrationRunner.ts` — sequential runner with budget, safe-mode, partial-failure resume, and duplicate detection
- `electron/boot/migrations/index.ts` — empty registry with a comment explaining why (infrastructure PR)
- `electron/bootstrap.ts` — wires the runner in before `app.whenReady`; errors are caught and logged; forward-only idempotency means a failed migration retries next boot automatically
- 21 unit tests covering round-trip state, partial-failure resume, save-failure recovery, safe-mode skip-all, duplicate detection, and budget signal

## Testing

Unit tests cover all the core runner behaviour. Acceptance check: `rg 'hasRun|migrated|_migrated' electron/services/` returns only Canopy-scoped hits (`TODO(0.9.0)` projectDirMigration.ts) and electron-store schema migrations — no unregistered one-shots remain outside the pipeline.

The renderer-side `agentPreferencesStore` localStorage merge is intentionally left in place; it runs in the renderer process and there's no pre-`whenReady` hook available there.