### PR TITLE
feat(panels): collapse agent and terminal panel kinds into a single dynamic kind

### DIFF
--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -142,7 +142,7 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t1",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "working",
           hasPty: true,
@@ -167,7 +167,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t1",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -176,7 +177,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t2",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "waiting",
           hasPty: true,
           cwd: "/tmp",
@@ -185,7 +187,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t3",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "running",
           hasPty: true,
           cwd: "/tmp",
@@ -194,7 +197,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t4",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "idle",
           hasPty: true,
           cwd: "/tmp",
@@ -220,7 +224,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t1",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           isTrashed: true,
@@ -239,7 +244,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t3",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: false,
           cwd: "/tmp",
@@ -249,6 +255,7 @@ describe("handleProjectGetBulkStats", () => {
           id: "t4",
           projectId: "proj-a",
           kind: "terminal",
+          // Plain terminal (no agentId) — filtered out by the agent-count guard.
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -257,7 +264,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t5",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -316,7 +324,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t1",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -325,7 +334,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t2",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "waiting",
           hasPty: true,
           cwd: "/tmp",
@@ -334,7 +344,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t3",
           projectId: "proj-b",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "running",
           hasPty: true,
           cwd: "/tmp",
@@ -343,7 +354,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t4",
           projectId: "proj-c",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -403,7 +415,8 @@ describe("handleProjectGetBulkStats", () => {
         {
           id: "t1",
           projectId: "proj-ok",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",
@@ -464,11 +477,20 @@ describe("handleProjectGetBulkStats", () => {
   it("skips terminals without a projectId", async () => {
     const ptyClient = makePtyClient({
       getAllTerminalsAsync: vi.fn().mockResolvedValue([
-        { id: "t1", kind: "agent", agentState: "working", hasPty: true, cwd: "/tmp", spawnedAt: 1 }, // no projectId
+        {
+          id: "t1",
+          kind: "terminal",
+          agentId: "claude",
+          agentState: "working",
+          hasPty: true,
+          cwd: "/tmp",
+          spawnedAt: 1,
+        }, // no projectId
         {
           id: "t2",
           projectId: "proj-a",
-          kind: "agent",
+          kind: "terminal",
+          agentId: "claude",
           agentState: "working",
           hasPty: true,
           cwd: "/tmp",

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -71,7 +71,7 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
       if (terminal.isTrashed) continue;
       if (terminal.kind === "dev-preview") continue;
       if (terminal.hasPty === false) continue;
-      if (terminal.kind !== "agent" && !terminal.agentId) continue;
+      if (!terminal.agentId) continue;
 
       if (terminal.agentState === "waiting") {
         counts.waiting += 1;

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -117,7 +117,7 @@ describe("agent command injection via shell -c flag", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude --dangerously-skip-permissions",
     });
@@ -137,7 +137,7 @@ describe("agent command injection via shell -c flag", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
       shell: "/usr/bin/fish",
@@ -182,7 +182,7 @@ describe("agent command injection via shell -c flag", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
     });
@@ -210,7 +210,7 @@ describe("agent command injection via shell -c flag", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude\nmalicious",
     });
@@ -231,7 +231,7 @@ describe("agent command injection via shell -c flag", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       agentId: "gemini",
       command: "gemini chat",
     });

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.poolInspection.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.poolInspection.test.ts
@@ -23,7 +23,7 @@ describe("terminal pool inspection handlers", () => {
         getAvailableTerminalsAsync: vi.fn(async () => [
           {
             id: "t-idle",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "idle",
@@ -31,7 +31,7 @@ describe("terminal pool inspection handlers", () => {
           },
           {
             id: "t-waiting",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "waiting",
@@ -102,7 +102,7 @@ describe("terminal pool inspection handlers", () => {
         getAvailableTerminalsAsync: vi.fn(async () => [
           {
             id: "t-idle",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "idle",
@@ -140,7 +140,7 @@ describe("terminal pool inspection handlers", () => {
         getTerminalsByStateAsync: vi.fn(async () => [
           {
             id: "t-working-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "working",
@@ -148,7 +148,7 @@ describe("terminal pool inspection handlers", () => {
           },
           {
             id: "t-working-2",
-            kind: "agent",
+            kind: "terminal",
             type: "codex",
             cwd: "/tmp",
             agentState: "working",
@@ -182,7 +182,7 @@ describe("terminal pool inspection handlers", () => {
         getTerminalsByStateAsync: vi.fn(async () => [
           {
             id: "t-working",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "working",
@@ -287,7 +287,7 @@ describe("terminal pool inspection handlers", () => {
           {
             id: "t-full",
             projectId: "proj-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude Agent",
@@ -342,7 +342,7 @@ describe("terminal pool inspection handlers", () => {
         getAllTerminalsAsync: vi.fn(async () => [
           {
             id: "t-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "idle",
@@ -358,7 +358,7 @@ describe("terminal pool inspection handlers", () => {
           },
           {
             id: "t-3",
-            kind: "agent",
+            kind: "terminal",
             type: "codex",
             cwd: "/tmp",
             agentState: "working",
@@ -424,7 +424,7 @@ describe("terminal pool inspection handlers", () => {
         getAllTerminalsAsync: vi.fn(async () => [
           {
             id: "t-active",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             cwd: "/tmp",
             agentState: "working",
@@ -434,7 +434,7 @@ describe("terminal pool inspection handlers", () => {
           },
           {
             id: "t-background",
-            kind: "agent",
+            kind: "terminal",
             type: "codex",
             cwd: "/tmp",
             agentState: "idle",

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -44,15 +44,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
     const type = validatedOptions.type || "terminal";
 
-    // Normalize kind and agentId from type when type is a registered agent
-    // This ensures agent terminals are consistently identified across all layers
-    // Override kind when type is an agent to prevent mixed metadata
+    // Agent identity now lives on agentId; panel kind is always "terminal"
+    // for PTY-backed panels. Derive agentId from a registered agent type when
+    // the renderer omitted it (legacy spawn path).
     const { isRegisteredAgent } = await import("../../../../shared/config/agentRegistry.js");
     const isAgentType = type !== "terminal" && isRegisteredAgent(type);
 
-    const kind = isAgentType
-      ? "agent"
-      : validatedOptions.kind || (validatedOptions.agentId ? "agent" : "terminal");
+    const kind = "terminal";
     const agentId = validatedOptions.agentId || (isAgentType ? type : undefined);
     const title = validatedOptions.title;
 
@@ -78,7 +76,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     let projectShell: string | undefined;
     let projectArgs: string[] | undefined;
     let projectCwd: string | undefined;
-    if (projectId && kind !== "agent") {
+    if (projectId && !agentId) {
       const projSettings = await projectStore.getProjectSettings(projectId);
       const ts = projSettings.terminalSettings;
       if (ts) {
@@ -151,7 +149,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // commands, prompts, stty tricks) since the shell runs the command directly
     // after sourcing rc files, with no interactive prompt.
     const trimmedCommand = validatedOptions.command?.trim() || "";
-    const isAgent = kind === "agent" || Boolean(agentId);
+    const isAgent = Boolean(agentId);
     const useShellExec = isAgent && trimmedCommand.length > 0 && process.platform !== "win32";
 
     let spawnArgs = resolvedArgs;

--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -191,7 +191,7 @@ describe("Terminal Entry Validation Schemas", () => {
     it("accepts valid snapshot with all fields", () => {
       const snapshot = {
         id: "snap-123",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude Agent",
@@ -255,7 +255,7 @@ describe("Terminal Entry Validation Schemas", () => {
     it("rejects PTY panel snapshot without cwd (agent)", () => {
       const snapshot = {
         id: "agent-123",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         title: "Claude",
         location: "grid",

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -130,7 +130,7 @@ export class ProjectStatsService {
         // (detectedAgentId). Uses the LIVE signal only — everDetectedAgent
         // is deliberately excluded so panels whose agent has exited do not
         // inflate the count.
-        if (terminal.kind !== "agent" && !terminal.agentId && !terminal.detectedAgentId) continue;
+        if (!terminal.agentId && !terminal.detectedAgentId) continue;
 
         if (terminal.agentState === "waiting") {
           counts.waiting += 1;

--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -238,7 +238,7 @@ export class TaskOrchestrator {
   /**
    * Find any available agent using simple availability-based selection.
    * Used as fallback when no routing hints are present. Accepts either
-   * stored identity (`kind === "agent"` / `agentId`) or runtime-detected
+   * stored identity (`agentId`) or runtime-detected
    * identity (`detectedAgentId`) so agent CLIs launched from plain
    * terminals can receive tasks.
    */

--- a/electron/services/__tests__/AgentClassification.integration.test.ts
+++ b/electron/services/__tests__/AgentClassification.integration.test.ts
@@ -22,7 +22,7 @@ describe("Agent Classification Matrix", () => {
         cwd: process.cwd(),
         cols: 80,
         rows: 24,
-        kind: "agent" as PanelKind,
+        kind: "terminal" as PanelKind,
         type: "terminal" as TerminalType,
       });
 
@@ -143,7 +143,7 @@ describe("Agent Classification Matrix", () => {
         cwd: process.cwd(),
         cols: 80,
         rows: 24,
-        kind: "agent" as PanelKind,
+        kind: "terminal" as PanelKind,
         agentId: "claude",
       });
 

--- a/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
@@ -69,7 +69,7 @@ const DEFAULT_APP_STATE = {
   terminals: [
     {
       id: "term-1",
-      kind: "agent",
+      kind: "terminal",
       agentId: "agent-1",
       title: "Claude Agent",
       location: "dock" as const,

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -66,7 +66,7 @@ const DEFAULT_APP_STATE = {
   terminals: [
     {
       id: "term-1",
-      kind: "agent",
+      kind: "terminal",
       agentId: "agent-1",
       title: "Claude Agent",
       location: "dock",
@@ -391,7 +391,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude Agent",
               location: "grid",
@@ -414,7 +414,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "My Custom Agent",
               location: "dock",
@@ -497,7 +497,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude Agent",
               location: "grid",
@@ -555,7 +555,7 @@ describe("AgentNotificationService", () => {
         activeWorktreeId: "wt-1",
         terminals: Array.from({ length: count }, (_, i) => ({
           id: `term-${i + 1}`,
-          kind: "agent",
+          kind: "terminal",
           agentId: `agent-${i + 1}`,
           title: `Agent ${i + 1}`,
           location: "dock" as const,
@@ -706,7 +706,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude Agent",
               location: "grid",
@@ -969,7 +969,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude",
               location: "dock",
@@ -999,7 +999,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude",
               location: "dock",
@@ -1029,7 +1029,7 @@ describe("AgentNotificationService", () => {
           terminals: [
             {
               id: "term-1",
-              kind: "agent",
+              kind: "terminal",
               agentId: "agent-1",
               title: "Claude",
               location: "dock",

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -116,7 +116,7 @@ describe("CrashRecoveryService adversarial", () => {
     writeBackup(tmpDir, {
       capturedAt: Date.now(),
       appState: {
-        terminals: [{ id: "agent-1", kind: "agent", title: "Recovered" }],
+        terminals: [{ id: "agent-1", kind: "terminal", title: "Recovered" }],
       },
       windowState: {
         width: 1200,
@@ -136,7 +136,7 @@ describe("CrashRecoveryService adversarial", () => {
 
     expect(service.restoreBackup()).toBe(true);
     expect(storeMock.set).toHaveBeenCalledWith("appState", {
-      terminals: [{ id: "agent-1", kind: "agent", title: "Recovered" }],
+      terminals: [{ id: "agent-1", kind: "terminal", title: "Recovered" }],
     });
     expect(storeMock.set).toHaveBeenCalledWith("windowState", {
       width: 1200,
@@ -161,7 +161,7 @@ describe("CrashRecoveryService adversarial", () => {
         terminals: [
           {
             id: "panel-1",
-            kind: "agent",
+            kind: "terminal",
             meta: {
               badges: ["active", "pinned"],
               layout: {
@@ -175,7 +175,7 @@ describe("CrashRecoveryService adversarial", () => {
       windowStates: {
         main: {
           bounds: { width: 1440, height: 900 },
-          tabs: [{ id: "panel-1", kind: "agent" }],
+          tabs: [{ id: "panel-1", kind: "terminal" }],
         },
       },
       windowState: {
@@ -191,7 +191,7 @@ describe("CrashRecoveryService adversarial", () => {
       terminals: [
         {
           id: "panel-1",
-          kind: "agent",
+          kind: "terminal",
           meta: {
             badges: ["active", "pinned"],
             layout: {
@@ -205,7 +205,7 @@ describe("CrashRecoveryService adversarial", () => {
     expect(storeMock.set).toHaveBeenCalledWith("windowStates", {
       main: {
         bounds: { width: 1440, height: 900 },
-        tabs: [{ id: "panel-1", kind: "agent" }],
+        tabs: [{ id: "panel-1", kind: "terminal" }],
       },
     });
     expect(storeMock.set).toHaveBeenCalledWith("windowState", {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -173,7 +173,7 @@ describe("CrashRecoveryService", () => {
           appState: {
             terminals: [
               { id: "t1", kind: "terminal" },
-              { id: "t2", kind: "agent" },
+              { id: "t2", kind: "terminal" },
             ],
           },
         })
@@ -197,7 +197,7 @@ describe("CrashRecoveryService", () => {
       expect(typeof pending!.entry.nodeVersion).toBe("string");
       expect(typeof pending!.entry.totalMemory).toBe("number");
       expect(pending!.entry.panelCount).toBe(2);
-      expect(pending!.entry.panelKinds).toEqual({ terminal: 1, agent: 1 });
+      expect(pending!.entry.panelKinds).toEqual({ terminal: 2 });
     });
 
     it("surfaces dev-mode marker with crashLogPath as a genuine crash", () => {
@@ -302,7 +302,7 @@ describe("CrashRecoveryService", () => {
           return {
             terminals: [
               { id: "t1", kind: "terminal" },
-              { id: "t2", kind: "agent" },
+              { id: "t2", kind: "terminal" },
               { id: "t3", kind: "terminal" },
             ],
           };
@@ -330,7 +330,7 @@ describe("CrashRecoveryService", () => {
       expect(entry.windowCount).toBe(1);
       expect(entry.gpuAccelerationDisabled).toBe(false);
       expect(entry.panelCount).toBe(3);
-      expect(entry.panelKinds).toEqual({ terminal: 2, agent: 1 });
+      expect(entry.panelKinds).toEqual({ terminal: 3 });
     });
 
     it("does not record crash twice (idempotent)", () => {
@@ -508,7 +508,7 @@ describe("CrashRecoveryService", () => {
           sidebarWidth: 999,
           terminals: [
             { id: "t1", kind: "terminal", title: "T1" },
-            { id: "t2", kind: "agent", title: "T2" },
+            { id: "t2", kind: "terminal", title: "T2" },
             { id: "t3", kind: "browser", title: "T3" },
           ],
         },
@@ -623,7 +623,7 @@ describe("CrashRecoveryService", () => {
       fs.mkdirSync(backupDir, { recursive: true });
       const terminals = [
         { id: "t1", kind: "terminal", title: "Shell", cwd: "/home", location: "grid" },
-        { id: "t2", kind: "agent", title: "Claude", location: "dock", worktreeId: "w1" },
+        { id: "t2", kind: "terminal", title: "Claude", location: "dock", worktreeId: "w1" },
       ];
       fs.writeFileSync(
         path.join(backupDir, "session-state.json"),
@@ -651,7 +651,7 @@ describe("CrashRecoveryService", () => {
       expect(pending!.panels).toBeDefined();
       expect(pending!.panels!.length).toBe(2);
       expect(pending!.panels![0]).toMatchObject({ id: "t1", kind: "terminal", title: "Shell" });
-      expect(pending!.panels![1]).toMatchObject({ id: "t2", kind: "agent", location: "dock" });
+      expect(pending!.panels![1]).toMatchObject({ id: "t2", kind: "terminal", location: "dock" });
     });
 
     it("marks panels as suspect when created near crash time", () => {
@@ -711,7 +711,7 @@ describe("CrashRecoveryService", () => {
         },
         {
           id: "t2",
-          kind: "agent",
+          kind: "terminal",
           title: "Claude",
           location: "dock",
           agentState: "working",

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -122,14 +122,14 @@ describe("ProjectStatsService adversarial", () => {
     const ptyClient = makePtyClient();
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
-      { projectId: "p1", isTrashed: true, kind: "agent", agentState: "working" },
+      { projectId: "p1", isTrashed: true, kind: "terminal", agentState: "working" },
       { projectId: "p1", kind: "dev-preview", agentState: "running" },
-      { projectId: "p1", hasPty: false, kind: "agent", agentState: "working" },
+      { projectId: "p1", hasPty: false, kind: "terminal", agentState: "working" },
       { projectId: "p1", kind: "terminal", agentState: "running" }, // no agentId, not "agent" kind → skip
       { projectId: "p1", kind: "terminal", agentId: "x", agentState: "waiting" }, // counts (waiting)
-      { projectId: "p1", kind: "agent", agentId: "x", agentState: "working" }, // counts (active)
-      { projectId: "p1", kind: "agent", agentId: "x", agentState: "running" }, // counts (active)
-      { projectId: "p1", kind: "agent", agentId: "x", agentState: "idle" }, // counts neither
+      { projectId: "p1", kind: "terminal", agentId: "x", agentState: "working" }, // counts (active)
+      { projectId: "p1", kind: "terminal", agentId: "x", agentState: "running" }, // counts (active)
+      { projectId: "p1", kind: "terminal", agentId: "x", agentState: "idle" }, // counts neither
     ]);
     ptyClient.getProjectStats.mockResolvedValue({
       projectId: "p1",

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -393,7 +393,7 @@ describe("PtyManager adversarial", () => {
     manager.spawn(
       "agent-1",
       spawnOptions({
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         projectId: "project-a",
         agentId: "agent-1",
@@ -429,7 +429,7 @@ describe("PtyManager adversarial", () => {
 
     manager.spawn(
       "agent-1",
-      spawnOptions({ kind: "agent", type: "claude", agentId: "agent-1", projectId: "project-a" })
+      spawnOptions({ kind: "terminal", type: "claude", agentId: "agent-1", projectId: "project-a" })
     );
 
     const created = shared.created[0]!;
@@ -473,7 +473,7 @@ describe("PtyManager adversarial", () => {
 
     manager.spawn(
       "agent-1",
-      spawnOptions({ kind: "agent", type: "claude", agentId: "agent-1", projectId: "project-a" })
+      spawnOptions({ kind: "terminal", type: "claude", agentId: "agent-1", projectId: "project-a" })
     );
     manager.spawn("term-1", spawnOptions({ projectId: "project-a" }));
 

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -83,7 +83,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -104,7 +104,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "waiting",
         },
@@ -124,7 +124,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "working",
         },
@@ -185,13 +185,13 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-a",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "idle",
         },
         {
           id: "term-b",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "idle",
         },
@@ -214,7 +214,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -232,7 +232,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -260,7 +260,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -288,7 +288,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -351,7 +351,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "waiting",
         },
@@ -405,7 +405,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -439,13 +439,13 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-a",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "idle",
         },
         {
           id: "term-b",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "idle",
         },
@@ -484,7 +484,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           agentState: "idle",
         },
@@ -530,7 +530,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -713,7 +713,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
           worktreeId: "wt-1",
@@ -753,7 +753,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -794,7 +794,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "routed-agent",
           agentState: "idle",
         },
@@ -831,7 +831,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "fallback-agent",
           agentState: "idle",
         },
@@ -851,7 +851,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "any-agent",
           agentState: "idle",
         },
@@ -883,7 +883,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "different-agent",
           agentState: "idle",
         },
@@ -928,7 +928,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -950,7 +950,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },
@@ -976,7 +976,7 @@ describe("TaskOrchestrator", () => {
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
         {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           agentId: "agent-1",
           agentState: "idle",
         },

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -63,7 +63,7 @@ function createAgentTerminal(deps?: Partial<TerminalProcessDeps>): TerminalProce
     cwd: process.cwd(),
     cols: 80,
     rows: 24,
-    kind: "agent",
+    kind: "terminal",
     type: "claude",
     agentId: "claude",
   } as TerminalProcessOptions;

--- a/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
@@ -96,7 +96,7 @@ describe("TerminalProcess exit code persistence", () => {
   });
 
   it("stores exitCode on clean exit for agent terminals", () => {
-    const terminal = createTerminal({ kind: "agent", type: "claude" });
+    const terminal = createTerminal({ kind: "terminal", type: "claude" });
 
     expect(exitHandler).not.toBeNull();
     exitHandler!({ exitCode: 0 });
@@ -107,7 +107,7 @@ describe("TerminalProcess exit code persistence", () => {
   });
 
   it("stores non-zero exitCode when agent terminal shouldPreserveOnExit returns false", () => {
-    const terminal = createTerminal({ kind: "agent", type: "claude" });
+    const terminal = createTerminal({ kind: "terminal", type: "claude" });
 
     expect(exitHandler).not.toBeNull();
     exitHandler!({ exitCode: 1 });
@@ -130,7 +130,7 @@ describe("TerminalProcess exit code persistence", () => {
   });
 
   it("does not store exitCode for killed terminals", () => {
-    const terminal = createTerminal({ kind: "agent", type: "claude" });
+    const terminal = createTerminal({ kind: "terminal", type: "claude" });
 
     terminal.kill("test");
     exitHandler!({ exitCode: 0 });

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -77,7 +77,7 @@ function createAgentTerminal(handles: MockPtyHandles): TerminalProcess {
     cwd: process.cwd(),
     cols: 80,
     rows: 24,
-    kind: "agent",
+    kind: "terminal",
     type: "claude",
     agentId: "claude",
   };

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -116,7 +116,7 @@ describe("TerminalProcess.kill — agent state event", () => {
     const emitAgentKilledSpy = vi.fn();
 
     const terminal = createTerminal(
-      { kind: "agent", type: "claude", agentId: "claude" },
+      { kind: "terminal", type: "claude", agentId: "claude" },
       {
         agentStateService: {
           handleActivityState: () => {},
@@ -153,7 +153,7 @@ describe("TerminalProcess.kill — session persistence", () => {
   });
 
   it("does not persist session for agent terminals on kill", () => {
-    const terminal = createTerminal({ kind: "agent", type: "claude" });
+    const terminal = createTerminal({ kind: "terminal", type: "claude" });
 
     vi.spyOn(terminal, "getSerializedState").mockReturnValue("scrollback-data");
 

--- a/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.osc.test.ts
@@ -57,7 +57,7 @@ function createAgentTerminal(
       cwd: process.cwd(),
       cols: 80,
       rows: 24,
-      kind: "agent",
+      kind: "terminal",
       type: agentId,
       agentId,
       ...options,

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -54,7 +54,7 @@ function createTerminal(options?: Partial<TerminalProcessOptions>): TerminalProc
     cwd: process.cwd(),
     cols: 80,
     rows: 24,
-    kind: "agent" as const,
+    kind: "terminal" as const,
     type: "claude" as const,
     agentId: "claude",
     ...options,

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -119,7 +119,7 @@ describe("TerminalProcess.submit", () => {
 
   it("does not use bracketed paste for Gemini; uses soft newlines and then sends CR", async () => {
     vi.useFakeTimers();
-    const terminal = createTerminal({ kind: "agent", type: "gemini" });
+    const terminal = createTerminal({ kind: "terminal", type: "gemini" });
 
     terminal.submit("line1\nline2");
 
@@ -132,7 +132,7 @@ describe("TerminalProcess.submit", () => {
 
   it("sends Enter immediately for Copilot with submitEnterDelayMs: 0", async () => {
     vi.useFakeTimers();
-    const terminal = createTerminal({ kind: "agent", type: "copilot" });
+    const terminal = createTerminal({ kind: "terminal", type: "copilot" });
 
     terminal.submit("test");
 

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -26,10 +26,9 @@ export function computeSpawnContext(id: string, options: PtySpawnOptions): Spawn
   const shell = options.shell || getDefaultShell();
   const args = options.args || getDefaultShellArgs(shell);
 
-  const isAgentByKind = options.kind === "agent";
   const isAgentByAgentId = !!options.agentId;
   const isAgentByType = !!(options.type && options.type !== "terminal");
-  const isAgentTerminal = isAgentByKind || isAgentByAgentId || isAgentByType;
+  const isAgentTerminal = isAgentByAgentId || isAgentByType;
   const agentId = isAgentTerminal
     ? (options.agentId ?? (options.type !== "terminal" ? options.type : id))
     : undefined;

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -21,17 +21,20 @@ describe("panelKindRegistry metadata", () => {
     expect(panelKindUsesTerminalUi("dev-preview")).toBe(false);
   });
 
-  it("terminal and agent use terminal UI", () => {
+  it("terminal uses terminal UI", () => {
     expect(panelKindUsesTerminalUi("terminal")).toBe(true);
-    expect(panelKindUsesTerminalUi("agent")).toBe(true);
   });
 
   it("browser does not use terminal UI", () => {
     expect(panelKindUsesTerminalUi("browser")).toBe(false);
   });
 
+  it('legacy "agent" kind is unregistered (collapsed into terminal)', () => {
+    expect(getPanelKindConfig("agent")).toBeUndefined();
+  });
+
   it("returns config for all built-in kinds", () => {
-    for (const kind of ["terminal", "agent", "browser", "dev-preview"]) {
+    for (const kind of ["terminal", "browser", "dev-preview"]) {
       const config = getPanelKindConfig(kind);
       expect(config).toBeDefined();
       expect(config!.id).toBe(kind);
@@ -43,7 +46,7 @@ describe("panelKindRegistry metadata", () => {
   });
 });
 
-const BUILT_IN_KINDS = ["terminal", "agent", "browser", "dev-preview"] as const;
+const BUILT_IN_KINDS = ["terminal", "browser", "dev-preview"] as const;
 
 const makeExtensionConfig = (id: string, extensionId: string): PanelKindConfig => ({
   id,

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -65,17 +65,6 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: false,
   },
-  agent: {
-    id: "agent",
-    name: "Agent",
-    iconId: "agent",
-    color: PANEL_KIND_BRAND_COLORS.agent,
-    hasPty: true,
-    canRestart: true,
-    canConvert: true,
-    keepAliveOnProjectSwitch: true,
-    showInPalette: false,
-  },
   browser: {
     id: "browser",
     name: "Browser",
@@ -175,12 +164,13 @@ export function isRegisteredPanelKind(kind: PanelKind): boolean {
  * Get the default title for a panel based on its kind and optional agent ID.
  *
  * @param kind - The panel kind
- * @param agentId - Optional agent ID for agent panels
+ * @param agentId - Optional agent ID; when present on a PTY panel, the agent's
+ *   display name takes precedence over the kind's default title
  * @returns The default title for the panel
  */
 export function getDefaultPanelTitle(kind: PanelKind, agentId?: string): string {
-  // Agent panels use agent-specific title
-  if (kind === "agent" && agentId) {
+  // Agent identity (via agentId) takes precedence over the generic kind title.
+  if (agentId) {
     const agentConfig = getAgentConfig(agentId);
     if (agentConfig) return agentConfig.name;
   }
@@ -197,12 +187,13 @@ export function getDefaultPanelTitle(kind: PanelKind, agentId?: string): string 
  * Get the color for a panel based on its kind and optional agent ID.
  *
  * @param kind - The panel kind
- * @param agentId - Optional agent ID for agent panels
+ * @param agentId - Optional agent ID; when present on a PTY panel, the agent's
+ *   brand color takes precedence over the kind's default color
  * @returns The hex color for the panel
  */
 export function getPanelKindColor(kind: PanelKind, agentId?: string): string {
-  // Agent panels use agent-specific color
-  if (kind === "agent" && agentId) {
+  // Agent identity (via agentId) takes precedence over the generic kind color.
+  if (agentId) {
     const agentConfig = getAgentConfig(agentId);
     if (agentConfig) return agentConfig.color;
   }
@@ -238,9 +229,8 @@ export function panelKindHasPty(kind: PanelKind): boolean {
  * @returns True if the panel kind supports restart, false otherwise (including unregistered kinds)
  *
  * @example
- * // Terminal and agent panels can be restarted
+ * // Terminal panels can be restarted (agent terminals are just terminals with agentId set)
  * panelKindCanRestart('terminal') // true
- * panelKindCanRestart('agent')    // true
  *
  * // Browser panels cannot be restarted
  * panelKindCanRestart('browser')  // false
@@ -280,7 +270,7 @@ export function panelKindKeepsAliveOnProjectSwitch(kind: PanelKind): boolean {
  * Get all built-in panel kinds.
  */
 export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
-  return ["terminal", "agent", "browser", "dev-preview"];
+  return ["terminal", "browser", "dev-preview"];
 }
 
 /**

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -39,7 +39,7 @@ export interface AddPanelOptionsBase {
   // --- PTY-related fields (optional on all types, only used by PTY panel kinds) ---
   shell?: string;
   command?: string;
-  /** Agent ID when kind is 'agent' */
+  /** Agent identity, when spawning an agent-running terminal. Absent for plain shells. */
   agentId?: string;
   agentState?: AgentState;
   lastStateChange?: number;
@@ -73,18 +73,14 @@ export interface AddPanelOptionsBase {
   fallbackChainIndex?: number;
 }
 
-/** Options for creating a terminal panel */
+/**
+ * Options for creating a terminal panel.
+ *
+ * Agent-running terminals set `agentId` (and typically `command`). There is no
+ * separate "agent" panel kind — agent identity lives on the `agentId` field.
+ */
 export interface TerminalPanelOptions extends AddPanelOptionsBase {
   kind?: "terminal";
-}
-
-/** Options for creating an agent panel */
-export interface AgentPanelOptions extends AddPanelOptionsBase {
-  kind: "agent";
-  /** Agent ID (e.g., "claude", "gemini") — required for agent panels to prevent bare-shell spawns */
-  agentId: string;
-  /** Launch command — required for agent panels to prevent bare-shell spawns */
-  command: string;
 }
 
 /** Options for creating a browser panel */
@@ -140,8 +136,4 @@ export interface ExtensionPanelOptions extends AddPanelOptionsBase {
 }
 
 /** Discriminated union of all built-in panel creation option types */
-export type AddPanelOptions =
-  | TerminalPanelOptions
-  | AgentPanelOptions
-  | BrowserPanelOptions
-  | DevPreviewPanelOptions;
+export type AddPanelOptions = TerminalPanelOptions | BrowserPanelOptions | DevPreviewPanelOptions;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -62,7 +62,6 @@ export { isBuiltInPanelKind, isPtyPanelKind, TerminalRefreshTier } from "./panel
 export type {
   AddPanelOptionsBase,
   TerminalPanelOptions,
-  AgentPanelOptions,
   BrowserPanelOptions,
   DevPreviewPanelOptions,
   ExtensionPanelOptions,

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -3,13 +3,14 @@ import type { BuiltInAgentId } from "../config/agentIds.js";
 import type { BrowserHistory } from "./browser.js";
 
 /** Built-in panel kinds */
-export type BuiltInPanelKind = "terminal" | "agent" | "browser" | "dev-preview";
+export type BuiltInPanelKind = "terminal" | "browser" | "dev-preview";
 
 /**
- * Panel kind: distinguishes between default terminals, agent-driven terminals, browser panels,
- * and extension-provided panel types.
+ * Panel kind: distinguishes between default terminals, browser panels, and
+ * extension-provided panel types. Agent identity is represented via `agentId`
+ * on PTY panels rather than a distinct panel kind.
  *
- * Built-in kinds: "terminal" | "agent" | "browser"
+ * Built-in kinds: "terminal" | "browser" | "dev-preview"
  * Extensions can register additional kinds as strings.
  */
 export type PanelKind = BuiltInPanelKind | (string & {});
@@ -64,11 +65,11 @@ export interface DockRenderState {
 
 /** Type guard to check if a panel kind is a built-in kind */
 export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
-  return kind === "terminal" || kind === "agent" || kind === "browser" || kind === "dev-preview";
+  return kind === "terminal" || kind === "browser" || kind === "dev-preview";
 }
 
 /**
- * Check if a built-in panel kind requires PTY (terminal or agent).
+ * Check if a built-in panel kind requires PTY.
  * For extension kinds, use `panelKindHasPty()` from panelKindRegistry
  * which consults the runtime registry configuration.
  * Note: dev-preview panels manage their own ephemeral PTYs via useDevServer hook,
@@ -76,7 +77,7 @@ export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
  */
 export function isPtyPanelKind(kind: PanelKind): boolean {
   // Built-in kinds - for extension kinds, use panelKindHasPty() from registry
-  return kind === "terminal" || kind === "agent";
+  return kind === "terminal";
 }
 
 /**
@@ -171,14 +172,14 @@ interface BasePanelData {
 }
 
 export interface PtyPanelData extends BasePanelData {
-  kind: "terminal" | "agent";
+  kind: "terminal";
   /**
-   * Legacy field retained for persistence; new code should prefer `kind`.
+   * Legacy field retained for persistence; new code should prefer `agentId`.
    * - "terminal" for default terminals
    * - legacy agent ids ("claude", "gemini", "codex") when migrated from old state
    */
   type: TerminalType;
-  /** Agent ID when kind is 'agent' */
+  /** Agent identity, when this terminal is running an agent. Absent for plain shells. */
   agentId?: AgentId;
   /** Current working directory of the terminal */
   cwd: string;
@@ -332,7 +333,7 @@ export type PanelInstance = PtyPanelData | BrowserPanelData | DevPreviewPanelDat
 
 export function isPtyPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
-  return kind === "terminal" || kind === "agent";
+  return kind === "terminal";
 }
 
 export function isBrowserPanel(panel: PanelInstance | TerminalInstance): panel is BrowserPanelData {

--- a/shared/utils/__tests__/inferPanelKind.test.ts
+++ b/shared/utils/__tests__/inferPanelKind.test.ts
@@ -3,7 +3,15 @@ import { inferKind } from "../inferPanelKind.js";
 
 describe("inferKind", () => {
   it("returns saved kind when present", () => {
-    expect(inferKind({ kind: "agent" })).toBe("agent");
+    expect(inferKind({ kind: "browser" })).toBe("browser");
+  });
+
+  it('migrates legacy "agent" kind to "terminal" (agent identity lives on agentId)', () => {
+    expect(inferKind({ kind: "agent" })).toBe("terminal");
+  });
+
+  it('migrates legacy "agent" kind even when other fields are present', () => {
+    expect(inferKind({ kind: "agent", cwd: "/project", command: "claude" })).toBe("terminal");
   });
 
   it("infers browser from browserUrl", () => {

--- a/shared/utils/inferPanelKind.ts
+++ b/shared/utils/inferPanelKind.ts
@@ -10,6 +10,8 @@ interface InferKindInput {
 }
 
 export function inferKind(saved: InferKindInput): PanelKind {
+  // Migration: legacy persisted "agent" kind collapses into "terminal"; agent identity lives on agentId.
+  if (saved.kind === "agent") return "terminal";
   if (saved.kind) return saved.kind;
   if (saved.browserUrl !== undefined) return "browser";
   if (saved.devCommand !== undefined) return "dev-preview";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -583,7 +583,7 @@ function App() {
               );
               if (command && agentConfig) {
                 addPanel({
-                  kind: "agent",
+                  kind: "terminal",
                   type: session.agentId as TerminalType,
                   agentId: session.agentId,
                   title: agentConfig.name,
@@ -600,7 +600,7 @@ function App() {
               }
             } else {
               addPanel({
-                kind: result.id as Exclude<BuiltInPanelKind, "agent">,
+                kind: result.id as BuiltInPanelKind,
                 cwd: defaultTerminalCwd,
                 worktreeId: activeWorktreeId ?? undefined,
                 location: "grid",
@@ -621,7 +621,7 @@ function App() {
               );
               if (command && agentConfig) {
                 addPanel({
-                  kind: "agent",
+                  kind: "terminal",
                   type: session.agentId as TerminalType,
                   agentId: session.agentId,
                   title: agentConfig.name,
@@ -638,7 +638,7 @@ function App() {
               }
             } else {
               addPanel({
-                kind: selected.id as Exclude<BuiltInPanelKind, "agent">,
+                kind: selected.id as BuiltInPanelKind,
                 cwd: defaultTerminalCwd,
                 worktreeId: activeWorktreeId ?? undefined,
                 location: "grid",

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -99,7 +99,7 @@ function makeAgent(
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -46,7 +46,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -33,7 +33,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -823,7 +823,7 @@ export function BulkCreateWorktreeDialog({
                       });
 
                       panelId = await usePanelStore.getState().addPanel({
-                        kind: "agent",
+                        kind: "terminal",
                         agentId: t.type,
                         command,
                         title: t.title,

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1323,8 +1323,10 @@ describe("BulkCreateWorktreeDialog", () => {
       })
     );
 
-    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "agent");
+    // Agent-running terminals are now kind: "terminal" with agentId set.
+    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].agentId === "claude");
     expect(agentCall).toBeDefined();
+    expect(agentCall?.[0].kind).toBe("terminal");
     expect(agentCall?.[0].command).toBe("claude --fresh-generated");
     expect(agentCall?.[0].agentId).toBe("claude");
     expect(agentCall?.[0].command).not.toContain("stale-session");
@@ -1334,7 +1336,9 @@ describe("BulkCreateWorktreeDialog", () => {
 
     // Plain terminal command is passed through verbatim (it's a user-authored
     // shell command, not a path-scoped agent invocation).
-    const terminalCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "terminal");
+    const terminalCall = mockAddPanel.mock.calls.find(
+      (c) => c[0].kind === "terminal" && !c[0].agentId
+    );
     expect(terminalCall).toBeDefined();
     expect(terminalCall?.[0].command).toBe("npm test");
 
@@ -1371,7 +1375,7 @@ describe("BulkCreateWorktreeDialog", () => {
       "claude",
       expect.objectContaining({ clipboardDirectory: undefined })
     );
-    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "agent");
+    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].agentId === "claude");
     expect(agentCall?.[0].command).toBe("claude --default");
   });
 

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -81,7 +81,7 @@ export function AgentButton({
       const p = panelsById[pid];
       if (
         !p ||
-        p.kind !== "agent" ||
+        !p.agentId ||
         p.agentId !== type ||
         p.location === "trash" ||
         p.location === "background"

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -328,14 +328,7 @@ export function AgentTrayButton({
     const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
     for (const pid of panelIds) {
       const p = panelsById[pid];
-      if (
-        !p ||
-        p.kind !== "agent" ||
-        !p.agentId ||
-        p.location === "trash" ||
-        p.location === "background"
-      )
-        continue;
+      if (!p || !p.agentId || p.location === "trash" || p.location === "background") continue;
       if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
       if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
       const arr = statesPerAgent.get(p.agentId) ?? [];

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -58,7 +58,7 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
   const terminalName = (() => {
     const observed = terminal.lastObservedTitle;
     if (observed && !isUselessTitle(observed)) return observed;
-    if (terminal.kind === "agent" || terminal.agentId) {
+    if (terminal.agentId) {
       if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
       const agentConfig = terminal.agentId ? getEffectiveAgentConfig(terminal.agentId) : undefined;
       return agentConfig?.name ?? terminal.agentId ?? terminal.type ?? "Agent";

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -402,7 +402,7 @@ describe("AgentTrayButton", () => {
     mockPanelsById = {
       "panel-1": {
         id: "panel-1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         worktreeId: "wt-1",
         location: "grid",
@@ -820,7 +820,7 @@ describe("AgentTrayButton", () => {
     mockPanelsById = {
       "panel-1": {
         id: "panel-1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         worktreeId: "wt-other",
         location: "grid",

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@shared/config/agentRegistry", () => ({
 function makeAgentTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
     id: "t1",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     type: "claude",
     title: "claude",

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -194,10 +194,10 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   const effectiveAgentState = ambientAgentState ?? agentState;
   const blockedState = useDockBlockedState(effectiveAgentState);
   const isWorkingState = effectiveAgentState === "working";
-  // Auto-construct TerminalHeaderContent for terminal/agent kinds if headerContent not provided
+  // Auto-construct TerminalHeaderContent for PTY-backed terminals if headerContent not provided
   const resolvedHeaderContent = useMemo(() => {
     if (headerContent !== undefined) return headerContent;
-    if (kind === "terminal" || kind === "agent") {
+    if (kind === "terminal") {
       return (
         <TerminalHeaderContent
           id={id}

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -59,7 +59,7 @@ const mockPanels = [
   },
   {
     id: "t2",
-    kind: "agent",
+    kind: "terminal",
     title: "Claude",
     cwd: "/project",
     location: "dock" as const,

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -715,8 +715,9 @@ function TerminalPaneComponent({
   const isWorking = agentState === "working";
   const allowPing = !isMaximized && (location !== "grid" || (gridPanelCount ?? 2) > 1);
 
-  // Determine panel kind based on agent
-  const kind = effectiveAgentId ? "agent" : "terminal";
+  // Panel kind is always "terminal" for PTY panels — agent identity lives on
+  // effectiveAgentId, which flows to ContentPanel as a separate prop.
+  const kind = "terminal" as const;
 
   const agentHeaderActions = useMemo(() => {
     if (!effectiveAgentId) return undefined;

--- a/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
@@ -130,7 +130,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
     });
 
     it("should include Terminal option and agents for agent terminal", () => {
-      const terminal = { type: "claude", kind: "agent", agentId: "claude" };
+      const terminal = { type: "claude", kind: "terminal", agentId: "claude" };
       const submenu = buildConvertToSubmenu(terminal);
 
       expect(submenu.length).toBeGreaterThan(0);
@@ -158,7 +158,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
     });
 
     it("should disable current agent in submenu", () => {
-      const terminal = { type: "gemini", kind: "agent", agentId: "gemini" };
+      const terminal = { type: "gemini", kind: "terminal", agentId: "gemini" };
       const submenu = buildConvertToSubmenu(terminal);
 
       const currentAgentItem = submenu.find((i) => i.id === "convert-to:gemini");
@@ -169,7 +169,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
     });
 
     it("should keep current agent visible even if missing after initialization", () => {
-      const terminal = { type: "claude", kind: "agent", agentId: "claude" };
+      const terminal = { type: "claude", kind: "terminal", agentId: "claude" };
       const availability: CliAvailability = Object.fromEntries(
         AGENT_IDS.map((id) => [id, "missing"])
       ) as CliAvailability;
@@ -189,7 +189,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
 
     it("should handle legacy agent terminal (type without agentId)", () => {
       const agentType = AGENT_IDS[0]!;
-      const terminal = { type: agentType, kind: "agent" };
+      const terminal = { type: agentType, kind: "terminal" };
       const submenu = buildConvertToSubmenu(terminal);
 
       const terminalItem = submenu.find((i) => i.id === "convert-to:terminal");
@@ -228,7 +228,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
     });
 
     it("should handle unknown agent type gracefully", () => {
-      const terminal = { type: "some-unknown-agent", kind: "agent" };
+      const terminal = { type: "some-unknown-agent", kind: "terminal" };
       const submenu = buildConvertToSubmenu(terminal);
 
       const terminalItem = submenu.find((i) => i.id === "convert-to:terminal");
@@ -275,7 +275,7 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
       const launched = AGENT_IDS[1] ?? AGENT_IDS[0]!;
       const terminal = {
         type: launched,
-        kind: "agent",
+        kind: "terminal",
         agentId: launched,
         detectedAgentId: detected,
       };

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -213,7 +213,7 @@ describe("TerminalInfoDialog", () => {
   it("renders Launch Context and Live State sections for agent terminals", async () => {
     const payload = makePayload({
       isAgentTerminal: true,
-      kind: "agent",
+      kind: "terminal",
       type: "claude",
       agentId: "agent-1",
       detectedAgentType: "claude",
@@ -247,7 +247,7 @@ describe("TerminalInfoDialog", () => {
   it("shows 'None — agent has exited' in Live State when agent panel has no detectedAgentId", async () => {
     const payload = makePayload({
       isAgentTerminal: true,
-      kind: "agent",
+      kind: "terminal",
       type: "claude",
       agentId: "agent-1",
       detectedAgentId: undefined,
@@ -292,7 +292,7 @@ describe("TerminalInfoDialog", () => {
   it("includes Spawn Command and both Agent sections in clipboard export", async () => {
     const payload = makePayload({
       isAgentTerminal: true,
-      kind: "agent",
+      kind: "terminal",
       type: "claude",
       agentId: "agent-1",
       detectedAgentType: "claude",

--- a/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
@@ -155,7 +155,17 @@ describe("gridPanelPropsAreEqual", () => {
 
   it("returns false when terminal.kind changes", () => {
     const prev = baseProps({ terminal: { ...baseTerminal, kind: "terminal" } as TerminalInstance });
-    const next = baseProps({ terminal: { ...baseTerminal, kind: "agent" } as TerminalInstance });
+    const next = baseProps({ terminal: { ...baseTerminal, kind: "browser" } as TerminalInstance });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when terminal.agentId changes (identity swap)", () => {
+    const prev = baseProps({
+      terminal: { ...baseTerminal, kind: "terminal", agentId: undefined } as TerminalInstance,
+    });
+    const next = baseProps({
+      terminal: { ...baseTerminal, kind: "terminal", agentId: "claude" } as TerminalInstance,
+    });
     expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
   });
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -145,7 +145,7 @@ async function cloneLayoutPanels(
         modelId: t.agentModelId,
       });
       await addPanel({
-        kind: "agent",
+        kind: "terminal",
         agentId: t.type,
         command,
         title: t.title,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -179,7 +179,7 @@ describe("WorktreeTerminalSection arming click handlers", () => {
   });
 
   it("plain click on an eligible agent tile arms it", () => {
-    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "terminal", hasPty: true });
     const onSelect = vi.fn();
     renderSection({
       isExpanded: true,
@@ -200,9 +200,9 @@ describe("WorktreeTerminalSection arming click handlers", () => {
     // The grid uses Shift = single add; the sidebar mirrors the same model
     // so the gesture is consistent across surfaces. There is no range
     // extension on either surface.
-    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
-    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "agent", hasPty: true });
-    const t3 = makeTerminal({ id: "a3", agentId: "claude", kind: "agent", hasPty: true });
+    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "terminal", hasPty: true });
+    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "terminal", hasPty: true });
+    const t3 = makeTerminal({ id: "a3", agentId: "claude", kind: "terminal", hasPty: true });
     renderSection({
       isExpanded: true,
       terminals: [t1, t2, t3],
@@ -218,8 +218,8 @@ describe("WorktreeTerminalSection arming click handlers", () => {
   });
 
   it("cmd-click (metaKey) toggles the armed state without clearing others", () => {
-    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
-    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "agent", hasPty: true });
+    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "terminal", hasPty: true });
+    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "terminal", hasPty: true });
     renderSection({
       isExpanded: true,
       terminals: [t1, t2],
@@ -257,7 +257,7 @@ describe("WorktreeTerminalSection arming click handlers", () => {
   });
 
   it("armed tile gets aria-selected=true", () => {
-    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "terminal", hasPty: true });
     renderSection({
       isExpanded: true,
       terminals: [term],
@@ -272,7 +272,7 @@ describe("WorktreeTerminalSection arming click handlers", () => {
   });
 
   it("scroll container has aria-multiselectable", () => {
-    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "terminal", hasPty: true });
     const { container } = renderSection({
       isExpanded: true,
       terminals: [term],

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -99,7 +99,7 @@ class TerminalRegistryController {
   async spawn(options: SpawnTerminalOptions): Promise<SpawnTerminalResult> {
     const legacyType: TerminalType = options.type || "terminal";
     const agentId = options.agentId ?? (isRegisteredAgent(legacyType) ? legacyType : undefined);
-    const kind: "terminal" = "terminal";
+    const kind = "terminal" as const;
     const title = options.title || getDefaultTitle(legacyType, agentId);
 
     const commandToExecute = options.skipCommandExecution ? undefined : options.command;

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -64,7 +64,7 @@ export interface SpawnTerminalOptions {
  */
 export interface SpawnTerminalResult {
   id: string;
-  kind: "terminal" | "agent";
+  kind: "terminal";
   type: TerminalType;
   agentId?: string;
   title: string;
@@ -97,10 +97,9 @@ class TerminalRegistryController {
    * Returns spawn result with derived values (kind, agentId, title, etc.)
    */
   async spawn(options: SpawnTerminalOptions): Promise<SpawnTerminalResult> {
-    const requestedKind = options.kind ?? (options.agentId ? "agent" : "terminal");
     const legacyType: TerminalType = options.type || "terminal";
     const agentId = options.agentId ?? (isRegisteredAgent(legacyType) ? legacyType : undefined);
-    const kind: "terminal" | "agent" = agentId ? "agent" : requestedKind;
+    const kind: "terminal" = "terminal";
     const title = options.title || getDefaultTitle(legacyType, agentId);
 
     const commandToExecute = options.skipCommandExecution ? undefined : options.command;
@@ -126,7 +125,7 @@ class TerminalRegistryController {
       type: legacyType,
       agentId,
       title,
-      agentState: kind === "agent" ? "idle" : undefined,
+      agentState: agentId ? "idle" : undefined,
     };
   }
 
@@ -134,18 +133,14 @@ class TerminalRegistryController {
    * Prewarm a terminal's renderer-side xterm instance.
    * Call this after spawning to ensure no output is lost.
    */
-  prewarm(
-    id: string,
-    type: TerminalType,
-    kind: "terminal" | "agent",
-    location: PanelLocation
-  ): void {
+  prewarm(id: string, type: TerminalType, location: PanelLocation, agentId?: string): void {
+    const isAgent = Boolean(agentId);
     try {
       const appearance = getTerminalAppearanceSnapshot();
       const { fontSize, fontFamily, performanceMode } = appearance;
 
       // Project-level scrollback override applies to non-agent terminals only
-      const projectScrollback = kind !== "agent" ? appearance.projectScrollback : undefined;
+      const projectScrollback = isAgent ? undefined : appearance.projectScrollback;
       const effectiveScrollback = performanceMode
         ? PERFORMANCE_MODE_SCROLLBACK
         : getScrollbackForType(type, projectScrollback ?? appearance.scrollbackLines);
@@ -172,7 +167,7 @@ class TerminalRegistryController {
       // For offscreen agents, prewarmTerminal's fit() already handles initial
       // PTY resize through settled strategy. Only send explicit resize for
       // active grid spawns where fit() is skipped.
-      if (kind === "agent" && !offscreen) {
+      if (isAgent && !offscreen) {
         const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
         const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
         const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));

--- a/src/hooks/__tests__/useAgentClusters.hook.test.tsx
+++ b/src/hooks/__tests__/useAgentClusters.hook.test.tsx
@@ -20,7 +20,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     location: "grid",

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -9,7 +9,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     location: "grid",

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -6,7 +6,7 @@ import type { PendingCrash, CrashRecoveryConfig, CrashRecoveryAction } from "@sh
 
 const mockPanels = [
   { id: "t1", kind: "terminal", title: "Shell", location: "grid" as const, isSuspect: false },
-  { id: "t2", kind: "agent", title: "Claude", location: "dock" as const, isSuspect: false },
+  { id: "t2", kind: "terminal", title: "Claude", location: "dock" as const, isSuspect: false },
 ];
 
 const mockCrash: PendingCrash = {

--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -177,10 +177,9 @@ describe("useGettingStartedChecklist", () => {
         panelIds: [] as string[],
       };
       const next = {
-        panelsById: { t1: { id: "t1", kind: "agent", agentState: "idle" } } as Record<
-          string,
-          TerminalLike
-        >,
+        panelsById: {
+          t1: { id: "t1", kind: "terminal", agentId: "claude", agentState: "idle" },
+        } as Record<string, TerminalLike>,
         panelIds: ["t1"],
       };
       for (const sub of terminalSubscribers) sub(next, prev);

--- a/src/hooks/app/__tests__/useOrchestrationMilestones.test.tsx
+++ b/src/hooks/app/__tests__/useOrchestrationMilestones.test.tsx
@@ -104,7 +104,7 @@ describe("useOrchestrationMilestones", () => {
 
   it("silently marks already-achieved milestones during reconciliation", async () => {
     terminalState = {
-      panelsById: { t1: { id: "t1", kind: "agent", agentState: "completed" } },
+      panelsById: { t1: { id: "t1", kind: "terminal", agentState: "completed" } },
       panelIds: ["t1"],
     };
 
@@ -120,14 +120,14 @@ describe("useOrchestrationMilestones", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const prev = {
-      panelsById: { t1: { id: "t1", kind: "agent", agentState: "working" } } as Record<
+      panelsById: { t1: { id: "t1", kind: "terminal", agentState: "working" } } as Record<
         string,
         TerminalLike
       >,
       panelIds: ["t1"],
     };
     const next = {
-      panelsById: { t1: { id: "t1", kind: "agent", agentState: "completed" } } as Record<
+      panelsById: { t1: { id: "t1", kind: "terminal", agentState: "completed" } } as Record<
         string,
         TerminalLike
       >,
@@ -154,14 +154,14 @@ describe("useOrchestrationMilestones", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const prev = {
-      panelsById: { t1: { id: "t1", kind: "agent", agentState: "working" } } as Record<
+      panelsById: { t1: { id: "t1", kind: "terminal", agentState: "working" } } as Record<
         string,
         TerminalLike
       >,
       panelIds: ["t1"],
     };
     const next = {
-      panelsById: { t1: { id: "t1", kind: "agent", agentState: "completed" } } as Record<
+      panelsById: { t1: { id: "t1", kind: "terminal", agentState: "completed" } } as Record<
         string,
         TerminalLike
       >,
@@ -213,10 +213,10 @@ describe("useOrchestrationMilestones", () => {
     };
     const next1 = {
       panelsById: {
-        t1: { id: "t1", kind: "agent", agentState: "completed" },
-        t2: { id: "t2", kind: "agent", agentState: "working" },
-        t3: { id: "t3", kind: "agent", agentState: "working" },
-        t4: { id: "t4", kind: "agent", agentState: "working" },
+        t1: { id: "t1", kind: "terminal", agentState: "completed" },
+        t2: { id: "t2", kind: "terminal", agentState: "working" },
+        t3: { id: "t3", kind: "terminal", agentState: "working" },
+        t4: { id: "t4", kind: "terminal", agentState: "working" },
       } as Record<string, TerminalLike>,
       panelIds: ["t1", "t2", "t3", "t4"],
     };

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -11,7 +11,7 @@ import type { TerminalInstance } from "@shared/types/panel";
 function countActiveAgentPanels(panelsById: Record<string, TerminalInstance>): number {
   let count = 0;
   for (const panel of Object.values(panelsById)) {
-    if (panel?.kind !== "agent") continue;
+    if (!panel?.agentId) continue;
     const state = panel.agentState;
     if (state && ACTIVE_AGENT_STATES.has(state)) count += 1;
     if (count >= 2) return count;
@@ -44,7 +44,7 @@ function reconcileCurrentState(
     !cl.items.launchedAgent &&
     usePanelStore.getState().panelIds.some((id) => {
       const p = usePanelStore.getState().panelsById[id];
-      return p?.kind === "agent" || p?.everDetectedAgent === true;
+      return Boolean(p?.agentId) || p?.everDetectedAgent === true;
     })
   ) {
     markItem("launchedAgent");
@@ -176,7 +176,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
           !cl.items.launchedAgent &&
           state.panelIds.some((id) => {
             const p = state.panelsById[id];
-            return p?.kind === "agent" || p?.everDetectedAgent === true;
+            return Boolean(p?.agentId) || p?.everDetectedAgent === true;
           })
         ) {
           markItem("launchedAgent");

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -301,7 +301,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
 
       const options: AddPanelOptions = isAgent
         ? {
-            kind: "agent",
+            kind: "terminal",
             type: agentId as import("@shared/types/panel").TerminalType,
             agentId,
             command: command as string,

--- a/src/panels/__tests__/registry.defaults.test.ts
+++ b/src/panels/__tests__/registry.defaults.test.ts
@@ -57,10 +57,10 @@ describe("panelKindRegistry createDefaults (co-located)", () => {
     expect(Object.keys(result)).toHaveLength(0);
   });
 
-  it("agent factory returns empty object (PTY path handles fields)", () => {
-    const config = getPanelKindConfig("agent")!;
+  it("terminal factory with agentId still returns empty (PTY path handles fields)", () => {
+    const config = getPanelKindConfig("terminal")!;
     const result = config.createDefaults!({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
     } as AddPanelOptions);

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -21,14 +21,14 @@ import { initBuiltInPanelKinds } from "../registry";
 // binding catches renames and key removals at TypeScript compile time.
 //
 // Asymmetries:
-//  - terminal/agent have no getDeserializer() entry — they restore through
-//    buildArgsForRespawn / buildArgsForBackendTerminal using backend PTY state.
-//    Serializer coverage only.
+//  - terminal has no getDeserializer() entry — agent-running terminals restore
+//    through buildArgsForRespawn / buildArgsForBackendTerminal using backend
+//    PTY state. Serializer coverage only.
 //  - dev-preview `cwd` and `exitBehavior` are injected by
 //    buildArgsForNonPtyRecreation's base args, not the registry deserializer.
 //    Excluded from the deserializer-side check for that kind.
 
-type PtyData = Extract<PanelInstance, { kind: "terminal" | "agent" }>;
+type PtyData = Extract<PanelInstance, { kind: "terminal" }>;
 type BrowserData = Extract<PanelInstance, { kind: "browser" }>;
 type DevPreviewData = Extract<PanelInstance, { kind: "dev-preview" }>;
 
@@ -64,7 +64,6 @@ const PERSISTED_DEV_PREVIEW_FIELDS = [
 
 const BUILT_IN_KINDS = [
   "terminal",
-  "agent",
   "browser",
   "dev-preview",
 ] as const satisfies readonly BuiltInPanelKind[];
@@ -104,11 +103,6 @@ const terminalFixture: TerminalInstance = {
   agentModelId: "claude-3-5-sonnet",
   agentState: "idle",
   lastStateChange: 1_700_000_000_000,
-};
-
-const agentFixture: TerminalInstance = {
-  ...terminalFixture,
-  ...baseFields("agent"),
 };
 
 const browserFixture: TerminalInstance = {
@@ -201,11 +195,6 @@ describe("panel serializer field coverage", () => {
     assertCovers("terminal serializer", output, PERSISTED_PTY_FIELDS);
   });
 
-  it("agent serializer covers every persisted PTY field", () => {
-    const output = getPanelKindConfig("agent")!.serialize!(agentFixture) as Record<string, unknown>;
-    assertCovers("agent serializer", output, PERSISTED_PTY_FIELDS);
-  });
-
   it("browser serializer covers every persisted browser field", () => {
     const output = getPanelKindConfig("browser")!.serialize!(browserFixture) as Record<
       string,
@@ -245,12 +234,12 @@ describe("panel deserializer field coverage", () => {
     ]);
   });
 
-  it("terminal and agent have no deserializer registry entry", () => {
-    // PTY kinds restore through buildArgsForRespawn / buildArgsForBackendTerminal
-    // using BackendTerminalData, not the getDeserializer() registry. Pinning
-    // this asymmetry so an accidental registry entry forces a deliberate
-    // decision about the new restore path.
+  it("terminal has no deserializer registry entry", () => {
+    // PTY panels (including agent-running terminals) restore through
+    // buildArgsForRespawn / buildArgsForBackendTerminal using BackendTerminalData,
+    // not the getDeserializer() registry. Pinning this asymmetry so an
+    // accidental registry entry forces a deliberate decision about the new
+    // restore path.
     expect(getDeserializer("terminal")).toBeUndefined();
-    expect(getDeserializer("agent")).toBeUndefined();
   });
 });

--- a/src/panels/__tests__/registry.init.test.ts
+++ b/src/panels/__tests__/registry.init.test.ts
@@ -6,7 +6,7 @@ describe("initBuiltInPanelKinds", () => {
   it("registers serialize and createDefaults on built-in kinds", () => {
     initBuiltInPanelKinds();
 
-    for (const kind of ["terminal", "agent", "browser", "dev-preview"]) {
+    for (const kind of ["terminal", "browser", "dev-preview"]) {
       const config = getPanelKindConfig(kind);
       expect(config?.serialize, `${kind} should have serialize`).toBeTypeOf("function");
       expect(config?.createDefaults, `${kind} should have createDefaults`).toBeTypeOf("function");

--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -181,15 +181,6 @@ describe("panel serializer round-trip (property tests)", () => {
     });
   });
 
-  describe("agent", () => {
-    test.prop([ptyArb])("agent serializer output equals terminal serializer output", (fields) => {
-      const input: TerminalInstance = { ...basePanel("agent"), ...fields };
-      const terminalOut = getPanelKindConfig("terminal")!.serialize!(input);
-      const agentOut = getPanelKindConfig("agent")!.serialize!(input);
-      expect(agentOut).toEqual(terminalOut);
-    });
-  });
-
   describe("browser", () => {
     test.prop([browserArb])(
       "deserialize(serialize(x)) preserves all persisted fields",

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -70,21 +70,6 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
     });
   });
 
-  describe("agent", () => {
-    it("serializes identically to terminal", () => {
-      const termConfig = getPanelKindConfig("terminal");
-      const agentConfig = getPanelKindConfig("agent");
-      const panel = makePanel({
-        type: "claude",
-        agentId: "claude",
-        cwd: "/project",
-        command: "claude",
-        agentSessionId: "s1",
-      });
-      expect(agentConfig!.serialize!(panel)).toEqual(termConfig!.serialize!(panel));
-    });
-  });
-
   describe("browser", () => {
     it("serializes browser fields", () => {
       const config = getPanelKindConfig("browser");

--- a/src/panels/agent/defaults.ts
+++ b/src/panels/agent/defaults.ts
@@ -1,6 +1,0 @@
-import type { PtyPanelData } from "@shared/types/panel";
-import type { AgentPanelOptions } from "@shared/types/addPanelOptions";
-
-export function createAgentDefaults(_options: AgentPanelOptions): Partial<PtyPanelData> {
-  return {};
-}

--- a/src/panels/agent/serializer.ts
+++ b/src/panels/agent/serializer.ts
@@ -1,1 +1,0 @@
-export { serializePtyPanel as serializeAgent } from "../terminal/serializer";

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -9,7 +9,6 @@ import type {
 } from "@shared/types/panel";
 import type {
   TerminalPanelOptions,
-  AgentPanelOptions,
   BrowserPanelOptions,
   DevPreviewPanelOptions,
 } from "@shared/types/addPanelOptions";
@@ -20,8 +19,6 @@ import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
 
 import { serializePtyPanel } from "./terminal/serializer";
 import { createTerminalDefaults } from "./terminal/defaults";
-import { serializeAgent } from "./agent/serializer";
-import { createAgentDefaults } from "./agent/defaults";
 import { serializeBrowser } from "./browser/serializer";
 import { createBrowserDefaults } from "./browser/defaults";
 import { serializeDevPreview } from "./dev-preview/serializer";
@@ -80,22 +77,21 @@ function DevPreviewPaneWrapper(props: any) {
 }
 
 /**
- * Maps each built-in panel kind to its panel data variant. Terminal/agent share
- * `PtyPanelData`; dev-preview carries an optional `type` that originates from
- * the legacy `TerminalInstance` shape. `createdAt` is intentionally widened on
- * the PTY and dev-preview entries so serializers can read the legacy field
- * without modifying the shared variant interfaces.
+ * Maps each built-in panel kind to its panel data variant. `PtyPanelData` covers
+ * all PTY-backed terminals (agent identity lives on `agentId`); dev-preview
+ * carries an optional `type` that originates from the legacy `TerminalInstance`
+ * shape. `createdAt` is intentionally widened on the PTY and dev-preview entries
+ * so serializers can read the legacy field without modifying the shared variant
+ * interfaces.
  */
 interface BuiltInPanelMap {
   terminal: PtyPanelData & { createdAt?: number };
-  agent: PtyPanelData & { createdAt?: number };
   browser: BrowserPanelData;
   "dev-preview": DevPreviewPanelData & { createdAt?: number; type?: TerminalType };
 }
 
 interface BuiltInPanelOptionsMap {
   terminal: TerminalPanelOptions;
-  agent: AgentPanelOptions;
   browser: BrowserPanelOptions;
   "dev-preview": DevPreviewPanelOptions;
 }
@@ -109,7 +105,6 @@ type BuiltInSerializeDefaults = {
 
 const BUILT_IN_SERIALIZE_DEFAULTS = {
   terminal: { serialize: serializePtyPanel, createDefaults: createTerminalDefaults },
-  agent: { serialize: serializeAgent, createDefaults: createAgentDefaults },
   browser: { serialize: serializeBrowser, createDefaults: createBrowserDefaults },
   "dev-preview": { serialize: serializeDevPreview, createDefaults: createDevPreviewDefaults },
 } satisfies BuiltInSerializeDefaults;
@@ -140,7 +135,6 @@ function requirePanelKindConfig(kind: string): PanelKindConfig {
 
 const PANEL_KIND_DEFINITION_REGISTRY: Record<string, PanelKindDefinition> = {
   terminal: { ...requirePanelKindConfig("terminal"), component: TerminalPane },
-  agent: { ...requirePanelKindConfig("agent"), component: TerminalPane },
   browser: { ...requirePanelKindConfig("browser"), component: BrowserPaneWrapper },
   "dev-preview": { ...requirePanelKindConfig("dev-preview"), component: DevPreviewPaneWrapper },
 };

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -7,7 +7,7 @@ function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
     id: "p1",
     title: "Claude",
-    kind: "agent",
+    kind: "terminal",
     type: "claude",
     agentId: "claude",
     cwd: "/project",

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -52,7 +52,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -16,8 +16,9 @@ vi.mock("@/services/terminal/panelDuplicationService", () => ({
 
 vi.mock("@shared/config/panelKindRegistry", () => ({
   getDefaultPanelTitle: (kind: string, agentId?: string) => {
-    if (kind === "agent" && agentId === "claude") return "Claude";
-    if (kind === "agent" && agentId === "gemini") return "Gemini";
+    // Agent identity takes precedence, matching production behavior
+    if (agentId === "claude") return "Claude";
+    if (agentId === "gemini") return "Gemini";
     if (kind === "terminal") return "Terminal";
     if (kind === "browser") return "Browser";
     if (kind === "notes") return "Notes";
@@ -96,7 +97,9 @@ describe("terminal.duplicate (copy) suffix", () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     setPanelState({
       focusedId: "p1",
-      panels: [{ id: "p1", location: "grid", kind: "agent", agentId: "claude", title: "Claude" }],
+      panels: [
+        { id: "p1", location: "grid", kind: "terminal", agentId: "claude", title: "Claude" },
+      ],
       addPanel,
     });
     const run = setupActions();
@@ -110,7 +113,9 @@ describe("terminal.duplicate (copy) suffix", () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     setPanelState({
       focusedId: "p1",
-      panels: [{ id: "p1", location: "grid", kind: "agent", agentId: "claude", title: "API work" }],
+      panels: [
+        { id: "p1", location: "grid", kind: "terminal", agentId: "claude", title: "API work" },
+      ],
       addPanel,
     });
     const run = setupActions();
@@ -139,7 +144,7 @@ describe("terminal.duplicate (copy) suffix", () => {
     setPanelState({
       focusedId: "p1",
       panels: [
-        { id: "p1", location: "grid", kind: "agent", agentId: "gemini", title: "Refactor run" },
+        { id: "p1", location: "grid", kind: "terminal", agentId: "gemini", title: "Refactor run" },
       ],
       addPanel,
     });
@@ -183,7 +188,7 @@ describe("terminal.duplicate (copy) suffix", () => {
   it("preserves stale-preset title normalization (no (copy) when service normalized title)", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     buildPanelDuplicateOptionsMock.mockResolvedValueOnce({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "claude",
       title: "Claude", // normalized by service (stale preset dropped)
@@ -196,7 +201,7 @@ describe("terminal.duplicate (copy) suffix", () => {
         {
           id: "p1",
           location: "grid",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           title: "Claude (Deleted Preset)",
         },

--- a/src/services/terminal/TerminalAgentStateController.ts
+++ b/src/services/terminal/TerminalAgentStateController.ts
@@ -50,7 +50,7 @@ export class TerminalAgentStateController {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
 
-    if (managed.kind === "agent" && managed.canonicalAgentState === "waiting") {
+    if (managed.agentId && managed.canonicalAgentState === "waiting") {
       if (managed.agentState === "working") return;
 
       const count = this.compositionCounts.get(id) ?? 0;
@@ -99,7 +99,7 @@ export class TerminalAgentStateController {
   onEnterPressed(id: string): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;
-    if (managed.kind !== "agent" || managed.canonicalAgentState !== "waiting") return;
+    if (!managed.agentId || managed.canonicalAgentState !== "waiting") return;
     if (managed.agentState === "working") return;
 
     const timer = this.directingTimers.get(id);

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -44,7 +44,7 @@ export class TerminalHibernationManager {
     if (
       !managed ||
       managed.isHibernated ||
-      (managed.kind === "agent" &&
+      (managed.agentId &&
         managed.canonicalAgentState !== "completed" &&
         managed.canonicalAgentState !== "exited")
     )
@@ -337,7 +337,7 @@ export class TerminalHibernationManager {
     }
 
     // Reinstall agent Enter key listener
-    if (managed.kind === "agent") {
+    if (managed.agentId) {
       const keyDisposable = terminal.onKey(({ domEvent }) => {
         if (
           !managed.isInputLocked &&

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -759,7 +759,7 @@ class TerminalInstanceService {
     });
     listeners.push(unsubExit);
 
-    const kind: "terminal" = "terminal";
+    const kind = "terminal" as const;
     const agentId =
       type === "claude" || type === "gemini" || type === "codex" || type === "opencode"
         ? type

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -269,7 +269,7 @@ class TerminalInstanceService {
           }
         }
 
-        if (managed.kind === "agent") {
+        if (managed.agentId) {
           if (
             tier === TerminalRefreshTier.FOCUSED ||
             tier === TerminalRefreshTier.BURST ||
@@ -349,7 +349,7 @@ class TerminalInstanceService {
    * element. Throttled per terminal.
    */
   private maybeReflowTerminal(managed: ManagedTerminal): void {
-    if (managed.kind === "agent") return;
+    if (managed.agentId) return;
     if (managed.isHibernated) return;
     if (!managed.isVisible) return;
     if (managed.isAttaching) return;
@@ -759,11 +759,11 @@ class TerminalInstanceService {
     });
     listeners.push(unsubExit);
 
-    const kind =
+    const kind: "terminal" = "terminal";
+    const agentId =
       type === "claude" || type === "gemini" || type === "codex" || type === "opencode"
-        ? "agent"
-        : "terminal";
-    const agentId = kind === "agent" ? type : undefined;
+        ? type
+        : undefined;
 
     const managed: ManagedTerminal = {
       terminal,
@@ -1046,7 +1046,7 @@ class TerminalInstanceService {
     });
     listeners.push(() => inputDisposable.dispose());
 
-    if (kind === "agent") {
+    if (agentId) {
       const keyDisposable = terminal.onKey(({ domEvent }) => {
         if (
           !managed.isInputLocked &&
@@ -1201,7 +1201,7 @@ class TerminalInstanceService {
       managed.isOpened = true;
       logDebug(`[TIS.attach] Opened terminal ${id}`);
       if (
-        managed.kind === "agent" &&
+        managed.agentId &&
         (managed.lastAppliedTier === TerminalRefreshTier.FOCUSED ||
           managed.lastAppliedTier === TerminalRefreshTier.BURST ||
           managed.lastAppliedTier === TerminalRefreshTier.VISIBLE)
@@ -1858,7 +1858,7 @@ class TerminalInstanceService {
       if (managed.isHibernated) continue;
       if (managed.isFocused) continue;
       if (
-        managed.kind === "agent" &&
+        managed.agentId &&
         managed.canonicalAgentState !== "completed" &&
         managed.canonicalAgentState !== "exited"
       )
@@ -1889,7 +1889,7 @@ class TerminalInstanceService {
   private isHibernationEligible(tier: TerminalRefreshTier, managed: ManagedTerminal): boolean {
     if (tier !== TerminalRefreshTier.BACKGROUND) return false;
     return (
-      managed.kind !== "agent" ||
+      !managed.agentId ||
       managed.canonicalAgentState === "completed" ||
       managed.canonicalAgentState === "exited"
     );

--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -35,14 +35,14 @@ export class TerminalParserHandler {
     blockAltScreen: boolean;
     blockMouseReporting: boolean;
   } {
-    if (this.managed.kind !== "agent") {
+    if (!this.managed.agentId) {
       return {
         blockAltScreen: false,
         blockMouseReporting: false,
       };
     }
 
-    const effectiveAgentId = this.managed.agentId ?? this.managed.type;
+    const effectiveAgentId = this.managed.agentId;
     const config = getAgentConfig(effectiveAgentId);
 
     return {
@@ -142,7 +142,7 @@ export class TerminalParserHandler {
 
   private shouldBlock(): boolean {
     // Block for all agent terminals by default
-    return this.managed.kind === "agent";
+    return Boolean(this.managed.agentId);
   }
 
   dispose(): void {

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -39,7 +39,7 @@ export function restoreScrollback(managed: ManagedTerminal): void {
     return;
   }
 
-  const isAgent = managed.kind === "agent";
+  const isAgent = Boolean(managed.agentId);
   const projectScrollback = !isAgent
     ? getValidScrollbackBase(
         useProjectSettingsStore.getState().settings?.terminalSettings?.scrollbackLines

--- a/src/services/terminal/__tests__/TerminalAgentStateController.postCompleteHook.test.ts
+++ b/src/services/terminal/__tests__/TerminalAgentStateController.postCompleteHook.test.ts
@@ -46,7 +46,7 @@ function makeMockMarker(line: number) {
 
 function makeMockManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
   return {
-    kind: "agent",
+    kind: "terminal",
     agentState: undefined,
     canonicalAgentState: undefined,
     agentStateSubscribers: new Set(),

--- a/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
+++ b/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
@@ -18,7 +18,8 @@ vi.mock("@/utils/logger", () => ({
 
 function makeMockManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
   return {
-    kind: "agent",
+    kind: "terminal",
+    agentId: "claude",
     agentState: undefined,
     canonicalAgentState: undefined,
     agentStateSubscribers: new Set(),
@@ -124,6 +125,7 @@ describe("TerminalAgentStateController", () => {
     it("does not set directing for non-agent terminals", () => {
       const managed = makeMockManaged({
         kind: "terminal",
+        agentId: undefined,
         canonicalAgentState: "waiting",
         agentState: "waiting",
       });
@@ -505,6 +507,7 @@ describe("TerminalAgentStateController", () => {
     it("no-ops for non-agent terminals", () => {
       const managed = makeMockManaged({
         kind: "terminal",
+        agentId: undefined,
         canonicalAgentState: "waiting",
         agentState: "waiting",
       });

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -194,21 +194,21 @@ describe("TerminalHibernationManager", () => {
     });
 
     it("should no-op for working agent terminal", () => {
-      managed.kind = "agent";
+      managed.agentId = "claude";
       managed.canonicalAgentState = "working";
       manager.hibernate("t1");
       expect(managed.isHibernated).toBeFalsy();
     });
 
     it("should no-op for waiting agent terminal", () => {
-      managed.kind = "agent";
+      managed.agentId = "claude";
       managed.canonicalAgentState = "waiting";
       manager.hibernate("t1");
       expect(managed.isHibernated).toBeFalsy();
     });
 
     it("should hibernate completed agent terminal", () => {
-      managed.kind = "agent";
+      managed.agentId = "claude";
       managed.canonicalAgentState = "completed";
       manager.hibernate("t1");
       expect(managed.isHibernated).toBe(true);

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -260,13 +260,15 @@ describe("TerminalInstanceService adversarial", () => {
     TerminalWebGLManager.setMaxContexts(1);
 
     const managedA = makeManaged({
-      kind: "agent",
+      kind: "terminal",
+      agentId: "claude",
       type: "claude",
       isOpened: false,
       lastAppliedTier: TerminalRefreshTier.FOCUSED,
     });
     const managedB = makeManaged({
-      kind: "agent",
+      kind: "terminal",
+      agentId: "claude",
       type: "codex",
       isOpened: false,
       lastAppliedTier: TerminalRefreshTier.FOCUSED,
@@ -286,7 +288,8 @@ describe("TerminalInstanceService adversarial", () => {
 
   it("ATTACH_AFTER_DESTROY_RETURNS_NULL", () => {
     const managed = makeManaged({
-      kind: "agent",
+      kind: "terminal",
+      agentId: "claude",
       type: "claude",
       isOpened: false,
       lastAppliedTier: TerminalRefreshTier.FOCUSED,

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -710,7 +710,6 @@ describe("TerminalInstanceService - Hibernation", () => {
         kind: "terminal",
         agentId: "claude",
         type: "claude",
-        agentId: "claude",
         ipcListenerCount: 0,
       });
       agent.listeners = [];
@@ -745,7 +744,6 @@ describe("TerminalInstanceService - Hibernation", () => {
         kind: "terminal",
         agentId: "claude",
         type: "claude",
-        agentId: "claude",
         ipcListenerCount: 0,
       });
       agent.listeners = [];
@@ -787,7 +785,6 @@ describe("TerminalInstanceService - Hibernation", () => {
         kind: "terminal",
         agentId: "claude",
         type: "claude",
-        agentId: "claude",
         canonicalAgentState: "completed",
         onInput: vi.fn(),
       });

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -237,7 +237,8 @@ describe("TerminalInstanceService - Hibernation", () => {
 
     it("should never hibernate active agent terminals", () => {
       const managed = makeMockManaged({
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "working",
       });
@@ -251,7 +252,8 @@ describe("TerminalInstanceService - Hibernation", () => {
 
     it("should never hibernate waiting agent terminals", () => {
       const managed = makeMockManaged({
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "waiting",
       });
@@ -265,7 +267,8 @@ describe("TerminalInstanceService - Hibernation", () => {
 
     it("should hibernate completed agent terminals", () => {
       const managed = makeMockManaged({
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "completed",
       });
@@ -417,7 +420,8 @@ describe("TerminalInstanceService - Hibernation", () => {
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         isVisible: false,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "working",
       });
@@ -433,7 +437,8 @@ describe("TerminalInstanceService - Hibernation", () => {
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         isVisible: false,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "completed",
       });
@@ -449,7 +454,8 @@ describe("TerminalInstanceService - Hibernation", () => {
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,
         isVisible: false,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "completed",
       });
@@ -701,7 +707,8 @@ describe("TerminalInstanceService - Hibernation", () => {
       const agent = makeMockManaged({
         isHibernated: true,
         isOpened: false,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         agentId: "claude",
         ipcListenerCount: 0,
@@ -735,7 +742,8 @@ describe("TerminalInstanceService - Hibernation", () => {
       const agent = makeMockManaged({
         isHibernated: true,
         isOpened: false,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         agentId: "claude",
         ipcListenerCount: 0,
@@ -776,7 +784,8 @@ describe("TerminalInstanceService - Hibernation", () => {
 
       const managed = makeMockManaged({
         ipcListenerCount: 2,
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         agentId: "claude",
         canonicalAgentState: "completed",

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -182,7 +182,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
   });
 
   it("skips agent terminals (WebGL — immune)", () => {
-    const managed = makeManaged({ kind: "agent" });
+    const managed = makeManaged({ kind: "terminal", agentId: "claude" });
     service.maybeReflowTerminal(managed);
     expect(paddingHistory(managed).length).toBe(0);
     expect(managed.lastReflowAt).toBe(0);

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -221,7 +221,7 @@ describe("TerminalInstanceService - Scrollback", () => {
 
     it("ignores project override for agent terminals", () => {
       mockProjectSettingsStore.settings = { terminalSettings: { scrollbackLines: 2000 } };
-      const managed = makeMockManaged({ type: "claude", kind: "agent" });
+      const managed = makeMockManaged({ type: "claude", kind: "terminal", agentId: "claude" });
       managed.terminal.options.scrollback = 100;
       service.instances.set("t1", managed);
 
@@ -267,13 +267,15 @@ describe("TerminalInstanceService - Scrollback", () => {
 
     it("skips active agent terminals but reduces completed agents", () => {
       const working = makeMockManaged({
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "working",
       });
       working.terminal.buffer.active.length = 3000;
       const completed = makeMockManaged({
-        kind: "agent",
+        kind: "terminal",
+        agentId: "claude",
         type: "claude",
         canonicalAgentState: "completed",
       });

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -207,12 +207,17 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   let webGLManager: import("../TerminalWebGLManager").TerminalWebGLManager;
   let managed: ManagedTerminal;
 
-  function makeManagedTerminal(kind: "terminal" | "terminal" = "agent"): ManagedTerminal {
+  function makeManagedTerminal(agentId?: string | null): ManagedTerminal {
+    // After the #5777 kind collapse, agent identity lives on `agentId`, not
+    // `kind`. WebGL reservation gates on `managed.agentId`. Tests that want
+    // a plain (non-agent) terminal pass `null` (or omit — but `null` is more
+    // explicit and avoids the default-param trap when callers pass `undefined`).
     return {
       terminal: { loadAddon: vi.fn(), refresh: vi.fn(), rows: 24 },
       isOpened: true,
       lastActiveTime: Date.now(),
-      kind,
+      kind: "terminal",
+      agentId: agentId === null ? undefined : (agentId ?? "claude"),
     } as unknown as ManagedTerminal;
   }
 
@@ -226,7 +231,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   });
 
   function simulateOnTierApplied(id: string, tier: TerminalRefreshTier, m: ManagedTerminal) {
-    if ((m as unknown as { kind?: string }).kind !== "agent") return;
+    if (!(m as unknown as { agentId?: string }).agentId) return;
 
     if (
       tier === TerminalRefreshTier.FOCUSED ||
@@ -302,13 +307,13 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   });
 
   it("standard terminal at FOCUSED never acquires WebGL context", () => {
-    const stdManaged = makeManagedTerminal("terminal");
+    const stdManaged = makeManagedTerminal(null);
     simulateOnTierApplied("t-std", TerminalRefreshTier.FOCUSED, stdManaged);
     expect(webGLManager.isActive("t-std")).toBe(false);
   });
 
   it("standard terminal at BURST/VISIBLE never acquires WebGL context", () => {
-    const stdManaged = makeManagedTerminal("terminal");
+    const stdManaged = makeManagedTerminal(null);
     simulateOnTierApplied("t-std", TerminalRefreshTier.BURST, stdManaged);
     expect(webGLManager.isActive("t-std")).toBe(false);
     simulateOnTierApplied("t-std", TerminalRefreshTier.VISIBLE, stdManaged);
@@ -316,7 +321,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   });
 
   it("rapid tier churn on standard terminal does not create pool entries", () => {
-    const stdManaged = makeManagedTerminal("terminal");
+    const stdManaged = makeManagedTerminal(null);
     const tiers = [
       TerminalRefreshTier.FOCUSED,
       TerminalRefreshTier.BURST,
@@ -333,9 +338,9 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   it("mixed pool: standard terminals don't consume agent WebGL slots", () => {
     const agents = Array.from({ length: 3 }, (_, i) => ({
       id: `agent-${i}`,
-      m: makeManagedTerminal("agent"),
+      m: makeManagedTerminal("claude"),
     }));
-    const stdManaged = makeManagedTerminal("terminal");
+    const stdManaged = makeManagedTerminal(null);
 
     for (const { id, m } of agents) {
       simulateOnTierApplied(id, TerminalRefreshTier.FOCUSED, m);

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -207,7 +207,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   let webGLManager: import("../TerminalWebGLManager").TerminalWebGLManager;
   let managed: ManagedTerminal;
 
-  function makeManagedTerminal(kind: "agent" | "terminal" = "agent"): ManagedTerminal {
+  function makeManagedTerminal(kind: "terminal" | "terminal" = "agent"): ManagedTerminal {
     return {
       terminal: { loadAddon: vi.fn(), refresh: vi.fn(), rows: 24 },
       isOpened: true,

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -40,7 +40,7 @@ describe("TerminalParserHandler", () => {
 
     mockManaged = {
       terminal: mockTerminal,
-      kind: "agent", // Default to agent for blocking tests
+      kind: "terminal", // Default to agent for blocking tests
       agentId: "codex",
       type: "codex",
     } as any;

--- a/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.adversarial.test.ts
@@ -74,7 +74,7 @@ describe("TerminalScrollbackController adversarial", () => {
 
     const terminalManaged = createManagedTerminal();
     const agentManaged = createManagedTerminal({
-      kind: "agent",
+      kind: "terminal",
       type: "claude",
     });
 

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -136,7 +136,7 @@ describe("TerminalScrollbackController", () => {
 
     it("ignores project override for agent terminals", () => {
       mockProjectSettingsStore.settings = { terminalSettings: { scrollbackLines: 2000 } };
-      const managed = makeMockManaged({ type: "claude", kind: "agent" });
+      const managed = makeMockManaged({ type: "claude", kind: "terminal", agentId: "claude" });
       managed.terminal.options.scrollback = 100;
 
       restoreScrollback(managed);

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -120,9 +120,10 @@ describe("buildPanelSnapshotOptions", () => {
     expect(result.browserConsoleOpen).toBe(true);
   });
 
-  it("copies agent fields for agent panels", () => {
+  it("copies agent fields for agent terminals", () => {
     const panel = makePanel({
       agentId: "claude",
+      command: "claude --flag",
       agentModelId: "opus",
       agentLaunchFlags: ["--verbose"],
     });
@@ -138,27 +139,29 @@ describe("buildPanelSnapshotOptions", () => {
     expect(result!.agentLaunchFlags).toBeUndefined();
   });
 
-  it("returns null for broken agent panels (missing command)", () => {
+  it("returns null for broken agent terminals (missing command)", () => {
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: undefined,
     });
     expect(buildPanelSnapshotOptions(panel)).toBeNull();
   });
 
-  it("returns null for broken agent panels (missing agentId)", () => {
+  it("returns a plain terminal snapshot when agentId is absent", () => {
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: undefined,
-      command: "claude --flag",
+      command: "bash",
     });
-    expect(buildPanelSnapshotOptions(panel)).toBeNull();
+    const result = buildPanelSnapshotOptions(panel);
+    expect(result).toMatchObject({ kind: "terminal", command: "bash" });
+    expect(result!.agentId).toBeUndefined();
   });
 
-  it("returns a valid agent snapshot when command and agentId are present", () => {
+  it("returns a valid agent terminal snapshot when command and agentId are present", () => {
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude --flag",
       agentModelId: "opus",
@@ -166,7 +169,7 @@ describe("buildPanelSnapshotOptions", () => {
     });
     const result = buildPanelSnapshotOptions(panel);
     expect(result).toMatchObject({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude --flag",
       agentModelId: "opus",
@@ -310,31 +313,32 @@ describe("panelDuplicationService", () => {
     expect(result.cwd).toBe("");
   });
 
-  it("throws when duplicating agent panel with missing command", async () => {
+  it("throws when duplicating agent terminal with missing command", async () => {
     const { agentSettingsClient } = await import("@/clients");
     (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error("settings unavailable")
     );
 
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "unknown-agent",
       command: undefined,
     });
     await expect(buildPanelDuplicateOptions(panel, "grid")).rejects.toThrow(
-      /Cannot duplicate agent panel.*command/
+      /Cannot duplicate agent terminal.*command/
     );
   });
 
-  it("throws when duplicating agent panel with missing agentId", async () => {
+  it("duplicates without agent identity when agentId is missing (plain terminal path)", async () => {
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: undefined,
       command: "claude --flag",
     });
-    await expect(buildPanelDuplicateOptions(panel, "grid")).rejects.toThrow(
-      /Cannot duplicate agent panel.*agentId/
-    );
+    const result = await buildPanelDuplicateOptions(panel, "grid");
+    expect(result.kind).toBe("terminal");
+    expect(result.agentId).toBeUndefined();
+    expect(result.command).toBe("claude --flag");
   });
 
   it("copies agentPresetId to duplicate options", async () => {
@@ -367,7 +371,7 @@ describe("panelDuplicationService", () => {
     });
 
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       agentPresetId: "user-abc",
     });
@@ -384,7 +388,7 @@ describe("panelDuplicationService", () => {
     getMergedPresetMock.mockReturnValue({ id: "user-abc", name: "No Env" });
 
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       agentPresetId: "user-abc",
     });
@@ -399,7 +403,7 @@ describe("panelDuplicationService", () => {
       agents: { claude: {} },
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: undefined });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: undefined });
     const result = await buildPanelDuplicateOptions(panel, "grid");
 
     expect(result.env).toBeUndefined();
@@ -419,7 +423,7 @@ describe("panelDuplicationService", () => {
       },
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: undefined });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: undefined });
     const result = await buildPanelDuplicateOptions(panel, "grid");
 
     expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://proxy.example.com" });
@@ -440,7 +444,7 @@ describe("panelDuplicationService", () => {
       env: { SHARED_KEY: "preset-wins", PRESET_ONLY: "yes" },
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     const result = await buildPanelDuplicateOptions(panel, "grid");
 
     expect(result.env).toEqual({
@@ -463,7 +467,7 @@ describe("panelDuplicationService", () => {
     getMergedPresetMock.mockReturnValue(undefined);
 
     const panel = makePanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       agentPresetId: "user-deleted",
       agentPresetColor: "#ff00ff",
@@ -516,7 +520,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
       dangerousEnabled: true,
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     expect(spy).toHaveBeenCalled();
@@ -536,7 +540,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
       customFlags: "--extra-flag",
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     const entry = spy.mock.calls[0]![1] as Record<string, unknown>;
@@ -551,7 +555,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
     });
     getMergedPresetMock.mockReturnValue({ id: "user-abc", name: "NoInline", inlineMode: false });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     const entry = spy.mock.calls[0]![1] as Record<string, unknown>;
@@ -566,7 +570,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
     });
     getMergedPresetMock.mockReturnValue({ id: "user-abc", name: "NoOverride" });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     const entry = spy.mock.calls[0]![1] as Record<string, unknown>;
@@ -585,7 +589,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
       args: ["--verbose", "--trace"],
     });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     const opts = spy.mock.calls[0]![3] as Record<string, unknown>;
@@ -600,7 +604,7 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
     });
     getMergedPresetMock.mockReturnValue({ id: "user-abc", name: "NoArgs" });
 
-    const panel = makePanel({ kind: "agent", agentId: "claude", agentPresetId: "user-abc" });
+    const panel = makePanel({ kind: "terminal", agentId: "claude", agentPresetId: "user-abc" });
     await buildPanelDuplicateOptions(panel, "grid");
 
     const opts = spy.mock.calls[0]![3] as Record<string, unknown>;

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -107,20 +107,20 @@ function buildDevPreviewOptions(panel: TerminalInstance) {
  * Does not include location — callers inject it at use time.
  *
  * Called synchronously from `trashPanel` / `trashPanelGroup` — must not throw.
- * Returns `null` for broken agent panels (missing `command` or `agentId`).
- * Callers should treat `null` as "don't overwrite lastClosedConfig". Returning
- * a terminal-kind fallback is unsafe: `addPanel` re-derives `kind: "agent"`
- * from `agentId` on reopen (core.ts), resurrecting the #5211 bare-shell bug.
+ * Returns `null` for broken agent-running terminals (missing `command` or
+ * `agentId`). Callers should treat `null` as "don't overwrite lastClosedConfig" —
+ * silently dropping agent identity (the #5211 bare-shell bug) is worse than no
+ * snapshot.
  */
 export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOptions | null {
   const kind = panel.kind ?? "terminal";
 
-  if (kind === "agent") {
-    if (!panel.agentId || !panel.command) {
+  if (panel.agentId && kind === "terminal") {
+    if (!panel.command) {
       return null;
     }
     return {
-      kind: "agent",
+      kind: "terminal",
       type: panel.type,
       agentId: panel.agentId,
       command: panel.command,
@@ -189,11 +189,9 @@ export async function buildPanelDuplicateOptions(
   const kind = sourcePanel.kind ?? "terminal";
   const { command, env, presetWasStale } = await resolveCommandForPanel(sourcePanel);
 
-  if (kind === "agent") {
-    if (!sourcePanel.agentId || !command) {
-      throw new Error(
-        `Cannot duplicate agent panel: ${!sourcePanel.agentId ? "agentId" : "command"} is missing`
-      );
+  if (sourcePanel.agentId && kind === "terminal") {
+    if (!command) {
+      throw new Error(`Cannot duplicate agent terminal: command is missing`);
     }
     // When the saved preset no longer resolves (deleted custom preset, CCR
     // route removed from config), null out the preset-derived fields so the
@@ -205,7 +203,7 @@ export async function buildPanelDuplicateOptions(
     const agentPresetColor = presetWasStale ? undefined : sourcePanel.agentPresetColor;
     const title = presetWasStale ? fallbackTitle : sourcePanel.title;
     return {
-      kind: "agent",
+      kind: "terminal",
       type: sourcePanel.type,
       agentId: sourcePanel.agentId,
       command,

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -21,7 +21,7 @@ function makeAgentTerminal(
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/store/__tests__/fleetFailureStore.test.ts
+++ b/src/store/__tests__/fleetFailureStore.test.ts
@@ -21,7 +21,7 @@ function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): Termi
     id,
     title: id,
     type: "terminal",
-    kind: "agent",
+    kind: "terminal",
     agentId: "claude",
     worktreeId: "wt-1",
     projectId: "proj-1",

--- a/src/store/__tests__/panelStore.adversarial.test.ts
+++ b/src/store/__tests__/panelStore.adversarial.test.ts
@@ -215,7 +215,7 @@ describe("panelStore adversarial", () => {
           location: "grid",
           createdAt: 1,
           type: "claude",
-          kind: "agent",
+          kind: "terminal",
         } as unknown as never,
       },
       panelIds: ["agent1"],

--- a/src/store/__tests__/panelStore.refreshTier.test.ts
+++ b/src/store/__tests__/panelStore.refreshTier.test.ts
@@ -28,7 +28,7 @@ describe("getTerminalRefreshTier - runtime agent identity", () => {
     // detectedAgentId is now undefined but everDetectedAgent is true is a
     // genuine ex-agent and should be free to hibernate.
     const terminal = makeTerminal({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       detectedAgentId: undefined,
       everDetectedAgent: true,
@@ -50,7 +50,7 @@ describe("getTerminalRefreshTier - runtime agent identity", () => {
     // detectedAgentId is undefined during the first few seconds; the spawn-time
     // fallback keeps the panel at VISIBLE so it doesn't immediately hibernate.
     const terminal = makeTerminal({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       detectedAgentId: undefined,
       agentState: "idle",
@@ -65,7 +65,7 @@ describe("getTerminalRefreshTier - runtime agent identity", () => {
   it("drops an exited agent even when detectedAgentId is still set (race guard)", () => {
     // Covers the race between onAgentExited and the process-detector exit event.
     const terminal = makeTerminal({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       detectedAgentId: "claude",
       agentState: "exited",
@@ -75,7 +75,7 @@ describe("getTerminalRefreshTier - runtime agent identity", () => {
 
   it("drops a completed agent to BACKGROUND", () => {
     const terminal = makeTerminal({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       detectedAgentId: "claude",
       agentState: "completed",

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -122,7 +122,7 @@ describe("recipeStore", () => {
       panelStoreState.panelsById = {
         "panel-agent": {
           id: "panel-agent",
-          kind: "agent",
+          kind: "terminal",
           agentId: "claude",
           title: "Claude",
           worktreeId: "wt-1",
@@ -390,7 +390,7 @@ describe("recipeStore", () => {
 
     expect(addTerminalMock).toHaveBeenCalledTimes(1);
     const spawned = addTerminalMock.mock.calls[0]?.[0];
-    expect(spawned.kind).toBe("agent");
+    expect(spawned.kind).toBe("terminal");
     expect(spawned.agentId).toBe("codex");
     expect(spawned.command).toContain("codex");
     expect(spawned.command).toContain("/prompts:merge-prs");

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -36,16 +36,19 @@ const { useWorktreeSelectionStore } = await import("../worktreeStore");
 
 function makeTerminal(
   id: string,
-  kind: "terminal" | "terminal",
+  _legacyKind: "terminal" | "agent",
   agentId?: string,
   worktreeId?: string,
   detectedAgentId?: "claude" | "gemini" | "codex",
   everDetectedAgent?: boolean
 ) {
+  // After the kind collapse (#5777), all PTY panels have kind:"terminal".
+  // The `_legacyKind` parameter is retained only so legacy test call sites
+  // keep compiling — agent-ness is expressed via `agentId` / `detectedAgentId`.
   return {
     id,
     type: "terminal" as const,
-    kind: kind as "agent" | "terminal",
+    kind: "terminal" as const,
     agentId,
     worktreeId,
     title: id,

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -36,7 +36,7 @@ const { useWorktreeSelectionStore } = await import("../worktreeStore");
 
 function makeTerminal(
   id: string,
-  kind: "agent" | "terminal",
+  kind: "terminal" | "terminal",
   agentId?: string,
   worktreeId?: string,
   detectedAgentId?: "claude" | "gemini" | "codex",

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -165,7 +165,7 @@ describe("PanelPersistence", () => {
 
       const terminal = createMockTerminal({
         id: "test-1",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude",
@@ -184,7 +184,7 @@ describe("PanelPersistence", () => {
       expect(client.setTerminals).toHaveBeenCalledWith(projectId, [
         {
           id: "test-1",
-          kind: "agent",
+          kind: "terminal",
           type: "claude",
           agentId: "claude",
           title: "Claude",

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -565,7 +565,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             recipeArgs: terminal.args?.trim() || undefined,
           });
           terminalId = await terminalStore.addPanel({
-            kind: "agent",
+            kind: "terminal",
             agentId: terminal.type,
             command,
             title: terminal.title,

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -719,7 +719,7 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
   it("includes a freshly-spawned agent panel before the detector fires (boot window)", () => {
     // detectedAgentId is undefined during boot; kind/agentId fallback keeps it in cycle
     terminals = [
-      makeTerminal("fresh-agent", { kind: "agent", agentId: "claude" }),
+      makeTerminal("fresh-agent", { kind: "terminal", agentId: "claude" }),
       makeTerminal("shell-1", { kind: "terminal" }),
     ];
     state.focusedId = "shell-1";
@@ -747,12 +747,12 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
     // Spawned as agent, detector fired then cleared on exit — no longer in cycle.
     terminals = [
       makeTerminal("ex-agent", {
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         everDetectedAgent: true,
       }),
       makeTerminal("live-agent", {
-        kind: "agent",
+        kind: "terminal",
         agentId: "gemini",
         detectedAgentId: "gemini",
       }),
@@ -783,11 +783,11 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
 
   it("focusPreviousAgent wraps across a mixed set using runtime identity", () => {
     terminals = [
-      makeTerminal("agent-1", { kind: "agent", agentId: "claude", detectedAgentId: "claude" }),
+      makeTerminal("agent-1", { kind: "terminal", agentId: "claude", detectedAgentId: "claude" }),
       // Demoted: kind agent but detection fired and cleared → skipped
-      makeTerminal("demoted", { kind: "agent", agentId: "gemini", everDetectedAgent: true }),
+      makeTerminal("demoted", { kind: "terminal", agentId: "gemini", everDetectedAgent: true }),
       makeTerminal("shell", { kind: "terminal" }),
-      makeTerminal("agent-2", { kind: "agent", agentId: "codex", detectedAgentId: "codex" }),
+      makeTerminal("agent-2", { kind: "terminal", agentId: "codex", detectedAgentId: "codex" }),
     ];
     state.focusedId = "agent-1";
 
@@ -800,7 +800,7 @@ describe("TerminalFocusSlice - focusNextAgent / focusPreviousAgent runtime ident
   it("is a no-op when only ex-agent panels remain", () => {
     terminals = [
       makeTerminal("ex-agent", {
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         everDetectedAgent: true,
       }),

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -253,7 +253,7 @@ describe("hydration batch (#5196)", () => {
         ...state.panelsById,
         "term-1": {
           id: "term-1",
-          kind: "agent",
+          kind: "terminal",
           type: "terminal",
           title: "Agent",
           cwd: "/",
@@ -273,7 +273,7 @@ describe("hydration batch (#5196)", () => {
 
     const token = beginHydrationBatch();
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
       existingId: "term-1",
@@ -297,7 +297,7 @@ describe("hydration batch (#5196)", () => {
 
     const token = beginHydrationBatch();
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
       type: "terminal",

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -113,7 +113,7 @@ const { usePanelStore } = await import("../../../panelStore");
 const agentTerminal = {
   id: "test-1",
   type: "claude" as const,
-  kind: "agent" as const,
+  kind: "terminal" as const,
   agentId: "claude",
   title: "Claude",
   cwd: "/old/path",

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -106,7 +106,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",
@@ -147,7 +147,7 @@ describe("optimistic panel spawn (#5789)", () => {
     const { addPanel } = usePanelStore.getState();
     const launches = Array.from({ length: 6 }, (_, i) =>
       addPanel({
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         type: "terminal",
         command: "claude",
@@ -196,7 +196,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",
@@ -223,7 +223,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
       existingId: "reconnect-1",
@@ -256,7 +256,7 @@ describe("optimistic panel spawn (#5789)", () => {
     const { addPanel, removePanel } = usePanelStore.getState();
     // Panel A (will fail).
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",
@@ -270,7 +270,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     // Reconnect path reuses the id (spawnStatus: "ready", spawn is skipped).
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       command: "claude",
       existingId: "shared-id",
@@ -309,7 +309,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel, removePanel } = usePanelStore.getState();
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",
@@ -360,7 +360,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel } = usePanelStore.getState();
     const id = await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",
@@ -386,7 +386,7 @@ describe("optimistic panel spawn (#5789)", () => {
 
     const { addPanel } = usePanelStore.getState();
     await addPanel({
-      kind: "agent",
+      kind: "terminal",
       agentId: "claude",
       type: "terminal",
       command: "claude",

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -100,7 +100,7 @@ const { usePanelStore } = await import("../../../panelStore");
 const agentPanelBase = {
   id: "test-1",
   type: "claude" as const,
-  kind: "agent" as const,
+  kind: "terminal" as const,
   agentId: "claude",
   agentLaunchFlags: ["--persisted-flag"],
   title: "Claude",
@@ -169,7 +169,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
     expect(payload.agentLaunchFlags).toBeUndefined();
   });
 
-  it("restarts as agent when agent is still active (working)", async () => {
+  it("restarts as agent terminal when agent is still active (working)", async () => {
     const active = { ...agentPanelBase, agentState: "working" as const };
     usePanelStore.setState({
       panelsById: { [active.id]: active },
@@ -180,7 +180,7 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
 
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const payload = mockSpawn.mock.calls[0]![0];
-    expect(payload.kind).toBe("agent");
+    expect(payload.kind).toBe("terminal");
     expect(payload.type).toBe("claude");
     expect(payload.agentId).toBe("claude");
     expect(payload.agentLaunchFlags).toEqual(["--persisted-flag"]);

--- a/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateAgentStateGuard.test.ts
@@ -38,7 +38,7 @@ const { usePanelStore } = await import("../../../panelStore");
 const baseTerminal = {
   id: "test-terminal-1",
   type: "terminal" as const,
-  kind: "agent" as const,
+  kind: "terminal" as const,
   title: "Test Agent",
   cwd: "/test",
   cols: 80,

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -218,7 +218,7 @@ export const createCorePanelActions = (
       }
     }
 
-    const requestedKind = options.kind ?? (options.agentId ? "agent" : "terminal");
+    const requestedKind = options.kind ?? "terminal";
     const legacyType = options.type || "terminal";
 
     // Handle panels that use custom UI (browser, dev-preview, extensions) separately
@@ -290,16 +290,12 @@ export const createCorePanelActions = (
       return id;
     }
 
-    // PTY panels: terminal/agent/dev-preview
-    // Derive agentId: explicit option, or from legacy type if it's a registered agent
+    // PTY panels: terminal / dev-preview. Agent identity lives on `agentId`.
+    // Derive agentId: explicit option, or from legacy type if it's a registered agent.
     const agentId = options.agentId ?? (isRegisteredAgent(legacyType) ? legacyType : undefined);
     // Determine kind for PTY handling (dev-preview keeps its own kind)
-    const kind: "terminal" | "agent" | "dev-preview" =
-      requestedKind === "dev-preview"
-        ? "dev-preview"
-        : agentId || requestedKind === "agent"
-          ? "agent"
-          : "terminal";
+    const kind: "terminal" | "dev-preview" =
+      requestedKind === "dev-preview" ? "dev-preview" : "terminal";
     const title = options.title || getDefaultTitle(kind, legacyType, agentId);
 
     // Auto-dock if grid is full and user requested grid location
@@ -364,7 +360,7 @@ export const createCorePanelActions = (
     const capturedProjectId = projectStore.getState().currentProject?.id;
 
     const isReconnect = !!options.existingId;
-    const isAgent = kind === "agent";
+    const isAgent = Boolean(agentId);
     // Reserve the id up front so the panel can be committed to the store before
     // any async work (env fetch, spawn IPC). #5789: commit-then-spawn collapses
     // six rapid agent clicks from serialized spawns into six parallel placeholders.
@@ -492,7 +488,7 @@ export const createCorePanelActions = (
       const { fontSize, fontFamily, performanceMode } = appearance;
 
       // Project-level scrollback override for non-agent terminals
-      const projectScrollback = kind !== "agent" ? appearance.projectScrollback : undefined;
+      const projectScrollback = isAgent ? undefined : appearance.projectScrollback;
 
       const effectiveScrollback = performanceMode
         ? PERFORMANCE_MODE_SCROLLBACK
@@ -519,7 +515,7 @@ export const createCorePanelActions = (
         (currentActiveWorktreeId !== null &&
           (options.worktreeId ?? null) !== (currentActiveWorktreeId ?? null));
 
-      if (kind !== "agent") {
+      if (!isAgent) {
         terminalInstanceService.prewarmTerminal(id, legacyType, terminalOptions, {
           offscreen: offscreenOrInactive,
           widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -372,8 +372,9 @@ export const createRestartActions = (
         // Demoted panels must spawn as plain terminals. Every agent-adjacent
         // field must be cleared — the IPC handler re-derives agent-ness from
         // `type` and `agentId` (electron/ipc/handlers/terminal/lifecycle.ts),
-        // so forcing only `kind` is not enough (issue #5764).
-        kind: isAgent ? (currentTerminal.kind ?? "agent") : "terminal",
+        // so forcing only `kind` is not enough (issue #5764). All PTY panels
+        // use `kind: "terminal"`; agent identity lives on `agentId`.
+        kind: "terminal",
         type: isAgent ? currentTerminal.type : "terminal",
         agentId: isAgent ? currentTerminal.agentId : undefined,
         title: currentTerminal.title,
@@ -705,7 +706,8 @@ export const createRestartActions = (
     );
 
     const effectiveAgentId = newAgentId ?? (isRegisteredAgent(newType) ? newType : undefined);
-    const newKind: "terminal" | "agent" = effectiveAgentId ? "agent" : "terminal";
+    // All PTY panels use `kind: "terminal"`; agent identity lives on `agentId`.
+    const newKind = "terminal" as const;
     const newTitle = getDefaultTitle(newKind, newType, effectiveAgentId);
 
     let commandToRun: string | undefined;
@@ -1017,7 +1019,7 @@ export const createRestartActions = (
         cwd: terminal.cwd,
         cols: spawnCols,
         rows: spawnRows,
-        kind: terminal.kind ?? "agent",
+        kind: "terminal",
         type: terminal.type,
         agentId: terminal.agentId,
         title: terminal.title,

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -453,7 +453,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -502,7 +502,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -537,7 +537,7 @@ describe("hydrateAppState", () => {
     expect(addPanel).toHaveBeenCalledTimes(1);
     expect(addPanel).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: "agent",
+        kind: "terminal",
         requestedId: "agent-1",
       })
     );
@@ -552,7 +552,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude Agent",
@@ -576,7 +576,7 @@ describe("hydrateAppState", () => {
       exists: true,
       id: "agent-1",
       projectId: "project-1",
-      kind: "agent",
+      kind: "terminal",
       type: "claude",
       agentId: "claude",
       title: "Claude Agent",
@@ -608,7 +608,7 @@ describe("hydrateAppState", () => {
     expect(addPanel).toHaveBeenCalledTimes(1);
     expect(addPanel).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         existingId: "agent-1", // reconnect path uses existingId
         agentState: "waiting",
@@ -1192,7 +1192,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -1235,7 +1235,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -1279,7 +1279,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -1313,7 +1313,7 @@ describe("hydrateAppState", () => {
     expect(addPanel).toHaveBeenCalledTimes(1);
     expect(addPanel).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: "agent",
+        kind: "terminal",
         requestedId: "agent-1",
       })
     );
@@ -1325,7 +1325,7 @@ describe("hydrateAppState", () => {
         terminals: [
           {
             id: "agent-1",
-            kind: "agent",
+            kind: "terminal",
             type: "claude",
             agentId: "claude",
             title: "Claude",
@@ -1348,7 +1348,7 @@ describe("hydrateAppState", () => {
         id: "agent-1",
         hasPty: true,
         cwd: "/project",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude",
@@ -2347,7 +2347,7 @@ describe("hydrateAppState", () => {
           id: "dead-agent-1",
           hasPty: false,
           cwd: "/project",
-          kind: "agent",
+          kind: "terminal",
           type: "claude",
           agentId: "claude",
           title: "Claude",
@@ -2415,7 +2415,7 @@ describe("hydrateAppState", () => {
           id: "live-agent-1",
           hasPty: true,
           cwd: "/project",
-          kind: "agent",
+          kind: "terminal",
           type: "claude",
           agentId: "claude",
           title: "Claude",
@@ -2477,7 +2477,7 @@ describe("hydrateAppState", () => {
           terminals: [
             {
               id: "agent-1",
-              kind: "agent",
+              kind: "terminal",
               type: "claude",
               agentId: "claude",
               title: "Claude",
@@ -2497,7 +2497,7 @@ describe("hydrateAppState", () => {
           id: "agent-1",
           hasPty: false,
           cwd: "/project",
-          kind: "agent",
+          kind: "terminal",
           type: "claude",
           agentId: "claude",
           title: "Claude",
@@ -2566,7 +2566,7 @@ describe("hydrateAppState", () => {
           terminals: [
             {
               id: "agent-1",
-              kind: "agent",
+              kind: "terminal",
               type: "claude",
               agentId: "claude",
               title: "Claude",
@@ -2607,7 +2607,7 @@ describe("hydrateAppState", () => {
 
       // Agent should still respawn on timeout (could be a temporary network issue)
       expect(addPanel).toHaveBeenCalledTimes(1);
-      expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ kind: "agent" }));
+      expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ kind: "terminal" }));
     });
 
     it("still respawns non-agent terminal when not found in backend", async () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -78,7 +78,11 @@ beforeEach(() => {
 
 describe("inferKind", () => {
   it("returns saved kind when present", () => {
-    expect(inferKind({ id: "t1", kind: "agent" })).toBe("agent");
+    expect(inferKind({ id: "t1", kind: "browser" })).toBe("browser");
+  });
+
+  it('migrates legacy "agent" kind to "terminal"', () => {
+    expect(inferKind({ id: "t1", kind: "agent" })).toBe("terminal");
   });
 
   it("infers browser from browserUrl", () => {
@@ -111,8 +115,14 @@ describe("inferAgentIdFromTitle", () => {
     expect(inferAgentIdFromTitle("Claude AI", "agent", "gemini", "t1", "test")).toBe("gemini");
   });
 
-  it("returns undefined for non-agent kind", () => {
-    expect(inferAgentIdFromTitle("Claude", "terminal", undefined, "t1", "test")).toBeUndefined();
+  it("returns undefined for non-PTY kind (e.g. browser)", () => {
+    expect(inferAgentIdFromTitle("Claude", "browser", undefined, "t1", "test")).toBeUndefined();
+  });
+
+  it("infers claude from terminal title (PTY panels can carry agent identity)", () => {
+    expect(inferAgentIdFromTitle("Claude Code", "terminal", undefined, "t1", "test")).toBe(
+      "claude"
+    );
   });
 
   it("infers claude from title", () => {
@@ -227,14 +237,24 @@ describe("buildArgsForBackendTerminal", () => {
     expect(result.devCommand).toBeUndefined();
   });
 
-  it("infers agentId from backend title for agent kind", () => {
+  it("infers agentId from backend title and emits terminal kind", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", title: "Claude Code" },
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Claude Code" },
       { id: "t1", location: "grid" },
       "/p"
     );
     expect(result.agentId).toBe("claude");
-    expect(result.kind).toBe("agent");
+    expect(result.kind).toBe("terminal");
+  });
+
+  it('migrates legacy backend kind "agent" to "terminal" while preserving agentId', () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude", title: "Claude Code" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.agentId).toBe("claude");
+    expect(result.kind).toBe("terminal");
   });
 
   it("prefers saved title over backend title to preserve user renames", () => {
@@ -257,7 +277,7 @@ describe("buildArgsForBackendTerminal", () => {
 
   it("uses saved worktreeId (renderer-owned layout state)", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", title: "Claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Claude" },
       { id: "t1", location: "grid", worktreeId: "wt-dragged" },
       "/p"
     );
@@ -295,7 +315,7 @@ describe("buildArgsForReconnectedFallback", () => {
 
   it("uses saved worktreeId (renderer-owned layout state)", () => {
     const result = buildArgsForReconnectedFallback(
-      { id: "t1", cwd: "/p", kind: "agent", title: "Claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Claude" },
       { id: "t1", location: "grid", worktreeId: "wt-dragged" },
       "/p"
     );
@@ -344,10 +364,10 @@ describe("buildArgsForRespawn", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
   });
 
-  it("builds respawn args with resume command for agent with session", () => {
+  it("builds respawn args with resume command for agent terminal with session", () => {
     const saved = {
       id: "t1",
-      kind: "agent" as const,
+      kind: "terminal" as const,
       agentId: "claude",
       title: "Claude Code",
       cwd: "/project",
@@ -356,9 +376,17 @@ describe("buildArgsForRespawn", () => {
       agentLaunchFlags: ["--flag"],
     };
 
-    const result = buildArgsForRespawn(saved, "agent", "/project", { agents: {} }, false, "/tmp");
+    const result = buildArgsForRespawn(
+      saved,
+      "terminal",
+      "/project",
+      { agents: {} },
+      false,
+      "/tmp"
+    );
     expect(result.command).toBe("claude --resume sess-123");
-    expect(result.kind).toBe("agent");
+    expect(result.kind).toBe("terminal");
+    expect(result.agentId).toBe("claude");
     expect(result.requestedId).toBe("t1");
     expect(result.restore).toBe(true);
   });
@@ -375,10 +403,10 @@ describe("buildArgsForRespawn", () => {
     expect(result.requestedId).toBeUndefined();
   });
 
-  it("generates fresh command for agent without session", () => {
+  it("generates fresh command for agent terminal without session", () => {
     const result = buildArgsForRespawn(
-      { id: "t1", kind: "agent" as const, agentId: "claude", cwd: "/p", location: "grid" },
-      "agent",
+      { id: "t1", kind: "terminal" as const, agentId: "claude", cwd: "/p", location: "grid" },
+      "terminal",
       "/p",
       { agents: { claude: {} } },
       false,
@@ -387,17 +415,17 @@ describe("buildArgsForRespawn", () => {
     expect(result.command).toBe("claude --generated");
   });
 
-  it("clears exitBehavior for agent panels", () => {
+  it("clears exitBehavior for agent terminals", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
         exitBehavior: "keep",
       },
-      "agent",
+      "terminal",
       "/p",
       { agents: {} },
       false,
@@ -411,20 +439,21 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
         agentSessionId: "sess-expired",
       },
-      "agent",
+      "terminal",
       "/p",
       { agents: { claude: {} } },
       false,
       "/tmp/clip"
     );
     expect(result.command).toBe("claude --generated");
-    expect(result.kind).toBe("agent");
+    expect(result.kind).toBe("terminal");
+    expect(result.agentId).toBe("claude");
   });
 
   it("preserves exitBehavior for non-agent panels", () => {
@@ -443,7 +472,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -463,7 +492,7 @@ describe("buildArgsForRespawn", () => {
     buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -488,7 +517,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -509,7 +538,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -531,7 +560,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -554,7 +583,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -574,7 +603,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "gemini",
         cwd: "/p",
         location: "grid",
@@ -595,7 +624,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "gemini",
         cwd: "/p",
         location: "grid",
@@ -620,7 +649,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -649,7 +678,7 @@ describe("buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent" as const,
+        kind: "terminal" as const,
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -676,7 +705,7 @@ describe("buildArgsForRespawn", () => {
 describe("agentModelId propagation", () => {
   it("buildArgsForBackendTerminal includes agentModelId", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       {
         id: "t1",
         location: "grid",
@@ -776,7 +805,7 @@ describe("detectedAgentId propagation", () => {
   it("buildArgsForRespawn does not carry detectedAgentId even if saved JSON somehow has one", () => {
     const saved = {
       id: "t1",
-      kind: "agent" as const,
+      kind: "terminal" as const,
       agentId: "claude",
       title: "Claude",
       cwd: "/p",
@@ -882,13 +911,13 @@ describe("buildArgsForOrphanedTerminal", () => {
     expect(result.worktreeId).toBeUndefined();
   });
 
-  it("infers agent kind from title", () => {
+  it("infers agentId from title on orphaned terminals", () => {
     const result = buildArgsForOrphanedTerminal(
-      { id: "t1", kind: "agent", title: "Gemini", cwd: "/p" },
+      { id: "t1", kind: "terminal", title: "Gemini", cwd: "/p" },
       "/p"
     );
     expect(result.agentId).toBe("gemini");
-    expect(result.kind).toBe("agent");
+    expect(result.kind).toBe("terminal");
   });
 
   it("falls back to projectRoot when cwd is empty", () => {
@@ -900,7 +929,7 @@ describe("buildArgsForOrphanedTerminal", () => {
     const result = buildArgsForOrphanedTerminal(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude",
@@ -918,7 +947,14 @@ describe("buildArgsForOrphanedTerminal", () => {
 
   it("handles empty agentLaunchFlags array correctly", () => {
     const result = buildArgsForOrphanedTerminal(
-      { id: "t1", kind: "agent", title: "Claude", cwd: "/p", agentLaunchFlags: [] },
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        title: "Claude",
+        cwd: "/p",
+        agentLaunchFlags: [],
+      },
       "/p"
     );
     expect(result.agentLaunchFlags).toEqual([]);
@@ -1074,7 +1110,7 @@ describe("buildArgsForBackendTerminal — agent launch flags", () => {
     const result = buildArgsForBackendTerminal(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude",
@@ -1095,7 +1131,7 @@ describe("buildArgsForBackendTerminal — agent launch flags", () => {
 
   it("falls back to saved when backend has no flags", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", kind: "agent", type: "claude", agentId: "claude", title: "Claude", cwd: "/p" },
+      { id: "t1", kind: "terminal", type: "claude", agentId: "claude", title: "Claude", cwd: "/p" },
       { id: "t1", agentLaunchFlags: ["--saved-flag"], agentModelId: "saved-model" },
       "/p"
     );
@@ -1107,7 +1143,7 @@ describe("buildArgsForBackendTerminal — agent launch flags", () => {
     const result = buildArgsForBackendTerminal(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         type: "claude",
         agentId: "claude",
         title: "Claude",
@@ -1126,7 +1162,7 @@ describe("buildArgsForBackendTerminal — agent launch flags", () => {
 describe("buildArgsForReconnectedFallback — agent launch flags", () => {
   it("prefers reconnected flags over saved", () => {
     const result = buildArgsForReconnectedFallback(
-      { id: "t1", kind: "agent", title: "Claude", cwd: "/p", agentLaunchFlags: ["--new"] },
+      { id: "t1", kind: "terminal", title: "Claude", cwd: "/p", agentLaunchFlags: ["--new"] },
       { id: "t1", agentLaunchFlags: ["--old"] },
       "/p"
     );
@@ -1135,7 +1171,7 @@ describe("buildArgsForReconnectedFallback — agent launch flags", () => {
 
   it("falls back to saved when reconnected has no flags", () => {
     const result = buildArgsForReconnectedFallback(
-      { id: "t1", kind: "agent", title: "Claude", cwd: "/p" },
+      { id: "t1", kind: "terminal", title: "Claude", cwd: "/p" },
       { id: "t1", agentLaunchFlags: ["--saved"], agentModelId: "saved-m" },
       "/p"
     );
@@ -1165,7 +1201,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1185,7 +1221,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1205,7 +1241,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1230,7 +1266,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1250,7 +1286,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1269,7 +1305,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
 
   it("does not call getMergedPreset when agentPresetId is absent", () => {
     buildArgsForRespawn(
-      { id: "t1", kind: "agent", agentId: "claude", cwd: "/p", location: "grid" },
+      { id: "t1", kind: "terminal", agentId: "claude", cwd: "/p", location: "grid" },
       "agent",
       "/p",
       { agents: { claude: {} } },
@@ -1282,7 +1318,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
   it("preserves agentPresetId through all four buildArgs paths", () => {
     // buildArgsForBackendTerminal
     const r1 = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       { id: "t1", location: "grid", agentPresetId: "user-aaa" },
       "/p"
     );
@@ -1301,7 +1337,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     const r3 = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1338,7 +1374,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
     };
 
     const r1 = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       legacy,
       "/p"
     );
@@ -1351,7 +1387,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
 
     getMergedPresetMock.mockReturnValue({ id: "old-aaa", name: "Legacy", color: "#00ff00" });
     const r3 = buildArgsForRespawn(
-      { ...legacy, kind: "agent", agentId: "claude", cwd: "/p" },
+      { ...legacy, kind: "terminal", agentId: "claude", cwd: "/p" },
       "agent",
       "/p",
       { agents: { claude: {} } },
@@ -1376,7 +1412,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
       agentFlavorColor: "#ff0000",
     };
     const r = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       mixed,
       "/p"
     );
@@ -1394,7 +1430,7 @@ describe("buildArgsForRespawn — preset overrides", () => {
 describe("adversarial: behavioral overrides flow through to generateAgentCommand", () => {
   const BASE = {
     id: "t1",
-    kind: "agent" as const,
+    kind: "terminal" as const,
     agentId: "claude",
     cwd: "/p",
     location: "grid" as const,
@@ -1509,7 +1545,7 @@ describe("adversarial: behavioral overrides flow through to generateAgentCommand
   it("no preset → generateAgentCommand receives unmodified base entry", () => {
     const baseWithNoPreset = {
       id: "t1",
-      kind: "agent" as const,
+      kind: "terminal" as const,
       agentId: "claude",
       cwd: "/p",
       location: "grid" as const,
@@ -1552,7 +1588,7 @@ describe("adversarial: agentPresetColor must be carried through buildArgsForResp
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1572,7 +1608,7 @@ describe("adversarial: agentPresetColor must be carried through buildArgsForResp
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1597,7 +1633,7 @@ describe("adversarial: agentPresetColor must be carried through buildArgsForResp
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1624,7 +1660,7 @@ describe("adversarial: agentPresetColor must be carried through buildArgsForResp
 describe("Adversarial: buildArgsForBackendTerminal preserves agentPresetColor", () => {
   it("forwards agentPresetColor from saved state", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       { id: "t1", location: "grid", agentPresetId: "user-x", agentPresetColor: "#ff6600" },
       "/p"
     );
@@ -1633,7 +1669,7 @@ describe("Adversarial: buildArgsForBackendTerminal preserves agentPresetColor", 
 
   it("returns undefined agentPresetColor when saved has none", () => {
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       { id: "t1", location: "grid", agentPresetId: "user-x" },
       "/p"
     );
@@ -1644,7 +1680,7 @@ describe("Adversarial: buildArgsForBackendTerminal preserves agentPresetColor", 
 describe("Adversarial: buildArgsForReconnectedFallback preserves agentPresetColor", () => {
   it("forwards agentPresetColor from saved state", () => {
     const result = buildArgsForReconnectedFallback(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       { id: "t1", location: "grid", agentPresetId: "user-x", agentPresetColor: "#ff6600" },
       "/p"
     );
@@ -1653,7 +1689,7 @@ describe("Adversarial: buildArgsForReconnectedFallback preserves agentPresetColo
 
   it("returns undefined agentPresetColor when saved has none", () => {
     const result = buildArgsForReconnectedFallback(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       { id: "t1", location: "grid", agentPresetId: "user-x" },
       "/p"
     );
@@ -1688,7 +1724,7 @@ describe("Adversarial: buildArgsForOrphanedTerminal preserves agentPresetColor",
   // and therefore the result is always undefined (by design — no saved state available).
   it("result has no agentPresetColor (backend-only data — no saved state available)", () => {
     const result = buildArgsForOrphanedTerminal(
-      { id: "t1", cwd: "/p", kind: "agent", agentId: "claude" },
+      { id: "t1", cwd: "/p", kind: "terminal", agentId: "claude" },
       "/p"
     );
     expect(result.agentPresetColor).toBeUndefined();
@@ -1708,7 +1744,7 @@ describe("Adversarial: globalEnv merge in buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1732,7 +1768,7 @@ describe("Adversarial: globalEnv merge in buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1758,7 +1794,7 @@ describe("Adversarial: globalEnv merge in buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",
@@ -1778,7 +1814,7 @@ describe("Adversarial: globalEnv merge in buildArgsForRespawn", () => {
     const result = buildArgsForRespawn(
       {
         id: "t1",
-        kind: "agent",
+        kind: "terminal",
         agentId: "claude",
         cwd: "/p",
         location: "grid",

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -119,10 +119,13 @@ describe("inferAgentIdFromTitle", () => {
     expect(inferAgentIdFromTitle("Claude", "browser", undefined, "t1", "test")).toBeUndefined();
   });
 
-  it("infers claude from terminal title (PTY panels can carry agent identity)", () => {
-    expect(inferAgentIdFromTitle("Claude Code", "terminal", undefined, "t1", "test")).toBe(
-      "claude"
-    );
+  it("does not mine plain terminal titles (avoids #5777 respawn takeover regression)", () => {
+    // A user-renamed plain terminal "Claude notes" must not be silently
+    // promoted to a Claude agent terminal on respawn. Title mining is gated
+    // on the legacy kind: "agent" marker — plain terminals do not enter.
+    expect(
+      inferAgentIdFromTitle("Claude notes", "terminal", undefined, "t1", "test")
+    ).toBeUndefined();
   });
 
   it("infers claude from title", () => {
@@ -237,9 +240,12 @@ describe("buildArgsForBackendTerminal", () => {
     expect(result.devCommand).toBeUndefined();
   });
 
-  it("infers agentId from backend title and emits terminal kind", () => {
+  it('infers agentId from backend title on legacy kind:"agent" and emits terminal kind', () => {
+    // Legacy persistence: backend reports kind:"agent" with no explicit
+    // agentId. Title mining recovers the identity; the returned args emit
+    // the normalized kind:"terminal" per the #5777 collapse.
     const result = buildArgsForBackendTerminal(
-      { id: "t1", cwd: "/p", kind: "terminal", title: "Claude Code" },
+      { id: "t1", cwd: "/p", kind: "agent", title: "Claude Code" },
       { id: "t1", location: "grid" },
       "/p"
     );
@@ -911,9 +917,13 @@ describe("buildArgsForOrphanedTerminal", () => {
     expect(result.worktreeId).toBeUndefined();
   });
 
-  it("infers agentId from title on orphaned terminals", () => {
+  it('recovers agentId from title on orphaned legacy kind:"agent" terminals', () => {
+    // Legacy pre-refactor persistence: backend reports kind:"agent" with no
+    // explicit agentId. The migration shim normalizes kind to "terminal" in
+    // the returned args, but the agentId is recovered from the title mining
+    // path because the input `kind: "agent"` still signals agent intent.
     const result = buildArgsForOrphanedTerminal(
-      { id: "t1", kind: "terminal", title: "Gemini", cwd: "/p" },
+      { id: "t1", kind: "agent", title: "Gemini", cwd: "/p" },
       "/p"
     );
     expect(result.agentId).toBe("gemini");

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -463,8 +463,7 @@ export async function hydrateAppState(
                   // Skip dead agent backend terminals — they create phantom idle panels
                   const isDeadAgentBackend =
                     backendTerminal.hasPty === false &&
-                    (backendTerminal.kind === "agent" ||
-                      resolveAgentId(backendTerminal.agentId, backendTerminal.type) !== undefined);
+                    resolveAgentId(backendTerminal.agentId, backendTerminal.type) !== undefined;
                   if (isDeadAgentBackend) {
                     logHydrationInfo(`Skipping dead agent backend terminal: ${backendTerminal.id}`);
                     backendTerminalMap.delete(saved.id);
@@ -593,8 +592,7 @@ export async function hydrateAppState(
                       // panels that no longer exist in the backend — they are phantoms.
                       // On cold app restart (_switchId undefined), not_found simply means the
                       // PTY process was killed on quit and needs to be respawned.
-                      const isAgentKind =
-                        kind === "agent" || resolveAgentId(saved.agentId, saved.type) !== undefined;
+                      const isAgentKind = resolveAgentId(saved.agentId, saved.type) !== undefined;
                       if (
                         isAgentKind &&
                         reconnectOutcome.status === "not_found" &&
@@ -621,7 +619,7 @@ export async function hydrateAppState(
                       }
 
                       logHydrationInfo(
-                        `Respawning PTY panel: ${saved.id} (${respawnArgs.kind === "agent" ? "agent" : "terminal"})`
+                        `Respawning PTY panel: ${saved.id} (${respawnArgs.agentId ? "agent" : "terminal"})`
                       );
 
                       logHydrationInfo(`[HYDRATION-RESPAWN] Adding terminal:`, {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -14,7 +14,6 @@ import {
   buildResumeCommand,
   buildLaunchCommandFromFlags,
 } from "@shared/types";
-import { logWarn } from "@/utils/logger";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
 import { getDeserializer } from "@/config/panelKindSerialisers";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -125,11 +124,14 @@ export function inferAgentIdFromTitle(
   title: string | undefined,
   kind: PanelKind | undefined,
   existingAgentId: string | undefined,
-  terminalId: string,
-  logContext: string
+  _terminalId: string,
+  _logContext: string
 ): string | undefined {
   if (existingAgentId) return existingAgentId;
-  if (kind !== "agent") return undefined;
+  // Only recover agent identity for PTY-backed panels; browser/dev-preview
+  // titles must not be mined for agent names. The legacy "agent" kind is
+  // treated as "terminal" after migration.
+  if (kind !== undefined && kind !== "terminal" && kind !== "agent") return undefined;
 
   const titleLower = (title ?? "").toLowerCase();
   if (titleLower.includes("claude")) return "claude";
@@ -137,9 +139,6 @@ export function inferAgentIdFromTitle(
   if (titleLower.includes("codex")) return "codex";
   if (titleLower.includes("opencode")) return "opencode";
 
-  logWarn(
-    `${logContext} agent terminal ${terminalId} missing agentId and title doesn't match known agents: "${title ?? ""}"`
-  );
   return undefined;
 }
 
@@ -157,6 +156,17 @@ export function resolveAgentId(
 }
 
 export const inferKind: (saved: SavedTerminalData) => PanelKind = inferKindShared;
+
+/**
+ * Normalize a kind value for hydration builders. Legacy `"agent"` values
+ * (from persisted state written before the kind collapse) migrate to
+ * `"terminal"`. Missing/unknown values fall through to `"terminal"`, matching
+ * the previous fallback behavior for PTY panels.
+ */
+function normalizePtyKind(kind: PanelKind | undefined): PanelKind {
+  if (!kind || kind === "agent") return "terminal";
+  return kind;
+}
 
 export function buildArgsForBackendTerminal(
   backendTerminal: BackendTerminalData,
@@ -178,7 +188,7 @@ export function buildArgsForBackendTerminal(
   const devCommand = isDevPreview ? saved.command?.trim() : undefined;
 
   return {
-    kind: backendTerminal.kind ?? (agentId ? "agent" : "terminal"),
+    kind: normalizePtyKind(backendTerminal.kind),
     type: backendTerminal.type,
     agentId,
     title: saved.title ?? backendTerminal.title,
@@ -233,7 +243,7 @@ export function buildArgsForReconnectedFallback(
   const devCommand = isDevPreview ? saved.command?.trim() : undefined;
 
   return {
-    kind: reconnectedKind ?? (agentId ? "agent" : "terminal"),
+    kind: normalizePtyKind(reconnectedKind),
     type: reconnectedTerminal.type ?? saved.type,
     agentId,
     title: saved.title ?? reconnectedTerminal.title,
@@ -278,7 +288,7 @@ export function buildArgsForRespawn(
     "Respawn"
   );
 
-  const isAgentPanel = kind === "agent" || Boolean(effectiveAgentId);
+  const isAgentPanel = Boolean(effectiveAgentId);
   const agentId = effectiveAgentId;
   let command = saved.command?.trim() || undefined;
   let presetEnv: Record<string, string> | undefined;
@@ -345,7 +355,7 @@ export function buildArgsForRespawn(
     }
   }
 
-  const respawnKind = isAgentPanel ? "agent" : kind;
+  const respawnKind = normalizePtyKind(kind);
   const isDevPreview = kind === "dev-preview";
   const location = (saved.location === "dock" ? "dock" : "grid") as "grid" | "dock";
 
@@ -453,7 +463,7 @@ export function buildArgsForOrphanedTerminal(
   agentId = inferAgentIdFromTitle(terminal.title, terminal.kind, agentId, terminal.id, "Orphaned");
 
   return {
-    kind: terminal.kind ?? (agentId ? "agent" : "terminal"),
+    kind: normalizePtyKind(terminal.kind),
     type: terminal.type,
     agentId,
     title: terminal.title,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -128,10 +128,12 @@ export function inferAgentIdFromTitle(
   _logContext: string
 ): string | undefined {
   if (existingAgentId) return existingAgentId;
-  // Only recover agent identity for PTY-backed panels; browser/dev-preview
-  // titles must not be mined for agent names. The legacy "agent" kind is
-  // treated as "terminal" after migration.
-  if (kind !== undefined && kind !== "terminal" && kind !== "agent") return undefined;
+  // Only recover agent identity from persisted state that was *itself* written
+  // as an agent panel — the legacy `kind: "agent"` marker. Plain terminals with
+  // incidental "claude" or "gemini" in their user-assigned title must not be
+  // silently promoted to agent terminals during respawn (that would regenerate
+  // a Claude launch command and take over the user's renamed shell).
+  if (kind !== "agent") return undefined;
 
   const titleLower = (title ?? "").toLowerCase();
   if (titleLower.includes("claude")) return "claude";


### PR DESCRIPTION
## Summary

- Eliminates the stored `kind === "agent"` distinction. Panel kind is now derived from runtime agent identity, not persisted independently. Existing sessions with `kind: "agent"` hydrate cleanly since `agentId` was already stored alongside `kind`.
- Panel palette and "new panel" UX treat agent configs as seeds (preset `agentId` on a PTY panel) rather than a separate kind. The component tree, PTY process, and xterm instance stay stable across promotion and demotion.
- Recipes remain agent-aware: capturing a panel running Claude records `agentId: "claude"` as launch intent; Apply continues to seed `agentId` on new panels.

Resolves #5777

## Changes

- `shared/types/panel.ts` and `panelKindRegistry.ts`: removed `"agent"` from the kind union; `inferPanelKind` now derives kind from `agentId`
- Serializer updated to write `agentId` but ignore stored `kind` at hydration time
- `statePatcher` and `stateHydration` handle migration from persisted `kind: "agent"` state
- `panelDuplicationService`, `TerminalInstanceService`, `TerminalRegistryController`, and all panel registry slices updated to use the unified kind
- `src/panels/agent/` entry points (defaults, serializer) removed; registry consolidated under `terminal/`
- 107 files updated, 13,485 tests passing; all typecheck, lint, and format checks clean

## Testing

All unit tests pass (`vitest`). Typecheck clean. Format and lint auto-fix run with zero file changes. Serialisation round-trip tests cover the migration path from legacy `kind: "agent"` persisted state. Panel duplication, hibernation, and scrollback tests updated to exercise the unified kind.