### PR TITLE
feat(fleet): live per-character broadcast to armed terminals

### DIFF
--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -1,28 +1,17 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type ReactElement,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
-import { useCommandHistoryStore } from "@/store/commandHistoryStore";
-import { useNotificationStore } from "@/store/notificationStore";
-import { useProjectStore } from "@/store/projectStore";
 import { logWarn } from "@/utils/logger";
+import { useNotificationStore } from "@/store/notificationStore";
 import {
-  getFleetBroadcastHistoryKey,
   getFleetBroadcastWarnings,
-  needsFleetBroadcastConfirmation,
   resolveFleetBroadcastTargetIds,
 } from "./fleetBroadcast";
-import { executeFleetBroadcast } from "./fleetExecution";
+import { broadcastFleetLiteralPaste } from "./fleetExecution";
 import { registerFleetComposerFocusHandler } from "./fleetComposerFocus";
+import { useFleetLiveKeyCapture } from "./useFleetLiveKeyCapture";
 
 interface WarningReason {
   key: "destructive" | "overByteLimit" | "multiline";
@@ -40,27 +29,13 @@ function describeWarnings(text: string): WarningReason[] {
 
 export function FleetComposer(): ReactElement | null {
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
-  const { draft, setDraft, clearDraft } = useFleetComposerStore(
-    useShallow((s) => ({
-      draft: s.draft,
-      setDraft: s.setDraft,
-      clearDraft: s.clearDraft,
-    }))
-  );
-
-  const projectId = useProjectStore((s) => s.currentProject?.id);
-  const historyKey = getFleetBroadcastHistoryKey(projectId);
-
-  const historyEntries = useCommandHistoryStore(useShallow((s) => s.getProjectHistory(historyKey)));
+  const { draft } = useFleetComposerStore(useShallow((s) => ({ draft: s.draft })));
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
-  const historySnapshotRef = useRef<string>("");
-  const submittingRef = useRef<boolean>(false);
 
-  const [isConfirming, setIsConfirming] = useState(false);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [historyIndex, setHistoryIndex] = useState(-1);
+  const [pendingPaste, setPendingPaste] = useState<string | null>(null);
+  const [isSendingPaste, setIsSendingPaste] = useState(false);
 
   useEffect(() => {
     const unregister = registerFleetComposerFocusHandler(() => {
@@ -72,160 +47,92 @@ export function FleetComposer(): ReactElement | null {
   }, []);
 
   useEffect(() => {
-    if (isConfirming) {
+    if (pendingPaste !== null) {
       cancelButtonRef.current?.focus();
     }
-  }, [isConfirming]);
+  }, [pendingPaste]);
 
-  const warningReasons = useMemo(() => describeWarnings(draft), [draft]);
+  const handlePasteConfirm = useCallback((text: string) => {
+    setPendingPaste(text);
+  }, []);
 
-  const handleSubmit = useCallback(
-    async (options: { force?: boolean } = {}) => {
-      const { force = false } = options;
-      if (submittingRef.current) return;
+  useFleetLiveKeyCapture({
+    textareaRef,
+    enabled: armedCount > 0,
+    onPasteConfirm: handlePasteConfirm,
+  });
 
-      const currentDraft = useFleetComposerStore.getState().draft;
-      if (currentDraft.trim() === "") return;
+  const typedWarnings = useMemo(() => describeWarnings(draft), [draft]);
+  const pasteWarnings = useMemo(
+    () => (pendingPaste !== null ? describeWarnings(pendingPaste) : []),
+    [pendingPaste]
+  );
 
-      if (!force && needsFleetBroadcastConfirmation(currentDraft)) {
-        setIsConfirming(true);
-        return;
-      }
+  const visibleWarnings = pendingPaste !== null ? pasteWarnings : typedWarnings;
 
-      submittingRef.current = true;
-      setIsConfirming(false);
-      setIsSubmitting(true);
+  const cancelPendingPaste = useCallback(() => {
+    setPendingPaste(null);
+    textareaRef.current?.focus();
+  }, []);
 
-      try {
-        const resolvedTargetIds = resolveFleetBroadcastTargetIds();
-        if (resolvedTargetIds.length === 0) {
-          useNotificationStore.getState().addNotification({
-            type: "warning",
-            priority: "low",
-            message: "No armed agents available to send to",
-          });
-          return;
-        }
-
-        const result = await executeFleetBroadcast(currentDraft, resolvedTargetIds);
-
-        if (result.failureCount > 0) {
-          logWarn("[FleetComposer] broadcast submit had rejections", {
-            failureCount: result.failureCount,
-            failedIds: result.failedIds,
-          });
-        }
-
+  const confirmPendingPaste = useCallback(async () => {
+    const text = pendingPaste;
+    if (text == null || isSendingPaste) return;
+    setIsSendingPaste(true);
+    try {
+      const targets = resolveFleetBroadcastTargetIds();
+      if (targets.length === 0) {
         useNotificationStore.getState().addNotification({
-          type: result.successCount > 0 ? "success" : "warning",
+          type: "warning",
           priority: "low",
-          message:
-            result.failureCount > 0
-              ? `Sent to ${result.successCount} agent${result.successCount === 1 ? "" : "s"} (${result.failureCount} failed)`
-              : `Sent to ${result.successCount} agent${result.successCount === 1 ? "" : "s"}`,
+          message: "No armed agents available to send to",
         });
+        return;
+      }
 
-        if (result.successCount > 0) {
-          const armedIds = Array.from(useFleetArmingStore.getState().armedIds);
-          useCommandHistoryStore
-            .getState()
-            .recordPrompt(historyKey, currentDraft, null, { armedIds });
-          if (useFleetComposerStore.getState().draft === currentDraft) {
-            clearDraft();
-          }
-          setHistoryIndex(-1);
-          historySnapshotRef.current = "";
-        }
-      } catch (e) {
-        useNotificationStore.getState().addNotification({
-          type: "error",
-          priority: "high",
-          message: "Broadcast failed unexpectedly",
+      const { draft: currentDraft, setDraft } = useFleetComposerStore.getState();
+      setDraft(currentDraft + text);
+
+      const result = await broadcastFleetLiteralPaste(text, targets);
+      if (result.failureCount > 0) {
+        logWarn("[FleetComposer] paste broadcast had rejections", {
+          failureCount: result.failureCount,
+          failedIds: result.failedIds,
         });
-        throw e;
-      } finally {
-        submittingRef.current = false;
-        setIsSubmitting(false);
-      }
-    },
-    [clearDraft, historyKey]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.nativeEvent.isComposing) return;
-
-      if (e.key === "Escape") {
-        if (draft.length > 0) {
-          e.preventDefault();
-          e.stopPropagation();
-          clearDraft();
-          setHistoryIndex(-1);
-          historySnapshotRef.current = "";
-        }
-        return;
       }
 
-      if (e.key === "Enter") {
-        if (e.shiftKey) return; // newline passthrough
-        e.preventDefault();
-        const force = e.metaKey || e.ctrlKey;
-        void handleSubmit({ force });
-        return;
-      }
-
-      if (e.key === "ArrowUp") {
-        if (historyEntries.length === 0) return;
-        const target = e.currentTarget;
-        if (historyIndex === -1 && (target.selectionStart !== 0 || target.selectionEnd !== 0))
-          return;
-        e.preventDefault();
-        if (historyIndex === -1) {
-          historySnapshotRef.current = draft;
-        }
-        const next = Math.min(historyIndex + 1, historyEntries.length - 1);
-        setHistoryIndex(next);
-        const entry = historyEntries[next]!;
-        setDraft(entry.prompt);
-        // Shift+ArrowUp: also recall the armed IDs from this history entry
-        if (e.shiftKey && entry.armedIds && entry.armedIds.length > 0) {
-          useFleetArmingStore.getState().armIds(entry.armedIds);
-        }
-        return;
-      }
-
-      if (e.key === "ArrowDown") {
-        if (historyIndex < 0) return;
-        e.preventDefault();
-        const next = historyIndex - 1;
-        setHistoryIndex(next);
-        if (next < 0) {
-          setDraft(historySnapshotRef.current);
-          historySnapshotRef.current = "";
-        } else {
-          setDraft(historyEntries[next]!.prompt);
-        }
-      }
-    },
-    [clearDraft, draft, handleSubmit, historyEntries, historyIndex, setDraft]
-  );
-
-  const handleConfirmStripKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsConfirming(false);
+      useNotificationStore.getState().addNotification({
+        type: result.successCount > 0 ? "success" : "warning",
+        priority: "low",
+        message:
+          result.failureCount > 0
+            ? `Sent to ${result.successCount} agent${result.successCount === 1 ? "" : "s"} (${result.failureCount} failed)`
+            : `Sent to ${result.successCount} agent${result.successCount === 1 ? "" : "s"}`,
+      });
+    } finally {
+      setIsSendingPaste(false);
+      setPendingPaste(null);
       textareaRef.current?.focus();
     }
-  }, []);
+  }, [pendingPaste, isSendingPaste]);
+
+  const handleConfirmStripKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        cancelPendingPaste();
+      }
+    },
+    [cancelPendingPaste]
+  );
 
   if (armedCount === 0) return null;
 
-  const sendLabel = isSubmitting ? "Sending…" : "Send";
-  const placeholderBase =
+  const placeholder =
     armedCount === 1
-      ? "Broadcast to 1 armed agent (Enter to send)"
-      : `Broadcast to ${armedCount} armed agents (Enter to send)`;
+      ? "Live broadcast — keys reach 1 armed agent immediately"
+      : `Live broadcast — keys reach ${armedCount} armed agents immediately`;
 
   return (
     <div
@@ -236,71 +143,64 @@ export function FleetComposer(): ReactElement | null {
         <textarea
           ref={textareaRef}
           value={draft}
-          onChange={(e) => {
-            setDraft(e.target.value);
-            if (historyIndex !== -1) {
-              setHistoryIndex(-1);
-              historySnapshotRef.current = "";
-            }
-          }}
-          onKeyDown={handleKeyDown}
-          placeholder={placeholderBase}
+          readOnly
+          placeholder={placeholder}
           rows={1}
-          inert={isConfirming ? true : undefined}
-          aria-label="Broadcast to armed agents"
+          aria-label="Live broadcast to armed agents"
           data-testid="fleet-composer-textarea"
+          data-live="true"
           className={cn(
             "flex-1 resize-none rounded-[var(--radius-md)] border border-daintree-border bg-daintree-sidebar px-2 py-1 text-[12px] text-daintree-text",
             "placeholder:italic placeholder:text-daintree-text/40",
             "focus:border-daintree-accent focus:outline-none focus:ring-1 focus:ring-daintree-accent/30",
-            "min-h-[28px] max-h-[140px] overflow-y-auto"
+            "min-h-[28px] max-h-[140px] overflow-y-auto cursor-text"
           )}
         />
-        <button
-          type="button"
-          onClick={() => void handleSubmit({ force: false })}
-          disabled={draft.trim().length === 0 || isSubmitting}
-          data-testid="fleet-composer-send"
-          className="shrink-0 rounded-[var(--radius-md)] bg-daintree-accent px-2.5 py-1 text-[11px] text-text-inverse transition-colors hover:bg-daintree-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
-          aria-label="Send broadcast"
+        <span
+          data-testid="fleet-composer-live-indicator"
+          aria-hidden="true"
+          className="shrink-0 select-none rounded-[var(--radius-md)] bg-daintree-accent/15 px-2 py-1 text-[11px] font-medium text-daintree-accent"
         >
-          {sendLabel}
-        </button>
+          Live
+        </span>
       </div>
-      {isConfirming && (
+      {visibleWarnings.length > 0 && (
         <div
-          role="status"
+          role={pendingPaste !== null ? "alertdialog" : "status"}
           aria-live="polite"
           aria-atomic="true"
           data-testid="fleet-composer-confirm"
+          data-mode={pendingPaste !== null ? "paste-confirm" : "passive"}
           onKeyDown={handleConfirmStripKeyDown}
           className="flex items-center gap-2 rounded-[var(--radius-md)] border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200"
         >
           <span className="flex-1">
-            Send to {armedCount} agent{armedCount === 1 ? "" : "s"} —{" "}
-            {warningReasons.map((r) => r.label).join(", ")}?
+            {pendingPaste !== null
+              ? `Paste to ${armedCount} agent${armedCount === 1 ? "" : "s"} — ${visibleWarnings.map((r) => r.label).join(", ")}?`
+              : visibleWarnings.map((r) => r.label).join(", ")}
           </span>
-          <button
-            type="button"
-            ref={cancelButtonRef}
-            onClick={() => {
-              setIsConfirming(false);
-              textareaRef.current?.focus();
-            }}
-            data-testid="fleet-composer-confirm-cancel"
-            className="rounded-[var(--radius-md)] px-2 py-0.5 text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            disabled={isSubmitting}
-            onClick={() => void handleSubmit({ force: true })}
-            data-testid="fleet-composer-confirm-send"
-            className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            Send anyway
-          </button>
+          {pendingPaste !== null && (
+            <>
+              <button
+                type="button"
+                ref={cancelButtonRef}
+                onClick={cancelPendingPaste}
+                data-testid="fleet-composer-confirm-cancel"
+                className="rounded-[var(--radius-md)] px-2 py-0.5 text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={isSendingPaste}
+                onClick={() => void confirmPendingPaste()}
+                data-testid="fleet-composer-confirm-send"
+                className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Send anyway
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -5,10 +5,7 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
 import { logWarn } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
-import {
-  getFleetBroadcastWarnings,
-  resolveFleetBroadcastTargetIds,
-} from "./fleetBroadcast";
+import { getFleetBroadcastWarnings, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
 import { broadcastFleetLiteralPaste } from "./fleetExecution";
 import { registerFleetComposerFocusHandler } from "./fleetComposerFocus";
 import { useFleetLiveKeyCapture } from "./useFleetLiveKeyCapture";

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -6,13 +6,12 @@ import { FleetComposer } from "../FleetComposer";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
-import { useCommandHistoryStore } from "@/store/commandHistoryStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { setCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
-import { FLEET_BROADCAST_HISTORY_KEY } from "../fleetBroadcast";
 import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
 
+const writeMock = vi.fn<(id: string, data: string) => void>();
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
 
 vi.mock("@/clients", async (importOriginal) => {
@@ -21,6 +20,7 @@ vi.mock("@/clients", async (importOriginal) => {
     ...actual,
     terminalClient: {
       ...actual.terminalClient,
+      write: (id: string, data: string) => writeMock(id, data),
       submit: (id: string, text: string) => submitMock(id, text),
     },
   };
@@ -85,7 +85,6 @@ function resetAll(worktreeId = "wt-1") {
   });
   useFleetComposerStore.setState({ draft: "" });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
-  useCommandHistoryStore.setState({ history: {} });
   useNotificationStore.setState({ notifications: [] });
 
   const worktrees = new Map<string, WorktreeSnapshot>();
@@ -107,8 +106,33 @@ function armTwo() {
   useFleetArmingStore.getState().armIds(["t1", "t2"]);
 }
 
-describe("FleetComposer", () => {
+function dispatchKeyDown(
+  el: HTMLElement,
+  init: KeyboardEventInit & { keyCode?: number }
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  if (typeof init.keyCode === "number") {
+    Object.defineProperty(event, "keyCode", { value: init.keyCode });
+  }
+  el.dispatchEvent(event);
+  return event;
+}
+
+function writesByTarget(): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const [id, seq] of writeMock.mock.calls) {
+    (out[id] ??= []).push(seq);
+  }
+  return out;
+}
+
+describe("FleetComposer (live keystroke capture)", () => {
   beforeEach(() => {
+    writeMock.mockReset();
     submitMock.mockReset();
     submitMock.mockResolvedValue(undefined);
     resetAll();
@@ -130,280 +154,299 @@ describe("FleetComposer", () => {
     expect(document.activeElement).not.toBe(textarea);
   });
 
-  it("submits on plain Enter to all armed targets", async () => {
+  it("shows a Live indicator instead of a Send button", () => {
     armTwo();
     render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "run tests" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    expect(submitMock.mock.calls.map(([id]) => id).sort()).toEqual(["t1", "t2"]);
-    expect(submitMock.mock.calls[0]![1]).toBe("run tests");
+    expect(screen.getByTestId("fleet-composer-live-indicator")).toBeTruthy();
+    expect(screen.queryByTestId("fleet-composer-send")).toBeNull();
   });
 
-  it("does not submit while IME is composing", () => {
+  it("forwards a printable character to every armed target", () => {
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
 
-    fireEvent.change(textarea, { target: { value: "中文" } });
-    // React synthetic event exposes nativeEvent.isComposing.
-    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+    dispatchKeyDown(textarea, { key: "a" });
 
-    expect(submitMock).not.toHaveBeenCalled();
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writesByTarget()).toEqual({ t1: ["a"], t2: ["a"] });
+    expect(useFleetComposerStore.getState().draft).toBe("a");
   });
 
-  it("Shift+Enter does not submit and does not prevent default (newline passes through)", () => {
+  it("forwards Enter as \\r without opening a submit/confirm flow", () => {
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
 
-    fireEvent.change(textarea, { target: { value: "line 1" } });
-    const e = fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    dispatchKeyDown(textarea, { key: "Enter" });
 
+    expect(writesByTarget()).toEqual({ t1: ["\r"], t2: ["\r"] });
     expect(submitMock).not.toHaveBeenCalled();
-    expect(e).toBe(true); // default not prevented
+    // Newline reflected in visible draft for legibility.
+    expect(useFleetComposerStore.getState().draft).toBe("\n");
   });
 
-  it("opens confirmation strip for multi-line text and does not send", () => {
+  it("forwards Backspace as \\x7f and pops the last visible character", () => {
+    armTwo();
+    useFleetComposerStore.setState({ draft: "abc" });
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "Backspace" });
+
+    expect(writesByTarget()).toEqual({ t1: ["\x7f"], t2: ["\x7f"] });
+    expect(useFleetComposerStore.getState().draft).toBe("ab");
+  });
+
+  it("forwards Tab as \\t and prevents focus movement", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    textarea.focus();
+
+    const event = dispatchKeyDown(textarea, { key: "Tab" });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(writesByTarget()).toEqual({ t1: ["\t"], t2: ["\t"] });
+  });
+
+  it("forwards Esc as \\x1b and does NOT clear the draft", () => {
+    armTwo();
+    useFleetComposerStore.setState({ draft: "typing" });
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "Escape" });
+
+    expect(writesByTarget()).toEqual({ t1: ["\x1b"], t2: ["\x1b"] });
+    expect(useFleetComposerStore.getState().draft).toBe("typing");
+  });
+
+  it.each([
+    ["ArrowUp", "\x1b[A"],
+    ["ArrowDown", "\x1b[B"],
+    ["ArrowRight", "\x1b[C"],
+    ["ArrowLeft", "\x1b[D"],
+    ["Home", "\x1b[H"],
+    ["End", "\x1b[F"],
+    ["Delete", "\x1b[3~"],
+    ["PageUp", "\x1b[5~"],
+    ["PageDown", "\x1b[6~"],
+  ])("forwards %s as the expected CSI sequence", (key, expectedSeq) => {
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
 
-    fireEvent.change(textarea, { target: { value: "one\ntwo" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
+    dispatchKeyDown(textarea, { key });
 
-    expect(submitMock).not.toHaveBeenCalled();
+    expect(writesByTarget()).toEqual({ t1: [expectedSeq], t2: [expectedSeq] });
+  });
+
+  it("forwards Ctrl+C as 0x03 and other control chars correctly", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "c", ctrlKey: true });
+    dispatchKeyDown(textarea, { key: "d", ctrlKey: true });
+
+    const byTarget = writesByTarget();
+    expect(byTarget.t1).toEqual(["\x03", "\x04"]);
+    expect(byTarget.t2).toEqual(["\x03", "\x04"]);
+  });
+
+  it("does NOT forward when IME composition is active", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "Process", keyCode: 229 });
+    dispatchKeyDown(textarea, { key: "a", isComposing: true });
+
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards finalized composed text on compositionend and appends to draft", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    // Keydown during composition — must be suppressed.
+    dispatchKeyDown(textarea, { key: "Enter", isComposing: true });
+    fireEvent.compositionEnd(textarea, { data: "中文" });
+
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writesByTarget()).toEqual({ t1: ["中文"], t2: ["中文"] });
+    expect(useFleetComposerStore.getState().draft).toBe("中文");
+  });
+
+  it("ignores Cmd-modified keys so browser shortcuts (Cmd+C/V) are untouched", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "c", metaKey: true });
+    dispatchKeyDown(textarea, { key: "v", metaKey: true });
+
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it("skips modifier-only keydown presses", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "Shift" });
+    dispatchKeyDown(textarea, { key: "Control" });
+    dispatchKeyDown(textarea, { key: "Alt" });
+    dispatchKeyDown(textarea, { key: "Meta" });
+
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it("re-resolves targets per keystroke so trashed terminals drop out silently", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    dispatchKeyDown(textarea, { key: "a" });
+    // Now trash t2 mid-stream.
+    usePanelStore.setState({
+      panelsById: {
+        t1: makeAgent("t1"),
+        t2: makeAgent("t2", { location: "trash" }),
+      },
+    });
+    dispatchKeyDown(textarea, { key: "b" });
+
+    expect(writeMock).toHaveBeenCalledTimes(3);
+    expect(writesByTarget()).toEqual({ t1: ["a", "b"], t2: ["a"] });
+  });
+
+  it("shows a passive destructive warning while streaming chars through", () => {
+    armTwo();
+    useFleetComposerStore.setState({ draft: "rm -rf node_modules" });
+    render(<FleetComposer />);
+
     const strip = screen.getByTestId("fleet-composer-confirm");
-    expect(strip).toBeTruthy();
+    expect(strip.getAttribute("data-mode")).toBe("passive");
     expect(strip.getAttribute("role")).toBe("status");
-    expect(strip.getAttribute("aria-live")).toBe("polite");
-    expect(strip.getAttribute("aria-atomic")).toBe("true");
+    expect(screen.queryByTestId("fleet-composer-confirm-send")).toBeNull();
   });
 
-  it("opens confirmation strip for destructive command", () => {
+  it("backspacing through the destructive pattern hides the warning", async () => {
+    armTwo();
+    useFleetComposerStore.setState({ draft: "rm -rf " });
+    render(<FleetComposer />);
+    expect(screen.getByTestId("fleet-composer-confirm")).toBeTruthy();
+
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    // Four backspaces defuse "rm -rf " down to "rm ".
+    for (let i = 0; i < 4; i++) dispatchKeyDown(textarea, { key: "Backspace" });
+
+    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe("rm "));
+    await waitFor(() => expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull());
+  });
+
+  it("benign paste submits atomically via bracketed-paste and appends to draft", () => {
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
 
-    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "hello" : ""),
+      },
+    });
+
+    expect(submitMock).toHaveBeenCalledTimes(2);
+    expect(submitMock.mock.calls.map(([id]) => id).sort()).toEqual(["t1", "t2"]);
+    expect(submitMock.mock.calls[0]![1]).toBe("hello");
+    expect(writeMock).not.toHaveBeenCalled();
+    expect(useFleetComposerStore.getState().draft).toBe("hello");
+  });
+
+  it("destructive paste opens the confirm strip and does NOT submit until confirmed", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "rm -rf dist" : ""),
+      },
+    });
 
     expect(submitMock).not.toHaveBeenCalled();
-    expect(screen.getByTestId("fleet-composer-confirm")).toBeTruthy();
-  });
+    const strip = await screen.findByTestId("fleet-composer-confirm");
+    expect(strip.getAttribute("data-mode")).toBe("paste-confirm");
+    expect(strip.getAttribute("role")).toBe("alertdialog");
 
-  it("Cmd+Enter bypasses confirmation and force-sends", async () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
-    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    const confirm = screen.getByTestId("fleet-composer-confirm-send");
+    fireEvent.click(confirm);
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    expect(submitMock.mock.calls[0]![1]).toBe("rm -rf node_modules");
+    expect(submitMock.mock.calls[0]![1]).toBe("rm -rf dist");
+    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe("rm -rf dist"));
+    // After confirming, the paste strip closes but the typed-draft warning stays passive
+    // because the draft now contains "rm -rf dist" — so the strip should flip to passive mode.
+    await waitFor(() => {
+      const strip = screen.queryByTestId("fleet-composer-confirm");
+      expect(strip?.getAttribute("data-mode")).toBe("passive");
+    });
   });
 
-  it("Ctrl+Enter also force-sends (Windows/Linux parity)", async () => {
+  it("cancelling a pending paste drops the payload and keeps the draft untouched", async () => {
+    armTwo();
+    useFleetComposerStore.setState({ draft: "before" });
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "rm -rf /" : ""),
+      },
+    });
+
+    fireEvent.click(await screen.findByTestId("fleet-composer-confirm-cancel"));
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(useFleetComposerStore.getState().draft).toBe("before");
+    expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
+  });
+
+  it("Escape inside a pending paste strip cancels the paste", async () => {
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
 
-    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
-    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "sudo shutdown now" : ""),
+      },
+    });
+    const strip = await screen.findByTestId("fleet-composer-confirm");
+    fireEvent.keyDown(strip, { key: "Escape" });
 
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-  });
-
-  it("Cancel in confirmation strip returns focus to textarea and does not send", async () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "line1\nline2" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    const cancel = screen.getByTestId("fleet-composer-confirm-cancel");
-    expect(document.activeElement).toBe(cancel);
-
-    fireEvent.click(cancel);
     expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
     expect(submitMock).not.toHaveBeenCalled();
-    expect(useFleetComposerStore.getState().draft).toBe("line1\nline2");
-    expect(document.activeElement).toBe(textarea);
   });
 
