### PR TITLE
fix(settings): keep custom colour picker open during native OS picker session

### DIFF
--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, X } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -48,6 +48,18 @@ export function PresetColorPicker({
 }: PresetColorPickerProps) {
   const [open, setOpen] = useState(false);
   const nativeInputRef = useRef<HTMLInputElement>(null);
+  // True while the native `<input type="color">` has opened NSColorPanel and the
+  // renderer has lost focus. Used to suppress Radix's focus-outside dismissal so
+  // the hidden input stays mounted for the duration of the OS picker session.
+  const customColorOpenRef = useRef(false);
+
+  useEffect(() => {
+    const clearGuard = () => {
+      customColorOpenRef.current = false;
+    };
+    window.addEventListener("focus", clearGuard);
+    return () => window.removeEventListener("focus", clearGuard);
+  }, []);
 
   const effectiveColor = color ?? agentColor;
 
@@ -62,11 +74,19 @@ export function PresetColorPicker({
   };
 
   const handleCustomClick = () => {
-    nativeInputRef.current?.click();
+    if (!nativeInputRef.current) return;
+    customColorOpenRef.current = true;
+    nativeInputRef.current.click();
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) customColorOpenRef.current = false;
+        setOpen(next);
+      }}
+    >
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -86,6 +106,12 @@ export function PresetColorPicker({
         sideOffset={6}
         className="w-auto p-2 space-y-2"
         data-testid="preset-color-picker-popover"
+        onFocusOutside={(e) => {
+          // NSColorPanel opens an OS-level window that steals renderer focus
+          // with no pointerdown event. Suppress Radix's focus-outside close
+          // while the native picker session is active so the input stays mounted.
+          if (customColorOpenRef.current) e.preventDefault();
+        }}
       >
         <div className="grid grid-cols-5 gap-1">
           {PALETTE.map((c) => {
@@ -138,7 +164,10 @@ export function PresetColorPicker({
             type="color"
             className="sr-only"
             value={pickerValue}
-            onChange={(e) => handleSelect(e.target.value)}
+            onChange={(e) => {
+              customColorOpenRef.current = false;
+              handleSelect(e.target.value);
+            }}
             aria-hidden="true"
             tabIndex={-1}
           />

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -108,9 +108,12 @@ export function PresetColorPicker({
         data-testid="preset-color-picker-popover"
         onFocusOutside={(e) => {
           // NSColorPanel opens an OS-level window that steals renderer focus
-          // with no pointerdown event. Suppress Radix's focus-outside close
-          // while the native picker session is active so the input stays mounted.
-          if (customColorOpenRef.current) e.preventDefault();
+          // without firing a pointerdown. Suppress Radix's focus-outside close
+          // only while the guard is set AND the document has actually lost focus.
+          // The hasFocus check is a self-recovery: if the guard is stuck true
+          // (e.g., the OS picker never opened), normal in-window dismissals
+          // still work because they fire with document.hasFocus() === true.
+          if (customColorOpenRef.current && !document.hasFocus()) e.preventDefault();
         }}
       >
         <div className="grid grid-cols-5 gap-1">

--- a/src/components/Settings/__tests__/PresetColorPicker.test.tsx
+++ b/src/components/Settings/__tests__/PresetColorPicker.test.tsx
@@ -101,14 +101,34 @@ describe("PresetColorPicker", () => {
   });
 
   it("Custom… suppresses focus-outside dismissal while the native picker is open", () => {
-    const { getByTestId } = render(
-      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
-    );
-    fireEvent.click(getByTestId("preset-color-custom"));
-    expect(capturedOnFocusOutside).toBeDefined();
-    const preventDefault = vi.fn();
-    capturedOnFocusOutside!({ preventDefault });
-    expect(preventDefault).toHaveBeenCalledTimes(1);
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    try {
+      const { getByTestId } = render(
+        <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+      );
+      fireEvent.click(getByTestId("preset-color-custom"));
+      expect(capturedOnFocusOutside).toBeDefined();
+      const preventDefault = vi.fn();
+      capturedOnFocusOutside!({ preventDefault });
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
+  });
+
+  it("focus-outside dismissal is allowed when document still has focus (stuck-guard recovery)", () => {
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    try {
+      const { getByTestId } = render(
+        <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+      );
+      fireEvent.click(getByTestId("preset-color-custom"));
+      const preventDefault = vi.fn();
+      capturedOnFocusOutside!({ preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    } finally {
+      hasFocusSpy.mockRestore();
+    }
   });
 
   it("focus-outside dismissal is allowed again after a color is picked", () => {

--- a/src/components/Settings/__tests__/PresetColorPicker.test.tsx
+++ b/src/components/Settings/__tests__/PresetColorPicker.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import { PresetColorPicker } from "../PresetColorPicker";
 
 vi.mock("lucide-react", () => ({
@@ -8,12 +8,26 @@ vi.mock("lucide-react", () => ({
   X: () => <span data-testid="x-icon" />,
 }));
 
+// Captures the onFocusOutside callback passed to PopoverContent so tests can
+// invoke it directly (matches the dockPopoverGuard test pattern — assert on
+// preventDefault rather than relying on jsdom to wire up Radix dismissal).
+let capturedOnFocusOutside: ((e: { preventDefault: () => void }) => void) | undefined;
+
 // Radix Popover renders conditionally via portal — mock to render all children
 // inline so we can assert on the palette grid without real portal plumbing.
 vi.mock("@/components/ui/popover", () => ({
   Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({
+    children,
+    onFocusOutside,
+  }: {
+    children: React.ReactNode;
+    onFocusOutside?: (e: { preventDefault: () => void }) => void;
+  }) => {
+    capturedOnFocusOutside = onFocusOutside;
+    return <>{children}</>;
+  },
 }));
 
 describe("PresetColorPicker", () => {
@@ -21,6 +35,7 @@ describe("PresetColorPicker", () => {
 
   beforeEach(() => {
     onChange = vi.fn<(color: string | undefined) => void>();
+    capturedOnFocusOutside = undefined;
   });
 
   it("trigger swatch reflects the current color", () => {
@@ -83,5 +98,41 @@ describe("PresetColorPicker", () => {
     );
     const swatch = getByTestId("preset-color-swatch-e06c75");
     expect(swatch.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("Custom… suppresses focus-outside dismissal while the native picker is open", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+    );
+    fireEvent.click(getByTestId("preset-color-custom"));
+    expect(capturedOnFocusOutside).toBeDefined();
+    const preventDefault = vi.fn();
+    capturedOnFocusOutside!({ preventDefault });
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("focus-outside dismissal is allowed again after a color is picked", () => {
+    const { getByTestId, container } = render(
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+    );
+    fireEvent.click(getByTestId("preset-color-custom"));
+    const nativeInput = container.querySelector('input[type="color"]') as HTMLInputElement;
+    fireEvent.change(nativeInput, { target: { value: "#123456" } });
+    const preventDefault = vi.fn();
+    capturedOnFocusOutside!({ preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("focus-outside dismissal is allowed again after window regains focus (cancel path)", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+    );
+    fireEvent.click(getByTestId("preset-color-custom"));
+    act(() => {
+      window.dispatchEvent(new FocusEvent("focus"));
+    });
+    const preventDefault = vi.fn();
+    capturedOnFocusOutside!({ preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Clicking **Custom…** in the preset colour picker opens macOS NSColorPanel as a separate OS-level window. Any interaction inside it fired a Radix `onFocusOutside` event that dismissed the popover, unmounting the hidden `<input type="color">` and closing NSColorPanel along with it.
- Added a `customColorOpenRef` guard set synchronously before triggering the native input click. `PopoverContent`'s `onFocusOutside` calls `e.preventDefault()` only when the guard is active and `document.hasFocus()` is false (confirming it's the OS picker stealing focus, not an unrelated outside click).
- The guard self-recovers on colour pick (`onChange`), popover close (`onOpenChange(false)`), and a `window 'focus'` listener that catches the NSColorPanel cancel path, so normal dismiss behaviour is preserved in all other cases.

Resolves #5736

## Changes

- `src/components/Settings/PresetColorPicker.tsx` — `customColorOpenRef` guard + `onFocusOutside` handler + `window 'focus'` cleanup listener
- `src/components/Settings/__tests__/PresetColorPicker.test.tsx` — 4 new tests covering suppress-while-open, post-pick recovery, cancel-via-focus, and stuck-guard self-recovery (10 tests total, all passing)

## Testing

All 10 unit tests pass. Typecheck clean. Lint warnings down by 5 (no new warnings introduced). Manually verified: Custom… opens NSColorPanel, hue slider and colour field are fully draggable, picking a colour applies it and closes the popover, pressing Escape on the OS picker cancels cleanly without leaving the popover stuck open.