### PR TITLE
feat(panel): promote runtime agent identity to first-class panel field

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -203,6 +203,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             agentLaunchFlags: terminal.agentLaunchFlags,
             agentModelId: terminal.agentModelId,
             everDetectedAgent: terminal.everDetectedAgent,
+            detectedAgentId: terminal.detectedAgentId,
           });
         }
       }
@@ -251,6 +252,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
           everDetectedAgent: t.everDetectedAgent,
+          detectedAgentId: t.detectedAgentId,
         }));
 
       logInfo(`terminal:getAvailable: found ${sanitized.length} available terminals`);
@@ -299,6 +301,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
           everDetectedAgent: t.everDetectedAgent,
+          detectedAgentId: t.detectedAgentId,
         }));
 
       logInfo(`terminal:getByState(${state}): found ${sanitized.length} terminals`);
@@ -336,6 +339,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           agentLaunchFlags: t.agentLaunchFlags,
           agentModelId: t.agentModelId,
           everDetectedAgent: t.everDetectedAgent,
+          detectedAgentId: t.detectedAgentId,
         }));
 
       logInfo(`terminal:getAll: found ${sanitized.length} terminals`);
@@ -387,6 +391,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         agentLaunchFlags: terminal.agentLaunchFlags,
         agentModelId: terminal.agentModelId,
         everDetectedAgent: terminal.everDetectedAgent,
+        detectedAgentId: terminal.detectedAgentId,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -38,6 +38,7 @@ import { setLogLevelOverrides } from "./utils/logger.js";
 import type { AgentEvent } from "./services/AgentStateMachine.js";
 import type { PtyHostEvent, SpawnResult } from "../shared/types/pty-host.js";
 import { normalizeScrollbackLines } from "../shared/config/scrollback.js";
+import { isBuiltInAgentId, type BuiltInAgentId } from "../shared/config/agentIds.js";
 import { setSessionPersistSuppressed } from "./services/pty/terminalSessionPersistence.js";
 import {
   appendEmergencyLog,
@@ -235,6 +236,11 @@ const resourceGovernor = new ResourceGovernor({
 // Helper to convert data to string for IPC fallback (IPC events expect string)
 function toStringForIpc(data: string | Uint8Array): string {
   return typeof data === "string" ? data : textDecoder.decode(data);
+}
+
+/** Narrow a backend TerminalType-valued detection field to BuiltInAgentId for IPC. */
+function narrowDetectedAgentId(value: unknown): BuiltInAgentId | undefined {
+  return isBuiltInAgentId(value) ? value : undefined;
 }
 
 // Wire up PtyManager events
@@ -1318,6 +1324,7 @@ port.on("message", async (rawMsg: any) => {
                 agentLaunchFlags: terminal.agentLaunchFlags,
                 agentModelId: terminal.agentModelId,
                 everDetectedAgent: terminal.everDetectedAgent,
+                detectedAgentId: narrowDetectedAgentId(terminal.detectedAgentType),
               }
             : null,
         });
@@ -1440,6 +1447,7 @@ port.on("message", async (rawMsg: any) => {
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
             everDetectedAgent: t.everDetectedAgent,
+            detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
           })),
         });
         break;
@@ -1470,6 +1478,7 @@ port.on("message", async (rawMsg: any) => {
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
             everDetectedAgent: t.everDetectedAgent,
+            detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
           })),
         });
         break;
@@ -1500,6 +1509,7 @@ port.on("message", async (rawMsg: any) => {
             agentLaunchFlags: t.agentLaunchFlags,
             agentModelId: t.agentModelId,
             everDetectedAgent: t.everDetectedAgent,
+            detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
           })),
         });
         break;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -59,6 +59,7 @@ import type { AgentStateChangeTrigger } from "../types/index.js";
 import type { AgentState, AgentId } from "../../shared/types/agent.js";
 import type { TerminalType, PanelKind } from "../../shared/types/panel.js";
 import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
+import type { BuiltInAgentId } from "../../shared/config/agentIds.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -86,6 +87,8 @@ interface TerminalInfoResponse {
   agentModelId?: string;
   /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
   everDetectedAgent?: boolean;
