### PR TITLE
feat(panel): unify chrome on runtime-detected agent identity

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -31,6 +31,7 @@ import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
 import { deleteSessionFile } from "./pty/terminalSessionPersistence.js";
 import { persistAgentSession } from "./pty/agentSessionHistory.js";
+import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
 
 /**
  * PtyManager - Facade for terminal process management.
@@ -511,6 +512,9 @@ export class PtyManager extends EventEmitter {
       hasPty,
       isAgentTerminal: terminal.getIsAgentTerminal(),
       detectedAgentType: terminalInfo.detectedAgentType,
+      detectedAgentId: isBuiltInAgentId(terminalInfo.detectedAgentType)
+        ? terminalInfo.detectedAgentType
+        : undefined,
       analysisEnabled: terminalInfo.analysisEnabled,
       resizeStrategy: terminal.getResizeStrategy(),
       ptyPid: ptyProcess?.pid,

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -526,6 +526,7 @@ export class PtyManager extends EventEmitter {
       agentLaunchFlags: terminalInfo.agentLaunchFlags,
       agentModelId: terminalInfo.agentModelId,
       exitCode: terminalInfo.exitCode,
+      everDetectedAgent: terminalInfo.everDetectedAgent,
     };
   }
 

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -214,6 +214,8 @@ export interface TerminalInfoPayload {
   isAgentTerminal?: boolean;
   /** Runtime-detected agent type (from process tree analysis) */
   detectedAgentType?: TerminalType;
+  /** Runtime-detected agent identity (cleared when the agent exits). */
+  detectedAgentId?: BuiltInAgentId;
   /** Whether semantic analysis is enabled for this terminal */
   analysisEnabled?: boolean;
   /** Resize strategy: "default" (immediate) or "settled" (batched for TUI agents) */

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -17,7 +17,7 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
     return <div className={cn("h-full rounded-[var(--radius-lg)] bg-daintree-bg/50", className)} />;
   }
 
