### PR TITLE
feat(agent-identity): use live runtime identity for focus nav, refresh tier, and trash fallback

### DIFF
--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -2,7 +2,7 @@ import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, useWorktreeSelectionStore, useDockStore } from "@/store";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useTerminalNotificationCounts } from "@/hooks/useTerminalSelectors";
-import { isAgentTerminal } from "@/utils/terminalType";
+import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import type { DockRenderState } from "@shared/types";
 
 /**
@@ -53,7 +53,7 @@ export function useDockRenderState(): DockRenderState & {
       if (!hybridInputEnabled) return false;
       const focusedTerminal = state.focusedId ? state.panelsById[state.focusedId] : undefined;
       if (!focusedTerminal) return false;
-      return isAgentTerminal(focusedTerminal.kind ?? focusedTerminal.type, focusedTerminal.agentId);
+      return isRuntimeAgentTerminal(focusedTerminal);
     })
   );
 

--- a/src/store/__tests__/panelStore.refreshTier.test.ts
+++ b/src/store/__tests__/panelStore.refreshTier.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { getTerminalRefreshTier } from "../panelStore";
+import { TerminalRefreshTier } from "@shared/types/panel";
+import type { TerminalInstance } from "@shared/types";
+
+// Pure unit tests for the refresh-tier gate that decides which panels are
+// eligible to hibernate. Uses runtime-detected agent identity (#5772) so that
+// a panel spawned as an agent but no longer running one can drop to BACKGROUND.
+
+function makeTerminal(overrides: Partial<TerminalInstance>): TerminalInstance {
+  return {
+    id: overrides.id ?? "t-1",
+    title: "test",
+    type: "terminal",
+    cwd: "/test",
+    location: "grid",
+    isVisible: true,
+    cols: 80,
+    rows: 24,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+describe("getTerminalRefreshTier - runtime agent identity", () => {
+  it("drops a demoted ex-agent (detection fired then cleared) to BACKGROUND", () => {
+    // everDetectedAgent distinguishes "boot window" from "exited agent" — the
+    // sticky flag is set on first detection and never cleared, so a panel whose
+    // detectedAgentId is now undefined but everDetectedAgent is true is a
+    // genuine ex-agent and should be free to hibernate.
+    const terminal = makeTerminal({
+      kind: "agent",
+      agentId: "claude",
+      detectedAgentId: undefined,
+      everDetectedAgent: true,
+      agentState: "idle",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.BACKGROUND);
+  });
+
+  it("keeps a promoted shell (kind:terminal + detectedAgentId) at VISIBLE", () => {
+    const terminal = makeTerminal({
+      kind: "terminal",
+      detectedAgentId: "claude",
+      agentState: "idle",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.VISIBLE);
+  });
+
+  it("keeps a freshly-spawned agent at VISIBLE during the boot window (before detection)", () => {
+    // detectedAgentId is undefined during the first few seconds; the spawn-time
+    // fallback keeps the panel at VISIBLE so it doesn't immediately hibernate.
+    const terminal = makeTerminal({
+      kind: "agent",
+      agentId: "claude",
+      detectedAgentId: undefined,
+      agentState: "idle",
+    });
+    // Boot window behaviour matches the current guard: without state override,
+    // the spawn-time fallback holds.
+    expect(getTerminalRefreshTier({ ...terminal, agentState: undefined }, false)).toBe(
+      TerminalRefreshTier.VISIBLE
+    );
+  });
+
+  it("drops an exited agent even when detectedAgentId is still set (race guard)", () => {
+    // Covers the race between onAgentExited and the process-detector exit event.
+    const terminal = makeTerminal({
+      kind: "agent",
+      agentId: "claude",
+      detectedAgentId: "claude",
+      agentState: "exited",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.BACKGROUND);
+  });
+
+  it("drops a completed agent to BACKGROUND", () => {
+    const terminal = makeTerminal({
+      kind: "agent",
+      agentId: "claude",
+      detectedAgentId: "claude",
+      agentState: "completed",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.BACKGROUND);
+  });
+
+  it("returns FOCUSED for a working agent regardless of focus or identity", () => {
+    const terminal = makeTerminal({
+      kind: "terminal",
+      detectedAgentId: undefined,
+      agentState: "working",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.FOCUSED);
+  });
+
+  it("returns FOCUSED when the terminal is focused, regardless of agent state", () => {
+    const terminal = makeTerminal({
+      kind: "terminal",
+      detectedAgentId: undefined,
+      agentState: "idle",
+    });
+    expect(getTerminalRefreshTier(terminal, true)).toBe(TerminalRefreshTier.FOCUSED);
+  });
+
+  it("returns VISIBLE when the terminal reference is missing (defensive default)", () => {
+    expect(getTerminalRefreshTier(undefined, false)).toBe(TerminalRefreshTier.VISIBLE);
+  });
+
+  it("drops a plain non-agent terminal to BACKGROUND when unfocused", () => {
+    const terminal = makeTerminal({
+      kind: "terminal",
+      detectedAgentId: undefined,
+      agentState: "idle",
+    });
+    expect(getTerminalRefreshTier(terminal, false)).toBe(TerminalRefreshTier.BACKGROUND);
+  });
+});

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -261,6 +261,71 @@ describe("trashPanelGroup agent-aware focus", () => {
     expect(usePanelStore.getState().focusedId).toBe("agent-3");
   });
 
+  it("should not prefer another agent when trashing a group whose focused panel is a demoted ex-agent", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "ex-agent": makeTerminal("ex-agent", "agent", "claude", undefined, undefined, true),
+        "agent-paired": makeTerminal("agent-paired", "agent", "gemini"),
+        "shell-1": makeTerminal("shell-1", "terminal"),
+        // Another live agent that would be preferred if wasAgent were true
+        "agent-live": makeTerminal("agent-live", "agent", "codex", undefined, "codex"),
+      },
+      panelIds: ["ex-agent", "agent-paired", "shell-1", "agent-live"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["ex-agent", "agent-paired"],
+            activeTabId: "ex-agent",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "ex-agent",
+    });
+
+    usePanelStore.getState().trashPanelGroup("ex-agent");
+
+    // Focused panel was a demoted ex-agent → wasAgent is false → pick first grid terminal
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("should prefer another agent when trashing a group whose focused panel is a promoted shell", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "promoted-shell": makeTerminal(
+          "promoted-shell",
+          "terminal",
+          undefined,
+          undefined,
+          "claude"
+        ),
+        "plain-shell": makeTerminal("plain-shell", "terminal"),
+        "next-shell": makeTerminal("next-shell", "terminal"),
+        "live-agent": makeTerminal("live-agent", "agent", "gemini", undefined, "gemini"),
+      },
+      panelIds: ["promoted-shell", "plain-shell", "next-shell", "live-agent"],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["promoted-shell", "plain-shell"],
+            activeTabId: "promoted-shell",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "promoted-shell",
+    });
+
+    usePanelStore.getState().trashPanelGroup("promoted-shell");
+
+    // Focused panel was a promoted shell running claude → wasAgent is true → prefer next agent
+    expect(usePanelStore.getState().focusedId).toBe("live-agent");
+  });
+
   it("should fall back to non-agent when no agents remain after group trash", () => {
     usePanelStore.setState({
       panelsById: {

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -38,7 +38,9 @@ function makeTerminal(
   id: string,
   kind: "agent" | "terminal",
   agentId?: string,
-  worktreeId?: string
+  worktreeId?: string,
+  detectedAgentId?: "claude" | "gemini" | "codex",
+  everDetectedAgent?: boolean
 ) {
   return {
     id,
@@ -51,6 +53,8 @@ function makeTerminal(
     cols: 80,
     rows: 24,
     location: "grid" as const,
+    detectedAgentId,
+    everDetectedAgent,
   };
 }
 
@@ -157,6 +161,53 @@ describe("trashPanel agent-aware focus", () => {
     usePanelStore.getState().trashPanel("agent-1");
 
     expect(usePanelStore.getState().focusedId).toBeNull();
+  });
+
+  // Runtime identity coverage for #5772: trash fallback should treat a panel as
+  // an agent based on what's running now (detectedAgentId + sticky
+  // everDetectedAgent), not only how it was spawned (kind/agentId).
+  it("should not prefer another agent when a demoted ex-agent is trashed", () => {
+    usePanelStore.setState({
+      panelsById: {
+        // Spawned as agent, detector fired then cleared on exit — demoted.
+        "ex-agent": makeTerminal("ex-agent", "agent", "claude", undefined, undefined, true),
+        "shell-1": makeTerminal("shell-1", "terminal"),
+        // Another live agent further down the grid
+        "agent-2": makeTerminal("agent-2", "agent", "gemini", undefined, "gemini"),
+      },
+      panelIds: ["ex-agent", "shell-1", "agent-2"],
+      focusedId: "ex-agent",
+    });
+
+    usePanelStore.getState().trashPanel("ex-agent");
+
+    // Because the trashed panel was not a runtime agent, fallback picks the
+    // first grid terminal rather than preferring the next agent.
+    expect(usePanelStore.getState().focusedId).toBe("shell-1");
+  });
+
+  it("should prefer another agent when trashing a promoted shell with a detected agent", () => {
+    usePanelStore.setState({
+      panelsById: {
+        // Spawned as plain terminal but runtime-detected as claude
+        "promoted-shell": makeTerminal(
+          "promoted-shell",
+          "terminal",
+          undefined,
+          undefined,
+          "claude"
+        ),
+        "shell-1": makeTerminal("shell-1", "terminal"),
+        "agent-2": makeTerminal("agent-2", "agent", "gemini"),
+      },
+      panelIds: ["promoted-shell", "shell-1", "agent-2"],
+      focusedId: "promoted-shell",
+    });
+
+    usePanelStore.getState().trashPanel("promoted-shell");
+
+    // Trashed panel is a runtime agent, so prefer the next agent.
+    expect(usePanelStore.getState().focusedId).toBe("agent-2");
   });
 });
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -31,7 +31,7 @@ import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useWorktreeSelectionStore } from "./worktreeStore";
 import type { CrashType } from "@shared/types/pty-host";
-import { isAgentTerminal } from "@/utils/terminalType";
+import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logWarn, logError } from "@/utils/logger";
 import { clearTerminalRestartGuard } from "./restartExitSuppression";
 import { buildPanelSnapshotOptions } from "@/services/terminal/panelDuplicationService";
@@ -62,8 +62,9 @@ export function getTerminalRefreshTier(
 
   // Active agent terminals stay at VISIBLE minimum to preserve live output.
   // Completed agents drop to BACKGROUND so they can be hibernated to free memory.
+  // Uses runtime-detected identity so panels that have left agent mode can hibernate.
   if (
-    isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId) &&
+    isRuntimeAgentTerminal(terminal) &&
     terminal.agentState !== "completed" &&
     terminal.agentState !== "exited"
   ) {
@@ -238,11 +239,9 @@ export const usePanelStore = create<PanelGridState>()(
               gridTerminals.push(t);
           }
           const trashedTerminal = state.panelsById[id];
-          const wasAgent =
-            trashedTerminal &&
-            isAgentTerminal(trashedTerminal.kind ?? trashedTerminal.type, trashedTerminal.agentId);
+          const wasAgent = trashedTerminal && isRuntimeAgentTerminal(trashedTerminal);
           const nextAgent = wasAgent
-            ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
+            ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
             : undefined;
           updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
         }
@@ -294,11 +293,9 @@ export const usePanelStore = create<PanelGridState>()(
               gridTerminals.push(t);
           }
           const focusedTerminal = state.panelsById[state.focusedId!];
-          const wasAgent =
-            focusedTerminal &&
-            isAgentTerminal(focusedTerminal.kind ?? focusedTerminal.type, focusedTerminal.agentId);
+          const wasAgent = focusedTerminal && isRuntimeAgentTerminal(focusedTerminal);
           const nextAgent = wasAgent
-            ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
+            ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
             : undefined;
           updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
         }

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -729,6 +729,20 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
     expect(state.focusedId).toBe("fresh-agent");
   });
 
+  it("includes legacy type-only agents (no kind, TerminalType='claude')", () => {
+    // Legacy persisted panels predate `kind`; their identity comes from `type`.
+    // isAgentTerminal(kind ?? type, agentId) must still classify them as agents.
+    terminals = [
+      makeTerminal("legacy-agent", { kind: undefined, type: "claude" }),
+      makeTerminal("shell-1", { kind: "terminal" }),
+    ];
+    state.focusedId = "shell-1";
+
+    state.focusNextAgent(neverInTrash, validWorktrees);
+
+    expect(state.focusedId).toBe("legacy-agent");
+  });
+
   it("excludes an ex-agent panel whose runtime identity has cleared", () => {
     // Spawned as agent, detector fired then cleared on exit — no longer in cycle.
     terminals = [

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -635,6 +635,172 @@ describe("TerminalFocusSlice - focusNextBlockedDock", () => {
   });
 });
 
+describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime identity", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        electron: {
+          notification: { acknowledgeWaiting: vi.fn(), acknowledgeWorkingPulse: vi.fn() },
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  const makeTerminal = (
+    id: string,
+    opts: {
+      kind?: "agent" | "terminal";
+      type?: string;
+      agentId?: string;
+      detectedAgentId?: string;
+      everDetectedAgent?: boolean;
+    } = {}
+  ): TerminalInstance =>
+    ({
+      id,
+      title: id,
+      type: (opts.type ?? "terminal") as TerminalInstance["type"],
+      kind: opts.kind,
+      agentId: opts.agentId,
+      detectedAgentId: opts.detectedAgentId,
+      everDetectedAgent: opts.everDetectedAgent,
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    }) as TerminalInstance;
+
+  let terminals: TerminalInstance[];
+  let state: TerminalFocusSlice;
+
+  const setup = () => {
+    const getTerminals = vi.fn(() => terminals);
+    const getState = vi.fn((): TerminalFocusSlice => state);
+    const setState = vi.fn(
+      (
+        updater:
+          | Partial<TerminalFocusSlice>
+          | ((s: TerminalFocusSlice) => Partial<TerminalFocusSlice>)
+      ) => {
+        const currentState = getState();
+        const updates = typeof updater === "function" ? updater(currentState) : updater;
+        state = { ...currentState, ...updates };
+      }
+    );
+    return { getTerminals, setState, getState };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const { getTerminals, setState, getState } = setup();
+    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId)(
+      setState as never,
+      getState as never,
+      {} as never
+    );
+  });
+
+  const neverInTrash = () => false;
+  const validWorktrees = new Set(["worktree-1"]);
+
+  it("includes a freshly-spawned agent panel before the detector fires (boot window)", () => {
+    // detectedAgentId is undefined during boot; kind/agentId fallback keeps it in cycle
+    terminals = [
+      makeTerminal("fresh-agent", { kind: "agent", agentId: "claude" }),
+      makeTerminal("shell-1", { kind: "terminal" }),
+    ];
+    state.focusedId = "shell-1";
+
+    state.focusNextAgent(neverInTrash, validWorktrees);
+
+    expect(state.focusedId).toBe("fresh-agent");
+  });
+
+  it("excludes an ex-agent panel whose runtime identity has cleared", () => {
+    // Spawned as agent, detector fired then cleared on exit — no longer in cycle.
+    terminals = [
+      makeTerminal("ex-agent", {
+        kind: "agent",
+        agentId: "claude",
+        everDetectedAgent: true,
+      }),
+      makeTerminal("live-agent", {
+        kind: "agent",
+        agentId: "gemini",
+        detectedAgentId: "gemini",
+      }),
+    ];
+    // Seed focus on the ex-agent so the cycle has to make a choice
+    state.focusedId = "ex-agent";
+
+    state.focusNextAgent(neverInTrash, validWorktrees);
+
+    // Only live-agent is a runtime agent; cycle lands there regardless of seed
+    expect(state.focusedId).toBe("live-agent");
+  });
+
+  it("includes a promoted shell that a runtime agent has entered", () => {
+    terminals = [
+      makeTerminal("promoted-shell", {
+        kind: "terminal",
+        detectedAgentId: "claude",
+      }),
+      makeTerminal("shell-2", { kind: "terminal" }),
+    ];
+    state.focusedId = "shell-2";
+
+    state.focusNextAgent(neverInTrash, validWorktrees);
+
+    expect(state.focusedId).toBe("promoted-shell");
+  });
+
+  it("focusPreviousAgent wraps across a mixed set using runtime identity", () => {
+    terminals = [
+      makeTerminal("agent-1", { kind: "agent", agentId: "claude", detectedAgentId: "claude" }),
+      // Demoted: kind agent but detection fired and cleared → skipped
+      makeTerminal("demoted", { kind: "agent", agentId: "gemini", everDetectedAgent: true }),
+      makeTerminal("shell", { kind: "terminal" }),
+      makeTerminal("agent-2", { kind: "agent", agentId: "codex", detectedAgentId: "codex" }),
+    ];
+    state.focusedId = "agent-1";
+
+    state.focusPreviousAgent(neverInTrash, validWorktrees);
+
+    // Previous from agent-1 wraps to agent-2, skipping "demoted" and shell
+    expect(state.focusedId).toBe("agent-2");
+  });
+
+  it("is a no-op when only ex-agent panels remain", () => {
+    terminals = [
+      makeTerminal("ex-agent", {
+        kind: "agent",
+        agentId: "claude",
+        everDetectedAgent: true,
+      }),
+    ];
+    state.focusedId = "ex-agent";
+
+    state.focusNextAgent(neverInTrash, validWorktrees);
+
+    // No cycle candidates because the sole agent has no runtime identity;
+    // focus is left untouched.
+    expect(state.focusedId).toBe("ex-agent");
+  });
+});
+
 describe("TerminalFocusSlice - setFocused ping gating", () => {
   const mockTerminals: TerminalInstance[] = [
     {

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -2,7 +2,7 @@ import type { StateCreator } from "zustand";
 import type { TerminalInstance } from "./panelRegistrySlice";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isAgentTerminal } from "@/utils/terminalType";
+import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
 
@@ -412,11 +412,11 @@ export const createTerminalFocusSlice =
         const terminals = getTerminals();
         const { focusedId, activateTerminal, pingTerminal } = get();
 
-        // Find all agent terminals excluding trash and orphaned
+        // Find all agent terminals excluding trash and orphaned.
+        // Uses runtime identity so ex-agent panels are excluded and promoted shells
+        // with a detected agent are included.
         const agentTerminals = terminals.filter(
-          (t) =>
-            isAgentTerminal(t.kind ?? t.type, t.agentId) &&
-            isTerminalVisible(t, isInTrash, validWorktreeIds)
+          (t) => isRuntimeAgentTerminal(t) && isTerminalVisible(t, isInTrash, validWorktreeIds)
         );
 
         if (agentTerminals.length === 0) return;
@@ -437,11 +437,11 @@ export const createTerminalFocusSlice =
         const terminals = getTerminals();
         const { focusedId, activateTerminal, pingTerminal } = get();
 
-        // Find all agent terminals excluding trash and orphaned
+        // Find all agent terminals excluding trash and orphaned.
+        // Uses runtime identity so ex-agent panels are excluded and promoted shells
+        // with a detected agent are included.
         const agentTerminals = terminals.filter(
-          (t) =>
-            isAgentTerminal(t.kind ?? t.type, t.agentId) &&
-            isTerminalVisible(t, isInTrash, validWorktreeIds)
+          (t) => isRuntimeAgentTerminal(t) && isTerminalVisible(t, isInTrash, validWorktreeIds)
         );
 
         if (agentTerminals.length === 0) return;

--- a/src/utils/terminalType.ts
+++ b/src/utils/terminalType.ts
@@ -15,6 +15,30 @@ export function hasAgentDefaults(kindOrType?: PanelKind | TerminalType, agentId?
   return isAgentTerminal(kindOrType, agentId);
 }
 
+/**
+ * Runtime-aware agent terminal predicate. Prefers the backend-detected identity
+ * (`detectedAgentId`) so panels that have left agent mode — or plain shells that
+ * entered agent mode mid-session — are classified correctly.
+ *
+ * Ambiguity resolution: `detectedAgentId === undefined` means either "detection
+ * hasn't fired yet" (boot window) or "the agent exited and detection cleared".
+ * The sticky `everDetectedAgent` flag — set on first detection, never cleared —
+ * disambiguates: if it's true and `detectedAgentId` is gone, the panel is a
+ * demoted ex-agent and should be excluded. Otherwise, fall back to the spawn-time
+ * signal so freshly-spawned agents aren't excluded before the detector fires.
+ */
+export function isRuntimeAgentTerminal(terminal: {
+  detectedAgentId?: string;
+  everDetectedAgent?: boolean;
+  kind?: PanelKind;
+  type?: TerminalType;
+  agentId?: string;
+}): boolean {
+  if (terminal.detectedAgentId) return true;
+  if (terminal.everDetectedAgent) return false;
+  return isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
+}
+
 export function detectTerminalTypeFromCommand(_command: string): TerminalType {
   return "terminal";
 }


