### PR TITLE
feat(ipc): typed event pub/sub foundation and handler registry integrity

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CHANNELS } from "../channels.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const MAPS_TS = path.join(REPO_ROOT, "shared", "types", "ipc", "maps.ts");
+const PRELOAD_CTS = path.join(REPO_ROOT, "electron", "preload.cts");
+
+/**
+ * IpcInvokeMap keys that intentionally do NOT correspond to a CHANNELS value.
+ * Adding a key here should be rare and require a comment in `maps.ts` explaining why.
+ */
+const INVOKE_MAP_CHANNEL_ALLOWLIST = new Set<string>([]);
+
+/**
+ * Strings inside the `IpcInvokeMap` block that are NOT channel names — e.g. literal
+ * union members inside `args`/`result` types. The drift scanner works at line
+ * granularity and only matches property keys at the left margin (two spaces + quote),
+ * but this set is available as an escape hatch if a new spurious match appears.
+ */
+const INVOKE_MAP_STRING_IGNORE = new Set<string>([]);
+
+/**
+ * Extract the `IpcInvokeMap` block from `maps.ts` and return the channel-string
+ * literals used as property keys. Greps lines that look like `  "foo:bar": {`.
+ */
+async function extractInvokeMapKeys(): Promise<string[]> {
+  const source = await readFile(MAPS_TS, "utf8");
+  const start = source.indexOf("export interface IpcInvokeMap {");
+  if (start === -1) throw new Error("Could not locate IpcInvokeMap in maps.ts");
+  const end = source.indexOf("\n}", start);
+  if (end === -1) throw new Error("Could not locate IpcInvokeMap closing brace");
+  const block = source.slice(start, end);
+
+  const keys = new Set<string>();
+  for (const line of block.split("\n")) {
+    const match = line.match(/^ {2}"([^"]+)":\s*\{\s*$/);
+    if (!match) continue;
+    const key = match[1]!;
+    if (INVOKE_MAP_STRING_IGNORE.has(key)) continue;
+    keys.add(key);
+  }
+  return [...keys];
+}
+
+/**
+ * Extract the inlined `const CHANNELS = { ... } as const;` block from preload.cts
+ * and return its key→value map. The preload copy must mirror channels.ts by hand
+ * (per lesson #4893 — the preload is bundled separately so it cannot import).
+ */
+async function extractPreloadChannels(): Promise<Record<string, string>> {
+  const source = await readFile(PRELOAD_CTS, "utf8");
+  const start = source.indexOf("const CHANNELS = {");
+  if (start === -1) throw new Error("Could not locate inlined CHANNELS in preload.cts");
+  const end = source.indexOf("} as const;", start);
+  if (end === -1) throw new Error("Could not locate inlined CHANNELS closing brace");
+  const block = source.slice(start, end);
+
+  const entries: Record<string, string> = {};
+  for (const line of block.split("\n")) {
+    const match = line.match(/^\s{2}([A-Z0-9_]+):\s*"([^"]+)",?\s*$/);
+    if (!match) continue;
+    entries[match[1]!] = match[2]!;
+  }
+  return entries;
+}
+
+describe("IPC channel drift guardrails", () => {
+  it("every IpcInvokeMap key resolves to a declared CHANNELS value", async () => {
+    const invokeKeys = await extractInvokeMapKeys();
+    const channelValues = new Set<string>(Object.values(CHANNELS));
+
+    expect(invokeKeys.length).toBeGreaterThan(0);
+
+    const orphans = invokeKeys.filter(
+      (k) => !channelValues.has(k) && !INVOKE_MAP_CHANNEL_ALLOWLIST.has(k)
+    );
+
+    expect(
+      orphans,
+      "IpcInvokeMap keys without a matching CHANNELS value. Either add the channel " +
+        "to electron/ipc/channels.ts or, if intentional, to INVOKE_MAP_CHANNEL_ALLOWLIST " +
+        "with a documented reason."
+    ).toEqual([]);
+  });
+
+  it("preload inline CHANNELS mirrors electron/ipc/channels.ts key-for-key", async () => {
+    const preloadChannels = await extractPreloadChannels();
+    const canonical = CHANNELS as Readonly<Record<string, string>>;
+
+    const canonicalKeys = new Set(Object.keys(canonical));
+    const preloadKeys = new Set(Object.keys(preloadChannels));
+
+    const missingInPreload = [...canonicalKeys].filter((k) => !preloadKeys.has(k));
+    const extraInPreload = [...preloadKeys].filter((k) => !canonicalKeys.has(k));
+
+    expect(
+      missingInPreload,
+      "Channels declared in electron/ipc/channels.ts but missing from the inlined " +
+        "CHANNELS object in electron/preload.cts. Add them there too — the preload is " +
+        "bundled separately and cannot import at runtime (see lesson #4893)."
+    ).toEqual([]);
+
+    expect(
+      extraInPreload,
+      "Channels present in the preload inline copy but not in electron/ipc/channels.ts. " +
+        "Remove them from preload.cts or add them to channels.ts."
+    ).toEqual([]);
+
+    const valueMismatches: Array<{ key: string; canonical: string; preload: string }> = [];
+    for (const key of canonicalKeys) {
+      if (!preloadKeys.has(key)) continue;
+      if (canonical[key] !== preloadChannels[key]) {
+        valueMismatches.push({
+          key,
+          canonical: canonical[key]!,
+          preload: preloadChannels[key]!,
+        });
+      }
+    }
+
+    expect(
+      valueMismatches,
+      "Channel string values differ between channels.ts and preload.cts inline copy."
+    ).toEqual([]);
+  });
+});

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -197,6 +197,7 @@ export const CHANNELS = {
   EVENT_INSPECTOR_UNSUBSCRIBE: "event-inspector:unsubscribe",
 
   EVENTS_EMIT: "events:emit",
+  EVENTS_PUSH: "events:push",
 
   PROJECT_GET_ALL: "project:get-all",
   PROJECT_GET_CURRENT: "project:get-current",

--- a/electron/ipc/handlers/__tests__/events.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/events.handlers.test.ts
@@ -32,10 +32,11 @@ import { registerEventsHandlers } from "../events.js";
 
 function setup() {
   const emit = vi.fn();
-  const events = { emit } as unknown as Parameters<typeof registerEventsHandlers>[0]["events"];
+  const on = vi.fn(() => () => {});
+  const events = { emit, on } as unknown as Parameters<typeof registerEventsHandlers>[0]["events"];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cleanup = registerEventsHandlers({ events } as any);
-  return { emit, cleanup };
+  return { emit, on, cleanup };
 }
 
 const base = {

--- a/electron/ipc/handlers/__tests__/events.typedBus.test.ts
+++ b/electron/ipc/handlers/__tests__/events.typedBus.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentStateChangePayload } from "../../../../shared/types/ipc/agent.js";
+import type { EventBusEnvelope } from "../../../../shared/types/ipc/maps.js";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+const utilsMock = vi.hoisted(() => ({
+  typedHandle: vi.fn(() => () => {}),
+  broadcastToRenderer: vi.fn(),
+}));
+
+vi.mock("../../utils.js", () => utilsMock);
+
+import { registerEventsHandlers } from "../events.js";
+
+type Listener = (payload: AgentStateChangePayload) => void;
+
+function makeTypedEventBus() {
+  const listeners = new Map<string, Set<Listener>>();
+  const emit = vi.fn((name: string, payload: AgentStateChangePayload) => {
+    for (const l of listeners.get(name) ?? []) l(payload);
+  });
+  const on = vi.fn((name: string, listener: Listener) => {
+    if (!listeners.has(name)) listeners.set(name, new Set());
+    listeners.get(name)!.add(listener);
+    return () => listeners.get(name)?.delete(listener);
+  });
+  return { emit, on, listeners };
+}
+
+function samplePayload(overrides: Partial<AgentStateChangePayload> = {}): AgentStateChangePayload {
+  return {
+    terminalId: "term-1",
+    state: "working",
+    previousState: "idle",
+    timestamp: 1_700_000_000_000,
+    trigger: "heuristic",
+    confidence: 1,
+    ...overrides,
+  };
+}
+
+describe("events IPC handler — typed event bus bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("subscribes to agent:state-changed and broadcasts an envelope on events:push", () => {
+    const bus = makeTypedEventBus();
+    const cleanup = registerEventsHandlers({
+      events: bus,
+    } as unknown as Parameters<typeof registerEventsHandlers>[0]);
+
+    expect(bus.on).toHaveBeenCalledWith("agent:state-changed", expect.any(Function));
+
+    const payload = samplePayload();
+    bus.emit("agent:state-changed", payload);
+
+    expect(utilsMock.broadcastToRenderer).toHaveBeenCalledTimes(1);
+    const [channel, envelope] = utilsMock.broadcastToRenderer.mock.calls[0]!;
+    expect(channel).toBe("events:push");
+    expect(envelope).toEqual<EventBusEnvelope>({
+      name: "agent:state-changed",
+      payload,
+    });
+
+    cleanup();
+  });
+
+  it("unsubscribes from the bus on cleanup so later emits do not broadcast", () => {
+    const bus = makeTypedEventBus();
+    const cleanup = registerEventsHandlers({
+      events: bus,
+    } as unknown as Parameters<typeof registerEventsHandlers>[0]);
+
+    cleanup();
+
+    bus.emit("agent:state-changed", samplePayload());
+
+    expect(utilsMock.broadcastToRenderer).not.toHaveBeenCalled();
+  });
+
+  it("does not wire the bridge when events bus is undefined", () => {
+    const cleanup = registerEventsHandlers({
+      events: undefined,
+    } as unknown as Parameters<typeof registerEventsHandlers>[0]);
+
+    expect(utilsMock.broadcastToRenderer).not.toHaveBeenCalled();
+    cleanup();
+  });
+});

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -1,9 +1,17 @@
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import type { DaintreeEventMap } from "../../services/events.js";
-import { typedHandle } from "../utils.js";
+import type { IpcEventBusMap } from "../../../shared/types/ipc/maps.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
 
 const ALLOWED_RENDERER_EVENTS: ReadonlySet<keyof DaintreeEventMap> = new Set(["action:dispatched"]);