+  /** Runtime-detected agent identity (cleared when the agent exits). */
+  detectedAgentId?: BuiltInAgentId;
 }
 
 export interface PtyClientConfig {

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -19,3 +19,7 @@ export type AgentKeyAction = `agent.${BuiltInAgentId}`;
 export const BUILT_IN_AGENT_KEY_ACTIONS: readonly AgentKeyAction[] = BUILT_IN_AGENT_IDS.map(
   (id) => `agent.${id}` as AgentKeyAction
 );
+
+export function isBuiltInAgentId(value: unknown): value is BuiltInAgentId {
+  return typeof value === "string" && (BUILT_IN_AGENT_IDS as readonly string[]).includes(value);
+}

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -8,6 +8,7 @@ import type {
 import type { BrowserHistory } from "./browser.js";
 import type { AgentState } from "./agent.js";
 import type { TerminalSpawnSource } from "./panel.js";
+import type { BuiltInAgentId } from "../config/agentIds.js";
 
 /** Fields shared by all panel creation requests */
 export interface AddPanelOptionsBase {
@@ -58,6 +59,8 @@ export interface AddPanelOptionsBase {
   agentModelId?: string;
   /** Sticky "runtime agent ever detected" flag, rehydrated from backend during reconnect. */
   everDetectedAgent?: boolean;
+  /** Runtime-detected agent identity at hydration time; cleared when the agent exits. Rehydrated from backend reconnect payload. */
+  detectedAgentId?: BuiltInAgentId;
   /** Preset ID selected at launch time for per-panel preset selection */
   agentPresetId?: string;
   /** Preset brand color (hex) captured at launch time for per-panel icon tinting */

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -1,6 +1,7 @@
 import type { TerminalType, PanelKind, PanelLocation } from "../panel.js";
 import type { AgentId } from "../agent.js";
 import type { AgentState } from "../agent.js";
+import type { BuiltInAgentId } from "../../config/agentIds.js";
 
 /** Terminal spawn options */
 export interface TerminalSpawnOptions {
@@ -161,6 +162,8 @@ export interface BackendTerminalInfo {
   agentModelId?: string;
   /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
   everDetectedAgent?: boolean;
+  /** Runtime-detected agent identity (cleared when the agent exits). */
+  detectedAgentId?: BuiltInAgentId;
 }
 
 /** Result from terminal reconnect operation */
@@ -182,6 +185,8 @@ export interface TerminalReconnectResult {
   agentLaunchFlags?: string[];
   agentModelId?: string;
   everDetectedAgent?: boolean;
+  /** Runtime-detected agent identity (cleared when the agent exits). */
+  detectedAgentId?: BuiltInAgentId;
 }
 
 /** Terminal information payload for diagnostic display */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -252,6 +252,12 @@ export interface PtyPanelData extends BasePanelData {
    * (not persisted); rehydrated from backend reconnect payload.
    */
   everDetectedAgent?: boolean;
+  /**
+   * Runtime-detected agent identity. Reflects the agent currently running in this terminal as
+   * identified by the backend process detector. Cleared on agent exit. Live-session-only
+   * (not persisted); rehydrated from backend reconnect payload.
+   */
+  detectedAgentId?: BuiltInAgentId;
   /** Captured agent session ID from graceful shutdown (used for session resume) */
   agentSessionId?: string;
   /** Process-level flags captured at launch time, persisted for session resume */
@@ -425,6 +431,12 @@ export interface TerminalInstance {
    * (not persisted); rehydrated from backend reconnect payload.
    */
   everDetectedAgent?: boolean;
+  /**
+   * Runtime-detected agent identity. Reflects the agent currently running in this terminal as
+   * identified by the backend process detector. Cleared on agent exit. Live-session-only
+   * (not persisted); rehydrated from backend reconnect payload.
+   */
+  detectedAgentId?: BuiltInAgentId;
   /** Captured agent session ID from graceful shutdown (used for session resume) */
   agentSessionId?: string;
   /** Process-level flags captured at launch time, persisted for session resume */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -10,6 +10,7 @@
 import type { AgentState, AgentId, WaitingReason } from "./agent.js";
 import type { TerminalType, PanelKind, TerminalFlowStatus } from "./panel.js";
 import type { ResourceProfile } from "./resourceProfile.js";
+import type { BuiltInAgentId } from "../config/agentIds.js";
 
 export type { TerminalFlowStatus };
 
@@ -287,6 +288,8 @@ export interface PtyHostTerminalInfo {
   originalAgentPresetId?: string;
   /** Set once on first runtime agent detection; never cleared. Sticky across agent exit/re-enter within session. */
   everDetectedAgent?: boolean;
+  /** Runtime-detected agent identity (cleared when the agent exits). */
+  detectedAgentId?: BuiltInAgentId;
 }
 
 /** Payload for agent:spawned event */

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -111,3 +111,13 @@ describe("serializePtyPanel — agentPresetColor (Bug: not serialized)", () => {
     expect("agentFlavorColor" in snapshot).toBe(false);
   });
 });
+
+// Runtime detection identity (#5768) is recomputed by the backend detector on
+// every PTY attach — it must not be persisted into project JSON.
+describe("serializePtyPanel — detectedAgentId is never persisted", () => {
+  it("omits detectedAgentId even when the panel currently carries one", () => {
+    const panel = makePanel({ detectedAgentId: "claude" });
+    const snapshot = serializePtyPanel(panel) as Record<string, unknown>;
+    expect("detectedAgentId" in snapshot).toBe(false);
+  });
+});

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -318,6 +318,72 @@ describe("terminalStore process detection listeners", () => {
     cleanup();
   });
 
+  it("stores detectedAgentId when agent:detected carries a BuiltInAgentId", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "claude",
+      processIconId: "claude",
+      processName: "claude",
+      timestamp: Date.now(),
+    });
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBe("claude");
+    cleanup();
+  });
+
+  it("ignores unknown agentType values for detectedAgentId", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "not-a-real-agent",
+      processIconId: "mystery",
+      processName: "mystery",
+      timestamp: Date.now(),
+    });
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    cleanup();
+  });
+
+  it("does not set detectedAgentId for non-agent detections", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+
+    detected?.({
+      terminalId: "term-1",
+      processIconId: "npm",
+      processName: "npm",
+      timestamp: Date.now(),
+    });
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    cleanup();
+  });
+
+  it("clears detectedAgentId when agent:exited fires", () => {
+    const cleanup = setupTerminalStoreListeners();
+    const detected = handlers.agentDetected;
+    const exited = handlers.agentExited;
+
+    detected?.({
+      terminalId: "term-1",
+      agentType: "gemini",
+      processIconId: "gemini",
+      processName: "gemini",
+      timestamp: Date.now(),
+    });
+    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBe("gemini");
+
+    exited?.({ terminalId: "term-1", timestamp: Date.now() });
+    expect(usePanelStore.getState().panelsById["term-1"]?.detectedAgentId).toBeUndefined();
+    cleanup();
+  });
+
   it("keeps everDetectedAgent true after agent:exited fires (sticky flag)", () => {
     const cleanup = setupTerminalStoreListeners();
     const detected = handlers.agentDetected;

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -19,6 +19,7 @@ import { getMergedPresets } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useNotificationStore } from "@/store/notificationStore";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
 
 function normalizeCrashType(value: unknown): CrashType | null {
   const validTypes: CrashType[] = [
@@ -270,7 +271,8 @@ export function setupTerminalStoreListeners() {
         // preservation guard in the renderer survives even if the snapshot IPC is
         // reordered relative to the exit event.
         const nextEverDetectedAgent = agentType ? true : undefined;
-        if (!processIconId && !nextEverDetectedAgent) return;
+        const nextDetectedAgentId = isBuiltInAgentId(agentType) ? agentType : undefined;
+        if (!processIconId && !nextEverDetectedAgent && !nextDetectedAgentId) return;
 
         usePanelStore.setState((state) => {
           const terminal = state.panelsById[terminalId];
@@ -280,8 +282,10 @@ export function setupTerminalStoreListeners() {
             processIconId !== undefined && terminal.detectedProcessId !== processIconId;
           const needsStickyUpdate =
             nextEverDetectedAgent === true && terminal.everDetectedAgent !== true;
+          const needsAgentIdUpdate =
+            nextDetectedAgentId !== undefined && terminal.detectedAgentId !== nextDetectedAgentId;
 
-          if (!needsIconUpdate && !needsStickyUpdate) return state;
+          if (!needsIconUpdate && !needsStickyUpdate && !needsAgentIdUpdate) return state;
 
           return {
             panelsById: {
@@ -290,6 +294,7 @@ export function setupTerminalStoreListeners() {
                 ...terminal,
                 ...(needsIconUpdate && { detectedProcessId: processIconId }),
                 ...(needsStickyUpdate && { everDetectedAgent: true }),
+                ...(needsAgentIdUpdate && { detectedAgentId: nextDetectedAgentId }),
               },
             },
           };
@@ -306,11 +311,18 @@ export function setupTerminalStoreListeners() {
 
         usePanelStore.setState((state) => {
           const terminal = state.panelsById[terminalId];
-          if (!terminal || !terminal.detectedProcessId) return state;
+          if (!terminal) return state;
+          if (terminal.detectedProcessId === undefined && terminal.detectedAgentId === undefined) {
+            return state;
+          }
           return {
             panelsById: {
               ...state.panelsById,
-              [terminalId]: { ...terminal, detectedProcessId: undefined },
+              [terminalId]: {
+                ...terminal,
+                detectedProcessId: undefined,
+                detectedAgentId: undefined,
+              },
             },
           };
         });

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -466,6 +466,7 @@ export const createCorePanelActions = (
         agentLaunchFlags: options.agentLaunchFlags,
         agentModelId: options.agentModelId,
         everDetectedAgent: options.everDetectedAgent,
+        detectedAgentId: options.detectedAgentId,
         agentPresetId: options.agentPresetId,
         agentPresetColor: options.agentPresetColor,
         originalPresetId: options.originalPresetId ?? options.agentPresetId,
@@ -497,6 +498,9 @@ export const createCorePanelActions = (
                   extensionState: terminal.extensionState ?? existing.extensionState,
                   // Sticky: once detected, never downgrade on a partial reconnect payload.
                   everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                  // Prefer the fresh reconnect value if present; otherwise keep an existing
+                  // live detection (live IPC event may have landed before reconnect flush).
+                  detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
                 }
               : terminal;
           return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
@@ -518,6 +522,9 @@ export const createCorePanelActions = (
                   extensionState: terminal.extensionState ?? existing.extensionState,
                   // Sticky: once detected, never downgrade on a partial reconnect payload.
                   everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                  // Prefer the fresh reconnect value if present; otherwise keep an existing
+                  // live detection (live IPC event may have landed before reconnect flush).
+                  detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
                 }
               : terminal;
             const newById = { ...state.panelsById, [id]: preservedTerminal };

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -770,6 +770,22 @@ describe("detectedAgentId propagation", () => {
     );
     expect(result.detectedAgentId).toBeUndefined();
   });
+
+  // Runtime detection must never be resurrected from saved JSON — the cold-start
+  // path relies on the backend detector to repopulate the field post-spawn.
+  it("buildArgsForRespawn does not carry detectedAgentId even if saved JSON somehow has one", () => {
+    const saved = {
+      id: "t1",
+      kind: "agent" as const,
+      agentId: "claude",
+      title: "Claude",
+      cwd: "/p",
+      location: "grid",
+    } as Parameters<typeof buildArgsForRespawn>[0] & { detectedAgentId?: string };
+    (saved as { detectedAgentId?: string }).detectedAgentId = "claude";
+    const result = buildArgsForRespawn(saved, "agent", "/p", { agents: {} }, false, undefined);
+    expect((result as { detectedAgentId?: string }).detectedAgentId).toBeUndefined();
+  });
 });
 
 describe("buildArgsForNonPtyRecreation", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -732,6 +732,46 @@ describe("everDetectedAgent propagation", () => {
   });
 });
 
+// #5768: the live-detected agent identity must survive every reconnect
+// hydration builder so consumers (fleet arming, focus nav, headlines) can
+// read a single source of truth after a project switch.
+describe("detectedAgentId propagation", () => {
+  it("buildArgsForBackendTerminal forwards detectedAgentId", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", detectedAgentId: "claude" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.detectedAgentId).toBe("claude");
+  });
+
+  it("buildArgsForReconnectedFallback forwards detectedAgentId", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p", detectedAgentId: "gemini" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.detectedAgentId).toBe("gemini");
+  });
+
+  it("buildArgsForOrphanedTerminal forwards detectedAgentId", () => {
+    const result = buildArgsForOrphanedTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", detectedAgentId: "codex" },
+      "/p"
+    );
+    expect(result.detectedAgentId).toBe("codex");
+  });
+
+  it("buildArgsForBackendTerminal leaves detectedAgentId undefined when backend has none", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.detectedAgentId).toBeUndefined();
+  });
+});
+
 describe("buildArgsForNonPtyRecreation", () => {
   it("builds browser panel args", () => {
     const result = buildArgsForNonPtyRecreation(

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -2,6 +2,7 @@ import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { BrowserHistory } from "@shared/types/browser";
 import type { PanelExitBehavior } from "@shared/types/panel";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import {
   isRegisteredAgent,
   getAgentConfig,
@@ -96,6 +97,7 @@ interface BackendTerminalData {
   agentLaunchFlags?: string[];
   agentModelId?: string;
   everDetectedAgent?: boolean;
+  detectedAgentId?: BuiltInAgentId;
 }
 
 interface ReconnectedTerminalData {
@@ -112,6 +114,7 @@ interface ReconnectedTerminalData {
   agentLaunchFlags?: string[];
   agentModelId?: string;
   everDetectedAgent?: boolean;
+  detectedAgentId?: BuiltInAgentId;
 }
 
 interface AgentSettingsData {
@@ -195,6 +198,7 @@ export function buildArgsForBackendTerminal(
     agentLaunchFlags: backendTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,
     agentModelId: backendTerminal.agentModelId ?? saved.agentModelId,
     everDetectedAgent: backendTerminal.everDetectedAgent,
+    detectedAgentId: backendTerminal.detectedAgentId,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,
@@ -249,6 +253,7 @@ export function buildArgsForReconnectedFallback(
     agentLaunchFlags: reconnectedTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,
     agentModelId: reconnectedTerminal.agentModelId ?? saved.agentModelId,
     everDetectedAgent: reconnectedTerminal.everDetectedAgent,
+    detectedAgentId: reconnectedTerminal.detectedAgentId,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,
@@ -461,5 +466,6 @@ export function buildArgsForOrphanedTerminal(
     agentLaunchFlags: terminal.agentLaunchFlags,
     agentModelId: terminal.agentModelId,
     everDetectedAgent: terminal.everDetectedAgent,
+    detectedAgentId: terminal.detectedAgentId,
   };
 }


### PR DESCRIPTION
## Summary

- Surfaces `detectedAgentId` as a reactive, non-persisted field on `PtyPanelData`, fed by the existing backend `detectedAgentType` signal
- Removes the split-brain between `panel.kind`, `panel.agentId`, `terminal.type`, and `detectedAgentType` by giving all subsystems a single live-runtime field to read from
- Persisted `agentId` continues to represent launch identity (what to restart as), independent from the new runtime field

Resolves #5768

## Changes

- `shared/types/panel.ts` — adds `detectedAgentId` to `PtyPanelData`
- `shared/types/ipc/terminal.ts`, `shared/types/pty-host.ts` — exposes `detectedAgentId` in IPC surface
- `shared/types/addPanelOptions.ts` — optional field on panel creation
- `shared/config/agentIds.ts` — typed constant set for known agent IDs
- `electron/pty-host.ts`, `electron/ipc/handlers/terminal/snapshots.ts`, `electron/services/PtyClient.ts` — plumbs `detectedAgentId` from the backend process detector through to snapshots
- `src/store/panelStoreListeners.ts`, `src/store/slices/panelRegistry/core.ts`, `src/utils/stateHydration/statePatcher.ts` — updates the renderer store to write and hydrate the field, with a respawn guard that resets it when a terminal respawns so stale identity doesn't carry over
- `src/panels/terminal/__tests__/serializer.test.ts`, `src/store/panelStore.processDetectionListeners.test.ts`, `src/utils/stateHydration/__tests__/statePatcher.test.ts` — unit test coverage for the new field, the respawn guard, and state patching

## Testing

Unit tests cover the respawn guard, process detection listener, serializer round-trip, and state patcher. All existing tests pass. Format and lint clean.