### PR TITLE
fix(pty): restore process icon badge for npm, pnpm, docker in plain terminals

### DIFF
--- a/e2e/core/core-process-badge.spec.ts
+++ b/e2e/core/core-process-badge.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { runTerminalCommand, waitForTerminalText } from "../helpers/terminal";
+import { getFirstGridPanel, openTerminal } from "../helpers/panels";
+import { T_LONG } from "../helpers/timeouts";
+
+let ctx: AppContext;
+let fixtureDir: string;
+
+// #5813: the process icon badge (npm, pnpm, docker, node, etc.) must surface
+// on plain terminals running a recognised non-agent process. The badge is
+// driven by `agent:detected` events whose payload carries `processIconId`
+// without `agentType`; the renderer threads that through to the panel's
+// `data-detected-process-id` attribute.
+test.describe.serial("Core: Process Icon Badge", () => {
+  test.beforeAll(async () => {
+    fixtureDir = createFixtureRepo({ name: "process-badge" });
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Process Badge Test");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("node process running a timed script surfaces the node badge, then clears on exit", async () => {
+    const { window } = ctx;
+    await openTerminal(window);
+    const panel = getFirstGridPanel(window);
+    await expect(panel).toBeVisible({ timeout: T_LONG });
+
+    const panelId = await panel.getAttribute("data-panel-id");
+    expect(panelId).toBeTruthy();
+
+    // Run a bounded `node` process — `node` is in PROCESS_ICON_MAP, so
+    // either the process-tree detector or the shell-command fallback should
+    // commit the "node" icon within the hysteresis window (~3s baseline).
+    // SENTINEL_READY lets us confirm the script is actually executing.
+    await runTerminalCommand(
+      window,
+      panel,
+      `node -e "console.log('SENTINEL_READY'); setTimeout(()=>{}, 8000)"`
+    );
+    await waitForTerminalText(panel, "SENTINEL_READY", T_LONG);
+
+    // Badge appears. T_LONG accommodates CI slowness plus the 1500ms-poll
+    // × 2-poll hysteresis baseline.
+    await expect
+      .poll(
+        async () => {
+          return await window.evaluate(
+            (id) =>
+              document
+                .querySelector(`[data-panel-id="${id}"]`)
+                ?.getAttribute("data-detected-process-id"),
+            panelId
+          );
+        },
+        { timeout: T_LONG, intervals: [500] }
+      )
+      .toBe("node");
+
+    // Badge clears after the process exits.
+    await expect
+      .poll(
+        async () => {
+          return await window.evaluate(
+            (id) =>
+              document
+                .querySelector(`[data-panel-id="${id}"]`)
+                ?.getAttribute("data-detected-process-id"),
+            panelId
+          );
+        },
+        { timeout: T_LONG, intervals: [500] }
+      )
+      .toBeNull();
+  });
+});

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -218,10 +218,25 @@ export class ProcessDetector {
 
     logDebug(`Starting ProcessDetector for terminal ${this.terminalId}, PID ${this.ptyPid}`);
 
+    // Always-on startup log — lets us see in logs whether the detector was
+    // attached at all for this terminal. Silent failures in this path have
+    // previously masked badge-pipeline regressions (#5813).
+    console.log(`[ProcessDetector ${this.terminalId.slice(0, 8)}] start pid=${this.ptyPid}`);
+
     this.isStarted = true;
     this.detect();
 
+    let firstRefresh = true;
     this.unsubscribe = this.cache.onRefresh(() => {
+      if (firstRefresh) {
+        firstRefresh = false;
+        // One-shot log on first cache refresh callback — confirms the detector
+        // is actually being ticked by the cache, independent of whether any
+        // state transitions are committed by the hysteresis gate.
+        console.log(
+          `[ProcessDetector ${this.terminalId.slice(0, 8)}] first refresh pid=${this.ptyPid} children=${this.cache.getChildren(this.ptyPid).length}`
+        );
+      }
       this.detect();
     });
   }

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -218,11 +218,6 @@ export class ProcessDetector {
 
     logDebug(`Starting ProcessDetector for terminal ${this.terminalId}, PID ${this.ptyPid}`);
 
-    // Always-on startup log — lets us see in logs whether the detector was
-    // attached at all for this terminal. Silent failures in this path have
-    // previously masked badge-pipeline regressions (#5813).
-    console.log(`[ProcessDetector ${this.terminalId.slice(0, 8)}] start pid=${this.ptyPid}`);
-
     this.isStarted = true;
     this.detect();
 
@@ -230,11 +225,12 @@ export class ProcessDetector {
     this.unsubscribe = this.cache.onRefresh(() => {
       if (firstRefresh) {
         firstRefresh = false;
-        // One-shot log on first cache refresh callback — confirms the detector
-        // is actually being ticked by the cache, independent of whether any
-        // state transitions are committed by the hysteresis gate.
-        console.log(
-          `[ProcessDetector ${this.terminalId.slice(0, 8)}] first refresh pid=${this.ptyPid} children=${this.cache.getChildren(this.ptyPid).length}`
+        // One-shot verbose-gated log on first cache refresh callback —
+        // confirms the detector is actually being ticked by the cache,
+        // independent of whether any state transitions are committed by the
+        // hysteresis gate. Gated so normal runs stay quiet. #5813
+        logDebug(
+          `ProcessDetector ${this.terminalId.slice(0, 8)} first refresh pid=${this.ptyPid} children=${this.cache.getChildren(this.ptyPid).length}`
         );
       }
       this.detect();

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -30,6 +30,7 @@ export class ProcessTreeCache {
   private isWindows: boolean = process.platform === "win32";
   private refreshCallbacks: Set<RefreshCallback> = new Set();
   private lastError: Error | null = null;
+  private loggedZeroSubscriberSkip: boolean = false;
   private cpuSnapshots = new Map<
     string,
     { kernelTicks: bigint; userTicks: bigint; wallMs: number }
@@ -117,11 +118,21 @@ export class ProcessTreeCache {
   async refresh(): Promise<void> {
     // Skip refresh if nobody is listening - saves CPU especially on Windows
     if (this.refreshCallbacks.size === 0) {
+      // Log once per lifecycle when we skip due to no subscribers. If
+      // ProcessDetector instances aren't registering, detection goes silent —
+      // this surfaces the cause instead of failing silently (#5813).
+      if (!this.loggedZeroSubscriberSkip) {
+        this.loggedZeroSubscriberSkip = true;
+        console.log(
+          "[ProcessTreeCache] refresh skipped — no subscribers (ProcessDetector not attached?)"
+        );
+      }
       if (!this.disposed) {
         this.schedulePoll(this.currentIntervalMs);
       }
       return;
     }
+    this.loggedZeroSubscriberSkip = false;
 
     if (this.isRefreshing) {
       return;

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -1,6 +1,7 @@
 import { exec } from "child_process";
 import os from "node:os";
 import { promisify } from "util";
+import { logDebug } from "../utils/logger.js";
 
 const execAsync = promisify(exec);
 
@@ -120,10 +121,12 @@ export class ProcessTreeCache {
     if (this.refreshCallbacks.size === 0) {
       // Log once per lifecycle when we skip due to no subscribers. If
       // ProcessDetector instances aren't registering, detection goes silent —
-      // this surfaces the cause instead of failing silently (#5813).
+      // this surfaces the cause instead of failing silently (#5813). Verbose-gated
+      // because normal startup briefly has no subscribers between cache.start()
+      // and the first ProcessDetector attaching.
       if (!this.loggedZeroSubscriberSkip) {
         this.loggedZeroSubscriberSkip = true;
-        console.log(
+        logDebug(
           "[ProcessTreeCache] refresh skipped — no subscribers (ProcessDetector not attached?)"
         );
       }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -560,10 +560,14 @@ export class TerminalProcess {
     }
 
     const bracketedPaste = isBracketedPaste(data);
+    // Shell input capture is only meaningless when a live AGENT owns the PTY
+    // (agents have their own input semantics). A plain process badge (npm,
+    // pnpm, docker, etc.) does not change the shell semantics — the shell
+    // is still the direct recipient of typed commands, and the next command
+    // must still be visible to the fallback detector so a follow-up
+    // `pnpm build` can re-identify the badge. #5813
     const canCaptureShellInput =
-      !bracketedPaste &&
-      this.terminalInfo.detectedAgentType === undefined &&
-      this.lastDetectedProcessIconId === undefined;
+      !bracketedPaste && this.terminalInfo.detectedAgentType === undefined;
     const submittedCommandText = canCaptureShellInput ? this.captureShellInput(data) : undefined;
 
     if (!bracketedPaste && /[\r\n]/.test(data)) {
@@ -1118,7 +1122,12 @@ export class TerminalProcess {
       return;
     }
 
-    if (this.terminalInfo.detectedAgentType || this.lastDetectedProcessIconId) {
+    // Only skip when a live agent is already detected. A stale
+    // `lastDetectedProcessIconId` must not block re-arming the fallback — if
+    // the user ran `npm run dev` then Ctrl+C then typed `pnpm dev`, the new
+    // command must be allowed to restart detection regardless of whether the
+    // previous badge was cleared by the process-tree path yet.
+    if (this.terminalInfo.detectedAgentType) {
       return;
     }
 
@@ -1169,12 +1178,7 @@ export class TerminalProcess {
 
   private pollShellIdentityFallback(): void {
     const submittedAt = this.shellIdentityFallbackSubmittedAt;
-    if (
-      submittedAt === null ||
-      this.terminalInfo.isExited ||
-      this.terminalInfo.wasKilled ||
-      !this.terminalInfo.headlessTerminal
-    ) {
+    if (submittedAt === null || this.terminalInfo.isExited || this.terminalInfo.wasKilled) {
       this.stopShellIdentityFallbackWatcher();
       return;
     }
@@ -1193,9 +1197,17 @@ export class TerminalProcess {
     }
 
     const promptVisible = this.isShellPromptVisible();
-    const hasLiveIdentity =
-      this.terminalInfo.detectedAgentType !== undefined ||
-      this.lastDetectedProcessIconId !== undefined;
+    // A live identity only pre-empts the fallback commit when it matches what
+    // the fallback detected — a stale badge (e.g. a prior `npm run dev` whose
+    // icon hasn't been cleared yet) must NOT block the fallback from emitting
+    // a fresh `pnpm`/`docker`/etc. detection for the next command. #5813
+    const fallbackIdentity = this.shellIdentityFallbackIdentity;
+    const liveIdentityMatchesFallback =
+      fallbackIdentity !== null &&
+      ((fallbackIdentity.agentType !== undefined &&
+        this.terminalInfo.detectedAgentType === fallbackIdentity.agentType) ||
+        (fallbackIdentity.processIconId !== undefined &&
+          this.lastDetectedProcessIconId === fallbackIdentity.processIconId));
 
     if (!this.shellIdentityFallbackIdentity) {
       if (promptVisible && Date.now() - submittedAt >= SHELL_IDENTITY_FALLBACK_COMMIT_MS) {
@@ -1205,7 +1217,7 @@ export class TerminalProcess {
     }
 
     if (!this.shellIdentityFallbackCommitted) {
-      if (hasLiveIdentity) {
+      if (liveIdentityMatchesFallback) {
         this.shellIdentityFallbackCommitted = true;
         return;
       }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1586,6 +1586,7 @@ export class TerminalProcess {
 
       this.stopProcessDetector();
       this.stopActivityMonitor();
+      this.stopShellIdentityFallbackWatcher();
       this.semanticBufferManager.flush();
 
       if (this.inputWriteTimeout) {

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -554,4 +554,101 @@ describe("TerminalProcess shell-command identity fallback", () => {
       terminal.dispose();
     }
   });
+
+  // #5813: user runs a plain-process command, the badge appears via the
+  // fallback, they Ctrl+C, then run a DIFFERENT plain-process command. The
+  // second command must re-arm the fallback even though lastDetectedProcessIconId
+  // from the first command hasn't been cleared by the process-tree path yet.
+  it("re-arms the fallback for a second plain-process command when the first badge hasn't cleared", async () => {
+    const terminal = createPlainTerminal("t-fallback-rearm");
+    const pty = getMockPty(terminal);
+
+    try {
+      terminal.write("npm run dev\r");
+      pty.__emitData("npm run dev\r\n");
+      pty.__emitData("> canopy-app@1.0.0 dev\r\n");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(terminal.getInfo().detectedProcessIconId).toBe("npm");
+
+      // Second command while first badge is still latched. No process-tree
+      // clear has fired yet.
+      terminal.write("pnpm build\r");
+      pty.__emitData("pnpm build\r\n");
+      pty.__emitData("> build output\r\n");
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(terminal.getInfo().detectedProcessIconId).toBe("pnpm");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});
+
+// #5813: the live ProcessDetector path for plain terminals running a
+// recognised non-agent process (npm, pnpm, python, docker, etc.) must emit
+// `agent:detected` with `processIconId` but no `agentType`. This is the
+// primary pipeline — the shell-command fallback is belt-and-suspenders.
+describe("TerminalProcess.handleAgentDetection — plain process icon badge emission", () => {
+  it("emits agent:detected with processIconId only (no agentType) for a plain-process detection", () => {
+    const terminal = createPlainTerminal("t-plain-badge");
+    const detectedEvents: Array<{
+      terminalId: string;
+      agentType?: string;
+      processIconId?: string;
+      processName?: string;
+    }> = [];
+    const unsub = events.on("agent:detected", (payload) => {
+      detectedEvents.push({
+        terminalId: payload.terminalId,
+        agentType: payload.agentType,
+        processIconId: payload.processIconId,
+        processName: payload.processName,
+      });
+    });
+
+    try {
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, processIconId: "npm", processName: "npm" },
+        getSpawnedAt(terminal)
+      );
+
+      expect(detectedEvents).toHaveLength(1);
+      expect(detectedEvents[0].terminalId).toBe("t-plain-badge");
+      expect(detectedEvents[0].agentType).toBeUndefined();
+      expect(detectedEvents[0].processIconId).toBe("npm");
+      expect(detectedEvents[0].processName).toBe("npm");
+      expect(terminal.getInfo().detectedProcessIconId).toBe("npm");
+    } finally {
+      unsub();
+      terminal.dispose();
+    }
+  });
+
+  it("clears detectedProcessIconId and emits agent:exited when the plain process goes away", () => {
+    const terminal = createPlainTerminal("t-plain-badge-clear");
+    const exitedEvents: Array<{ terminalId: string; agentType?: string }> = [];
+    const unsub = events.on("agent:exited", (payload) => {
+      exitedEvents.push({ terminalId: payload.terminalId, agentType: payload.agentType });
+    });
+
+    try {
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, processIconId: "npm", processName: "npm" },
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().detectedProcessIconId).toBe("npm");
+
+      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+
+      expect(terminal.getInfo().detectedProcessIconId).toBeUndefined();
+      expect(exitedEvents).toHaveLength(1);
+      expect(exitedEvents[0].terminalId).toBe("t-plain-badge-clear");
+      expect(exitedEvents[0].agentType).toBeUndefined();
+    } finally {
+      unsub();
+      terminal.dispose();
+    }
+  });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -555,6 +555,38 @@ describe("TerminalProcess shell-command identity fallback", () => {
     }
   });
 
+  // #5813 regression: when the PTY exits on the non-preserved path,
+  // `disposeHeadless()` nulls the headless terminal but neither `isExited`
+  // nor `wasKilled` is set — so the fallback watcher, which had
+  // `!headlessTerminal` removed from its stop guard, must instead be stopped
+  // explicitly in the `onExit` handler. Otherwise the interval runs forever
+  // and keeps the TerminalProcess alive past registry deletion.
+  it("stops the fallback watcher on non-preserved PTY exit (no orphan timer)", async () => {
+    const terminal = createPlainTerminal("t-fallback-exit");
+    const pty = getMockPty(terminal);
+    const emittedEventsAfterExit: string[] = [];
+
+    try {
+      terminal.write("npm run dev\r");
+      pty.__emitData("npm run dev\r\n");
+      pty.__emitData("> canopy-app@1.0.0 dev\r\n");
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(terminal.getInfo().detectedProcessIconId).toBe("npm");
+
+      const unsub = events.on("agent:detected", (payload) => {
+        emittedEventsAfterExit.push(payload.terminalId);
+      });
+      pty.__emitExit(0);
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      // No post-exit detection events; watcher is gone.
+      expect(emittedEventsAfterExit).toHaveLength(0);
+      unsub();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
   // #5813: user runs a plain-process command, the badge appears via the
   // fallback, they Ctrl+C, then run a DIFFERENT plain-process command. The
   // second command must re-arm the fallback even though lastDetectedProcessIconId

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -289,6 +289,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         ref={ref}
         data-panel-id={id}
         data-panel-location={location}
+        data-detected-process-id={detectedProcessId || undefined}
         data-selected={isSelected || undefined}
         style={{
           contain: "content",


### PR DESCRIPTION
## Summary

- Four over-broad guards in `TerminalProcess.ts` were gating shell-input capture and the fallback lifecycle watcher on `lastDetectedProcessIconId`, which meant the badge detection/refresh cycle never ran for recognised non-agent commands (npm, pnpm, docker, node, etc.)
- Removed those guards so the detection path runs unconditionally for all terminal types. The shell-command identity fallback introduced in 40fedf354 for title-rewriting CLIs now applies to plain process badges too.
- Added a `data-detected-process-id` DOM attribute on `ContentPanel` as a stable anchor for automation and testing.

Resolves #5813

## Changes

- `electron/services/pty/TerminalProcess.ts` — removed four `lastDetectedProcessIconId`-gated guards that were short-circuiting re-arm and exit-cleanup logic for plain terminals
- `electron/services/ProcessDetector.ts` — minor diagnostic logging improvements so failures surface which leg dropped the badge
- `electron/services/ProcessTreeCache.ts` — additional debug logging for cache misses
- `src/components/Panel/ContentPanel.tsx` — `data-detected-process-id` DOM anchor added
- `electron/services/pty/TerminalProcess.agentDetection.test.ts` — unit tests covering re-arm, exit cleanup, and plain-process emission paths
- `e2e/core/core-process-badge.spec.ts` — E2E test that launches a plain terminal, runs a bounded npm command, and asserts the icon flips within the 5-second window

## Testing

Unit tests cover the three main paths (re-arm after process change, badge clear on exit, plain process emission without agent detection). The E2E test in `e2e/core/` provides an end-to-end observable anchor: it runs a real npm command and checks `data-detected-process-id` flips to `"npm"` within 5 seconds, then clears on exit. Manually verified npm and pnpm badges reappear in the running build.