### PR DESCRIPTION
## Summary

- Focus navigation (`focusNextAgent` / `focusPrevAgent`) now reads runtime agent identity instead of spawn-time `agentId`, so panels that have exited agent mode are excluded from the agent cycle and ex-shells that are now running an agent get included correctly.
- Refresh-tier computation switches to runtime identity so panels that leave agent mode drop from `VISIBLE` to hibernation-eligible immediately, rather than holding their high-priority tier indefinitely and bloating memory.
- Dock fade-for-input and trash-focus fallback receive the same fix, eliminating the ghost-hunting behaviour on both paths.

Resolves #5772

## Changes

- `src/store/slices/terminalFocusSlice.ts` — `focusNextAgent` / `focusPrevAgent` use `getRuntimeAgentIdentity` instead of `panel.agentId`
- `src/store/panelStore.ts` — refresh-tier selector reads runtime identity; reactive so tier drops the moment the agent process exits
- `src/hooks/useDockRenderState.ts` — dock-fade check updated to runtime identity
- `src/utils/terminalType.ts` — `getRuntimeAgentIdentity` helper added (agentIdentity field with spawn-time fallback for legacy panels)
- Test coverage added across `terminalFocusSlice`, `panelStore.refreshTier`, and `trashTerminalAgentFocus`

## Testing

Unit tests cover the four key scenarios: active agent panels enter the focus cycle, demoted panels (agent exited) are excluded, promoted plain terminals (now running an agent) are included, and refresh tier drops reactively when agent state transitions to completed. Trash-focus fallback test confirms it does not target a panel whose runtime identity is no longer an agent.