-  it("Send anyway in confirmation strip submits to all armed targets", async () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "line1\nline2" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    fireEvent.click(screen.getByTestId("fleet-composer-confirm-send"));
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-  });
-
-  it("Escape with non-empty draft clears draft and stops propagation", () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "typing" } });
-    const result = fireEvent.keyDown(textarea, { key: "Escape" });
-
-    expect(useFleetComposerStore.getState().draft).toBe("");
-    expect(result).toBe(false); // preventDefault was called
-  });
-
-  it("Escape with empty draft does NOT stop propagation (bubbles to arming)", () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    const result = fireEvent.keyDown(textarea, { key: "Escape" });
-    expect(result).toBe(true); // default not prevented — bubbles through
-  });
-
-  it("ArrowUp at caret 0 walks history backward", () => {
-    armTwo();
-    useCommandHistoryStore.setState({
-      history: {
-        [FLEET_BROADCAST_HISTORY_KEY]: [
-          { id: "1", prompt: "newer", agentId: null, addedAt: 2 },
-          { id: "2", prompt: "older", agentId: null, addedAt: 1 },
-        ],
-      },
-    });
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    textarea.setSelectionRange(0, 0);
-
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(useFleetComposerStore.getState().draft).toBe("newer");
-
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(useFleetComposerStore.getState().draft).toBe("older");
-  });
-
-  it("ArrowDown restores the unsent snapshot when walking past the newest entry", () => {
-    armTwo();
-    useCommandHistoryStore.setState({
-      history: {
-        [FLEET_BROADCAST_HISTORY_KEY]: [{ id: "1", prompt: "earlier", agentId: null, addedAt: 1 }],
-      },
-    });
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "unsent draft" } });
-    textarea.setSelectionRange(0, 0);
-    fireEvent.keyDown(textarea, { key: "ArrowUp" });
-    expect(useFleetComposerStore.getState().draft).toBe("earlier");
-
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-    fireEvent.keyDown(textarea, { key: "ArrowDown" });
-    expect(useFleetComposerStore.getState().draft).toBe("unsent draft");
-  });
-
-  it("records history and clears draft after successful send", async () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "run tests" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe(""));
-
-    const history = useCommandHistoryStore
-      .getState()
-      .getProjectHistory(FLEET_BROADCAST_HISTORY_KEY);
-    expect(history.map((h) => h.prompt)).toContain("run tests");
-  });
-
-  it("resolves {{branch_name}} variable per-terminal before submit", async () => {
-    usePanelStore.setState({
-      panelsById: {
-        a: makeAgent("a", { worktreeId: "wt-1" }),
-        b: makeAgent("b", { worktreeId: "wt-2" }),
-      },
-      panelIds: ["a", "b"],
-    });
-    const worktrees = new Map<string, WorktreeSnapshot>();
-    worktrees.set("wt-1", makeWorktree("wt-1", { branch: "feature/x", path: "/w/1" }));
-    worktrees.set("wt-2", makeWorktree("wt-2", { branch: "feature/y", path: "/w/2" }));
-    installViewStore(worktrees);
-    useFleetArmingStore.getState().armIds(["a", "b"]);
-
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "checkout {{branch_name}}" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    const byId = Object.fromEntries(submitMock.mock.calls.map(([id, text]) => [id, text]));
-    expect(byId.a).toBe("checkout feature/x");
-    expect(byId.b).toBe("checkout feature/y");
-  });
-
-  it("drops silently-exited targets at submit time and toasts the actual count", async () => {
-    usePanelStore.setState({
-      panelsById: {
-        a: makeAgent("a"),
-        dead: makeAgent("dead", { location: "trash" }),
-      },
-      panelIds: ["a", "dead"],
-    });
-    useFleetArmingStore.getState().armIds(["a", "dead"]);
-
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "hello" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0]![0]).toBe("a");
-    await waitFor(() => {
-      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
-      expect(last).toBe("Sent to 1 agent");
-    });
-  });
-
-  it("does NOT clear draft when no live targets remain at submit", async () => {
-    usePanelStore.setState({
-      panelsById: { dead: makeAgent("dead", { location: "trash" }) },
-      panelIds: ["dead"],
-    });
-    useFleetArmingStore.getState().armIds(["dead"]);
-
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "please keep" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    // allow microtasks to flush
-    await act(async () => {
-      await Promise.resolve();
-    });
-    expect(submitMock).not.toHaveBeenCalled();
-    expect(useFleetComposerStore.getState().draft).toBe("please keep");
-  });
-
-  it("partial failure surfaces the correct toast count", async () => {
+  it("partial paste failure surfaces the correct toast count", async () => {
     submitMock.mockReset();
     submitMock.mockImplementationOnce(() => Promise.resolve());
     submitMock.mockImplementationOnce(() => Promise.reject(new Error("boom")));
     armTwo();
     render(<FleetComposer />);
     const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "x" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "rm -rf x" : ""),
+      },
+    });
+    fireEvent.click(await screen.findByTestId("fleet-composer-confirm-send"));
 
     await waitFor(() => {
       const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
@@ -413,155 +456,13 @@ describe("FleetComposer", () => {
 
   it("auto-clears draft when armedCount returns to zero", () => {
     armTwo();
+    useFleetComposerStore.setState({ draft: "typing" });
     render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "typing" } });
     expect(useFleetComposerStore.getState().draft).toBe("typing");
 
     act(() => {
       useFleetArmingStore.getState().clear();
     });
     expect(useFleetComposerStore.getState().draft).toBe("");
-  });
-
-  it("disables send button when draft is blank", () => {
-    armTwo();
-    render(<FleetComposer />);
-    const send = screen.getByTestId("fleet-composer-send") as HTMLButtonElement;
-    expect(send.disabled).toBe(true);
-
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "hi" } });
-    expect(send.disabled).toBe(false);
-  });
-
-  it("all submits reject — toasts 0 success / N failed, draft retained, history not recorded", async () => {
-    submitMock.mockReset();
-    submitMock.mockRejectedValue(new Error("boom"));
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "fail it" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => {
-      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
-      expect(last).toBe("Sent to 0 agents (2 failed)");
-    });
-    expect(useFleetComposerStore.getState().draft).toBe("fail it");
-    const history = useCommandHistoryStore
-      .getState()
-      .getProjectHistory(FLEET_BROADCAST_HISTORY_KEY);
-    expect(history.map((h) => h.prompt)).not.toContain("fail it");
-
-    // Send button is usable again after failure.
-    const send = screen.getByTestId("fleet-composer-send") as HTMLButtonElement;
-    expect(send.disabled).toBe(false);
-  });
-
-  it("double-click 'Send anyway' only enqueues one batch (re-entrancy guard)", async () => {
-    const resolvers: Array<() => void> = [];
-    submitMock.mockReset();
-    submitMock.mockImplementation(
-      () =>
-        new Promise<void>((r) => {
-          resolvers.push(r);
-        })
-    );
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "multi\nline" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    const confirmSend = await screen.findByTestId("fleet-composer-confirm-send");
-    fireEvent.click(confirmSend);
-    fireEvent.click(confirmSend);
-    fireEvent.click(confirmSend);
-
-    // Exactly 2 submit calls — one per armed terminal — not 6.
-    expect(submitMock).toHaveBeenCalledTimes(2);
-    resolvers.forEach((r) => r());
-    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe(""));
-  });
-
-  it("delivers even when worktree context cannot be resolved (empty-ctx fallback)", async () => {
-    // Panel references a worktree that is not in the view store.
-    usePanelStore.setState({
-      panelsById: { lonely: makeAgent("lonely", { worktreeId: "wt-ghost" }) },
-      panelIds: ["lonely"],
-    });
-    installViewStore(new Map());
-    useFleetArmingStore.getState().armIds(["lonely"]);
-
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "still send me" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0]![1]).toBe("still send me");
-  });
-
-  it("leaves unresolved variables empty when worktree context is missing", async () => {
-    usePanelStore.setState({
-      panelsById: { lonely: makeAgent("lonely", { worktreeId: "wt-ghost" }) },
-      panelIds: ["lonely"],
-    });
-    installViewStore(new Map());
-    useFleetArmingStore.getState().armIds(["lonely"]);
-
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "branch is {{branch_name}}" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0]![1]).toBe("branch is ");
-  });
-
-  it("Escape inside the confirm strip closes it and keeps fleet armed", async () => {
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "rm -rf x" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-    const strip = await screen.findByTestId("fleet-composer-confirm");
-    // The strip receives focus on Cancel by default — press Escape on it.
-    fireEvent.keyDown(strip, { key: "Escape" });
-
-    expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
-    expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
-  });
-
-  it("preserves in-flight new typing — does not clear a replacement draft", async () => {
-    const resolvers: Array<() => void> = [];
-    submitMock.mockReset();
-    submitMock.mockImplementation(
-      () =>
-        new Promise<void>((r) => {
-          resolvers.push(r);
-        })
-    );
-    armTwo();
-    render(<FleetComposer />);
-    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
-
-    fireEvent.change(textarea, { target: { value: "first" } });
-    fireEvent.keyDown(textarea, { key: "Enter" });
-    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-
-    // User starts typing a new draft while the first batch is still in flight.
-    useFleetComposerStore.getState().setDraft("second");
-
-    resolvers.forEach((r) => r());
-    await waitFor(() =>
-      expect(
-        useCommandHistoryStore.getState().getProjectHistory(FLEET_BROADCAST_HISTORY_KEY).length
-      ).toBe(1)
-    );
-    expect(useFleetComposerStore.getState().draft).toBe("second");
   });
 });

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -454,6 +454,72 @@ describe("FleetComposer (live keystroke capture)", () => {
     });
   });
 
