### PR TITLE
feat(ui): motion tokens, component-level reduced-motion, and dial back continuous loops

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -79,6 +79,7 @@ export type BuiltInActionId =
   | "preferences.showDeveloperTools.set"
   | "preferences.showGridAgentHighlights.set"
   | "preferences.showDockAgentHighlights.set"
+  | "preferences.reduceAnimations.set"
   | "window.toggleFullscreen"
   | "window.reload"
   | "window.forceReload"

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -13,7 +13,13 @@ import { ChordIndicator } from "./ChordIndicator";
 import { DemoCaptureBridge, DemoCursor, DemoOverlay } from "../Demo";
 
 import { AllClearOverlay } from "../AllClearOverlay";
-import { useDiagnosticsStore, useDockStore, useThemeBrowserStore, type PanelState } from "@/store";
+import {
+  useDiagnosticsStore,
+  useDockStore,
+  usePreferencesStore,
+  useThemeBrowserStore,
+  type PanelState,
+} from "@/store";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
@@ -62,6 +68,7 @@ export function AppLayout({
   const currentProject = useProjectStore((state) => state.currentProject);
   const layout = useLayoutState();
   const themeBrowserOpen = useThemeBrowserStore((s) => s.isOpen);
+  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const showSidebar = !layout.isFocusMode && currentProject != null;
 
   useEffect(() => {
@@ -71,6 +78,17 @@ export function AppLayout({
       document.body.removeAttribute("data-performance-mode");
     }
   }, [layout.performanceMode]);
+
+  useEffect(() => {
+    if (reduceAnimations) {
+      document.body.setAttribute("data-reduce-animations", "true");
+    } else {
+      document.body.removeAttribute("data-reduce-animations");
+    }
+    return () => {
+      document.body.removeAttribute("data-reduce-animations");
+    };
+  }, [reduceAnimations]);
 
   const handleToggleProblems = () => {
     const dock = useDiagnosticsStore.getState();

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -274,7 +274,7 @@ export function ProjectSwitcher() {
                     className={cn(
                       "absolute top-1 right-1 h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
                       badgeStatus.color,
-                      badgeStatus.pulse && "animate-agent-pulse"
+                      badgeStatus.pulse && "animate-activity-pulse"
                     )}
                   />
                 )}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -84,7 +84,7 @@ const StatusDot = memo(function StatusDot({ project }: { project: SearchableProj
   if (hasActive) {
     return (
       <div
-        className="w-1.5 h-1.5 rounded-full bg-daintree-accent animate-agent-pulse shrink-0"
+        className="w-1.5 h-1.5 rounded-full bg-daintree-accent animate-activity-pulse shrink-0"
         aria-label="Agents working"
       />
     );

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -283,8 +283,8 @@ function StatusDot({ status }: { status: TaskStatus }) {
     <span
       className={cn(
         "h-1.5 w-1.5 rounded-full shrink-0",
-        status === "running" && "bg-status-success animate-agent-pulse",
-        status === "restarting" && "bg-status-warning animate-agent-pulse",
+        status === "running" && "bg-status-success animate-activity-pulse",
+        status === "restarting" && "bg-status-warning animate-activity-pulse",
         status === "success" && "bg-status-success",
         status === "failed" && "bg-status-error"
       )}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -11,6 +11,7 @@ import {
   Info,
   ExternalLink,
   RefreshCw,
+  Gauge,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon, ProjectPulseIcon } from "@/components/icons";
@@ -132,6 +133,7 @@ export function GeneralTab({
   const showDeveloperTools = usePreferencesStore((s) => s.showDeveloperTools);
   const showGridAgentHighlights = usePreferencesStore((s) => s.showGridAgentHighlights);
   const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
+  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
 
   useEffect(() => {
     let cancelled = false;
@@ -832,6 +834,31 @@ export function GeneralTab({
                 void actionService.dispatch(
                   "preferences.showDockAgentHighlights.set",
                   { show: false },
+                  { source: "user" }
+                )
+              }
+            />
+          </div>
+
+          <div id="general-reduce-animations">
+            <SettingsSwitchCard
+              icon={Gauge}
+              title="Reduce UI Animations"
+              subtitle="Minimize motion across the interface, independent of your OS reduce-motion setting."
+              isEnabled={reduceAnimations}
+              onChange={() =>
+                void actionService.dispatch(
+                  "preferences.reduceAnimations.set",
+                  { value: !reduceAnimations },
+                  { source: "user" }
+                )
+              }
+              ariaLabel="Reduce UI Animations Toggle"
+              isModified={reduceAnimations}
+              onReset={() =>
+                void actionService.dispatch(
+                  "preferences.reduceAnimations.set",
+                  { value: false },
                   { source: "user" }
                 )
               }

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
 import type { AgentState } from "@/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -15,7 +16,6 @@ const STATE_CONFIG: Record<
     bgColor?: string;
     borderColor?: string;
     glow?: string;
-    pulse: boolean;
     label: string;
     tooltip: string;
   }
@@ -23,7 +23,6 @@ const STATE_CONFIG: Record<
   working: {
     icon: "⟳",
     color: "status-working",
-    pulse: false,
     label: "working",
     tooltip: "Agent is working on your request",
   },
@@ -31,7 +30,6 @@ const STATE_CONFIG: Record<
     icon: "▶",
     color: "text-status-info",
     borderColor: "border-status-info",
-    pulse: false,
     label: "running",
     tooltip: "Process is running",
   },
@@ -40,21 +38,18 @@ const STATE_CONFIG: Record<
     color: "text-daintree-bg",
     bgColor: "bg-state-waiting",
     glow: "shadow-[0_0_8px_color-mix(in_srgb,var(--color-activity-waiting)_40%,transparent)]",
-    pulse: false,
     label: "waiting",
     tooltip: "Agent is waiting for your direction",
   },
   completed: {
     icon: "✓",
     color: "text-status-success",
-    pulse: false,
     label: "completed",
     tooltip: "Agent finished this task",
   },
   exited: {
     icon: "–",
     color: "text-daintree-text/40",
-    pulse: false,
     label: "exited",
     tooltip: "Process exited",
   },
@@ -62,13 +57,25 @@ const STATE_CONFIG: Record<
     icon: "✎",
     color: "text-status-info",
     borderColor: "border-status-info",
-    pulse: false,
     label: "directing",
     tooltip: "You are typing a prompt for this agent",
   },
 };
 
 export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorProps) {
+  const prevStateRef = useRef<AgentState | null | undefined>(state);
+  const [isFlashing, setIsFlashing] = useState(false);
+
+  // Trigger a one-shot flash when the state actually changes — replaces the
+  // previous 1.5s infinite pulse. Status being a value doesn't deserve motion;
+  // status changing does. Skipped on first render (prevState seeded to current).
+  useEffect(() => {
+    if (prevStateRef.current !== state) {
+      prevStateRef.current = state;
+      setIsFlashing(true);
+    }
+  }, [state]);
+
   if (!state || state === "idle" || state === "waiting") {
     return null;
   }
@@ -89,11 +96,12 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
             config.borderColor && "border",
             config.borderColor,
             config.glow,
-            config.pulse && "animate-agent-pulse",
+            isFlashing && "animate-agent-pulse",
             className
           )}
           role="img"
           aria-label={`Agent status: ${config.label}`}
+          onAnimationEnd={() => setIsFlashing(false)}
         >
           {config.icon}
         </span>

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -76,6 +76,17 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
     }
   }, [state]);
 
+  // Safety cleanup — under reduced-motion CSS sets `animation: none`, so the
+  // `animationend` event never fires and `isFlashing` would latch true,
+  // preventing subsequent transitions from producing a class-remove/re-add
+  // cycle. The timeout is slightly longer than the animation so it only wins
+  // the race when `animationend` is suppressed.
+  useEffect(() => {
+    if (!isFlashing) return;
+    const timer = setTimeout(() => setIsFlashing(false), 250);
+    return () => clearTimeout(timer);
+  }, [isFlashing]);
+
   if (!state || state === "idle" || state === "waiting") {
     return null;
   }

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -44,6 +44,47 @@ describe("AgentStatusIndicator", () => {
     expect(container.querySelector('[role="img"]')).toBeNull();
     expect(container.querySelector('[role="status"]')).toBeNull();
   });
+
+  it("does not apply the flash class on first render (no pulse-on-mount)", () => {
+    const { container } = render(<AgentStatusIndicator state="working" />);
+    const el = container.querySelector('[role="img"]');
+    expect(el?.className).not.toContain("animate-agent-pulse");
+  });
+
+  it("applies the flash class when agent state transitions", () => {
+    const { container, rerender } = render(<AgentStatusIndicator state="working" />);
+    rerender(<AgentStatusIndicator state="completed" />);
+    const el = container.querySelector('[role="img"]');
+    expect(el?.className).toContain("animate-agent-pulse");
+  });
+
+  it("wires an onAnimationEnd handler on the indicator element", () => {
+    const { container, rerender } = render(<AgentStatusIndicator state="working" />);
+    rerender(<AgentStatusIndicator state="completed" />);
+    const el = container.querySelector('[role="img"]') as HTMLElement;
+    expect(el.className).toContain("animate-agent-pulse");
+    // The CSS uses iteration-count:1 / fill-mode:both so the animation
+    // self-terminates after ~150ms. onAnimationEnd also clears the React
+    // state so the same class can be applied again on the next transition.
+    // We don't fireEvent here because React 19's delegated animationend
+    // handling in jsdom is flaky; the behavior is covered by visual QA.
+    const hasHandler = (el as unknown as { onanimationend?: unknown }).onanimationend;
+    // React attaches via synthetic events, not as a native property, so this
+    // just asserts we still have the class wired — the handler's presence is
+    // guaranteed by the render paths above.
+    expect(hasHandler === null || hasHandler === undefined).toBe(true);
+  });
+
+  it("re-applies the flash class on each state transition (not a mount-only effect)", () => {
+    const { container, rerender } = render(<AgentStatusIndicator state="working" />);
+    rerender(<AgentStatusIndicator state="running" />);
+    let el = container.querySelector('[role="img"]') as HTMLElement;
+    expect(el.className).toContain("animate-agent-pulse");
+
+    rerender(<AgentStatusIndicator state="completed" />);
+    el = container.querySelector('[role="img"]') as HTMLElement;
+    expect(el.className).toContain("animate-agent-pulse");
+  });
 });
 
 describe("getDominantAgentState", () => {

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { act, render, cleanup } from "@testing-library/react";
 import { AgentStatusIndicator, getDominantAgentState } from "../AgentStatusIndicator";
 import type { AgentState } from "@/types";
 
@@ -58,32 +58,49 @@ describe("AgentStatusIndicator", () => {
     expect(el?.className).toContain("animate-agent-pulse");
   });
 
-  it("wires an onAnimationEnd handler on the indicator element", () => {
-    const { container, rerender } = render(<AgentStatusIndicator state="working" />);
-    rerender(<AgentStatusIndicator state="completed" />);
-    const el = container.querySelector('[role="img"]') as HTMLElement;
-    expect(el.className).toContain("animate-agent-pulse");
-    // The CSS uses iteration-count:1 / fill-mode:both so the animation
-    // self-terminates after ~150ms. onAnimationEnd also clears the React
-    // state so the same class can be applied again on the next transition.
-    // We don't fireEvent here because React 19's delegated animationend
-    // handling in jsdom is flaky; the behavior is covered by visual QA.
-    const hasHandler = (el as unknown as { onanimationend?: unknown }).onanimationend;
-    // React attaches via synthetic events, not as a native property, so this
-    // just asserts we still have the class wired — the handler's presence is
-    // guaranteed by the render paths above.
-    expect(hasHandler === null || hasHandler === undefined).toBe(true);
+  it("clears the flash class after the safety timeout fires", () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(<AgentStatusIndicator state="working" />);
+      rerender(<AgentStatusIndicator state="completed" />);
+      let el = container.querySelector('[role="img"]') as HTMLElement;
+      expect(el.className).toContain("animate-agent-pulse");
+
+      // Under reduced-motion CSS sets `animation: none`, so `animationend`
+      // never fires. The 250ms safety timeout must still clear the class so
+      // subsequent transitions can re-arm it.
+      act(() => {
+        vi.advanceTimersByTime(260);
+      });
+
+      el = container.querySelector('[role="img"]') as HTMLElement;
+      expect(el.className).not.toContain("animate-agent-pulse");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("re-applies the flash class on each state transition (not a mount-only effect)", () => {
-    const { container, rerender } = render(<AgentStatusIndicator state="working" />);
-    rerender(<AgentStatusIndicator state="running" />);
-    let el = container.querySelector('[role="img"]') as HTMLElement;
-    expect(el.className).toContain("animate-agent-pulse");
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(<AgentStatusIndicator state="working" />);
+      rerender(<AgentStatusIndicator state="running" />);
+      let el = container.querySelector('[role="img"]') as HTMLElement;
+      expect(el.className).toContain("animate-agent-pulse");
 
-    rerender(<AgentStatusIndicator state="completed" />);
-    el = container.querySelector('[role="img"]') as HTMLElement;
-    expect(el.className).toContain("animate-agent-pulse");
+      // Let the first flash clear via the safety timeout, then trigger a
+      // second transition. If the latch bug returned, the class wouldn't
+      // remove and re-add.
+      act(() => {
+        vi.advanceTimersByTime(260);
+      });
+
+      rerender(<AgentStatusIndicator state="completed" />);
+      el = container.querySelector('[role="img"]') as HTMLElement;
+      expect(el.className).toContain("animate-agent-pulse");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/index.css
+++ b/src/index.css
@@ -404,6 +404,38 @@
     "Liberation Mono", "Courier New", monospace;
 }
 
+/* Motion token scale — single source of truth for durations and easings.
+ * Emitted to :root (plain @theme, not inline) so @keyframes rules can use var().
+ * Also generates Tailwind utilities (duration-*, ease-*) via the Tailwind v4
+ * theme namespace convention. Philosophy: every token is sub-300ms; interaction
+ * motion clarifies what happened, it never makes the user wait.
+ */
+@theme {
+  --duration-75: 75ms;
+  --duration-100: 100ms;
+  --duration-150: 150ms;
+  --duration-200: 200ms;
+  --duration-250: 250ms;
+  --duration-300: 300ms;
+  --ease-snappy: cubic-bezier(0.2, 0, 0, 1);
+  --ease-spring-critical: linear(
+    0,
+    0.007,
+    0.029 2.2%,
+    0.118 4.7%,
+    0.625 14.4%,
+    0.826 19%,
+    0.902 24%,
+    0.962 29.8%,
+    0.984 33.3%,
+    1.004 37.8%,
+    1.01 42.4%,
+    1.011 52.2%,
+    1.001
+  );
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 pre code.hljs {
   display: block;
   overflow-x: auto;
@@ -947,20 +979,28 @@ body,
   will-change: opacity, transform;
 }
 
-/* Agent status indicator pulse animation */
+/* Agent status indicator flash — single-shot scale+opacity on state transition.
+ * Previously infinite (1.5s loop), now a 150ms one-shot driven by the consumer
+ * toggling the class on state change (see AgentStatusIndicator).
+ */
 @keyframes agent-pulse {
-  0%,
+  0% {
+    opacity: 0.7;
+    transform: scale(0.92);
+  }
+  60% {
+    opacity: 1;
+    transform: scale(1.06);
+  }
   100% {
     opacity: 1;
-  }
-  50% {
-    opacity: 0.7;
+    transform: scale(1);
   }
 }
 
 .animate-agent-pulse {
-  animation: agent-pulse 1.5s ease-in-out infinite;
-  will-change: opacity;
+  animation: agent-pulse var(--duration-150) var(--ease-out-expo) 1 both;
+  will-change: opacity, transform;
 }
 
 /* Organic breathing animation for waiting/loading states
@@ -1162,7 +1202,11 @@ body,
   will-change: opacity;
 }
 
-/* Respect user's motion preferences */
+/* Respect user's motion preferences — OS prefers-reduced-motion and the
+ * Daintree-level "Reduce UI animations" toggle (body[data-reduce-animations])
+ * both remove spatial motion while leaving opacity changes intact.
+ * WCAG 2.2 SC 2.3.3: remove motion, don't just speed it up.
+ */
 @media (prefers-reduced-motion: reduce) {
   .animate-activity-pulse,
   .animate-agent-pulse,
@@ -1182,12 +1226,10 @@ body,
     will-change: auto;
   }
 
-  /* Disable focus ring transitions for reduced motion */
   *:focus-visible {
     transition: none !important;
   }
 
-  /* Disable window-unfocused transitions for reduced motion */
   .animate-activity-pulse,
   .animate-agent-pulse,
   .animate-breathe,
@@ -1196,7 +1238,6 @@ body,
     transition: none;
   }
 
-  /* Disable button scale transforms for reduced motion */
   button,
   [role="button"],
   [type="button"],
@@ -1205,6 +1246,48 @@ body,
     transform: none !important;
     transition: none !important;
   }
+}
+
+body[data-reduce-animations="true"]
+  :is(
+    .animate-activity-pulse,
+    .animate-agent-pulse,
+    .animate-breathe,
+    .animate-spin-slow,
+    .animate-pulse-delayed,
+    .animate-pulse-immediate,
+    .status-working,
+    .animate-badge-bump,
+    .animate-activity-blip,
+    .animate-trash-pulse,
+    .animate-all-clear-flash,
+    .animate-diagnostics-flash
+  ) {
+  animation: none;
+  opacity: 1;
+  transform: none;
+  will-change: auto;
+}
+
+body[data-reduce-animations="true"] *:focus-visible {
+  transition: none !important;
+}
+
+body[data-reduce-animations="true"]
+  :is(
+    .animate-activity-pulse,
+    .animate-agent-pulse,
+    .animate-breathe,
+    .status-working,
+    .panel-state-working
+  ) {
+  transition: none;
+}
+
+body[data-reduce-animations="true"]
+  :is(button, [role="button"], [type="button"], [type="submit"], [type="reset"]) {
+  transform: none !important;
+  transition: none !important;
 }
 
 /* Terminal trash/restore animations */
@@ -1245,6 +1328,10 @@ body,
   }
 }
 
+body[data-reduce-animations="true"] :is(.terminal-restoring, .terminal-trashing) {
+  animation: none;
+}
+
 /* Terminal Selection State */
 .terminal-selected {
   border-color: color-mix(in oklab, var(--theme-border-strong) 92%, var(--theme-text-primary));
@@ -1267,25 +1354,15 @@ body,
     0 0 0 1px color-mix(in oklab, var(--color-activity-waiting) 10%, transparent);
 }
 
+/* Working state hint — static colored border. Was a 4s infinite breathe,
+ * which in peripheral vision across a multi-panel grid was a fatigue trigger
+ * (WCAG COGA). Status being a value doesn't justify continuous motion.
+ */
 .panel-state-working {
-  animation: panel-working-breathe 4s ease-in-out infinite;
-}
-
-@keyframes panel-working-breathe {
-  0%,
-  100% {
-    border-color: color-mix(in oklab, var(--color-activity-working) 25%, transparent);
-  }
-  50% {
-    border-color: color-mix(in oklab, var(--color-activity-working) 55%, transparent);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .panel-state-working {
-    animation: none;
-    border-color: color-mix(in oklab, var(--color-activity-working) 35%, transparent);
-  }
+  border-color: color-mix(in oklab, var(--color-activity-working) 35%, transparent);
+  box-shadow:
+    inset 0 0 0 1px color-mix(in oklab, var(--color-activity-working) 12%, transparent),
+    0 0 0 1px color-mix(in oklab, var(--color-activity-working) 8%, transparent);
 }
 
 /* Per-worktree color identity — left-edge stripe on grid panels */
@@ -1479,7 +1556,7 @@ body,
   will-change: text-shadow;
 }
 
-/* Respect reduced motion */
+/* Respect reduced motion — OS + Daintree toggle */
 @media (prefers-reduced-motion: reduce) {
   .animate-terminal-ping::before,
   .animate-terminal-ping::after,
@@ -1501,10 +1578,32 @@ body,
     text-shadow: none;
   }
 
-  /* Disable terminal glow transitions for reduced motion */
   .terminal-pane {
     transition: none !important;
   }
+}
+
+body[data-reduce-animations="true"] .animate-terminal-ping::before,
+body[data-reduce-animations="true"] .animate-terminal-ping::after,
+body[data-reduce-animations="true"] .animate-terminal-header-ping {
+  animation: none;
+  opacity: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+body[data-reduce-animations="true"] .animate-terminal-ping-select {
+  animation: none !important;
+  transition: none !important;
+}
+
+body[data-reduce-animations="true"] :is(.animate-eco-title, .animate-eco-title-select) {
+  animation: none;
+  text-shadow: none;
+}
+
+body[data-reduce-animations="true"] .terminal-pane {
+  transition: none !important;
 }
 
 /* GitHub Status Indicator Animations

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -1,28 +1,45 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  DURATION_75,
+  DURATION_100,
+  DURATION_150,
+  DURATION_200,
+  DURATION_250,
+  DURATION_300,
+  EASE_OUT_EXPO,
+  EASE_SNAPPY,
+  EASE_SPRING_CRITICAL,
   getPanelTransitionDuration,
+  getUiAnimationDuration,
   getUiTransitionDuration,
   PANEL_MINIMIZE_DURATION,
   PANEL_RESTORE_DURATION,
+  UI_ANIMATION_DURATION,
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
 } from "../animationUtils";
 
+describe("motion token constants", () => {
+  it("exposes the 75–300ms duration scale", () => {
+    expect(DURATION_75).toBe(75);
+    expect(DURATION_100).toBe(100);
+    expect(DURATION_150).toBe(150);
+    expect(DURATION_200).toBe(200);
+    expect(DURATION_250).toBe(250);
+    expect(DURATION_300).toBe(300);
+  });
+
+  it("exposes semantic easing tokens as valid CSS strings", () => {
+    expect(EASE_SNAPPY).toMatch(/^cubic-bezier\(/);
+    expect(EASE_OUT_EXPO).toMatch(/^cubic-bezier\(/);
+    expect(EASE_SPRING_CRITICAL).toMatch(/^linear\(/);
+  });
+});
+
 describe("getPanelTransitionDuration", () => {
-  let matchMediaSpy: ReturnType<typeof vi.fn>;
-
-  beforeEach(() => {
-    matchMediaSpy = vi.fn().mockReturnValue({ matches: false });
-    vi.stubGlobal("matchMedia", matchMediaSpy);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("returns 120ms for minimize direction", () => {
     expect(getPanelTransitionDuration("minimize")).toBe(PANEL_MINIMIZE_DURATION);
     expect(getPanelTransitionDuration("minimize")).toBe(120);
@@ -33,16 +50,18 @@ describe("getPanelTransitionDuration", () => {
     expect(getPanelTransitionDuration("restore")).toBe(200);
   });
 
-  it("returns 0 for both directions when prefers-reduced-motion is active", () => {
-    matchMediaSpy.mockReturnValue({ matches: true });
+  it("ignores prefers-reduced-motion — CSS owns reduced-motion, not JS timers", () => {
+    // WCAG 2.2 SC 2.3.3: remove motion via component-level @media overrides,
+    // don't zero out the duration (that produces a spatial jump).
+    const matchMediaSpy = vi.fn().mockReturnValue({ matches: true });
+    vi.stubGlobal("matchMedia", matchMediaSpy);
 
-    expect(getPanelTransitionDuration("minimize")).toBe(0);
-    expect(getPanelTransitionDuration("restore")).toBe(0);
-  });
-
-  it("queries the correct media query", () => {
-    getPanelTransitionDuration("minimize");
-    expect(matchMediaSpy).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
+    try {
+      expect(getPanelTransitionDuration("minimize")).toBe(120);
+      expect(getPanelTransitionDuration("restore")).toBe(200);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 
@@ -67,16 +86,36 @@ describe("getUiTransitionDuration", () => {
     expect(getUiTransitionDuration("exit")).toBe(120);
   });
 
-  it("returns 0 when prefers-reduced-motion is active", () => {
+  it("still returns the full duration when prefers-reduced-motion is active", () => {
     matchMediaSpy.mockReturnValue({ matches: true });
+    expect(getUiTransitionDuration("enter")).toBe(200);
+    expect(getUiTransitionDuration("exit")).toBe(120);
+  });
+
+  it("returns 0 when performance mode is active (skip-timer signal)", () => {
+    document.body.dataset.performanceMode = "true";
     expect(getUiTransitionDuration("enter")).toBe(0);
     expect(getUiTransitionDuration("exit")).toBe(0);
+  });
+});
+
+describe("getUiAnimationDuration", () => {
+  beforeEach(() => {
+    document.body.dataset.performanceMode = "false";
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.performanceMode;
+  });
+
+  it("returns the UI animation token regardless of prefers-reduced-motion", () => {
+    expect(getUiAnimationDuration()).toBe(UI_ANIMATION_DURATION);
+    expect(getUiAnimationDuration()).toBe(150);
   });
 
   it("returns 0 when performance mode is active", () => {
     document.body.dataset.performanceMode = "true";
-    expect(getUiTransitionDuration("enter")).toBe(0);
-    expect(getUiTransitionDuration("exit")).toBe(0);
+    expect(getUiAnimationDuration()).toBe(0);
   });
 });
 

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -1,55 +1,62 @@
-export const TERMINAL_ANIMATION_DURATION = 150;
-export const UI_ANIMATION_DURATION = 150;
+/* Motion token scale — mirrors the CSS custom properties in src/index.css so
+ * React components using `motion` props and JS timers stay in sync with CSS
+ * keyframes and Tailwind utilities. See @theme block at the top of index.css.
+ */
+export const DURATION_75 = 75;
+export const DURATION_100 = 100;
+export const DURATION_150 = 150;
+export const DURATION_200 = 200;
+export const DURATION_250 = 250;
+export const DURATION_300 = 300;
+
+export const EASE_SNAPPY = "cubic-bezier(0.2, 0, 0, 1)";
+export const EASE_SPRING_CRITICAL =
+  "linear(0, 0.007, 0.029 2.2%, 0.118 4.7%, 0.625 14.4%, 0.826 19%, 0.902 24%, 0.962 29.8%, 0.984 33.3%, 1.004 37.8%, 1.01 42.4%, 1.011 52.2%, 1.001)";
+export const EASE_OUT_EXPO = "cubic-bezier(0.16, 1, 0.3, 1)";
+
+export const TERMINAL_ANIMATION_DURATION = DURATION_150;
+export const UI_ANIMATION_DURATION = DURATION_150;
 
 export function getTerminalAnimationDuration(): number {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
-    return TERMINAL_ANIMATION_DURATION;
-
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  return reducedMotion ? 0 : TERMINAL_ANIMATION_DURATION;
+  return TERMINAL_ANIMATION_DURATION;
 }
 
 export function getUiAnimationDuration(): number {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+  if (typeof window === "undefined" || typeof document === "undefined") {
     return UI_ANIMATION_DURATION;
+  }
 
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  // Performance mode skips timers entirely — callers use duration === 0 as a
+  // signal to complete synchronously. Reduced-motion no longer short-circuits
+  // here: CSS owns reduced-motion presentation (transform removed, opacity
+  // kept) so JS durations stay intact.
   const performanceMode = document.body.dataset.performanceMode === "true";
-
-  return reducedMotion || performanceMode ? 0 : UI_ANIMATION_DURATION;
+  return performanceMode ? 0 : UI_ANIMATION_DURATION;
 }
 
-export const UI_ENTER_DURATION = 200;
+export const UI_ENTER_DURATION = DURATION_200;
 export const UI_EXIT_DURATION = 120;
 
-export const UI_ENTER_EASING =
-  "linear(0, 0.007, 0.029 2.2%, 0.118 4.7%, 0.625 14.4%, 0.826 19%, 0.902 24%, 0.962 29.8%, 0.984 33.3%, 1.004 37.8%, 1.01 42.4%, 1.011 52.2%, 1.001)";
+export const UI_ENTER_EASING = EASE_SPRING_CRITICAL;
 export const UI_EXIT_EASING = "cubic-bezier(0.2, 0, 0.7, 0)";
 
 export function getUiTransitionDuration(direction: "enter" | "exit"): number {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+  if (typeof window === "undefined" || typeof document === "undefined") {
     return direction === "enter" ? UI_ENTER_DURATION : UI_EXIT_DURATION;
+  }
 
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const performanceMode = document.body.dataset.performanceMode === "true";
-
-  if (reducedMotion || performanceMode) return 0;
+  if (performanceMode) return 0;
 
   return direction === "enter" ? UI_ENTER_DURATION : UI_EXIT_DURATION;
 }
 
 export const PANEL_MINIMIZE_DURATION = 120;
-export const PANEL_RESTORE_DURATION = 200;
+export const PANEL_RESTORE_DURATION = DURATION_200;
 
 export const PANEL_MINIMIZE_EASING = "cubic-bezier(0.3, 0, 0.8, 0.15)";
-export const PANEL_RESTORE_EASING = "cubic-bezier(0.16, 1, 0.3, 1)";
+export const PANEL_RESTORE_EASING = EASE_OUT_EXPO;
 
 export function getPanelTransitionDuration(direction: "minimize" | "restore"): number {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
-    return direction === "minimize" ? PANEL_MINIMIZE_DURATION : PANEL_RESTORE_DURATION;
-
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  if (reducedMotion) return 0;
-
   return direction === "minimize" ? PANEL_MINIMIZE_DURATION : PANEL_RESTORE_DURATION;
 }

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -551,6 +551,7 @@ describe("preferences action hardening", () => {
       "help.launchAgent",
       "help.togglePanel",
       "modal.close",
+      "preferences.reduceAnimations.set",
       "app.quit",
       "app.forceQuit",
     ]);

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -93,6 +93,21 @@ export function registerPreferencesActions(
     },
   }));
 
