### PR TITLE
fix(pty): preserve terminals that ran an agent mid-session on clean exit

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -202,6 +202,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             agentSessionId: terminal.agentSessionId,
             agentLaunchFlags: terminal.agentLaunchFlags,
             agentModelId: terminal.agentModelId,
+            everDetectedAgent: terminal.everDetectedAgent,
           });
         }
       }
@@ -249,6 +250,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentSessionId: t.agentSessionId,
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
+          everDetectedAgent: t.everDetectedAgent,
         }));
 
       logInfo(`terminal:getAvailable: found ${sanitized.length} available terminals`);
@@ -296,6 +298,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentSessionId: t.agentSessionId,
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
+          everDetectedAgent: t.everDetectedAgent,
         }));
 
       logInfo(`terminal:getByState(${state}): found ${sanitized.length} terminals`);
@@ -332,6 +335,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentSessionId: t.agentSessionId,
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
+          everDetectedAgent: t.everDetectedAgent,
         }));
 
       logInfo(`terminal:getAll: found ${sanitized.length} terminals`);
@@ -382,6 +386,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         agentSessionId: terminal.agentSessionId,
         agentLaunchFlags: terminal.agentLaunchFlags,
         agentModelId: terminal.agentModelId,
+        everDetectedAgent: terminal.everDetectedAgent,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1317,6 +1317,7 @@ port.on("message", async (rawMsg: any) => {
                 agentSessionId: terminal.agentSessionId,
                 agentLaunchFlags: terminal.agentLaunchFlags,
                 agentModelId: terminal.agentModelId,
+                everDetectedAgent: terminal.everDetectedAgent,
               }
             : null,
         });
@@ -1438,6 +1439,7 @@ port.on("message", async (rawMsg: any) => {
             agentSessionId: t.agentSessionId,
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
+            everDetectedAgent: t.everDetectedAgent,
           })),
         });
         break;
@@ -1467,6 +1469,7 @@ port.on("message", async (rawMsg: any) => {
             agentSessionId: t.agentSessionId,
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
+            everDetectedAgent: t.everDetectedAgent,
           })),
         });
         break;
