### PR TITLE
fix(fleet): stop auto-entering fleet scope when arming (#5746)

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -260,6 +260,13 @@ export function FleetArmingRibbon(): ReactElement | null {
         <>
           <DropdownMenuSeparator />
           <DropdownMenuItem
+            onSelect={() => {
+              void actionService.dispatch("fleet.scope.enter", undefined, { source: "user" });
+            }}
+          >
+            Focus selection
+          </DropdownMenuItem>
+          <DropdownMenuItem
             destructive
             onSelect={() => {
               clear();

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -436,6 +436,19 @@ describe("FleetArmingRibbon", () => {
       expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
     });
 
+    it("'Focus selection' dispatches fleet.scope.enter with source user", async () => {
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      const actionServiceModule = await import("@/services/ActionService");
+      const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+      render(<FleetArmingRibbon />);
+      fireEvent.click(findMenuItem(/Focus selection/));
+      const match = dispatchSpy.mock.calls.find((c) => c[0] === "fleet.scope.enter");
+      expect(match).toBeDefined();
+      expect(match?.[1]).toBeUndefined();
+      expect(match?.[2]).toEqual({ source: "user" });
+      dispatchSpy.mockRestore();
+    });
+
     it("'All working' arms agents in 'running' state alongside 'working'", () => {
       seed([makeAgent("t1", "working"), makeAgent("t2", "running")]);
       useFleetArmingStore.getState().armIds(["t1", "t2"]);

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -101,11 +101,6 @@ export function useWorktreeActions({
   const handleBroadcastToAgents = useCallback(() => {
     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
     useFleetArmingStore.getState().armAll("current");
-    // Avoid a stuck-scope state: if the worktree has no eligible agents, the
-    // ribbon and composer both stay hidden, and the user has no visible exit
-    // from an active but empty fleet scope.
-    if (useFleetArmingStore.getState().armedIds.size === 0) return;
-    void actionService.dispatch("fleet.scope.enter", undefined, { source: "user" });
   }, [worktree.id]);
 
   const handleCopyTree = useCallback(async () => {

--- a/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
@@ -303,7 +303,7 @@ describe("terminalInputActions adversarial", () => {
       return { armAll };
     }
 
-    it("arms current worktree and enters scope when scoped mode is hydrated", async () => {
+    it("arms current worktree but does NOT auto-enter fleet scope (scoped, hydrated)", async () => {
       const { armAll } = setArmed(3);
       fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
         mode: "scoped",
@@ -318,10 +318,10 @@ describe("terminalInputActions adversarial", () => {
       await run("terminal.bulkCommand");
 
       expect(armAll).toHaveBeenCalledWith("current");
-      expect(enterFleetScope).toHaveBeenCalled();
+      expect(enterFleetScope).not.toHaveBeenCalled();
     });
 
-    it("arms current worktree but does NOT enter scope in legacy mode", async () => {
+    it("arms current worktree without entering scope in legacy mode", async () => {
       const { armAll } = setArmed(2);
       fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
         mode: "legacy",
@@ -339,7 +339,7 @@ describe("terminalInputActions adversarial", () => {
       expect(enterFleetScope).not.toHaveBeenCalled();
     });
 
-    it("arms current worktree but does NOT enter scope before hydration", async () => {
+    it("arms current worktree without entering scope before hydration", async () => {
       const { armAll } = setArmed(1);
       fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
         mode: "scoped",

--- a/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
@@ -12,16 +12,6 @@ const bracketedMock = vi.hoisted(() => ({
   formatWithBracketedPaste: vi.fn((t: string) => `<BP>${t}</BP>`),
 }));
 const sendToAgentMock = vi.hoisted(() => ({ openSendToAgentPalette: vi.fn() }));
-const fleetScopeFlagMock = vi.hoisted(() => ({
-  useFleetScopeFlagStore: {
-    getState: vi.fn(() => ({ mode: "legacy", isHydrated: false })),
-  },
-}));
-const worktreeSelectionMock = vi.hoisted(() => ({
-  useWorktreeSelectionStore: {
-    getState: vi.fn(() => ({ enterFleetScope: vi.fn() })),
-  },
-}));
 const terminalInputStoreMock = vi.hoisted(() => ({
   triggerStashInput: vi.fn(),
   triggerPopStash: vi.fn(),
@@ -49,8 +39,6 @@ vi.mock("@/services/terminal/TerminalInstanceService", () => ({
 vi.mock("@/clients", () => ({ terminalClient: terminalClientMock }));
 vi.mock("@shared/utils/terminalInputProtocol", () => bracketedMock);
 vi.mock("@/hooks/useSendToAgentPalette", () => sendToAgentMock);
-vi.mock("@/store/fleetScopeFlagStore", () => fleetScopeFlagMock);
-vi.mock("@/store/worktreeStore", () => worktreeSelectionMock);
 vi.mock("@/store/terminalInputStore", () => terminalInputStoreMock);
 vi.mock("@/store/fleetArmingStore", () => fleetArmingMock);
 vi.mock("@shared/config/panelKindRegistry", () => ({
@@ -294,85 +282,18 @@ describe("terminalInputActions adversarial", () => {
   });
 
   describe("terminal.bulkCommand (fleet broadcast entry)", () => {
-    function setArmed(size: number): { armAll: ReturnType<typeof vi.fn> } {
+    it("arms the current worktree and performs no other store side effects", async () => {
       const armAll = vi.fn();
       fleetArmingMock.useFleetArmingStore.getState.mockReturnValue({
-        armedIds: { size } as Set<string>,
+        armedIds: { size: 3 } as Set<string>,
         armAll,
       } as never);
-      return { armAll };
-    }
-
-    it("arms current worktree but does NOT auto-enter fleet scope (scoped, hydrated)", async () => {
-      const { armAll } = setArmed(3);
-      fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
-        mode: "scoped",
-        isHydrated: true,
-      } as never);
-      const enterFleetScope = vi.fn();
-      worktreeSelectionMock.useWorktreeSelectionStore.getState.mockReturnValue({
-        enterFleetScope,
-      } as never);
 
       const { run } = setupActions();
       await run("terminal.bulkCommand");
 
       expect(armAll).toHaveBeenCalledWith("current");
-      expect(enterFleetScope).not.toHaveBeenCalled();
-    });
-
-    it("arms current worktree without entering scope in legacy mode", async () => {
-      const { armAll } = setArmed(2);
-      fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
-        mode: "legacy",
-        isHydrated: true,
-      } as never);
-      const enterFleetScope = vi.fn();
-      worktreeSelectionMock.useWorktreeSelectionStore.getState.mockReturnValue({
-        enterFleetScope,
-      } as never);
-
-      const { run } = setupActions();
-      await run("terminal.bulkCommand");
-
-      expect(armAll).toHaveBeenCalledWith("current");
-      expect(enterFleetScope).not.toHaveBeenCalled();
-    });
-
-    it("arms current worktree without entering scope before hydration", async () => {
-      const { armAll } = setArmed(1);
-      fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
-        mode: "scoped",
-        isHydrated: false,
-      } as never);
-      const enterFleetScope = vi.fn();
-      worktreeSelectionMock.useWorktreeSelectionStore.getState.mockReturnValue({
-        enterFleetScope,
-      } as never);
-
-      const { run } = setupActions();
-      await run("terminal.bulkCommand");
-
-      expect(armAll).toHaveBeenCalledWith("current");
-      expect(enterFleetScope).not.toHaveBeenCalled();
-    });
-
-    it("does NOT enter scope when the worktree has zero eligible agents", async () => {
-      const { armAll } = setArmed(0);
-      fleetScopeFlagMock.useFleetScopeFlagStore.getState.mockReturnValue({
-        mode: "scoped",
-        isHydrated: true,
-      } as never);
-      const enterFleetScope = vi.fn();
-      worktreeSelectionMock.useWorktreeSelectionStore.getState.mockReturnValue({
-        enterFleetScope,
-      } as never);
-
-      const { run } = setupActions();
-      await run("terminal.bulkCommand");
-
-      expect(armAll).toHaveBeenCalledWith("current");
-      expect(enterFleetScope).not.toHaveBeenCalled();
+      expect(armAll).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -5,9 +5,7 @@ import { openSendToAgentPalette } from "@/hooks/useSendToAgentPalette";
 import { openPanelContextMenu } from "@/lib/panelContextMenu";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
-import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { triggerPopStash, triggerStashInput } from "@/store/terminalInputStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
@@ -157,7 +155,7 @@ export function registerTerminalInputActions(
   actions.set("terminal.bulkCommand", () => ({
     id: "terminal.bulkCommand",
     title: "Fleet: Broadcast",
-    description: "Arm every agent in the current worktree and enter Fleet scope to broadcast",
+    description: "Arm every agent in the current worktree for broadcast",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -165,13 +163,6 @@ export function registerTerminalInputActions(
     keywords: ["broadcast", "fleet", "multi"],
     run: async () => {
       useFleetArmingStore.getState().armAll("current");
-      // Guard against a stuck-scope state when the worktree has no eligible
-      // agents to arm — see useWorktreeActions.handleBroadcastToAgents.
-      if (useFleetArmingStore.getState().armedIds.size === 0) return;
-      const flag = useFleetScopeFlagStore.getState();
-      if (flag.isHydrated && flag.mode === "scoped") {
-        useWorktreeSelectionStore.getState().enterFleetScope();
-      }
     },
   }));
 


### PR DESCRIPTION
## Summary

- Arming a worktree no longer silently forces the whole app into fleet scope. `terminal.bulkCommand` now arms the current worktree's agents without dispatching `fleet.scope.enter`, and `handleBroadcastToAgents` in `useWorktreeActions` no longer does either.
- The cross-worktree flat grid is still there, just reachable as an explicit opt-in via a new "Focus selection" item in the `FleetArmingRibbon` armed menu.
- Selection and layout are now orthogonal: arming is a quiet noun, the fleet view is a deliberate zoom.

Resolves #5746

## Changes

- `terminalInputActions.ts`: removed `fleet.scope.enter` dispatch from `terminal.bulkCommand`
- `useWorktreeActions.ts`: removed auto `fleet.scope.enter` from `handleBroadcastToAgents`
- `FleetArmingRibbon.tsx`: added "Focus selection" `DropdownMenuItem` that explicitly dispatches `fleet.scope.enter` on demand
- `FleetArmingRibbon.test.tsx`: regression test confirming arming via the menu does not flip `isFleetScopeActive`
- `terminalInputActions.adversarial.test.ts`: dropped dead mocks, collapsed redundant cases, aligned with new behaviour

## Testing

47 vitest tests targeted (fleet arming + adversarial input), all passing. Lint: 363 warnings, 0 errors (5 fewer than baseline). Typecheck and prettier clean.