### PR TITLE
feat(animation): structural micro-animations for spatial continuity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,6 +128,7 @@ import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { isAgentReady } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
+import { MotionConfig } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
@@ -479,331 +480,336 @@ function App() {
   }
 
   return (
-    <ErrorBoundary variant="fullscreen" componentName="App">
-      <E2EFaultInjector />
-      {isSafeMode && <SafeModeBanner />}
-      <DndProvider>
-        <VoiceRecordingAnnouncer />
-        <AccessibilityAnnouncer />
-        <Profiler id="app-layout" onRender={onLayoutRender}>
-          <AppLayout
-            sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
-            onLaunchAgent={handleLaunchAgent}
-            onSettings={handleSettings}
-            onPreloadSettings={handlePreloadSettings}
-            onRetry={handleErrorRetry}
-            onCancelRetry={handleCancelRetry}
-            agentAvailability={availability}
-            agentSettings={agentSettings}
-            isHydrated={isStateLoaded}
-            projectSwitcherPalette={projectSwitcherPalette}
-          >
-            <Profiler id="content-grid" onRender={onContentGridRender}>
-              <ContentGrid
-                className="h-full w-full"
-                agentAvailability={availability}
-                defaultCwd={defaultTerminalCwd}
-                emptyContent={
-                  currentProject === null ? (
-                    <WelcomeScreen gettingStarted={gettingStarted} />
-                  ) : undefined
-                }
-              />
-            </Profiler>
-          </AppLayout>
-        </Profiler>
-      </DndProvider>
+    <MotionConfig reducedMotion="user">
+      <ErrorBoundary variant="fullscreen" componentName="App">
+        <E2EFaultInjector />
+        {isSafeMode && <SafeModeBanner />}
+        <DndProvider>
+          <VoiceRecordingAnnouncer />
+          <AccessibilityAnnouncer />
+          <Profiler id="app-layout" onRender={onLayoutRender}>
+            <AppLayout
+              sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
+              onLaunchAgent={handleLaunchAgent}
+              onSettings={handleSettings}
+              onPreloadSettings={handlePreloadSettings}
+              onRetry={handleErrorRetry}
+              onCancelRetry={handleCancelRetry}
+              agentAvailability={availability}
+              agentSettings={agentSettings}
+              isHydrated={isStateLoaded}
+              projectSwitcherPalette={projectSwitcherPalette}
+            >
+              <Profiler id="content-grid" onRender={onContentGridRender}>
+                <ContentGrid
+                  className="h-full w-full"
+                  agentAvailability={availability}
+                  defaultCwd={defaultTerminalCwd}
+                  emptyContent={
+                    currentProject === null ? (
+                      <WelcomeScreen gettingStarted={gettingStarted} />
+                    ) : undefined
+                  }
+                />
+              </Profiler>
+            </AppLayout>
+          </Profiler>
+        </DndProvider>
 
-      <QuickSwitcher
-        isOpen={quickSwitcher.isOpen}
-        query={quickSwitcher.query}
-        results={quickSwitcher.results}
-        totalResults={quickSwitcher.totalResults}
-        selectedIndex={quickSwitcher.selectedIndex}
-        close={quickSwitcher.close}
-        setQuery={quickSwitcher.setQuery}
-        selectPrevious={quickSwitcher.selectPrevious}
-        selectNext={quickSwitcher.selectNext}
-        selectItem={quickSwitcher.selectItem}
-        confirmSelection={quickSwitcher.confirmSelection}
-      />
-      <SendToAgentPalette
-        isOpen={sendToAgentPalette.isOpen}
-        query={sendToAgentPalette.query}
-        results={sendToAgentPalette.results}
-        totalResults={sendToAgentPalette.totalResults}
-        selectedIndex={sendToAgentPalette.selectedIndex}
-        close={sendToAgentPalette.close}
-        setQuery={sendToAgentPalette.setQuery}
-        selectPrevious={sendToAgentPalette.selectPrevious}
-        selectNext={sendToAgentPalette.selectNext}
-        selectItem={sendToAgentPalette.selectItem}
-        confirmSelection={sendToAgentPalette.confirmSelection}
-      />
-      <NewTerminalPalette
-        isOpen={newTerminalPalette.isOpen}
-        query={newTerminalPalette.query}
-        results={newTerminalPalette.results}
-        totalResults={newTerminalPalette.totalResults}
-        selectedIndex={newTerminalPalette.selectedIndex}
-        onQueryChange={newTerminalPalette.setQuery}
-        onSelectPrevious={newTerminalPalette.selectPrevious}
-        onSelectNext={newTerminalPalette.selectNext}
-        onSelect={newTerminalPalette.handleSelect}
-        onConfirm={newTerminalPalette.confirmSelection}
-        onClose={newTerminalPalette.close}
-      />
-      <WorktreePalette
-        isOpen={worktreePalette.isOpen}
-        query={worktreePalette.query}
-        results={worktreePalette.results}
-        totalResults={worktreePalette.totalResults}
-        activeWorktreeId={worktreePalette.activeWorktreeId}
-        selectedIndex={worktreePalette.selectedIndex}
-        onQueryChange={worktreePalette.setQuery}
-        onSelectPrevious={worktreePalette.selectPrevious}
-        onSelectNext={worktreePalette.selectNext}
-        onSelect={worktreePalette.selectWorktree}
-        onConfirm={worktreePalette.confirmSelection}
-        onClose={worktreePalette.close}
-      />
-      <QuickCreatePalette palette={quickCreatePalette} />
-      <PanelPalette
-        isOpen={panelPalette.isOpen}
-        query={panelPalette.query}
-        results={panelPalette.results}
-        totalResults={panelPalette.totalResults}
-        selectedIndex={panelPalette.selectedIndex}
-        matchesById={panelPalette.matchesById}
-        onQueryChange={panelPalette.setQuery}
-        onSelectPrevious={panelPalette.selectPrevious}
-        onSelectNext={panelPalette.selectNext}
-        onSelect={(kind) => {
-          const result = panelPalette.handleSelect(kind);
-          if (!result) return;
-          if (result.resumeSession) {
-            const session = result.resumeSession;
-            const agentConfig = getEffectiveAgentConfig(session.agentId);
-            const command = buildResumeCommand(
-              session.agentId,
-              session.sessionId,
-              session.agentLaunchFlags
-            );
-            if (command && agentConfig) {
+        <QuickSwitcher
+          isOpen={quickSwitcher.isOpen}
+          query={quickSwitcher.query}
+          results={quickSwitcher.results}
+          totalResults={quickSwitcher.totalResults}
+          selectedIndex={quickSwitcher.selectedIndex}
+          close={quickSwitcher.close}
+          setQuery={quickSwitcher.setQuery}
+          selectPrevious={quickSwitcher.selectPrevious}
+          selectNext={quickSwitcher.selectNext}
+          selectItem={quickSwitcher.selectItem}
+          confirmSelection={quickSwitcher.confirmSelection}
+        />
+        <SendToAgentPalette
+          isOpen={sendToAgentPalette.isOpen}
+          query={sendToAgentPalette.query}
+          results={sendToAgentPalette.results}
+          totalResults={sendToAgentPalette.totalResults}
+          selectedIndex={sendToAgentPalette.selectedIndex}
+          close={sendToAgentPalette.close}
+          setQuery={sendToAgentPalette.setQuery}
+          selectPrevious={sendToAgentPalette.selectPrevious}
+          selectNext={sendToAgentPalette.selectNext}
+          selectItem={sendToAgentPalette.selectItem}
+          confirmSelection={sendToAgentPalette.confirmSelection}
+        />
+        <NewTerminalPalette
+          isOpen={newTerminalPalette.isOpen}
+          query={newTerminalPalette.query}
+          results={newTerminalPalette.results}
+          totalResults={newTerminalPalette.totalResults}
+          selectedIndex={newTerminalPalette.selectedIndex}
+          onQueryChange={newTerminalPalette.setQuery}
+          onSelectPrevious={newTerminalPalette.selectPrevious}
+          onSelectNext={newTerminalPalette.selectNext}
+          onSelect={newTerminalPalette.handleSelect}
+          onConfirm={newTerminalPalette.confirmSelection}
+          onClose={newTerminalPalette.close}
+        />
+        <WorktreePalette
+          isOpen={worktreePalette.isOpen}
+          query={worktreePalette.query}
+          results={worktreePalette.results}
+          totalResults={worktreePalette.totalResults}
+          activeWorktreeId={worktreePalette.activeWorktreeId}
+          selectedIndex={worktreePalette.selectedIndex}
+          onQueryChange={worktreePalette.setQuery}
+          onSelectPrevious={worktreePalette.selectPrevious}
+          onSelectNext={worktreePalette.selectNext}
+          onSelect={worktreePalette.selectWorktree}
+          onConfirm={worktreePalette.confirmSelection}
+          onClose={worktreePalette.close}
+        />
+        <QuickCreatePalette palette={quickCreatePalette} />
+        <PanelPalette
+          isOpen={panelPalette.isOpen}
+          query={panelPalette.query}
+          results={panelPalette.results}
+          totalResults={panelPalette.totalResults}
+          selectedIndex={panelPalette.selectedIndex}
+          matchesById={panelPalette.matchesById}
+          onQueryChange={panelPalette.setQuery}
+          onSelectPrevious={panelPalette.selectPrevious}
+          onSelectNext={panelPalette.selectNext}
+          onSelect={(kind) => {
+            const result = panelPalette.handleSelect(kind);
+            if (!result) return;
+            if (result.resumeSession) {
+              const session = result.resumeSession;
+              const agentConfig = getEffectiveAgentConfig(session.agentId);
+              const command = buildResumeCommand(
+                session.agentId,
+                session.sessionId,
+                session.agentLaunchFlags
+              );
+              if (command && agentConfig) {
+                addPanel({
+                  kind: "agent",
+                  type: session.agentId as TerminalType,
+                  agentId: session.agentId,
+                  title: agentConfig.name,
+                  cwd: defaultTerminalCwd,
+                  worktreeId: activeWorktreeId ?? undefined,
+                  command,
+                  location: "grid",
+                });
+              }
+            } else if (result.id.startsWith("agent:")) {
+              const agentId = result.id.slice("agent:".length);
+              if (agentId) {
+                launchAgent(agentId);
+              }
+            } else {
               addPanel({
-                kind: "agent",
-                type: session.agentId as TerminalType,
-                agentId: session.agentId,
-                title: agentConfig.name,
+                kind: result.id as Exclude<BuiltInPanelKind, "agent">,
                 cwd: defaultTerminalCwd,
                 worktreeId: activeWorktreeId ?? undefined,
-                command,
                 location: "grid",
               });
             }
-          } else if (result.id.startsWith("agent:")) {
-            const agentId = result.id.slice("agent:".length);
-            if (agentId) {
-              launchAgent(agentId);
-            }
-          } else {
-            addPanel({
-              kind: result.id as Exclude<BuiltInPanelKind, "agent">,
-              cwd: defaultTerminalCwd,
-              worktreeId: activeWorktreeId ?? undefined,
-              location: "grid",
-            });
-          }
-        }}
-        onConfirm={() => {
-          const selected = panelPalette.confirmSelection();
-          if (!selected) return;
-          if (selected.id === MORE_AGENTS_PANEL_ID) return;
-          if (selected.resumeSession) {
-            const session = selected.resumeSession;
-            const agentConfig = getEffectiveAgentConfig(session.agentId);
-            const command = buildResumeCommand(
-              session.agentId,
-              session.sessionId,
-              session.agentLaunchFlags
-            );
-            if (command && agentConfig) {
+          }}
+          onConfirm={() => {
+            const selected = panelPalette.confirmSelection();
+            if (!selected) return;
+            if (selected.id === MORE_AGENTS_PANEL_ID) return;
+            if (selected.resumeSession) {
+              const session = selected.resumeSession;
+              const agentConfig = getEffectiveAgentConfig(session.agentId);
+              const command = buildResumeCommand(
+                session.agentId,
+                session.sessionId,
+                session.agentLaunchFlags
+              );
+              if (command && agentConfig) {
+                addPanel({
+                  kind: "agent",
+                  type: session.agentId as TerminalType,
+                  agentId: session.agentId,
+                  title: agentConfig.name,
+                  cwd: defaultTerminalCwd,
+                  worktreeId: activeWorktreeId ?? undefined,
+                  command,
+                  location: "grid",
+                });
+              }
+            } else if (selected.id.startsWith("agent:")) {
+              const agentId = selected.id.slice("agent:".length);
+              if (agentId) {
+                launchAgent(agentId);
+              }
+            } else {
               addPanel({
-                kind: "agent",
-                type: session.agentId as TerminalType,
-                agentId: session.agentId,
-                title: agentConfig.name,
+                kind: selected.id as Exclude<BuiltInPanelKind, "agent">,
                 cwd: defaultTerminalCwd,
                 worktreeId: activeWorktreeId ?? undefined,
-                command,
                 location: "grid",
               });
             }
-          } else if (selected.id.startsWith("agent:")) {
-            const agentId = selected.id.slice("agent:".length);
-            if (agentId) {
-              launchAgent(agentId);
-            }
-          } else {
-            addPanel({
-              kind: selected.id as Exclude<BuiltInPanelKind, "agent">,
-              cwd: defaultTerminalCwd,
-              worktreeId: activeWorktreeId ?? undefined,
-              location: "grid",
-            });
-          }
-        }}
-        onClose={panelPalette.close}
-      />
-      <ProjectMruSwitcherOverlay
-        isVisible={mruSwitcher.isVisible}
-        projects={mruSwitcher.projects}
-        selectedIndex={mruSwitcher.selectedIndex}
-      />
-      <ProjectSwitcherPalette
-        isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
-        query={projectSwitcherPalette.query}
-        results={projectSwitcherPalette.results}
-        selectedIndex={projectSwitcherPalette.selectedIndex}
-        onQueryChange={projectSwitcherPalette.setQuery}
-        onSelectPrevious={projectSwitcherPalette.selectPrevious}
-        onSelectNext={projectSwitcherPalette.selectNext}
-        onSelect={projectSwitcherPalette.selectProject}
-        onClose={projectSwitcherPalette.close}
-        onSelectNewWindow={(project) => {
-          projectSwitcherPalette.close();
-          void actionService.dispatch(
-            "app.newWindow",
-            { projectPath: project.path },
-            { source: "user" }
-          );
-        }}
-      />
-      <ConfirmDialog
-        isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
-        onClose={() => {
-          if (projectSwitcherPalette.isStoppingProject) return;
-          projectSwitcherPalette.setStopConfirmProjectId(null);
-        }}
-        title={`Stop project?`}
-        description="This will terminate all running sessions in this project. This can't be undone."
-        confirmLabel="Stop project"
-        cancelLabel="Cancel"
-        onConfirm={projectSwitcherPalette.confirmStopProject}
-        isConfirmLoading={projectSwitcherPalette.isStoppingProject}
-        variant="destructive"
-      />
+          }}
+          onClose={panelPalette.close}
+        />
+        <ProjectMruSwitcherOverlay
+          isVisible={mruSwitcher.isVisible}
+          projects={mruSwitcher.projects}
+          selectedIndex={mruSwitcher.selectedIndex}
+        />
+        <ProjectSwitcherPalette
+          isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
+          query={projectSwitcherPalette.query}
+          results={projectSwitcherPalette.results}
+          selectedIndex={projectSwitcherPalette.selectedIndex}
+          onQueryChange={projectSwitcherPalette.setQuery}
+          onSelectPrevious={projectSwitcherPalette.selectPrevious}
+          onSelectNext={projectSwitcherPalette.selectNext}
+          onSelect={projectSwitcherPalette.selectProject}
+          onClose={projectSwitcherPalette.close}
+          onSelectNewWindow={(project) => {
+            projectSwitcherPalette.close();
+            void actionService.dispatch(
+              "app.newWindow",
+              { projectPath: project.path },
+              { source: "user" }
+            );
+          }}
+        />
+        <ConfirmDialog
+          isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
+          onClose={() => {
+            if (projectSwitcherPalette.isStoppingProject) return;
+            projectSwitcherPalette.setStopConfirmProjectId(null);
+          }}
+          title={`Stop project?`}
+          description="This will terminate all running sessions in this project. This can't be undone."
+          confirmLabel="Stop project"
+          cancelLabel="Cancel"
+          onConfirm={projectSwitcherPalette.confirmStopProject}
+          isConfirmLoading={projectSwitcherPalette.isStoppingProject}
+          variant="destructive"
+        />
 
-      <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
+        <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
 
-      <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
+        <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
 
-      <ActionPalette
-        isOpen={actionPalette.isOpen}
-        query={actionPalette.query}
-        results={actionPalette.results}
-        totalResults={actionPalette.totalResults}
-        selectedIndex={actionPalette.selectedIndex}
-        close={actionPalette.close}
-        setQuery={actionPalette.setQuery}
-        selectPrevious={actionPalette.selectPrevious}
-        selectNext={actionPalette.selectNext}
-        executeAction={actionPalette.executeAction}
-        confirmSelection={actionPalette.confirmSelection}
-      />
+        <ActionPalette
+          isOpen={actionPalette.isOpen}
+          query={actionPalette.query}
+          results={actionPalette.results}
+          totalResults={actionPalette.totalResults}
+          selectedIndex={actionPalette.selectedIndex}
+          close={actionPalette.close}
+          setQuery={actionPalette.setQuery}
+          selectPrevious={actionPalette.selectPrevious}
+          selectNext={actionPalette.selectNext}
+          executeAction={actionPalette.executeAction}
+          confirmSelection={actionPalette.confirmSelection}
+        />
 
-      <WorktreeOverviewModal
-        isOpen={isWorktreeOverviewOpen}
-        onClose={closeWorktreeOverview}
-        worktrees={worktrees}
-        activeWorktreeId={activeWorktreeId}
-        focusedWorktreeId={focusedWorktreeId}
-        onSelectWorktree={selectWorktree}
-        onCopyTree={overviewWorktreeActions.handleCopyTree}
-        onOpenEditor={overviewWorktreeActions.handleOpenEditor}
-        onSaveLayout={undefined}
-        onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
-        agentAvailability={availability}
-        agentSettings={agentSettings}
-        homeDir={homeDir}
-      />
+        <WorktreeOverviewModal
+          isOpen={isWorktreeOverviewOpen}
+          onClose={closeWorktreeOverview}
+          worktrees={worktrees}
+          activeWorktreeId={activeWorktreeId}
+          focusedWorktreeId={focusedWorktreeId}
+          onSelectWorktree={selectWorktree}
+          onCopyTree={overviewWorktreeActions.handleCopyTree}
+          onOpenEditor={overviewWorktreeActions.handleOpenEditor}
+          onSaveLayout={undefined}
+          onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
+          agentAvailability={availability}
+          agentSettings={agentSettings}
+          homeDir={homeDir}
+        />
 
-      <CrossWorktreeDiff
-        isOpen={crossDiffDialog.isOpen}
-        onClose={closeCrossWorktreeDiff}
-        initialWorktreeId={crossDiffDialog.initialWorktreeId}
-      />
+        <CrossWorktreeDiff
+          isOpen={crossDiffDialog.isOpen}
+          onClose={closeCrossWorktreeDiff}
+          initialWorktreeId={crossDiffDialog.initialWorktreeId}
+        />
 
-      {(isSettingsOpen || hasOpenedSettings) && (
-        <Suspense fallback={null}>
-          <LazySettingsDialog
-            isOpen={isSettingsOpen}
-            onClose={() => setIsSettingsOpen(false)}
-            defaultTab={settingsTab}
-            defaultSubtab={settingsSubtab}
-            defaultSectionId={settingsSectionId}
-            onSettingsChange={refreshSettings}
-            projectId={currentProject?.id ?? null}
+        {(isSettingsOpen || hasOpenedSettings) && (
+          <Suspense fallback={null}>
+            <LazySettingsDialog
+              isOpen={isSettingsOpen}
+              onClose={() => setIsSettingsOpen(false)}
+              defaultTab={settingsTab}
+              defaultSubtab={settingsSubtab}
+              defaultSectionId={settingsSectionId}
+              onSettingsChange={refreshSettings}
+              projectId={currentProject?.id ?? null}
+            />
+          </Suspense>
+        )}
+
+        <ShortcutReferenceDialog
+          isOpen={isShortcutsOpen}
+          onClose={() => setIsShortcutsOpen(false)}
+        />
+
+        <TerminalInfoDialogHost />
+        <FileViewerModalHost />
+
+        {gitInitDirectoryPath && (
+          <GitInitDialog
+            isOpen={gitInitDialogOpen}
+            directoryPath={gitInitDirectoryPath}
+            onSuccess={handleGitInitSuccess}
+            onCancel={closeGitInitDialog}
           />
-        </Suspense>
-      )}
+        )}
 
-      <ShortcutReferenceDialog isOpen={isShortcutsOpen} onClose={() => setIsShortcutsOpen(false)} />
+        {onboardingProjectId && (
+          <ProjectOnboardingWizard
+            isOpen={onboardingWizardOpen}
+            projectId={onboardingProjectId}
+            onClose={closeOnboardingWizard}
+            onFinish={handleWizardFinish}
+          />
+        )}
 
-      <TerminalInfoDialogHost />
-      <FileViewerModalHost />
-
-      {gitInitDirectoryPath && (
-        <GitInitDialog
-          isOpen={gitInitDialogOpen}
-          directoryPath={gitInitDirectoryPath}
-          onSuccess={handleGitInitSuccess}
-          onCancel={closeGitInitDialog}
+        <CreateProjectFolderDialog
+          isOpen={createFolderDialogOpen}
+          onClose={closeCreateFolderDialog}
         />
-      )}
 
-      {onboardingProjectId && (
-        <ProjectOnboardingWizard
-          isOpen={onboardingWizardOpen}
-          projectId={onboardingProjectId}
-          onClose={closeOnboardingWizard}
-          onFinish={handleWizardFinish}
+        <CloneRepoDialog
+          isOpen={cloneRepoDialogOpen}
+          onSuccess={handleCloneSuccess}
+          onCancel={closeCloneRepoDialog}
         />
-      )}
 
-      <CreateProjectFolderDialog
-        isOpen={createFolderDialogOpen}
-        onClose={closeCreateFolderDialog}
-      />
+        <PanelTransitionOverlay />
+        <PanelLimitConfirmDialog />
 
-      <CloneRepoDialog
-        isOpen={cloneRepoDialogOpen}
-        onSuccess={handleCloneSuccess}
-        onCancel={closeCloneRepoDialog}
-      />
-
-      <PanelTransitionOverlay />
-      <PanelLimitConfirmDialog />
-
-      <Toaster />
-      <ShortcutHint />
-      <ReEntrySummary state={reEntrySummary} />
-      <OnboardingFlow
-        availability={availability}
-        onRefreshSettings={refreshSettings}
-        onComplete={gettingStarted.notifyOnboardingComplete}
-      />
-      {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
-        <GettingStartedChecklist
-          checklist={gettingStarted.checklist}
-          collapsed={gettingStarted.collapsed}
-          onDismiss={gettingStarted.dismiss}
-          onToggleCollapse={gettingStarted.toggleCollapse}
-          onMarkItem={gettingStarted.markItem}
+        <Toaster />
+        <ShortcutHint />
+        <ReEntrySummary state={reEntrySummary} />
+        <OnboardingFlow
+          availability={availability}
+          onRefreshSettings={refreshSettings}
+          onComplete={gettingStarted.notifyOnboardingComplete}
         />
-      )}
-      {gettingStarted.showCelebration && <CelebrationConfetti />}
-    </ErrorBoundary>
+        {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
+          <GettingStartedChecklist
+            checklist={gettingStarted.checklist}
+            collapsed={gettingStarted.collapsed}
+            onDismiss={gettingStarted.dismiss}
+            onToggleCollapse={gettingStarted.toggleCollapse}
+            onMarkItem={gettingStarted.markItem}
+          />
+        )}
+        {gettingStarted.showCelebration && <CelebrationConfetti />}
+      </ErrorBoundary>
+    </MotionConfig>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,7 @@ import {
   useAgentPreferencesStore,
   usePaletteStore,
   useNotificationSettingsStore,
+  usePreferencesStore,
 } from "./store";
 import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { isAgentReady } from "../shared/utils/agentAvailability";
@@ -451,6 +452,7 @@ function App() {
   useFileDropGuard();
 
   const isSafeMode = useSafeModeStore((s) => s.safeMode);
+  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
 
   if (!isElectronAvailable()) {
     return (
@@ -480,7 +482,7 @@ function App() {
   }
 
   return (
-    <MotionConfig reducedMotion="user">
+    <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
       <ErrorBoundary variant="fullscreen" componentName="App">
         <E2EFaultInjector />
         {isSafeMode && <SafeModeBanner />}

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -349,7 +349,7 @@ export function AppLayout({
           className="flex-1 flex overflow-hidden"
           style={{ flex: 1, display: "flex", overflow: "hidden" }}
         >
-          {showSidebar && (
+          {currentProject != null && (
             <ErrorBoundary variant="section" componentName="Sidebar">
               <Sidebar width={effectiveSidebarWidth} onResize={handleSidebarResize}>
                 {sidebarContent}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -104,10 +104,13 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           aria-label="Sidebar"
           data-macro-focus={isMacroFocused ? "true" : undefined}
           className={cn(
-            "relative shrink-0 flex flex-col outline-none",
+            "relative shrink-0 flex flex-col outline-none overflow-hidden",
             "surface-chrome",
             "border-r border-divider",
             "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
+            !isResizing &&
+              "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+            width === 0 && "pointer-events-none",
             className
           )}
           style={{ width }}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { ProjectResourceBadge, QuickRun } from "@/components/Project";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
+import { usePreferencesStore } from "@/store";
 import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
 import { actionService } from "@/services/ActionService";
 import {
@@ -37,6 +38,8 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
+  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
+  const animateWidth = !isResizing && !reduceAnimations;
 
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
@@ -108,7 +111,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             "surface-chrome",
             "border-r border-divider",
             "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
-            !isResizing &&
+            animateWidth &&
               "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
             width === 0 && "pointer-events-none",
             className
@@ -128,7 +131,8 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             aria-valuenow={width}
             aria-valuemin={200}
             aria-valuemax={600}
-            tabIndex={0}
+            tabIndex={width === 0 ? -1 : 0}
+            aria-hidden={width === 0 ? "true" : undefined}
             className={cn(
               "group absolute top-0 -right-1.5 w-3 h-full cursor-col-resize flex items-center justify-center z-50",
               "hover:bg-overlay-soft transition-colors focus-visible:outline-none focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -15,9 +15,14 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
     expect(source).toContain("const showSidebar = !layout.isFocusMode && currentProject != null");
   });
 
-  it("uses showSidebar for the sidebar JSX render guard", () => {
-    expect(source).toMatch(/\{showSidebar && \(/);
-    // The old bare isFocusMode guard should not be used for the sidebar
+  it("mounts the sidebar whenever a project is active so the width transition can run", () => {
+    // Issue #5697: the sidebar stays mounted in focus mode (width=0) so the
+    // CSS width transition runs instead of an abrupt unmount. The render guard
+    // is now `currentProject != null`; visibility is driven by width via
+    // effectiveSidebarWidth and by macro focus via setVisibility(showSidebar).
+    expect(source).toMatch(/\{currentProject != null && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
+    // The old unmount-in-focus-mode guard must not be reintroduced.
+    expect(source).not.toMatch(/\{showSidebar && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
     expect(source).not.toMatch(/\{!layout\.isFocusMode && \(\s*\n\s*<ErrorBoundary[^>]*Sidebar/);
   });
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -37,6 +37,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import { LayoutGroup } from "framer-motion";
 import type { PanelKind, TerminalType } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { formatShortcutForTooltip, createTooltipWithShortcut } from "@/lib/platform";
@@ -501,56 +502,58 @@ function PanelHeaderComponent({
                   aria-label="Panel tabs"
                   onKeyDown={handleTabListKeyDown}
                 >
-                  <div className="flex items-center">
-                    {tabs.map((tab) => (
-                      <SortableTabButton
-                        key={tab.id}
-                        id={tab.id}
-                        title={getBaseTitle(tab.title)}
-                        type={tab.type}
-                        agentId={tab.agentId}
-                        detectedProcessId={tab.detectedProcessId}
-                        kind={tab.kind}
-                        agentState={tab.agentState}
-                        isActive={tab.isActive}
-                        presetColor={tab.presetColor}
-                        isUsingFallback={tab.isUsingFallback}
-                        fallbackTooltip={tab.fallbackTooltip}
-                        hasDangerousFlags={tab.hasDangerousFlags}
-                        onClick={() => onTabClick?.(tab.id)}
-                        onClose={() => onTabClose?.(tab.id)}
-                        onRename={
-                          onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                        }
-                      />
-                    ))}
-                    {onAddTab && (
-                      <TooltipProvider>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onAddTab();
-                              }}
-                              onPointerDown={(e) => e.stopPropagation()}
-                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                              aria-label="Duplicate panel as new tab"
-                              type="button"
-                            >
-                              <Plus className="w-3 h-3" aria-hidden="true" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {createTooltipWithShortcut(
-                              "Duplicate panel as new tab",
-                              duplicateShortcut
-                            )}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    )}
-                  </div>
+                  <LayoutGroup id={`panel-tabs-${id}`}>
+                    <div className="flex items-center">
+                      {tabs.map((tab) => (
+                        <SortableTabButton
+                          key={tab.id}
+                          id={tab.id}
+                          title={getBaseTitle(tab.title)}
+                          type={tab.type}
+                          agentId={tab.agentId}
+                          detectedProcessId={tab.detectedProcessId}
+                          kind={tab.kind}
+                          agentState={tab.agentState}
+                          isActive={tab.isActive}
+                          presetColor={tab.presetColor}
+                          isUsingFallback={tab.isUsingFallback}
+                          fallbackTooltip={tab.fallbackTooltip}
+                          hasDangerousFlags={tab.hasDangerousFlags}
+                          onClick={() => onTabClick?.(tab.id)}
+                          onClose={() => onTabClose?.(tab.id)}
+                          onRename={
+                            onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                          }
+                        />
+                      ))}
+                      {onAddTab && (
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  onAddTab();
+                                }}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                                aria-label="Duplicate panel as new tab"
+                                type="button"
+                              >
+                                <Plus className="w-3 h-3" aria-hidden="true" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">
+                              {createTooltipWithShortcut(
+                                "Duplicate panel as new tab",
+                                duplicateShortcut
+                              )}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      )}
+                    </div>
+                  </LayoutGroup>
                 </div>
                 {tabsCanScrollRight && (
                   <div
@@ -600,51 +603,58 @@ function PanelHeaderComponent({
               aria-label="Panel tabs"
               onKeyDown={handleTabListKeyDown}
             >
-              <div className="flex items-center">
-                {tabs.map((tab) => (
-                  <TabButton
-                    key={tab.id}
-                    id={tab.id}
-                    title={getBaseTitle(tab.title)}
-                    type={tab.type}
-                    agentId={tab.agentId}
-                    detectedProcessId={tab.detectedProcessId}
-                    kind={tab.kind}
-                    agentState={tab.agentState}
-                    isActive={tab.isActive}
-                    presetColor={tab.presetColor}
-                    isUsingFallback={tab.isUsingFallback}
-                    fallbackTooltip={tab.fallbackTooltip}
-                    hasDangerousFlags={tab.hasDangerousFlags}
-                    onClick={() => onTabClick?.(tab.id)}
-                    onClose={() => onTabClose?.(tab.id)}
-                    onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}
-                  />
-                ))}
-                {onAddTab && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onAddTab();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
-                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                          aria-label="Duplicate panel as new tab"
-                          type="button"
-                        >
-                          <Plus className="w-3 h-3" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
-              </div>
+              <LayoutGroup id={`panel-tabs-${id}`}>
+                <div className="flex items-center">
+                  {tabs.map((tab) => (
+                    <TabButton
+                      key={tab.id}
+                      id={tab.id}
+                      title={getBaseTitle(tab.title)}
+                      type={tab.type}
+                      agentId={tab.agentId}
+                      detectedProcessId={tab.detectedProcessId}
+                      kind={tab.kind}
+                      agentState={tab.agentState}
+                      isActive={tab.isActive}
+                      presetColor={tab.presetColor}
+                      isUsingFallback={tab.isUsingFallback}
+                      fallbackTooltip={tab.fallbackTooltip}
+                      hasDangerousFlags={tab.hasDangerousFlags}
+                      onClick={() => onTabClick?.(tab.id)}
+                      onClose={() => onTabClose?.(tab.id)}
+                      onRename={
+                        onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                      }
+                    />
+                  ))}
+                  {onAddTab && (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onAddTab();
+                            }}
+                            onPointerDown={(e) => e.stopPropagation()}
+                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                            aria-label="Duplicate panel as new tab"
+                            type="button"
+                          >
+                            <Plus className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          {createTooltipWithShortcut(
+                            "Duplicate panel as new tab",
+                            duplicateShortcut
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  )}
+                </div>
+              </LayoutGroup>
             </div>
             {tabsCanScrollRight && (
               <div

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect, forwardRef } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
+import { motion } from "framer-motion";
 import { X, AlertTriangle } from "lucide-react";
 import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
@@ -237,7 +238,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
             onKeyDown={handleKeyDown}
             onPointerDown={handlePointerDown}
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
+              "relative flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
               "border-r border-divider transition-colors",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
               isActive
@@ -248,6 +249,15 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
             {...mergedAttributes}
             {...sortableListeners}
           >
+            {isActive && (
+              <motion.div
+                layoutId="panel-tab-indicator"
+                layout="position"
+                className="absolute inset-x-0 bottom-0 h-0.5 bg-daintree-accent pointer-events-none"
+                transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+                aria-hidden="true"
+              />
+            )}
             <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5">
               <TerminalIcon
                 type={type}

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { PanelHeader } from "../PanelHeader";
@@ -8,6 +9,27 @@ vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
   return { ...actual, createPortal: (children: React.ReactNode) => children };
 });
+
+vi.mock("framer-motion", () => ({
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+      ({ children, ...props }, ref) => {
+        const {
+          layoutId: _layoutId,
+          layout: _layout,
+          transition: _transition,
+          ...rest
+        } = props as Record<string, unknown>;
+        return (
+          <div ref={ref} {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+            {children}
+          </div>
+        );
+      }
+    ),
+  },
+}));
 
 const mockScrollLeft = vi.fn();
 const mockScrollRight = vi.fn();

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -99,7 +99,7 @@ describe("TabButton", () => {
     const tooltipContent = screen.queryByText(
       "Launched with dangerous permissions — agent can modify files without prompting"
     );
-    expect(tooltipContent).toBeDefined();
+    expect(tooltipContent).not.toBeNull();
   });
 
   it("renders the active indicator element when isActive is true", () => {

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { TabButton } from "../TabButton";
@@ -7,6 +8,30 @@ vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
   return { ...actual, createPortal: (children: React.ReactNode) => children };
 });
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+      ({ children, ...props }, ref) => {
+        const {
+          layoutId: _layoutId,
+          layout: _layout,
+          transition: _transition,
+          ...rest
+        } = props as Record<string, unknown>;
+        return (
+          <div
+            ref={ref}
+            data-testid="motion-div"
+            {...(rest as React.HTMLAttributes<HTMLDivElement>)}
+          >
+            {children}
+          </div>
+        );
+      }
+    ),
+  },
+}));
 
 vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -75,5 +100,18 @@ describe("TabButton", () => {
       "Launched with dangerous permissions — agent can modify files without prompting"
     );
     expect(tooltipContent).toBeDefined();
+  });
+
+  it("renders the active indicator element when isActive is true", () => {
+    render(<TabButton {...defaultProps} isActive={true} />);
+    const indicator = screen.queryByTestId("motion-div");
+    expect(indicator).not.toBeNull();
+    expect(indicator?.className).toContain("bg-daintree-accent");
+  });
+
+  it("does not render the active indicator when isActive is false", () => {
+    render(<TabButton {...defaultProps} isActive={false} />);
+    const indicator = screen.queryByTestId("motion-div");
+    expect(indicator).toBeNull();
   });
 });

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -334,6 +334,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                     aria-label={isExpanded ? "Collapse" : "Expand"}
                   >
                     <ChevronRight
+                      data-animated-chevron
                       className={cn(
                         "h-4 w-4 text-daintree-text/60 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
                         isExpanded && "rotate-90"

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -1,13 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import {
-  ChevronDown,
-  ChevronRight,
-  RotateCcw,
-  Power,
-  PowerOff,
-  AlertCircle,
-  Search,
-} from "lucide-react";
+import { ChevronRight, RotateCcw, Power, PowerOff, AlertCircle, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { commandsClient } from "@/clients/commandsClient";
 import type { CommandManifestEntry, CommandOverride } from "@shared/types/commands";
@@ -341,11 +333,12 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                     className="p-0.5 rounded hover:bg-daintree-border/50 transition-colors"
                     aria-label={isExpanded ? "Collapse" : "Expand"}
                   >
-                    {isExpanded ? (
-                      <ChevronDown className="h-4 w-4 text-daintree-text/60" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4 text-daintree-text/60" />
-                    )}
+                    <ChevronRight
+                      className={cn(
+                        "h-4 w-4 text-daintree-text/60 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                        isExpanded && "rotate-90"
+                      )}
+                    />
                   </button>
                 )}
                 {!canExpand && <div className="w-5" />}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from "react";
 import {
-  ChevronDown,
   ChevronRight,
   Moon,
   CheckCircle,
@@ -581,11 +580,12 @@ export function GeneralTab({
               aria-controls="keyboard-shortcuts-content"
               className="flex items-center gap-2 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
             >
-              {isShortcutsOpen ? (
-                <ChevronDown className="w-4 h-4" />
-              ) : (
-                <ChevronRight className="w-4 h-4" />
-              )}
+              <ChevronRight
+                className={cn(
+                  "w-4 h-4 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                  isShortcutsOpen && "rotate-90"
+                )}
+              />
               <span>{isShortcutsOpen ? "Hide shortcuts" : "Show shortcuts"}</span>
             </button>
 

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -581,6 +581,7 @@ export function GeneralTab({
               className="flex items-center gap-2 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
             >
               <ChevronRight
+                data-animated-chevron
                 className={cn(
                   "w-4 h-4 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
                   isShortcutsOpen && "rotate-90"

--- a/src/index.css
+++ b/src/index.css
@@ -1290,6 +1290,10 @@ body[data-reduce-animations="true"]
   transition: none !important;
 }
 
+body[data-reduce-animations="true"] [data-animated-chevron] {
+  transition: none !important;
+}
+
 /* Terminal trash/restore animations */
 @keyframes terminal-restore {
   from {

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -27,3 +27,7 @@
     transition: none;
   }
 }
+
+body[data-reduce-animations="true"] .sidebar-worktree-card {
+  transition: none;
+}

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -1,3 +1,9 @@
+.sidebar-worktree-card {
+  transition:
+    background-color var(--duration-150) var(--ease-out-expo),
+    box-shadow var(--duration-150) var(--ease-out-expo);
+}
+
 .sidebar-worktree-card[data-active="true"] {
   background: var(--sidebar-active-bg, rgba(255, 255, 255, 0.03));
   box-shadow: inset 2px 0 0 var(--theme-accent-primary);
@@ -14,4 +20,10 @@
 
 .worktree-section-button:hover {
   background: var(--worktree-section-hover-bg, var(--theme-overlay-hover));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-worktree-card {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary

- Sliding shared-element active indicator on panel tabs using Framer Motion `layoutId` — the indicator glides between tabs in 150ms rather than snapping, matching the Zed/Cursor pattern where tab content stays instant but the indicator follows.
- Sidebar width animates via CSS `transition-[width]` instead of unmounting, keeping xterm instances alive and firing `suppressResizesDuringLayoutTransition()` to block the SIGWINCH flood. Collapsed sidebar gets `pointer-events-none` + `aria-hidden` on the resize separator so keyboard users can't tab into a hidden control.
- Sidebar worktree card active indicator transitions background-colour and box-shadow in 150ms rather than snapping. Settings section chevrons replaced the icon-swap pattern with a single `ChevronRight` that rotates 90° with `transition-transform`.
- `MotionConfig reducedMotion` wraps the app root so Framer respects both the OS `prefers-reduced-motion` query and Daintree's in-app Reduce Animations toggle simultaneously.

Resolves #5697

## Changes

- `src/App.tsx` — `MotionConfig` wrapper with `reduceAnimations`-aware `reducedMotion` prop
- `src/components/Panel/PanelHeader.tsx` + `TabButton.tsx` — `LayoutGroup` + `motion.div` with `layoutId="panel-tab-indicator"`
- `src/components/Layout/AppLayout.tsx` + `Sidebar.tsx` — mount-at-zero-width pattern + transition-width + accessibility fixes
- `src/styles/components/sidebar.css` — `transition` on active card background/shadow with `@media (prefers-reduced-motion)` + `body[data-reduce-animations]` suppression
- `src/components/Settings/GeneralTab.tsx` + `CommandOverridesTab.tsx` — rotate-90 chevron pattern with `data-animated-chevron` suppression
- `src/index.css` — `data-reduce-animations` CSS hook
- Tests updated: framer-motion mock, active-indicator assertions, sidebar mount gate, tooltip fix

## Testing

- Unit tests pass (TabButton, PanelHeader, AppLayout.sidebar)
- Lint warnings at 363, down from baseline 368
- Reduced-motion path verified via both `@media (prefers-reduced-motion: reduce)` and toggling Reduce Animations in Settings
- No SIGWINCH flood observed when toggling sidebar (SIDEBAR_TOGGLE_LOCK_MS guard confirmed active)