### PR TITLE
feat(fleet): read live agent identity for arming and broadcast eligibility

### DIFF
--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -228,6 +228,33 @@ describe("resolveFleetBroadcastTargetIds", () => {
     useFleetArmingStore.getState().armIds(["a", "ghost"]);
     expect(resolveFleetBroadcastTargetIds()).toEqual(["a"]);
   });
+
+  it("includes a plain terminal running a detected agent", () => {
+    seedPanels([
+      makeAgent("a"),
+      makeAgent("p", {
+        kind: "terminal",
+        agentId: undefined,
+        detectedAgentId: "claude",
+      }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a", "p"]);
+    expect(resolveFleetBroadcastTargetIds()).toEqual(["a", "p"]);
+  });
+
+  it("keeps a plain terminal armed after detected agent exits (sticky everDetectedAgent)", () => {
+    seedPanels([
+      makeAgent("a"),
+      makeAgent("p", {
+        kind: "terminal",
+        agentId: undefined,
+        detectedAgentId: undefined,
+        everDetectedAgent: true,
+      }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a", "p"]);
+    expect(resolveFleetBroadcastTargetIds()).toEqual(["a", "p"]);
+  });
 });
 
 describe("areAgentStatesBroadcastCompatible", () => {

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -398,6 +398,73 @@ describe("fleetArmingStore", () => {
     it("rejects undefined", () => {
       expect(isFleetArmEligible(undefined)).toBe(false);
     });
+
+    it("accepts a plain terminal currently running a detected agent", () => {
+      expect(
+        isFleetArmEligible(
+          makeAgentTerminal("a", {
+            kind: "terminal",
+            agentId: undefined,
+            detectedAgentId: "claude",
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("accepts a plain terminal that has ever run an agent this session", () => {
+      expect(
+        isFleetArmEligible(
+          makeAgentTerminal("a", {
+            kind: "terminal",
+            agentId: undefined,
+            everDetectedAgent: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("remains eligible after detectedAgentId clears when everDetectedAgent is sticky", () => {
+      // Sticky rule: once a panel has ever run an agent, it stays fleet-eligible
+      // even after the live process exits. Prevents the armed set from collapsing
+      // mid-operation when agents bounce.
+      expect(
+        isFleetArmEligible(
+          makeAgentTerminal("a", {
+            kind: "terminal",
+            agentId: undefined,
+            detectedAgentId: undefined,
+            everDetectedAgent: true,
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("trash guard beats runtime-detected identity", () => {
+      expect(
+        isFleetArmEligible(
+          makeAgentTerminal("a", {
+            kind: "terminal",
+            agentId: undefined,
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            location: "trash",
+          })
+        )
+      ).toBe(false);
+    });
+
+    it("hasPty=false guard beats runtime-detected identity", () => {
+      expect(
+        isFleetArmEligible(
+          makeAgentTerminal("a", {
+            kind: "terminal",
+            agentId: undefined,
+            everDetectedAgent: true,
+            hasPty: false,
+          })
+        )
+      ).toBe(false);
+    });
   });
 
   describe("panel prune subscription", () => {

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -219,6 +219,25 @@ describe("fleetArmingStore", () => {
       useFleetArmingStore.getState().armAll("all");
       expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
     });
+
+    it("includes plain terminals currently running a detected agent", () => {
+      seedPanels([
+        makeAgentTerminal("a1"),
+        makeAgentTerminal("p1", {
+          kind: "terminal",
+          agentId: undefined,
+          detectedAgentId: "claude",
+        }),
+        makeAgentTerminal("p2", {
+          kind: "terminal",
+          agentId: undefined,
+          everDetectedAgent: true,
+        }),
+        makeAgentTerminal("p3", { kind: "terminal", agentId: undefined }),
+      ]);
+      useFleetArmingStore.getState().armAll("current");
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "p1", "p2"]);
+    });
   });
 
   describe("armMatchingFilter", () => {
@@ -304,6 +323,26 @@ describe("fleetArmingStore", () => {
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1", "wt-1", "wt-1"]);
       expect(useFleetArmingStore.getState().armOrder).toEqual(["a1", "a2"]);
+    });
+
+    it("includes plain terminals with runtime-detected agent identity", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("p1", {
+          worktreeId: "wt-1",
+          kind: "terminal",
+          agentId: undefined,
+          detectedAgentId: "claude",
+        }),
+        makeAgentTerminal("p2", {
+          worktreeId: "wt-1",
+          kind: "terminal",
+          agentId: undefined,
+          everDetectedAgent: true,
+        }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "p1", "p2"]);
     });
 
     it("is fully idempotent — repeated calls preserve armOrder, armOrderById, and lastArmedId", () => {

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -53,7 +53,9 @@ export function isFleetArmEligible(t: TerminalInstance | undefined): t is Termin
   if (!t) return false;
   if (t.location === "trash" || t.location === "background") return false;
   if (t.hasPty === false) return false;
-  return isAgentTerminal(t.kind ?? t.type, t.agentId);
+  return (
+    isAgentTerminal(t.kind ?? t.type, t.agentId) || !!t.detectedAgentId || !!t.everDetectedAgent
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fleet arming eligibility now accepts panels where `detectedAgentId` or `everDetectedAgent` is set, so plain terminals running an agent participate in fleet arming, broadcast, and commands without relying on spawn-time `kind`/`agentId`.
- Sticky via `everDetectedAgent`: eligibility survives agent exit and restart, so a mid-operation fleet doesn't silently collapse when a process bounces.
- All downstream consumers (fleet broadcast, fleet execution, the ribbon, action definitions) auto-benefit through the shared `isFleetArmEligible` predicate — no changes needed there.

Resolves #5771

## Changes

- `src/store/fleetArmingStore.ts`: extended the `isFleetArmEligible` predicate with `|| !!t.detectedAgentId || !!t.everDetectedAgent`
- `src/store/__tests__/fleetArmingStore.test.ts`: new test cases covering `armAll('current')` and `armMatchingFilter` with runtime-detected identity, including sticky behaviour after agent exit
- `src/components/Fleet/__tests__/fleetBroadcast.test.ts`: broadcast target resolution tested against plain terminals with `detectedAgentId`, confirming they stay armed post-exit via `everDetectedAgent`

## Testing

Unit tests cover the three affected paths: `armAll`, `armMatchingFilter`, and `resolveFleetBroadcastTargetIds`. Both the transient (`detectedAgentId` present) and sticky (`everDetectedAgent` set, agent has exited) cases are exercised.