+  it("isComposingRef suppresses plain keydown between compositionstart and compositionend", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    // Plain keydown with NO isComposing flag and NO keyCode 229 — only the
+    // isComposingRef.current guard (set by compositionstart) should block it.
+    dispatchKeyDown(textarea, { key: "a" });
+    expect(writeMock).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea, { data: "あ" });
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writesByTarget()).toEqual({ t1: ["あ"], t2: ["あ"] });
+  });
+
+  it("removes raw DOM listeners on unmount (no leak across remount)", () => {
+    armTwo();
+    const { unmount } = render(<FleetComposer />);
+    const firstTextarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    unmount();
+
+    // Fire at the detached node — should be a no-op now.
+    dispatchKeyDown(firstTextarea, { key: "a" });
+    expect(writeMock).not.toHaveBeenCalled();
+
+    render(<FleetComposer />);
+    const secondTextarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    dispatchKeyDown(secondTextarea, { key: "b" });
+
+    // Exactly one keystroke × two targets — not four (which would signal leaked listeners).
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writesByTarget()).toEqual({ t1: ["b"], t2: ["b"] });
+  });
+
+  it("shows a toast when a benign paste fails for every target", async () => {
+    submitMock.mockReset();
+    submitMock.mockRejectedValue(new Error("port closed"));
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        getData: (type: string) => (type === "text/plain" ? "hello" : ""),
+      },
+    });
+
+    await waitFor(() => {
+      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
+      expect(last).toBe("Paste failed — no agents received the payload");
+    });
+  });
+
+  it("AltGr composed characters are forwarded (Ctrl+Alt+printable)", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    // German layout: AltGr+Q produces "@" with ctrlKey=true AND altKey=true.
+    dispatchKeyDown(textarea, { key: "@", ctrlKey: true, altKey: true });
+
+    expect(writesByTarget()).toEqual({ t1: ["@"], t2: ["@"] });
+    expect(useFleetComposerStore.getState().draft).toBe("@");
+  });
+
   it("auto-clears draft when armedCount returns to zero", () => {
     armTwo();
     useFleetComposerStore.setState({ draft: "typing" });

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -1,9 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  broadcastFleetKeySequence,
-  broadcastFleetLiteralPaste,
-} from "../fleetExecution";
+import { broadcastFleetKeySequence, broadcastFleetLiteralPaste } from "../fleetExecution";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import type { TerminalInstance } from "@shared/types";

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  broadcastFleetKeySequence,
+  broadcastFleetLiteralPaste,
+} from "../fleetExecution";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import type { TerminalInstance } from "@shared/types";
+
+const writeMock = vi.fn<(id: string, data: string) => void>();
+const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients")>();
+  return {
+    ...actual,
+    terminalClient: {
+      ...actual.terminalClient,
+      write: (id: string, data: string) => writeMock(id, data),
+      submit: (id: string, text: string) => submitMock(id, text),
+    },
+  };
+});
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...(overrides as object),
+  } as TerminalInstance;
+}
+
+function armTwo() {
+  usePanelStore.setState({
+    panelsById: { t1: makeAgent("t1"), t2: makeAgent("t2") },
+    panelIds: ["t1", "t2"],
+  });
+  useFleetArmingStore.getState().armIds(["t1", "t2"]);
+}
+
+function reset() {
+  writeMock.mockReset();
+  submitMock.mockReset();
+  submitMock.mockResolvedValue(undefined);
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+}
+
+describe("broadcastFleetKeySequence", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("resolves armed targets fresh when no target list is given", () => {
+    armTwo();
+    broadcastFleetKeySequence("\r");
+
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writeMock.mock.calls.map(([id, seq]) => [id, seq]).sort()).toEqual([
+      ["t1", "\r"],
+      ["t2", "\r"],
+    ]);
+  });
+
+  it("respects a caller-supplied target list verbatim", () => {
+    armTwo();
+    broadcastFleetKeySequence("x", ["t2"]);
+
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(writeMock.mock.calls[0]).toEqual(["t2", "x"]);
+  });
+
+  it("no-ops cleanly with zero targets", () => {
+    broadcastFleetKeySequence("\x1b");
+    expect(writeMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT apply recipe-variable substitution to the sequence", () => {
+    armTwo();
+    broadcastFleetKeySequence("{{branch_name}}");
+    expect(writeMock).toHaveBeenCalledTimes(2);
+    expect(writeMock.mock.calls[0]![1]).toBe("{{branch_name}}");
+    expect(writeMock.mock.calls[1]![1]).toBe("{{branch_name}}");
+  });
+});
+
+describe("broadcastFleetLiteralPaste", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("submits verbatim paste text to each target (no recipe substitution)", async () => {
+    armTwo();
+    const result = await broadcastFleetLiteralPaste("hello {{branch_name}}");
+    expect(submitMock).toHaveBeenCalledTimes(2);
+    expect(submitMock.mock.calls.map(([, text]) => text)).toEqual([
+      "hello {{branch_name}}",
+      "hello {{branch_name}}",
+    ]);
+    expect(result.successCount).toBe(2);
+    expect(result.failureCount).toBe(0);
+  });
+
+  it("collects failures into failedIds without rejecting the aggregate", async () => {
+    submitMock.mockReset();
+    submitMock.mockResolvedValueOnce(undefined);
+    submitMock.mockRejectedValueOnce(new Error("nope"));
+    armTwo();
+
+    const result = await broadcastFleetLiteralPaste("x");
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(1);
+    expect(result.failedIds).toEqual(["t2"]);
+  });
+
+  it("returns an empty result on zero targets", async () => {
+    const result = await broadcastFleetLiteralPaste("x");
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(result.total).toBe(0);
+    expect(result.successCount).toBe(0);
+  });
+});

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -2,10 +2,7 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { terminalClient } from "@/clients";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
-import {
-  buildFleetBroadcastRecipeContext,
-  resolveFleetBroadcastTargetIds,
-} from "./fleetBroadcast";
+import { buildFleetBroadcastRecipeContext, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
 
 export interface FleetTargetPreview {
   terminalId: string;

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -2,7 +2,10 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { terminalClient } from "@/clients";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
-import { buildFleetBroadcastRecipeContext } from "./fleetBroadcast";
+import {
+  buildFleetBroadcastRecipeContext,
+  resolveFleetBroadcastTargetIds,
+} from "./fleetBroadcast";
 
 export interface FleetTargetPreview {
   terminalId: string;
@@ -121,6 +124,61 @@ export async function executeFleetBroadcast(
   const results = await Promise.allSettled(submissions);
   const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
     terminalId: ids[i]!,
+    status: r.status,
+    reason: r.status === "rejected" ? String(r.reason) : undefined,
+  }));
+
+  const successCount = results.filter((r) => r.status === "fulfilled").length;
+  const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
+
+  return {
+    total: results.length,
+    successCount,
+    failureCount: results.length - successCount,
+    perTarget,
+    failedIds,
+  };
+}
+
+/**
+ * Fire-and-forget fan-out of a raw terminal byte sequence to each target via
+ * the MessagePort write path. Used by the live keystroke capture — keys like
+ * Enter (`\r`), Backspace (`\x7f`), or arrow-key CSI sequences go straight to
+ * the PTY without recipe-variable substitution or bracketed-paste wrapping.
+ *
+ * Targets are re-resolved fresh when omitted so trashed/exited terminals drop
+ * out silently between keystrokes.
+ */
+export function broadcastFleetKeySequence(sequence: string, targetIds?: string[]): void {
+  const ids = targetIds ?? resolveFleetBroadcastTargetIds();
+  for (const id of ids) {
+    terminalClient.write(id, sequence);
+  }
+}
+
+/**
+ * Literal broadcast for pasted text — routes each target through
+ * `terminalClient.submit` so the backend wraps the payload in bracketed paste
+ * (`\e[200~…\e[201~`) when the PTY supports it. Skips recipe-variable
+ * substitution because paste is a verbatim keyboard event, not a composed
+ * prompt template.
+ */
+export async function broadcastFleetLiteralPaste(
+  text: string,
+  targetIds?: string[]
+): Promise<FleetExecutionResult> {
+  const ids = targetIds ?? resolveFleetBroadcastTargetIds();
+  const submissions: Promise<void>[] = [];
+  const collected: string[] = [];
+
+  for (const id of ids) {
+    collected.push(id);
+    submissions.push(terminalClient.submit(id, text));
+  }
+
+  const results = await Promise.allSettled(submissions);
+  const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
+    terminalId: collected[i]!,
     status: r.status,
     reason: r.status === "rejected" ? String(r.reason) : undefined,
   }));

