### PR TITLE
fix(panel): skip '(copy)' suffix when duplicating default-titled panels

### DIFF
--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+import type { AddPanelOptions } from "@/store/slices/panelRegistry/types";
+
+const panelStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const layoutUndoMock = vi.hoisted(() => ({
+  getState: vi.fn(() => ({ pushLayoutSnapshot: vi.fn() })),
+}));
+const buildPanelDuplicateOptionsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/panelStore", () => ({ usePanelStore: panelStoreMock }));
+vi.mock("@/store/layoutUndoStore", () => ({ useLayoutUndoStore: layoutUndoMock }));
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: buildPanelDuplicateOptionsMock,
+}));
+
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  getDefaultPanelTitle: (kind: string, agentId?: string) => {
+    if (kind === "agent" && agentId === "claude") return "Claude";
+    if (kind === "agent" && agentId === "gemini") return "Gemini";
+    if (kind === "terminal") return "Terminal";
+    if (kind === "browser") return "Browser";
+    if (kind === "notes") return "Notes";
+    if (kind === "dev-preview") return "Dev Preview";
+    return kind.charAt(0).toUpperCase() + kind.slice(1);
+  },
+}));
+
+import { registerTerminalSpawnActions } from "../terminalSpawnActions";
+
+function setupActions() {
+  const actions: ActionRegistry = new Map();
+  const callbacks: ActionCallbacks = {
+    getDefaultCwd: () => "/cwd",
+    getActiveWorktreeId: () => "wt-1",
+  } as unknown as ActionCallbacks;
+  registerTerminalSpawnActions(actions, callbacks);
+  return async (id: string, args?: unknown): Promise<unknown> => {
+    const factory = actions.get(id);
+    if (!factory) throw new Error(`missing ${id}`);
+    const def = factory() as AnyActionDefinition;
+    return def.run(args, {} as never);
+  };
+}
+
+type MockPanel = {
+  id: string;
+  location: "grid" | "dock" | "trash";
+  kind?: "agent" | "terminal" | "browser" | "notes" | "dev-preview";
+  type?: string;
+  agentId?: string;
+  title?: string;
+};
+
+function setPanelState(options: {
+  focusedId?: string | null;
+  panels?: MockPanel[];
+  addPanel?: ReturnType<typeof vi.fn>;
+  lastClosedConfig?: AddPanelOptions | null;
+}) {
+  const panels = options.panels ?? [];
+  const panelsById: Record<string, MockPanel> = {};
+  for (const p of panels) panelsById[p.id] = p;
+  panelStoreMock.getState.mockReturnValue({
+    focusedId: options.focusedId ?? null,
+    panelIds: panels.map((p) => p.id),
+    panelsById,
+    addPanel: options.addPanel ?? vi.fn().mockResolvedValue(undefined),
+    lastClosedConfig: options.lastClosedConfig ?? null,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildPanelDuplicateOptionsMock.mockImplementation(
+    async (panel: MockPanel, location: "grid" | "dock") => ({
+      kind: panel.kind ?? "terminal",
+      type: panel.type,
+      agentId: panel.agentId,
+      title: panel.title,
+      location,
+      cwd: "",
+    })
+  );
+});
+
+describe("terminal.duplicate (copy) suffix", () => {
+  it("does not append (copy) when agent panel title matches the default", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid", kind: "agent", agentId: "claude", title: "Claude" }],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel).toHaveBeenCalledTimes(1);
+    expect(addPanel.mock.calls[0]![0].title).toBe("Claude");
+  });
+
+  it("appends (copy) when agent panel title is user-customized", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid", kind: "agent", agentId: "claude", title: "API work" }],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("API work (copy)");
+  });
+
+  it("does not append (copy) for a default-titled terminal panel", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [
+        { id: "p1", location: "grid", kind: "terminal", type: "terminal", title: "Terminal" },
+      ],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("Terminal");
+  });
+
+  it("appends (copy) when Gemini panel is renamed", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [
+        { id: "p1", location: "grid", kind: "agent", agentId: "gemini", title: "Refactor run" },
+      ],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("Refactor run (copy)");
+  });
+
+  it("leaves title untouched when source panel has no title", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid", kind: "terminal", type: "terminal" }],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBeUndefined();
+  });
+
+  it("does not append (copy) for a default-titled browser panel", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid", kind: "browser", title: "Browser" }],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("Browser");
+  });
+});

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -72,15 +72,22 @@ function setPanelState(options: {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Mirror the real buildPanelDuplicateOptions: browser panels don't carry a title
+  // into the returned options (see panelDuplicationService.ts). All other kinds
+  // seed options.title from the source panel.
   buildPanelDuplicateOptionsMock.mockImplementation(
-    async (panel: MockPanel, location: "grid" | "dock") => ({
-      kind: panel.kind ?? "terminal",
-      type: panel.type,
-      agentId: panel.agentId,
-      title: panel.title,
-      location,
-      cwd: "",
-    })
+    async (panel: MockPanel, location: "grid" | "dock") => {
+      const kind = panel.kind ?? "terminal";
+      const base = {
+        kind,
+        type: panel.type,
+        agentId: panel.agentId,
+        location,
+        cwd: "",
+      };
+      if (kind === "browser" || kind === "dev-preview") return base;
+      return { ...base, title: panel.title };
+    }
   );
 });
 
