### PR TITLE
perf(panels): optimistic panel commit decouples agent launch from PTY spawn

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -453,6 +453,13 @@ export interface TerminalInstance {
   startedAt?: number;
   /** Exit code from the last process exit */
   exitCode?: number;
+  /**
+   * Live-only spawn lifecycle state. "spawning" from the moment the optimistic
+   * placeholder lands in `panelsById` until the PTY IPC round-trip resolves;
+   * then "ready". Absent (undefined) on hydrated panels — treat as "ready".
+   * Never serialized — see `serializePtyPanel`.
+   */
+  spawnStatus?: "spawning" | "ready";
   /** Original user-selected preset ID; immutable across fallback hops. */
   originalPresetId?: string;
   /** Whether this panel is currently running on a fallback preset. */

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -324,10 +324,12 @@ describe("hydration batch (#5196)", () => {
     expect(after?.activityHeadline).toBe("writing code");
   });
 
-  it("does not append ids whose addPanel failed before reaching panelsById", async () => {
+  it("removes the optimistic placeholder when the background spawn rejects", async () => {
+    // #5789: addPanel is optimistic — the panel lands in panelsById before spawn
+    // resolves. If spawn rejects, the placeholder must be cleaned up so the grid
+    // doesn't end up with a zombie panel that has no live PTY.
     const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 
-    // Make spawn reject for one id, succeed for the next.
     const { terminalClient } = (await import("@/clients")) as unknown as {
       terminalClient: { spawn: ReturnType<typeof vi.fn> };
     };
@@ -338,17 +340,13 @@ describe("hydration batch (#5196)", () => {
       .mockImplementationOnce(async ({ id }: { id?: string }) => id ?? "ok");
 
     const token = beginHydrationBatch();
-    // First addPanel: spawn throws, caught by addPanel's outer try/catch and re-thrown.
-    await expect(
-      addPanel({
-        kind: "terminal",
-        type: "terminal",
-        requestedId: "fail-1",
-        cwd: "/",
-        bypassLimits: true,
-      })
-    ).rejects.toThrow("spawn failed");
-    // Second addPanel succeeds.
+    await addPanel({
+      kind: "terminal",
+      type: "terminal",
+      requestedId: "fail-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
     await addPanel({
       kind: "terminal",
       type: "terminal",
@@ -357,17 +355,22 @@ describe("hydration batch (#5196)", () => {
       bypassLimits: true,
     });
 
+    // Drain microtasks so the failed spawn's rejection handler runs removePanel.
+    // The background spawn promise chains through Promise.all(env) → spawn → .then,
+    // which takes several ticks.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+
     saveNormalizedMock.mockClear();
     flushHydrationBatch(token);
 
-    // Only the successful id lands in panelIds.
+    // The failed id is evicted from panelsById by removePanel; the flush filter
+    // only appends ids that still exist in panelsById, so panelIds gets just ok-1.
     expect(usePanelStore.getState().panelIds).toEqual(["ok-1"]);
     expect(usePanelStore.getState().panelsById["fail-1"]).toBeUndefined();
 
-    // saveNormalized fired once with the correct id list.
-    expect(saveNormalizedMock).toHaveBeenCalledTimes(1);
-    const [, savedIds] = saveNormalizedMock.mock.calls[0] as [Record<string, unknown>, string[]];
-    expect(savedIds).toEqual(["ok-1"]);
+    expect(saveNormalizedMock).toHaveBeenCalled();
+    const lastCall = saveNormalizedMock.mock.calls.at(-1) as [Record<string, unknown>, string[]];
+    expect(lastCall[1]).toEqual(["ok-1"]);
   });
 
   it("collapses N panel additions into a single panelIds render", async () => {

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -236,6 +236,149 @@ describe("optimistic panel spawn (#5789)", () => {
     expect(terminalClient.spawn).not.toHaveBeenCalled();
   });
 
+  it("does not remove a replacement panel when a stale spawn rejects", async () => {
+    // Edge case: user closes spawning panel A (id X), a reconnect path reuses
+    // id X with spawnStatus already "ready", then A's original spawn rejects.
+    // The reject handler must not evict the replacement.
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    let rejectA: (reason: Error) => void = () => {};
+    const gateA = new Promise<never>((_, reject) => {
+      rejectA = reject;
+    });
+    terminalClient.spawn.mockImplementationOnce(async () => {
+      await gateA;
+      return "never";
+    });
+
+    const { addPanel, removePanel } = usePanelStore.getState();
+    // Panel A (will fail).
+    await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "shared-id",
+      cwd: "/",
+      bypassLimits: true,
+    });
+    // User closes it mid-spawn.
+    removePanel("shared-id");
+    expect(usePanelStore.getState().panelsById["shared-id"]).toBeUndefined();
+
+    // Reconnect path reuses the id (spawnStatus: "ready", spawn is skipped).
+    await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      command: "claude",
+      existingId: "shared-id",
+      cwd: "/",
+      bypassLimits: true,
+    });
+    expect(usePanelStore.getState().panelsById["shared-id"]?.spawnStatus).toBe("ready");
+
+    // Now A's spawn finally rejects. The replacement must survive.
+    rejectA(new Error("late failure"));
+    await drainMicrotasks();
+
+    const after = usePanelStore.getState().panelsById["shared-id"];
+    expect(after).toBeDefined();
+    expect(after?.spawnStatus).toBe("ready");
+  });
+
+  it("issues a compensating kill when the panel is removed mid-spawn", async () => {
+    // Edge case: user closes panel before spawn IPC arrives at the backend.
+    // removePanel's kill was a no-op then (no terminal yet); when the spawn
+    // eventually succeeds, the success handler must issue a follow-up kill so
+    // the PTY isn't orphaned.
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> };
+    };
+
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    terminalClient.spawn.mockImplementationOnce(async ({ id }: { id?: string }) => {
+      await gate;
+      return id ?? "late";
+    });
+    terminalClient.kill.mockClear();
+
+    const { addPanel, removePanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "orphan-id",
+      cwd: "/",
+      bypassLimits: true,
+    });
+    removePanel("orphan-id");
+    // removePanel fires kill (no-op on the backend since the PTY isn't spawned yet).
+    expect(terminalClient.kill).toHaveBeenCalledWith("orphan-id");
+    const killCallsAfterRemove = terminalClient.kill.mock.calls.length;
+
+    release();
+    await drainMicrotasks();
+
+    // A compensating kill must have fired after spawn succeeded for the
+    // now-missing panel.
+    expect(terminalClient.kill.mock.calls.length).toBeGreaterThan(killCallsAfterRemove);
+    expect(terminalClient.kill).toHaveBeenLastCalledWith("orphan-id");
+  });
+
+  it("does not block the panel render on env fetch latency", async () => {
+    // The panel must appear before window.electron.globalEnv.get() and
+    // projectClient.getSettings() resolve — env fetch is background, not gating.
+    const electron = (
+      globalThis as unknown as {
+        window: { electron: { globalEnv: { get: ReturnType<typeof vi.fn> } } };
+      }
+    ).window.electron;
+    let releaseEnv: () => void = () => {};
+    electron.globalEnv.get = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseEnv = () => resolve({});
+        })
+    );
+
+    const { projectClient } = (await import("@/clients")) as unknown as {
+      projectClient: { getSettings: ReturnType<typeof vi.fn> };
+    };
+    let releaseSettings: () => void = () => {};
+    projectClient.getSettings.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseSettings = () => resolve({});
+        })
+    );
+
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "env-latent",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("env-latent");
+    expect(usePanelStore.getState().panelsById["env-latent"]?.spawnStatus).toBe("spawning");
+    expect(usePanelStore.getState().panelIds).toContain("env-latent");
+
+    releaseEnv();
+    releaseSettings();
+    await drainMicrotasks();
+    expect(usePanelStore.getState().panelsById["env-latent"]?.spawnStatus).toBe("ready");
+  });
+
   it("propagates the pre-assigned id to terminalClient.spawn", async () => {
     const { terminalClient } = (await import("@/clients")) as unknown as {
       terminalClient: { spawn: ReturnType<typeof vi.fn> };

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for optimistic panel spawn (#5789).
+ *
+ * Before this change, `addPanel` awaited `terminalClient.spawn()` (and env IPC
+ * round-trips) before committing to `panelsById` / `panelIds`. Six rapid agent
+ * clicks serialised into six sequential boots. Now the panel commits to the
+ * store synchronously (as a "spawning" placeholder), and env fetch + spawn run
+ * in the background — six clicks surface as six parallel placeholders.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+// Drain microtasks. The background spawn promise chains through Promise.all
+// (env fetch) → terminalClient.spawn → .then, which takes several ticks.
+async function drainMicrotasks(iterations = 20): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("optimistic panel spawn (#5789)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+  });
+
+  it("commits the panel to the store before terminalClient.spawn resolves", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    let release: (() => void) | null = null;
+    const spawnGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    terminalClient.spawn.mockImplementationOnce(async ({ id }: { id?: string }) => {
+      await spawnGate;
+      return id ?? "delayed";
+    });
+
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "opt-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("opt-1");
+    const panel = usePanelStore.getState().panelsById["opt-1"];
+    expect(panel).toBeDefined();
+    expect(panel?.spawnStatus).toBe("spawning");
+    expect(usePanelStore.getState().panelIds).toContain("opt-1");
+
+    release!();
+    // Drain microtasks so spawnStatus transitions to "ready".
+    await drainMicrotasks();
+
+    const after = usePanelStore.getState().panelsById["opt-1"];
+    expect(after?.spawnStatus).toBe("ready");
+  });
+
+  it("registers six concurrent agent launches as six parallel placeholders", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    // Block every spawn call to prove the placeholders land before spawn resolves.
+    let releaseAll: () => void = () => {};
+    const barrier = new Promise<void>((resolve) => {
+      releaseAll = resolve;
+    });
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => {
+      await barrier;
+      return id ?? "barrier";
+    });
+
+    const { addPanel } = usePanelStore.getState();
+    const launches = Array.from({ length: 6 }, (_, i) =>
+      addPanel({
+        kind: "agent",
+        agentId: "claude",
+        type: "terminal",
+        command: "claude",
+        requestedId: `concurrent-${i}`,
+        cwd: "/",
+        bypassLimits: true,
+      })
+    );
+
+    // All addPanel promises resolve immediately — no serialization on spawn.
+    const ids = (await Promise.all(launches)).filter((id): id is string => id !== null);
+    expect(ids).toEqual([
+      "concurrent-0",
+      "concurrent-1",
+      "concurrent-2",
+      "concurrent-3",
+      "concurrent-4",
+      "concurrent-5",
+    ]);
+
+    const state = usePanelStore.getState();
+    for (const id of ids) {
+      expect(state.panelsById[id]?.spawnStatus).toBe("spawning");
+      expect(state.panelIds).toContain(id);
+    }
+
+    // All six spawn IPCs were dispatched in parallel, not queued.
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(6);
+
+    releaseAll();
+    await drainMicrotasks();
+
+    const after = usePanelStore.getState();
+    for (const id of ids) {
+      expect(after.panelsById[id]?.spawnStatus).toBe("ready");
+    }
+  });
+
+  it("removes the panel when the background spawn rejects", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockImplementationOnce(async () => {
+      throw new Error("spawn boom");
+    });
+
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "will-fail",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("will-fail");
+    expect(usePanelStore.getState().panelsById["will-fail"]).toBeDefined();
+
+    // Drain microtasks for the rejection handler to run removePanel.
+    await drainMicrotasks();
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["will-fail"]).toBeUndefined();
+    expect(state.panelIds).not.toContain("will-fail");
+  });
+
+  it("marks reconnect panels as 'ready' without calling spawn", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      command: "claude",
+      existingId: "reconnect-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("reconnect-1");
+    expect(usePanelStore.getState().panelsById["reconnect-1"]?.spawnStatus).toBe("ready");
+    expect(terminalClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("propagates the pre-assigned id to terminalClient.spawn", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "agent",
+      agentId: "claude",
+      type: "terminal",
+      command: "claude",
+      requestedId: "stable-id",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    // Drain microtasks so the background spawn has run.
+    await drainMicrotasks();
+
+    const spawnCall = terminalClient.spawn.mock.calls[0]?.[0] as { id?: string } | undefined;
+    expect(spawnCall?.id).toBe("stable-id");
+  });
+});

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -630,20 +630,38 @@ export const createCorePanelActions = (
     void spawnPromise.then(
       () => {
         // Promote spawnStatus to "ready" once the PTY is live. If the panel was
-        // removed during the spawn window, skip the patch entirely.
+        // removed during the spawn window, issue a compensating kill to avoid
+        // orphaning the freshly-spawned PTY (removePanel's kill IPC was a no-op
+        // at the time because the backend had no terminal yet).
+        let orphaned = false;
         set((state) => {
           const current = state.panelsById[id];
-          if (!current || current.spawnStatus !== "spawning") return state;
+          if (!current) {
+            orphaned = true;
+            return state;
+          }
+          if (current.spawnStatus !== "spawning") return state;
           return {
             panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
           };
         });
+        if (orphaned) {
+          terminalClient.kill(id).catch((killError) => {
+            logWarn("[TerminalStore] Compensating kill after orphan spawn failed", {
+              id,
+              error: killError,
+            });
+          });
+        }
       },
       (error) => {
         logError("[TerminalStore] Failed to spawn terminal", error);
-        // Remove the optimistic placeholder so the user isn't left with a dead
-        // panel. A notification for spawn errors comes from the error-handling
-        // path downstream (see onSpawnError IPC handler).
+        // Only remove the placeholder we committed. If the id has been reused
+        // (e.g. the user closed the panel mid-spawn and a reconnect slot picked
+        // the id up) or the panel was already removed, skip the cleanup —
+        // otherwise we'd destroy someone else's panel.
+        const current = get().panelsById[id];
+        if (current?.spawnStatus !== "spawning") return;
         try {
           get().removePanel(id);
         } catch (removeError) {

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -363,265 +363,299 @@ export const createCorePanelActions = (
     const projectStore = await resolveProjectStore();
     const capturedProjectId = projectStore.getState().currentProject?.id;
 
-    // Merge environment variables: global < project < spawn-time (later wins)
-    let mergedEnv: Record<string, string> | undefined = options.env;
-    try {
-      let globalEnvVars: Record<string, string> = {};
-      try {
-        globalEnvVars = await window.electron.globalEnv.get();
-      } catch (error) {
-        logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
-      }
+    const isReconnect = !!options.existingId;
+    const isAgent = kind === "agent";
+    // Reserve the id up front so the panel can be committed to the store before
+    // any async work (env fetch, spawn IPC). #5789: commit-then-spawn collapses
+    // six rapid agent clicks from serialized spawns into six parallel placeholders.
+    const id =
+      options.existingId ??
+      options.requestedId ??
+      `${kind}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
-      let projectEnvVars: Record<string, string> = {};
-      if (capturedProjectId) {
-        const projectSettings = await projectClient.getSettings(capturedProjectId);
-        if (
-          projectSettings?.environmentVariables &&
-          Object.keys(projectSettings.environmentVariables).length > 0
-        ) {
-          projectEnvVars = projectSettings.environmentVariables;
+    // For reconnects, use the backend's state directly - don't default to "working".
+    // For new spawns, start with "working" in UI to show spinner immediately during boot.
+    const agentState = isReconnect
+      ? options.agentState
+      : (options.agentState ?? (isAgent ? "working" : undefined));
+    const lastStateChange = isReconnect
+      ? options.lastStateChange
+      : (options.lastStateChange ?? (agentState !== undefined ? Date.now() : undefined));
+
+    // PTY-backed plugin-contributed kinds are rare today, but stamp pluginId
+    // if the registry has an entry so the panel survives plugin removal.
+    const ptyKindConfig = getPanelKindConfig(kind);
+    const ptyPluginId = ptyKindConfig?.extensionId ?? options.pluginId;
+    // Reconnects don't go through a fresh spawn — mark them "ready" directly.
+    const spawnStatus: "spawning" | "ready" = isReconnect ? "ready" : "spawning";
+    const terminal: TerminalInstance = {
+      id,
+      kind,
+      type: legacyType,
+      agentId,
+      title,
+      worktreeId: options.worktreeId,
+      cwd: options.cwd ?? "",
+      cols: 80,
+      rows: 24,
+      agentState,
+      lastStateChange,
+      location,
+      command: options.command,
+      // Initialize grid terminals as visible to avoid initial under-throttling
+      // IntersectionObserver will update this once mounted
+      isVisible: location === "grid" ? true : false,
+      runtimeStatus,
+      isInputLocked: options.isInputLocked,
+      exitBehavior: options.exitBehavior,
+      agentSessionId: options.agentSessionId,
+      agentLaunchFlags: options.agentLaunchFlags,
+      agentModelId: options.agentModelId,
+      everDetectedAgent: options.everDetectedAgent,
+      detectedAgentId: options.detectedAgentId,
+      agentPresetId: options.agentPresetId,
+      agentPresetColor: options.agentPresetColor,
+      originalPresetId: options.originalPresetId ?? options.agentPresetId,
+      isUsingFallback: options.isUsingFallback,
+      fallbackChainIndex: options.fallbackChainIndex,
+      extensionState: options.extensionState,
+      pluginId: ptyPluginId,
+      spawnedBy: options.spawnedBy,
+      startedAt: Date.now(),
+      spawnStatus,
+    };
+
+    // Commit the panel to `panelsById` BEFORE any async IPC (#5789 optimistic
+    // placeholder) so the user sees the panel immediately and IPC event
+    // listeners (onAgentStateChanged, onExit, onAgentDetected, activity flushes,
+    // etc.) that look panels up by id always find the entry.
+    if (isHydrationBatchActive()) {
+      // Batched path: commit `panelsById` immediately; defer `panelIds` append.
+      set((state) => {
+        const existing = state.panelsById[id];
+        const preservedTerminal =
+          existing && isReconnect
+            ? {
+                ...terminal,
+                agentState: terminal.agentState ?? existing.agentState,
+                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                extensionState: terminal.extensionState ?? existing.extensionState,
+                // Sticky: once detected, never downgrade on a partial reconnect payload.
+                everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                // Prefer the fresh reconnect value if present; otherwise keep an existing
+                // live detection (live IPC event may have landed before reconnect flush).
+                detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
+              }
+            : terminal;
+        return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
+      });
+      collectPanelIdForBatch(id);
+    } else {
+      set((state) => {
+        const existing = state.panelsById[id];
+        if (existing) {
+          // Update existing terminal in place (reconnection case or double hydration)
+          logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
+          // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
+          const preservedTerminal = isReconnect
+            ? {
+                ...terminal,
+                agentState: terminal.agentState ?? existing.agentState,
+                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                extensionState: terminal.extensionState ?? existing.extensionState,
+                // Sticky: once detected, never downgrade on a partial reconnect payload.
+                everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
+                // Prefer the fresh reconnect value if present; otherwise keep an existing
+                // live detection (live IPC event may have landed before reconnect flush).
+                detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
+              }
+            : terminal;
+          const newById = { ...state.panelsById, [id]: preservedTerminal };
+          saveNormalized(newById, state.panelIds);
+          return { panelsById: newById };
         }
-      }
-
-      const hasGlobal = Object.keys(globalEnvVars).length > 0;
-      const hasProject = Object.keys(projectEnvVars).length > 0;
-
-      if (hasGlobal || hasProject) {
-        mergedEnv = { ...globalEnvVars, ...projectEnvVars, ...options.env };
-      }
-    } catch (error) {
-      logWarn("[TerminalStore] Failed to fetch environment variables", { error });
+        const newById = { ...state.panelsById, [id]: terminal };
+        const newIds = [...state.panelIds, id];
+        saveNormalized(newById, newIds);
+        return { panelsById: newById, panelIds: newIds };
+      });
     }
 
+    // Prewarm renderer-side xterm immediately so we never drop startup output/ANSI while hidden.
+    // earlyDataBuffer in terminalClient buffers any data that arrives before the
+    // xterm data callback is registered, so prewarming with the pre-assigned id
+    // before spawn completes is safe (see #5789 research notes).
     try {
-      let id: string;
+      const appearance = getTerminalAppearanceSnapshot();
+      const { fontSize, fontFamily, performanceMode } = appearance;
 
-      if (options.existingId) {
-        // Reconnecting to existing backend process - don't spawn new
-        id = options.existingId;
-        logDebug("[TerminalStore] Reconnecting to existing terminal", { id });
-      } else {
-        // Spawn new process - only execute command if not skipping
-        const commandToExecute = options.skipCommandExecution ? undefined : options.command;
-        id = await terminalClient.spawn({
-          id: options.requestedId,
-          projectId: capturedProjectId,
-          cwd: options.cwd,
-          shell: options.shell,
-          cols: 80,
-          rows: 24,
-          command: commandToExecute,
-          kind,
-          type: legacyType,
-          agentId,
-          title,
-          env: mergedEnv,
-          restore: options.restore,
-          agentLaunchFlags: options.agentLaunchFlags,
-          agentModelId: options.agentModelId,
-          worktreeId: options.worktreeId,
-          agentPresetId: options.agentPresetId,
-          originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
+      // Project-level scrollback override for non-agent terminals
+      const projectScrollback = kind !== "agent" ? appearance.projectScrollback : undefined;
+
+      const effectiveScrollback = performanceMode
+        ? PERFORMANCE_MODE_SCROLLBACK
+        : getScrollbackForType(legacyType, projectScrollback ?? appearance.scrollbackLines);
+
+      const terminalOptions = getXtermOptions({
+        fontSize,
+        fontFamily,
+        scrollback: effectiveScrollback,
+        performanceMode,
+        theme: appearance.effectiveTheme,
+        screenReaderMode: appearance.screenReaderMode,
+      });
+
+      // Prewarm ALL terminal types to ensure managed instance exists.
+      // This is critical for terminals in inactive worktrees - they need a managed
+      // instance for proper BACKGROUND→VISIBLE tier transitions when worktree activates.
+      const currentActiveWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      // When activeWorktreeId is null (hydration in progress), don't treat the
+      // terminal as offscreen — it would be prewarmed in the offscreen container
+      // at -20000px and backgrounded, suppressing data flow from the pty-host.
+      const offscreenOrInactive =
+        location === "dock" ||
+        (currentActiveWorktreeId !== null &&
+          (options.worktreeId ?? null) !== (currentActiveWorktreeId ?? null));
+
+      if (kind !== "agent") {
+        terminalInstanceService.prewarmTerminal(id, legacyType, terminalOptions, {
+          offscreen: offscreenOrInactive,
+          widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,
+          heightPx: location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT,
         });
+      } else {
+        // Agent terminals also need prewarm for proper tier management.
+        // This ensures they can receive wake signals when their worktree activates.
+        const widthPx = location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH;
+        const heightPx = location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT;
+
+        terminalInstanceService.prewarmTerminal(id, legacyType, terminalOptions, {
+          offscreen: offscreenOrInactive,
+          widthPx,
+          heightPx,
+        });
+
+        // For offscreen/inactive agents, prewarmTerminal's fit() already handles
+        // initial PTY resize through settled strategy. Only send explicit resize
+        // for active grid spawns where fit() is skipped.
+        if (!offscreenOrInactive) {
+          const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
+          const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
+          const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
+          const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
+          terminalInstanceService.sendPtyResize(id, cols, rows);
+        }
+      }
+    } catch (error) {
+      logWarn("[TerminalStore] Failed to prewarm terminal", { id, error });
+    }
+
+    // Determine if terminal should start backgrounded:
+    // 1. Dock terminals are always backgrounded (offscreen)
+    // 2. Grid terminals in inactive worktrees should also be backgrounded
+    //    since they won't mount until the worktree becomes active
+    if (shouldBackground) {
+      // Terminal is either in dock or in an inactive worktree.
+      // Apply BACKGROUND policy to prevent renderer updates for unmounted terminals.
+      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+    }
+
+    terminalInstanceService.setInputLocked(id, !!options.isInputLocked);
+
+    if (isReconnect) {
+      // Reconnect path does not spawn; the panel is already "ready".
+      logDebug("[TerminalStore] Reconnecting to existing terminal", { id });
+      return id;
+    }
+
+    // Fire env fetch + spawn IPC in the background so the panel render is not
+    // blocked on ~200-500ms of IPC round-trips. Any caller that needs to pipe
+    // input after spawn already gates on agentState (which starts at "working"
+    // for agents and only drops to "idle" once the PTY reports ready).
+    const spawnPromise = (async () => {
+      let mergedEnv: Record<string, string> | undefined = options.env;
+      try {
+        const [globalEnvVars, projectEnvVars] = await Promise.all([
+          window.electron.globalEnv.get().catch((error: unknown) => {
+            logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
+            return {} as Record<string, string>;
+          }),
+          capturedProjectId
+            ? projectClient.getSettings(capturedProjectId).then(
+                (s) => s?.environmentVariables ?? ({} as Record<string, string>),
+                (error: unknown) => {
+                  logWarn("[TerminalStore] Failed to fetch project environment variables", {
+                    error,
+                  });
+                  return {} as Record<string, string>;
+                }
+              )
+            : Promise.resolve({} as Record<string, string>),
+        ]);
+
+        const hasGlobal = Object.keys(globalEnvVars).length > 0;
+        const hasProject = Object.keys(projectEnvVars).length > 0;
+        if (hasGlobal || hasProject) {
+          mergedEnv = { ...globalEnvVars, ...projectEnvVars, ...options.env };
+        }
+      } catch (error) {
+        logWarn("[TerminalStore] Failed to fetch environment variables", { error });
       }
 
-      const isAgent = kind === "agent";
-      const isReconnect = !!options.existingId;
-
-      // For reconnects, use the backend's state directly - don't default to "working".
-      // For new spawns, start with "working" in UI to show spinner immediately during boot.
-      const agentState = isReconnect
-        ? options.agentState
-        : (options.agentState ?? (isAgent ? "working" : undefined));
-      const lastStateChange = isReconnect
-        ? options.lastStateChange
-        : (options.lastStateChange ?? (agentState !== undefined ? Date.now() : undefined));
-
-      // PTY-backed plugin-contributed kinds are rare today, but stamp pluginId
-      // if the registry has an entry so the panel survives plugin removal.
-      const ptyKindConfig = getPanelKindConfig(kind);
-      const ptyPluginId = ptyKindConfig?.extensionId ?? options.pluginId;
-      const terminal: TerminalInstance = {
+      const commandToExecute = options.skipCommandExecution ? undefined : options.command;
+      await terminalClient.spawn({
         id,
+        projectId: capturedProjectId,
+        cwd: options.cwd,
+        shell: options.shell,
+        cols: 80,
+        rows: 24,
+        command: commandToExecute,
         kind,
         type: legacyType,
         agentId,
         title,
-        worktreeId: options.worktreeId,
-        cwd: options.cwd ?? "",
-        cols: 80,
-        rows: 24,
-        agentState,
-        lastStateChange,
-        location,
-        command: options.command,
-        // Initialize grid terminals as visible to avoid initial under-throttling
-        // IntersectionObserver will update this once mounted
-        isVisible: location === "grid" ? true : false,
-        runtimeStatus,
-        isInputLocked: options.isInputLocked,
-        exitBehavior: options.exitBehavior,
-        agentSessionId: options.agentSessionId,
+        env: mergedEnv,
+        restore: options.restore,
         agentLaunchFlags: options.agentLaunchFlags,
         agentModelId: options.agentModelId,
-        everDetectedAgent: options.everDetectedAgent,
-        detectedAgentId: options.detectedAgentId,
+        worktreeId: options.worktreeId,
         agentPresetId: options.agentPresetId,
-        agentPresetColor: options.agentPresetColor,
-        originalPresetId: options.originalPresetId ?? options.agentPresetId,
-        isUsingFallback: options.isUsingFallback,
-        fallbackChainIndex: options.fallbackChainIndex,
-        extensionState: options.extensionState,
-        pluginId: ptyPluginId,
-        spawnedBy: options.spawnedBy,
-        startedAt: Date.now(),
-      };
+        originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
+      });
+    })();
 
-      // Commit the panel to `panelsById` BEFORE prewarm so IPC event listeners
-      // (onAgentStateChanged, onExit, onAgentDetected, activity flushes, etc.)
-      // that look panels up by id always find the entry — even during the
-      // spawn/prewarm window of concurrent panels in the same hydration batch.
-      // Prewarm is synchronous so any React render from this `set` runs after
-      // the managed terminal instance is created.
-      if (isHydrationBatchActive()) {
-        // Batched path: commit `panelsById` immediately; defer `panelIds` append.
+    void spawnPromise.then(
+      () => {
+        // Promote spawnStatus to "ready" once the PTY is live. If the panel was
+        // removed during the spawn window, skip the patch entirely.
         set((state) => {
-          const existing = state.panelsById[id];
-          const preservedTerminal =
-            existing && isReconnect
-              ? {
-                  ...terminal,
-                  agentState: terminal.agentState ?? existing.agentState,
-                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                  extensionState: terminal.extensionState ?? existing.extensionState,
-                  // Sticky: once detected, never downgrade on a partial reconnect payload.
-                  everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
-                  // Prefer the fresh reconnect value if present; otherwise keep an existing
-                  // live detection (live IPC event may have landed before reconnect flush).
-                  detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
-                }
-              : terminal;
-          return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
+          const current = state.panelsById[id];
+          if (!current || current.spawnStatus !== "spawning") return state;
+          return {
+            panelsById: { ...state.panelsById, [id]: { ...current, spawnStatus: "ready" } },
+          };
         });
-        collectPanelIdForBatch(id);
-      } else {
-        set((state) => {
-          const existing = state.panelsById[id];
-          if (existing) {
-            // Update existing terminal in place (reconnection case or double hydration)
-            logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
-            // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
-            const preservedTerminal = isReconnect
-              ? {
-                  ...terminal,
-                  agentState: terminal.agentState ?? existing.agentState,
-                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                  extensionState: terminal.extensionState ?? existing.extensionState,
-                  // Sticky: once detected, never downgrade on a partial reconnect payload.
-                  everDetectedAgent: terminal.everDetectedAgent || existing.everDetectedAgent,
-                  // Prefer the fresh reconnect value if present; otherwise keep an existing
-                  // live detection (live IPC event may have landed before reconnect flush).
-                  detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
-                }
-              : terminal;
-            const newById = { ...state.panelsById, [id]: preservedTerminal };
-            saveNormalized(newById, state.panelIds);
-            return { panelsById: newById };
-          }
-          const newById = { ...state.panelsById, [id]: terminal };
-          const newIds = [...state.panelIds, id];
-          saveNormalized(newById, newIds);
-          return { panelsById: newById, panelIds: newIds };
-        });
-      }
-
-      // Prewarm renderer-side xterm immediately so we never drop startup output/ANSI while hidden.
-      // For docked terminals, also open + fit offscreen so the PTY starts with correct dimensions.
-      try {
-        const appearance = getTerminalAppearanceSnapshot();
-        const { fontSize, fontFamily, performanceMode } = appearance;
-
-        // Project-level scrollback override for non-agent terminals
-        const projectScrollback = kind !== "agent" ? appearance.projectScrollback : undefined;
-
-        const effectiveScrollback = performanceMode
-          ? PERFORMANCE_MODE_SCROLLBACK
-          : getScrollbackForType(legacyType, projectScrollback ?? appearance.scrollbackLines);
-
-        const terminalOptions = getXtermOptions({
-          fontSize,
-          fontFamily,
-          scrollback: effectiveScrollback,
-          performanceMode,
-          theme: appearance.effectiveTheme,
-          screenReaderMode: appearance.screenReaderMode,
-        });
-
-        // Prewarm ALL terminal types to ensure managed instance exists.
-        // This is critical for terminals in inactive worktrees - they need a managed
-        // instance for proper BACKGROUND→VISIBLE tier transitions when worktree activates.
-        const currentActiveWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-        // When activeWorktreeId is null (hydration in progress), don't treat the
-        // terminal as offscreen — it would be prewarmed in the offscreen container
-        // at -20000px and backgrounded, suppressing data flow from the pty-host.
-        const offscreenOrInactive =
-          location === "dock" ||
-          (currentActiveWorktreeId !== null &&
-            (options.worktreeId ?? null) !== (currentActiveWorktreeId ?? null));
-
-        if (kind !== "agent") {
-          terminalInstanceService.prewarmTerminal(id, legacyType, terminalOptions, {
-            offscreen: offscreenOrInactive,
-            widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,
-            heightPx: location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT,
+      },
+      (error) => {
+        logError("[TerminalStore] Failed to spawn terminal", error);
+        // Remove the optimistic placeholder so the user isn't left with a dead
+        // panel. A notification for spawn errors comes from the error-handling
+        // path downstream (see onSpawnError IPC handler).
+        try {
+          get().removePanel(id);
+        } catch (removeError) {
+          logWarn("[TerminalStore] Failed to remove panel after spawn failure", {
+            id,
+            error: removeError,
           });
-        } else {
-          // Agent terminals also need prewarm for proper tier management.
-          // This ensures they can receive wake signals when their worktree activates.
-          const widthPx = location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH;
-          const heightPx = location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT;
-
-          terminalInstanceService.prewarmTerminal(id, legacyType, terminalOptions, {
-            offscreen: offscreenOrInactive,
-            widthPx,
-            heightPx,
-          });
-
-          // For offscreen/inactive agents, prewarmTerminal's fit() already handles
-          // initial PTY resize through settled strategy. Only send explicit resize
-          // for active grid spawns where fit() is skipped.
-          if (!offscreenOrInactive) {
-            const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
-            const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
-            const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
-            const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
-            terminalInstanceService.sendPtyResize(id, cols, rows);
-          }
         }
-      } catch (error) {
-        logWarn("[TerminalStore] Failed to prewarm terminal", { id, error });
       }
+    );
 
-      // Determine if terminal should start backgrounded:
-      // 1. Dock terminals are always backgrounded (offscreen)
-      // 2. Grid terminals in inactive worktrees should also be backgrounded
-      //    since they won't mount until the worktree becomes active
-      if (shouldBackground) {
-        // Terminal is either in dock or in an inactive worktree.
-        // Apply BACKGROUND policy to prevent renderer updates for unmounted terminals.
-        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
-      }
-
-      terminalInstanceService.setInputLocked(id, !!options.isInputLocked);
-
-      return id;
-    } catch (error) {
-      logError("[TerminalStore] Failed to spawn terminal", error);
-      throw error;
-    }
+    return id;
   },
 
   removePanel: (id) => {


### PR DESCRIPTION
## Summary

- Panel is committed to the store synchronously on click with \`spawnStatus: "spawning"\`, so the grid reflows and focuses the placeholder immediately. Env fetch and PTY spawn run in the background.
- Six rapid agent clicks now produce six placeholders in parallel rather than serialising each click behind its own \`terminalClient.spawn()\` round-trip.
- Stale-id guards and a compensating \`terminalClient.kill()\` handle the edge cases: panel removed mid-spawn won't leak an orphan PTY, and a reconnect path (existing terminal id) skips spawn entirely and starts ready.

Resolves #5789

## Changes

- `src/store/slices/panelRegistry/core.ts` — refactored \`addPanel\` to commit the panel before spawning; background async handler promotes \`spawnStatus\` to \`"ready"\` on success or removes the placeholder on failure
- `shared/types/panel.ts` — added optional \`spawnStatus?: "spawning" | "ready"\` to \`TerminalInstance\`; excluded from serialisation allowlist
- `src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts` — 9 new tests covering placeholder-before-spawn, concurrent launches, rejection cleanup, reconnect, stale-id non-eviction, orphan kill, env latency, and pre-assigned id
- `src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts` — updated to account for the new spawn flow

## Testing

Unit tests cover the full async lifecycle: placeholder appears before spawn resolves, six concurrent spawns run in parallel, stale-id guard prevents evicting a reused panel, compensating kill fires when a panel is removed during spawn. All 9 new tests pass alongside the updated hydration batch test.