+  actions.set("preferences.reduceAnimations.set", () => ({
+    id: "preferences.reduceAnimations.set",
+    title: "Set Reduce UI Animations",
+    description: "Minimize motion across the interface, independent of OS settings",
+    category: "preferences",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ value: z.boolean() }),
+    run: async (args: unknown) => {
+      const { value } = args as { value: boolean };
+      usePreferencesStore.getState().setReduceAnimations(value);
+    },
+  }));
+
   actions.set("window.toggleFullscreen", () => ({
     id: "window.toggleFullscreen",
     title: "Toggle Fullscreen",

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -167,4 +167,70 @@ describe("preferencesStore migration", () => {
     expect(state.assignWorktreeToSelf).toBe(true);
     expect(state.lastSelectedWorktreeRecipeIdByProject).toEqual({ "proj-1": "r1" });
   });
+
+  describe("reduceAnimations", () => {
+    it("defaults to false on a fresh install", async () => {
+      const store = await loadStore();
+      expect(store.getState().reduceAnimations).toBe(false);
+    });
+
+    it("setReduceAnimations updates the flag", async () => {
+      const store = await loadStore();
+      store.getState().setReduceAnimations(true);
+      expect(store.getState().reduceAnimations).toBe(true);
+      store.getState().setReduceAnimations(false);
+      expect(store.getState().reduceAnimations).toBe(false);
+    });
+
+    it("persists the value to localStorage", async () => {
+      const store = await loadStore();
+      store.getState().setReduceAnimations(true);
+      await vi.waitFor(() => {
+        const persisted = storageMock.getItem(STORAGE_KEY);
+        expect(persisted).not.toBeNull();
+        const parsed = JSON.parse(persisted!);
+        expect(parsed.state.reduceAnimations).toBe(true);
+      });
+    });
+
+    it("migrates v3 state (pre-reduceAnimations) to v4 with default false", async () => {
+      setStoredState(
+        {
+          showProjectPulse: true,
+          showDeveloperTools: false,
+          showGridAgentHighlights: true,
+          showDockAgentHighlights: false,
+          dockDensity: "comfortable",
+          assignWorktreeToSelf: false,
+          lastSelectedWorktreeRecipeIdByProject: {},
+        },
+        3
+      );
+
+      const store = await loadStore();
+      const state = store.getState();
+      expect(state.reduceAnimations).toBe(false);
+      expect(state.dockDensity).toBe("comfortable");
+      expect(state.showGridAgentHighlights).toBe(true);
+    });
+
+    it("preserves an explicitly persisted true value across v4 migrations", async () => {
+      setStoredState(
+        {
+          reduceAnimations: true,
+          showProjectPulse: true,
+          showDeveloperTools: false,
+          showGridAgentHighlights: false,
+          showDockAgentHighlights: false,
+          dockDensity: "normal",
+          assignWorktreeToSelf: false,
+          lastSelectedWorktreeRecipeIdByProject: {},
+        },
+        3
+      );
+
+      const store = await loadStore();
+      expect(store.getState().reduceAnimations).toBe(true);
+    });
+  });
 });

--- a/src/store/__tests__/preferencesStore.test.ts
+++ b/src/store/__tests__/preferencesStore.test.ts
@@ -232,5 +232,20 @@ describe("preferencesStore migration", () => {
       const store = await loadStore();
       expect(store.getState().reduceAnimations).toBe(true);
     });
+
+    it("migrates fresh v4 state (reduceAnimations absent) to default false", async () => {
+      setStoredState(
+        {
+          showProjectPulse: true,
+          dockDensity: "normal",
+          assignWorktreeToSelf: false,
+          lastSelectedWorktreeRecipeIdByProject: {},
+        },
+        4
+      );
+
+      const store = await loadStore();
+      expect(store.getState().reduceAnimations).toBe(false);
+    });
   });
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -18,6 +18,8 @@ interface PreferencesState {
   setDockDensity: (density: DockDensity) => void;
   assignWorktreeToSelf: boolean;
   setAssignWorktreeToSelf: (value: boolean) => void;
+  reduceAnimations: boolean;
+  setReduceAnimations: (value: boolean) => void;
   lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>;
   setLastSelectedWorktreeRecipeIdByProject: (
     projectId: string,
@@ -40,6 +42,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setDockDensity: (density) => set({ dockDensity: density }),
       assignWorktreeToSelf: false,
       setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
+      reduceAnimations: false,
+      setReduceAnimations: (value) => set({ reduceAnimations: value }),
       lastSelectedWorktreeRecipeIdByProject: {},
       setLastSelectedWorktreeRecipeIdByProject: (projectId, id) =>
         set((state) => ({
@@ -52,7 +56,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage(),
-      version: 3,
+      version: 4,
       migrate: (persisted, version) => {
         if (version === 0 || version === undefined) {
           if (persisted && typeof persisted === "object") {
@@ -76,6 +80,12 @@ export const usePreferencesStore = create<PreferencesState>()(
             state.dockDensity ??= "normal";
           }
         }
+        if (version < 4) {
+          if (persisted && typeof persisted === "object") {
+            const state = persisted as Record<string, unknown>;
+            state.reduceAnimations ??= false;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -86,5 +96,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined> }",
 });

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -634,3 +634,85 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
     expect(state.activeDockTerminalId).toBe("d1");
   });
 });
+
+describe("TerminalFocusSlice - setFocused ping gating", () => {
+  const mockTerminals: TerminalInstance[] = [
+    {
+      id: "term-1",
+      title: "Terminal 1",
+      type: "claude",
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    },
+    {
+      id: "term-2",
+      title: "Terminal 2",
+      type: "terminal",
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    },
+  ] as TerminalInstance[];
+
+  const getTerminals = vi.fn(() => mockTerminals);
+
+  let state: TerminalFocusSlice;
+  let setState: any;
+  let getState: any;
+  let pingSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setState = vi.fn((updater) => {
+      const currentState = getState();
+      const updates = typeof updater === "function" ? updater(currentState) : updater;
+      state = { ...currentState, ...updates };
+    });
+    getState = vi.fn(() => state);
+    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId)(
+      setState,
+      getState,
+      {} as never
+    );
+    // Spy on pingTerminal so we can assert without running the 1600ms timer.
+    pingSpy = vi.fn();
+    state.pingTerminal = pingSpy as unknown as TerminalFocusSlice["pingTerminal"];
+  });
+
+  it("pings on initial focus (no previously focused terminal)", () => {
+    state.setFocused("term-1", true);
+    expect(pingSpy).toHaveBeenCalledWith("term-1");
+  });
+
+  it("pings when focus moves to a different terminal", () => {
+    state.setFocused("term-1", true);
+    pingSpy.mockClear();
+
+    state.setFocused("term-2", true);
+    expect(pingSpy).toHaveBeenCalledWith("term-2");
+  });
+
+  it("does not ping when re-focusing the already-focused terminal", () => {
+    state.setFocused("term-1", true);
+    pingSpy.mockClear();
+
+    state.setFocused("term-1", true);
+    expect(pingSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not ping when shouldPing is false, even on focus change", () => {
+    state.setFocused("term-1", false);
+    expect(pingSpy).not.toHaveBeenCalled();
+    state.setFocused("term-2", false);
+    expect(pingSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -111,6 +111,7 @@ export const createTerminalFocusSlice =
       preMaximizeLayout: null,
       setFocused: (id, shouldPing = false) => {
         if (id) {
+          const previousFocusedId = get().focusedId;
           const terminal = getTerminals().find((t) => t.id === id);
           if (terminal?.location === "dock") {
             set({ focusedId: id, activeDockTerminalId: id });
@@ -122,7 +123,9 @@ export const createTerminalFocusSlice =
           if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
             terminalInstanceService.wake(id);
           }
-          if (shouldPing) {
+          // Only ping when selection actually changes — re-focusing the already
+          // selected terminal should be a no-op visually (no 1.6s ping loop).
+          if (shouldPing && id !== previousFocusedId) {
             get().pingTerminal(id);
           }
         } else {


### PR DESCRIPTION
## Summary

- Introduces a motion token scale (75–300ms durations, 3 semantic easings) as `@theme` tokens in `src/index.css`, mirrored as JS constants in `src/lib/animationUtils.ts`, giving CSS keyframes, Tailwind utilities, and `motion` props a single source of truth.
- Replaces the `duration→0` anti-pattern for reduced-motion with proper component-level `@media (prefers-reduced-motion)` overrides per WCAG 2.2 SC 2.3.3 (removes transform, preserves opacity). Adds a Daintree-level "Reduce UI animations" preference in Settings > General > Display, wired through the preferencesStore (v3→v4 migration) and projected to `body[data-reduce-animations]` from AppLayout.
- Dials back three continuous peripheral motion loops: `.animate-agent-pulse` replaced with a 150ms one-shot scale+opacity flash on `agentState` transition; `.panel-state-working` breathe loop replaced with a static coloured border hint; terminal ping gated so re-focusing an already-focused terminal is a visual no-op.

Resolves #5696

## Changes

- `src/index.css` — motion token scale, reduced-motion overrides, one-shot agent flash keyframe, static panel-working border
- `src/lib/animationUtils.ts` — JS constants mirroring token scale
- `src/store/preferencesStore.ts` — `reduceAnimations` preference, v3→v4 migration
- `src/components/Layout/AppLayout.tsx` — projects `data-reduce-animations` to body
- `src/components/Worktree/AgentStatusIndicator.tsx` — one-shot flash with `onAnimationEnd` cleanup and 250ms safety timeout
- `src/store/slices/terminalFocusSlice.ts` — ping-gating on already-focused terminal
- `src/components/Project/ProjectSwitcher.tsx`, `ProjectSwitcherPalette.tsx`, `RunningTaskList.tsx` — switched to `animate-activity-pulse` for continuous status indication
- `src/components/Settings/GeneralTab.tsx` — "Reduce UI animations" toggle
- `src/services/actions/definitions/preferencesActions.ts` — action wiring
- `shared/types/actions.ts` — new action ID

## Testing

- `src/lib/__tests__/animationUtils.test.ts` updated (12 tests covering duration/easing constants; performance mode still zeroes timers, reduced-motion preference no longer short-circuits)
- New `src/store/__tests__/preferencesStore.test.ts` (default, setter, persistence, v3→v4 migration, v4-fresh migration)
- `src/store/slices/__tests__/terminalFocusSlice.test.ts` extended with 4 new ping-gating tests
- `src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx` extended with 3 new tests (one-shot flash, safety timeout, re-arming on consecutive transitions)
- Lint clean (363 pre-existing warnings, 0 errors), format check clean, typecheck clean across all three tsconfigs