### PR TITLE
test(e2e): skip Ctrl+Tab nav tests on all Linux, not just CI

### DIFF
--- a/e2e/full/core-keyboard-navigation-advanced.spec.ts
+++ b/e2e/full/core-keyboard-navigation-advanced.spec.ts
@@ -47,10 +47,7 @@ test.describe.serial("Core: Keyboard Terminal Navigation", () => {
   });
 
   test("Ctrl+Tab cycles forward through terminals", async () => {
-    test.skip(
-      !!process.env.CI && process.platform === "linux",
-      "Ctrl+Tab is intercepted by the Linux CI window manager"
-    );
+    test.skip(process.platform === "linux", "Ctrl+Tab is intercepted by the Linux window manager");
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
 
@@ -80,10 +77,7 @@ test.describe.serial("Core: Keyboard Terminal Navigation", () => {
   });
 
   test("Ctrl+Shift+Tab cycles backward through terminals", async () => {
-    test.skip(
-      !!process.env.CI && process.platform === "linux",
-      "Ctrl+Tab is intercepted by the Linux CI window manager"
-    );
+    test.skip(process.platform === "linux", "Ctrl+Tab is intercepted by the Linux window manager");
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
 


### PR DESCRIPTION
## Summary

- The Ctrl+Tab keyboard navigation E2E tests were conditionally skipped only when running in CI on Linux (`!!process.env.CI && process.platform === "linux"`), meaning they still ran on local Linux environments and failed there too.
- Widened the skip guard to `process.platform === "linux"` unconditionally, since the underlying issue (Ctrl+Tab being intercepted by the desktop environment or window manager) is a Linux platform constraint, not a CI-specific one.

Resolves #5725. Supersedes #5727. Original contribution by @dev-en-m.

## Changes

- `e2e/full/core-keyboard-navigation-advanced.spec.ts`: updated 2 skip guards from `!!process.env.CI && process.platform === "linux"` to `process.platform === "linux"`

## Testing

The two affected `test.skip` calls now correctly skip on any Linux runner regardless of whether `CI` is set.