+
+/**
+ * Curated list of DaintreeEventMap keys bridged to the renderer via the
+ * multiplexed `events:push` channel. Must stay in sync with `IpcEventBusMap`.
+ * Adding a key here exposes it to `window.electron.events.on(name, cb)`.
+ */
+const EVENT_BUS_BRIDGED_EVENTS: ReadonlyArray<keyof IpcEventBusMap> = ["agent:state-changed"];
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -149,6 +157,21 @@ export function registerEventsHandlers(deps: HandlerDependencies): () => void {
     );
   };
   handlers.push(typedHandle(CHANNELS.EVENTS_EMIT, handleEventsEmit));
+
+  // Bridge selected TypedEventBus events to the renderer via the multiplexed
+  // `events:push` channel. The renderer subscribes via
+  // `window.electron.events.on(name, callback)`.
+  if (events) {
+    for (const name of EVENT_BUS_BRIDGED_EVENTS) {
+      const unsubscribe = events.on(name, (payload) => {
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name,
+          payload,
+        } as { name: typeof name; payload: IpcEventBusMap[typeof name] });
+      });
+      handlers.push(unsubscribe);
+    }
+  }
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -7,11 +7,17 @@ import { broadcastToRenderer, typedHandle } from "../utils.js";
 const ALLOWED_RENDERER_EVENTS: ReadonlySet<keyof DaintreeEventMap> = new Set(["action:dispatched"]);
 
 /**
- * Curated list of DaintreeEventMap keys bridged to the renderer via the
- * multiplexed `events:push` channel. Must stay in sync with `IpcEventBusMap`.
- * Adding a key here exposes it to `window.electron.events.on(name, cb)`.
+ * Manifest of bridged events. The `satisfies Record<keyof IpcEventBusMap, true>`
+ * clause makes tsc fail if `IpcEventBusMap` grows and a key is not added here —
+ * forcing the main-side bridge to stay in lockstep with the renderer-facing type.
  */
