### PR TITLE
fix(ProcessDetector): add hysteresis gate to prevent thrashing on short-lived agent processes

### DIFF
--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -90,6 +90,12 @@ export interface DetectionResult {
 export type DetectionCallback = (result: DetectionResult, spawnedAt: number) => void;
 
 export class ProcessDetector {
+  // Require N consecutive polls agreeing on a new agent/icon state before
+  // committing it. At the 2500 ms base poll interval that is ~5 s of confirmation,
+  // which is enough to filter out short-lived processes (e.g. `claude --version`)
+  // that would otherwise cause the detector to thrash between on/off.
+  private static readonly HYSTERESIS_THRESHOLD = 2;
+
   private terminalId: string;
   private spawnedAt: number;
   private ptyPid: number;
@@ -101,6 +107,9 @@ export class ProcessDetector {
   private cache: ProcessTreeCache;
   private unsubscribe: (() => void) | null = null;
   private isStarted: boolean = false;
+  private onStreak: number = 0;
+  private offStreak: number = 0;
+  private pendingDetected: { agentType?: TerminalType; processIconId?: string } | null = null;
 
   constructor(
     terminalId: string,
@@ -134,6 +143,28 @@ export class ProcessDetector {
 
   stop(): void {
     if (this.unsubscribe) {
+      // Flush a pending OFF streak on teardown so a detected agent whose process
+      // exited inside the hysteresis window does not leave ghost state in the UI.
+      if (this.offStreak > 0 && (this.lastDetected !== null || this.lastProcessIconId !== null)) {
+        const spawnedAt = this.spawnedAt;
+        this.lastDetected = null;
+        this.lastProcessIconId = null;
+        this.lastBusyState = false;
+        this.lastCurrentCommand = undefined;
+        this.offStreak = 0;
+        this.onStreak = 0;
+        this.pendingDetected = null;
+        try {
+          this.callback({ detected: false, isBusy: false, currentCommand: undefined }, spawnedAt);
+        } catch (err) {
+          console.error(`ProcessDetector stop flush error for terminal ${this.terminalId}:`, err);
+        }
+      } else {
+        this.onStreak = 0;
+        this.offStreak = 0;
+        this.pendingDetected = null;
+      }
+
       this.unsubscribe();
       this.unsubscribe = null;
       logDebug(`Stopped ProcessDetector for terminal ${this.terminalId}`);
@@ -145,32 +176,76 @@ export class ProcessDetector {
     try {
       const result = this.detectAgent();
 
-      const nextAgent = result.agentType ?? null;
-      const agentChanged =
-        (result.detected && nextAgent !== this.lastDetected) ||
-        (!result.detected && this.lastDetected !== null);
+      const rawAgent = result.agentType ?? null;
+      const rawIcon = result.processIconId ?? null;
+      const rawDetected = result.detected;
+      const committedAgent = this.lastDetected;
+      const committedIcon = this.lastProcessIconId;
 
-      const processIconChanged = (result.processIconId ?? null) !== this.lastProcessIconId;
+      const agentOrIconDiffers = rawAgent !== committedAgent || rawIcon !== committedIcon;
+
+      let gatedCommitted = false;
+
+      if (agentOrIconDiffers) {
+        if (rawDetected) {
+          // ON or swap direction: count consecutive polls agreeing on the same
+          // candidate; a different candidate mid-streak resets the counter.
+          const sameCandidate =
+            this.pendingDetected !== null &&
+            (this.pendingDetected.agentType ?? null) === rawAgent &&
+            (this.pendingDetected.processIconId ?? null) === rawIcon;
+
+          this.onStreak = sameCandidate ? this.onStreak + 1 : 1;
+          this.pendingDetected = {
+            agentType: result.agentType,
+            processIconId: result.processIconId,
+          };
+          this.offStreak = 0;
+
+          if (this.onStreak >= ProcessDetector.HYSTERESIS_THRESHOLD) {
+            this.lastDetected = rawAgent;
+            this.lastProcessIconId = rawIcon;
+            this.onStreak = 0;
+            this.pendingDetected = null;
+            gatedCommitted = true;
+          }
+        } else {
+          // OFF direction: raw reports no detection but committed state has one.
+          this.offStreak += 1;
+          this.onStreak = 0;
+          this.pendingDetected = null;
+
+          if (this.offStreak >= ProcessDetector.HYSTERESIS_THRESHOLD) {
+            this.lastDetected = null;
+            this.lastProcessIconId = null;
+            this.offStreak = 0;
+            gatedCommitted = true;
+          }
+        }
+      } else {
+        // Raw matches committed state — no transition in flight.
+        this.onStreak = 0;
+        this.offStreak = 0;
+        this.pendingDetected = null;
+      }
+
+      const inPendingTransition = this.onStreak > 0 || this.offStreak > 0;
 
       const busyChanged = result.isBusy !== undefined && result.isBusy !== this.lastBusyState;
-
       const commandChanged = result.currentCommand !== this.lastCurrentCommand;
-
-      if (result.detected) {
-        this.lastDetected = result.agentType ?? null;
-        this.lastProcessIconId = result.processIconId ?? null;
-      } else {
-        this.lastDetected = null;
-        this.lastProcessIconId = null;
-      }
 
       if (result.isBusy !== undefined) {
         this.lastBusyState = result.isBusy;
       }
-
       this.lastCurrentCommand = result.currentCommand;
 
-      if (agentChanged || processIconChanged || busyChanged || commandChanged) {
+      // Suppress busy/command emissions while a gated transition is pending —
+      // otherwise a one-poll blip would leak through the side-channel and undo
+      // the hysteresis gate. Once the gated streak commits (or the raw state
+      // stabilises back onto committed), immediate emissions resume.
+      const shouldEmitImmediate = (busyChanged || commandChanged) && !inPendingTransition;
+
+      if (gatedCommitted || shouldEmitImmediate) {
         this.callback(result, this.spawnedAt);
       }
     } catch (_error) {

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -234,11 +234,6 @@ export class ProcessDetector {
       const busyChanged = result.isBusy !== undefined && result.isBusy !== this.lastBusyState;
       const commandChanged = result.currentCommand !== this.lastCurrentCommand;
 
-      if (result.isBusy !== undefined) {
-        this.lastBusyState = result.isBusy;
-      }
-      this.lastCurrentCommand = result.currentCommand;
-
       // Suppress busy/command emissions while a gated transition is pending —
       // otherwise a one-poll blip would leak through the side-channel and undo
       // the hysteresis gate. Once the gated streak commits (or the raw state
@@ -246,6 +241,10 @@ export class ProcessDetector {
       const shouldEmitImmediate = (busyChanged || commandChanged) && !inPendingTransition;
 
       if (gatedCommitted || shouldEmitImmediate) {
+        if (result.isBusy !== undefined) {
+          this.lastBusyState = result.isBusy;
+        }
+        this.lastCurrentCommand = result.currentCommand;
         this.callback(result, this.spawnedAt);
       }
     } catch (_error) {

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -49,6 +49,7 @@ describe("ProcessDetector", () => {
 
     const detector = new ProcessDetector("terminal-1", Date.now(), 100, callback, cache as never);
     detector.start();
+    cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -75,6 +76,7 @@ describe("ProcessDetector", () => {
 
     const detector = new ProcessDetector("terminal-2", Date.now(), 100, callback, cache as never);
     detector.start();
+    cache.emitRefresh();
     cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledTimes(1);
@@ -104,6 +106,7 @@ describe("ProcessDetector", () => {
 
     const detector = new ProcessDetector("terminal-map", Date.now(), 100, callback, cache as never);
     detector.start();
+    cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -132,6 +135,7 @@ describe("ProcessDetector", () => {
       cache as never
     );
     detector.start();
+    cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -160,6 +164,7 @@ describe("ProcessDetector", () => {
       cache as never
     );
     detector.start();
+    cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -207,9 +212,13 @@ describe("ProcessDetector", () => {
       callback,
       cache as never
     );
+    // Two polls to commit the ON state (hysteresis threshold).
     detector.start();
+    cache.emitRefresh();
 
+    // Two polls with no children to commit the OFF state (hysteresis threshold).
     cache.setChildren(100, []);
+    cache.emitRefresh();
     cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledTimes(2);
@@ -236,6 +245,7 @@ describe("ProcessDetector", () => {
 
     const detector = new ProcessDetector("terminal-win", Date.now(), 100, callback, cache as never);
     detector.start();
+    cache.emitRefresh();
 
     expect(callback).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -247,5 +257,222 @@ describe("ProcessDetector", () => {
       }),
       expect.any(Number)
     );
+  });
+
+  describe("hysteresis", () => {
+    it("does not emit detection after a single agent poll", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-1",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("commits detection after two consecutive matching polls and emits once", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-2",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          agentType: "claude",
+          processIconId: "claude",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("does not emit off after a single absent poll; commits after two", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-3",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          detected: false,
+          isBusy: false,
+          currentCommand: undefined,
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("does not commit detection when polls alternate between present and absent", () => {
+      const cache = createCacheMock();
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-4",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      detector.start();
+
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      cache.emitRefresh();
+
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+
+      // Alternation may update busy/command, but the gated agent/icon state must
+      // never flip into a detected state while the on-streak keeps resetting.
+      const detectedCalls = callback.mock.calls.filter(([result]) => result.detected === true);
+      expect(detectedCalls).toHaveLength(0);
+      expect(detector.getLastDetected()).toBeNull();
+    });
+
+    it("requires two consecutive polls for a new agent when swapping from another", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-5",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith(
+        expect.objectContaining({ agentType: "claude" }),
+        expect.any(Number)
+      );
+
+      cache.setChildren(100, [{ pid: 201, comm: "codex", command: "codex --model o3" }]);
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith(
+        expect.objectContaining({ agentType: "codex" }),
+        expect.any(Number)
+      );
+    });
+
+    it("flushes a pending off streak on stop() so teardown does not leave ghost state", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-6",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      detector.stop();
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          detected: false,
+          isBusy: false,
+          currentCommand: undefined,
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("does not emit a synthetic on event when stop() is called mid on-streak", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-7",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      detector.stop();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("does not emit a second off flush on repeated stop() calls", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-8",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      detector.stop();
+
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      detector.stop();
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -450,6 +450,64 @@ describe("ProcessDetector", () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
+    it("does not emit a spurious idle callback after a one-poll blip on an idle terminal", () => {
+      const cache = createCacheMock();
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-blip",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+
+      // Idle start: emits the baseline { detected:false, isBusy:false } once.
+      detector.start();
+      const baseline = callback.mock.calls.length;
+
+      // One-poll blip of a short-lived agent process.
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --version" }]);
+      cache.emitRefresh();
+
+      // Back to idle — side-channel state must not have been mutated during the
+      // suppressed on-streak, so no spurious callback fires here.
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledTimes(baseline);
+    });
+
+    it("does not emit a spurious command-change callback after an aborted agent swap", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+
+      const detector = new ProcessDetector(
+        "terminal-hys-swap-abort",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+
+      // Commit claude.
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      // One-poll blip of codex (swap candidate).
+      cache.setChildren(100, [{ pid: 201, comm: "codex", command: "codex --version" }]);
+      cache.emitRefresh();
+
+      // Back to claude — committed state matches raw again, and side-channel
+      // state was not overwritten by the aborted swap, so no callback fires.
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
     it("does not emit a second off flush on repeated stop() calls", () => {
       const cache = createCacheMock();
       cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);


### PR DESCRIPTION
## Summary

- `ProcessDetector` previously emitted on/off state changes on every poll cycle, meaning short-lived processes like `claude --version` or `gemini --help` could trigger agent promotion, icon flicker, and stuck states in the UI
- Added a hysteresis gate requiring `HYSTERESIS_THRESHOLD` (2) consecutive polls agreeing on a state change before committing it — at the 2500ms base poll interval that's roughly 5s of confirmation before any transition fires
- Busy and command state emissions are suppressed while a gated transition is pending, closing the side-channel that would otherwise let a one-poll blip bypass the gate

Resolves #5763

## Changes

- `electron/services/ProcessDetector.ts`: added `onStreak`, `offStreak`, and `pendingDetected` tracking; gated all state commits behind `HYSTERESIS_THRESHOLD`; deferred busy/command mutations during pending transitions; flush pending OFF state on `stop()` so exiting processes inside the hysteresis window don't leave ghost UI state
- `electron/services/__tests__/ProcessDetector.test.ts`: 285 lines of new tests covering hysteresis on/off behaviour, streak resets on candidate swaps, busy/command suppression during pending transitions, and stop-flush edge cases

## Testing

Unit tests cover the full hysteresis matrix. Manually verified that running `claude --version` in a terminal no longer causes the agent icon to flash on and then immediately clear.