### PR TITLE
refactor(ipc): migrate 18 broadcast channels to typed event bus

### DIFF
--- a/e2e/full/core-ipc-cleanup.spec.ts
+++ b/e2e/full/core-ipc-cleanup.spec.ts
@@ -15,15 +15,12 @@ import {
 import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../helpers/workflows";
 import { rmSync } from "fs";
 
-const MONITORED_CHANNELS = [
-  "worktree:update",
-  "agent:state-changed",
-  "terminal:activity",
-  "terminal:exit",
-  "terminal:data",
-];
+// Migrated events (worktree:update, agent:state-changed, terminal:exit, ...)
+// now travel over the multiplexed `events:push` channel so their listener
+// counts are observed there, not on the per-event channel.
+const MONITORED_CHANNELS = ["events:push", "terminal:activity", "terminal:data"];
 
-const RENDERER_CHANNELS = ["worktree:update", "agent:state-changed", "terminal:activity"];
+const RENDERER_CHANNELS = ["events:push", "terminal:activity"];
 
 test.describe.serial("Core: IPC Cleanup Verification", () => {
   let ctx: AppContext;

--- a/e2e/full/core-ipc-error-propagation.spec.ts
+++ b/e2e/full/core-ipc-error-propagation.spec.ts
@@ -60,10 +60,16 @@ async function emitSpawnResult(
     ({ webContents }, { id, code, msg }) => {
       for (const wc of webContents.getAllWebContents()) {
         if (wc.isDestroyed()) continue;
-        wc.send("terminal:spawn-result", id, {
-          success: false,
-          id,
-          error: { code, message: msg },
+        wc.send("events:push", {
+          name: "terminal:spawn-result",
+          payload: [
+            id,
+            {
+              success: false,
+              id,
+              error: { code, message: msg },
+            },
+          ],
         });
       }
     },

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -2,7 +2,6 @@ export const CHANNELS = {
   WORKTREE_GET_ALL: "worktree:get-all",
   WORKTREE_REFRESH: "worktree:refresh",
   WORKTREE_SET_ACTIVE: "worktree:set-active",
-  WORKTREE_UPDATE: "worktree:update",
   WORKTREE_REMOVE: "worktree:remove",
   WORKTREE_ACTIVATED: "worktree:activated",
   WORKTREE_CREATE: "worktree:create",
@@ -25,13 +24,11 @@ export const CHANNELS = {
   WORKTREE_RESTART_SERVICE: "worktree:restart-service",
 
   TERMINAL_SPAWN: "terminal:spawn",
-  TERMINAL_SPAWN_RESULT: "terminal:spawn-result",
   TERMINAL_DATA: "terminal:data",
   TERMINAL_INPUT: "terminal:input",
   TERMINAL_SUBMIT: "terminal:submit",
   TERMINAL_RESIZE: "terminal:resize",
   TERMINAL_KILL: "terminal:kill",
-  TERMINAL_EXIT: "terminal:exit",
   TERMINAL_ERROR: "terminal:error",
   TERMINAL_TRASH: "terminal:trash",
   TERMINAL_RESTORE: "terminal:restore",
@@ -54,8 +51,6 @@ export const CHANNELS = {
   TERMINAL_FORCE_RESUME: "terminal:force-resume",
   TERMINAL_GRACEFUL_KILL: "terminal:graceful-kill",
   TERMINAL_STATUS: "terminal:status",
-  TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
-  TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
   TERMINAL_BATCH_DOUBLE_ESCAPE: "terminal:batch-double-escape",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
@@ -70,12 +65,6 @@ export const CHANNELS = {
 
   FILES_SEARCH: "files:search",
   FILES_READ: "files:read",
-
-  AGENT_STATE_CHANGED: "agent:state-changed",
-  AGENT_ALL_CLEAR: "agent:all-clear",
-  AGENT_DETECTED: "agent:detected",
-  AGENT_EXITED: "agent:exited",
-  AGENT_FALLBACK_TRIGGERED: "agent:fallback-triggered",
 
   TERMINAL_ACTIVITY: "terminal:activity",
 
@@ -106,7 +95,6 @@ export const CHANNELS = {
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
   SYSTEM_GET_AGENT_CLI_DETAILS: "system:get-agent-cli-details",
-  SYSTEM_WAKE: "system:wake",
   SYSTEM_GET_AGENT_VERSIONS: "system:get-agent-versions",
   SYSTEM_REFRESH_AGENT_VERSIONS: "system:refresh-agent-versions",
   SYSTEM_GET_AGENT_UPDATE_SETTINGS: "system:get-agent-update-settings",
@@ -371,7 +359,6 @@ export const CHANNELS = {
   WORKTREE_CONFIG_GET: "worktree-config:get",
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
 
-  WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
   WINDOW_TOGGLE_FULLSCREEN: "window:toggle-fullscreen",
   WINDOW_RELOAD: "window:reload",
   WINDOW_FORCE_RELOAD: "window:force-reload",
@@ -381,12 +368,8 @@ export const CHANNELS = {
   WINDOW_ZOOM_RESET: "window:zoom-reset",
   WINDOW_CLOSE: "window:close",
   WINDOW_NEW: "window:new",
-  WINDOW_RECLAIM_MEMORY: "window:reclaim-memory",
-  WINDOW_DESTROY_HIDDEN_WEBVIEWS: "window:destroy-hidden-webviews",
-  WINDOW_DISK_SPACE_STATUS: "window:disk-space-status",
 
   SOUND_TRIGGER: "sound:trigger",
-  SOUND_CANCEL: "sound:cancel",
   SOUND_GET_DIR: "sound:get-dir",
 
   NOTIFICATION_UPDATE: "notification:update",
@@ -437,9 +420,7 @@ export const CHANNELS = {
   APP_AGENT_HAS_API_KEY: "app-agent:has-api-key",
   APP_AGENT_TEST_API_KEY: "app-agent:test-api-key",
   APP_AGENT_TEST_MODEL: "app-agent:test-model",
-  APP_AGENT_DISPATCH_ACTION_REQUEST: "app-agent:dispatch-action-request",
   APP_AGENT_DISPATCH_ACTION_RESPONSE: "app-agent:dispatch-action-response",
-  APP_AGENT_CONFIRMATION_REQUEST: "app-agent:confirmation-request",
   APP_AGENT_CONFIRMATION_RESPONSE: "app-agent:confirmation-response",
 
   // Agent Capabilities channels
@@ -622,9 +603,6 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_GET: "plugin:actions-get",
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
-  PLUGIN_ACTIONS_CHANGED: "plugin:actions-changed",
-
-  RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -56,9 +56,7 @@ const EVENT_BUS_RELAYED_EVENTS = (
   >
 )
   .filter(([, mode]) => mode === "bus")
-  .map(([name]) => name) as Array<
-  Extract<keyof IpcEventBusMap, keyof DaintreeEventMap>
->;
+  .map(([name]) => name) as Array<Extract<keyof IpcEventBusMap, keyof DaintreeEventMap>>;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -7,16 +7,57 @@ import { broadcastToRenderer, typedHandle } from "../utils.js";
 const ALLOWED_RENDERER_EVENTS: ReadonlySet<keyof DaintreeEventMap> = new Set(["action:dispatched"]);
 
 /**
- * Manifest of bridged events. The `satisfies Record<keyof IpcEventBusMap, true>`
- * clause makes tsc fail if `IpcEventBusMap` grows and a key is not added here —
- * forcing the main-side bridge to stay in lockstep with the renderer-facing type.
+ * Manifest classifying how each bus event reaches the renderer.
+ *
+ * - `"bus"`: relayed here from the main-side `TypedEventBus` (services emit on
+ *   `events.emit(name, payload)` and the bridge loop below forwards to every
+ *   renderer on `CHANNELS.EVENTS_PUSH`). Must also be a key of `DaintreeEventMap`.
+ * - `"external"`: the producer wraps the payload itself and sends on
+ *   `CHANNELS.EVENTS_PUSH` via `sendToRenderer`/`webContents.send` (window-scoped)
+ *   or `broadcastToRenderer` (global). The bridge loop here does NOT relay these
+ *   — double-emission would duplicate renderer delivery.
+ *
+ * The `satisfies Record<keyof IpcEventBusMap, ...>` clause makes tsc fail if
+ * `IpcEventBusMap` grows and a key is not classified here, keeping the main-side
+ * bridge in lockstep with the renderer-facing type.
  */
 const EVENT_BUS_BRIDGED_MANIFEST = {
-  "agent:state-changed": true,
-} as const satisfies Record<keyof IpcEventBusMap, true>;
+  // Agent lifecycle: emitted on TypedEventBus; relayed here.
+  "agent:state-changed": "bus",
+  "agent:all-clear": "bus",
+  "agent:detected": "bus",
+  "agent:exited": "bus",
+  "agent:fallback-triggered": "bus",
 
-const EVENT_BUS_BRIDGED_EVENTS = Object.keys(EVENT_BUS_BRIDGED_MANIFEST) as Array<
-  keyof IpcEventBusMap
+  // Window-scoped events: producers send envelopes directly to the target
+  // window's webContents to preserve per-window routing.
+  "worktree:update": "external",
+  "window:fullscreen-change": "external",
+  "window:reclaim-memory": "external",
+  "window:destroy-hidden-webviews": "external",
+  "window:disk-space-status": "external",
+  "system:wake": "external",
+  "app-agent:dispatch-action-request": "external",
+  "app-agent:confirmation-request": "external",
+  "terminal:backend-crashed": "external",
+  "terminal:backend-ready": "external",
+
+  // Global broadcasts emitted externally (no TypedEventBus counterpart).
+  "resource:profile-changed": "external",
+  "sound:cancel": "external",
+  "plugin:actions-changed": "external",
+  "terminal:exit": "external",
+  "terminal:spawn-result": "external",
+} as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;
+
+const EVENT_BUS_RELAYED_EVENTS = (
+  Object.entries(EVENT_BUS_BRIDGED_MANIFEST) as Array<
+    [keyof IpcEventBusMap, (typeof EVENT_BUS_BRIDGED_MANIFEST)[keyof IpcEventBusMap]]
+  >
+)
+  .filter(([, mode]) => mode === "bus")
+  .map(([name]) => name) as Array<
+  Extract<keyof IpcEventBusMap, keyof DaintreeEventMap>
 >;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -164,11 +205,16 @@ export function registerEventsHandlers(deps: HandlerDependencies): () => void {
   };
   handlers.push(typedHandle(CHANNELS.EVENTS_EMIT, handleEventsEmit));
 
-  // Bridge selected TypedEventBus events to the renderer via the multiplexed
-  // `events:push` channel. The renderer subscribes via
+  // Bridge events emitted on the main-side `TypedEventBus` to every renderer
+  // via the multiplexed `events:push` channel. The renderer subscribes via
   // `window.electron.events.on(name, callback)`.
+  //
+  // Events marked `"external"` in `EVENT_BUS_BRIDGED_MANIFEST` are NOT relayed
+  // here — their producers emit the envelope directly on `CHANNELS.EVENTS_PUSH`
+  // via `sendToRenderer` or `broadcastToRenderer`, to preserve window-scoped
+  // routing or avoid a `TypedEventBus` hop for channels without a counterpart.
   if (events) {
-    for (const name of EVENT_BUS_BRIDGED_EVENTS) {
+    for (const name of EVENT_BUS_RELAYED_EVENTS) {
       const unsubscribe = events.on(name, (payload) => {
         broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
           name,

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -5,6 +5,7 @@
 import { CHANNELS } from "../../channels.js";
 import { broadcastToRenderer } from "../../utils.js";
 import { events, type DaintreeEventMap } from "../../../services/events.js";
+import type { SpawnResult } from "../../../../shared/types/pty-host.js";
 import type { HandlerDependencies } from "../../types.js";
 
 export function registerTerminalEventHandlers(deps: HandlerDependencies): () => void {
@@ -14,7 +15,9 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   }
   const handlers: Array<() => void> = [];
 
-  // PTY data/exit/error events
+  // PTY data/exit/error events. `terminal:data` stays on its dedicated channel
+  // (high-frequency binary — keeping it off the event bus avoids envelope overhead
+  // and JSON/base64 churn; see lessons #4899/#4862/#4639).
   const handlePtyData = (id: string, data: string | Uint8Array) => {
     broadcastToRenderer(CHANNELS.TERMINAL_DATA, id, data);
   };
@@ -22,7 +25,10 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   handlers.push(() => ptyClient.off("data", handlePtyData));
 
   const handlePtyExit = (id: string, exitCode: number) => {
-    broadcastToRenderer(CHANNELS.TERMINAL_EXIT, id, exitCode);
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "terminal:exit",
+      payload: [id, exitCode],
+    });
   };
   ptyClient.on("exit", handlePtyExit);
   handlers.push(() => ptyClient.off("exit", handlePtyExit));
@@ -34,11 +40,11 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   handlers.push(() => ptyClient.off("error", handlePtyError));
 
   // Spawn result events (success or failure)
-  const handleSpawnResult = (
-    id: string,
-    result: { success: boolean; id: string; error?: unknown }
-  ) => {
-    broadcastToRenderer(CHANNELS.TERMINAL_SPAWN_RESULT, id, result);
+  const handleSpawnResult = (id: string, result: SpawnResult) => {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "terminal:spawn-result",
+      payload: [id, result],
+    });
   };
   ptyClient.on("spawn-result", handleSpawnResult);
   handlers.push(() => ptyClient.off("spawn-result", handleSpawnResult));
@@ -56,31 +62,10 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   ptyClient.on("terminal-status", handleTerminalStatus);
   handlers.push(() => ptyClient.off("terminal-status", handleTerminalStatus));
 
-  // Agent events
-  const unsubAgentState = events.on("agent:state-changed", (payload: unknown) => {
-    broadcastToRenderer(CHANNELS.AGENT_STATE_CHANGED, payload);
-  });
-  handlers.push(unsubAgentState);
-
-  const unsubAllClear = events.on("agent:all-clear", (payload) => {
-    broadcastToRenderer(CHANNELS.AGENT_ALL_CLEAR, payload);
-  });
-  handlers.push(unsubAllClear);
-
-  const unsubAgentDetected = events.on("agent:detected", (payload: unknown) => {
-    broadcastToRenderer(CHANNELS.AGENT_DETECTED, payload);
-  });
-  handlers.push(unsubAgentDetected);
-
-  const unsubAgentExited = events.on("agent:exited", (payload: unknown) => {
-    broadcastToRenderer(CHANNELS.AGENT_EXITED, payload);
-  });
-  handlers.push(unsubAgentExited);
-
-  const unsubFallbackTriggered = events.on("agent:fallback-triggered", (payload: unknown) => {
-    broadcastToRenderer(CHANNELS.AGENT_FALLBACK_TRIGGERED, payload);
-  });
-  handlers.push(unsubFallbackTriggered);
+  // Agent lifecycle events (agent:state-changed, agent:all-clear, agent:detected,
+  // agent:exited, agent:fallback-triggered) are relayed by `registerEventsHandlers`
+  // via the multiplexed events:push channel. Emitters continue to publish on
+  // `TypedEventBus` (`events.emit(...)`); do not duplicate relays here.
 
   // Artifact events
   const unsubArtifactDetected = events.on("artifact:detected", (payload: unknown) => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -505,7 +505,10 @@ function _ensureEventBusWired(): void {
     if (typeof envelope.name !== "string") return;
     const subs = _eventBusSubscribers.get(envelope.name);
     if (!subs || subs.size === 0) return;
-    for (const cb of subs) {
+    // Snapshot before iterating: a subscriber may unsubscribe itself or
+    // another subscriber during dispatch; iterating the live Set would make
+    // delivery to surviving subscribers depend on insertion order.
+    for (const cb of [...subs]) {
       try {
         cb(envelope.payload);
       } catch (err) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -154,8 +154,9 @@ ipcRenderer.on("workspace-port", (event: Electron.IpcRendererEvent) => {
     const fakeEvent = {} as Electron.IpcRendererEvent;
     switch (data.type) {
       case "worktree-update":
-        ipcRenderer.emit(CHANNELS.WORKTREE_UPDATE, fakeEvent, {
-          worktree: data.worktree,
+        ipcRenderer.emit(CHANNELS.EVENTS_PUSH, fakeEvent, {
+          name: "worktree:update",
+          payload: { worktree: data.worktree },
         });
         break;
       case "worktree-removed":
@@ -486,13 +487,60 @@ function _typedOn<K extends Extract<keyof IpcEventMap, string>>(
   return () => ipcRenderer.removeListener(channel, handler);
 }
 
+// Shared multiplexer for the typed event bus. All `window.electron.events.on`
+// subscribers — plus the migrated per-domain helpers below (terminal.onExit,
+// window.onFullscreenChange, etc.) — dispatch through a single ipcRenderer
+// listener on CHANNELS.EVENTS_PUSH. Ref-counted per event name so Node's
+// MaxListenersExceededWarning (fires at 10 listeners per channel) can't trip
+// as more events migrate; the ipcRenderer listener stays at exactly 1.
+type EventBusSubscriber = (payload: unknown) => void;
+const _eventBusSubscribers = new Map<keyof IpcEventBusMap, Set<EventBusSubscriber>>();
+let _eventBusWired = false;
+
+function _ensureEventBusWired(): void {
+  if (_eventBusWired) return;
+  _eventBusWired = true;
+  ipcRenderer.on(CHANNELS.EVENTS_PUSH, (_event, envelope: EventBusEnvelope) => {
+    if (!envelope || typeof envelope !== "object") return;
+    if (typeof envelope.name !== "string") return;
+    const subs = _eventBusSubscribers.get(envelope.name);
+    if (!subs || subs.size === 0) return;
+    for (const cb of subs) {
+      try {
+        cb(envelope.payload);
+      } catch (err) {
+        console.error("[Preload] events:push subscriber threw for", envelope.name, err);
+      }
+    }
+  });
+}
+
+function _eventBusOn<K extends keyof IpcEventBusMap>(
+  name: K,
+  callback: (payload: IpcEventBusMap[K]) => void
+): () => void {
+  _ensureEventBusWired();
+  let set = _eventBusSubscribers.get(name);
+  if (!set) {
+    set = new Set();
+    _eventBusSubscribers.set(name, set);
+  }
+  const wrapped = callback as EventBusSubscriber;
+  set.add(wrapped);
+  return () => {
+    const current = _eventBusSubscribers.get(name);
+    if (!current) return;
+    current.delete(wrapped);
+    if (current.size === 0) _eventBusSubscribers.delete(name);
+  };
+}
+
 // Inlined to avoid runtime module resolution issues with CommonJS
 const CHANNELS = {
   // Worktree channels
   WORKTREE_GET_ALL: "worktree:get-all",
   WORKTREE_REFRESH: "worktree:refresh",
   WORKTREE_SET_ACTIVE: "worktree:set-active",
-  WORKTREE_UPDATE: "worktree:update",
   WORKTREE_REMOVE: "worktree:remove",
   WORKTREE_ACTIVATED: "worktree:activated",
   WORKTREE_CREATE: "worktree:create",
@@ -516,13 +564,11 @@ const CHANNELS = {
 
   // Terminal channels
   TERMINAL_SPAWN: "terminal:spawn",
-  TERMINAL_SPAWN_RESULT: "terminal:spawn-result",
   TERMINAL_DATA: "terminal:data",
   TERMINAL_INPUT: "terminal:input",
   TERMINAL_SUBMIT: "terminal:submit",
   TERMINAL_RESIZE: "terminal:resize",
   TERMINAL_KILL: "terminal:kill",
-  TERMINAL_EXIT: "terminal:exit",
   TERMINAL_ERROR: "terminal:error",
   TERMINAL_TRASH: "terminal:trash",
   TERMINAL_RESTORE: "terminal:restore",
@@ -545,8 +591,6 @@ const CHANNELS = {
   TERMINAL_FORCE_RESUME: "terminal:force-resume",
   TERMINAL_GRACEFUL_KILL: "terminal:graceful-kill",
   TERMINAL_STATUS: "terminal:status",
-  TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
-  TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
   TERMINAL_BATCH_DOUBLE_ESCAPE: "terminal:batch-double-escape",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
@@ -562,13 +606,6 @@ const CHANNELS = {
   // Files channels
   FILES_SEARCH: "files:search",
   FILES_READ: "files:read",
-
-  // Agent state channels
-  AGENT_STATE_CHANGED: "agent:state-changed",
-  AGENT_ALL_CLEAR: "agent:all-clear",
-  AGENT_DETECTED: "agent:detected",
-  AGENT_EXITED: "agent:exited",
-  AGENT_FALLBACK_TRIGGERED: "agent:fallback-triggered",
 
   // Terminal activity channels
   TERMINAL_ACTIVITY: "terminal:activity",
@@ -623,7 +660,6 @@ const CHANNELS = {
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",
   DIAGNOSTICS_GET_HEAP_STATS: "diagnostics:get-heap-stats",
   DIAGNOSTICS_GET_INFO: "diagnostics:get-info",
-  SYSTEM_WAKE: "system:wake",
 
   // PR detection channels
   PR_DETECTED: "pr:detected",
@@ -896,7 +932,6 @@ const CHANNELS = {
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
 
   // Window channels
-  WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
   WINDOW_TOGGLE_FULLSCREEN: "window:toggle-fullscreen",
   WINDOW_RELOAD: "window:reload",
   WINDOW_FORCE_RELOAD: "window:force-reload",
@@ -906,13 +941,9 @@ const CHANNELS = {
   WINDOW_ZOOM_RESET: "window:zoom-reset",
   WINDOW_CLOSE: "window:close",
   WINDOW_NEW: "window:new",
-  WINDOW_RECLAIM_MEMORY: "window:reclaim-memory",
-  WINDOW_DESTROY_HIDDEN_WEBVIEWS: "window:destroy-hidden-webviews",
-  WINDOW_DISK_SPACE_STATUS: "window:disk-space-status",
 
   // Notification channels
   SOUND_TRIGGER: "sound:trigger",
-  SOUND_CANCEL: "sound:cancel",
   SOUND_GET_DIR: "sound:get-dir",
 
   NOTIFICATION_UPDATE: "notification:update",
@@ -959,9 +990,7 @@ const CHANNELS = {
   APP_AGENT_HAS_API_KEY: "app-agent:has-api-key",
   APP_AGENT_TEST_API_KEY: "app-agent:test-api-key",
   APP_AGENT_TEST_MODEL: "app-agent:test-model",
-  APP_AGENT_DISPATCH_ACTION_REQUEST: "app-agent:dispatch-action-request",
   APP_AGENT_DISPATCH_ACTION_RESPONSE: "app-agent:dispatch-action-response",
-  APP_AGENT_CONFIRMATION_REQUEST: "app-agent:confirmation-request",
   APP_AGENT_CONFIRMATION_RESPONSE: "app-agent:confirmation-response",
 
   // Agent Capabilities channels
@@ -1144,9 +1173,6 @@ const CHANNELS = {
   PLUGIN_ACTIONS_GET: "plugin:actions-get",
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
-  PLUGIN_ACTIONS_CHANGED: "plugin:actions-changed",
-
-  RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 
   APP_RELOAD_CONFIG: "app:reload-config",
   APP_CONFIG_RELOADED: "app:config-reloaded",
@@ -1215,12 +1241,8 @@ const api: ElectronAPI = {
 
     restartService: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RESTART_SERVICE),
 
-    onUpdate: (callback: (state: WorktreeState) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, payload: { worktree: WorktreeState }) =>
-        callback(payload.worktree);
-      ipcRenderer.on(CHANNELS.WORKTREE_UPDATE, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.WORKTREE_UPDATE, handler);
-    },
+    onUpdate: (callback: (state: WorktreeState) => void) =>
+      _eventBusOn("worktree:update", (payload) => callback(payload.worktree)),
 
     onRemove: (callback: (data: { worktreeId: string }) => void) =>
       _typedOn(CHANNELS.WORKTREE_REMOVE, callback),
@@ -1279,31 +1301,29 @@ const api: ElectronAPI = {
       return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_DATA, handler);
     },
 
-    // Tuple payload [id, exitCode] requires special handling
-    onExit: (callback: (id: string, exitCode: number) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, id: unknown, exitCode: unknown) => {
+    onExit: (callback: (id: string, exitCode: number) => void) =>
+      _eventBusOn("terminal:exit", (payload) => {
+        if (!Array.isArray(payload)) return;
+        const [id, exitCode] = payload;
         if (typeof id === "string" && typeof exitCode === "number") {
           callback(id, exitCode);
         }
-      };
-      ipcRenderer.on(CHANNELS.TERMINAL_EXIT, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_EXIT, handler);
-    },
+      }),
 
     onAgentStateChanged: (callback: (data: AgentStateChangePayload) => void) =>
-      _typedOn(CHANNELS.AGENT_STATE_CHANGED, callback),
+      _eventBusOn("agent:state-changed", callback),
 
     onAgentDetected: (callback: (data: AgentDetectedPayload) => void) =>
-      _typedOn(CHANNELS.AGENT_DETECTED, callback),
+      _eventBusOn("agent:detected", callback),
 
     onAgentExited: (callback: (data: AgentExitedPayload) => void) =>
-      _typedOn(CHANNELS.AGENT_EXITED, callback),
+      _eventBusOn("agent:exited", callback),
 
     onFallbackTriggered: (callback: (data: AgentFallbackTriggeredPayload) => void) =>
-      _typedOn(CHANNELS.AGENT_FALLBACK_TRIGGERED, callback),
+      _eventBusOn("agent:fallback-triggered", callback),
 
     onAllAgentsClear: (callback: (data: { timestamp: number }) => void) =>
-      _typedOn(CHANNELS.AGENT_ALL_CLEAR, callback),
+      _eventBusOn("agent:all-clear", callback),
 
     onActivity: (callback: (data: TerminalActivityPayload) => void) =>
       _typedOn(CHANNELS.TERMINAL_ACTIVITY, callback),
@@ -1375,20 +1395,10 @@ const api: ElectronAPI = {
         signal: string | null;
         timestamp: number;
       }) => void
-    ): (() => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        data: { crashType: string; code: number | null; signal: string | null; timestamp: number }
-      ) => callback(data);
-      ipcRenderer.on(CHANNELS.TERMINAL_BACKEND_CRASHED, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_BACKEND_CRASHED, handler);
-    },
+    ): (() => void) => _eventBusOn("terminal:backend-crashed", callback),
 
-    onBackendReady: (callback: () => void): (() => void) => {
-      const handler = () => callback();
-      ipcRenderer.on(CHANNELS.TERMINAL_BACKEND_READY, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_BACKEND_READY, handler);
-    },
+    onBackendReady: (callback: () => void): (() => void) =>
+      _eventBusOn("terminal:backend-ready", () => callback()),
 
     sendKey: (id: string, key: string) => ipcRenderer.send(CHANNELS.TERMINAL_SEND_KEY, id, key),
 
@@ -1401,15 +1411,14 @@ const api: ElectronAPI = {
     updateObservedTitle: (id: string, title: string) =>
       ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE, { id, title }),
 
-    onSpawnResult: (callback: (id: string, result: SpawnResultPayload) => void): (() => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, id: unknown, result: unknown) => {
+    onSpawnResult: (callback: (id: string, result: SpawnResultPayload) => void): (() => void) =>
+      _eventBusOn("terminal:spawn-result", (payload) => {
+        if (!Array.isArray(payload)) return;
+        const [id, result] = payload;
         if (typeof id === "string" && typeof result === "object" && result !== null) {
           callback(id, result as SpawnResultPayload);
         }
-      };
-      ipcRenderer.on(CHANNELS.TERMINAL_SPAWN_RESULT, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_SPAWN_RESULT, handler);
-    },
+      }),
 
     onReduceScrollback: (
       callback: (data: { terminalIds: string[]; targetLines: number }) => void
@@ -1420,11 +1429,8 @@ const api: ElectronAPI = {
 
     restartService: (): Promise<void> => _unwrappingInvoke(CHANNELS.TERMINAL_RESTART_SERVICE),
 
-    onReclaimMemory: (callback: () => void) => {
-      const handler = () => callback();
-      ipcRenderer.on(CHANNELS.WINDOW_RECLAIM_MEMORY, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.WINDOW_RECLAIM_MEMORY, handler);
-    },
+    onReclaimMemory: (callback: () => void) =>
+      _eventBusOn("window:reclaim-memory", () => callback()),
   },
 
   // Files API
@@ -1570,12 +1576,7 @@ const api: ElectronAPI = {
     getDiagnosticsInfo: () => _unwrappingInvoke(CHANNELS.DIAGNOSTICS_GET_INFO),
 
     onWake: (callback: (data: { sleepDuration: number; timestamp: number }) => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        data: { sleepDuration: number; timestamp: number }
-      ) => callback(data);
-      ipcRenderer.on(CHANNELS.SYSTEM_WAKE, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.SYSTEM_WAKE, handler);
+      return _eventBusOn("system:wake", callback);
     },
 
     installAgent: (payload: { agentId: string; methodIndex?: number; jobId: string }) =>
@@ -1585,12 +1586,8 @@ const api: ElectronAPI = {
       callback: (event: { jobId: string; chunk: string; stream: "stdout" | "stderr" }) => void
     ) => _typedOn(CHANNELS.SETUP_AGENT_INSTALL_PROGRESS, callback),
 
-    onResourceProfileChanged: (callback: (payload: ResourceProfilePayload) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, payload: ResourceProfilePayload) =>
-        callback(payload);
-      ipcRenderer.on(CHANNELS.RESOURCE_PROFILE_CHANGED, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.RESOURCE_PROFILE_CHANGED, handler);
-    },
+    onResourceProfileChanged: (callback: (payload: ResourceProfilePayload) => void) =>
+      _eventBusOn("resource:profile-changed", callback),
   },
 
   // App State API
@@ -1709,20 +1706,7 @@ const api: ElectronAPI = {
     on: <K extends keyof IpcEventBusMap>(
       name: K,
       callback: (payload: IpcEventBusMap[K]) => void
-    ): (() => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, envelope: EventBusEnvelope) => {
-        if (
-          envelope &&
-          typeof envelope === "object" &&
-          envelope.name === name &&
-          "payload" in envelope
-        ) {
-          callback(envelope.payload as IpcEventBusMap[K]);
-        }
-      };
-      ipcRenderer.on(CHANNELS.EVENTS_PUSH, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.EVENTS_PUSH, handler);
-    },
+    ): (() => void) => _eventBusOn(name, callback),
   },
 
   // Project API
@@ -2444,12 +2428,8 @@ const api: ElectronAPI = {
 
   // Window API
   window: {
-    onFullscreenChange: (callback: (isFullscreen: boolean) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, isFullscreen: boolean) =>
-        callback(isFullscreen);
-      ipcRenderer.on(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
-    },
+    onFullscreenChange: (callback: (isFullscreen: boolean) => void) =>
+      _eventBusOn("window:fullscreen-change", callback),
     toggleFullscreen: (): Promise<boolean> => _unwrappingInvoke(CHANNELS.WINDOW_TOGGLE_FULLSCREEN),
     reload: (): Promise<void> => _unwrappingInvoke(CHANNELS.WINDOW_RELOAD),
     forceReload: (): Promise<void> => _unwrappingInvoke(CHANNELS.WINDOW_FORCE_RELOAD),
@@ -2461,30 +2441,15 @@ const api: ElectronAPI = {
     close: (): Promise<void> => _unwrappingInvoke(CHANNELS.WINDOW_CLOSE),
     openNew: (projectPath?: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.WINDOW_NEW, projectPath),
-    onDestroyHiddenWebviews: (callback: (payload: { tier: 1 | 2 }) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, payload: { tier: 1 | 2 }) =>
-        callback(payload);
-      ipcRenderer.on(CHANNELS.WINDOW_DESTROY_HIDDEN_WEBVIEWS, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.WINDOW_DESTROY_HIDDEN_WEBVIEWS, handler);
-    },
+    onDestroyHiddenWebviews: (callback: (payload: { tier: 1 | 2 }) => void) =>
+      _eventBusOn("window:destroy-hidden-webviews", callback),
     onDiskSpaceStatus: (
       callback: (payload: {
         status: "normal" | "warning" | "critical";
         availableMb: number;
         writesSuppressed: boolean;
       }) => void
-    ) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        payload: {
-          status: "normal" | "warning" | "critical";
-          availableMb: number;
-          writesSuppressed: boolean;
-        }
-      ) => callback(payload);
-      ipcRenderer.on(CHANNELS.WINDOW_DISK_SPACE_STATUS, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.WINDOW_DISK_SPACE_STATUS, handler);
-    },
+    ) => _eventBusOn("window:disk-space-status", callback),
   },
 
   // Recovery API (used by recovery.html)
@@ -2575,11 +2540,7 @@ const api: ElectronAPI = {
   sound: {
     onTrigger: (callback: (payload: { soundFile: string; detune?: number }) => void) =>
       _typedOn(CHANNELS.SOUND_TRIGGER, callback),
-    onCancel: (callback: () => void) => {
-      const handler = () => callback();
-      ipcRenderer.on(CHANNELS.SOUND_CANCEL, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.SOUND_CANCEL, handler);
-    },
+    onCancel: (callback: () => void) => _eventBusOn("sound:cancel", () => callback()),
     getSoundDir: (): Promise<string> => _unwrappingInvoke(CHANNELS.SOUND_GET_DIR),
   },
 
@@ -2676,25 +2637,7 @@ const api: ElectronAPI = {
         };
         confirmed?: boolean;
       }) => void
-    ) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        payload: {
-          requestId: string;
-          actionId: string;
-          args?: Record<string, unknown>;
-          context: {
-            projectId?: string;
-            activeWorktreeId?: string;
-            focusedWorktreeId?: string;
-            focusedTerminalId?: string;
-          };
-          confirmed?: boolean;
-        }
-      ) => callback(payload);
-      ipcRenderer.on(CHANNELS.APP_AGENT_DISPATCH_ACTION_REQUEST, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.APP_AGENT_DISPATCH_ACTION_REQUEST, handler);
-    },
+    ) => _eventBusOn("app-agent:dispatch-action-request", callback),
 
     // Send action dispatch response back to main process
     sendDispatchActionResponse: (payload: {
@@ -2711,20 +2654,7 @@ const api: ElectronAPI = {
         args?: Record<string, unknown>;
         danger: "safe" | "confirm" | "restricted";
       }) => void
-    ) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        payload: {
-          requestId: string;
-          actionId: string;
-          actionName?: string;
-          args?: Record<string, unknown>;
-          danger: "safe" | "confirm" | "restricted";
-        }
-      ) => callback(payload);
-      ipcRenderer.on(CHANNELS.APP_AGENT_CONFIRMATION_REQUEST, handler);
-      return () => ipcRenderer.removeListener(CHANNELS.APP_AGENT_CONFIRMATION_REQUEST, handler);
-    },
+    ) => _eventBusOn("app-agent:confirmation-request", callback),
 
     // Send confirmation response back to main process
     sendConfirmationResponse: (payload: { requestId: string; approved: boolean }) =>
@@ -3018,16 +2948,8 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_REGISTER, pluginId, contribution),
     unregisterAction: (pluginId: string, actionId: string) =>
       _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, pluginId, actionId),
-    onActionsChanged: (callback: (payload: { actions: PluginActionDescriptor[] }) => void) => {
-      const handler = (
-        _event: Electron.IpcRendererEvent,
-        payload: { actions: PluginActionDescriptor[] }
-      ) => callback(payload);
-      ipcRenderer.on(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);
-      return () => {
-        ipcRenderer.removeListener(CHANNELS.PLUGIN_ACTIONS_CHANGED, handler);
-      };
-    },
+    onActionsChanged: (callback: (payload: { actions: PluginActionDescriptor[] }) => void) =>
+      _eventBusOn("plugin:actions-changed", callback),
   },
 
   crashRecovery: {
@@ -3176,9 +3098,11 @@ if (window.top === window && isTrustedRendererUrl(window.location.href)) {
   }
 }
 
-// Private listener: reclaim renderer memory when notified by the main process.
+/// Private listener: reclaim renderer memory when notified by the main process.
 // Not exposed through window.electron — this is an internal optimization.
-ipcRenderer.on(CHANNELS.WINDOW_RECLAIM_MEMORY, () => {
+// Subscribed through the shared events:push dispatcher so the underlying
+// ipcRenderer listener is ref-counted alongside user-facing subscribers.
+_eventBusOn("window:reclaim-memory", () => {
   webFrame.clearCache();
   (globalThis as unknown as { gc?: () => void }).gc?.();
 });

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -678,8 +678,9 @@ export class PluginService {
   }
 
   private broadcastPluginActions(): void {
-    broadcastToRenderer(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
-      actions: this.listPluginActions(),
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:actions-changed",
+      payload: { actions: this.listPluginActions() },
     });
   }
 }

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -234,7 +234,7 @@ export class ResourceProfileService {
     // Broadcast to renderer
     try {
       const payload: ResourceProfilePayload = { profile, config };
-      broadcastToRenderer(CHANNELS.RESOURCE_PROFILE_CHANGED, payload);
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "resource:profile-changed", payload });
     } catch {
       // non-critical — window may be closing
     }

--- a/electron/services/SoundService.ts
+++ b/electron/services/SoundService.ts
@@ -119,7 +119,7 @@ class SoundService {
   }
 
   cancel(): void {
-    broadcastToRenderer(CHANNELS.SOUND_CANCEL);
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
     for (const voice of this.activeVoices) {
       voice.handle.cancel();
     }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -220,8 +220,9 @@ export class WorkspaceClient extends EventEmitter {
             entry.projectPath
           );
         }
-        this.sendToEntryWindows(entry, CHANNELS.WORKTREE_UPDATE, {
-          worktree,
+        this.sendToEntryWindows(entry, CHANNELS.EVENTS_PUSH, {
+          name: "worktree:update",
+          payload: { worktree },
         });
         this.emit("worktree-update", { worktree, projectPath: entry.projectPath });
         events.emit("sys:worktree:update", {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1249,8 +1249,9 @@ describe("Plugin action registry", () => {
       kind: "command",
       danger: "safe",
     });
-    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
-      actions,
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:actions-changed",
+      payload: { actions },
     });
   });
 
@@ -1321,8 +1322,9 @@ describe("Plugin action registry", () => {
     service.unregisterPluginAction("acme.my-plugin", "acme.my-plugin.doThing");
 
     expect(service.listPluginActions()).toEqual([]);
-    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.PLUGIN_ACTIONS_CHANGED, {
-      actions: [],
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:actions-changed",
+      payload: { actions: [] },
     });
   });
 
@@ -1356,7 +1358,11 @@ describe("Plugin action registry", () => {
     expect(service.listPluginActions()).toEqual([]);
     // Exactly one broadcast for the bulk removal (no per-action spam)
     const broadcasts = broadcastToRendererMock.mock.calls.filter(
-      (call: unknown[]) => call[0] === CHANNELS.PLUGIN_ACTIONS_CHANGED
+      (call: unknown[]) =>
+        call[0] === CHANNELS.EVENTS_PUSH &&
+        typeof call[1] === "object" &&
+        call[1] !== null &&
+        (call[1] as { name?: unknown }).name === "plugin:actions-changed"
     );
     expect(broadcasts).toHaveLength(1);
   });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -214,10 +214,13 @@ describe("ResourceProfileService", () => {
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
 
     expect(broadcastToRenderer).toHaveBeenCalledWith(
-      "resource:profile-changed",
+      "events:push",
       expect.objectContaining({
-        profile: "efficiency",
-        config: RESOURCE_PROFILE_CONFIGS.efficiency,
+        name: "resource:profile-changed",
+        payload: expect.objectContaining({
+          profile: "efficiency",
+          config: RESOURCE_PROFILE_CONFIGS.efficiency,
+        }),
       })
     );
 

--- a/electron/services/__tests__/SoundService.test.ts
+++ b/electron/services/__tests__/SoundService.test.ts
@@ -154,7 +154,10 @@ describe("SoundService", () => {
   it("cancel sends sound:cancel IPC via broadcast", () => {
     soundService.cancel();
 
-    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("sound:cancel");
+    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("events:push", {
+      name: "sound:cancel",
+      payload: undefined,
+    });
   });
 
   it("preview sends the base file without variant selection via IPC", () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -570,8 +570,11 @@ describe("WorkspaceClient multi-process manager", () => {
         worktree: { id: "wt-1", path: "/a/wt", name: "wt", branch: "main" },
       });
 
-      expect(wc.send).toHaveBeenCalledWith("worktree:update", {
-        worktree: expect.objectContaining({ id: "wt-1" }),
+      expect(wc.send).toHaveBeenCalledWith("events:push", {
+        name: "worktree:update",
+        payload: {
+          worktree: expect.objectContaining({ id: "wt-1" }),
+        },
       });
     });
 

--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -68,7 +68,7 @@ describe("setupPowerMonitor", () => {
     }));
 
     vi.doMock("../../ipc/channels.js", () => ({
-      CHANNELS: { SYSTEM_WAKE: "system:wake" },
+      CHANNELS: { EVENTS_PUSH: "events:push" },
     }));
 
     mockGetAppWebContents = vi.fn((win: { webContents: unknown }) => win.webContents);
@@ -165,10 +165,13 @@ describe("setupPowerMonitor", () => {
     expect(ptyClient.resumeAll).toHaveBeenCalledTimes(1);
     expect(ptyClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
     expect(wc.send).toHaveBeenCalledWith(
-      "system:wake",
+      "events:push",
       expect.objectContaining({
-        sleepDuration: expect.any(Number),
-        timestamp: expect.any(Number),
+        name: "system:wake",
+        payload: expect.objectContaining({
+          sleepDuration: expect.any(Number),
+          timestamp: expect.any(Number),
+        }),
       })
     );
   });
@@ -224,7 +227,10 @@ describe("setupPowerMonitor", () => {
 
     expect(ptyClient.resumeAll).toHaveBeenCalledTimes(1);
     expect(ptyClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
-    expect(wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+    expect(wc.send).toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({ name: "system:wake", payload: expect.any(Object) })
+    );
   });
 
   it("catches and logs errors from workspaceClient.refresh", async () => {
@@ -259,7 +265,10 @@ describe("setupPowerMonitor", () => {
     powerHandlers.get("resume")!();
     await vi.advanceTimersByTimeAsync(2000);
 
-    expect(live.wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+    expect(live.wc.send).toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({ name: "system:wake", payload: expect.any(Object) })
+    );
     expect(dead.wc.send).not.toHaveBeenCalled();
   });
 
@@ -294,7 +303,10 @@ describe("setupPowerMonitor", () => {
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
     expect(workspaceClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
     expect(workspaceClient.refresh).toHaveBeenCalledTimes(1);
-    expect(wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+    expect(wc.send).toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({ name: "system:wake", payload: expect.any(Object) })
+    );
   });
 
   it("skips SYSTEM_WAKE for a window whose webContents is destroyed", async () => {

--- a/electron/window/__tests__/reclaimMemory.test.ts
+++ b/electron/window/__tests__/reclaimMemory.test.ts
@@ -74,8 +74,9 @@ describe("reclaimMemory — minimize debounce", () => {
 
     vi.advanceTimersByTime(5000);
     expect(mockSendToRenderer).toHaveBeenCalledOnce();
-    expect(mockSendToRenderer).toHaveBeenCalledWith(win, CHANNELS.WINDOW_RECLAIM_MEMORY, {
-      reason: "minimize",
+    expect(mockSendToRenderer).toHaveBeenCalledWith(win, CHANNELS.EVENTS_PUSH, {
+      name: "window:reclaim-memory",
+      payload: { reason: "minimize" },
     });
   });
 
@@ -158,8 +159,9 @@ function createReclaimHelper(win: ReturnType<typeof createMockWindow>) {
       reclaimTimer = setTimeout(() => {
         reclaimTimer = null;
         if (!win.isDestroyed() && win.isMinimized()) {
-          vi.mocked(sendToRenderer)(win as never, CHANNELS.WINDOW_RECLAIM_MEMORY, {
-            reason: "minimize",
+          vi.mocked(sendToRenderer)(win as never, CHANNELS.EVENTS_PUSH, {
+            name: "window:reclaim-memory",
+            payload: { reason: "minimize" },
           });
         }
       }, RECLAIM_DELAY_MS);

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -474,18 +474,16 @@ export function setupBrowserWindow(
   });
 
   // Fullscreen events
-  win.on("enter-full-screen", () => {
-    sendToRenderer(win, CHANNELS.WINDOW_FULLSCREEN_CHANGE, true);
-  });
-  win.on("leave-full-screen", () => {
-    sendToRenderer(win, CHANNELS.WINDOW_FULLSCREEN_CHANGE, false);
-  });
-  win.on("enter-html-full-screen", () => {
-    sendToRenderer(win, CHANNELS.WINDOW_FULLSCREEN_CHANGE, true);
-  });
-  win.on("leave-html-full-screen", () => {
-    sendToRenderer(win, CHANNELS.WINDOW_FULLSCREEN_CHANGE, false);
-  });
+  const sendFullscreen = (isFullscreen: boolean) => {
+    sendToRenderer(win, CHANNELS.EVENTS_PUSH, {
+      name: "window:fullscreen-change",
+      payload: isFullscreen,
+    });
+  };
+  win.on("enter-full-screen", () => sendFullscreen(true));
+  win.on("leave-full-screen", () => sendFullscreen(false));
+  win.on("enter-html-full-screen", () => sendFullscreen(true));
+  win.on("leave-html-full-screen", () => sendFullscreen(false));
 
   // Memory reclamation: clear renderer caches after sustained minimize
   const RECLAIM_DELAY_MS = 5_000;
@@ -496,7 +494,10 @@ export function setupBrowserWindow(
     reclaimTimer = setTimeout(() => {
       reclaimTimer = null;
       if (!win.isDestroyed() && win.isMinimized()) {
-        sendToRenderer(win, CHANNELS.WINDOW_RECLAIM_MEMORY, { reason: "minimize" });
+        sendToRenderer(win, CHANNELS.EVENTS_PUSH, {
+          name: "window:reclaim-memory",
+          payload: { reason: "minimize" },
+        });
       }
     }, RECLAIM_DELAY_MS);
   });

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -68,9 +68,12 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
             const wc = getAppWebContents(win);
             if (!wc.isDestroyed()) {
               try {
-                wc.send(CHANNELS.SYSTEM_WAKE, {
-                  sleepDuration,
-                  timestamp: Date.now(),
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "system:wake",
+                  payload: {
+                    sleepDuration,
+                    timestamp: Date.now(),
+                  },
                 });
               } catch {
                 // Silently ignore send failures during window disposal.

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -390,7 +390,10 @@ export async function setupWindowServices(
             if (windowRegistry) {
               for (const wCtx of windowRegistry.all()) {
                 if (!wCtx.browserWindow.isDestroyed()) {
-                  sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DISK_SPACE_STATUS, payload);
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                    name: "window:disk-space-status",
+                    payload,
+                  });
                 }
               }
             }
@@ -451,8 +454,9 @@ export async function setupWindowServices(
               for (const wCtx of windowRegistry.all()) {
                 if (!wCtx.browserWindow.isDestroyed()) {
                   try {
-                    sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_RECLAIM_MEMORY, {
-                      reason: "memory-pressure",
+                    sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                      name: "window:reclaim-memory",
+                      payload: { reason: "memory-pressure" },
                     });
                   } catch {
                     /* non-critical */
@@ -478,8 +482,9 @@ export async function setupWindowServices(
                   /* non-critical */
                 }
                 try {
-                  sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DESTROY_HIDDEN_WEBVIEWS, {
-                    tier,
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                    name: "window:destroy-hidden-webviews",
+                    payload: { tier },
                   });
                 } catch {
                   /* non-critical */
@@ -601,11 +606,14 @@ export async function setupWindowServices(
             const wc = getAppWebContents(w);
             if (!wc.isDestroyed()) {
               try {
-                wc.send(CHANNELS.TERMINAL_BACKEND_CRASHED, {
-                  crashType: details.crashType,
-                  code: details.code,
-                  signal: details.signal,
-                  timestamp: details.timestamp,
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "terminal:backend-crashed",
+                  payload: {
+                    crashType: details.crashType,
+                    code: details.code,
+                    signal: details.signal,
+                    timestamp: details.timestamp,
+                  },
                 });
               } catch {
                 // Silently ignore send failures during window disposal.
@@ -635,7 +643,10 @@ export async function setupWindowServices(
           const w = wCtx.browserWindow;
           if (!w.isDestroyed()) {
             try {
-              sendToRenderer(w, CHANNELS.WINDOW_RECLAIM_MEMORY, { reason: "pty-host-pressure" });
+              sendToRenderer(w, CHANNELS.EVENTS_PUSH, {
+                name: "window:reclaim-memory",
+                payload: { reason: "pty-host-pressure" },
+              });
             } catch {
               /* non-critical */
             }
@@ -658,7 +669,10 @@ export async function setupWindowServices(
             if (!wc.isDestroyed()) {
               distributePortsToView(wCtx.browserWindow, wCtx, wc, ptyClient);
               try {
-                wc.send(CHANNELS.TERMINAL_BACKEND_READY);
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "terminal:backend-ready",
+                  payload: undefined,
+                });
               } catch {
                 // Silently ignore send failures during window disposal.
               }
@@ -796,7 +810,10 @@ export async function setupWindowServices(
       flushPendingErrors();
       const diskStatus = getCurrentDiskSpaceStatus();
       if (diskStatus.status !== "normal") {
-        sendToRenderer(win, CHANNELS.WINDOW_DISK_SPACE_STATUS, diskStatus);
+        sendToRenderer(win, CHANNELS.EVENTS_PUSH, {
+          name: "window:disk-space-status",
+          payload: diskStatus,
+        });
       }
     });
 

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2363,18 +2363,80 @@ export interface IpcEventMap {
     actions: import("../plugin.js").PluginActionDescriptor[];
   };
 
+  // Resource profile change (main → renderer)
+  "resource:profile-changed": import("../resourceProfile.js").ResourceProfilePayload;
+
+  // App-agent action dispatch/confirmation request events (main → renderer)
+  "app-agent:dispatch-action-request": {
+    requestId: string;
+    actionId: string;
+    args?: Record<string, unknown>;
+    context: {
+      projectId?: string;
+      activeWorktreeId?: string;
+      focusedWorktreeId?: string;
+      focusedTerminalId?: string;
+    };
+    confirmed?: boolean;
+  };
+  "app-agent:confirmation-request": {
+    requestId: string;
+    actionId: string;
+    actionName?: string;
+    args?: Record<string, unknown>;
+    danger: "safe" | "confirm" | "restricted";
+  };
+
   // Typed event bus envelope (multiplexed main → renderer for IpcEventBusMap)
   "events:push": EventBusEnvelope;
 }
 
 /**
- * Typed event bus map — a curated subset of IpcEventMap exposed to the renderer
- * via `window.electron.events.on(name, cb)`. Coexists with per-event channels
- * (e.g. CHANNELS.AGENT_STATE_CHANGED); this provides a single multiplexed surface
- * for new consumers and future migration targets. Extend by adding keys here
- * and subscribing the main-side bridge in `registerEventsHandlers`.
+ * Typed event bus map — the subset of IpcEventMap bridged through the multiplexed
+ * `events:push` channel and exposed to the renderer via
+ * `window.electron.events.on(name, cb)`.
+ *
+ * The main-side bridge in `registerEventsHandlers` enforces that every key here
+ * has a corresponding entry in `EVENT_BUS_BRIDGED_MANIFEST` via
+ * `satisfies Record<keyof IpcEventBusMap, ...>`. Extend both when adding events.
+ *
+ * Excluded by design: binary / high-frequency channels (`terminal:data`,
+ * `terminal:resource-metrics`, `logs:batch`) stay on dedicated channels or the
+ * MessagePort path — envelope wrapping would force base64 encoding and add JS
+ * dispatch overhead unsuitable for hundreds-of-events-per-second streams.
  */
-export type IpcEventBusMap = Pick<IpcEventMap, "agent:state-changed">;
+export type IpcEventBusMap = Pick<
+  IpcEventMap,
+  // Agent lifecycle (global broadcast)
+  | "agent:state-changed"
+  | "agent:all-clear"
+  | "agent:detected"
+  | "agent:exited"
+  | "agent:fallback-triggered"
+  // Worktree updates (window-scoped — routed via EVENTS_PUSH directly by sender)
+  | "worktree:update"
+  // Window lifecycle (window-scoped)
+  | "window:fullscreen-change"
+  | "window:reclaim-memory"
+  | "window:destroy-hidden-webviews"
+  | "window:disk-space-status"
+  // System wake (per-webContents)
+  | "system:wake"
+  // Resource profile (global broadcast)
+  | "resource:profile-changed"
+  // Sound cancel (global broadcast)
+  | "sound:cancel"
+  // App-agent dispatch/confirmation (window-scoped)
+  | "app-agent:dispatch-action-request"
+  | "app-agent:confirmation-request"
+  // Plugin action registry (global broadcast)
+  | "plugin:actions-changed"
+  // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
+  | "terminal:exit"
+  | "terminal:backend-crashed"
+  | "terminal:backend-ready"
+  | "terminal:spawn-result"
+>;
 
 /**
  * Envelope carried on CHANNELS.EVENTS_PUSH. Discriminated by `name` so the


### PR DESCRIPTION
## Summary

- Expanded `IpcEventBusMap` from 1 to 18 events and migrated their senders and receivers off dedicated channels onto the multiplexed `EVENTS_PUSH` envelope.
- Preload now uses a ref-counted single-listener dispatcher backed by `Map<name, Set<cb>>`, with `EVENT_BUS_BRIDGED_MANIFEST` providing compile-time lockstep enforcement between classified routes and the type map.
- 20 channel constants removed from `channels.ts` and the preload mirror; binary/high-frequency channels (`terminal:data`, `terminal:resource-metrics`, `logs:batch`) intentionally left on dedicated channels.

Resolves #5690

## Changes

- `shared/types/ipc/maps.ts` — 17 new event entries added to `IpcEventBusMap`
- `electron/ipc/handlers/events.ts` — unified event fan-out handler replacing per-channel send calls
- `electron/preload.cts` — ref-counted dispatcher, 20 preload bindings removed
- `electron/ipc/channels.ts` — 20 channel constants deleted
- `electron/window/windowServices.ts`, `createWindow.ts`, `powerMonitor.ts` — migrated to typed emit
- `electron/services/SoundService.ts`, `ResourceProfileService.ts`, `WorkspaceClient.ts`, `PluginService.ts` — migrated to typed emit
- `electron/ipc/handlers/terminal/events.ts` — terminal lifecycle events migrated
- Tests and E2E listener-tracking updated to match new emission paths

## Testing

Unit tests for `SoundService`, `powerMonitor`, and `PluginService` updated and passing. E2E spawn-result assertions updated. Handler registry integrity test stays green throughout.