-  const { title, type, kind, agentId, detectedProcessId } = activeTerminal;
+  const { title, type, kind, agentId, detectedAgentId, detectedProcessId } = activeTerminal;
 
   return (
     <div
@@ -41,6 +41,7 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
             type={type}
             kind={kind}
             agentId={agentId}
+            detectedAgentId={detectedAgentId}
             detectedProcessId={detectedProcessId}
             className="w-3.5 h-3.5"
           />

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -210,6 +210,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
                         type={item.terminal.type}
                         kind={item.terminal.kind}
                         agentId={item.terminal.agentId}
+                        detectedAgentId={item.terminal.detectedAgentId}
                         detectedProcessId={item.terminal.detectedProcessId}
                         className="h-3 w-3"
                       />
@@ -311,6 +312,7 @@ function BackgroundGroupItem({
                     type={terminal.type}
                     kind={terminal.kind}
                     agentId={terminal.agentId}
+                    detectedAgentId={terminal.detectedAgentId}
                     detectedProcessId={terminal.detectedProcessId}
                     className="w-2.5 h-2.5 opacity-60"
                   />

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -365,7 +365,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const panelPresetColors = useMemo(() => {
     return new Map(
       panels.map((p) => {
-        const fallbackColor = getBrandColorHex(p.agentId ?? p.type);
+        const fallbackColor = getBrandColorHex(p.detectedAgentId ?? p.agentId ?? p.type);
         if (!p.agentPresetId || !p.agentId) return [p.id, fallbackColor] as const;
         const presets = getMergedPresets(
           p.agentId,
@@ -390,7 +390,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
   const brandColor =
     panelPresetColors.get(activePanel.id) ??
-    getBrandColorHex(activePanel.agentId ?? activePanel.type);
+    getBrandColorHex(activePanel.detectedAgentId ?? activePanel.agentId ?? activePanel.type);
   const agentState = activePanel.agentState;
   const displayTitle = getBaseTitle(activePanel.title);
   const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
@@ -440,6 +440,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 type={activePanel.type}
                 kind={activePanel.kind}
                 agentId={activePanel.agentId}
+                detectedAgentId={activePanel.detectedAgentId}
                 detectedProcessId={activePanel.detectedProcessId}
                 className="w-3.5 h-3.5"
                 brandColor={brandColor}
@@ -544,6 +545,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   title={getBaseTitle(panel.title)}
                   type={panel.type}
                   agentId={panel.agentId}
+                  detectedAgentId={panel.detectedAgentId}
                   detectedProcessId={panel.detectedProcessId}
                   kind={panel.kind ?? "terminal"}
                   agentState={panel.agentState}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -194,7 +194,9 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     terminal.agentId ? s.presetsByAgent[terminal.agentId] : undefined
   );
   const brandColor = useMemo(() => {
-    const fallbackColor = getBrandColorHex(terminal.agentId ?? terminal.type);
+    const fallbackColor = getBrandColorHex(
+      terminal.detectedAgentId ?? terminal.agentId ?? terminal.type
+    );
     if (!terminal.agentPresetId || !terminal.agentId) return fallbackColor;
     const preset = getMergedPresets(
       terminal.agentId,
@@ -205,6 +207,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     return preset?.color ?? terminal.agentPresetColor ?? fallbackColor;
   }, [
     terminal.agentId,
+    terminal.detectedAgentId,
     terminal.type,
     terminal.agentPresetId,
     terminal.agentPresetColor,
@@ -275,6 +278,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 type={terminal.type}
                 kind={terminal.kind}
                 agentId={terminal.agentId}
+                detectedAgentId={terminal.detectedAgentId}
                 detectedProcessId={terminal.detectedProcessId}
                 className="w-3.5 h-3.5"
                 brandColor={brandColor}

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -133,6 +133,7 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
                       type={terminal.type}
                       kind={terminal.kind}
                       agentId={terminal.agentId}
+                      detectedAgentId={terminal.detectedAgentId}
                       detectedProcessId={terminal.detectedProcessId}
                       className="h-3 w-3"
                     />

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -73,6 +73,7 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
           type={terminal.type}
           kind={terminal.kind}
           agentId={terminal.agentId}
+          detectedAgentId={terminal.detectedAgentId}
           detectedProcessId={terminal.detectedProcessId}
           className="w-3 h-3"
         />

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -188,6 +188,7 @@ export function TrashGroupItem({
                     type={terminal.type}
                     kind={terminal.kind}
                     agentId={terminal.agentId}
+                    detectedAgentId={terminal.detectedAgentId}
                     detectedProcessId={terminal.detectedProcessId}
                     className="w-2.5 h-2.5 opacity-60"
                   />

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -55,6 +55,8 @@ export interface ContentPanelProps extends BasePanelProps {
   // Terminal-specific header props (optional, only used for terminal/agent panels)
   type?: TerminalType;
   agentId?: string;
+  /** Runtime-detected agent identity (cleared on agent exit). Drives panel chrome. */
+  detectedAgentId?: string;
   detectedProcessId?: string;
   presetColor?: string;
   agentLaunchFlags?: string[];
@@ -127,6 +129,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     "aria-selected": ariaSelected,
     type,
     agentId,
+    detectedAgentId,
     detectedProcessId,
     presetColor,
     agentLaunchFlags,
@@ -324,6 +327,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           kind={kind}
           type={type}
           agentId={agentId}
+          detectedAgentId={detectedAgentId}
           detectedProcessId={detectedProcessId}
           presetColor={presetColor}
           agentLaunchFlags={agentLaunchFlags}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -53,6 +53,7 @@ import {
   useKeybindingDisplay,
 } from "@/hooks";
 import { usePanelStore } from "@/store/panelStore";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -74,6 +75,8 @@ export interface PanelHeaderProps {
   kind: PanelKind;
   type?: TerminalType;
   agentId?: string;
+  /** Runtime-detected agent identity (cleared when the agent exits). Drives icons and the watch button. */
+  detectedAgentId?: string;
   detectedProcessId?: string;
   presetColor?: string;
   worktreeAccentColor?: string;
@@ -139,6 +142,7 @@ function PanelHeaderComponent({
   kind,
   type,
   agentId,
+  detectedAgentId,
   detectedProcessId,
   presetColor,
   worktreeAccentColor,
@@ -239,7 +243,11 @@ function PanelHeaderComponent({
   const isWatched = usePanelStore((state) => state.watchedPanels.has(id));
   const watchPanel = usePanelStore((state) => state.watchPanel);
   const unwatchPanel = usePanelStore((state) => state.unwatchPanel);
-  const showWatchButton = !!agentId;
+  // Watch button tracks live agent identity: visible when an agent is currently
+  // running (`detectedAgentId`) OR was launched as one (`agentId`). The fallback
+  // keeps the button available right after spawn before the process detector fires.
+  const effectiveAgentId = resolveEffectiveAgentId(detectedAgentId, agentId);
+  const showWatchButton = !!effectiveAgentId;
 
   // Fleet failure state for this pane: when the most recent broadcast
   // rejected on this terminal (e.g. PTY died mid-paste), surface a red
@@ -717,9 +725,10 @@ function PanelHeaderComponent({
               type={type}
               kind={kind}
               agentId={agentId}
+              detectedAgentId={detectedAgentId}
               detectedProcessId={detectedProcessId}
               className="w-3.5 h-3.5"
-              brandColor={presetColor ?? getBrandColorHex(agentId ?? type)}
+              brandColor={presetColor ?? getBrandColorHex(effectiveAgentId ?? type)}
             />
           </span>
 

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -6,6 +6,7 @@ import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
 import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import {
@@ -19,6 +20,7 @@ export interface TabInfo {
   title: string;
   type?: TerminalType;
   agentId?: string;
+  detectedAgentId?: string;
   detectedProcessId?: string;
   kind: PanelKind;
   agentState?: AgentState;
@@ -34,6 +36,7 @@ export interface TabButtonProps {
   title: string;
   type?: TerminalType;
   agentId?: string;
+  detectedAgentId?: string;
   detectedProcessId?: string;
   kind: PanelKind;
   agentState?: AgentState;
@@ -55,6 +58,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     title,
     type,
     agentId,
+    detectedAgentId,
     detectedProcessId,
     kind,
     agentState,
@@ -263,9 +267,13 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
                 type={type}
                 kind={kind}
                 agentId={agentId}
+                detectedAgentId={detectedAgentId}
                 detectedProcessId={detectedProcessId}
                 className="w-3.5 h-3.5"
-                brandColor={presetColor ?? getBrandColorHex(agentId ?? type)}
+                brandColor={
+                  presetColor ??
+                  getBrandColorHex(resolveEffectiveAgentId(detectedAgentId, agentId) ?? type)
+                }
               />
             </span>
 

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -5,6 +5,7 @@ import { getBrandColorHex } from "@/lib/colorUtils";
 import { WorktreeIcon } from "@/components/icons";
 import type { QuickSwitcherItem as QuickSwitcherItemData } from "@/hooks/useQuickSwitcher";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 
 export interface QuickSwitcherItemProps {
   item: QuickSwitcherItemData;
@@ -42,8 +43,11 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
             type={item.terminalType}
             kind={item.terminalKind}
             agentId={item.agentId}
+            detectedAgentId={item.detectedAgentId}
             detectedProcessId={item.detectedProcessId}
-            brandColor={getBrandColorHex(item.agentId ?? item.terminalType)}
+            brandColor={getBrandColorHex(
+              resolveEffectiveAgentId(item.detectedAgentId, item.agentId) ?? item.terminalType
+            )}
           />
         ) : (
           <WorktreeIcon className="w-4 h-4" />
@@ -61,7 +65,11 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
                 : "bg-status-success/10 text-status-success border-status-success/30"
             )}
           >
-            {item.type === "terminal" ? (item.terminalType ?? "terminal") : "worktree"}
+            {item.type === "terminal"
+              ? (resolveEffectiveAgentId(item.detectedAgentId, item.agentId) ??
+                item.terminalType ??
+                "terminal")
+              : "worktree"}
           </span>
         </div>
         {item.subtitle && (

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -190,6 +190,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         title: p.title,
         type: p.type,
         agentId: p.agentId,
+        detectedAgentId: p.detectedAgentId,
         detectedProcessId: p.detectedProcessId,
         kind: p.kind ?? "terminal",
         agentState: p.agentState,

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -6,6 +6,7 @@ import { getBrandColorHex } from "@/lib/colorUtils";
 import { Lock } from "lucide-react";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import type { SendToAgentItem } from "@/hooks/useSendToAgentPalette";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 
 export interface SendToAgentPaletteProps {
   isOpen: boolean;
@@ -57,8 +58,11 @@ const SendToAgentItemRow = React.memo(function SendToAgentItemRow({
           type={item.terminalType}
           kind={item.terminalKind}
           agentId={item.agentId}
+          detectedAgentId={item.detectedAgentId}
           detectedProcessId={item.detectedProcessId}
-          brandColor={getBrandColorHex(item.agentId ?? item.terminalType)}
+          brandColor={getBrandColorHex(
+            resolveEffectiveAgentId(item.detectedAgentId, item.agentId) ?? item.terminalType
+          )}
         />
       </span>
 

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -315,7 +315,9 @@ export function TerminalContextMenu({
   );
 
   const currentAgentId =
-    terminal?.agentId ?? (terminal?.type !== "terminal" ? terminal?.type : null);
+    terminal?.detectedAgentId ??
+    terminal?.agentId ??
+    (terminal?.type !== "terminal" ? terminal?.type : null);
   const isPlainTerminal = terminal?.type === "terminal" || terminal?.kind === "terminal";
 
   const visibleAgentIds = useMemo(() => {

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import type { TerminalType, PanelKind } from "@/types";
 import type { ComponentType } from "react";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   NpmIcon,
   YarnIcon,
@@ -53,6 +54,11 @@ export interface TerminalIconProps {
   type?: TerminalType;
   kind?: PanelKind;
   agentId?: string;
+  /**
+   * Runtime-detected agent (cleared when the agent exits). Takes precedence
+   * over `agentId` so the icon reflects the live process, not the launch intent.
+   */
+  detectedAgentId?: string;
   detectedProcessId?: string;
   className?: string;
   brandColor?: string;
@@ -62,6 +68,7 @@ export function TerminalIcon({
   type,
   kind,
   agentId,
+  detectedAgentId,
   detectedProcessId,
   className,
   brandColor,
@@ -81,8 +88,10 @@ export function TerminalIcon({
     return <Monitor {...finalProps} className={cn(finalProps.className, "text-status-info")} />;
   }
 
-  // Get effective agent ID - either from explicit agentId prop or from type (backward compat)
-  const effectiveAgentId = agentId ?? (type && isRegisteredAgent(type) ? type : undefined);
+  // Prefer runtime-detected identity, then launch-time agentId, then legacy type fallback.
+  const effectiveAgentId =
+    resolveEffectiveAgentId(detectedAgentId, agentId) ??
+    (type && isRegisteredAgent(type) ? type : undefined);
 
   if (effectiveAgentId) {
     const config = getAgentConfig(effectiveAgentId);

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -166,14 +166,17 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
     };
   }, [isOpen, terminalId]);
 
-  const showAgentSection = (info: TerminalInfoPayload): boolean =>
+  // "Launch Context" reflects how the panel was configured at spawn time.
+  const showAgentLaunchSection = (info: TerminalInfoPayload): boolean =>
     !!(
-      info.isAgentTerminal ||
       info.agentId ||
-      info.detectedAgentType ||
       (info.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
       info.agentModelId
     );
+  // "Live State" reflects what's running right now — only shown for agent panels
+  // (`isAgentTerminal`) or when a runtime detection is active (`detectedAgentId`).
+  const showAgentLiveSection = (info: TerminalInfoPayload): boolean =>
+    !!(info.isAgentTerminal || info.detectedAgentId);
 
   const formatArgsForClipboard = (args: string[] | undefined): string => {
     if (args === undefined) return "N/A";
@@ -184,15 +187,24 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const copyToClipboard = async () => {
     if (!info) return;
 
-    const agentSection = showAgentSection(info)
+    const launchSection = showAgentLaunchSection(info)
       ? `
 
-Agent:
+Agent — Launch Context:
   Agent ID: ${info.agentId ?? "N/A"}
-  Detected Agent: ${info.detectedAgentType ?? "N/A"}
   Launch Flags: ${formatArgsForClipboard(info.agentLaunchFlags)}
   Model: ${info.agentModelId ?? "N/A"}`
       : "";
+
+    const liveSection = showAgentLiveSection(info)
+      ? `
+
+Agent — Live State:
+  Detected Agent ID: ${info.detectedAgentId ?? "None — agent has exited"}
+  Detected Agent Type: ${info.detectedAgentType ?? "N/A"}`
+      : "";
+
+    const agentSection = launchSection + liveSection;
 
     const diagnosticInfo = `Terminal Diagnostic Information
 =====================================
@@ -288,14 +300,20 @@ Performance & Diagnostics:
               <InfoListRow label="Args" items={info.spawnArgs} />
             </InfoSection>
 
-            {showAgentSection(info) && (
-              <InfoSection title="Agent">
+            {showAgentLaunchSection(info) && (
+              <InfoSection title="Agent — Launch Context">
                 {info.agentId && <InfoRow label="Agent ID" value={info.agentId} />}
-                {info.detectedAgentType && (
-                  <InfoRow label="Detected Agent" value={info.detectedAgentType} />
-                )}
                 <InfoListRow label="Launch Flags" items={info.agentLaunchFlags} />
                 {info.agentModelId && <InfoRow label="Model" value={info.agentModelId} mono />}
+              </InfoSection>
+            )}
+
+            {showAgentLiveSection(info) && (
+              <InfoSection title="Agent — Live State">
+                <InfoRow
+                  label="Detected Agent"
+                  value={info.detectedAgentId ?? "None — agent has exited"}
+                />
               </InfoSection>
             )}
 

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -173,10 +173,11 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
       (info.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
       info.agentModelId
     );
-  // "Live State" reflects what's running right now — only shown for agent panels
-  // (`isAgentTerminal`) or when a runtime detection is active (`detectedAgentId`).
+  // "Live State" reflects what's running right now. Shown for agent panels,
+  // while a runtime agent is detected, or once an agent has ever been detected
+  // in this session (so plain terminals that ran `claude` still show the exit).
   const showAgentLiveSection = (info: TerminalInfoPayload): boolean =>
-    !!(info.isAgentTerminal || info.detectedAgentId);
+    !!(info.isAgentTerminal || info.detectedAgentId || info.everDetectedAgent);
 
   const formatArgsForClipboard = (args: string[] | undefined): string => {
     if (args === undefined) return "N/A";

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -74,6 +74,8 @@ export interface TerminalPaneProps {
   title: string;
   type?: TerminalType;
   agentId?: string;
+  /** Runtime-detected agent identity (cleared on agent exit). Drives panel chrome (icons, badges). */
+  detectedAgentId?: string;
   agentPresetId?: string;
   presetColor?: string;
   worktreeId?: string;
@@ -116,6 +118,7 @@ function TerminalPaneComponent({
   title,
   type,
   agentId,
+  detectedAgentId,
   agentPresetId,
   presetColor,
   worktreeId,
@@ -743,6 +746,7 @@ function TerminalPaneComponent({
       kind={kind}
       type={type}
       agentId={agentId}
+      detectedAgentId={detectedAgentId}
       presetColor={livePresetColor}
       isFocused={isFocused}
       isMaximized={isMaximized}

--- a/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
@@ -23,14 +23,21 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
 
   describe("Submenu generation logic", () => {
     function buildConvertToSubmenu(
-      terminal: { type: string; kind?: string; agentId?: string | null } | null,
+      terminal: {
+        type: string;
+        kind?: string;
+        agentId?: string | null;
+        detectedAgentId?: string | null;
+      } | null,
       isAvailabilityInitialized: boolean = false,
       availability?: CliAvailability
     ): MenuItemOption[] {
       if (!terminal) return [];
 
       const currentAgentId =
-        terminal.agentId ?? (terminal.type !== "terminal" ? terminal.type : null);
+        terminal.detectedAgentId ??
+        terminal.agentId ??
+        (terminal.type !== "terminal" ? terminal.type : null);
       const isPlainTerminal = terminal.type === "terminal" || terminal.kind === "terminal";
 
       const visibleAgentIds = (() => {
@@ -261,6 +268,34 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
         (item) => item.type !== "separator" && item.id.startsWith("convert-to:")
       );
       expect(agentItems.length).toBe(0);
+    });
+
+    it("should prefer detectedAgentId over launch-time agentId", () => {
+      const detected = AGENT_IDS[0]!;
+      const launched = AGENT_IDS[1] ?? AGENT_IDS[0]!;
+      const terminal = {
+        type: launched,
+        kind: "agent",
+        agentId: launched,
+        detectedAgentId: detected,
+      };
+      const submenu = buildConvertToSubmenu(terminal);
+
+      // Detected agent is current — disabled
+      const detectedItem = submenu.find((i) => i.id === `convert-to:${detected}`);
+      expect(detectedItem).toBeDefined();
+      if (detectedItem && detectedItem.type !== "separator") {
+        expect(detectedItem.enabled).toBe(false);
+      }
+
+      // Launched-only agent (if different) is not marked current — enabled
+      if (launched !== detected) {
+        const launchedItem = submenu.find((i) => i.id === `convert-to:${launched}`);
+        expect(launchedItem).toBeDefined();
+        if (launchedItem && launchedItem.type !== "separator") {
+          expect(launchedItem.enabled).toBe(true);
+        }
+      }
     });
 
     it("should show all states including ready", () => {

--- a/src/components/Terminal/__tests__/TerminalIcon.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalIcon.test.tsx
@@ -50,4 +50,24 @@ describe("TerminalIcon", () => {
     expect(explicitAgent).not.toBe(npmDetected);
     expect(explicitAgent).not.toBe(fallback);
   });
+
+  it("prefers detectedAgentId over launch-time agentId", () => {
+    const claudeLaunch = render(<TerminalIcon kind="agent" agentId="claude" />).container.innerHTML;
+    const geminiDetected = render(
+      <TerminalIcon kind="agent" agentId="claude" detectedAgentId="gemini" />
+    ).container.innerHTML;
+    const geminiOnly = render(<TerminalIcon kind="agent" agentId="gemini" />).container.innerHTML;
+
+    expect(geminiDetected).not.toBe(claudeLaunch);
+    expect(geminiDetected).toBe(geminiOnly);
+  });
+
+  it("falls back to agentId when detectedAgentId is undefined", () => {
+    const launchOnly = render(<TerminalIcon kind="agent" agentId="claude" />).container.innerHTML;
+    const withUndefinedDetected = render(
+      <TerminalIcon kind="agent" agentId="claude" detectedAgentId={undefined} />
+    ).container.innerHTML;
+
+    expect(withUndefinedDetected).toBe(launchOnly);
+  });
 });

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -210,13 +210,14 @@ describe("TerminalInfoDialog", () => {
     expect(screen.queryByText("Args:")).toBeNull();
   });
 
-  it("renders Agent section with launch flag chips and model for agent terminals", async () => {
+  it("renders Launch Context and Live State sections for agent terminals", async () => {
     const payload = makePayload({
       isAgentTerminal: true,
       kind: "agent",
       type: "claude",
       agentId: "agent-1",
       detectedAgentType: "claude",
+      detectedAgentId: "claude",
       agentLaunchFlags: ["--dangerously-skip-permissions", "--verbose"],
       agentModelId: "claude-opus-4-7",
     });
@@ -225,24 +226,51 @@ describe("TerminalInfoDialog", () => {
     render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
 
     await waitFor(() => {
-      expect(screen.getByText("Agent")).toBeTruthy();
+      expect(screen.getByText("Agent — Launch Context")).toBeTruthy();
     });
 
     expect(screen.getByText("Agent ID:")).toBeTruthy();
     expect(screen.getByText("agent-1")).toBeTruthy();
-    expect(screen.getByText("Detected Agent:")).toBeTruthy();
     expect(screen.getByText("Launch Flags:")).toBeTruthy();
     expect(screen.getByText("--dangerously-skip-permissions")).toBeTruthy();
     expect(screen.getByText("--verbose")).toBeTruthy();
     expect(screen.getByText("Model:")).toBeTruthy();
     expect(screen.getByText("claude-opus-4-7")).toBeTruthy();
+
+    // Live State section shows the detected agent identity
+    expect(screen.getByText("Agent — Live State")).toBeTruthy();
+    expect(screen.getByText("Detected Agent:")).toBeTruthy();
+    // "claude" appears for the type row and the detected-agent row; at least two matches is enough
+    expect(screen.getAllByText("claude").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("omits Agent section entirely for plain terminals with no agent metadata", async () => {
+  it("shows 'None — agent has exited' in Live State when agent panel has no detectedAgentId", async () => {
+    const payload = makePayload({
+      isAgentTerminal: true,
+      kind: "agent",
+      type: "claude",
+      agentId: "agent-1",
+      detectedAgentId: undefined,
+      agentLaunchFlags: ["--verbose"],
+      agentModelId: "claude-opus-4-7",
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent — Live State")).toBeTruthy();
+    });
+
+    expect(screen.getByText("None — agent has exited")).toBeTruthy();
+  });
+
+  it("omits Agent sections entirely for plain terminals with no agent metadata", async () => {
     const payload = makePayload({
       isAgentTerminal: false,
       agentId: undefined,
       detectedAgentType: undefined,
+      detectedAgentId: undefined,
       agentLaunchFlags: undefined,
       agentModelId: undefined,
     });
@@ -257,17 +285,18 @@ describe("TerminalInfoDialog", () => {
     expect(screen.queryByText("Agent ID:")).toBeNull();
     expect(screen.queryByText("Launch Flags:")).toBeNull();
     expect(screen.queryByText("Model:")).toBeNull();
-    // The Agent section heading should not exist either
-    expect(screen.queryByRole("heading", { name: "Agent" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Agent — Launch Context" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Agent — Live State" })).toBeNull();
   });
 
-  it("includes Spawn Command and Agent sections in clipboard export", async () => {
+  it("includes Spawn Command and both Agent sections in clipboard export", async () => {
     const payload = makePayload({
       isAgentTerminal: true,
       kind: "agent",
       type: "claude",
       agentId: "agent-1",
       detectedAgentType: "claude",
+      detectedAgentId: "claude",
       shell: "/usr/local/bin/claude",
       spawnArgs: ["--model", "claude-opus-4-7"],
       agentLaunchFlags: ["--dangerously-skip-permissions"],
@@ -290,16 +319,20 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).toContain("Spawn Command:");
     expect(clipboardText).toContain("Shell: /usr/local/bin/claude");
     expect(clipboardText).toContain("Args: --model claude-opus-4-7");
-    expect(clipboardText).toContain("Agent:");
+    expect(clipboardText).toContain("Agent — Launch Context:");
     expect(clipboardText).toContain("Agent ID: agent-1");
     expect(clipboardText).toContain("Launch Flags: --dangerously-skip-permissions");
     expect(clipboardText).toContain("Model: claude-opus-4-7");
+    expect(clipboardText).toContain("Agent — Live State:");
+    expect(clipboardText).toContain("Detected Agent ID: claude");
+    expect(clipboardText).toContain("Detected Agent Type: claude");
   });
 
-  it("includes Agent section when only detectedAgentType is set on a non-agent terminal", async () => {
+  it("includes Live State but not Launch Context when only a runtime agent is detected", async () => {
     const payload = makePayload({
       isAgentTerminal: false,
       detectedAgentType: "claude",
+      detectedAgentId: "claude",
     });
     dispatchMock.mockResolvedValue({ ok: true, result: payload });
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
@@ -311,15 +344,14 @@ describe("TerminalInfoDialog", () => {
       expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
     });
 
-    // UI shows the Agent section
-    expect(screen.getByText("Agent")).toBeTruthy();
-    expect(screen.getByText("Detected Agent:")).toBeTruthy();
+    expect(screen.getByText("Agent — Live State")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Agent — Launch Context" })).toBeNull();
 
-    // Clipboard also includes the Agent section — UI and clipboard guards must agree
     fireEvent.click(screen.getByText("Copy to Clipboard"));
     const clipboardText = writeTextMock.mock.calls[0]![0] as string;
-    expect(clipboardText).toContain("Agent:");
-    expect(clipboardText).toContain("Detected Agent: claude");
+    expect(clipboardText).toContain("Agent — Live State:");
+    expect(clipboardText).toContain("Detected Agent ID: claude");
+    expect(clipboardText).not.toContain("Agent — Launch Context:");
   });
 
   it("renders empty spawnArgs as (none) in clipboard and omits the Args row in UI", async () => {
@@ -343,7 +375,7 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).not.toContain("Args: N/A");
   });
 
-  it("omits Agent section from clipboard for non-agent terminals", async () => {
+  it("omits Agent sections from clipboard for non-agent terminals", async () => {
     const payload = makePayload({ isAgentTerminal: false, spawnArgs: ["-l"] });
     dispatchMock.mockResolvedValue({ ok: true, result: payload });
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
@@ -360,7 +392,8 @@ describe("TerminalInfoDialog", () => {
     const clipboardText = writeTextMock.mock.calls[0]![0] as string;
     expect(clipboardText).toContain("Spawn Command:");
     expect(clipboardText).toContain("Args: -l");
-    expect(clipboardText).not.toContain("\nAgent:\n");
+    expect(clipboardText).not.toContain("Agent — Launch Context:");
+    expect(clipboardText).not.toContain("Agent — Live State:");
     expect(clipboardText).not.toContain("Launch Flags:");
   });
 });

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -103,6 +103,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
               type={term.type}
               kind={term.kind}
               agentId={term.agentId}
+              detectedAgentId={term.detectedAgentId}
               detectedProcessId={term.detectedProcessId}
               className="w-3 h-3"
             />

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -17,6 +17,7 @@ export interface QuickSwitcherItem {
   terminalType?: TerminalInstance["type"];
   terminalKind?: TerminalInstance["kind"];
   agentId?: TerminalInstance["agentId"];
+  detectedAgentId?: TerminalInstance["detectedAgentId"];
   detectedProcessId?: TerminalInstance["detectedProcessId"];
   worktreeId?: string;
 }
@@ -89,6 +90,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
         terminalType: t.type,
         terminalKind: t.kind,
         agentId: t.agentId,
+        detectedAgentId: t.detectedAgentId,
         detectedProcessId: t.detectedProcessId,
         worktreeId: t.worktreeId,
       });

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -17,6 +17,7 @@ export interface SendToAgentItem {
   terminalType?: TerminalInstance["type"];
   terminalKind?: TerminalInstance["kind"];
   agentId?: TerminalInstance["agentId"];
+  detectedAgentId?: TerminalInstance["detectedAgentId"];
   detectedProcessId?: TerminalInstance["detectedProcessId"];
   isInputLocked?: boolean;
 }
@@ -107,6 +108,7 @@ export function useSendToAgentPalette() {
         terminalType: t.type,
         terminalKind: t.kind,
         agentId: t.agentId,
+        detectedAgentId: t.detectedAgentId,
         detectedProcessId: t.detectedProcessId,
         isInputLocked: t.isInputLocked,
       });

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -98,7 +98,8 @@ export function useSendToAgentPalette() {
       if (t.kind && !panelKindHasPty(t.kind)) continue;
       if (t.hasPty === false) continue;
 
-      const agentConfig = t.agentId ? getAgentConfig(t.agentId) : null;
+      const effectiveAgentId = t.detectedAgentId ?? t.agentId;
+      const agentConfig = effectiveAgentId ? getAgentConfig(effectiveAgentId) : null;
       const subtitle = agentConfig ? agentConfig.name : t.type !== "terminal" ? t.type : "Terminal";
 
       result.push({

--- a/src/utils/__tests__/agentIdentity.test.ts
+++ b/src/utils/__tests__/agentIdentity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveAgentId } from "../agentIdentity";
+
+describe("resolveEffectiveAgentId", () => {
+  it("prefers detectedAgentId when both are present", () => {
+    expect(resolveEffectiveAgentId("gemini", "claude")).toBe("gemini");
+  });
+
+  it("falls back to agentId when detectedAgentId is absent", () => {
+    expect(resolveEffectiveAgentId(undefined, "claude")).toBe("claude");
+  });
+
+  it("returns detectedAgentId when agentId is absent", () => {
+    expect(resolveEffectiveAgentId("claude", undefined)).toBe("claude");
+  });
+
+  it("returns undefined when neither is present", () => {
+    expect(resolveEffectiveAgentId(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/src/utils/agentIdentity.ts
+++ b/src/utils/agentIdentity.ts
@@ -1,0 +1,18 @@
+import type { BuiltInAgentId } from "../../shared/config/agentIds.js";
+import type { AgentId } from "../../shared/types/agent.js";
+
+type MaybeAgentId = BuiltInAgentId | AgentId | string | undefined;
+
+/**
+ * Resolve the effective agent identity for panel chrome (icons, badges, labels).
+ *
+ * Prefers the runtime-detected agent (`detectedAgentId`) over the launch-time
+ * intent (`agentId`). Used so chrome stops claiming an agent is live once the
+ * process exits — the launch-time field remains for session-capability gates.
+ */
+export function resolveEffectiveAgentId(
+  detectedAgentId: MaybeAgentId,
+  agentId: MaybeAgentId
+): string | undefined {
+  return detectedAgentId ?? agentId ?? undefined;
+}

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -65,6 +65,7 @@ export function buildPanelProps({
     // Terminal-specific
     type: terminal.type,
     agentId: terminal.agentId,
+    detectedAgentId: terminal.detectedAgentId,
     agentPresetId: terminal.agentPresetId,
     presetColor: terminal.agentPresetColor,
     agentLaunchFlags: terminal.agentLaunchFlags,


### PR DESCRIPTION
## Summary

- Introduces `resolveEffectiveAgentId` to prefer live runtime identity (`detectedAgentId`) over launch-time `agentId`, giving all panel chrome a single source of truth for whether an agent is currently running.
- Threads `detectedAgentId` through every UI surface that gates on agent identity: tab icons, panel header action buttons, quick switcher badges, send-to-agent palette labels, context menu items, and the terminal info dialog.
- Splits the info dialog agent section into "Launch Context" and "Live State" so launch metadata and live state are clearly separated; panels that ran an agent transiently now show "None — agent has exited" rather than looking half-agent.

Resolves #5775

## Changes

- `PtyManager.getTerminalInfo` now includes `detectedAgentId` and `everDetectedAgent` from live PTY host state
- New `src/utils/agentIdentity.ts` with `resolveEffectiveAgentId` helper
- `TerminalIcon`, `PanelHeader`, `TabButton`, `QuickSwitcherItem`, `SendToAgentPalette`, `TerminalContextMenu`, and all layout containers updated to carry and prefer `detectedAgentId`
- `TerminalInfoDialog` Live State section visible whenever `everDetectedAgent` is true, not only when the agent is currently active
- Unit tests covering `TerminalIcon`, `TerminalInfoDialog`, `TerminalContextMenu`, and the `agentIdentity` helper

## Testing

- Unit tests added for the new helper and all affected components; all pass.
- Manually verified: agent icon and watch button appear correctly for live-detected agents that have no launch-time `agentId`, and clear when the agent exits.