-const EVENT_BUS_BRIDGED_EVENTS: ReadonlyArray<keyof IpcEventBusMap> = ["agent:state-changed"];
+const EVENT_BUS_BRIDGED_MANIFEST = {
+  "agent:state-changed": true,
+} as const satisfies Record<keyof IpcEventBusMap, true>;
+
+const EVENT_BUS_BRIDGED_EVENTS = Object.keys(EVENT_BUS_BRIDGED_MANIFEST) as Array<
+  keyof IpcEventBusMap
+>;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -27,6 +27,8 @@ import type {
   CreateWorktreeOptions,
   IpcInvokeMap,
   IpcEventMap,
+  IpcEventBusMap,
+  EventBusEnvelope,
   AgentSettingsEntry,
   PRDetectedPayload,
   PRClearedPayload,
@@ -707,6 +709,7 @@ const CHANNELS = {
   EVENT_INSPECTOR_SUBSCRIBE: "event-inspector:subscribe",
   EVENT_INSPECTOR_UNSUBSCRIBE: "event-inspector:unsubscribe",
   EVENTS_EMIT: "events:emit",
+  EVENTS_PUSH: "events:push",
 
   // Project channels
   PROJECT_GET_ALL: "project:get-all",
@@ -1702,6 +1705,19 @@ const api: ElectronAPI = {
   events: {
     emit: (eventType: string, payload: unknown) =>
       _unwrappingInvoke(CHANNELS.EVENTS_EMIT, eventType, payload),
+
+    on: <K extends keyof IpcEventBusMap>(
+      name: K,
+      callback: (payload: IpcEventBusMap[K]) => void
+    ): (() => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, envelope: EventBusEnvelope) => {
+        if (envelope && envelope.name === name) {
+          callback(envelope.payload as IpcEventBusMap[K]);
+        }
+      };
+      ipcRenderer.on(CHANNELS.EVENTS_PUSH, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.EVENTS_PUSH, handler);
+    },
   },
 
   // Project API

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1711,7 +1711,12 @@ const api: ElectronAPI = {
       callback: (payload: IpcEventBusMap[K]) => void
     ): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, envelope: EventBusEnvelope) => {
-        if (envelope && envelope.name === name) {
+        if (
+          envelope &&
+          typeof envelope === "object" &&
+          envelope.name === name &&
+          "payload" in envelope
+        ) {
           callback(envelope.payload as IpcEventBusMap[K]);
         }
       };

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -232,6 +232,8 @@ export type {
   // IPC Contract Maps
   IpcInvokeMap,
   IpcEventMap,
+  IpcEventBusMap,
+  EventBusEnvelope,
   IpcInvokeArgs,
   IpcInvokeResult,
   IpcEventPayload,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -10,7 +10,7 @@ import type {
   TerminalRecipe,
   TerminalSnapshot,
 } from "../project.js";
-import type { OnboardingState, ChecklistState, ChecklistItemId } from "./maps.js";
+import type { OnboardingState, ChecklistState, ChecklistItemId, IpcEventBusMap } from "./maps.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
@@ -420,6 +420,10 @@ export interface ElectronAPI {
   };
   events: {
     emit(eventType: string, payload: unknown): Promise<void>;
+    on<K extends keyof IpcEventBusMap>(
+      name: K,
+      callback: (payload: IpcEventBusMap[K]) => void
+    ): () => void;
   };
   project: {
     getAll(): Promise<Project[]>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2362,7 +2362,27 @@ export interface IpcEventMap {
   "plugin:actions-changed": {
     actions: import("../plugin.js").PluginActionDescriptor[];
   };
+
+  // Typed event bus envelope (multiplexed main → renderer for IpcEventBusMap)
+  "events:push": EventBusEnvelope;
 }
+
+/**
+ * Typed event bus map — a curated subset of IpcEventMap exposed to the renderer
+ * via `window.electron.events.on(name, cb)`. Coexists with per-event channels
+ * (e.g. CHANNELS.AGENT_STATE_CHANGED); this provides a single multiplexed surface
+ * for new consumers and future migration targets. Extend by adding keys here
+ * and subscribing the main-side bridge in `registerEventsHandlers`.
+ */
+export type IpcEventBusMap = Pick<IpcEventMap, "agent:state-changed">;
+
+/**
+ * Envelope carried on CHANNELS.EVENTS_PUSH. Discriminated by `name` so the
+ * renderer-side `events.on(name, cb)` can filter and narrow the payload type.
+ */
+export type EventBusEnvelope = {
+  [K in keyof IpcEventBusMap]: { name: K; payload: IpcEventBusMap[K] };
+}[keyof IpcEventBusMap];
 
 export type IpcInvokeArgs<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["args"];
 export type IpcInvokeResult<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["result"];


### PR DESCRIPTION
## Summary

- Adds a typed event bus (`window.electron.events.on`) backed by `IpcEventBusMap` in shared types, with payload types enforced at both send and receive sites and a cleanup function returned from `on()`
- Bridges the bus in main via `EVENT_BUS_BRIDGED_MANIFEST` (a `satisfies Record<keyof IpcEventBusMap, true>` check) so the compiler catches any unhandled events as the map grows
- Adds `channelDrift.test.ts` to assert `IpcInvokeMap` keys stay in sync with `CHANNELS` values and that the preload inline CHANNELS object stays in sync with `channels.ts` key-for-key

Resolves #5689

## Changes

- `shared/types/ipc/maps.ts` — `IpcEventBusMap` (scoped Pick of `IpcEventMap`) and discriminated `EventBusEnvelope` type
- `electron/ipc/channels.ts` + preload inline — `CHANNELS.EVENTS_PUSH = "events:push"`
- `electron/ipc/handlers/events.ts` — bridge subscribes to `events.on("agent:state-changed", ...)`, emits envelope to renderer via `broadcastToRenderer`
- `electron/preload.cts` — `window.electron.events.on<K>(name, cb)` filters by envelope name, guards against malformed payloads
- `shared/types/ipc/api.ts` — typed `events.on` surface on `ElectronAPI`
- `electron/ipc/handlers/__tests__/events.typedBus.test.ts` — 3 tests: bridge subscription, cleanup, no-op when bus absent
- `electron/ipc/__tests__/channelDrift.test.ts` — drift assertions for invoke map and preload CHANNELS

## Testing

Typecheck, lint, and format all pass clean. Pilot event (`agent:state-changed`) runs end-to-end through the new bus with passing unit tests. Channel drift test passes against current state and will catch any future drift in CI.

Coexists with existing per-event channels — no migration in this PR. First consumer of `window.electron.events.on` is deferred to the follow-up.