### PR TITLE
fix(orchestrator): recognise live agents in routing, stats, and onboarding

### DIFF
--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -126,7 +126,11 @@ export class ProjectStatsService {
         if (terminal.isTrashed) continue;
         if (terminal.kind === "dev-preview") continue;
         if (terminal.hasPty === false) continue;
-        if (terminal.kind !== "agent" && !terminal.agentId) continue;
+        // Include plain terminals hosting a runtime-detected agent
+        // (detectedAgentId). Uses the LIVE signal only — everDetectedAgent
+        // is deliberately excluded so panels whose agent has exited do not
+        // inflate the count.
+        if (terminal.kind !== "agent" && !terminal.agentId && !terminal.detectedAgentId) continue;
 
         if (terminal.agentState === "waiting") {
           counts.waiting += 1;

--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -29,8 +29,24 @@ export class TaskOrchestrator {
   /** Map of runId -> taskId for correlating agent completions to tasks */
   private runToTaskMap: Map<string, string> = new Map();
 
-  /** Map of agentId -> runId for tracking current runs */
+  /**
+   * Map of terminalId -> runId for tracking current runs.
+   *
+   * Keyed by terminalId (immutable for the panel's lifetime) rather than the
+   * logical agentId. This avoids collisions when multiple panels share an
+   * agentId of the same named type (e.g. two "claude" panels) and lets the
+   * orchestrator track runtime-detected agents — plain terminals with a
+   * `detectedAgentId` but no stored `agentId` — without colliding on the
+   * shared agent type.
+   */
   private agentToRunMap: Map<string, string> = new Map();
+
+  /**
+   * Map of runId -> terminalId. Used to clean up `agentToRunMap` during
+   * worktree removal, since `task.assignedAgentId` holds the logical agent
+   * identity rather than the terminal id.
+   */
+  private terminalIdByRunId: Map<string, string> = new Map();
 
   /** Lock to prevent concurrent assignment operations */
   private isAssigning = false;
@@ -118,18 +134,18 @@ export class TaskOrchestrator {
         }
 
         // Try capability-based routing first if routing hints are present
-        let selectedAgentId: string | null = null;
+        let selected: SelectedAgent | null = null;
 
         if (task.routingHints) {
-          selectedAgentId = await this.routeTaskWithHints(task.routingHints, task.worktreeId);
+          selected = await this.routeTaskWithHints(task.routingHints, task.worktreeId);
         }
 
         // Fall back to simple availability-based selection
-        if (!selectedAgentId) {
-          selectedAgentId = await this.findAvailableAgent(task.worktreeId);
+        if (!selected) {
+          selected = await this.findAvailableAgent(task.worktreeId);
         }
 
-        if (!selectedAgentId) {
+        if (!selected) {
           // No available agents - task will stay queued for next attempt
           break;
         }
@@ -139,15 +155,22 @@ export class TaskOrchestrator {
 
         // Set tracking maps BEFORE marking running to avoid race with fast agent events
         this.runToTaskMap.set(runId, task.id);
-        this.agentToRunMap.set(selectedAgentId, runId);
+        this.agentToRunMap.set(selected.terminalId, runId);
+        this.terminalIdByRunId.set(runId, selected.terminalId);
 
-        // Mark task as running (atomic state transition)
+        // Mark task as running (atomic state transition).
+        // Note: markRunning receives the logical agentId (which may originate
+        // from either stored `agentId` or runtime-detected `detectedAgentId`),
+        // so `Task.assignedAgentId` retains its documented agent-identity
+        // semantics. The orchestrator's internal bookkeeping is keyed by the
+        // immutable terminalId.
         try {
-          await this.queueService.markRunning(task.id, selectedAgentId, runId);
+          await this.queueService.markRunning(task.id, selected.agentId, runId);
         } catch (error) {
           // Task state transition failed - roll back tracking maps
           this.runToTaskMap.delete(runId);
-          this.agentToRunMap.delete(selectedAgentId);
+          this.agentToRunMap.delete(selected.terminalId);
+          this.terminalIdByRunId.delete(runId);
 
           console.warn(
             `[TaskOrchestrator] Failed to mark task ${task.id} as running:`,
@@ -168,12 +191,15 @@ export class TaskOrchestrator {
 
   /**
    * Route a task using capability-based routing.
-   * Returns the best agent ID or null if no suitable agent is found.
+   * Returns the selected terminal + logical agentId, or null if no suitable
+   * agent is found. Matches on stored identity (`agentId`) OR runtime
+   * detection (`detectedAgentId`) so plain terminals that have an agent CLI
+   * detected at runtime are also eligible.
    */
   private async routeTaskWithHints(
     hints: TaskRoutingHints,
     worktreeId?: string
-  ): Promise<string | null> {
+  ): Promise<SelectedAgent | null> {
     const routedAgentId = await this.router.routeTask({
       ...hints,
       worktreeId,
@@ -184,56 +210,66 @@ export class TaskOrchestrator {
     }
 
     // Verify the routed agent is still available in the terminal list
-    // and not already running a task
+    // and not already running a task. Lock check is keyed by terminalId.
     const availableTerminals = await this.ptyClient.getAvailableTerminalsAsync();
     const terminal = availableTerminals.find(
       (t) =>
-        t.kind === "agent" &&
-        t.agentId === routedAgentId &&
+        (t.agentId === routedAgentId || t.detectedAgentId === routedAgentId) &&
         isAgentAvailable(t.agentState) &&
-        !this.agentToRunMap.has(routedAgentId) &&
+        !this.agentToRunMap.has(t.id) &&
         (!worktreeId || t.worktreeId === worktreeId)
     );
 
-    return terminal ? routedAgentId : null;
+    return terminal ? { terminalId: terminal.id, agentId: routedAgentId } : null;
   }
 
   /**
    * Find any available agent using simple availability-based selection.
-   * Used as fallback when no routing hints are present.
+   * Used as fallback when no routing hints are present. Accepts either
+   * stored identity (`kind === "agent"` / `agentId`) or runtime-detected
+   * identity (`detectedAgentId`) so agent CLIs launched from plain
+   * terminals can receive tasks.
    */
-  private async findAvailableAgent(worktreeId?: string): Promise<string | null> {
+  private async findAvailableAgent(worktreeId?: string): Promise<SelectedAgent | null> {
     const availableTerminals = await this.ptyClient.getAvailableTerminalsAsync();
 
-    // Filter to only agent-type terminals that are actually available
-    // Match worktree if task has one, otherwise allow any agent
-    const availableAgent = availableTerminals.find(
-      (t) =>
-        t.kind === "agent" &&
-        t.agentId &&
+    // Filter to terminals that look like an agent (stored OR detected) and
+    // are available. Lock check is keyed by terminalId so two panels of the
+    // same named agent type can be tracked independently.
+    const availableAgent = availableTerminals.find((t) => {
+      const logicalAgentId = t.agentId ?? t.detectedAgentId;
+      return (
+        logicalAgentId &&
         isAgentAvailable(t.agentState) &&
-        !this.agentToRunMap.has(t.agentId) && // Not already running a task
-        (!worktreeId || t.worktreeId === worktreeId) // Worktree match if specified
-    );
+        !this.agentToRunMap.has(t.id) &&
+        (!worktreeId || t.worktreeId === worktreeId)
+      );
+    });
 
-    return availableAgent?.agentId ?? null;
+    if (!availableAgent) return null;
+    const logicalAgentId = availableAgent.agentId ?? availableAgent.detectedAgentId;
+    if (!logicalAgentId) return null;
+
+    return { terminalId: availableAgent.id, agentId: logicalAgentId };
   }
 
   /**
    * Handle agent state changes.
    * When an agent becomes idle or waiting, attempt to assign a new task.
+   * Triggers on either a stored `agentId` or a bare `terminalId` so
+   * runtime-detected agents (no stored agentId) also wake the scheduler.
    */
   private async handleAgentStateChange(
     payload: DaintreeEventMap["agent:state-changed"]
   ): Promise<void> {
     if (this.isDisposed) return;
 
-    const { state, agentId } = payload;
+    const { state, agentId, terminalId } = payload;
 
     // Only trigger assignment when agent becomes available
     // Don't clear run mappings here - let completion/failure events handle that
     // to avoid race conditions with out-of-order events
-    if (isAgentAvailable(state) && agentId) {
+    if (isAgentAvailable(state) && (agentId || terminalId)) {
       // Try to assign next task
       await this.assignNextTask();
     }
@@ -251,27 +287,64 @@ export class TaskOrchestrator {
   }
 
   /**
+   * Resolve the terminalId that owns a run, given an agent lifecycle payload.
+   * Prefers the payload's explicit `terminalId`; only when the payload has no
+   * terminalId does it fall back to matching by `agentId` against
+   * `task.assignedAgentId` for tasks currently tracked by the orchestrator.
+   *
+   * Real emitters (`AgentStateService`, `PtyEventsBridge`) always set
+   * `terminalId` on these events, but the type leaves it optional. The
+   * fallback preserves the old agentId-keyed behaviour when `terminalId` is
+   * genuinely absent, without risking mis-correlation when the payload
+   * includes a terminalId for a terminal the orchestrator isn't tracking.
+   */
+  private async resolveTerminalIdForRun(
+    payloadTerminalId: string | undefined,
+    payloadAgentId: string | undefined
+  ): Promise<string | null> {
+    if (payloadTerminalId) {
+      return this.agentToRunMap.has(payloadTerminalId) ? payloadTerminalId : null;
+    }
+    if (!payloadAgentId) return null;
+
+    // Fallback: scan tracked runs for a task whose assignedAgentId matches.
+    for (const [runId, terminalId] of this.terminalIdByRunId) {
+      const taskId = this.runToTaskMap.get(runId);
+      if (!taskId) continue;
+      const task = await this.queueService.getTask(taskId);
+      if (task?.assignedAgentId === payloadAgentId) {
+        return terminalId;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Handle agent completion.
    * Correlate the completion to a running task and mark it as completed.
    */
   private async handleAgentComplete(payload: DaintreeEventMap["agent:completed"]): Promise<void> {
     if (this.isDisposed) return;
 
-    const { agentId } = payload;
-    if (!agentId) return;
+    const { agentId, terminalId } = payload;
+    if (!agentId && !terminalId) return;
 
-    // Find the run ID for this agent
-    const runId = this.agentToRunMap.get(agentId);
-    if (!runId) {
+    const resolvedTerminalId = await this.resolveTerminalIdForRun(terminalId, agentId);
+    if (!resolvedTerminalId) {
       // Agent completed without a tracked task - that's fine
       return;
     }
+
+    // Find the run ID for this terminal
+    const runId = this.agentToRunMap.get(resolvedTerminalId);
+    if (!runId) return;
 
     // Find the task for this run
     const taskId = this.runToTaskMap.get(runId);
     if (!taskId) {
       // Run completed without a tracked task
-      this.agentToRunMap.delete(agentId);
+      this.agentToRunMap.delete(resolvedTerminalId);
+      this.terminalIdByRunId.delete(runId);
       return;
     }
 
@@ -280,14 +353,15 @@ export class TaskOrchestrator {
     if (!task || task.status !== "running" || task.runId !== runId) {
       // Task state has changed - don't update it
       this.runToTaskMap.delete(runId);
-      this.agentToRunMap.delete(agentId);
+      this.agentToRunMap.delete(resolvedTerminalId);
+      this.terminalIdByRunId.delete(runId);
       return;
     }
 
     // Mark task as completed
     try {
       await this.queueService.markCompleted(taskId, {
-        summary: `Completed by agent ${agentId}`,
+        summary: `Completed by agent ${task.assignedAgentId ?? agentId ?? "unknown"}`,
       });
     } catch (error) {
       console.error(
@@ -298,7 +372,8 @@ export class TaskOrchestrator {
 
     // Clean up tracking
     this.runToTaskMap.delete(runId);
-    this.agentToRunMap.delete(agentId);
+    this.agentToRunMap.delete(resolvedTerminalId);
+    this.terminalIdByRunId.delete(runId);
 
     // Try to assign next task now that this agent is free
     await this.assignNextTask();
@@ -311,22 +386,27 @@ export class TaskOrchestrator {
   private async handleAgentKilled(payload: DaintreeEventMap["agent:killed"]): Promise<void> {
     if (this.isDisposed) return;
 
-    const { agentId } = payload;
-    if (!agentId) return;
+    const { agentId, terminalId } = payload;
+    if (!agentId && !terminalId) return;
 
-    const runId = this.agentToRunMap.get(agentId);
+    const resolvedTerminalId = await this.resolveTerminalIdForRun(terminalId, agentId);
+    if (!resolvedTerminalId) return;
+
+    const runId = this.agentToRunMap.get(resolvedTerminalId);
     if (!runId) return;
 
     const taskId = this.runToTaskMap.get(runId);
     if (!taskId) {
-      this.agentToRunMap.delete(agentId);
+      this.agentToRunMap.delete(resolvedTerminalId);
+      this.terminalIdByRunId.delete(runId);
       return;
     }
 
     const task = await this.queueService.getTask(taskId);
     if (!task || task.status !== "running" || task.runId !== runId) {
       this.runToTaskMap.delete(runId);
-      this.agentToRunMap.delete(agentId);
+      this.agentToRunMap.delete(resolvedTerminalId);
+      this.terminalIdByRunId.delete(runId);
       return;
     }
 
@@ -340,7 +420,8 @@ export class TaskOrchestrator {
     }
 
     this.runToTaskMap.delete(runId);
-    this.agentToRunMap.delete(agentId);
+    this.agentToRunMap.delete(resolvedTerminalId);
+    this.terminalIdByRunId.delete(runId);
 
     await this.assignNextTask();
   }
@@ -368,10 +449,16 @@ export class TaskOrchestrator {
       try {
         await this.queueService.cancelTask(task.id);
 
-        // Clean up tracking for running tasks
-        if (task.runId && task.assignedAgentId) {
+        // Clean up tracking for running tasks. Look up the terminalId via
+        // the runId → terminalId map (task.assignedAgentId holds the logical
+        // agent identity, not the terminal id used as the agentToRunMap key).
+        if (task.runId) {
+          const terminalId = this.terminalIdByRunId.get(task.runId);
           this.runToTaskMap.delete(task.runId);
-          this.agentToRunMap.delete(task.assignedAgentId);
+          this.terminalIdByRunId.delete(task.runId);
+          if (terminalId) {
+            this.agentToRunMap.delete(terminalId);
+          }
         }
       } catch (error) {
         // Task may already be in a terminal state
@@ -395,7 +482,16 @@ export class TaskOrchestrator {
     this.unsubscribers = [];
     this.runToTaskMap.clear();
     this.agentToRunMap.clear();
+    this.terminalIdByRunId.clear();
   }
+}
+
+/** Internal result type for agent selection. */
+interface SelectedAgent {
+  /** Immutable terminal id used as the agentToRunMap key. */
+  terminalId: string;
+  /** Logical agent identity (stored `agentId` or runtime `detectedAgentId`), persisted as `Task.assignedAgentId`. */
+  agentId: string;
 }
 
 // Singleton instance

--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -90,6 +90,18 @@ export class TaskOrchestrator {
       })
     );
 
+    // Subscribe to agent exit (process gone from the terminal). This is the
+    // only lifecycle signal that fires for runtime-detected agents — the
+    // stored-identity `agent:completed`/`agent:killed` emitters in
+    // AgentStateService guard on `terminal.agentId` and skip detected-only
+    // terminals. Without this subscription, a task assigned to a detected-only
+    // terminal would lock that terminalId in `agentToRunMap` forever.
+    this.unsubscribers.push(
+      events.on("agent:exited", (payload) => {
+        void this.handleAgentExited(payload);
+      })
+    );
+
     // Subscribe to worktree removals
     this.unsubscribers.push(
       events.on("sys:worktree:remove", (payload) => {
@@ -297,6 +309,13 @@ export class TaskOrchestrator {
    * fallback preserves the old agentId-keyed behaviour when `terminalId` is
    * genuinely absent, without risking mis-correlation when the payload
    * includes a terminalId for a terminal the orchestrator isn't tracking.
+   *
+   * Trade-off: when `terminalId` is present but unknown (e.g. the tracking
+   * entry was lost to a dispose/reinit race, or a late event arrives after
+   * worktree removal), the run is not recovered and the task may remain in
+   * `"running"` until a higher-level reconciliation (e.g. worktree teardown)
+   * sweeps it. Preferring correctness over recovery is deliberate — a false
+   * match in this path would mark an unrelated task as completed.
    */
   private async resolveTerminalIdForRun(
     payloadTerminalId: string | undefined,
@@ -421,6 +440,64 @@ export class TaskOrchestrator {
 
     this.runToTaskMap.delete(runId);
     this.agentToRunMap.delete(resolvedTerminalId);
+    this.terminalIdByRunId.delete(runId);
+
+    await this.assignNextTask();
+  }
+
+  /**
+   * Handle agent exit.
+   *
+   * Fires when the CLI process leaves the terminal. For stored-identity
+   * agents this usually runs after `agent:completed`/`agent:killed` has
+   * already cleaned up, so the terminalId lookup misses and we no-op. For
+   * runtime-detected agents — whose `agent:completed`/`agent:killed` never
+   * fire because `AgentStateService` guards on `terminal.agentId` — this is
+   * the *only* cleanup path, and we mark the running task as completed so
+   * the user sees the task closed out and the next queued task can run.
+   *
+   * Exit codes are not available on `agent:exited`, so we cannot distinguish
+   * success from crash here. Marking completed is the pragmatic choice:
+   * tasks that assigned successfully and then exited are treated as done;
+   * the terminal output still reflects any errors, and the user can re-queue
+   * if needed.
+   */
+  private async handleAgentExited(payload: DaintreeEventMap["agent:exited"]): Promise<void> {
+    if (this.isDisposed) return;
+
+    const { terminalId } = payload;
+    if (!terminalId) return;
+
+    const runId = this.agentToRunMap.get(terminalId);
+    if (!runId) {
+      // Not tracking this terminal — normal for non-agent terminals and for
+      // stored-identity agents whose completion/kill events already cleaned up.
+      return;
+    }
+
+    const taskId = this.runToTaskMap.get(runId);
+    if (!taskId) {
+      this.agentToRunMap.delete(terminalId);
+      this.terminalIdByRunId.delete(runId);
+      return;
+    }
+
+    const task = await this.queueService.getTask(taskId);
+    if (task && task.status === "running" && task.runId === runId) {
+      try {
+        await this.queueService.markCompleted(taskId, {
+          summary: `Completed by agent ${task.assignedAgentId ?? "unknown"}`,
+        });
+      } catch (err) {
+        console.error(
+          `[TaskOrchestrator] Failed to mark task ${taskId} completed after agent exit:`,
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
+
+    this.runToTaskMap.delete(runId);
+    this.agentToRunMap.delete(terminalId);
     this.terminalIdByRunId.delete(runId);
 
     await this.assignNextTask();

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -150,6 +150,55 @@ describe("ProjectStatsService adversarial", () => {
     svc.stop();
   });
 
+  it("counts plain terminals with a runtime-detected agent as active/waiting", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      // Plain terminal, no stored agentId, runtime-detected — counts (active)
+      {
+        projectId: "p1",
+        kind: "terminal",
+        detectedAgentId: "claude",
+        agentState: "working",
+      },
+      // Plain terminal, no stored agentId, runtime-detected — counts (waiting)
+      {
+        projectId: "p1",
+        kind: "terminal",
+        detectedAgentId: "claude",
+        agentState: "waiting",
+      },
+      // Zombie guard: everDetectedAgent is set but the agent has exited
+      // (no detectedAgentId). Must NOT count — stats use LIVE signal only.
+      {
+        projectId: "p1",
+        kind: "terminal",
+        everDetectedAgent: true,
+        agentState: "working",
+      },
+      // Regression guard: plain terminal with neither agentId nor
+      // detectedAgentId is still excluded.
+      { projectId: "p1", kind: "terminal", agentState: "running" },
+    ]);
+    ptyClient.getProjectStats.mockResolvedValue({
+      projectId: "p1",
+      terminalCount: 4,
+    });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const lastCall = broadcastMock.mock.calls.at(-1);
+    const [, payload] = lastCall as [
+      string,
+      { p1: { activeAgentCount: number; waitingAgentCount: number } },
+    ];
+    expect(payload.p1.activeAgentCount).toBe(1);
+    expect(payload.p1.waitingAgentCount).toBe(1);
+    svc.stop();
+  });
+
   it("debounce coalesces a burst of agent:state-changed events into one compute", async () => {
     const ptyClient = makePtyClient();
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -310,7 +310,12 @@ describe("TaskOrchestrator", () => {
       expect(updated?.status).toBe("running");
     });
 
-    it("triggers assignment when runtime-detected agent becomes idle (terminalId only)", async () => {
+    it("handleAgentStateChange accepts terminalId-only payloads (defensive)", async () => {
+      // AgentStateService currently guards on `terminal.agentId` before
+      // emitting agent:state-changed, so a terminalId-only payload does not
+      // fire in production for runtime-detected agents. This test locks the
+      // orchestrator's behaviour in case that guard is relaxed upstream: a
+      // payload carrying only terminalId still wakes the scheduler.
       const task = await queueService.createTask({ title: "Test task" });
       await queueService.enqueueTask(task.id);
 
@@ -323,8 +328,6 @@ describe("TaskOrchestrator", () => {
         },
       ]);
 
-      // Emit an agent:state-changed payload with only terminalId (no agentId),
-      // as happens for runtime-detected agents in plain terminals.
       events.emit("agent:state-changed", {
         terminalId: "term-detected",
         state: "idle",
@@ -556,7 +559,116 @@ describe("TaskOrchestrator", () => {
     });
   });
 
+  describe("agent exit handling (runtime-detected agents)", () => {
+    it("frees a detected-only terminal when agent:exited fires, and runs the next task", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+
+      // First poll: detected-only terminal is idle.
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-detected",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+      await settle();
+
+      // Task 1 runs on the detected terminal; task 2 stays queued.
+      const running1 = await queueService.getTask(task1.id);
+      const queued2 = await queueService.getTask(task2.id);
+      expect(running1?.status).toBe("running");
+      expect(running1?.assignedAgentId).toBe("claude");
+      expect(queued2?.status).toBe("queued");
+
+      // CLI exits — only agent:exited fires for a detected-only terminal.
+      events.emit("agent:exited", {
+        terminalId: "term-detected",
+        agentType: "claude",
+        timestamp: Date.now(),
+      });
+
+      await settle();
+
+      // Task 1 must move out of "running" so the terminal slot clears.
+      const completed1 = await queueService.getTask(task1.id);
+      expect(completed1?.status).toBe("completed");
+
+      // Task 2 must be assigned to the now-free terminal.
+      const running2 = await queueService.getTask(task2.id);
+      expect(running2?.status).toBe("running");
+      expect(running2?.assignedAgentId).toBe("claude");
+    });
+
+    it("ignores agent:exited for untracked terminals", async () => {
+      // No orchestrator bookkeeping exists — this should be a silent no-op.
+      events.emit("agent:exited", {
+        terminalId: "term-untracked",
+        agentType: "claude",
+        timestamp: Date.now(),
+      });
+      await settle();
+      // No assertion needed beyond "did not throw". The test passes the
+      // guard implicitly by reaching this point without error.
+    });
+  });
+
   describe("worktree removal handling", () => {
+    it("cleans up tracking for a task on a runtime-detected terminal", async () => {
+      const task = await queueService.createTask({
+        title: "Detected-terminal task",
+        worktreeId: "wt-1",
+      });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-detected",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          agentState: "idle",
+          worktreeId: "wt-1",
+        },
+      ]);
+
+      await queueService.enqueueTask(task.id);
+      await settle();
+
+      const running = await queueService.getTask(task.id);
+      expect(running?.status).toBe("running");
+
+      events.emit("sys:worktree:remove", {
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+      await settle();
+
+      const cancelled = await queueService.getTask(task.id);
+      expect(cancelled?.status).toBe("cancelled");
+
+      // Queue a follow-up task — if tracking wasn't cleaned up, the terminal
+      // would still be locked and the new task would stay queued. Leave the
+      // follow-up task's worktreeId unset so the worktree-match predicate in
+      // findAvailableAgent doesn't interfere with the availability check.
+      const follow = await queueService.createTask({ title: "Follow-up" });
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-detected",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+      await queueService.enqueueTask(follow.id);
+      await settle();
+
+      const runningFollow = await queueService.getTask(follow.id);
+      expect(runningFollow?.status).toBe("running");
+    });
+
     it("cancels tasks for removed worktree", async () => {
       const task1 = await queueService.createTask({
         title: "Task 1",

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -155,6 +155,61 @@ describe("TaskOrchestrator", () => {
       expect(updatedTask?.status).toBe("queued");
     });
 
+    it("assigns queued task to plain terminal with detected agent", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-detected",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(task.id);
+      await settle();
+
+      const updatedTask = await queueService.getTask(task.id);
+      expect(updatedTask?.status).toBe("running");
+      // assignedAgentId persists the logical agent identity (detectedAgentId),
+      // not the terminal id.
+      expect(updatedTask?.assignedAgentId).toBe("claude");
+      expect(updatedTask?.runId).toBeDefined();
+    });
+
+    it("tracks two panels with the same agentId independently", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-a",
+          kind: "agent",
+          agentId: "claude",
+          agentState: "idle",
+        },
+        {
+          id: "term-b",
+          kind: "agent",
+          agentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+      await settle();
+
+      const running1 = await queueService.getTask(task1.id);
+      const running2 = await queueService.getTask(task2.id);
+      // Both tasks assigned — historically with agentId-keyed tracking, the
+      // second would stay queued because the "claude" slot was "taken".
+      expect(running1?.status).toBe("running");
+      expect(running2?.status).toBe("running");
+      expect(running1?.runId).not.toBe(running2?.runId);
+    });
+
     it("does not assign when no tasks queued", async () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
@@ -255,6 +310,37 @@ describe("TaskOrchestrator", () => {
       expect(updated?.status).toBe("running");
     });
 
+    it("triggers assignment when runtime-detected agent becomes idle (terminalId only)", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-detected",
+          kind: "terminal",
+          detectedAgentId: "gemini",
+          agentState: "idle",
+        },
+      ]);
+
+      // Emit an agent:state-changed payload with only terminalId (no agentId),
+      // as happens for runtime-detected agents in plain terminals.
+      events.emit("agent:state-changed", {
+        terminalId: "term-detected",
+        state: "idle",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
+      });
+
+      await settle();
+
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("running");
+      expect(updated?.assignedAgentId).toBe("gemini");
+    });
+
     it("triggers assignment when agent becomes waiting", async () => {
       const task = await queueService.createTask({ title: "Test task" });
       await queueService.enqueueTask(task.id);
@@ -341,6 +427,84 @@ describe("TaskOrchestrator", () => {
 
       const completedTask = await queueService.getTask(task.id);
       expect(completedTask?.status).toBe("completed");
+    });
+
+    it("correlates completion by terminalId when payload includes it", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-a",
+          kind: "agent",
+          agentId: "claude",
+          agentState: "idle",
+        },
+        {
+          id: "term-b",
+          kind: "agent",
+          agentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+      await settle();
+
+      const running1 = await queueService.getTask(task1.id);
+      const running2 = await queueService.getTask(task2.id);
+      expect(running1?.status).toBe("running");
+      expect(running2?.status).toBe("running");
+
+      // Complete only the second panel — the orchestrator must route the
+      // completion to task2 via terminalId, not just pick the first claude.
+      events.emit("agent:completed", {
+        agentId: "claude",
+        terminalId: "term-b",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+
+      await settle();
+
+      const updated1 = await queueService.getTask(task1.id);
+      const updated2 = await queueService.getTask(task2.id);
+      expect(updated1?.status).toBe("running");
+      expect(updated2?.status).toBe("completed");
+    });
+
+    it("ignores completion when payload terminalId is not tracked", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(task.id);
+      await settle();
+
+      // Emit completion for an untracked terminal (event carries terminalId
+      // but it doesn't match any tracked run).
+      events.emit("agent:completed", {
+        agentId: "claude",
+        terminalId: "term-untracked",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+
+      await settle();
+
+      // Task must remain running — no mis-correlation.
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("running");
     });
 
     it("ignores completion for unknown agents", async () => {

--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -35,7 +35,12 @@ vi.mock("../../useElectron", () => ({
   isElectronAvailable: () => true,
 }));
 
-type TerminalLike = { id?: string; kind?: string; agentState?: string };
+type TerminalLike = {
+  id?: string;
+  kind?: string;
+  agentState?: string;
+  everDetectedAgent?: boolean;
+};
 type WorktreeLike = { prState?: string };
 
 let projectState = { currentProject: null as string | null };
@@ -182,6 +187,52 @@ describe("useGettingStartedChecklist", () => {
     });
 
     expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("launchedAgent");
+  });
+
+  it("marks launchedAgent when panel has everDetectedAgent (plain terminal, runtime-detected)", async () => {
+    renderHook(() => useGettingStartedChecklist(true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      const prev = {
+        panelsById: {} as Record<string, TerminalLike>,
+        panelIds: [] as string[],
+      };
+      const next = {
+        panelsById: {
+          t1: { id: "t1", kind: "terminal", everDetectedAgent: true },
+        } as Record<string, TerminalLike>,
+        panelIds: ["t1"],
+      };
+      for (const sub of terminalSubscribers) sub(next, prev);
+    });
+
+    expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("launchedAgent");
+  });
+
+  it("does not mark launchedAgent for plain terminal without everDetectedAgent", async () => {
+    renderHook(() => useGettingStartedChecklist(true));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      const prev = {
+        panelsById: {} as Record<string, TerminalLike>,
+        panelIds: [] as string[],
+      };
+      const next = {
+        panelsById: {
+          t1: { id: "t1", kind: "terminal" },
+        } as Record<string, TerminalLike>,
+        panelIds: ["t1"],
+      };
+      for (const sub of terminalSubscribers) sub(next, prev);
+    });
+
+    expect(onboardingMock.markChecklistItem).not.toHaveBeenCalledWith("launchedAgent");
   });
 
   it("marks createdWorktree when worktree store fires", async () => {

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -42,9 +42,10 @@ function reconcileCurrentState(
   }
   if (
     !cl.items.launchedAgent &&
-    usePanelStore
-      .getState()
-      .panelIds.some((id) => usePanelStore.getState().panelsById[id]?.kind === "agent")
+    usePanelStore.getState().panelIds.some((id) => {
+      const p = usePanelStore.getState().panelsById[id];
+      return p?.kind === "agent" || p?.everDetectedAgent === true;
+    })
   ) {
     markItem("launchedAgent");
   }
@@ -173,7 +174,10 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         if (!cl || cl.dismissed) return;
         if (
           !cl.items.launchedAgent &&
-          state.panelIds.some((id) => state.panelsById[id]?.kind === "agent")
+          state.panelIds.some((id) => {
+            const p = state.panelsById[id];
+            return p?.kind === "agent" || p?.everDetectedAgent === true;
+          })
         ) {
           markItem("launchedAgent");
         }


### PR DESCRIPTION
## Summary

- `TaskOrchestrator` was keying `agentToRunMap` by stored `agentId` (e.g. `"claude"`, `"gemini"`), which collides across panels and silently ignores plain terminals running an agent CLI detected at runtime. Routing, completion, and lifecycle handling are now all keyed by `terminalId`.
- `ProjectStatsService` excluded terminals with no stored `agentId` from active/waiting counts. It now includes panels where `detectedAgentId` is set (live detection), while deliberately excluding `everDetectedAgent` to prevent zombie counts after the agent exits.
- `useGettingStartedChecklist` only marked "launchedAgent" for panels with `kind === "agent"`. It now also triggers when any panel has `everDetectedAgent` set, so a user who runs `claude` in a plain terminal gets credit.

Resolves #5774

## Changes

- `TaskOrchestrator`: `agentToRunMap` keyed by `terminalId`; `findAvailableAgent` and `routeTaskWithHints` accept `agentId || detectedAgentId`; added `handleAgentExited` (subscribes to `agent:exited`) to free detected-only terminals and dispatch queued tasks; `terminalIdByRunId` map for worktree-removal cleanup; completion resolution prefers `terminalId` with fallback scan.
- `ProjectStatsService`: live active/waiting counts now include terminals where `detectedAgentId` is non-null.
- `useGettingStartedChecklist`: onboarding detection extended to `everDetectedAgent` (sticky).
- 6 new tests covering runtime-detected assignment, dual-panel independent tracking, `terminalId`-keyed completion routing, untracked-terminal guard, `agent:exited` cleanup + next-task dispatch, worktree-removal cleanup for detected-only terminals, live-only stats behaviour, and `everDetectedAgent` onboarding detection.

## Testing

Unit tests cover all the new routing paths. The `agent:exited` cleanup path is tested end-to-end in `TaskOrchestrator.test.ts` including the next-queued-task dispatch. Stats live-only behaviour is validated in `ProjectStatsService.adversarial.test.ts`. Onboarding detection tested in `useGettingStartedChecklist.test.tsx`.