@@ -155,7 +162,7 @@ describe("terminal.duplicate (copy) suffix", () => {
     expect(addPanel.mock.calls[0]![0].title).toBeUndefined();
   });
 
-  it("does not append (copy) for a default-titled browser panel", async () => {
+  it("browser panel duplication never carries a (copy)-suffixed title (service omits title)", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     setPanelState({
       focusedId: "p1",
@@ -165,6 +172,59 @@ describe("terminal.duplicate (copy) suffix", () => {
     const run = setupActions();
     await run("terminal.duplicate");
 
-    expect(addPanel.mock.calls[0]![0].title).toBe("Browser");
+    const opts = addPanel.mock.calls[0]![0] as { title?: string };
+    expect(opts.title).toBeUndefined();
+  });
+
+  // Regression: buildPanelDuplicateOptions normalizes the title back to the
+  // agent default when a saved preset is stale (see panelDuplicationService.ts
+  // presetWasStale branch). The duplicate action must respect that normalized
+  // title and not re-append "(copy)" using the source panel's stale title.
+  it("preserves stale-preset title normalization (no (copy) when service normalized title)", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    buildPanelDuplicateOptionsMock.mockResolvedValueOnce({
+      kind: "agent",
+      agentId: "claude",
+      type: "claude",
+      title: "Claude", // normalized by service (stale preset dropped)
+      location: "grid",
+      cwd: "",
+    });
+    setPanelState({
+      focusedId: "p1",
+      panels: [
+        {
+          id: "p1",
+          location: "grid",
+          kind: "agent",
+          agentId: "claude",
+          title: "Claude (Deleted Preset)",
+        },
+      ],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("Claude");
+  });
+
+  it("appends (copy) when a browser panel has a user-renamed title", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    buildPanelDuplicateOptionsMock.mockResolvedValueOnce({
+      kind: "browser",
+      location: "grid",
+      cwd: "",
+      title: "My App",
+    });
+    setPanelState({
+      focusedId: "p1",
+      panels: [{ id: "p1", location: "grid", kind: "browser", title: "My App" }],
+      addPanel,
+    });
+    const run = setupActions();
+    await run("terminal.duplicate");
+
+    expect(addPanel.mock.calls[0]![0].title).toBe("My App (copy)");
   });
 });

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 export function registerTerminalSpawnActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -56,7 +57,10 @@ export function registerTerminalSpawnActions(
           terminal.location === "grid" || terminal.location === "dock" ? terminal.location : "grid";
         const options = await buildPanelDuplicateOptions(terminal, location);
         if (terminal.title) {
-          options.title = `${terminal.title} (copy)`;
+          const defaultTitle = getDefaultTitle(terminal.kind, terminal.type, terminal.agentId);
+          if (terminal.title !== defaultTitle) {
+            options.title = `${terminal.title} (copy)`;
+          }
         }
         await state.addPanel(options);
       } else if (nonTrashed.length === 0) {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -56,10 +56,10 @@ export function registerTerminalSpawnActions(
         const location =
           terminal.location === "grid" || terminal.location === "dock" ? terminal.location : "grid";
         const options = await buildPanelDuplicateOptions(terminal, location);
-        if (terminal.title) {
+        if (options.title) {
           const defaultTitle = getDefaultTitle(terminal.kind, terminal.type, terminal.agentId);
-          if (terminal.title !== defaultTitle) {
-            options.title = `${terminal.title} (copy)`;
+          if (options.title !== defaultTitle) {
+            options.title = `${options.title} (copy)`;
           }
         }
         await state.addPanel(options);


### PR DESCRIPTION
## Summary

- Panel duplicate (Cmd+T) was unconditionally appending `(copy)` to every duplicated panel title, including agent panels whose title is just the default agent name (e.g. `Claude`).
- The fix compares `options.title` (post-normalised by `buildPanelDuplicateOptions`) against the default title for that panel's kind/type/agent via `getDefaultTitle`. If they match, the suffix is skipped. If the user has customised the title, `(copy)` is appended as before.
- A second commit tightens the comparison to use the post-normalised value, closing a stale-preset edge case caught during review.

Resolves #5784

## Changes

- `src/services/actions/definitions/terminalSpawnActions.ts` — conditional `(copy)` suffix in `terminal.duplicate` action
- `src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts` — unit tests covering default-title panels (no suffix), custom-title panels (suffix), and the stale-preset regression

## Testing

Unit tests added covering the three distinct cases: default title inherits cleanly, custom title gets `(copy)`, and a panel whose stored title matches a now-stale preset default is treated as custom. All pass.