### PR TITLE
fix(settings): use theme tokens instead of hardcoded colors

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -685,7 +685,7 @@ export function AgentSettings({
                         onSettingsChange?.();
                       })();
                     }}
-                    agentColor={getAgentConfig(activeAgent.id)?.color ?? "#888888"}
+                    agentColor={getAgentConfig(activeAgent.id)?.color ?? "var(--theme-text-muted)"}
                   />
 
                   {/* Scope banner — mitigates context-hijack confusion when
@@ -741,7 +741,9 @@ export function AgentSettings({
                         {/* Color picker — preset palette with Clear + Custom escape hatch */}
                         <PresetColorPicker
                           color={selectedPreset.color}
-                          agentColor={getAgentConfig(activeAgent.id)?.color ?? "#888888"}
+                          agentColor={
+                            getAgentConfig(activeAgent.id)?.color ?? "var(--theme-text-muted)"
+                          }
                           onChange={(color) => handleUpdatePreset(selectedPreset.id, { color })}
                           ariaLabel="Preset color"
                         />

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -330,7 +330,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
               <PaletteStrip scheme={selectedScheme} />
             </div>
           )}
-          <div className="absolute bottom-0 inset-x-0 bg-scrim-medium backdrop-blur-sm px-3 py-1.5 flex items-center justify-between">
+          <div className="absolute bottom-0 inset-x-0 bg-black/40 backdrop-blur-sm px-3 py-1.5 flex items-center justify-between">
             <span className="text-sm font-medium text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
               {selectedScheme.name}
             </span>

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -330,7 +330,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
               <PaletteStrip scheme={selectedScheme} />
             </div>
           )}
-          <div className="absolute bottom-0 inset-x-0 bg-black/40 backdrop-blur-sm px-3 py-1.5 flex items-center justify-between">
+          <div className="absolute bottom-0 inset-x-0 bg-scrim-medium backdrop-blur-sm px-3 py-1.5 flex items-center justify-between">
             <span className="text-sm font-medium text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
               {selectedScheme.name}
             </span>

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -408,7 +408,7 @@ export function GeneralTab({
             className="settings-card flex items-start gap-4 p-4 rounded-[var(--radius-md)] border border-daintree-border"
           >
             <div className="h-12 w-12 rounded-xl flex items-center justify-center shrink-0 bg-surface-panel-elevated">
-              <DaintreeIcon size={28} className="shrink-0 text-daintree-accent" />
+              <DaintreeIcon size={28} className="shrink-0" style={{ color: "#36CE94" }} />
             </div>
             <div className="flex-1 min-w-0 space-y-1">
               <div className="flex items-center gap-2">

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -407,11 +407,8 @@ export function GeneralTab({
             id="general-about"
             className="settings-card flex items-start gap-4 p-4 rounded-[var(--radius-md)] border border-daintree-border"
           >
-            <div
-              className="h-12 w-12 rounded-xl flex items-center justify-center shrink-0"
-              style={{ backgroundColor: "#151616" }}
-            >
-              <DaintreeIcon size={28} className="shrink-0" style={{ color: "#36CE94" }} />
+            <div className="h-12 w-12 rounded-xl flex items-center justify-center shrink-0 bg-surface-panel-elevated">
+              <DaintreeIcon size={28} className="shrink-0 text-daintree-accent" />
             </div>
             <div className="flex-1 min-w-0 space-y-1">
               <div className="flex items-center gap-2">

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -51,6 +51,10 @@ export function PresetColorPicker({
 
   const effectiveColor = color ?? agentColor;
 
+  const isValidHex = (value: string): value is `#${string}` => /^#[0-9a-f]{6}$/i.test(value);
+
+  const pickerValue = isValidHex(color) ? color : isValidHex(agentColor) ? agentColor : "#e06c75";
+
   const handleSelect = (next: string | undefined) => {
     onChange(next);
     setOpen(false);
@@ -132,7 +136,7 @@ export function PresetColorPicker({
             ref={nativeInputRef}
             type="color"
             className="sr-only"
-            value={effectiveColor}
+            value={pickerValue}
             onChange={(e) => handleSelect(e.target.value)}
             aria-hidden="true"
             tabIndex={-1}

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -53,7 +53,8 @@ export function PresetColorPicker({
 
   const isValidHex = (value: string): value is `#${string}` => /^#[0-9a-f]{6}$/i.test(value);
 
-  const pickerValue = isValidHex(color) ? color : isValidHex(agentColor) ? agentColor : "#e06c75";
+  const pickerValue =
+    color && isValidHex(color) ? color : isValidHex(agentColor) ? agentColor : "#e06c75";
 
   const handleSelect = (next: string | undefined) => {
     onChange(next);


### PR DESCRIPTION
## Summary
Replaced hardcoded hex colour values in Settings components with theme-aware tokens. The About Daintree card icon chip now adapts properly to light themes instead of staying a fixed dark square. Agent color fallbacks and preset colour picker also now respect the current theme.

## Changes
- Updated GeneralTab.tsx About card to use theme tokens for icon chip background and icon colour
- Replaced agent color fallback (#888888) in AgentSettings.tsx with theme-aware muted token
- Added hex value preservation for PresetColorPicker's native colour input to maintain user selections

## Testing
Verified Settings General panel displays correctly across multiple built-in themes including light, dark, and high-contrast variants. About card icon chip now adapts to theme. Agent colour fallback displays appropriately. Preset colour picker maintains hex values when switching between custom and preset colours.

Resolves #5692