### PR TITLE
fix(pty): make OSC color-query responder runtime-identity aware

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -74,16 +74,19 @@ type CursorBuffer = {
 
 const EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS = 2000;
 
-// Matches OSC 10/11 "?" queries terminated by BEL (\x07) or ST (\x1b\\).
-// Used to strip handled queries from data forwarded to the renderer so that
-// the frontend xterm.js does not also respond (which would double-reply and
-// corrupt TUI agents that consume only the first response).
+// OSC 10/11 "?" queries terminated by BEL (\x07) or ST (\x1b\\).
+// Trigger and strip must use the same terminator-requiring pattern: if we
+// responded on an unterminated fragment but stripped only terminated ones,
+// a split chunk would leak the fragment to the renderer and double-respond
+// once xterm.js re-assembles the sequence.
 // eslint-disable-next-line no-control-regex
-const OSC_COLOR_QUERY_RE = /\x1b\]1[01];\?(?:\x07|\x1b\\)/g;
-
-function stripHandledOscColorQueries(data: string): string {
-  return data.replace(OSC_COLOR_QUERY_RE, "");
-}
+const OSC_10_QUERY_RE = /\x1b\]10;\?(?:\x07|\x1b\\)/;
+// eslint-disable-next-line no-control-regex
+const OSC_11_QUERY_RE = /\x1b\]11;\?(?:\x07|\x1b\\)/;
+// eslint-disable-next-line no-control-regex
+const OSC_10_QUERY_STRIP_RE = /\x1b\]10;\?(?:\x07|\x1b\\)/g;
+// eslint-disable-next-line no-control-regex
+const OSC_11_QUERY_STRIP_RE = /\x1b\]11;\?(?:\x07|\x1b\\)/g;
 
 export interface TerminalProcessCallbacks {
   emitData: (id: string, data: string | Uint8Array) => void;
@@ -1242,20 +1245,33 @@ export class TerminalProcess {
       // blocks for 5 seconds PER query waiting for responses that never come.
       // The renderer's xterm.js (@xterm/xterm BrowserTerminal) also replies to
       // OSC 10/11 by default; to keep exactly one responder active, we strip
-      // handled queries out of the data forwarded to the renderer below.
+      // queries whose backend response succeeded from data forwarded to the
+      // renderer. If a write fails, we leave that query intact so the renderer
+      // can still satisfy it and the TUI agent does not hang.
       let rendererData = data;
       if (this.shouldHandleOscColorQueries && data.includes("\x1b]1")) {
-        try {
-          if (data.includes("\x1b]10;?")) {
+        const has10 = OSC_10_QUERY_RE.test(data);
+        const has11 = OSC_11_QUERY_RE.test(data);
+        let handled10 = false;
+        let handled11 = false;
+        if (has10) {
+          try {
             terminal.ptyProcess.write("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
+            handled10 = true;
+          } catch (error) {
+            this.logWriteError(error, { operation: "write(osc-color-response)" });
           }
-          if (data.includes("\x1b]11;?")) {
-            terminal.ptyProcess.write("\x1b]11;rgb:0000/0000/0000\x1b\\");
-          }
-        } catch (error) {
-          this.logWriteError(error, { operation: "write(osc-color-response)" });
         }
-        rendererData = stripHandledOscColorQueries(data);
+        if (has11) {
+          try {
+            terminal.ptyProcess.write("\x1b]11;rgb:0000/0000/0000\x1b\\");
+            handled11 = true;
+          } catch (error) {
+            this.logWriteError(error, { operation: "write(osc-color-response)" });
+          }
+        }
+        if (handled10) rendererData = rendererData.replace(OSC_10_QUERY_STRIP_RE, "");
+        if (handled11) rendererData = rendererData.replace(OSC_11_QUERY_STRIP_RE, "");
       }
 
       terminal.headlessTerminal?.write(data);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -74,6 +74,17 @@ type CursorBuffer = {
 
 const EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS = 2000;
 
+// Matches OSC 10/11 "?" queries terminated by BEL (\x07) or ST (\x1b\\).
+// Used to strip handled queries from data forwarded to the renderer so that
+// the frontend xterm.js does not also respond (which would double-reply and
+// corrupt TUI agents that consume only the first response).
+// eslint-disable-next-line no-control-regex
+const OSC_COLOR_QUERY_RE = /\x1b\]1[01];\?(?:\x07|\x1b\\)/g;
+
+function stripHandledOscColorQueries(data: string): string {
+  return data.replace(OSC_COLOR_QUERY_RE, "");
+}
+
 export interface TerminalProcessCallbacks {
   emitData: (id: string, data: string | Uint8Array) => void;
   onExit: (id: string, exitCode: number) => void;
@@ -112,6 +123,13 @@ export class TerminalProcess {
 
   private readonly terminalInfo: TerminalInfo;
   private readonly isAgentTerminal: boolean;
+  // Live identity check for OSC 10/11 color-query responder ownership.
+  // Spawn-time agents (kind="agent") own the responder from construction;
+  // plain terminals promoted at runtime via handleAgentDetection own it while
+  // detectedAgentType is set and release it on demotion.
+  private get shouldHandleOscColorQueries(): boolean {
+    return this.isAgentTerminal || this.terminalInfo.detectedAgentType !== undefined;
+  }
   private forensicsBuffer = new TerminalForensicsBuffer();
   private _activityTier: "active" | "background" = "active";
   private _restoreBannerStart: IMarker | null = null;
@@ -1218,11 +1236,15 @@ export class TerminalProcess {
         this.ensureHeadlessResponder();
       }
 
-      // Respond to OSC 10/11 (foreground/background color queries) for agent terminals.
-      // xterm.js does not respond to these OSC queries, so there is no double-response
-      // risk with the frontend. Without this, termenv (used by Bubble Tea / OpenCode)
+      // Respond to OSC 10/11 (foreground/background color queries) whenever the
+      // terminal is agent-owned — spawn-time agent panel OR runtime-promoted
+      // plain terminal. Without this, termenv (Bubble Tea / OpenCode / Gemini CLI)
       // blocks for 5 seconds PER query waiting for responses that never come.
-      if (this.isAgentTerminal && data.includes("\x1b]1")) {
+      // The renderer's xterm.js (@xterm/xterm BrowserTerminal) also replies to
+      // OSC 10/11 by default; to keep exactly one responder active, we strip
+      // handled queries out of the data forwarded to the renderer below.
+      let rendererData = data;
+      if (this.shouldHandleOscColorQueries && data.includes("\x1b]1")) {
         try {
           if (data.includes("\x1b]10;?")) {
             terminal.ptyProcess.write("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
@@ -1233,12 +1255,13 @@ export class TerminalProcess {
         } catch (error) {
           this.logWriteError(error, { operation: "write(osc-color-response)" });
         }
+        rendererData = stripHandledOscColorQueries(data);
       }
 
       terminal.headlessTerminal?.write(data);
       this.scheduleSessionPersist();
 
-      this.emitData(data);
+      this.emitData(rendererData);
       this.forensicsBuffer.capture(data);
       this.semanticBufferManager.onData(data);
 

--- a/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
@@ -141,6 +141,7 @@ describe("TerminalProcess OSC color query responder", () => {
 
     expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
     expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]11;rgb:0000/0000/0000\x1b\\");
+    expect(ptyWriteMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not respond to OSC 10/11 for non-agent terminals", () => {
@@ -175,6 +176,7 @@ describe("TerminalProcess OSC color query responder", () => {
 
     expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
     expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]11;rgb:0000/0000/0000\x1b\\");
+    expect(emitDataMock).toHaveBeenCalledTimes(1);
     expect(emitDataMock).toHaveBeenCalledWith("t1", "beforemiddleafter");
   });
 
@@ -242,5 +244,47 @@ describe("TerminalProcess OSC color query responder", () => {
 
     expect(ptyWriteMock).not.toHaveBeenCalled();
     expect(emitDataMock).toHaveBeenCalledWith("t1", payload);
+  });
+
+  it("does not respond to an unterminated OSC query fragment", () => {
+    createAgentTerminal("opencode");
+
+    // Split-chunk regression: if the terminator hasn't arrived yet, responding
+    // on the fragment would mismatch the terminator-requiring strip and leak
+    // the fragment to the renderer, which would double-reply once xterm.js
+    // re-assembled the full sequence.
+    ptyOnDataCallback!("\x1b]10;?");
+
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenCalledWith("t1", "\x1b]10;?");
+  });
+
+  it("leaves the query in renderer data when the backend write fails", () => {
+    createAgentTerminal("opencode");
+    ptyWriteMock.mockImplementation(() => {
+      throw new Error("PTY dead");
+    });
+
+    const payload = "\x1b]11;?\x1b\\";
+    ptyOnDataCallback!(payload);
+
+    // Backend tried to respond, but failed. Renderer must still see the query
+    // so xterm.js can reply — otherwise the TUI agent hangs with no responder.
+    expect(emitDataMock).toHaveBeenCalledWith("t1", payload);
+  });
+
+  it("strips only queries whose write succeeded when one of two writes fails", () => {
+    createAgentTerminal("opencode");
+    // OSC 10 write succeeds, OSC 11 write throws.
+    ptyWriteMock
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error("PTY dead");
+      });
+
+    ptyOnDataCallback!("\x1b]10;?\x07\x1b]11;?\x07");
+
+    // OSC 10 was handled → stripped. OSC 11 failed → left in the stream.
+    expect(emitDataMock).toHaveBeenCalledWith("t1", "\x1b]11;?\x07");
   });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
@@ -5,6 +5,7 @@ import type { SpawnContext } from "../terminalSpawn.js";
 import type { TerminalType } from "../../../../shared/types/panel.js";
 
 let ptyWriteMock: ReturnType<typeof vi.fn<(data: string) => void>>;
+let emitDataMock: ReturnType<typeof vi.fn<(id: string, data: string | Uint8Array) => void>>;
 let ptyOnDataCallback: ((data: string) => void) | null = null;
 
 vi.mock("node-pty", () => {
@@ -61,7 +62,12 @@ function createAgentTerminal(
       agentId,
       ...options,
     },
-    { emitData: () => {}, onExit: () => {} },
+    {
+      emitData: (id, data) => {
+        emitDataMock(id, data);
+      },
+      onExit: () => {},
+    },
     {
       agentStateService: {
         handleActivityState: () => {},
@@ -85,7 +91,12 @@ function createPlainTerminal(): TerminalProcess {
       kind: "terminal",
       type: "terminal",
     },
-    { emitData: () => {}, onExit: () => {} },
+    {
+      emitData: (id, data) => {
+        emitDataMock(id, data);
+      },
+      onExit: () => {},
+    },
     {
       agentStateService: {
         handleActivityState: () => {},
@@ -101,6 +112,7 @@ function createPlainTerminal(): TerminalProcess {
 describe("TerminalProcess OSC color query responder", () => {
   beforeEach(() => {
     ptyWriteMock = vi.fn<(data: string) => void>();
+    emitDataMock = vi.fn<(id: string, data: string | Uint8Array) => void>();
     ptyOnDataCallback = null;
   });
 
@@ -154,5 +166,81 @@ describe("TerminalProcess OSC color query responder", () => {
     ptyOnDataCallback!("\x1b]11;?\x07");
 
     expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]11;rgb:0000/0000/0000\x1b\\");
+  });
+
+  it("strips handled OSC queries from renderer-forwarded data for spawn-time agents", () => {
+    createAgentTerminal("opencode");
+
+    ptyOnDataCallback!("before\x1b]10;?\x1b\\middle\x1b]11;?\x07after");
+
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]11;rgb:0000/0000/0000\x1b\\");
+    expect(emitDataMock).toHaveBeenCalledWith("t1", "beforemiddleafter");
+  });
+
+  it("forwards OSC queries unchanged to renderer for plain terminals", () => {
+    createPlainTerminal();
+
+    const payload = "\x1b]11;?\x1b\\";
+    ptyOnDataCallback!(payload);
+
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenCalledWith("t1", payload);
+  });
+
+  it("responds and strips queries after runtime promotion via detectedAgentType", () => {
+    const proc = createPlainTerminal();
+
+    // Pre-promotion: backend does not respond; renderer receives query.
+    ptyOnDataCallback!("\x1b]11;?\x1b\\");
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenLastCalledWith("t1", "\x1b]11;?\x1b\\");
+
+    // Simulate promotion: ProcessDetector would call handleAgentDetection,
+    // which sets detectedAgentType on terminalInfo. Mutate directly to isolate
+    // the OSC responder behavior.
+    proc.getInfo().detectedAgentType = "claude";
+
+    ptyOnDataCallback!("\x1b]11;?\x1b\\");
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]11;rgb:0000/0000/0000\x1b\\");
+    // Promoted terminal: renderer receives the query stripped.
+    expect(emitDataMock).toHaveBeenLastCalledWith("t1", "");
+  });
+
+  it("stops responding after demotion when detectedAgentType clears", () => {
+    const proc = createPlainTerminal();
+    proc.getInfo().detectedAgentType = "claude";
+
+    ptyOnDataCallback!("\x1b]10;?\x1b\\");
+    expect(ptyWriteMock).toHaveBeenCalledWith("\x1b]10;rgb:cccc/cccc/cccc\x1b\\");
+    ptyWriteMock.mockClear();
+
+    // Demotion: clear detectedAgentType as handleAgentDetection does on agent exit.
+    proc.getInfo().detectedAgentType = undefined;
+
+    ptyOnDataCallback!("\x1b]10;?\x1b\\");
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenLastCalledWith("t1", "\x1b]10;?\x1b\\");
+  });
+
+  it("does not strip unrelated OSC sequences (e.g. OSC 52 clipboard)", () => {
+    createAgentTerminal("opencode");
+
+    const payload = "\x1b]52;c;SGVsbG8=\x07";
+    ptyOnDataCallback!(payload);
+
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenCalledWith("t1", payload);
+  });
+
+  it("does not strip OSC 10/11 set requests (no '?'), only queries", () => {
+    createAgentTerminal("opencode");
+
+    // Setting the color (not querying) should pass through untouched.
+    const payload = "\x1b]10;rgb:ffff/ffff/ffff\x07";
+    ptyOnDataCallback!(payload);
+
+    expect(ptyWriteMock).not.toHaveBeenCalled();
+    expect(emitDataMock).toHaveBeenCalledWith("t1", payload);
   });
 });


### PR DESCRIPTION
## Summary

- The OSC 10/11 colour-query responder was installed (or skipped) based on the spawn-time `isAgentTerminal` flag, meaning a promoted terminal would have the wrong responder active.
- Replaced the spawn-time gate with a `shouldHandleOscColorQueries` getter that checks the live `terminalInfo.detectedAgentType`, so promotion and demotion are handled correctly without a restart.
- Added per-query BEL/ST terminator detection, write-success tracking, and selective stripping of handled queries from the renderer-bound data path while keeping raw data on headless, forensics, and agent output channels.

Resolves #5766

## Changes

- `electron/services/pty/TerminalProcess.ts`: new `shouldHandleOscColorQueries` getter, per-query regex, strip-on-success logic.
- `electron/services/pty/__tests__/TerminalProcess.osc.test.ts`: expanded from 6 to 15 tests covering promotion, demotion, strip-on-success, unterminated fragments, write-failure passthrough, partial failure strip, OSC set passthrough, OSC 52 passthrough, and exact call counts.

## Testing

All 15 unit tests pass. Typecheck and lint clean. Covers the key edge cases: runtime promotion activates the backend responder, demotion deactivates it, write failure falls back to passthrough rather than silently dropping the query.