### PR TITLE
feat(multi-select): hover selection handle on pane chrome

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -41,6 +41,7 @@ export interface ContentPanelProps extends BasePanelProps {
   // Slots
   headerContent?: ReactNode;
   headerActions?: ReactNode;
+  selectionControl?: ReactNode;
   toolbar?: ReactNode;
 
   // Container customization
@@ -103,6 +104,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     children,
     headerContent,
     headerActions,
+    selectionControl,
     toolbar,
     className,
     onClick,
@@ -272,7 +274,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
             : undefined),
         }}
         className={cn(
-          "flex flex-col h-full overflow-hidden group",
+          "flex flex-col h-full overflow-hidden group/panel",
           location === "grid" && !isMaximized && "bg-surface",
           (location === "dock" || isMaximized) && "bg-daintree-bg",
           location === "grid" &&
@@ -332,6 +334,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           wasJustSelected={wasJustSelected}
           headerContent={resolvedHeaderContent}
           headerActions={headerActions}
+          selectionControl={selectionControl}
           tabs={tabs}
           groupId={groupId}
           onTabClick={onTabClick}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -109,6 +109,7 @@ export interface PanelHeaderProps {
   // Slots for kind-specific content
   headerContent?: ReactNode;
   headerActions?: ReactNode;
+  selectionControl?: ReactNode;
 
   // Tab support
   tabs?: TabInfo[];
@@ -154,6 +155,7 @@ function PanelHeaderComponent({
   wasJustSelected = false,
   headerContent,
   headerActions,
+  selectionControl,
   tabs,
   groupId,
   onTabClick,
@@ -829,6 +831,9 @@ function PanelHeaderComponent({
       )}
 
       <div className="flex items-center gap-1">
+        {/* Multi-select handle — hover-revealed on eligible panels */}
+        {selectionControl}
+
         {/* Overflow menu — panel management actions */}
         {hasOverflowItems && (
           <TooltipProvider>

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -351,6 +351,34 @@ describe("PanelHeader", () => {
     });
   });
 
+  describe("selectionControl slot", () => {
+    it("renders the selectionControl before the overflow button", () => {
+      render(
+        <PanelHeader
+          {...makeProps({
+            selectionControl: (
+              <button data-testid="fake-select-handle" type="button">
+                select
+              </button>
+            ),
+          })}
+        />
+      );
+      const handle = screen.getByTestId("fake-select-handle");
+      const overflow = screen.getByLabelText("More panel actions");
+      expect(handle).toBeDefined();
+      // DOCUMENT_POSITION_FOLLOWING === 4: overflow follows handle in document order.
+      expect(handle.compareDocumentPosition(overflow) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING
+      );
+    });
+
+    it("renders nothing extra when no selectionControl is provided", () => {
+      render(<PanelHeader {...makeProps()} />);
+      expect(screen.queryByTestId("fake-select-handle")).toBeNull();
+    });
+  });
+
   describe("Collapse to Dock button", () => {
     it("renders when location is dock and onMinimize is provided", () => {
       const onMinimize = vi.fn();

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -1126,7 +1126,7 @@ export function ContentGrid({
                 gridPanelCount={1}
                 gridCols={1}
                 isMaximized={true}
-                orderedEligibleTerminalIds={groupPanels.map((t) => t.id)}
+                orderedEligibleTerminalIds={groupPanels.filter(isFleetArmEligible).map((t) => t.id)}
               />
             </div>
           </div>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { AlertTriangle, RefreshCw, Settings } from "lucide-react";
+import { AlertTriangle, CheckSquare, RefreshCw, Settings, Square } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import type {
   TerminalType,
@@ -56,6 +56,7 @@ const LazyHybridInputBar = lazy(() =>
   import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
 );
 import { getTerminalFocusTarget, shouldSuppressUnfocusedClick } from "./terminalFocus";
+import { decideChromeAction, decideSelectHandleAction } from "./multiSelectGestures";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
@@ -519,43 +520,31 @@ function TerminalPaneComponent({
         return;
       }
 
-      // Multi-select gestures for fleet-eligible agent terminals
-      const terminal = getTerminal(id);
-      const isEligible = terminal && isFleetArmEligible(terminal);
-      const isArmed = armedIds.has(id);
+      // Power-user chrome gestures live alongside focus. Shift-click is
+      // reserved for xterm's native selection-extend; multi-select now lives
+      // on the dedicated handle in the pane header.
+      if (e) {
+        const terminal = getTerminal(id);
+        const isEligible = !!(terminal && isFleetArmEligible(terminal));
+        const action = decideChromeAction(
+          { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey },
+          { isEligible, isArmed: armedIds.has(id) }
+        );
 
-      if (isEligible && e) {
-        const isShiftClick = e.shiftKey;
-        const isToggleClick = e.ctrlKey || e.metaKey;
-
-        if (isShiftClick && orderedEligibleTerminalIds) {
-          // Shift-click: extend selection to clicked terminal
-          const store = useFleetArmingStore.getState();
-          store.extendTo(id, orderedEligibleTerminalIds);
+        if (action.type === "toggle") {
+          useFleetArmingStore.getState().toggleId(id);
           e.preventDefault();
           return;
         }
-
-        if (isToggleClick) {
-          // Cmd/Ctrl-click: toggle selection
-          const store = useFleetArmingStore.getState();
-          store.toggleId(id);
-          e.preventDefault();
-          return;
-        }
-
-        // Plain click on eligible pane
-        if (isArmed) {
-          // Make this the primary selection (update lastArmedId)
-          const store = useFleetArmingStore.getState();
-          store.armId(id);
+        if (action.type === "bump-primary") {
+          useFleetArmingStore.getState().armId(id);
         }
       }
 
       setFocused(id);
       terminalInstanceService.boostRefreshRate(id);
     },
-    [id, setFocused, armedIds, orderedEligibleTerminalIds, getTerminal]
+    [id, setFocused, armedIds, getTerminal]
   );
 
   const handleXtermPointerDownCapture = useCallback(
@@ -697,6 +686,53 @@ function TerminalPaneComponent({
   // Determine panel kind based on agent
   const kind = effectiveAgentId ? "agent" : "terminal";
 
+  // Multi-select handle — hover-revealed button in the pane header chrome.
+  // Plain click toggles; shift-click range-extends using grid visual order.
+  // Only eligible agent terminals in the grid (not dock) show the handle.
+  const terminalForHandle = getTerminal(id);
+  const isFleetEligible = terminalForHandle ? isFleetArmEligible(terminalForHandle) : false;
+  const isArmed = armedIds.has(id);
+  const selectionHandle = useMemo(() => {
+    if (!isFleetEligible || location === "dock") return undefined;
+    const handleSelect = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const action = decideSelectHandleAction(
+        { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey },
+        orderedEligibleTerminalIds
+      );
+      if (action.type === "extend" && orderedEligibleTerminalIds) {
+        useFleetArmingStore.getState().extendTo(id, orderedEligibleTerminalIds);
+      } else {
+        useFleetArmingStore.getState().toggleId(id);
+      }
+    };
+    return (
+      <button
+        type="button"
+        aria-pressed={isArmed}
+        aria-label={isArmed ? `Remove ${title} from selection` : `Add ${title} to selection`}
+        data-testid="panel-select-handle"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={handleSelect}
+        className={cn(
+          "shrink-0 p-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-text/10",
+          "transition-opacity duration-150",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
+          isArmed
+            ? "opacity-100 text-daintree-accent pointer-events-auto"
+            : "opacity-0 pointer-events-none group-hover/panel:opacity-100 group-hover/panel:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+        )}
+      >
+        {isArmed ? (
+          <CheckSquare className="w-3 h-3" aria-hidden="true" />
+        ) : (
+          <Square className="w-3 h-3" aria-hidden="true" />
+        )}
+      </button>
+    );
+  }, [id, title, isFleetEligible, isArmed, location, orderedEligibleTerminalIds]);
+
   const agentHeaderActions = useMemo(() => {
     if (!effectiveAgentId) return undefined;
     const agentConfig = getAgentConfig(effectiveAgentId);
@@ -738,6 +774,7 @@ function TerminalPaneComponent({
       onMinimize={onMinimize}
       onRestore={onRestore}
       headerActions={agentHeaderActions}
+      selectionControl={selectionHandle}
       onRestart={handleRestart}
       isExited={isExited}
       exitCode={exitCode}

--- a/src/components/Terminal/__tests__/multiSelectGestures.test.ts
+++ b/src/components/Terminal/__tests__/multiSelectGestures.test.ts
@@ -32,6 +32,15 @@ describe("decideSelectHandleAction", () => {
       type: "toggle",
     });
   });
+
+  it("shift wins over ⌘/Ctrl when both are held (handle always prefers range-extend)", () => {
+    expect(
+      decideSelectHandleAction({ shiftKey: true, metaKey: true, ctrlKey: false }, ["a", "b"])
+    ).toEqual({ type: "extend" });
+    expect(
+      decideSelectHandleAction({ shiftKey: true, metaKey: false, ctrlKey: true }, ["a", "b"])
+    ).toEqual({ type: "extend" });
+  });
 });
 
 describe("decideChromeAction", () => {
@@ -75,5 +84,20 @@ describe("decideChromeAction", () => {
     expect(
       decideChromeAction({ ...noMods, shiftKey: true }, { isEligible: true, isArmed: true })
     ).toEqual({ type: "bump-primary" });
+  });
+
+  it("⌘/Ctrl wins over shift when both are held (chrome toggle beats xterm selection)", () => {
+    expect(
+      decideChromeAction(
+        { shiftKey: true, metaKey: true, ctrlKey: false },
+        { isEligible: true, isArmed: false }
+      )
+    ).toEqual({ type: "toggle" });
+    expect(
+      decideChromeAction(
+        { shiftKey: true, metaKey: false, ctrlKey: true },
+        { isEligible: true, isArmed: true }
+      )
+    ).toEqual({ type: "toggle" });
   });
 });

--- a/src/components/Terminal/__tests__/multiSelectGestures.test.ts
+++ b/src/components/Terminal/__tests__/multiSelectGestures.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { decideChromeAction, decideSelectHandleAction } from "../multiSelectGestures";
+
+const noMods = { shiftKey: false, metaKey: false, ctrlKey: false };
+
+describe("decideSelectHandleAction", () => {
+  it("plain click toggles the target", () => {
+    expect(decideSelectHandleAction(noMods, ["a", "b"])).toEqual({ type: "toggle" });
+  });
+
+  it("shift-click with an ordered list extends the selection", () => {
+    expect(decideSelectHandleAction({ ...noMods, shiftKey: true }, ["a", "b", "c"])).toEqual({
+      type: "extend",
+    });
+  });
+
+  it("shift-click without an ordered list falls back to toggle", () => {
+    expect(decideSelectHandleAction({ ...noMods, shiftKey: true }, undefined)).toEqual({
+      type: "toggle",
+    });
+  });
+
+  it("shift-click with an empty ordered list falls back to toggle", () => {
+    expect(decideSelectHandleAction({ ...noMods, shiftKey: true }, [])).toEqual({ type: "toggle" });
+  });
+
+  it("⌘/Ctrl on the handle are treated as plain toggle (no modifier semantics on the handle)", () => {
+    expect(decideSelectHandleAction({ ...noMods, metaKey: true }, ["a"])).toEqual({
+      type: "toggle",
+    });
+    expect(decideSelectHandleAction({ ...noMods, ctrlKey: true }, ["a"])).toEqual({
+      type: "toggle",
+    });
+  });
+});
+
+describe("decideChromeAction", () => {
+  it("returns none for ineligible panes regardless of modifiers", () => {
+    expect(
+      decideChromeAction({ ...noMods, metaKey: true }, { isEligible: false, isArmed: true })
+    ).toEqual({ type: "none" });
+    expect(
+      decideChromeAction({ ...noMods, shiftKey: true }, { isEligible: false, isArmed: false })
+    ).toEqual({ type: "none" });
+  });
+
+  it("⌘-click on an eligible pane toggles fleet selection", () => {
+    expect(
+      decideChromeAction({ ...noMods, metaKey: true }, { isEligible: true, isArmed: false })
+    ).toEqual({ type: "toggle" });
+  });
+
+  it("Ctrl-click on an eligible pane toggles fleet selection", () => {
+    expect(
+      decideChromeAction({ ...noMods, ctrlKey: true }, { isEligible: true, isArmed: false })
+    ).toEqual({ type: "toggle" });
+  });
+
+  it("plain click on an armed eligible pane bumps the primary anchor", () => {
+    expect(decideChromeAction(noMods, { isEligible: true, isArmed: true })).toEqual({
+      type: "bump-primary",
+    });
+  });
+
+  it("plain click on an unarmed eligible pane does nothing special (caller focuses)", () => {
+    expect(decideChromeAction(noMods, { isEligible: true, isArmed: false })).toEqual({
+      type: "none",
+    });
+  });
+
+  it("shift-click on chrome no longer mutates fleet selection (reserved for xterm)", () => {
+    expect(
+      decideChromeAction({ ...noMods, shiftKey: true }, { isEligible: true, isArmed: false })
+    ).toEqual({ type: "none" });
+    expect(
+      decideChromeAction({ ...noMods, shiftKey: true }, { isEligible: true, isArmed: true })
+    ).toEqual({ type: "bump-primary" });
+  });
+});

--- a/src/components/Terminal/multiSelectGestures.ts
+++ b/src/components/Terminal/multiSelectGestures.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers that decide how fleet multi-select gestures resolve for a
+ * terminal pane. The UI layer (TerminalPane) reads the decision and dispatches
+ * to `fleetArmingStore`. Keeping the logic pure lets us test each gesture path
+ * without mounting the full pane.
+ */
+
+export interface GestureModifiers {
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
+
+export type SelectHandleAction = { type: "toggle" } | { type: "extend" };
+
+export type ChromeAction = { type: "toggle" } | { type: "bump-primary" } | { type: "none" };
+
+/**
+ * Resolve a click on the dedicated selection handle button.
+ *
+ * - Shift-click (with a non-empty `orderedEligibleIds` list) extends the
+ *   current selection to the target using grid visual order.
+ * - All other clicks toggle the target.
+ *
+ * The handle is only rendered for eligible panels, so there's no eligibility
+ * gate here — the caller has already decided.
+ */
+export function decideSelectHandleAction(
+  modifiers: GestureModifiers,
+  orderedEligibleIds: string[] | undefined
+): SelectHandleAction {
+  if (modifiers.shiftKey && orderedEligibleIds && orderedEligibleIds.length > 0) {
+    return { type: "extend" };
+  }
+  return { type: "toggle" };
+}
+
+/**
+ * Resolve a click on the pane chrome (the container surface handled by
+ * `ContentPanel.onClick`, which flows through `TerminalPane.handleClick`).
+ *
+ * - Cmd/Ctrl-click on an eligible pane toggles fleet selection (power-user
+ *   shortcut retained after the rework).
+ * - Plain click on an already-armed eligible pane bumps the primary-selection
+ *   anchor so subsequent shift-clicks on handles range-extend from here.
+ * - Everything else is a normal focus click (caller handles it).
+ *
+ * Shift-click on chrome is deliberately NOT a fleet gesture — that slot is
+ * reserved for xterm's native selection-extend. See issue #5748.
+ */
+export function decideChromeAction(
+  modifiers: GestureModifiers,
+  options: { isEligible: boolean; isArmed: boolean }
+): ChromeAction {
+  if (!options.isEligible) return { type: "none" };
+  if (modifiers.metaKey || modifiers.ctrlKey) return { type: "toggle" };
+  if (options.isArmed) return { type: "bump-primary" };
+  return { type: "none" };
+}


### PR DESCRIPTION
## Summary

- Adds a hover-revealed selection handle (checkbox) to each pane's title bar, following the Material 3 / Linear / Notion card-grid pattern for discoverable multi-select
- Removes the shift-click gesture collision with xterm's native text selection by reserving shift-click on pane content for xterm; the handle carries range-extend instead
- Retains cmd-click on pane chrome as a power-user toggle for those who know it

Resolves #5748

## Changes

- `multiSelectGestures.ts` — new module encapsulating the gesture logic: click-to-toggle, shift-click range-extend (reuses `orderedEligibleTerminalIds`), cmd-click chrome toggle
- `TerminalPane.tsx` — integrates gesture handlers; shift-click on pane content no longer touches the arming set
- `PanelHeader.tsx` — renders the hover-revealed selection checkbox, positioned next to the existing "More actions" button
- `ContentPanel.tsx` — threads `orderedEligibleTerminalIds` and selection state through to the pane header
- `ContentGrid.tsx` — minor fix to filter ineligible panels from maximized tab-group range extension
- Unit tests for gesture module and panel header selection handle

## Testing

- Gesture unit tests cover click-toggle, shift-click range-extend, cmd-click, and the maximized tab-group boundary case
- Panel header tests confirm the handle renders and responds correctly to selection state
- Manually verified that xterm text selection (shift-click on content) is unaffected by the new gestures