### PR TITLE
fix(theme-browser): portal overlay, hover blur, full viewport height

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
-import { cn } from "@/lib/utils";
+import { createPortal } from "react-dom";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
 import { TerminalDockRegion } from "./TerminalDockRegion";
@@ -342,11 +342,7 @@ export function AppLayout({
       </div>
       <div
         {...(isThemeBrowserOpen ? { inert: true } : {})}
-        className={cn(
-          "flex-1 flex flex-col overflow-hidden",
-          "transition-[filter,opacity] duration-300",
-          isThemeBrowserOpen && "bg-scrim-soft/30 backdrop-blur-[2px]"
-        )}
+        className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
       >
         <div
@@ -387,22 +383,6 @@ export function AppLayout({
                   </div>
                 </ErrorBoundary>
               )}
-              {themeBrowserOpen && (
-                <ErrorBoundary
-                  variant="section"
-                  componentName="ThemeBrowser"
-                  onError={() => useThemeBrowserStore.getState().close()}
-                >
-                  <div
-                    className="absolute top-0 bottom-0 z-40 pointer-events-auto"
-                    style={{
-                      right: layout.portalOpen ? `${layout.portalWidth}px` : "0px",
-                    }}
-                  >
-                    <ThemeBrowser />
-                  </div>
-                </ErrorBoundary>
-              )}
               {layout.portalOpen && (
                 <ErrorBoundary variant="section" componentName="PortalDock">
                   <div className="absolute right-0 top-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border">
@@ -423,6 +403,30 @@ export function AppLayout({
       <ChordIndicator />
 
       <AllClearOverlay />
+      {themeBrowserOpen &&
+        createPortal(
+          <>
+            <div
+              aria-hidden="true"
+              className="fixed inset-0 z-30 bg-scrim-soft/30 transition-[backdrop-filter] duration-200 hover:backdrop-blur-[2px]"
+            />
+            <ErrorBoundary
+              variant="section"
+              componentName="ThemeBrowser"
+              onError={() => useThemeBrowserStore.getState().close()}
+            >
+              <div
+                className="fixed inset-y-0 z-40 pointer-events-auto"
+                style={{
+                  right: layout.portalOpen ? `${layout.portalWidth}px` : "0px",
+                }}
+              >
+                <ThemeBrowser />
+              </div>
+            </ErrorBoundary>
+          </>,
+          document.body
+        )}
       {window.electron?.demo && (
         <>
           <DemoOverlay />

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -20,15 +20,50 @@ describe("AppLayout theme browser mount gate — issue #5738", () => {
     // it as the mount gate produces a chicken-and-egg deadlock (the regression
     // from PR #5721). The gate must be driven by the store's isOpen flag.
     expect(source).toContain("const themeBrowserOpen = useThemeBrowserStore((s) => s.isOpen)");
-    expect(source).toMatch(/\{themeBrowserOpen && \(\s*\n\s*<ErrorBoundary[^>]*ThemeBrowser/);
-    expect(source).not.toMatch(/\{isThemeBrowserOpen && \(\s*\n\s*<ErrorBoundary[^>]*ThemeBrowser/);
+    expect(source).toMatch(/\{themeBrowserOpen &&\s*\n\s*createPortal\(/);
   });
 
-  it("keeps the overlay-claim variable for inert and scrim treatment", () => {
-    // The overlay claim is the correct signal for inert/scrim because it fires
-    // after ThemeBrowser has mounted — this is the intended PR #5721 behavior.
+  it("keeps the overlay-claim variable for inert on blocked wrappers", () => {
+    // The overlay claim is the correct signal for inert because it fires after
+    // ThemeBrowser has mounted — intended PR #5721 behavior. inert on the
+    // toolbar + main-content wrappers prevents interaction with blocked UI.
     expect(source).toContain('const isThemeBrowserOpen = overlayClaims.has("theme-browser")');
     expect(source).toContain("isThemeBrowserOpen ? { inert: true } : {}");
-    expect(source).toContain('isThemeBrowserOpen && "bg-scrim-soft/30 backdrop-blur-[2px]"');
+  });
+});
+
+describe("AppLayout theme browser overlay structure — issue #5791", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("portals the ThemeBrowser out of the inert subtree", () => {
+    // Bug 1: rendering inside the inert main-content wrapper made the picker
+    // itself unclickable. Portaling to document.body escapes the inert ancestor.
+    expect(source).toContain('import { createPortal } from "react-dom"');
+    expect(source).toMatch(/createPortal\([\s\S]*?<ThemeBrowser \/>[\s\S]*?document\.body/);
+  });
+
+  it("renders scrim as a sibling of the panel, not an ancestor", () => {
+    // Bug 2: backdrop-filter on an ancestor creates a containing block for
+    // position:fixed children (lesson #2574). The scrim must be flat sibling
+    // to the panel, with hover-driven blur via CSS hit-testing.
+    expect(source).toMatch(
+      /className="fixed inset-0 z-30 bg-scrim-soft\/30[^"]*hover:backdrop-blur-\[2px\]"/
+    );
+  });
+
+  it("anchors the panel with fixed positioning for full viewport height", () => {
+    // Bug 3: absolute + h-full inside <main> was bounded by the flex cell.
+    // fixed inset-y-0 anchors to the viewport regardless of docks/panels below.
+    expect(source).toMatch(/className="fixed inset-y-0 z-40 pointer-events-auto"/);
+  });
+
+  it("drops the static backdrop-blur from the main-content wrapper", () => {
+    // Bug 2: the blur is now hover-driven on the scrim, not a static ancestor
+    // effect. A static blur here also traps any position:fixed descendants.
+    expect(source).not.toMatch(/isThemeBrowserOpen && "bg-scrim-soft\/30 backdrop-blur-\[2px\]"/);
   });
 });


### PR DESCRIPTION
## Summary

- Moved `ThemeBrowser` and its scrim into `createPortal(document.body)` so both escape the `inert` subtree that was making the picker unclickable. The `inert` attribute was propagating down into the theme browser itself, locking out all interaction.
- Replaced the static `backdrop-blur-[2px]` on the main content wrapper with `hover:backdrop-blur-[2px]` on the portal scrim. The blur now activates when the cursor is over the blocked area and disappears when it's over the picker, making the unavailability signal cursor-driven rather than always-on. Also dropped the static blur from the ancestor wrapper entirely — `backdrop-filter` on an ancestor traps `position:fixed` descendants (lesson #2574).
- Switched the panel wrapper to `fixed inset-y-0` so the picker spans the full viewport height regardless of dock, diagnostics bar, or other layout elements in the flex tree.

Resolves #5791

## Changes

- `src/components/Layout/AppLayout.tsx` — portal the overlay + scrim out of the inert wrapper; scrim at z-30, panel at z-40; `hover:backdrop-blur-[2px]` on scrim; `fixed inset-y-0` on panel wrapper; removed `backdrop-blur-[2px]` from main content div
- `src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts` — updated tests to assert portal rendering, z-index layering, and blur behaviour

## Testing

Unit tests updated and passing. The three failure modes from the issue (unclickable picker, static blur, truncated height) are each covered by test assertions.