### PR TITLE
test(e2e): skip Ctrl+Tab nav tests on all Linux, not just CI

### DIFF
--- a/e2e/full/core-keyboard-navigation-advanced.spec.ts
+++ b/e2e/full/core-keyboard-navigation-advanced.spec.ts
@@ -47,10 +47,7 @@ test.describe.serial("Core: Keyboard Terminal Navigation", () => {
   });
 
   test("Ctrl+Tab cycles forward through terminals", async () => {
-    test.skip(
-      !!process.env.CI && process.platform === "linux",
-      "Ctrl+Tab is intercepted by the Linux CI window manager"
-    );
+    test.skip(process.platform === "linux", "Ctrl+Tab is intercepted by the Linux window manager");
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
 
@@ -80,10 +77,7 @@ test.describe.serial("Core: Keyboard Terminal Navigation", () => {
   });
 
   test("Ctrl+Shift+Tab cycles backward through terminals", async () => {
-    test.skip(
-      !!process.env.CI && process.platform === "linux",
-      "Ctrl+Tab is intercepted by the Linux CI window manager"
-    );
+    test.skip(process.platform === "linux", "Ctrl+Tab is intercepted by the Linux window manager");
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
 


### PR DESCRIPTION
## Summary

- Skip condition for Ctrl+Tab forward/backward terminal navigation tests was `!!process.env.CI && process.platform === "linux"`, meaning they only skipped in CI environments
- Desktop Linux window managers (GNOME, KDE, etc.) intercept Ctrl+Tab before Electron, causing failures on local Linux dev machines too
- Removed the `CI` check — both tests now skip on any Linux platform

## Changes

`e2e/full/core-keyboard-navigation-advanced.spec.ts` — 2 skip conditions updated:

```ts
// Before
test.skip(!!process.env.CI && process.platform === "linux", "Ctrl+Tab is intercepted by the Linux CI window manager");

// After
test.skip(process.platform === "linux", "Ctrl+Tab is intercepted by the Linux window manager");
```

## CI Impact

None. In CI on Linux, `process.env.CI` is already set, so these tests were already skipped. The new condition produces the same skip result in all CI environments. Only local Linux dev machines are affected (tests now correctly skip instead of failing).

| Environment | Before | After |
|---|---|---|
| CI / Linux | skipped | skipped (unchanged) |
| CI / macOS | runs | runs (unchanged) |
| CI / Windows | runs | runs (unchanged) |
| Local / Linux | **failed** | skipped ✓ |

## Test Results (Ubuntu, local)

```
- Ctrl+Tab cycles forward through terminals     [skipped]
- Ctrl+Shift+Tab cycles backward through terminals [skipped]
✓ cycling with single panel is no-op
✓ Cmd+Alt+] cycles to next worktree
✓ Cmd+Alt+[ cycles to previous worktree
✓ Cmd+Alt+N jumps to worktree by index
✓ focus state visible via DOM attributes after keyboard navigation

2 skipped, 5 passed
```

Fixes #5725