### PR TITLE
feat(activity-monitor): add reconfigure() to swap agent patterns at runtime

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -130,7 +130,7 @@ export class ActivityMonitor {
   private pendingStateRevalidation = false;
 
   // Pattern-based detection
-  private readonly patternDetector?: AgentPatternDetector;
+  private patternDetector?: AgentPatternDetector;
   private lastPatternResult?: PatternDetectionResult;
   private readonly getVisibleLines?: (n: number) => string[];
   private readonly getCursorLine?: () => string | null;
@@ -422,6 +422,24 @@ export class ActivityMonitor {
 
   getLastPatternResult(): PatternDetectionResult | undefined {
     return this.lastPatternResult;
+  }
+
+  reconfigure(agentId?: string, patternConfig?: PatternDetectionConfig): void {
+    if (this.isDisposed) return;
+
+    this.patternDetector =
+      agentId || patternConfig ? new AgentPatternDetector(agentId, patternConfig) : undefined;
+
+    // Old buffer contents and TTL-gated pattern results belong to the previous
+    // detector — leaving any of them would let stale matches hold working state
+    // through the debounce callback's WORKING_INDICATOR_TTL_MS window. Timing
+    // fields (lastActivityTimestamp, promptStableSince, CPU hysteresis,
+    // workingHoldUntil, debounceTimer) are preserved so busy/idle classification
+    // stays coherent across the swap.
+    this.patternBuf.reset();
+    this.lastPatternResult = undefined;
+    this.lastPatternResultAt = 0;
+    this.lastWorkingIndicatorTimestamp = 0;
   }
 
   notifySubmission(): void {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3746,4 +3746,154 @@ describe("ActivityMonitor", () => {
       expect(onStateChange).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("reconfigure", () => {
+    const CLAUDE_WORKING = "✽ Deliberating… (esc to interrupt · 15s)";
+    const GEMINI_WORKING = "⠼ Unpacking Project Details (esc to cancel, 14s)";
+
+    it("swaps detector so old-agent patterns no longer match after reconfigure", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-1", 1, onStateChange, { agentId: "claude" });
+
+      // Baseline: claude detector matches its own pattern
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+
+      monitor.reconfigure("gemini");
+
+      // Feed claude-only pattern — gemini detector should not match it
+      monitor.onData("✽ Deliberating…");
+      expect(monitor.getLastPatternResult()?.isWorking).toBeFalsy();
+
+      // Feed gemini-only pattern — new detector should match
+      monitor.onData(GEMINI_WORKING);
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+
+      monitor.dispose();
+    });
+
+    it("clears pattern buffer and TTL fields on reconfigure", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-2", 1, onStateChange, { agentId: "claude" });
+
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+
+      type MonitorInternals = {
+        patternBuf: { getText(): string };
+        lastPatternResult: unknown;
+        lastPatternResultAt: number;
+        lastWorkingIndicatorTimestamp: number;
+      };
+      const internals = monitor as unknown as MonitorInternals;
+      expect(internals.patternBuf.getText().length).toBeGreaterThan(0);
+
+      monitor.reconfigure("gemini");
+
+      expect(internals.patternBuf.getText()).toBe("");
+      expect(internals.lastPatternResult).toBeUndefined();
+      expect(internals.lastPatternResultAt).toBe(0);
+      expect(internals.lastWorkingIndicatorTimestamp).toBe(0);
+
+      monitor.dispose();
+    });
+
+    it("preserves timing state (lastActivityTimestamp, workingHoldUntil) across reconfigure", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-3", 1, onStateChange, { agentId: "claude" });
+
+      monitor.onData(CLAUDE_WORKING);
+
+      type MonitorInternals = {
+        lastActivityTimestamp: number;
+        workingHoldUntil: number;
+      };
+      const before = monitor as unknown as MonitorInternals;
+      const ts = before.lastActivityTimestamp;
+      const hold = before.workingHoldUntil;
+      expect(ts).toBeGreaterThan(0);
+
+      vi.setSystemTime(10050);
+      monitor.reconfigure("gemini");
+
+      expect(before.lastActivityTimestamp).toBe(ts);
+      expect(before.workingHoldUntil).toBe(hold);
+
+      monitor.dispose();
+    });
+
+    it("does not emit stale working state after reconfigure (debounce TTL guard)", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-4", 1, onStateChange, {
+        agentId: "claude",
+        idleDebounceMs: 1000,
+      });
+
+      // Enter working via claude pattern
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      // Swap to gemini — stale pattern result must not hold working through TTL
+      monitor.reconfigure("gemini");
+
+      // Advance past idle debounce. With stale TTL fields cleared, monitor should
+      // go idle (no new working signals from old detector's stale state).
+      vi.advanceTimersByTime(5000);
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).toHaveBeenCalledWith("reconf-4", 1, "idle");
+
+      monitor.dispose();
+    });
+
+    it("treats reconfigure with no args as disabling the detector", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-5", 1, onStateChange, { agentId: "claude" });
+
+      monitor.reconfigure();
+
+      // With no detector, claude pattern should not register a working result
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()).toBeUndefined();
+
+      monitor.dispose();
+    });
+
+    it("builds a detector when reconfigure is called on a monitor that had none", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-6", 1, onStateChange);
+
+      // No detector initially
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()).toBeUndefined();
+
+      monitor.reconfigure("claude");
+      monitor.onData(CLAUDE_WORKING);
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+
+      monitor.dispose();
+    });
+
+    it("is a no-op after dispose", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("reconf-7", 1, onStateChange, { agentId: "claude" });
+
+      monitor.dispose();
+
+      expect(() => monitor.reconfigure("gemini")).not.toThrow();
+
+      // Disposed monitor should not react to further data
+      onStateChange.mockClear();
+      monitor.onData(GEMINI_WORKING);
+      expect(onStateChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1441,6 +1441,8 @@ export class TerminalProcess {
         terminal.detectedAgentType = result.agentType;
         terminal.type = result.agentType;
 
+        this.activityMonitor?.reconfigure(result.agentType);
+
         if (!terminal.title || terminal.title === previousType || terminal.title === "Terminal") {
           const config = AGENT_REGISTRY[result.agentType];
           terminal.title =

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -61,6 +61,7 @@ import {
 import {
   createProcessStateValidator,
   buildActivityMonitorOptions,
+  buildPatternConfig,
 } from "./terminalActivityPatterns.js";
 import { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
 import { SemanticBufferManager } from "./SemanticBufferManager.js";
@@ -1441,7 +1442,9 @@ export class TerminalProcess {
         terminal.detectedAgentType = result.agentType;
         terminal.type = result.agentType;
 
-        this.activityMonitor?.reconfigure(result.agentType);
+        const detection = getEffectiveAgentConfig(result.agentType)?.detection;
+        const patternConfig = buildPatternConfig(detection, result.agentType);
+        this.activityMonitor?.reconfigure(result.agentType, patternConfig);
 
         if (!terminal.title || terminal.title === previousType || terminal.title === "Terminal") {
           const config = AGENT_REGISTRY[result.agentType];


### PR DESCRIPTION
## Summary

- `ActivityMonitor` previously baked agent pattern regexes at construction with no way to swap them at runtime, blocking any workflow where a terminal's agent identity changes after the monitor starts
- Added a `reconfigure(agentId?, patternConfig?)` method that swaps the `AgentPatternDetector` and resets pattern-match state (buffer, TTL results, working indicator timestamp) while preserving timing and CPU hysteresis so idle/busy classifications stay coherent across the swap
- Wired it up in `TerminalProcess.handleAgentDetection` so agent type transitions call `reconfigure` with the full compiled config from `getEffectiveAgentConfig` + `buildPatternConfig`

Resolves #5769

## Changes

- `electron/services/ActivityMonitor.ts`: removed `readonly` from `patternDetector`, added public `reconfigure()` that clears pattern-derived state while leaving timing state (lastActivityTimestamp, promptStableSince, workingHoldUntil, CPU hysteresis, debounce timer, polling interval) intact
- `electron/services/pty/TerminalProcess.ts`: on agent type change in `handleAgentDetection`, calls `this.activityMonitor?.reconfigure(result.agentType, patternConfig)` using the effective config so custom agents get their full detection setup
- `electron/services/__tests__/ActivityMonitor.test.ts`: 7 new tests covering detector swap, buffer and TTL reset, timing preservation, debounce TTL guard, disabled detector, and post-dispose no-op

## Testing

150 tests pass. Typecheck clean. Lint improved by 4 warnings vs baseline. Tests cover the core invariant directly: pattern state clears, timing state survives, and no events fire after dispose.