### PR TITLE
feat(notifications): route notifications and headlines via live agent identity

### DIFF
--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -43,7 +43,10 @@ export const AgentSpawnedSchema = EventContextSchema.extend({
 });
 
 export const AgentStateChangedSchema = EventContextSchema.extend({
-  agentId: z.string().min(1),
+  // Optional: runtime-detected agents (no persisted launch-time agentId) identify
+  // themselves via terminal.detectedAgentType, which the state service maps into
+  // this field. Consumers should fall back to terminalId when agentId is absent.
+  agentId: z.string().min(1).optional(),
   state: AgentStateSchema,
   previousState: AgentStateSchema,
   timestamp: z.number().int().positive(),

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -93,7 +93,11 @@ class AgentNotificationService {
     });
 
     const unsubSpawned = events.on("agent:spawned", (payload) => {
-      const agentKey = payload.agentId ?? payload.terminalId;
+      // Prefer terminalId so grace keys are always unique per-terminal —
+      // runtime-detected agents share agentId values across terminals (both
+      // are just "claude"), and collisions would cause one terminal's grace
+      // to expire a sibling's. #5773
+      const agentKey = payload.terminalId ?? payload.agentId;
       if (agentKey) {
         this.agentSpawnTimestamps.set(agentKey, Date.now());
       }
@@ -106,15 +110,12 @@ class AgentNotificationService {
     // fire agent:spawned — that event is only emitted for kind="agent" panels
     // with a persisted launch-time agentId. Seed spawn grace from agent:detected
     // so startup "waiting" states don't trigger immediate notification sounds
-    // for runtime-detected agents. #5773
+    // for runtime-detected agents. Key exclusively by terminalId to avoid
+    // cross-terminal grace bleed when two terminals detect the same agent type.
+    // #5773
     const unsubDetected = events.on("agent:detected", (payload) => {
-      if (!payload.agentType) return;
-      if (payload.terminalId) {
-        this.agentSpawnTimestamps.set(payload.terminalId, Date.now());
-      }
-      // Also key by the detected agent identity so grace lookups that pass
-      // agentId (from agent:state-changed) find the entry.
-      this.agentSpawnTimestamps.set(payload.agentType, Date.now());
+      if (!payload.agentType || !payload.terminalId) return;
+      this.agentSpawnTimestamps.set(payload.terminalId, Date.now());
     });
 
     this.unsubscribers.push(unsubStateChanged, unsubSpawned, unsubDetected);
@@ -125,7 +126,9 @@ class AgentNotificationService {
   }
 
   private isWithinSpawnGrace(agentId?: string, terminalId?: string): boolean {
-    const key = agentId ?? terminalId;
+    // Prefer terminalId so grace lookups match the per-terminal key used when
+    // seeding from agent:spawned / agent:detected. #5773
+    const key = terminalId ?? agentId;
     if (!key) return false;
     const spawnTime = this.agentSpawnTimestamps.get(key);
     if (spawnTime === undefined) return false;
@@ -173,8 +176,8 @@ class AgentNotificationService {
     // Clear spawn grace tracking once the agent starts doing real work
     // (waiting→working means the user gave input, so future waiting sounds are legitimate)
     if (state === "working" && previousState === "waiting") {
-      const key = agentId ?? terminalId;
-      if (key) this.agentSpawnTimestamps.delete(key);
+      const graceKey = terminalId ?? agentId;
+      if (graceKey) this.agentSpawnTimestamps.delete(graceKey);
     }
 
     // All-clear tracking runs regardless of notification settings
@@ -183,7 +186,10 @@ class AgentNotificationService {
     // Allow same-state transitions for waitingReason changes (e.g., prompt -> question)
     if (state === previousState && !(state === "waiting" && waitingReason !== undefined)) return;
 
-    const key = agentId ?? worktreeId ?? "agent";
+    // Prefer terminalId so per-terminal dedup timers don't collide when two
+    // runtime-detected terminals share the same agentId value (e.g. both
+    // detected as "claude"). #5773
+    const key = terminalId ?? agentId ?? worktreeId ?? "agent";
 
     // Cancel any pending completion timer for this agent when it leaves "completed"
     // (must run even when master toggle is off to prevent stale timers)

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -102,7 +102,22 @@ class AgentNotificationService {
       }
     });
 
-    this.unsubscribers.push(unsubStateChanged, unsubSpawned);
+    // Runtime-detected agents (plain terminals where a CLI was detected) never
+    // fire agent:spawned — that event is only emitted for kind="agent" panels
+    // with a persisted launch-time agentId. Seed spawn grace from agent:detected
+    // so startup "waiting" states don't trigger immediate notification sounds
+    // for runtime-detected agents. #5773
+    const unsubDetected = events.on("agent:detected", (payload) => {
+      if (!payload.agentType) return;
+      if (payload.terminalId) {
+        this.agentSpawnTimestamps.set(payload.terminalId, Date.now());
+      }
+      // Also key by the detected agent identity so grace lookups that pass
+      // agentId (from agent:state-changed) find the entry.
+      this.agentSpawnTimestamps.set(payload.agentType, Date.now());
+    });
+
+    this.unsubscribers.push(unsubStateChanged, unsubSpawned, unsubDetected);
   }
 
   private isWithinBootGrace(): boolean {

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1164,6 +1164,139 @@ describe("AgentNotificationService", () => {
       expect(soundServiceMock.playFile).toHaveBeenCalled();
     });
 
+    it("completion key is per-terminal — two runtime-detected terminals with same agent type both notify", () => {
+      // Two plain terminals both detect "claude" as their agent. Before the
+      // fix, both completion debounces shared the key "claude" and the
+      // second would cancel the first. Now the key is terminalId-first.
+      const appState = {
+        activeWorktreeId: "wt-1",
+        terminals: [
+          {
+            id: "term-1",
+            kind: "terminal",
+            title: "Terminal 1",
+            location: "dock",
+            worktreeId: "wt-1",
+          },
+          {
+            id: "term-2",
+            kind: "terminal",
+            title: "Terminal 2",
+            location: "dock",
+            worktreeId: "wt-1",
+          },
+        ],
+      };
+      mockStore({ completedEnabled: true }, appState);
+      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+
+      events.emit("agent:state-changed", {
+        state: "completed" as const,
+        previousState: "working" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      events.emit("agent:state-changed", {
+        state: "completed" as const,
+        previousState: "working" as const,
+        terminalId: "term-2",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+
+      // Advance past the 2s completion debounce + 0ms flush timer
+      vi.advanceTimersByTime(2001);
+
+      // Both completions should be captured (grouped into one "Agents completed"
+      // burst rather than silently dropping one).
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agents completed",
+        "2 agents finished their tasks",
+        expect.any(Object),
+        "notification:watch-navigate",
+        true
+      );
+    });
+
+    it("grace key is per-terminal — one terminal's interaction doesn't clear a sibling's grace", () => {
+      const appState = {
+        activeWorktreeId: "wt-1",
+        terminals: [
+          {
+            id: "term-1",
+            kind: "terminal",
+            title: "Terminal 1",
+            location: "dock",
+            worktreeId: "wt-1",
+          },
+          {
+            id: "term-2",
+            kind: "terminal",
+            title: "Terminal 2",
+            location: "dock",
+            worktreeId: "wt-1",
+          },
+        ],
+      };
+      mockStore({ waitingEnabled: true, soundEnabled: true }, appState);
+      agentNotificationService.syncWatchedPanels(["term-1", "term-2"]);
+      vi.advanceTimersByTime(10_000);
+
+      // Both terminals detect "claude" — each seeds its own grace entry
+      events.emit("agent:detected", {
+        terminalId: "term-1",
+        agentType: "claude",
+        processName: "claude",
+        timestamp: Date.now(),
+      });
+      events.emit("agent:detected", {
+        terminalId: "term-2",
+        agentType: "claude",
+        processName: "claude",
+        timestamp: Date.now(),
+      });
+
+      // Term-1 transitions waiting→working (user interacted), clearing ITS grace
+      events.emit("agent:state-changed", {
+        state: "waiting" as const,
+        previousState: "idle" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      events.emit("agent:state-changed", {
+        state: "working" as const,
+        previousState: "waiting" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+
+      // Term-2 hits waiting — its grace is still active, so no sound should fire
+      soundServiceMock.playFile.mockClear();
+      events.emit("agent:state-changed", {
+        state: "waiting" as const,
+        previousState: "working" as const,
+        terminalId: "term-2",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      vi.advanceTimersByTime(200);
+
+      expect(soundServiceMock.playFile).not.toHaveBeenCalled();
+    });
+
     it("handles state-changed payload whose agentId is the detected type (no persisted agentId)", () => {
       mockStore({ completedEnabled: true });
 

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1174,6 +1174,7 @@ describe("AgentNotificationService", () => {
           {
             id: "term-1",
             kind: "terminal",
+            agentId: "claude",
             title: "Terminal 1",
             location: "dock",
             worktreeId: "wt-1",
@@ -1181,6 +1182,7 @@ describe("AgentNotificationService", () => {
           {
             id: "term-2",
             kind: "terminal",
+            agentId: "claude",
             title: "Terminal 2",
             location: "dock",
             worktreeId: "wt-1",
@@ -1230,6 +1232,7 @@ describe("AgentNotificationService", () => {
           {
             id: "term-1",
             kind: "terminal",
+            agentId: "claude",
             title: "Terminal 1",
             location: "dock",
             worktreeId: "wt-1",
@@ -1237,6 +1240,7 @@ describe("AgentNotificationService", () => {
           {
             id: "term-2",
             kind: "terminal",
+            agentId: "claude",
             title: "Terminal 2",
             location: "dock",
             worktreeId: "wt-1",

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -1077,6 +1077,118 @@ describe("AgentNotificationService", () => {
     });
   });
 
+  // #5773 — Runtime-detected agents (plain terminals where an agent CLI was
+  // detected at runtime, no persisted launch-time agentId) never fire
+  // agent:spawned. Spawn grace must be seeded from agent:detected so startup
+  // "waiting" states don't immediately produce notification sounds.
+  describe("agent:detected spawn grace (#5773)", () => {
+    it("seeds spawn grace from agent:detected so waiting sound is suppressed within grace window", () => {
+      mockStore({ waitingEnabled: true, soundEnabled: true });
+      // Advance past boot grace so only spawn grace matters
+      vi.advanceTimersByTime(10_000);
+
+      events.emit("agent:detected", {
+        terminalId: "term-1",
+        agentType: "claude",
+        processName: "claude",
+        timestamp: Date.now(),
+      });
+
+      // Within the 5s spawn grace window, a waiting event should not trigger sound
+      events.emit("agent:state-changed", {
+        state: "waiting" as const,
+        previousState: "working" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      vi.advanceTimersByTime(200);
+
+      expect(soundServiceMock.playFile).not.toHaveBeenCalled();
+    });
+
+    it("does not seed grace when agent:detected lacks agentType (non-agent process)", () => {
+      mockStore({ waitingEnabled: true, soundEnabled: true });
+      vi.advanceTimersByTime(10_000);
+
+      // Non-agent process detection (npm/docker/etc.) — no agentType
+      events.emit("agent:detected", {
+        terminalId: "term-1",
+        processIconId: "npm",
+        processName: "npm",
+        timestamp: Date.now(),
+      });
+
+      events.emit("agent:state-changed", {
+        state: "waiting" as const,
+        previousState: "working" as const,
+        terminalId: "term-1",
+        agentId: "agent-1",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      vi.advanceTimersByTime(200);
+
+      // No grace was seeded; waiting sound fires normally
+      expect(soundServiceMock.playFile).toHaveBeenCalled();
+    });
+
+    it("spawn grace expires after SPAWN_GRACE_PERIOD_MS — waiting sound resumes", () => {
+      mockStore({ waitingEnabled: true, soundEnabled: true });
+      vi.advanceTimersByTime(10_000);
+
+      events.emit("agent:detected", {
+        terminalId: "term-1",
+        agentType: "claude",
+        processName: "claude",
+        timestamp: Date.now(),
+      });
+
+      // Advance past the 5s spawn grace
+      vi.advanceTimersByTime(6_000);
+
+      events.emit("agent:state-changed", {
+        state: "waiting" as const,
+        previousState: "working" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      vi.advanceTimersByTime(200);
+
+      expect(soundServiceMock.playFile).toHaveBeenCalled();
+    });
+
+    it("handles state-changed payload whose agentId is the detected type (no persisted agentId)", () => {
+      mockStore({ completedEnabled: true });
+
+      // Runtime-detected agent: agentId on the event carries detectedAgentType
+      events.emit("agent:state-changed", {
+        state: "completed" as const,
+        previousState: "working" as const,
+        terminalId: "term-1",
+        agentId: "claude",
+        timestamp: Date.now(),
+        trigger: "heuristic" as const,
+        confidence: 1,
+      });
+      vi.advanceTimersByTime(5000);
+
+      expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledWith(
+        "Agent completed",
+        expect.stringContaining("claude"),
+        expect.objectContaining({ panelId: "term-1" }),
+        "notification:watch-navigate",
+        true
+      );
+    });
+  });
+
   describe("quiet hours suppression", () => {
     it("scheduled quiet hours suppresses completion watch notifications", () => {
       const realDate = global.Date;

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -110,7 +110,11 @@ export class AgentStateService {
     sessionCost?: number,
     sessionTokens?: number
   ): boolean {
-    if (!terminal.agentId) {
+    // Runtime-detected agents (plain terminals where a CLI was detected at
+    // runtime, no persisted launch-time agentId) flow through the state machine
+    // using their detected type as the identity. #5773
+    const effectiveAgentId = terminal.agentId ?? terminal.detectedAgentType;
+    if (!effectiveAgentId) {
       return false;
     }
 
@@ -132,7 +136,7 @@ export class AgentStateService {
         );
 
         const stateChangePayload = {
-          agentId: terminal.agentId,
+          agentId: effectiveAgentId,
           state: newState,
           previousState,
           timestamp: getStateChangeTimestamp(),
@@ -172,7 +176,7 @@ export class AgentStateService {
 
     // Build and validate state change payload
     const stateChangePayload = {
-      agentId: terminal.agentId,
+      agentId: effectiveAgentId,
       state: newState,
       previousState,
       timestamp: terminal.lastStateChange,
@@ -297,7 +301,9 @@ export class AgentStateService {
       sessionTokens?: number;
     }
   ): void {
-    if (!terminal.agentId) {
+    // Runtime-detected agents without a persisted agentId still flow through
+    // the state machine via terminal.detectedAgentType. #5773
+    if (!terminal.agentId && !terminal.detectedAgentType) {
       return;
     }
 
@@ -336,7 +342,9 @@ export class AgentStateService {
     const { headline, status, type } = this.headlineGenerator.generate({
       terminalId: terminal.id,
       terminalType: terminal.type,
-      agentId: terminal.agentId,
+      // Runtime-detected agents identify via detectedAgentType; persisted
+      // agent panels via agentId. Both drive agent-style headlines. #5773
+      agentId: terminal.agentId ?? terminal.detectedAgentType,
       agentState: terminal.agentState,
       waitingReason: terminal.waitingReason,
     });

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1430,6 +1430,13 @@ export class TerminalProcess {
       return;
     }
 
+    // Set when we clear a runtime agent detection on this tick so the block
+    // below can suppress a same-tick shell-headline emission that would
+    // otherwise overwrite the "Exited" completion cue emitted by
+    // updateAgentState. The next detector poll emits the shell headline
+    // instead. #5773
+    let justClearedDetection = false;
+
     if (result.detected && result.agentType) {
       const previousType = terminal.detectedAgentType;
       terminal.everDetectedAgent = true;
@@ -1476,6 +1483,7 @@ export class TerminalProcess {
           agentType: previousType,
           timestamp: Date.now(),
         });
+        justClearedDetection = true;
       }
       if (this.lastDetectedProcessIconId !== result.processIconId) {
         this.lastDetectedProcessIconId = result.processIconId;
@@ -1493,6 +1501,7 @@ export class TerminalProcess {
         terminal.detectedAgentType = undefined;
         terminal.type = "terminal";
         terminal.title = "Terminal";
+        justClearedDetection = true;
       }
 
       this.lastDetectedProcessIconId = undefined;
@@ -1504,12 +1513,15 @@ export class TerminalProcess {
       });
     }
 
-    // Route to shell-style headlines only when neither a persisted agent
-    // (terminal.agentId) nor a live runtime-detected agent
-    // (terminal.detectedAgentType) is present. By the time we reach here in
-    // the detection-cleared branch, detectedAgentType is already undefined,
-    // so post-exit shell activity resumes driving shell headlines. #5773
-    if (!terminal.agentId && !terminal.detectedAgentType) {
+    // Route to shell-style headlines when no live agent is running. This covers
+    // plain terminals (no agentId, no detection) and persisted agent panels
+    // whose agent exited (agentState === "exited") — which keep an active
+    // shell PTY and should surface shell activity rather than a stale
+    // "Agent working" headline. Skip on the exact tick we just emitted an
+    // "Exited" completion cue so it isn't overwritten. #5773
+    const hasLiveAgent =
+      !!terminal.detectedAgentType || (!!terminal.agentId && terminal.agentState !== "exited");
+    if (!justClearedDetection && !hasLiveAgent) {
       const lastCommand = result.currentCommand || this.semanticBufferManager.getLastCommand();
 
       const { headline, status, type } = this.headlineGenerator.generate({

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1504,7 +1504,12 @@ export class TerminalProcess {
       });
     }
 
-    if (!terminal.agentId) {
+    // Route to shell-style headlines only when neither a persisted agent
+    // (terminal.agentId) nor a live runtime-detected agent
+    // (terminal.detectedAgentType) is present. By the time we reach here in
+    // the detection-cleared branch, detectedAgentType is already undefined,
+    // so post-exit shell activity resumes driving shell headlines. #5773
+    if (!terminal.agentId && !terminal.detectedAgentType) {
       const lastCommand = result.currentCommand || this.semanticBufferManager.getLastCommand();
 
       const { headline, status, type } = this.headlineGenerator.generate({

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -255,6 +255,126 @@ describe("AgentStateService", () => {
     expect(stateChanges[0]?.waitingReason).toBe("question");
   });
 
+  // #5773 — Runtime-detected agents (plain terminals where a CLI was detected
+  // via ProcessDetector) have no persisted launch-time agentId but should still
+  // flow through the state machine and emit agent events, keyed by their
+  // detectedAgentType.
+  describe("runtime-detected agent identity (#5773)", () => {
+    it("updateAgentState emits agent:state-changed using detectedAgentType when agentId is absent", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({
+        agentId: undefined,
+        detectedAgentType: "claude",
+        agentState: "idle",
+      });
+      const stateChanges: Array<{ state: string; agentId?: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({ state: payload.state, agentId: payload.agentId });
+      });
+
+      const changed = service.updateAgentState(terminal, { type: "busy" });
+
+      expect(changed).toBe(true);
+      expect(terminal.agentState).toBe("working");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.agentId).toBe("claude");
+    });
+
+    it("handleActivityState transitions state for runtime-detected agents", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({
+        agentId: undefined,
+        detectedAgentType: "gemini",
+        agentState: "working",
+      });
+      const stateChanges: Array<{ state: string; agentId?: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({ state: payload.state, agentId: payload.agentId });
+      });
+
+      service.handleActivityState(terminal, "idle", { trigger: "timeout" });
+
+      expect(terminal.agentState).toBe("waiting");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.agentId).toBe("gemini");
+    });
+
+    it("does nothing when both agentId and detectedAgentType are absent", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({
+        agentId: undefined,
+        detectedAgentType: undefined,
+        agentState: "idle",
+      });
+      const stateChanges: unknown[] = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push(payload);
+      });
+
+      const changed = service.updateAgentState(terminal, { type: "busy" });
+
+      expect(changed).toBe(false);
+      expect(terminal.agentState).toBe("idle");
+      expect(stateChanges).toHaveLength(0);
+    });
+
+    it("emitTerminalActivity produces agent-style headline for detectedAgentType-only terminal", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({
+        agentId: undefined,
+        detectedAgentType: "claude",
+        agentState: "working",
+      });
+      const activityEvents: Array<{ headline: string; status: string }> = [];
+
+      events.on("terminal:activity", (payload) => {
+        activityEvents.push({ headline: payload.headline, status: payload.status });
+      });
+
+      service.emitTerminalActivity(terminal);
+
+      expect(activityEvents).toHaveLength(1);
+      expect(activityEvents[0]?.headline).toBe("Agent working");
+      expect(activityEvents[0]?.status).toBe("working");
+    });
+
+    it("emits 'exited' completion cue when runtime-detected agent exits", () => {
+      const service = new AgentStateService();
+      // Simulate the state of the terminal at the moment the exit transition
+      // is observed — detectedAgentType is still set (TerminalProcess clears
+      // it AFTER calling updateAgentState).
+      const terminal = createTerminal({
+        agentId: undefined,
+        detectedAgentType: "claude",
+        agentState: "working",
+      });
+      const stateChanges: Array<{ state: string; agentId?: string }> = [];
+      const activityEvents: Array<{ headline: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({ state: payload.state, agentId: payload.agentId });
+      });
+      events.on("terminal:activity", (payload) => {
+        activityEvents.push({ headline: payload.headline });
+      });
+
+      const changed = service.updateAgentState(terminal, { type: "exit", code: 0 });
+
+      expect(changed).toBe(true);
+      expect(terminal.agentState).toBe("exited");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.state).toBe("exited");
+      expect(stateChanges[0]?.agentId).toBe("claude");
+      // The completion cue produces the "Exited" headline before the caller
+      // clears detectedAgentType and reverts to shell mode.
+      expect(activityEvents).toHaveLength(1);
+      expect(activityEvents[0]?.headline).toBe("Exited");
+    });
+  });
+
   it("emits completed event with non-negative duration", () => {
     const service = new AgentStateService();
     const terminal = createTerminal({ spawnedAt: Date.now() + 10_000, agentState: "working" });


### PR DESCRIPTION
## Summary

- `AgentStateService` now resolves effective identity as `terminal.agentId ?? detectedAgentType` at all state-machine guards, `stateChangePayload`, and `emitTerminalActivity`. Runtime-detected agents flow through the state machine and emit `agent:state-changed` events properly.
- `TerminalProcess` shell-headline guard now gates on `!detectedAgentType && (!agentId || agentState === "exited")`, with a `justClearedDetection` flag to prevent the same-tick shell headline from overwriting the "Exited" completion cue.
- `AgentNotificationService` subscribes to `agent:detected` to seed spawn grace for runtime-detected agents (which never fire `agent:spawned`). Completion dedup and grace keys prefer `terminalId` over `agentId` to eliminate cross-terminal collisions when both terminals are detected as the same agent type.

Resolves #5773

## Changes

- `electron/services/pty/AgentStateService.ts` — effective identity resolution at guards, payload, and activity emit
- `electron/services/pty/TerminalProcess.ts` — expanded shell-headline guard + `justClearedDetection` flag
- `electron/services/AgentNotificationService.ts` — `agent:detected` subscription for grace seeding; `terminalId`-keyed dedup and grace maps
- `electron/schemas/agent.ts` — `AgentStateChangedSchema.agentId` relaxed to optional (was already optional in IPC types)

## Testing

9 new unit tests across `AgentStateService` and `AgentNotificationService` covering: runtime-detected state transitions, exit completion cue preservation, spawn grace seeding via `agent:detected`, completion key collision across terminals, and grace isolation per terminal. All 107 tests pass. Typecheck, lint, and format clean.