### PR TITLE
feat(palette): instant filter and origin-scaled entry animation

### DIFF
--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useDeferredValue } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { Spinner } from "@/components/ui/Spinner";
@@ -47,7 +47,6 @@ export function CommandPicker({
   filter,
 }: CommandPickerProps) {
   const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const filteredCommands = useMemo(() => {
@@ -57,15 +56,15 @@ export function CommandPicker({
       result = result.filter((cmd) => filter.includes(cmd.category));
     }
 
-    if (deferredQuery.trim()) {
+    if (query.trim()) {
       result = result.filter((cmd) => {
         const searchText = `${cmd.id} ${cmd.label} ${cmd.description} ${cmd.keywords?.join(" ") ?? ""}`;
-        return fuzzyMatch(searchText, deferredQuery.trim());
+        return fuzzyMatch(searchText, query.trim());
       });
     }
 
     return result;
-  }, [commands, filter, deferredQuery]);
+  }, [commands, filter, query]);
 
   const groupedCommands = useMemo(() => {
     const groups = new Map<CommandCategory, CommandManifestEntry[]>();

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -10,6 +10,8 @@ import { usePaletteStore } from "@/store/paletteStore";
 import {
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
   getUiTransitionDuration,
@@ -119,16 +121,16 @@ export function AppPaletteDialog({
       <div
         ref={dialogRef}
         className={cn(
-          "w-full max-w-xl mx-4 bg-daintree-bg border border-[var(--border-overlay)] rounded-[var(--radius-xl)] shadow-modal overflow-hidden",
+          "w-full max-w-xl mx-4 bg-daintree-bg border border-[var(--border-overlay)] rounded-[var(--radius-xl)] shadow-modal overflow-hidden origin-top",
           "transition-[opacity,transform]",
-          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
-          isVisible
-            ? "opacity-100 translate-y-0 scale-100"
-            : "opacity-0 -translate-y-3 scale-[0.97]",
+          "motion-reduce:transition-opacity motion-reduce:scale-100",
+          isVisible ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]",
           className
         )}
         style={{
-          transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+          transitionDuration: isVisible
+            ? `${UI_PALETTE_ENTER_DURATION}ms`
+            : `${UI_PALETTE_EXIT_DURATION}ms`,
           transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
         }}
         onClick={(e) => e.stopPropagation()}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -112,6 +112,7 @@ export function AppPaletteDialog({
       )}
       style={{
         transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+        transitionTimingFunction: "linear",
       }}
       onClick={handleBackdropClick}
       role="dialog"

--- a/src/hooks/__tests__/useSearchablePalette.test.tsx
+++ b/src/hooks/__tests__/useSearchablePalette.test.tsx
@@ -51,21 +51,6 @@ describe("useSearchablePalette", () => {
     expect(result.current.selectedIndex).toBe(-1);
   });
 
-  it("exposes isStale as false when query matches deferred value", () => {
-    const items: PaletteItem[] = [{ id: "a", name: "Alpha" }];
-
-    const { result } = renderHook(() => useSearchablePalette<PaletteItem>({ items }));
-
-    expect(result.current.isStale).toBe(false);
-
-    act(() => {
-      result.current.setQuery("test");
-    });
-
-    // In test environment, useDeferredValue resolves synchronously within act()
-    expect(result.current.isStale).toBe(false);
-  });
-
   describe("totalResults", () => {
     it("exposes total count before slicing when results exceed maxResults", () => {
       const items: PaletteItem[] = Array.from({ length: 25 }, (_, i) => ({

--- a/src/hooks/useSearchablePalette.ts
+++ b/src/hooks/useSearchablePalette.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, useRef, useDeferredValue } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import Fuse, { type IFuseOptions, type FuseResultMatch } from "fuse.js";
 import { usePaletteStore, type PaletteId } from "@/store/paletteStore";
 
@@ -27,7 +27,6 @@ export interface UseSearchablePaletteReturn<T> {
   results: T[];
   totalResults: number;
   selectedIndex: number;
-  isStale: boolean;
   matchesById: Map<string, readonly FuseResultMatch[]>;
   open: () => void;
   close: () => void;
@@ -65,7 +64,6 @@ export function useSearchablePalette<T>(
 
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const deferredQuery = useDeferredValue(query);
 
   const effectiveFuseOptions = useMemo(() => {
     if (!fuseOptions) return null;
@@ -83,11 +81,11 @@ export function useSearchablePalette<T>(
     const matches = new Map<string, readonly FuseResultMatch[]>();
 
     if (filterFn) {
-      filtered = filterFn(items, deferredQuery);
-    } else if (!deferredQuery.trim()) {
+      filtered = filterFn(items, query);
+    } else if (!query.trim()) {
       filtered = items;
     } else if (fuse) {
-      const fuseResults = fuse.search(deferredQuery);
+      const fuseResults = fuse.search(query);
       filtered = fuseResults.map((r) => r.item);
       if (includeMatches) {
         for (const r of fuseResults) {
@@ -105,7 +103,7 @@ export function useSearchablePalette<T>(
       totalResults: filtered.length,
       matchesById: matches,
     };
-  }, [deferredQuery, items, fuse, filterFn, maxResults, includeMatches, getItemId]);
+  }, [query, items, fuse, filterFn, maxResults, includeMatches, getItemId]);
 
   const findNavigable = useCallback(
     (startIndex: number, direction: 1 | -1): number => {
@@ -205,15 +203,12 @@ export function useSearchablePalette<T>(
     });
   }, [results.length, canNavigate, findNavigable]);
 
-  const isStale = query !== deferredQuery;
-
   return {
     isOpen,
     query,
     results,
     totalResults,
     selectedIndex,
-    isStale,
     matchesById,
     open,
     close,

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -37,6 +37,9 @@ export function getUiAnimationDuration(): number {
 export const UI_ENTER_DURATION = DURATION_200;
 export const UI_EXIT_DURATION = 120;
 
+export const UI_PALETTE_ENTER_DURATION = DURATION_150;
+export const UI_PALETTE_EXIT_DURATION = DURATION_100;
+
 export const UI_ENTER_EASING = EASE_SPRING_CRITICAL;
 export const UI_EXIT_EASING = "cubic-bezier(0.2, 0, 0.7, 0)";
 


### PR DESCRIPTION
## Summary

- Removes `useDeferredValue` from `useSearchablePalette` and `CommandPicker` so filtering is synchronous on every keystroke. The palette was already fast enough that the deferred path only added perceived lag with no benefit.
- Adds origin-scaled entry animation: `scale(0.96) → 1` + `opacity 0 → 1` over 150ms enter / 100ms exit, anchored from the top of the palette. Backdrop fades at 200ms with linear easing. Reduced-motion falls back to opacity-only.
- New `UI_PALETTE_ENTER_DURATION` and `UI_PALETTE_EXIT_DURATION` constants in `animationUtils.ts` keep the timing values in one place.

Resolves #5699

## Changes

- `src/hooks/useSearchablePalette.ts` — removed `useDeferredValue`, dropped unused `isStale` return field
- `src/components/Commands/CommandPicker.tsx` — removed `useDeferredValue` wrapper, cleaned up unused state
- `src/components/ui/AppPaletteDialog.tsx` — origin-top scale animation, linear backdrop easing, reduced-motion guard
- `src/lib/animationUtils.ts` — added `UI_PALETTE_ENTER_DURATION` and `UI_PALETTE_EXIT_DURATION`
- `src/hooks/__tests__/useSearchablePalette.test.tsx` — removed `isStale` assertions that no longer apply

## Testing

- `useSearchablePalette` unit tests (8) pass
- Full hooks + Commands suite (601 tests) clean
- `tsc --noEmit` clean, lint and format clean