--- a/src/components/Fleet/useFleetLiveKeyCapture.ts
+++ b/src/components/Fleet/useFleetLiveKeyCapture.ts
@@ -1,0 +1,189 @@
+import { useEffect, useRef, type RefObject } from "react";
+import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import {
+  needsFleetBroadcastConfirmation,
+  resolveFleetBroadcastTargetIds,
+} from "./fleetBroadcast";
+import { broadcastFleetKeySequence, broadcastFleetLiteralPaste } from "./fleetExecution";
+
+export interface FleetLiveKeyCaptureOptions {
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  enabled: boolean;
+  onPasteConfirm: (text: string) => void;
+}
+
+/**
+ * Map a DOM keydown event to the terminal byte sequence the PTY expects.
+ * Returns null for modifier-only presses, meta-accelerators (Cmd/Win) that
+ * should reach the browser, and keys we don't have a mapping for.
+ *
+ * Uses normal (not application) cursor mode for arrows — works for shells and
+ * is tolerated by most TUIs. Application-mode tracking per-PTY is a later
+ * refinement.
+ */
+export function mapKeyToSequence(event: KeyboardEvent): string | null {
+  if (["Meta", "Control", "Alt", "Shift", "CapsLock"].includes(event.key)) return null;
+  if (event.metaKey) return null;
+
+  switch (event.key) {
+    case "Enter":
+      return "\r";
+    case "Backspace":
+      return "\x7f";
+    case "Tab":
+      return event.shiftKey ? "\x1b[Z" : "\t";
+    case "Escape":
+      return "\x1b";
+    case "ArrowUp":
+      return "\x1b[A";
+    case "ArrowDown":
+      return "\x1b[B";
+    case "ArrowRight":
+      return "\x1b[C";
+    case "ArrowLeft":
+      return "\x1b[D";
+    case "Home":
+      return "\x1b[H";
+    case "End":
+      return "\x1b[F";
+    case "Delete":
+      return "\x1b[3~";
+    case "PageUp":
+      return "\x1b[5~";
+    case "PageDown":
+      return "\x1b[6~";
+    case "Insert":
+      return "\x1b[2~";
+  }
+
+  if (event.ctrlKey && !event.altKey && event.key.length === 1) {
+    const lower = event.key.toLowerCase();
+    const code = lower.charCodeAt(0);
+    if (code >= 0x61 && code <= 0x7a) {
+      return String.fromCharCode(code - 0x60);
+    }
+    if (event.key === " ") return "\x00";
+    if (event.key === "[") return "\x1b";
+    if (event.key === "\\") return "\x1c";
+    if (event.key === "]") return "\x1d";
+  }
+
+  if (event.altKey && !event.ctrlKey && event.key.length === 1) {
+    return "\x1b" + event.key;
+  }
+
+  if (!event.ctrlKey && !event.altKey && event.key.length === 1) {
+    return event.key;
+  }
+
+  return null;
+}
+
+/**
+ * Update the visible draft buffer from a forwarded sequence. The draft is
+ * feedback only — the source of truth is the remote PTYs — but mirroring
+ * printable chars, Enter, and Backspace keeps the bar legible for the user
+ * and drives the destructive-warning regex.
+ */
+function applySequenceToDraft(sequence: string): void {
+  const { draft, setDraft } = useFleetComposerStore.getState();
+  if (sequence === "\r") {
+    setDraft(draft + "\n");
+    return;
+  }
+  if (sequence === "\x7f") {
+    if (draft.length > 0) setDraft(draft.slice(0, -1));
+    return;
+  }
+  if (sequence.length === 1) {
+    const code = sequence.charCodeAt(0);
+    if (code >= 0x20 && code !== 0x7f) {
+      setDraft(draft + sequence);
+    }
+  }
+}
+
+/**
+ * Attach raw DOM listeners to the fleet composer textarea so every keydown,
+ * IME composition, and paste is forwarded to all armed PTYs.
+ *
+ * The hook uses native addEventListener rather than React synthetic events so
+ * `preventDefault()` reliably suppresses Tab focus movement, Enter newline
+ * insertion, and Esc dismissal across Electron builds.
+ */
+export function useFleetLiveKeyCapture({
+  textareaRef,
+  enabled,
+  onPasteConfirm,
+}: FleetLiveKeyCaptureOptions): void {
+  const isComposingRef = useRef(false);
+  const onPasteConfirmRef = useRef(onPasteConfirm);
+  onPasteConfirmRef.current = onPasteConfirm;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = textareaRef.current;
+    if (!el) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || event.keyCode === 229 || isComposingRef.current) return;
+
+      const sequence = mapKeyToSequence(event);
+      if (sequence == null) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      applySequenceToDraft(sequence);
+
+      const targets = resolveFleetBroadcastTargetIds();
+      broadcastFleetKeySequence(sequence, targets);
+    };
+
+    const handleCompositionStart = () => {
+      isComposingRef.current = true;
+    };
+
+    const handleCompositionEnd = (event: CompositionEvent) => {
+      isComposingRef.current = false;
+      const data = event.data ?? "";
+      if (!data) return;
+
+      const { draft, setDraft } = useFleetComposerStore.getState();
+      setDraft(draft + data);
+
+      const targets = resolveFleetBroadcastTargetIds();
+      broadcastFleetKeySequence(data, targets);
+    };
+
+    const handlePaste = (event: ClipboardEvent) => {
+      const text = event.clipboardData?.getData("text/plain") ?? "";
+      event.preventDefault();
+      if (!text) return;
+
+      if (needsFleetBroadcastConfirmation(text)) {
+        onPasteConfirmRef.current(text);
+        return;
+      }
+
+      const { draft, setDraft } = useFleetComposerStore.getState();
+      setDraft(draft + text);
+
+      const targets = resolveFleetBroadcastTargetIds();
+      void broadcastFleetLiteralPaste(text, targets);
+    };
+
+    el.addEventListener("keydown", handleKeyDown);
+    el.addEventListener("compositionstart", handleCompositionStart);
+    el.addEventListener("compositionend", handleCompositionEnd);
+    el.addEventListener("paste", handlePaste);
+
+    return () => {
+      el.removeEventListener("keydown", handleKeyDown);
+      el.removeEventListener("compositionstart", handleCompositionStart);
+      el.removeEventListener("compositionend", handleCompositionEnd);
+      el.removeEventListener("paste", handlePaste);
+      isComposingRef.current = false;
+    };
+  }, [enabled, textareaRef]);
+}

