### PR TITLE
refactor(agent): retire 'running' AgentState and normalise vocabulary

### DIFF
--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -189,7 +189,7 @@ describe("handleProjectGetBulkStats", () => {
           projectId: "proj-a",
           kind: "terminal",
           agentId: "claude",
-          agentState: "running",
+          agentState: "working",
           hasPty: true,
           cwd: "/tmp",
           spawnedAt: 3,
@@ -214,7 +214,7 @@ describe("handleProjectGetBulkStats", () => {
       { activeAgentCount: number; waitingAgentCount: number }
     >;
 
-    expect(result["proj-a"].activeAgentCount).toBe(2); // working + running
+    expect(result["proj-a"].activeAgentCount).toBe(2); // working only
     expect(result["proj-a"].waitingAgentCount).toBe(1); // waiting only
   });
 
@@ -346,7 +346,7 @@ describe("handleProjectGetBulkStats", () => {
           projectId: "proj-b",
           kind: "terminal",
           agentId: "claude",
-          agentState: "running",
+          agentState: "working",
           hasPty: true,
           cwd: "/tmp",
           spawnedAt: 3,

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -79,7 +79,7 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
 
       if (terminal.agentState === "waiting") {
         counts.waiting += 1;
-      } else if (terminal.agentState === "working" || terminal.agentState === "running") {
+      } else if (terminal.agentState === "working") {
         counts.active += 1;
       }
     }

--- a/electron/schemas/__tests__/agent.test.ts
+++ b/electron/schemas/__tests__/agent.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { AgentStateSchema } from "../agent.js";
+
+describe("AgentStateSchema (issue #5810 migration)", () => {
+  it("preprocesses the retired 'running' value to 'working'", () => {
+    expect(AgentStateSchema.parse("running")).toBe("working");
+  });
+
+  it.each(["idle", "working", "waiting", "directing", "completed", "exited"])(
+    "accepts canonical state %s",
+    (state) => {
+      expect(AgentStateSchema.parse(state)).toBe(state);
+    }
+  );
+
+  it("rejects unknown values", () => {
+    expect(() => AgentStateSchema.parse("banana")).toThrow();
+  });
+});

--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -3,14 +3,10 @@ import { BUILT_IN_TERMINAL_TYPES } from "../../shared/config/agentIds.js";
 
 export const TerminalTypeSchema = z.enum(BUILT_IN_TERMINAL_TYPES);
 
-export const AgentStateSchema = z.enum([
-  "idle",
-  "working",
-  "running",
-  "waiting",
-  "completed",
-  "exited",
-]);
+export const AgentStateSchema = z.preprocess(
+  (value) => (value === "running" ? "working" : value),
+  z.enum(["idle", "working", "waiting", "directing", "completed", "exited"])
+);
 
 // @see shared/types/events.ts for the TypeScript interface definition.
 export const EventContextSchema = z.object({

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -13,7 +13,7 @@ const WORKING_PULSE_INITIAL_DELAY_MS = 10_000;
 const WORKING_PULSE_MIN_INTERVAL_MS = 8_000;
 const WORKING_PULSE_MAX_INTERVAL_MS = 10_000;
 const ALL_CLEAR_DEBOUNCE_MS = 500;
-const ACTIVE_AGENT_STATES = new Set(["working", "running", "directing"]);
+const ACTIVE_AGENT_STATES = new Set(["working", "directing"]);
 
 /**
  * Grace period after spawn during which waiting sounds are suppressed.

--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -13,9 +13,8 @@ export type AgentEvent =
   | { type: "respawn" }; // New agent session detected in same PTY after a prior exit
 
 const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
-  idle: ["working", "running", "exited"],
+  idle: ["working", "exited"],
   working: ["waiting", "completed", "exited"],
-  running: ["idle"], // Shell process state - managed by TerminalProcess, not this state machine
   waiting: ["working", "completed", "exited"],
   directing: [], // Renderer-only state, never produced by main process
   completed: ["working", "waiting", "exited"],

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -8,6 +8,7 @@ import type {
   PanelSummary,
   PendingCrash,
 } from "../../shared/types/ipc/crashRecovery.js";
+import { coerceAgentState } from "../../shared/types/agent.js";
 import { store } from "../store.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
@@ -280,7 +281,7 @@ export class CrashRecoveryService {
           typeof t.createdAt === "number"
             ? Math.abs(crashTimestamp - t.createdAt) < SUSPECT_WINDOW_MS
             : false,
-        agentState: typeof t.agentState === "string" ? t.agentState : undefined,
+        agentState: coerceAgentState(t.agentState),
         lastStateChange: typeof t.lastStateChange === "number" ? t.lastStateChange : undefined,
       }));
     } catch {

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -19,12 +19,7 @@ const MIN_THRESHOLD_MINUTES = 15;
 const MAX_THRESHOLD_MINUTES = 1440; // 24h
 const MIN_COOLDOWN_MINUTES = 60;
 
-const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set([
-  "working",
-  "running",
-  "waiting",
-  "directing",
-]);
+const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set(["working", "waiting", "directing"]);
 
 interface PtyManagerLike {
   getAll: () => Array<{

--- a/electron/services/PowerSaveBlockerService.ts
+++ b/electron/services/PowerSaveBlockerService.ts
@@ -2,7 +2,7 @@ import { powerSaveBlocker } from "electron";
 import { events } from "./events.js";
 import type { AgentState } from "../../shared/types/agent.js";
 
-const ACTIVE_STATES = new Set<AgentState>(["working", "running"]);
+const ACTIVE_STATES = new Set<AgentState>(["working"]);
 const SAFETY_TIMEOUT_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 export class PowerSaveBlockerService {

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -134,7 +134,7 @@ export class ProjectStatsService {
 
         if (terminal.agentState === "waiting") {
           counts.waiting += 1;
-        } else if (terminal.agentState === "working" || terminal.agentState === "running") {
+        } else if (terminal.agentState === "working") {
           counts.active += 1;
         }
       }

--- a/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.adversarial.test.ts
@@ -185,7 +185,7 @@ describe("AgentNotificationService adversarial", () => {
 
     events.emit("agent:state-changed", makePayload("completed", "working"));
     vi.advanceTimersByTime(1000);
-    events.emit("agent:state-changed", makePayload("completed", "running"));
+    events.emit("agent:state-changed", makePayload("completed", "directing"));
     vi.advanceTimersByTime(2001);
 
     expect(notificationServiceMock.showWatchNotification).toHaveBeenCalledTimes(1);

--- a/electron/services/__tests__/AgentNotificationService.allClear.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.allClear.test.ts
@@ -302,19 +302,19 @@ describe("AgentNotificationService – all-clear", () => {
     expect(soundServiceMock.play).not.toHaveBeenCalledWith("all-clear");
   });
 
-  it("fires for running and directing agent states", () => {
+  it("fires for working and directing agent states", () => {
     mockTerminals([
-      { id: "term-1", agentState: "running" },
+      { id: "term-1", agentState: "working" },
       { id: "term-2", agentState: "directing" },
     ]);
-    emitStateChange("running", "idle", "term-1");
+    emitStateChange("working", "idle", "term-1");
     emitStateChange("directing", "idle", "term-2");
 
     mockTerminals([
       { id: "term-1", agentState: "completed" },
       { id: "term-2", agentState: "completed" },
     ]);
-    emitStateChange("completed", "running", "term-1");
+    emitStateChange("completed", "working", "term-1");
     emitStateChange("completed", "directing", "term-2");
 
     vi.advanceTimersByTime(600);

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -329,7 +329,7 @@ describe("HibernationService", () => {
       expect(ptyManagerMock.gracefulKillByProject).not.toHaveBeenCalled();
     });
 
-    it.each(["working", "running", "waiting", "directing"] as const)(
+    it.each(["working", "waiting", "directing"] as const)(
       "skips projects with %s agent terminals",
       async (agentState) => {
         ptyManagerMock.getAll.mockReturnValue([makeTerminal({ agentState })]);
@@ -498,7 +498,7 @@ describe("HibernationService", () => {
       ]);
     }
 
-    it.each(["working", "running", "waiting", "directing"] as const)(
+    it.each(["working", "waiting", "directing"] as const)(
       "skips projects with %s agent in scheduled hibernation",
       async (agentState) => {
         setupScheduledTest();

--- a/electron/services/__tests__/PowerSaveBlockerService.test.ts
+++ b/electron/services/__tests__/PowerSaveBlockerService.test.ts
@@ -74,13 +74,6 @@ describe("PowerSaveBlockerService", () => {
       expect(service.getActiveCount()).toBe(0);
     });
 
-    it("starts blocker for running state", () => {
-      emitStateChanged("term-1", "running", { agentId: "agent-1" });
-
-      expect(powerSaveBlocker.start).toHaveBeenCalledWith("prevent-app-suspension");
-      expect(service.isBlocking()).toBe(true);
-    });
-
     it("does not start blocker for waiting state", () => {
       emitStateChanged("term-1", "waiting", { agentId: "agent-1" });
 
@@ -119,7 +112,7 @@ describe("PowerSaveBlockerService", () => {
 
     it("stops blocker when all agents become idle", () => {
       emitStateChanged("term-1", "working", { agentId: "agent-1" });
-      emitStateChanged("term-2", "running", { agentId: "agent-2" });
+      emitStateChanged("term-2", "working", { agentId: "agent-2" });
 
       emitStateChanged("term-1", "idle", { agentId: "agent-1" });
       emitStateChanged("term-2", "idle", { agentId: "agent-2" });

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -123,12 +123,12 @@ describe("ProjectStatsService adversarial", () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
       { projectId: "p1", isTrashed: true, kind: "terminal", agentState: "working" },
-      { projectId: "p1", kind: "dev-preview", agentState: "running" },
+      { projectId: "p1", kind: "dev-preview", agentState: "working" },
       { projectId: "p1", hasPty: false, kind: "terminal", agentState: "working" },
-      { projectId: "p1", kind: "terminal", agentState: "running" }, // no agentId, not "agent" kind → skip
+      { projectId: "p1", kind: "terminal", agentState: "working" }, // no agentId, not "agent" kind → skip
       { projectId: "p1", kind: "terminal", agentId: "x", agentState: "waiting" }, // counts (waiting)
       { projectId: "p1", kind: "terminal", agentId: "x", agentState: "working" }, // counts (active)
-      { projectId: "p1", kind: "terminal", agentId: "x", agentState: "running" }, // counts (active)
+      { projectId: "p1", kind: "terminal", agentId: "x", agentState: "working" }, // counts (active)
       { projectId: "p1", kind: "terminal", agentId: "x", agentState: "idle" }, // counts neither
     ]);
     ptyClient.getProjectStats.mockResolvedValue({
@@ -178,7 +178,7 @@ describe("ProjectStatsService adversarial", () => {
       },
       // Regression guard: plain terminal with neither agentId nor
       // detectedAgentId is still excluded.
-      { projectId: "p1", kind: "terminal", agentState: "running" },
+      { projectId: "p1", kind: "terminal", agentState: "working" },
     ]);
     ptyClient.getProjectStats.mockResolvedValue({
       projectId: "p1",

--- a/electron/utils/__tests__/quitWarning.test.ts
+++ b/electron/utils/__tests__/quitWarning.test.ts
@@ -37,21 +37,12 @@ describe("getActiveAgentCount", () => {
     expect(getActiveAgentCount(store)).toBe(1);
   });
 
-  it("counts running agents", () => {
+  it("ignores legacy running agents (retired state)", () => {
     const store = mockStore([
       { agentId: "a1", state: "running" },
       { agentId: "a2", state: "idle" },
     ]);
-    expect(getActiveAgentCount(store)).toBe(1);
-  });
-
-  it("counts both working and running agents", () => {
-    const store = mockStore([
-      { agentId: "a1", state: "working" },
-      { agentId: "a2", state: "running" },
-      { agentId: "a3", state: "idle" },
-    ]);
-    expect(getActiveAgentCount(store)).toBe(2);
+    expect(getActiveAgentCount(store)).toBe(0);
   });
 });
 

--- a/electron/utils/quitWarning.ts
+++ b/electron/utils/quitWarning.ts
@@ -3,7 +3,7 @@ import type { AgentAvailabilityStore } from "../services/AgentAvailabilityStore.
 
 type Dialog = typeof import("electron").dialog;
 
-const ACTIVE_STATES = new Set(["working", "running"]);
+const ACTIVE_STATES = new Set(["working"]);
 
 export function getActiveAgentCount(store: AgentAvailabilityStore): number {
   return store.getAgentsByAvailability().filter((a) => ACTIVE_STATES.has(a.state)).length;

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -249,7 +249,7 @@ describe("ProjectViewManager — eviction safety", () => {
     // (proj-a) and emit a telemetry event rather than let the pool grow unbounded.
     mockGetAll.mockReturnValue([
       { projectId: "proj-a", agentState: "directing" },
-      { projectId: "proj-b", agentState: "running" },
+      { projectId: "proj-b", agentState: "working" },
     ]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");

--- a/shared/types/__tests__/agent.test.ts
+++ b/shared/types/__tests__/agent.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { coerceAgentState, ACTIVE_AGENT_STATES } from "../agent";
+import type { AgentState } from "../agent";
+
+describe("coerceAgentState", () => {
+  it("maps the retired 'running' state to 'working'", () => {
+    expect(coerceAgentState("running")).toBe("working");
+  });
+
+  it.each<AgentState>(["idle", "working", "waiting", "directing", "completed", "exited"])(
+    "passes %s through unchanged",
+    (state) => {
+      expect(coerceAgentState(state)).toBe(state);
+    }
+  );
+
+  it("returns undefined for unknown strings", () => {
+    expect(coerceAgentState("banana")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string inputs", () => {
+    expect(coerceAgentState(undefined)).toBeUndefined();
+    expect(coerceAgentState(null)).toBeUndefined();
+    expect(coerceAgentState(42)).toBeUndefined();
+    expect(coerceAgentState({})).toBeUndefined();
+  });
+});
+
+describe("ACTIVE_AGENT_STATES", () => {
+  it("no longer includes the retired 'running' state", () => {
+    expect(ACTIVE_AGENT_STATES.has("running" as AgentState)).toBe(false);
+  });
+
+  it("still covers in-flight states", () => {
+    expect(ACTIVE_AGENT_STATES.has("working")).toBe(true);
+    expect(ACTIVE_AGENT_STATES.has("waiting")).toBe(true);
+    expect(ACTIVE_AGENT_STATES.has("directing")).toBe(true);
+  });
+});

--- a/shared/types/__tests__/agent.test.ts
+++ b/shared/types/__tests__/agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { coerceAgentState, ACTIVE_AGENT_STATES } from "../agent";
-import type { AgentState } from "../agent";
+import { coerceAgentState, ACTIVE_AGENT_STATES } from "../agent.js";
+import type { AgentState } from "../agent.js";
 
 describe("coerceAgentState", () => {
   it("maps the retired 'running' state to 'working'", () => {

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -1,20 +1,32 @@
-/** Agent lifecycle state: idle | working | running | waiting | directing | completed | exited */
-export type AgentState =
-  | "idle"
-  | "working"
-  | "running"
-  | "waiting"
-  | "directing"
-  | "completed"
-  | "exited";
+/** Agent lifecycle state: idle | working | waiting | directing | completed | exited */
+export type AgentState = "idle" | "working" | "waiting" | "directing" | "completed" | "exited";
 
 /** Agent states that indicate in-flight work — used to protect against eviction/hibernation */
 export const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set([
   "working",
-  "running",
   "waiting",
   "directing",
 ]);
+
+const CANONICAL_AGENT_STATES: ReadonlySet<AgentState> = new Set([
+  "idle",
+  "working",
+  "waiting",
+  "directing",
+  "completed",
+  "exited",
+]);
+
+/**
+ * Normalise a possibly-legacy agent state value. The retired "running" state
+ * (a pre-state-machine shell-process signal) collapses to "working"; unknown
+ * values return undefined so callers can decide on a default.
+ */
+export function coerceAgentState(value: unknown): AgentState | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value === "running") return "working";
+  return CANONICAL_AGENT_STATES.has(value as AgentState) ? (value as AgentState) : undefined;
+}
 
 /** Classification of why an agent is in the "waiting" state */
 export type WaitingReason = "prompt" | "question";

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -28,7 +28,7 @@ export type AgentStateChangeTrigger =
   | "title";
 
 /** Agent state */
-export type AgentState = "idle" | "working" | "running" | "waiting" | "completed" | "exited";
+export type AgentState = "idle" | "working" | "waiting" | "directing" | "completed" | "exited";
 
 /** Payload for agent state change events */
 export interface AgentStateChangePayload {

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -519,8 +519,8 @@ describe("FleetArmingRibbon", () => {
       dispatchSpy.mockRestore();
     });
 
-    it("'All working' arms agents in 'running' state alongside 'working'", () => {
-      seed([makeAgent("t1", "working"), makeAgent("t2", "running")]);
+    it("'All working' arms agents in 'working' state", () => {
+      seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
       useFleetArmingStore.getState().armIds(["t1", "t2"]);
       render(<FleetArmingRibbon />);
       fireEvent.click(findMenuItem(/All working — this worktree/));

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -258,10 +258,6 @@ describe("resolveFleetBroadcastTargetIds", () => {
 });
 
 describe("areAgentStatesBroadcastCompatible", () => {
-  it("treats working and running as one group", () => {
-    expect(areAgentStatesBroadcastCompatible("working", "running")).toBe(true);
-    expect(areAgentStatesBroadcastCompatible("running", "working")).toBe(true);
-  });
   it("treats completed and exited as one group", () => {
     expect(areAgentStatesBroadcastCompatible("completed", "exited")).toBe(true);
   });
@@ -305,26 +301,23 @@ describe("resolveFleetBroadcastByOrigin", () => {
       makeAgent("origin", { agentState: "waiting" }),
       makeAgent("peer-waiting", { agentState: "waiting" }),
       makeAgent("peer-working", { agentState: "working" }),
-      makeAgent("peer-running", { agentState: "running" }),
       makeAgent("peer-idle", { agentState: "idle" }),
     ]);
-    useFleetArmingStore
-      .getState()
-      .armIds(["origin", "peer-waiting", "peer-working", "peer-running", "peer-idle"]);
+    useFleetArmingStore.getState().armIds(["origin", "peer-waiting", "peer-working", "peer-idle"]);
     const result = resolveFleetBroadcastByOrigin("origin");
     expect(result.matched).toEqual(["peer-waiting"]);
-    expect(result.diverged.sort()).toEqual(["peer-idle", "peer-running", "peer-working"]);
+    expect(result.diverged.sort()).toEqual(["peer-idle", "peer-working"]);
   });
 
-  it("groups working and running peers when origin is working", () => {
+  it("groups completed and exited peers when origin is completed", () => {
     seedPanels([
-      makeAgent("origin", { agentState: "working" }),
-      makeAgent("peer-running", { agentState: "running" }),
+      makeAgent("origin", { agentState: "completed" }),
+      makeAgent("peer-exited", { agentState: "exited" }),
       makeAgent("peer-waiting", { agentState: "waiting" }),
     ]);
-    useFleetArmingStore.getState().armIds(["origin", "peer-running", "peer-waiting"]);
+    useFleetArmingStore.getState().armIds(["origin", "peer-exited", "peer-waiting"]);
     const result = resolveFleetBroadcastByOrigin("origin");
-    expect(result.matched).toEqual(["peer-running"]);
+    expect(result.matched).toEqual(["peer-exited"]);
     expect(result.diverged).toEqual(["peer-waiting"]);
   });
 

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -91,12 +91,11 @@ export function resolveFleetBroadcastTargetIds(): string[] {
 
 /**
  * Group AgentStates that should accept the same keystroke. Mirrors the
- * grouping in `fleetArmingStore.matchesPreset`: working/running act together,
- * completed/exited as "finished", everything else stays in its own group.
+ * grouping in `fleetArmingStore.matchesPreset`: completed/exited collapse to
+ * "finished", everything else stays in its own group.
  */
 function agentStateGroup(state: AgentState | null | undefined): string {
   if (state == null) return "unknown";
-  if (state === "working" || state === "running") return "active";
   if (state === "completed" || state === "exited") return "finished";
   return state;
 }
@@ -105,9 +104,7 @@ function agentStateGroup(state: AgentState | null | undefined): string {
  * Two states are broadcast-compatible when they sit in the same group. A
  * keystroke typed at a `[y/N]` prompt (waiting) should only fan out to other
  * waiting agents — sending `y` to a vim pane would yank a line, sending it to
- * an active task would inject a stray character. The grouping rule lets a
- * "working" origin still target a "running" peer because their input semantics
- * are identical.
+ * an active task would inject a stray character.
  */
 export function areAgentStatesBroadcastCompatible(
   origin: AgentState | null | undefined,

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -47,7 +47,6 @@ type AgentType = BuiltInAgentId;
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
   "idle",
   "working",
-  "running",
   "waiting",
   "directing",
 ]);

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -71,7 +71,6 @@ type AgentRow = {
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
   "idle",
   "working",
-  "running",
   "waiting",
   "directing",
 ]);

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -385,9 +385,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   }
 
   const isWorking = activePanel.agentState === "working";
-  const isRunning = activePanel.agentState === "running";
   const isWaiting = activePanel.agentState === "waiting";
-  const isActive = isWorking || isRunning || isWaiting;
+  const isActive = isWorking || isWaiting;
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
   const brandColor =
     panelPresetColors.get(activePanel.id) ??

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -218,9 +218,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   ]);
 
   const isWorking = terminal.agentState === "working";
-  const isRunning = terminal.agentState === "running";
   const isWaiting = terminal.agentState === "waiting";
-  const isActive = isWorking || isRunning || isWaiting;
+  const isActive = isWorking || isWaiting;
   const commandText = terminal.activityHeadline || terminal.lastCommand;
   const agentState = terminal.agentState;
   const blockedState = useDockBlockedState(terminal.agentState);

--- a/src/components/Layout/__tests__/useDockBlockedState.test.ts
+++ b/src/components/Layout/__tests__/useDockBlockedState.test.ts
@@ -139,11 +139,6 @@ describe("getGroupAmbientAgentState", () => {
     expect(getGroupAmbientAgentState(panels)).toBe("working");
   });
 
-  it("returns 'working' for running state (treated as working tier)", () => {
-    const panels = [{ agentState: "idle" as const }, { agentState: "running" as const }];
-    expect(getGroupAmbientAgentState(panels)).toBe("working");
-  });
-
   it("returns 'waiting' when waiting outranks working", () => {
     const panels = [{ agentState: "waiting" as const }, { agentState: "working" as const }];
     expect(getGroupAmbientAgentState(panels)).toBe("waiting");
@@ -191,11 +186,6 @@ describe("isGroupDeprioritized", () => {
 
   it("returns false when any panel is working", () => {
     const panels = [{ agentState: "idle" as const }, { agentState: "working" as const }];
-    expect(isGroupDeprioritized(panels)).toBe(false);
-  });
-
-  it("returns false when any panel is running", () => {
-    const panels = [{ agentState: "idle" as const }, { agentState: "running" as const }];
     expect(isGroupDeprioritized(panels)).toBe(false);
   });
 

--- a/src/components/Layout/useDockBlockedState.ts
+++ b/src/components/Layout/useDockBlockedState.ts
@@ -64,7 +64,7 @@ export function getGroupAmbientAgentState(
 
   for (const panel of panels) {
     if (panel.agentState === "waiting") hasWaiting = true;
-    else if (panel.agentState === "working" || panel.agentState === "running") hasWorking = true;
+    else if (panel.agentState === "working") hasWorking = true;
   }
 
   if (hasWaiting) return "waiting";

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -65,6 +65,7 @@ export interface ContentPanelProps extends BasePanelProps {
   isWorking?: boolean;
   agentState?: AgentState;
   activity?: ActivityState | null;
+  activityStatus?: "working" | "waiting" | "success" | "failure";
   lastCommand?: string;
   queueCount?: number;
   flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
@@ -138,6 +139,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     isWorking: _isWorking = false,
     agentState,
     activity,
+    activityStatus,
     lastCommand,
     queueCount = 0,
     flowStatus,
@@ -205,6 +207,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           type={type}
           agentState={agentState}
           activity={activity}
+          activityStatus={activityStatus}
           lastCommand={lastCommand}
           isExited={isExited}
           exitCode={exitCode}
@@ -221,6 +224,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     type,
     agentState,
     activity,
+    activityStatus,
     lastCommand,
     isExited,
     exitCode,

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -430,7 +430,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       let terminalCount = 0;
       let waitingTerminalCount = 0;
       let hasWorkingAgent = false;
-      let hasRunningAgent = false;
       let hasWaitingAgent = false;
       let hasCompletedAgent = false;
       let hasExitedAgent = false;
@@ -440,7 +439,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         if (!t || t.worktreeId !== worktree.id || t.location === "trash") continue;
         terminalCount++;
         if (t.agentState === "working") hasWorkingAgent = true;
-        if (t.agentState === "running") hasRunningAgent = true;
         if (t.agentState === "waiting") {
           hasWaitingAgent = true;
           waitingTerminalCount++;
@@ -470,13 +468,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         waitingTerminalCount,
         lifecycleStage,
         isComplete,
-        hasActiveAgent: hasWorkingAgent || hasRunningAgent,
+        hasActiveAgent: hasWorkingAgent,
       });
 
       map.set(worktree.id, {
         terminalCount,
         hasWorkingAgent,
-        hasRunningAgent,
         hasWaitingAgent,
         hasCompletedAgent,
         hasExitedAgent,
@@ -548,7 +545,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       const derived = derivedMetaMap.get(worktree.id) ?? {
         terminalCount: 0,
         hasWorkingAgent: false,
-        hasRunningAgent: false,
         hasWaitingAgent: false,
         hasCompletedAgent: false,
         hasExitedAgent: false,

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -130,7 +130,7 @@ function TerminalHeaderContentComponent({
   // Show command pill only for plain terminals (not agent terminals)
   // Use kind to distinguish - agent panels have kind="agent"
   const isPlainTerminal = kind === "terminal" || (!kind && type === "terminal");
-  const showCommandPill = isPlainTerminal && agentState === "running" && !!lastCommand;
+  const showCommandPill = isPlainTerminal && flowStatus === "running" && !!lastCommand;
 
   const renderAgentStateChip = () => {
     if (!agentState || agentState === "idle") {
@@ -152,15 +152,13 @@ function TerminalHeaderContentComponent({
         ? "bg-[color-mix(in_oklab,var(--color-state-working)_15%,transparent)] border-state-working/40"
         : agentState === "directing"
           ? "bg-[color-mix(in_oklab,var(--color-category-blue)_15%,transparent)] border-category-blue/40"
-          : agentState === "running"
-            ? "bg-[color-mix(in_oklab,var(--color-status-info)_15%,transparent)] border-status-info/40"
-            : agentState === "completed"
-              ? "bg-[color-mix(in_oklab,var(--color-status-success)_15%,transparent)] border-status-success/40"
-              : agentState === "exited"
-                ? "bg-overlay-soft border-divider"
-                : agentState === "waiting" && waitingReason === "prompt"
-                  ? "bg-[color-mix(in_oklab,var(--color-status-warning)_15%,transparent)] border-status-warning/40"
-                  : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
+          : agentState === "completed"
+            ? "bg-[color-mix(in_oklab,var(--color-status-success)_15%,transparent)] border-status-success/40"
+            : agentState === "exited"
+              ? "bg-overlay-soft border-divider"
+              : agentState === "waiting" && waitingReason === "prompt"
+                ? "bg-[color-mix(in_oklab,var(--color-status-warning)_15%,transparent)] border-status-warning/40"
+                : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
 
     const headline = activity?.headline?.trim() || `Agent ${agentState}`;
     const showConfidence = stateChangeConfidence != null && stateChangeConfidence < 1;

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -47,6 +47,7 @@ export interface TerminalHeaderContentProps {
   type?: TerminalType;
   agentState?: AgentState;
   activity?: ActivityState | null;
+  activityStatus?: "working" | "waiting" | "success" | "failure";
   lastCommand?: string;
   isExited?: boolean;
   exitCode?: number | null;
@@ -72,6 +73,7 @@ function TerminalHeaderContentComponent({
   type,
   agentState,
   activity,
+  activityStatus,
   lastCommand,
   isExited = false,
   exitCode = null,
@@ -130,7 +132,7 @@ function TerminalHeaderContentComponent({
   // Show command pill only for plain terminals (not agent terminals)
   // Use kind to distinguish - agent panels have kind="agent"
   const isPlainTerminal = kind === "terminal" || (!kind && type === "terminal");
-  const showCommandPill = isPlainTerminal && flowStatus === "running" && !!lastCommand;
+  const showCommandPill = isPlainTerminal && activityStatus === "working" && !!lastCommand;
 
   const renderAgentStateChip = () => {
     if (!agentState || agentState === "idle") {

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -28,7 +28,6 @@ vi.mock("@/components/Worktree/terminalStateConfig", () => {
   const STATE_ICONS: Record<string, typeof mockIcon> = {
     working: mockIcon,
     waiting: mockIcon,
-    running: mockIcon,
     directing: mockIcon,
     idle: mockIcon,
     completed: mockIcon,
@@ -36,7 +35,6 @@ vi.mock("@/components/Worktree/terminalStateConfig", () => {
   const STATE_COLORS: Record<string, string> = {
     working: "text-working",
     waiting: "text-waiting",
-    running: "text-running",
     directing: "text-directing",
     idle: "text-idle",
     completed: "text-completed",
@@ -44,7 +42,6 @@ vi.mock("@/components/Worktree/terminalStateConfig", () => {
   const STATE_LABELS: Record<string, string> = {
     working: "working",
     waiting: "waiting",
-    running: "running",
     directing: "directing",
     idle: "idle",
     completed: "done",

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -26,13 +26,6 @@ const STATE_CONFIG: Record<
     label: "working",
     tooltip: "Agent is working on your request",
   },
-  running: {
-    icon: "▶",
-    color: "text-status-info",
-    borderColor: "border-status-info",
-    label: "running",
-    tooltip: "Process is running",
-  },
   waiting: {
     icon: "?",
     color: "text-daintree-bg",
@@ -125,7 +118,6 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
 const STATE_PRIORITY: Record<AgentState, number> = {
   working: 7,
   directing: 6,
-  running: 5,
   completed: 4,
   waiting: 3,
   exited: 2,
@@ -156,7 +148,6 @@ export function getDominantAgentState(states: (AgentState | undefined)[]): Agent
 export function agentStateDotColor(state: AgentState): string {
   switch (state) {
     case "working":
-    case "running":
     case "directing":
       return "bg-state-working";
     case "waiting":

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -324,8 +324,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
   // same `isFleetArmEligible` subset (has PTY, not trash/background) that
   // `armAll`/`armByState` actually arm — otherwise the menu could show an
   // enabled item that silently no-ops (e.g. a background-located waiting
-  // terminal). `working` includes both "working" and "running" to match
-  // `matchesPreset("working")`.
+  // terminal).
   const eligibleAgents = useMemo(
     () => worktreeTerminals.filter(isFleetArmEligible),
     [worktreeTerminals]
@@ -336,8 +335,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
     [eligibleAgents]
   );
   const workingAgentCount = useMemo(
-    () =>
-      eligibleAgents.filter((t) => t.agentState === "working" || t.agentState === "running").length,
+    () => eligibleAgents.filter((t) => t.agentState === "working").length,
     [eligibleAgents]
   );
 
@@ -638,15 +636,9 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         waitingTerminalCount: terminalCounts.byState.waiting,
         lifecycleStage,
         isComplete,
-        hasActiveAgent: terminalCounts.byState.working > 0 || terminalCounts.byState.running > 0,
+        hasActiveAgent: terminalCounts.byState.working > 0,
       }),
-    [
-      terminalCounts.byState.waiting,
-      terminalCounts.byState.working,
-      terminalCounts.byState.running,
-      lifecycleStage,
-      isComplete,
-    ]
+    [terminalCounts.byState.waiting, terminalCounts.byState.working, lifecycleStage, isComplete]
   );
 
   const { setNodeRef, isOver } = useDroppable({

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -112,7 +112,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
             <span className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text">
               {term.title}
             </span>
-            {term.type === "terminal" && term.agentState === "running" && term.lastCommand && (
+            {term.type === "terminal" && term.flowStatus === "running" && term.lastCommand && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="truncate text-[11px] font-mono text-text-muted">

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -112,7 +112,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
             <span className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text">
               {term.title}
             </span>
-            {term.type === "terminal" && term.flowStatus === "running" && term.lastCommand && (
+            {term.type === "terminal" && term.activityStatus === "working" && term.lastCommand && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="truncate text-[11px] font-mono text-text-muted">

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -68,7 +68,7 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
 
 const baseCounts: WorktreeTerminalSectionProps["counts"] = {
   total: 2,
-  byState: { idle: 2, working: 0, running: 0, waiting: 0, directing: 0, completed: 0, exited: 0 },
+  byState: { idle: 2, working: 0, waiting: 0, directing: 0, completed: 0, exited: 0 },
 };
 
 function renderSection(overrides: Partial<WorktreeTerminalSectionProps> = {}) {

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -106,7 +106,6 @@ const GITHUB_OPTIONS: { value: GitHubFilter; label: string }[] = [
 const SESSION_OPTIONS: { value: SessionFilter; label: string }[] = [
   { value: "hasTerminals", label: "Has Terminals" },
   { value: "working", label: "Working" },
-  { value: "running", label: "Running" },
   { value: "waiting", label: "Waiting" },
   { value: "completed", label: "Completed" },
   { value: "exited", label: "Exited" },

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -218,7 +218,6 @@ export function WorktreeOverviewModal({
     for (const worktree of worktrees) {
       let terminalCount = 0;
       let hasWorkingAgent = false;
-      let hasRunningAgent = false;
       let hasWaitingAgent = false;
       let hasCompletedAgent = false;
       let hasExitedAgent = false;
@@ -227,7 +226,6 @@ export function WorktreeOverviewModal({
         if (!t || t.worktreeId !== worktree.id || t.location === "trash") continue;
         terminalCount++;
         if (t.agentState === "working") hasWorkingAgent = true;
-        if (t.agentState === "running") hasRunningAgent = true;
         if (t.agentState === "waiting") hasWaitingAgent = true;
         if (t.agentState === "completed") hasCompletedAgent = true;
         if (t.agentState === "exited") hasExitedAgent = true;
@@ -235,7 +233,6 @@ export function WorktreeOverviewModal({
       map.set(worktree.id, {
         terminalCount,
         hasWorkingAgent,
-        hasRunningAgent,
         hasWaitingAgent,
         hasCompletedAgent,
         hasExitedAgent,
@@ -263,7 +260,7 @@ export function WorktreeOverviewModal({
         continue;
       }
 
-      if (derived.hasWorkingAgent || derived.hasRunningAgent) workingCount++;
+      if (derived.hasWorkingAgent) workingCount++;
       if (derived.hasWaitingAgent) waitingCount++;
     }
 
@@ -296,7 +293,6 @@ export function WorktreeOverviewModal({
       const derived = derivedMetaMap.get(worktree.id) ?? {
         terminalCount: 0,
         hasWorkingAgent: false,
-        hasRunningAgent: false,
         hasWaitingAgent: false,
         hasCompletedAgent: false,
         hasExitedAgent: false,

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -20,7 +20,6 @@ describe("AgentStatusIndicator", () => {
 
   it.each([
     ["working", "⟳"],
-    ["running", "▶"],
     ["completed", "✓"],
     ["exited", "–"],
     ["directing", "✎"],
@@ -84,7 +83,7 @@ describe("AgentStatusIndicator", () => {
     vi.useFakeTimers();
     try {
       const { container, rerender } = render(<AgentStatusIndicator state="working" />);
-      rerender(<AgentStatusIndicator state="running" />);
+      rerender(<AgentStatusIndicator state="directing" />);
       let el = container.querySelector('[role="img"]') as HTMLElement;
       expect(el.className).toContain("animate-agent-pulse");
 
@@ -114,10 +113,10 @@ describe("getDominantAgentState", () => {
   });
 
   it("prefers working over lower-priority states", () => {
-    expect(getDominantAgentState(["idle", "running", "working"])).toBe("working");
+    expect(getDominantAgentState(["idle", "completed", "working"])).toBe("working");
   });
 
-  it("prefers directing over running", () => {
-    expect(getDominantAgentState(["running", "directing"])).toBe("directing");
+  it("prefers directing over completed", () => {
+    expect(getDominantAgentState(["completed", "directing"])).toBe("directing");
   });
 });

--- a/src/components/Worktree/__tests__/terminalStateConfig.test.ts
+++ b/src/components/Worktree/__tests__/terminalStateConfig.test.ts
@@ -29,14 +29,7 @@ describe("getEffectiveStateIcon", () => {
   });
 
   it("returns correct defaults for all states", () => {
-    const states: AgentState[] = [
-      "working",
-      "running",
-      "waiting",
-      "directing",
-      "idle",
-      "completed",
-    ];
+    const states: AgentState[] = ["working", "waiting", "directing", "idle", "completed"];
     for (const state of states) {
       expect(getEffectiveStateIcon(state)).toBe(STATE_ICONS[state]);
     }

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -1,4 +1,4 @@
-import { Play, Circle, CheckCircle2 } from "lucide-react";
+import { Circle, CheckCircle2 } from "lucide-react";
 import type { AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
 import {
@@ -12,7 +12,6 @@ import {
 
 export const STATE_ICONS: Record<AgentState, React.ComponentType<{ className?: string }>> = {
   working: SpinnerCircle,
-  running: Play,
   waiting: HollowCircle,
   directing: InteractingCircle,
   idle: Circle,
@@ -22,7 +21,6 @@ export const STATE_ICONS: Record<AgentState, React.ComponentType<{ className?: s
 
 export const STATE_COLORS: Record<AgentState, string> = {
   working: "text-state-working",
-  running: "text-status-info",
   waiting: "text-state-waiting",
   directing: "text-category-blue",
   idle: "text-daintree-text/40",
@@ -32,7 +30,6 @@ export const STATE_COLORS: Record<AgentState, string> = {
 
 export const STATE_LABELS: Record<AgentState, string> = {
   working: "working",
-  running: "running",
   idle: "idle",
   waiting: "waiting",
   directing: "directing",
@@ -44,7 +41,6 @@ export const STATE_PRIORITY: AgentState[] = [
   "working",
   "directing",
   "waiting",
-  "running",
   "completed",
   "exited",
   "idle",
@@ -54,10 +50,9 @@ export const STATE_SORT_PRIORITY: Record<AgentState, number> = {
   working: 0,
   directing: 1,
   waiting: 2,
-  running: 3,
-  idle: 4,
-  completed: 5,
-  exited: 6,
+  idle: 3,
+  completed: 4,
+  exited: 5,
 };
 
 export function getEffectiveStateIcon(

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -17,7 +17,6 @@ function calculateWorktreeCounts(terminals: TerminalInstance[], worktreeId: stri
   const byState: Record<AgentState, number> = {
     idle: 0,
     working: 0,
-    running: 0,
     waiting: 0,
     directing: 0,
     completed: 0,
@@ -47,7 +46,6 @@ describe("useWorktreeTerminals logic", () => {
     expect(result.counts.byState).toEqual({
       idle: 0,
       working: 0,
-      running: 0,
       waiting: 0,
       directing: 0,
       completed: 0,
@@ -262,7 +260,7 @@ describe("useWorktreeTerminals logic", () => {
     expect(result.counts.byState.completed).toBe(1);
   });
 
-  it("counts shell terminals in running state", () => {
+  it("counts shell terminals with mixed agent states", () => {
     const terminals: TerminalInstance[] = [
       {
         id: "term-1",
@@ -273,7 +271,7 @@ describe("useWorktreeTerminals logic", () => {
         cols: 80,
         rows: 24,
         location: "grid",
-        agentState: "running",
+        agentState: "working",
       },
       {
         id: "term-2",
@@ -291,7 +289,7 @@ describe("useWorktreeTerminals logic", () => {
     const result = calculateWorktreeCounts(terminals, "worktree-1");
 
     expect(result.counts.total).toBe(2);
-    expect(result.counts.byState.running).toBe(1);
+    expect(result.counts.byState.working).toBe(1);
     expect(result.counts.byState.idle).toBe(1);
   });
 });

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -15,7 +15,6 @@ function getAgentStateMessage(
 ): { msg: string; priority: "polite" | "assertive" } | null {
   switch (newState) {
     case "working":
-    case "running":
       return { msg: `${title} is working`, priority: "polite" };
     case "waiting":
       return { msg: `${title} is waiting for input`, priority: "polite" };

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -56,7 +56,6 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
     const byState: Record<AgentState, number> = {
       idle: 0,
       working: 0,
-      running: 0,
       waiting: 0,
       directing: 0,
       completed: 0,

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -39,7 +39,6 @@ const createEmptyFilters = (): FilterState => ({
 const createEmptyMeta = (): DerivedWorktreeMeta => ({
   terminalCount: 0,
   hasWorkingAgent: false,
-  hasRunningAgent: false,
   hasWaitingAgent: false,
   hasCompletedAgent: false,
   hasExitedAgent: false,
@@ -1220,11 +1219,6 @@ describe("matchesQuickStateFilter", () => {
 
   it('"working" matches when hasWorkingAgent and chipState is null', () => {
     const meta = { ...createEmptyMeta(), hasWorkingAgent: true, chipState: null };
-    expect(matchesQuickStateFilter("working", meta)).toBe(true);
-  });
-
-  it('"working" matches when hasRunningAgent and chipState is null', () => {
-    const meta = { ...createEmptyMeta(), hasRunningAgent: true, chipState: null };
     expect(matchesQuickStateFilter("working", meta)).toBe(true);
   });
 

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -33,7 +33,6 @@ function buildDerivedMeta(
   let terminalCount = 0;
   let waitingTerminalCount = 0;
   let hasWorkingAgent = false;
-  let hasRunningAgent = false;
   let hasWaitingAgent = false;
   let hasCompletedAgent = false;
   let hasExitedAgent = false;
@@ -43,7 +42,6 @@ function buildDerivedMeta(
     if (!t || t.worktreeId !== worktree.id || t.location === "trash") continue;
     terminalCount++;
     if (t.agentState === "working") hasWorkingAgent = true;
-    if (t.agentState === "running") hasRunningAgent = true;
     if (t.agentState === "waiting") {
       hasWaitingAgent = true;
       waitingTerminalCount++;
@@ -72,13 +70,12 @@ function buildDerivedMeta(
     waitingTerminalCount,
     lifecycleStage,
     isComplete,
-    hasActiveAgent: hasWorkingAgent || hasRunningAgent,
+    hasActiveAgent: hasWorkingAgent,
   });
 
   return {
     terminalCount,
     hasWorkingAgent,
-    hasRunningAgent,
     hasWaitingAgent,
     hasCompletedAgent,
     hasExitedAgent,

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -14,7 +14,6 @@ import type { ChipState } from "@/components/Worktree/utils/computeChipState";
 export interface DerivedWorktreeMeta {
   terminalCount: number;
   hasWorkingAgent: boolean;
-  hasRunningAgent: boolean;
   hasWaitingAgent: boolean;
   hasCompletedAgent: boolean;
   hasExitedAgent: boolean;
@@ -32,7 +31,7 @@ export function matchesQuickStateFilter(
     case "all":
       return true;
     case "working":
-      return (meta.hasWorkingAgent || meta.hasRunningAgent) && meta.chipState === null;
+      return meta.hasWorkingAgent && meta.chipState === null;
     case "waiting":
       return meta.chipState === "waiting";
     case "finished":
@@ -192,7 +191,6 @@ export function matchesFilters(
 
     if (filters.sessionFilters.has("hasTerminals") && derived.terminalCount > 0) hasMatch = true;
     if (filters.sessionFilters.has("working") && derived.hasWorkingAgent) hasMatch = true;
-    if (filters.sessionFilters.has("running") && derived.hasRunningAgent) hasMatch = true;
     if (filters.sessionFilters.has("waiting") && derived.hasWaitingAgent) hasMatch = true;
     if (filters.sessionFilters.has("completed") && derived.hasCompletedAgent) hasMatch = true;
     if (filters.sessionFilters.has("exited") && derived.hasExitedAgent) hasMatch = true;

--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -68,7 +68,6 @@ const exitBehaviorArb = fc.constantFrom(
 const agentStateArb = fc.constantFrom(
   "idle" as const,
   "working" as const,
-  "running" as const,
   "waiting" as const,
   "directing" as const,
   "completed" as const,

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -244,11 +244,11 @@ describe("fleet actions — threshold confirmation", () => {
     dispatchSpy.mockRestore();
   });
 
-  it("fleet.interrupt only targets working/waiting/running agents", async () => {
+  it("fleet.interrupt only targets working/waiting agents", async () => {
     seedPanels([
       makeAgent("a", { agentState: "working" }),
       makeAgent("b", { agentState: "waiting" }),
-      makeAgent("c", { agentState: "running" }),
+      makeAgent("c", { agentState: "working" }),
       makeAgent("d", { agentState: "completed" }),
       makeAgent("e", { agentState: "idle" }),
     ]);

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -45,7 +45,7 @@ function snapshotArmed(): ArmedSnapshot {
     // Interrupt only makes sense for agents that are actually doing
     // something — sending ESC ESC to a completed/idle/exited agent is
     // either a no-op or a spurious keystroke.
-    if (t.agentState === "working" || t.agentState === "running" || t.agentState === "waiting") {
+    if (t.agentState === "working" || t.agentState === "waiting") {
       interruptCandidates.push(t);
     }
     if (t.agentSessionId) sessionLossCount++;

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -135,7 +135,7 @@ describe("fleetArmingStore", () => {
     beforeEach(() => {
       seedPanels([
         makeAgentTerminal("t1", { agentState: "working" }),
-        makeAgentTerminal("t2", { agentState: "running" }),
+        makeAgentTerminal("t2", { agentState: "working" }),
         makeAgentTerminal("t3", { agentState: "waiting" }),
         makeAgentTerminal("t4", { agentState: "completed" }),
         makeAgentTerminal("t5", { agentState: "exited" }),
@@ -145,7 +145,7 @@ describe("fleetArmingStore", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
     });
 
-    it("arms working+running for 'working' preset in current scope", () => {
+    it("arms only 'working' agents for 'working' preset in current scope", () => {
       useFleetArmingStore.getState().armByState("working", "current", false);
       const s = useFleetArmingStore.getState();
       expect([...s.armedIds].sort()).toEqual(["t1", "t2"]);

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -406,6 +406,53 @@ describe("worktreeFilterStore persistence scoping", () => {
     expect(parsed.state.hideMainWorktree).toBe(true);
   });
 
+  it('strips retired "running" session filter from pre-v1 scoped blobs (issue #5810)', async () => {
+    const scopedBlob = JSON.stringify({
+      state: {
+        query: "",
+        statusFilters: [],
+        typeFilters: [],
+        githubFilters: [],
+        sessionFilters: ["running", "waiting"],
+        activityFilters: [],
+        pinnedWorktrees: [],
+        collapsedWorktrees: [],
+        manualOrder: [],
+      },
+      version: 0,
+    });
+
+    installLocalStorage({
+      getItem: (key) => (key === PROJECT_KEY ? scopedBlob : null),
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    expect([...store.getState().sessionFilters]).toEqual(["waiting"]);
+  });
+
+  it('strips retired "running" from sessionFilters recovered from the legacy global seed', async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        sessionFilters: ["running", "working"],
+        pinnedWorktrees: ["wt-pin"],
+      },
+    });
+
+    installLocalStorage({
+      getItem: (key) => (key === GLOBAL_KEY ? legacyBlob : null),
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    expect([...store.getState().sessionFilters].sort()).toEqual(["working"]);
+    expect(store.getState().pinnedWorktrees).toEqual(["wt-pin"]);
+  });
+
   it("isolates per-project pins across different projectIds in the URL", async () => {
     // Shared localStorage across both project loads — backing key-value store
     // persists through module resets, just like real localStorage does.

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -40,7 +40,7 @@ function rebuildOrderById(order: string[]): Record<string, number> {
 function matchesPreset(state: AgentState | null | undefined, preset: FleetArmStatePreset): boolean {
   switch (preset) {
     case "working":
-      return state === "working" || state === "running";
+      return state === "working";
     case "waiting":
       return state === "waiting";
     case "finished":

--- a/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
+++ b/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
@@ -72,12 +72,6 @@ describe("TerminalCommandQueueSlice", () => {
       expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
     });
 
-    it("should write user input immediately when agent is running", () => {
-      mockTerminal.agentState = "running";
-      state.queueCommand("test-terminal", "test data", "test description", "user");
-      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
-    });
-
     it("should write user input immediately when agent is waiting", () => {
       mockTerminal.agentState = "waiting";
       state.queueCommand("test-terminal", "test data", "test description", "user");
@@ -122,8 +116,8 @@ describe("TerminalCommandQueueSlice", () => {
       expect(terminalClient.write).not.toHaveBeenCalled();
     });
 
-    it("should queue automation input when agent is running", () => {
-      mockTerminal.agentState = "running";
+    it("should queue automation input when agent is directing", () => {
+      mockTerminal.agentState = "directing";
       state.queueCommand("test-terminal", "test data", "test description", "automation");
       expect(terminalClient.write).not.toHaveBeenCalled();
     });

--- a/src/store/slices/terminalCommandQueueSlice.ts
+++ b/src/store/slices/terminalCommandQueueSlice.ts
@@ -122,10 +122,10 @@ export const createTerminalCommandQueueSlice =
  * IMPORTANT: This function gates automation input (context injection, scripted commands)
  * to avoid interleaving with active TUI redraws. User input (keystrokes, Ctrl+C, prompt
  * responses) must NEVER be gated by agent state - it should always write immediately
- * via terminalClient.write(), regardless of working/running/waiting states.
+ * via terminalClient.write(), regardless of working/waiting states.
  *
  * User input invariant: terminal.onData → terminalClient.write (unconditional)
- * Automation input: may queue during working/running, flushes on idle/waiting
+ * Automation input: may queue during working, flushes on idle/waiting
  */
 export function isAgentReady(state: AgentState | undefined): boolean {
   return state === "idle" || state === "waiting";

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -28,13 +28,7 @@ export type TypeFilter =
   | "detached"
   | "other";
 export type GitHubFilter = "hasIssue" | "hasPR" | "prOpen" | "prMerged" | "prClosed";
-export type SessionFilter =
-  | "hasTerminals"
-  | "working"
-  | "running"
-  | "waiting"
-  | "completed"
-  | "exited";
+export type SessionFilter = "hasTerminals" | "working" | "waiting" | "completed" | "exited";
 export type ActivityFilter = "last15m" | "last1h" | "last24h" | "last7d";
 
 interface WorktreeFilterState {
@@ -179,6 +173,18 @@ function arrayOrUndefined<T>(value: unknown): T[] | undefined {
 }
 
 /**
+ * Strip the retired "running" session filter from a persisted list. The
+ * adjacent "working" option semantically covers its former intent — see
+ * issue #5810.
+ */
+function stripLegacySessionFilters(
+  values: SessionFilter[] | undefined
+): SessionFilter[] | undefined {
+  if (!values) return undefined;
+  return values.filter((v) => (v as string) !== "running");
+}
+
+/**
  * One-time migration seed: when the per-project key does not yet exist (or is
  * unparseable), but a legacy combined blob is present under the global key,
  * copy the per-project fields out of it so existing pins/order survive the
@@ -219,7 +225,9 @@ function loadLegacySeedForProject(): Partial<ProjectPersistedShape> {
     statusFilters: arrayOrUndefined<StatusFilter>(state.statusFilters),
     typeFilters: arrayOrUndefined<TypeFilter>(state.typeFilters),
     githubFilters: arrayOrUndefined<GitHubFilter>(state.githubFilters),
-    sessionFilters: arrayOrUndefined<SessionFilter>(state.sessionFilters),
+    sessionFilters: stripLegacySessionFilters(
+      arrayOrUndefined<SessionFilter>(state.sessionFilters)
+    ),
     activityFilters: arrayOrUndefined<ActivityFilter>(state.activityFilters),
     pinnedWorktrees: arrayOrUndefined<string>(state.pinnedWorktrees),
     collapsedWorktrees: arrayOrUndefined<string>(state.collapsedWorktrees),
@@ -299,6 +307,7 @@ const _projectStore = create<ProjectScopedState>()(
     }),
     {
       name: PROJECT_KEY,
+      version: 1,
       storage: createSafeJSONStorage(),
       partialize: (state): ProjectPersistedShape => ({
         query: state.query,
@@ -311,15 +320,27 @@ const _projectStore = create<ProjectScopedState>()(
         collapsedWorktrees: state.collapsedWorktrees,
         manualOrder: state.manualOrder,
       }),
+      migrate: (persistedState, version) => {
+        // v1 retires the "running" SessionFilter (#5810). Strip any stale
+        // entries from pre-v1 blobs so the Set coercion in `merge` doesn't
+        // restore a filter the UI no longer exposes.
+        if (version < 1) {
+          const legacy = (persistedState ?? {}) as Partial<ProjectPersistedShape>;
+          const cleaned = stripLegacySessionFilters(legacy.sessionFilters);
+          return { ...legacy, sessionFilters: cleaned } as ProjectPersistedShape;
+        }
+        return persistedState as ProjectPersistedShape;
+      },
       merge: (persisted, current) => {
         const p = persisted as Partial<ProjectPersistedShape> | undefined;
+        const persistedSessionFilters = stripLegacySessionFilters(p?.sessionFilters);
         return {
           ...current,
           query: p?.query ?? current.query,
           statusFilters: new Set(p?.statusFilters ?? Array.from(current.statusFilters)),
           typeFilters: new Set(p?.typeFilters ?? Array.from(current.typeFilters)),
           githubFilters: new Set(p?.githubFilters ?? Array.from(current.githubFilters)),
-          sessionFilters: new Set(p?.sessionFilters ?? Array.from(current.sessionFilters)),
+          sessionFilters: new Set(persistedSessionFilters ?? Array.from(current.sessionFilters)),
           activityFilters: new Set(p?.activityFilters ?? Array.from(current.activityFilters)),
           pinnedWorktrees: p?.pinnedWorktrees ?? current.pinnedWorktrees,
           collapsedWorktrees: p?.collapsedWorktrees ?? current.collapsedWorktrees,

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -78,6 +78,7 @@ export function buildPanelProps({
       terminal.activityStatus,
       terminal.activityType
     ),
+    activityStatus: terminal.activityStatus,
     lastCommand: terminal.lastCommand,
     flowStatus: terminal.flowStatus,
     restartKey: terminal.restartKey,

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -298,6 +298,21 @@ describe("buildArgsForBackendTerminal", () => {
     );
     expect(result.worktreeId).toBeUndefined();
   });
+
+  it('remaps the retired agentState "running" to "working" (issue #5810)', () => {
+    const result = buildArgsForBackendTerminal(
+      {
+        id: "t1",
+        cwd: "/p",
+        kind: "terminal",
+        title: "Shell",
+        agentState: "running" as never,
+      },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.agentState).toBe("working");
+  });
 });
 
 describe("buildArgsForReconnectedFallback", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -343,6 +343,21 @@ describe("buildArgsForReconnectedFallback", () => {
     expect(result.worktreeId).toBe("wt-dragged");
   });
 
+  it('remaps the retired agentState "running" to "working" (issue #5810)', () => {
+    const result = buildArgsForReconnectedFallback(
+      {
+        id: "t1",
+        cwd: "/p",
+        kind: "terminal",
+        title: "Shell",
+        agentState: "running" as never,
+      },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.agentState).toBe("working");
+  });
+
   it("returns undefined worktreeId when saved has none", () => {
     const result = buildArgsForReconnectedFallback(
       { id: "t1", cwd: "/p", kind: "terminal", title: "Shell" },
@@ -948,6 +963,20 @@ describe("buildArgsForOrphanedTerminal", () => {
   it("falls back to projectRoot when cwd is empty", () => {
     const result = buildArgsForOrphanedTerminal({ id: "t1", cwd: "", title: "Test" }, "/project");
     expect(result.cwd).toBe("/project");
+  });
+
+  it('remaps the retired agentState "running" to "working" (issue #5810)', () => {
+    const result = buildArgsForOrphanedTerminal(
+      {
+        id: "t1",
+        cwd: "/p",
+        kind: "terminal",
+        title: "Shell",
+        agentState: "running" as never,
+      },
+      "/p"
+    );
+    expect(result.agentState).toBe("working");
   });
 
   it("preserves agentLaunchFlags and agentModelId from backend", () => {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -1,4 +1,5 @@
 import type { PanelKind, TerminalType, AgentState } from "@/types";
+import { coerceAgentState } from "@shared/types/agent";
 import type { BrowserHistory } from "@shared/types/browser";
 import type { PanelExitBehavior } from "@shared/types/panel";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
@@ -200,7 +201,7 @@ export function buildArgsForBackendTerminal(
     worktreeId: saved.worktreeId,
     location,
     existingId: backendTerminal.id,
-    agentState: backendTerminal.agentState,
+    agentState: coerceAgentState(backendTerminal.agentState),
     lastStateChange: backendTerminal.lastStateChange,
     devCommand,
     browserUrl: isDevPreview ? saved.browserUrl : undefined,
@@ -256,7 +257,7 @@ export function buildArgsForReconnectedFallback(
     worktreeId: saved.worktreeId,
     location,
     existingId: reconnectedTerminal.id,
-    agentState: reconnectedTerminal.agentState,
+    agentState: coerceAgentState(reconnectedTerminal.agentState),
     lastStateChange: reconnectedTerminal.lastStateChange,
     devCommand,
     browserUrl: isDevPreview ? saved.browserUrl : undefined,
@@ -476,7 +477,7 @@ export function buildArgsForOrphanedTerminal(
     cwd,
     location: "grid",
     existingId: terminal.id,
-    agentState: terminal.agentState,
+    agentState: coerceAgentState(terminal.agentState),
     lastStateChange: terminal.lastStateChange,
     agentSessionId: terminal.agentSessionId,
     agentLaunchFlags: terminal.agentLaunchFlags,


### PR DESCRIPTION
## Summary

- Removes `running` from the `AgentState` union and every consumer across PTY services, renderer stores, fleet counters, tray labels, and stats surfaces. The state was no longer emitted in any real production path, leaving downstream branches dead or subtly wrong.
- Adds a `statePatcher` migration so persisted sessions that still carry `running` are coerced to `working` on load. Crash-recovery coercion and schema-level canonicalisation also handle the same case.
- Updates all affected tests to assert canonical states, and adds new unit tests for the patcher, schema coercion, and `worktreeFilterStore` to cover the migration path.

Resolves #5810

## Changes

- `shared/types/agent.ts` — `running` removed from the union; `ACTIVE_AGENT_STATES` and `WORKING_AGENT_STATES` sets updated
- `electron/services/AgentStateMachine.ts` / `CrashRecoveryService.ts` / `IdleTerminalNotificationService.ts` / `PowerSaveBlockerService.ts` / `ProjectStatsService.ts` — all `running` branches folded into `working`
- `electron/schemas/agent.ts` — `z.literal("running")` removed; Zod schema now rejects stale values cleanly
- `src/utils/stateHydration/statePatcher.ts` — migration rule added that rewrites `running → working` in persisted panel state
- Renderer components (AgentStatusIndicator, WorktreeCard, TerminalHeaderContent, AgentButton, AgentTrayButton, fleetBroadcast, worktreeFilters, worktreeCyclingOrder, etc.) — all `running` references removed
- 58 files changed; 49 in the initial refactor commit, 10 in a follow-up addressing review findings (three missed backend services, `showCommandPill` rewire, crash-recovery coercion, schema tests), and 3 fixing AgentNotificationService test assertions

## Testing

- `npm run check` passes cleanly (0 errors, warnings are pre-existing and unrelated)
- New unit tests: `shared/types/__tests__/agent.test.ts`, `electron/schemas/__tests__/agent.test.ts`, `src/utils/stateHydration/__tests__/statePatcher.test.ts`, `src/store/__tests__/worktreeFilterStore.test.ts`
- Existing tests updated to assert `working` instead of `running` where appropriate
- Grep for `"running"` (agent-state context) returns no production code hits; test fixtures asserting migration coercion are the only remaining occurrences