@@ -1496,6 +1499,7 @@ port.on("message", async (rawMsg: any) => {
             agentSessionId: t.agentSessionId,
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
+            everDetectedAgent: t.everDetectedAgent,
           })),
         });
         break;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -84,6 +84,8 @@ interface TerminalInfoResponse {
   agentSessionId?: string;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
+  everDetectedAgent?: boolean;
 }
 
 export interface PtyClientConfig {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -450,6 +450,7 @@ export class TerminalProcess {
       lastOutputTime: t.lastOutputTime,
       lastCheckTime: t.lastCheckTime,
       detectedAgentType: t.detectedAgentType,
+      everDetectedAgent: t.everDetectedAgent,
       restartCount: t.restartCount,
       activityTier: this._activityTier,
       hasPty,
@@ -1054,7 +1055,7 @@ export class TerminalProcess {
   }
 
   shouldPreserveOnExit(exitCode: number): boolean {
-    if (!this.isAgentTerminal) {
+    if (!this.isAgentTerminal && !this.terminalInfo.everDetectedAgent) {
       return false;
     }
     if (this.terminalInfo.wasKilled) {
@@ -1369,6 +1370,7 @@ export class TerminalProcess {
 
     if (result.detected && result.agentType) {
       const previousType = terminal.detectedAgentType;
+      terminal.everDetectedAgent = true;
 
       if (previousType !== result.agentType) {
         terminal.detectedAgentType = result.agentType;

--- a/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
@@ -138,6 +138,38 @@ describe("TerminalProcess exit code persistence", () => {
     const state = terminal.getPublicState();
     expect(state.exitCode).toBeUndefined();
   });
+
+  // Regression: plain terminals that host a runtime-detected agent (user typed
+  // `claude` inside a bare shell) must be preserved on clean exit — the sticky
+  // everDetectedAgent flag is the single source of truth used by
+  // shouldPreserveOnExit to catch that case.
+  it("preserves plain terminals on clean exit when everDetectedAgent is set", () => {
+    const terminal = createTerminal({ kind: "terminal", type: "terminal" });
+    (
+      terminal as unknown as { terminalInfo: { everDetectedAgent?: boolean } }
+    ).terminalInfo.everDetectedAgent = true;
+
+    expect(exitHandler).not.toBeNull();
+    exitHandler!({ exitCode: 0 });
+
+    const state = terminal.getPublicState();
+    expect(state.isExited).toBe(true);
+    expect(state.exitCode).toBe(0);
+    expect(state.everDetectedAgent).toBe(true);
+  });
+
+  it("does not preserve plain terminals on clean exit when everDetectedAgent is true but wasKilled is set", () => {
+    const terminal = createTerminal({ kind: "terminal", type: "terminal" });
+    (
+      terminal as unknown as { terminalInfo: { everDetectedAgent?: boolean } }
+    ).terminalInfo.everDetectedAgent = true;
+
+    terminal.kill("test");
+    exitHandler!({ exitCode: 0 });
+
+    const state = terminal.getPublicState();
+    expect(state.exitCode).toBeUndefined();
+  });
 });
 
 describe("TerminalProcess spawnArgs persistence", () => {

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -38,6 +38,8 @@ export interface TerminalPublicState {
   lastOutputTime: number;
   lastCheckTime: number;
   detectedAgentType?: TerminalType;
+  /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
+  everDetectedAgent?: boolean;
   restartCount: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -56,6 +56,8 @@ export interface AddPanelOptionsBase {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time for per-panel model selection */
   agentModelId?: string;
+  /** Sticky "runtime agent ever detected" flag, rehydrated from backend during reconnect. */
+  everDetectedAgent?: boolean;
   /** Preset ID selected at launch time for per-panel preset selection */
   agentPresetId?: string;
   /** Preset brand color (hex) captured at launch time for per-panel icon tinting */

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -231,6 +231,8 @@ export interface TerminalInfoPayload {
   agentModelId?: string;
   /** Exit code when terminal has exited */
   exitCode?: number;
+  /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
+  everDetectedAgent?: boolean;
 }
 
 import type { TerminalActivityPayload } from "../terminal.js";

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -159,6 +159,8 @@ export interface BackendTerminalInfo {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time */
   agentModelId?: string;
+  /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
+  everDetectedAgent?: boolean;
 }
 
 /** Result from terminal reconnect operation */
@@ -179,6 +181,7 @@ export interface TerminalReconnectResult {
   agentSessionId?: string;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  everDetectedAgent?: boolean;
 }
 
 /** Terminal information payload for diagnostic display */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -246,6 +246,12 @@ export interface PtyPanelData extends BasePanelData {
   exitBehavior?: PanelExitBehavior;
   /** Detected process icon ID for dynamic terminal icons (transient, not persisted) */
   detectedProcessId?: string;
+  /**
+   * Set once when runtime agent detection first fires in this terminal session; never cleared.
+   * Used at exit time to preserve plain terminals that ran an agent mid-session. Live-session-only
+   * (not persisted); rehydrated from backend reconnect payload.
+   */
+  everDetectedAgent?: boolean;
   /** Captured agent session ID from graceful shutdown (used for session resume) */
   agentSessionId?: string;
   /** Process-level flags captured at launch time, persisted for session resume */
@@ -413,6 +419,12 @@ export interface TerminalInstance {
   hasPty?: boolean;
   /** Detected process icon ID for dynamic terminal icons (transient, not persisted) */
   detectedProcessId?: string;
+  /**
+   * Set once when runtime agent detection first fires in this terminal session; never cleared.
+   * Used at exit time to preserve plain terminals that ran an agent mid-session. Live-session-only
+   * (not persisted); rehydrated from backend reconnect payload.
+   */
+  everDetectedAgent?: boolean;
   /** Captured agent session ID from graceful shutdown (used for session resume) */
   agentSessionId?: string;
   /** Process-level flags captured at launch time, persisted for session resume */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -285,6 +285,8 @@ export interface PtyHostTerminalInfo {
   agentPresetId?: string;
   /** Original user-selected preset ID; unchanged across fallback hops. */
   originalAgentPresetId?: string;
+  /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
+  everDetectedAgent?: boolean;
 }
 
 /** Payload for agent:spawned event */

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -10,6 +10,7 @@ type AgentStateHandler = (data: {
 }) => void;
 type AgentDetectedHandler = (data: {
   terminalId: string;
+  agentType?: string;
   processIconId?: string;
   processName: string;
   timestamp: number;
@@ -280,6 +281,59 @@ describe("terminalStore process detection listeners", () => {
       timestamp: Date.now(),
     });
     expect(usePanelStore.getState().panelsById["term-1"]?.detectedProcessId).toBeUndefined();
+    cleanup();
+  });
+
+  // Regression for #5765: once runtime detection sees an agent, the renderer must
+  // mirror the sticky everDetectedAgent flag so the onExit guard can preserve the
+  // panel even if snapshot IPC lags behind the exit event.
+  it("sets everDetectedAgent when agent:detected carries an agentType", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "claude",
+      processIconId: "claude",
+      processName: "claude",
+      timestamp: Date.now(),
+    });
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
+    cleanup();
+  });
+
+  it("does not set everDetectedAgent for non-agent detections", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+
+    detected?.({
+      terminalId: "term-1",
+      processIconId: "npm",
+      processName: "npm",
+      timestamp: Date.now(),
+    });
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBeUndefined();
+    cleanup();
+  });
+
+  it("keeps everDetectedAgent true after agent:exited fires (sticky flag)", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+    const exited = handlers.agentExited;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "claude",
+      processIconId: "claude",
+      processName: "claude",
+      timestamp: Date.now(),
+    });
+    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
+
+    exited?.({ terminalId: "term-1", timestamp: Date.now() });
+    expect(usePanelStore.getState().panelsById["term-1"]?.everDetectedAgent).toBe(true);
     cleanup();
   });
 

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -337,6 +337,42 @@ describe("terminalStore process detection listeners", () => {
     cleanup();
   });
 
+  // End-to-end regression for #5765: a plain terminal that ran an agent must not
+  // be trashed on clean exit — the sticky flag is what the onExit handler reads.
+  it("does not trash a plain terminal on clean exit after an agent was detected", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+    const exit = handlers.exit;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "claude",
+      processIconId: "claude",
+      processName: "claude",
+      timestamp: Date.now(),
+    });
+
+    exit?.("term-1", 0);
+
+    const panel = usePanelStore.getState().panelsById["term-1"];
+    expect(panel).toBeDefined();
+    expect(panel?.location).not.toBe("trash");
+    expect(panel?.everDetectedAgent).toBe(true);
+    cleanup();
+  });
+
+  it("still trashes a plain terminal on clean exit when no agent was ever detected", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const exit = handlers.exit;
+
+    exit?.("term-1", 0);
+
+    const panel = usePanelStore.getState().panelsById["term-1"];
+    // Either moved to trash (location === "trash") or removed entirely.
+    expect(panel === undefined || panel.location === "trash").toBe(true);
+    cleanup();
+  });
+
   it("is idempotent and does not register duplicate listeners", () => {
     const cleanupA = setupTerminalStoreListeners();
     const cleanupB = setupTerminalStoreListeners();

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -264,16 +264,33 @@ export function setupTerminalStoreListeners() {
   disposables.add(
     toDisposable(
       terminalRegistryController.onAgentDetected((data) => {
-        const { terminalId, processIconId } = data;
-        if (!terminalId || !processIconId) return;
+        const { terminalId, processIconId, agentType } = data;
+        if (!terminalId) return;
+        // When a runtime agent is detected, mirror the backend sticky flag so the exit
+        // preservation guard in the renderer survives even if the snapshot IPC is
+        // reordered relative to the exit event.
+        const nextEverDetectedAgent = agentType ? true : undefined;
+        if (!processIconId && !nextEverDetectedAgent) return;
 
         usePanelStore.setState((state) => {
           const terminal = state.panelsById[terminalId];
-          if (!terminal || terminal.detectedProcessId === processIconId) return state;
+          if (!terminal) return state;
+
+          const needsIconUpdate =
+            processIconId !== undefined && terminal.detectedProcessId !== processIconId;
+          const needsStickyUpdate =
+            nextEverDetectedAgent === true && terminal.everDetectedAgent !== true;
+
+          if (!needsIconUpdate && !needsStickyUpdate) return state;
+
           return {
             panelsById: {
               ...state.panelsById,
-              [terminalId]: { ...terminal, detectedProcessId: processIconId },
+              [terminalId]: {
+                ...terminal,
+                ...(needsIconUpdate && { detectedProcessId: processIconId }),
+                ...(needsStickyUpdate && { everDetectedAgent: true }),
+              },
             },
           };
         });
@@ -440,8 +457,13 @@ export function setupTerminalStoreListeners() {
           return;
         }
 
-        // Preserve successfully completed agent terminals to enable reboot and output review
-        if (isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId)) {
+        // Preserve successfully completed agent terminals to enable reboot and output review.
+        // Also preserve plain terminals that ran an agent mid-session (runtime detection);
+        // everDetectedAgent is sticky in the PTY host so it survives past the inner agent exit.
+        if (
+          isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId) ||
+          terminal.everDetectedAgent === true
+        ) {
           return;
         }
 

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -495,6 +495,8 @@ export const createCorePanelActions = (
                   lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
                   exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
                   extensionState: terminal.extensionState ?? existing.extensionState,
+                  // Sticky: once detected, never downgrade on a partial reconnect payload.
+                  everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
                 }
               : terminal;
           return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
@@ -514,6 +516,8 @@ export const createCorePanelActions = (
                   lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
                   exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
                   extensionState: terminal.extensionState ?? existing.extensionState,
+                  // Sticky: once detected, never downgrade on a partial reconnect payload.
+                  everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
                 }
               : terminal;
             const newById = { ...state.panelsById, [id]: preservedTerminal };

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -465,6 +465,7 @@ export const createCorePanelActions = (
         agentSessionId: options.agentSessionId,
         agentLaunchFlags: options.agentLaunchFlags,
         agentModelId: options.agentModelId,
+        everDetectedAgent: options.everDetectedAgent,
         agentPresetId: options.agentPresetId,
         agentPresetColor: options.agentPresetColor,
         originalPresetId: options.originalPresetId ?? options.agentPresetId,

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -701,6 +701,37 @@ describe("agentModelId propagation", () => {
   });
 });
 
+// Regression for #5765: the sticky everDetectedAgent flag must survive every
+// reconnect/hydration builder so a reload doesn't drop it and then expose the
+// original trash-on-exit bug.
+describe("everDetectedAgent propagation", () => {
+  it("buildArgsForBackendTerminal forwards everDetectedAgent", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", everDetectedAgent: true },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.everDetectedAgent).toBe(true);
+  });
+
+  it("buildArgsForReconnectedFallback forwards everDetectedAgent", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p", everDetectedAgent: true },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.everDetectedAgent).toBe(true);
+  });
+
+  it("buildArgsForOrphanedTerminal forwards everDetectedAgent", () => {
+    const result = buildArgsForOrphanedTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", everDetectedAgent: true },
+      "/p"
+    );
+    expect(result.everDetectedAgent).toBe(true);
+  });
+});
+
 describe("buildArgsForNonPtyRecreation", () => {
   it("builds browser panel args", () => {
     const result = buildArgsForNonPtyRecreation(

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -460,5 +460,6 @@ export function buildArgsForOrphanedTerminal(
     agentSessionId: terminal.agentSessionId,
     agentLaunchFlags: terminal.agentLaunchFlags,
     agentModelId: terminal.agentModelId,
+    everDetectedAgent: terminal.everDetectedAgent,
   };
 }

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -95,6 +95,7 @@ interface BackendTerminalData {
   agentSessionId?: string;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  everDetectedAgent?: boolean;
 }
 
 interface ReconnectedTerminalData {
@@ -110,6 +111,7 @@ interface ReconnectedTerminalData {
   agentSessionId?: string;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  everDetectedAgent?: boolean;
 }
 
 interface AgentSettingsData {
@@ -192,6 +194,7 @@ export function buildArgsForBackendTerminal(
     agentSessionId: backendTerminal.agentSessionId ?? saved.agentSessionId,
     agentLaunchFlags: backendTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,
     agentModelId: backendTerminal.agentModelId ?? saved.agentModelId,
+    everDetectedAgent: backendTerminal.everDetectedAgent,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,
@@ -245,6 +248,7 @@ export function buildArgsForReconnectedFallback(
     agentSessionId: reconnectedTerminal.agentSessionId ?? saved.agentSessionId,
     agentLaunchFlags: reconnectedTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,
     agentModelId: reconnectedTerminal.agentModelId ?? saved.agentModelId,
+    everDetectedAgent: reconnectedTerminal.everDetectedAgent,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,


### PR DESCRIPTION
## Summary

- `shouldPreserveOnExit` was keying on the spawn-time `isAgentTerminal` flag, so plain terminals where the user typed `claude` (or any agent) mid-session were silently trashed on clean exit even though they had live agent output worth reviewing.
- Added a sticky `everDetectedAgent` boolean to `TerminalPublicState` (set in `handleAgentDetection`, never cleared) and threaded it through all snapshot IPC handlers, type definitions, reconnect paths, and renderer state patchers. Both `shouldPreserveOnExit` and the renderer `onExit` guard now check this flag alongside `isAgentTerminal`.
- Covered with 10 regression tests across `TerminalProcess.exitCode.test.ts`, `panelStore.processDetectionListeners.test.ts`, and `statePatcher.test.ts`.

Resolves #5765

## Changes

- `electron/services/pty/TerminalProcess.ts` — `shouldPreserveOnExit` checks `everDetectedAgent`
- `electron/services/pty/types.ts` + `electron/pty-host.ts` — `everDetectedAgent` added to `TerminalPublicState` and all 4 inline PTY-host payloads
- `electron/ipc/handlers/terminal/snapshots.ts` — all 5 snapshot handlers propagate the flag
- `electron/services/PtyClient.ts` — client type updated
- `shared/types/ipc/terminal.ts`, `shared/types/panel.ts`, `shared/types/addPanelOptions.ts`, `shared/types/pty-host.ts` — type definitions updated across the board
- `src/store/panelStoreListeners.ts` — renderer `onExit` respects `everDetectedAgent`; `onAgentDetected` mirrors the flag
- `src/store/slices/panelRegistry/core.ts` — reconnect merge uses `||` so existing `true` is never downgraded
- `src/utils/stateHydration/statePatcher.ts` — all 3 state patcher builders propagate `everDetectedAgent`

## Testing

10 new unit tests covering: `shouldPreserveOnExit` respects the flag (2 cases), detect+exit flow where panel is not trashed (5 cases including the end-to-end scenario), and state patcher propagation (3 cases). Flag is live-session-only and intentionally not persisted in `PanelSnapshot`.