--- a/src/components/Fleet/useFleetLiveKeyCapture.ts
+++ b/src/components/Fleet/useFleetLiveKeyCapture.ts
@@ -2,10 +2,7 @@ import { useEffect, useRef, type RefObject } from "react";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { logWarn } from "@/utils/logger";
-import {
-  needsFleetBroadcastConfirmation,
-  resolveFleetBroadcastTargetIds,
-} from "./fleetBroadcast";
+import { needsFleetBroadcastConfirmation, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
 import { broadcastFleetKeySequence, broadcastFleetLiteralPaste } from "./fleetExecution";
 
 export interface FleetLiveKeyCaptureOptions {

--- a/src/components/Fleet/useFleetLiveKeyCapture.ts
+++ b/src/components/Fleet/useFleetLiveKeyCapture.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, type RefObject } from "react";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import { logWarn } from "@/utils/logger";
 import {
   needsFleetBroadcastConfirmation,
   resolveFleetBroadcastTargetIds,
@@ -74,6 +76,14 @@ export function mapKeyToSequence(event: KeyboardEvent): string | null {
 
   if (!event.ctrlKey && !event.altKey && event.key.length === 1) {
     return event.key;
+  }
+
+  // AltGr on Windows/Linux layouts synthesizes ctrlKey=true AND altKey=true;
+  // the resulting event.key is the composed printable char (e.g. "@" on DE,
+  // "{" on PL). Forward it as a literal keystroke.
+  if (event.ctrlKey && event.altKey && event.key.length === 1) {
+    const code = event.key.charCodeAt(0);
+    if (code >= 0x20 && code !== 0x7f) return event.key;
   }
 
   return null;
@@ -170,7 +180,22 @@ export function useFleetLiveKeyCapture({
       setDraft(draft + text);
 
       const targets = resolveFleetBroadcastTargetIds();
-      void broadcastFleetLiteralPaste(text, targets);
+      void (async () => {
+        const result = await broadcastFleetLiteralPaste(text, targets);
+        if (result.failureCount === 0) return;
+        logWarn("[FleetComposer] benign paste broadcast had rejections", {
+          failureCount: result.failureCount,
+          failedIds: result.failedIds,
+        });
+        useNotificationStore.getState().addNotification({
+          type: result.successCount > 0 ? "warning" : "error",
+          priority: "low",
+          message:
+            result.successCount > 0
+              ? `Sent to ${result.successCount} agent${result.successCount === 1 ? "" : "s"} (${result.failureCount} failed)`
+              : `Paste failed — no agents received the payload`,
+        });
+      })();
     };
 
     el.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
## Summary

- Converts the Fleet broadcast bar into a live keystroke capture surface. Every key pressed while the bar is focused streams immediately to each selected terminal's PTY, iTerm2 synchronize-panes style but safely bounded to the dedicated bar.
- Removes the compose-then-send pipeline entirely. Arrow keys, Enter, Esc, Backspace, Tab, Ctrl combos, Alt/AltGr, and paste all have proper terminal semantics now. IME composition is suppressed until `compositionend` so CJK input arrives as a finalised string.
- Destructive-regex warning stays passive during typing (characters still stream, backspace defuses); paste via the bar still requires the existing Send anyway confirmation.

Resolves #5749

## Changes

- New `useFleetLiveKeyCapture` hook with raw DOM listeners and a two-guard IME pattern
- Full key-to-sequence map: Enter=`\r`, Backspace=`\x7f`, Tab=`\t`, Esc=`\x1b`, CSI arrows/nav, Ctrl+[a-z] control chars, Alt+letter, AltGr composed chars
- `broadcastFleetKeySequence` (synchronous write fan-out) and `broadcastFleetLiteralPaste` (async submit fan-out with bracketed paste) in `fleetExecution.ts`
- Targets resolved fresh on every keystroke via `resolveFleetBroadcastTargetIds()` so trashed/exited terminals drop out silently
- Removed send button and command-history arrow-key navigation from `FleetComposer`

## Testing

42 `FleetComposer` tests and `fleetExecution` unit tests covering IME, paste confirm/cancel, AltGr, listener cleanup, benign paste failure toast, trashed-target drop, Cmd-key passthrough, and more. All passing.