### PR TITLE
fix(pty): clear partial prompt input before graceful shutdown quit

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -22,6 +22,7 @@ import {
   WRITE_INTERVAL_MS,
   GRACEFUL_SHUTDOWN_TIMEOUT_MS,
   GRACEFUL_SHUTDOWN_BUFFER_SIZE,
+  GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS,
 } from "./types.js";
 import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 import { events } from "../events.js";
@@ -799,13 +800,34 @@ export class TerminalProcess {
         finish(match?.[1] ?? null);
       });
 
-      try {
-        terminal.ptyProcess.write(quitCommand + "\r");
-      } catch {
-        origOnData.dispose();
-        origOnExit.dispose();
-        finish(null);
-      }
+      // Clear any partial user input at the agent prompt before issuing the quit command.
+      // Without this prelude, concatenated input (e.g. "half-typed/quit") is treated as a
+      // chat message by the agent and the session-ID line is never emitted. See #5785.
+      //   \x05 — Ctrl-E: move cursor to end of line
+      //   \x15 — Ctrl-U: erase from cursor to beginning of line
+      // ESC is avoided because it navigates/dismisses TUI state in bubbletea and ink CLIs.
+      (async () => {
+        try {
+          terminal.ptyProcess.write("\x05\x15");
+        } catch {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null);
+          return;
+        }
+
+        await new Promise<void>((r) => setTimeout(r, GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS));
+
+        if (resolved) return;
+
+        try {
+          terminal.ptyProcess.write(quitCommand + "\r");
+        } catch {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null);
+        }
+      })();
     });
   }
 

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+import { GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS, GRACEFUL_SHUTDOWN_TIMEOUT_MS } from "../types.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+interface MockPtyHandles {
+  pty: IPty;
+  writeMock: ReturnType<typeof vi.fn<(data: string) => void>>;
+  emitData: (data: string) => void;
+  emitExit: (exitCode: number, signal?: number) => void;
+}
+
+function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
+  let dataCallback: ((data: string) => void) | null = null;
+  let exitCallback: ((event: { exitCode: number; signal?: number }) => void) | null = null;
+
+  const writeMock = vi.fn<(data: string) => void>();
+
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: (data: string) => {
+      writeMock(data);
+      if (writeOverride) writeOverride(data);
+    },
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      dataCallback = cb;
+      return {
+        dispose: () => {
+          dataCallback = null;
+        },
+      };
+    },
+    onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
+      exitCallback = cb;
+      return {
+        dispose: () => {
+          exitCallback = null;
+        },
+      };
+    },
+  };
+
+  return {
+    pty: pty as IPty,
+    writeMock,
+    emitData: (data: string) => dataCallback?.(data),
+    emitExit: (exitCode: number, signal?: number) => exitCallback?.({ exitCode, signal }),
+  };
+}
+
+function defaultSpawnContext(overrides?: Partial<SpawnContext>): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    isAgentTerminal: true,
+    agentId: "claude",
+    env: {},
+    ...overrides,
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+
+function createAgentTerminal(handles: MockPtyHandles): TerminalProcess {
+  const opts: TerminalProcessOptions = {
+    cwd: process.cwd(),
+    cols: 80,
+    rows: 24,
+    kind: "agent",
+    type: "claude",
+    agentId: "claude",
+  };
+  return new TerminalProcess(
+    "t1",
+    opts,
+    { emitData: () => {}, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+      } as never,
+      ptyPool: null,
+      processTreeCache: null,
+    },
+    defaultSpawnContext(),
+    handles.pty
+  );
+}
+
+describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes Ctrl-E + Ctrl-U before the quit command, separated by the clear delay", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+
+    // Let microtasks run so the async IIFE inside gracefulShutdown emits the first write.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only the clear prelude should have been written — not the quit command yet.
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+
+    // Advance past the clear delay and the second write should fire.
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
+
+    // Emit the session-ID line and the promise should resolve with the captured ID.
+    handles.emitData("claude --resume abc-123\n");
+    await expect(shutdownPromise).resolves.toBe("abc-123");
+  });
+
+  it("captures session ID when surrounded by ANSI erase sequences from the clear prelude", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    // The CLI echoes back ANSI erase sequences in response to Ctrl-U before the real
+    // session-ID line. stripAnsiCodes in the matcher should strip these cleanly.
+    handles.emitData("\x1b[2K\x1b[0G");
+    handles.emitData("claude --resume session-xyz\n");
+
+    await expect(shutdownPromise).resolves.toBe("session-xyz");
+  });
+
+  it("resolves null when no session ID is emitted before the shutdown timeout", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+  });
+
+  it("resolves null when the clear-prelude write throws, without attempting the quit write", async () => {
+    let firstCall = true;
+    const handles = createMockPty((data: string) => {
+      if (firstCall && data === "\x05\x15") {
+        firstCall = false;
+        throw new Error("pty dead");
+      }
+    });
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await expect(shutdownPromise).resolves.toBeNull();
+
+    // Only the throwing prelude write should have been attempted.
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+  });
+
+  it("resolves null when the quit-command write throws after a successful prelude", async () => {
+    const handles = createMockPty((data: string) => {
+      if (data === "/quit\r") {
+        throw new Error("pty dead after prelude");
+      }
+    });
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null immediately for a terminal without agent shutdown config", async () => {
+    const handles = createMockPty();
+    const terminal = new TerminalProcess(
+      "t-no-agent",
+      {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        type: "terminal",
+      },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+        } as never,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      defaultSpawnContext({ isAgentTerminal: false, agentId: undefined }),
+      handles.pty
+    );
+
+    await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+    expect(handles.writeMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -131,6 +131,9 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     // Emit the session-ID line and the promise should resolve with the captured ID.
     handles.emitData("claude --resume abc-123\n");
     await expect(shutdownPromise).resolves.toBe("abc-123");
+
+    // The captured ID must also be stored on the terminal for resume-later callers.
+    expect(terminal.getInfo().agentSessionId).toBe("abc-123");
   });
 
   it("captures session ID when surrounded by ANSI erase sequences from the clear prelude", async () => {
@@ -156,6 +159,33 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
 
     await expect(shutdownPromise).resolves.toBeNull();
+    // Both writes must have been attempted before the timeout — guards against a
+    // broken async IIFE that silently swallows the second write.
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
+  });
+
+  it("skips the quit write when the PTY exits during the clear-delay window", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+
+    // Wait for the prelude write, then fire onExit before the delay timer elapses.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    handles.emitExit(0);
+
+    // Advance past the clear delay — the guarded branch should short-circuit and
+    // NOT issue the quit command after the process has already exited.
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
   });
 
   it("resolves null when the clear-prelude write throws, without attempting the quit write", async () => {

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -157,6 +157,9 @@ export { TRASH_TTL_MS } from "../../../shared/config/trash.js";
 // Graceful shutdown configuration
 export const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 2500;
 export const GRACEFUL_SHUTDOWN_BUFFER_SIZE = 8 * 1024;
+// Delay between writing the input-clear prelude and the quit command. Without this gap,
+// the target CLI's async event loop can drop or corrupt the quit command bytes under load.
+export const GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS = 100;
 
 // IPC Flow Control Configuration
 export const IPC_MAX_QUEUE_BYTES = 8 * 1024 * 1024; // 8MB max per terminal


### PR DESCRIPTION
## Summary

- When graceful shutdown writes the quit command, any partial input sitting at the agent prompt would get concatenated with it (e.g. `half-typed/quit`), causing the agent to treat it as a chat message rather than a command. No session ID gets emitted and resume-code capture fails.
- The fix writes `\x05\x15` (Ctrl-E + Ctrl-U) before the quit command to move the cursor to end-of-line and clear the input buffer, waits 100ms for the terminal to process it, then writes the quit command to a clean prompt.
- Added `GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS` constant to `types.ts` and converted the shutdown write path to an async IIFE with a resolved-guard check so the delay fits safely within the existing `GRACEFUL_SHUTDOWN_TIMEOUT_MS` budget.

Resolves #5785

## Changes

- `electron/services/pty/types.ts` — added `GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS = 100` constant
- `electron/services/pty/TerminalProcess.ts` — replaced synchronous quit write with an async IIFE that writes the Ctrl-E + Ctrl-U prelude, awaits the delay with a resolved guard, then writes the quit command; each write is in its own try/catch
- `electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts` — 7 new focused tests covering the prelude sequence, delay ordering, resolved-guard short-circuit, and write failure handling

## Testing

- New test file: 7/7 pass
- Full PTY test suite: 602/602 pass
- Typecheck, lint, and format all clean