### PR TITLE
fix(terminal): replace fixed shell-command delay with event-driven readiness contract

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -85,12 +85,20 @@ function createEmitterPtyClient() {
   });
 }
 
+/**
+ * Drain pending microtasks interleaved with fake-timer advances. Resolving a
+ * Promise from a timer callback queues a microtask that cannot be flushed by
+ * `vi.advanceTimersByTimeAsync` alone, so `.then(...)` bodies (the command
+ * write) may still be pending after the last timer fires. Alternating timer
+ * advances with `await Promise.resolve()` flushes them deterministically.
+ */
+async function flush(ms = 0) {
+  await vi.advanceTimersByTimeAsync(ms);
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("agent command injection via stdin write", () => {
-  // Under the new "terminals are the unit" model, agent terminals spawn a
-  // plain interactive shell and the agent command is written to stdin after
-  // a short delay — identical to non-agent terminals. This keeps the shell
-  // alive after the agent exits, so Ctrl+C Ctrl+C out of claude no longer
-  // kills the PTY; the shell reclaims the foreground instead.
   const project = { id: "proj-id", name: "Project", path: process.cwd() };
   const originalPlatform = process.platform;
 
@@ -98,7 +106,7 @@ describe("agent command injection via stdin write", () => {
   let cleanup: (() => void) | undefined;
 
   beforeEach(() => {
-    vi.useRealTimers();
+    vi.useFakeTimers();
     vi.clearAllMocks();
     Object.defineProperty(process, "platform", { value: "linux" });
     ptyClient = createEmitterPtyClient();
@@ -112,9 +120,10 @@ describe("agent command injection via stdin write", () => {
     Object.defineProperty(process, "platform", { value: originalPlatform });
     cleanup?.();
     ptyClient.removeAllListeners();
+    vi.useRealTimers();
   });
 
-  it("spawns agent terminal as plain interactive shell and writes command to stdin", async () => {
+  it("waits for a prompt before injecting the agent command", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     cleanup = registerTerminalLifecycleHandlers(deps);
     const handler = getSpawnHandler();
@@ -129,24 +138,25 @@ describe("agent command injection via stdin write", () => {
 
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    // No more -lic "exec ..." — the shell is spawned with default args so
-    // it survives the agent exit.
     expect(spawnArgs.args).toBeUndefined();
+    const id = ptyClient.spawn.mock.calls[0][0];
 
-    // After the settle delay, a clear-screen preamble + the agent command
-    // land on stdin. The shell forks the agent as a child process.
-    await vi.waitFor(
-      () => {
-        expect(ptyClient.write).toHaveBeenCalledTimes(2);
-      },
-      { timeout: 500 }
-    );
+    // No prompt yet → no write.
+    await flush(50);
+    expect(ptyClient.write).not.toHaveBeenCalled();
+
+    ptyClient.emit("data", id, "$ ");
+    await flush(199);
+    expect(ptyClient.write).not.toHaveBeenCalled();
+
+    await flush(1);
+    expect(ptyClient.write).toHaveBeenCalledTimes(2);
     const writes = ptyClient.write.mock.calls.map((c) => c[1] as string);
-    expect(writes[0]).toContain("\\x1b[2J"); // clear-screen preamble
+    expect(writes[0]).toContain("\\x1b[2J");
     expect(writes[1]).toBe("claude --dangerously-skip-permissions\r");
   });
 
-  it("non-agent terminal with command uses delayed stdin write (no clear preamble)", async () => {
+  it("tolerates a slow shell (1200ms RC delay) before the first prompt", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     cleanup = registerTerminalLifecycleHandlers(deps);
     const handler = getSpawnHandler();
@@ -157,18 +167,45 @@ describe("agent command injection via stdin write", () => {
       command: "ls -la",
     });
 
+    const id = ptyClient.spawn.mock.calls[0][0];
+
+    ptyClient.emit("data", id, "loading nvm...\r\n");
+    await flush(600);
+    ptyClient.emit("data", id, "sourcing ~/.zshrc...\r\n");
+    await flush(600);
     expect(ptyClient.write).not.toHaveBeenCalled();
 
-    await vi.waitFor(
-      () => {
-        expect(ptyClient.write).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 500 }
-    );
+    ptyClient.emit("data", id, "$ ");
+    await flush(200);
+    expect(ptyClient.write).toHaveBeenCalledTimes(1);
     expect(ptyClient.write.mock.calls[0][1]).toBe("ls -la\r");
   });
 
-  it("Windows agent terminal writes command to stdin without clear preamble", async () => {
+  it("handles p10k-style two-phase prompt by resetting quiescence", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    cleanup = registerTerminalLifecycleHandlers(deps);
+    const handler = getSpawnHandler();
+
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cols: 80,
+      rows: 24,
+      command: "echo hi",
+    });
+
+    const id = ptyClient.spawn.mock.calls[0][0];
+
+    ptyClient.emit("data", id, "❯ "); // instant prompt
+    await flush(100);
+    ptyClient.emit("data", id, "\r\n❯ "); // real prompt redraw
+    await flush(100);
+    expect(ptyClient.write).not.toHaveBeenCalled();
+
+    await flush(100);
+    expect(ptyClient.write).toHaveBeenCalledTimes(1);
+    expect(ptyClient.write.mock.calls[0][1]).toBe("echo hi\r");
+  });
+
+  it("Windows agent terminal writes command without clear preamble once shell is ready", async () => {
     Object.defineProperty(process, "platform", { value: "win32" });
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
@@ -183,17 +220,52 @@ describe("agent command injection via stdin write", () => {
       command: "claude",
     });
 
-    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.args).toBeUndefined();
+    const id = ptyClient.spawn.mock.calls[0][0];
 
-    await vi.waitFor(
-      () => {
-        expect(ptyClient.write).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 500 }
-    );
-    // No `; exit` suffix anymore — we want the shell to survive the agent.
+    ptyClient.emit("data", id, "> ");
+    await flush(200);
+    expect(ptyClient.write).toHaveBeenCalledTimes(1);
     expect(ptyClient.write.mock.calls[0][1]).toBe("claude\r");
+  });
+
+  it("skips write when terminal is killed mid-wait", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    cleanup = registerTerminalLifecycleHandlers(deps);
+    const handler = getSpawnHandler();
+
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cols: 80,
+      rows: 24,
+      kind: "terminal",
+      agentId: "claude",
+      command: "claude",
+    });
+
+    const id = ptyClient.spawn.mock.calls[0][0];
+
+    ptyClient.hasTerminal.mockReturnValue(false);
+    ptyClient.emit("exit", id, 0);
+    await flush(0);
+
+    expect(ptyClient.write).not.toHaveBeenCalled();
+    expect(ptyClient.listenerCount("data")).toBe(0);
+    expect(ptyClient.listenerCount("exit")).toBe(0);
+  });
+
+  it("injects the command via timeout fallback when no prompt ever appears", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    cleanup = registerTerminalLifecycleHandlers(deps);
+    const handler = getSpawnHandler();
+
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cols: 80,
+      rows: 24,
+      command: "ls",
+    });
+
+    await flush(10_000);
+    expect(ptyClient.write).toHaveBeenCalledTimes(1);
+    expect(ptyClient.write.mock.calls[0][1]).toBe("ls\r");
   });
 
   it("rejects multi-line commands for agent terminals", async () => {
@@ -214,12 +286,16 @@ describe("agent command injection via stdin write", () => {
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.args).toBeUndefined();
-    // Multi-line commands don't get written to stdin either.
+
+    // Multi-line commands don't get written to stdin; no listeners registered.
+    await flush(10_000);
     expect(ptyClient.write).not.toHaveBeenCalled();
+    expect(ptyClient.listenerCount("data")).toBe(0);
+    expect(ptyClient.listenerCount("exit")).toBe(0);
     consoleSpy.mockRestore();
   });
 
-  it("does not register data/exit listeners for agent terminals", async () => {
+  it("does not register listeners for terminals spawned without a command", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     cleanup = registerTerminalLifecycleHandlers(deps);
     const handler = getSpawnHandler();
@@ -227,12 +303,10 @@ describe("agent command injection via stdin write", () => {
     await handler({} as Electron.IpcMainInvokeEvent, {
       cols: 80,
       rows: 24,
-      kind: "terminal",
-      agentId: "gemini",
-      command: "gemini chat",
     });
 
     expect(ptyClient.listenerCount("data")).toBe(0);
     expect(ptyClient.listenerCount("exit")).toBe(0);
+    expect(ptyClient.write).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/shellReady.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { waitForShellReady } from "../shellReady.js";
+
+function createEmitterPtyClient() {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    hasTerminal: vi.fn(() => true),
+  });
+}
+
+async function flush(ms = 0) {
+  await vi.advanceTimersByTimeAsync(ms);
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("waitForShellReady", () => {
+  let ptyClient: ReturnType<typeof createEmitterPtyClient>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ptyClient = createEmitterPtyClient();
+  });
+
+  afterEach(() => {
+    ptyClient.removeAllListeners();
+    vi.useRealTimers();
+  });
+
+  it("resolves after quiescence once a prompt character is observed", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(199);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await flush(1);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores data for other terminals", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1", { timeoutMs: 1000 }).then(resolved);
+
+    ptyClient.emit("data", "t2", "$ ");
+    await flush(500);
+    expect(resolved).not.toHaveBeenCalled();
+
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets quiescence when new data arrives after the first prompt", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "❯ "); // p10k instant prompt
+    await flush(150);
+    expect(resolved).not.toHaveBeenCalled();
+
+    ptyClient.emit("data", "t1", "\r\n❯ "); // real prompt redraw
+    await flush(150);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await flush(50);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits past arbitrary RC-file output before the first prompt", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "loading nvm...\r\n");
+    await flush(500);
+    ptyClient.emit("data", "t1", "sourcing zshrc...\r\n");
+    await flush(800);
+    expect(resolved).not.toHaveBeenCalled();
+
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves on exit so the caller can skip the write", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("exit", "t1", 0);
+    await flush(0);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves on hard timeout when no prompt ever appears", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1", { timeoutMs: 5000 }).then(resolved);
+
+    await flush(4999);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await flush(1);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes all listeners on every resolution path", async () => {
+    const p1 = waitForShellReady(ptyClient, "t1");
+    const p2 = waitForShellReady(ptyClient, "t2", { timeoutMs: 1000 });
+    const p3 = waitForShellReady(ptyClient, "t3");
+
+    // Happy path
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(200);
+    await p1;
+
+    // Timeout path
+    await flush(1000);
+    await p2;
+
+    // Exit path
+    ptyClient.emit("exit", "t3", 0);
+    await flush(0);
+    await p3;
+
+    expect(ptyClient.listenerCount("data")).toBe(0);
+    expect(ptyClient.listenerCount("exit")).toBe(0);
+  });
+
+  it("detects prompt characters even when preceded by other output in the same chunk", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "welcome\r\n$ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips ANSI escapes before matching the prompt", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    // colored prompt with ANSI wrap
+    ptyClient.emit("data", "t1", "\x1b[32m$\x1b[0m ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cross-inject between concurrent terminals", async () => {
+    const r1 = vi.fn();
+    const r2 = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(r1);
+    waitForShellReady(ptyClient, "t2").then(r2);
+
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(200);
+    expect(r1).toHaveBeenCalledTimes(1);
+    expect(r2).not.toHaveBeenCalled();
+
+    ptyClient.emit("data", "t2", "$ ");
+    await flush(200);
+    expect(r2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/shellReady.test.ts
@@ -146,6 +146,63 @@ describe("waitForShellReady", () => {
     expect(resolved).toHaveBeenCalledTimes(1);
   });
 
+  it("detects prompts separated by a carriage return only (no newline)", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "checking env...\r$ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches common bash-style `user@host dir $` prompts", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "\r\ngpriday@studio ~/project $ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("matches oh-my-zsh arrow-theme prompts", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "\r\n➜  project git:(main) ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not false-positive on RC output that contains a prompt character mid-line", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1", { timeoutMs: 2000 }).then(resolved);
+
+    ptyClient.emit("data", "t1", "# loading plugin foo\r\n");
+    ptyClient.emit("data", "t1", "error: $VAR not set\r\n");
+    await flush(500);
+    expect(resolved).not.toHaveBeenCalled();
+
+    // Real prompt arrives after the noise — that's what resolves.
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(200);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("short-circuits via exit even when quiescence timer is running", async () => {
+    const resolved = vi.fn();
+    waitForShellReady(ptyClient, "t1").then(resolved);
+
+    ptyClient.emit("data", "t1", "$ ");
+    await flush(100); // inside 200ms quiescence
+    expect(resolved).not.toHaveBeenCalled();
+
+    ptyClient.emit("exit", "t1", 0);
+    await flush(0);
+    expect(resolved).toHaveBeenCalledTimes(1);
+    expect(ptyClient.listenerCount("data")).toBe(0);
+    expect(ptyClient.listenerCount("exit")).toBe(0);
+  });
+
   it("does not cross-inject between concurrent terminals", async () => {
     const r1 = vi.fn();
     const r2 = vi.fn();

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -14,8 +14,7 @@ import {
   listAgentSessions,
   clearAgentSessions,
 } from "../../../services/pty/agentSessionHistory.js";
-
-export const COMMAND_DELAY_MS = 100;
+import { waitForShellReady } from "./shellReady.js";
 
 export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -186,12 +185,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       });
 
       if (safeCommand.length > 0) {
-        // Write the command to stdin after a short delay so the shell has
-        // had time to source its rc files and print the initial prompt.
-        // Short enough that the user doesn't notice; long enough that the
-        // input lands in the shell's line editor rather than being swallowed
-        // by init-time prompts.
-        setTimeout(() => {
+        // Wait for the shell to print its first prompt and go quiet before
+        // injecting the command — a fixed delay races with slow RC files
+        // (oh-my-zsh, p10k, nvm, direnv). Fire-and-forget so the IPC
+        // response returns immediately; `hasTerminal` guards against the
+        // terminal being killed mid-wait.
+        void waitForShellReady(ptyClient, id).then(() => {
           if (!ptyClient.hasTerminal(id)) return;
           if (isAgent && process.platform !== "win32") {
             // Clear any shell init noise so the agent opens to a clean
@@ -201,7 +200,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
             ptyClient.write(id, "printf '\\x1b[H\\x1b[2J\\x1b[3J'\r");
           }
           ptyClient.write(id, `${safeCommand}\r`);
-        }, COMMAND_DELAY_MS);
+        });
       }
 
       return id;

--- a/electron/ipc/handlers/terminal/shellReady.ts
+++ b/electron/ipc/handlers/terminal/shellReady.ts
@@ -14,7 +14,6 @@
  */
 import type { EventEmitter } from "events";
 import { stripAnsi } from "../../../services/pty/AgentPatternDetector.js";
-import { DEFAULT_PROMPT_PATTERNS } from "../../../services/pty/PromptDetector.js";
 
 type PtyClientLike = Pick<EventEmitter, "on" | "off"> & {
   hasTerminal(id: string): boolean;
@@ -30,13 +29,27 @@ export interface WaitForShellReadyOptions {
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_QUIESCENCE_MS = 200;
 
+// End-anchored patterns: a real prompt places the cursor immediately after the
+// prompt character. This is stricter than a start-anchored match, so stray RC
+// lines like "# sourcing plugin" won't trip detection — the `#` isn't at the
+// end of the line. Covers plain prompts ($ # % > ❯), `user@host dir $`-style
+// bash/zsh, and oh-my-zsh arrow themes.
+const PROMPT_PATTERNS = [
+  /[>›❯⟩$#%]\s*$/,
+  /[A-Za-z0-9_.-]+@[\w.-]+(?:[^\r\n]*)?\s*[#$%>]\s*$/,
+  /[➜➤➟➔❯›]\s+[^\r\n]*$/,
+];
+
 function hasPromptCharacter(chunk: string): boolean {
   const clean = stripAnsi(chunk);
   if (clean.length === 0) return false;
-  for (const pattern of DEFAULT_PROMPT_PATTERNS) {
-    if (pattern.test(clean)) return true;
-    const lastLine = clean.slice(clean.lastIndexOf("\n") + 1);
-    if (lastLine !== clean && pattern.test(lastLine)) return true;
+  // A single chunk may contain multiple lines separated by \n, \r, or \r\n;
+  // we care about the last visible line because that's where the cursor sits.
+  const lastBreak = Math.max(clean.lastIndexOf("\n"), clean.lastIndexOf("\r"));
+  const lastLine = lastBreak >= 0 ? clean.slice(lastBreak + 1) : clean;
+  if (lastLine.length === 0) return false;
+  for (const pattern of PROMPT_PATTERNS) {
+    if (pattern.test(lastLine)) return true;
   }
   return false;
 }

--- a/electron/ipc/handlers/terminal/shellReady.ts
+++ b/electron/ipc/handlers/terminal/shellReady.ts
@@ -1,0 +1,102 @@
+/**
+ * Event-driven shell-readiness contract.
+ *
+ * Instead of waiting a fixed delay before injecting a command into a freshly
+ * spawned PTY, observe the shell's actual output: resolve once a prompt has
+ * appeared and the stream has been quiet for `quiescenceMs`. This survives
+ * slow-booting RC files (oh-my-zsh, p10k, nvm, direnv) and p10k's two-phase
+ * instant-prompt → real-prompt render by resetting the quiescence timer on
+ * any new data.
+ *
+ * Hard timeout resolves (does not reject) so the degraded fallback is "inject
+ * anyway" rather than hang the caller forever. An early `exit` event also
+ * resolves so the caller's `hasTerminal` guard can skip the write cleanly.
+ */
+import type { EventEmitter } from "events";
+import { stripAnsi } from "../../../services/pty/AgentPatternDetector.js";
+import { DEFAULT_PROMPT_PATTERNS } from "../../../services/pty/PromptDetector.js";
+
+type PtyClientLike = Pick<EventEmitter, "on" | "off"> & {
+  hasTerminal(id: string): boolean;
+};
+
+export interface WaitForShellReadyOptions {
+  /** Hard ceiling before giving up and resolving anyway. */
+  timeoutMs?: number;
+  /** Silence window after first prompt match before resolving. */
+  quiescenceMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_QUIESCENCE_MS = 200;
+
+function hasPromptCharacter(chunk: string): boolean {
+  const clean = stripAnsi(chunk);
+  if (clean.length === 0) return false;
+  for (const pattern of DEFAULT_PROMPT_PATTERNS) {
+    if (pattern.test(clean)) return true;
+    const lastLine = clean.slice(clean.lastIndexOf("\n") + 1);
+    if (lastLine !== clean && pattern.test(lastLine)) return true;
+  }
+  return false;
+}
+
+export function waitForShellReady(
+  ptyClient: PtyClientLike,
+  terminalId: string,
+  options: WaitForShellReadyOptions = {}
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const quiescenceMs = options.quiescenceMs ?? DEFAULT_QUIESCENCE_MS;
+
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    let quiescenceTimer: ReturnType<typeof setTimeout> | null = null;
+    let sawPrompt = false;
+
+    const cleanup = () => {
+      ptyClient.off("data", onData);
+      ptyClient.off("exit", onExit);
+      if (quiescenceTimer !== null) {
+        clearTimeout(quiescenceTimer);
+        quiescenceTimer = null;
+      }
+      clearTimeout(hardTimeout);
+    };
+
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+
+    const onData = (id: string, data: string) => {
+      if (id !== terminalId || settled) return;
+      if (!sawPrompt) {
+        if (hasPromptCharacter(data)) {
+          sawPrompt = true;
+          quiescenceTimer = setTimeout(settle, quiescenceMs);
+        }
+        return;
+      }
+      // Reset quiescence window on any subsequent output — handles p10k's
+      // two-phase prompt (instant placeholder, then real prompt once RC
+      // finishes).
+      if (quiescenceTimer !== null) {
+        clearTimeout(quiescenceTimer);
+      }
+      quiescenceTimer = setTimeout(settle, quiescenceMs);
+    };
+
+    const onExit = (id: string) => {
+      if (id !== terminalId) return;
+      settle();
+    };
+
+    const hardTimeout = setTimeout(settle, timeoutMs);
+
+    ptyClient.on("data", onData);
+    ptyClient.on("exit", onExit);
+  });
+}


### PR DESCRIPTION
## Summary

- Removes the `COMMAND_DELAY_MS = 100` constant and its `setTimeout` wrapper in `electron/ipc/handlers/terminal/lifecycle.ts`, replacing it with an event-driven shell-ready contract.
- Adds `waitForShellReady()` in `electron/ipc/handlers/terminal/shellReady.ts`: subscribes to PTY data/exit events, detects first prompt via strip-ANSI + end-anchored patterns (covering bash, zsh, oh-my-zsh, p10k arrow themes), starts a 200ms quiescence window, resets on subsequent data to handle p10k's two-phase init, and falls back gracefully after a 10s hard timeout.
- Agent command injection is now fire-and-forget from `handleTerminalSpawn`, so the IPC response is non-blocking and slow shells (noisy RCs, p10k, direnv, nvm) can no longer race the injected command.

Resolves #5808

## Changes

- `electron/ipc/handlers/terminal/lifecycle.ts` — removed `COMMAND_DELAY_MS`, wired up `waitForShellReady`
- `electron/ipc/handlers/terminal/shellReady.ts` — new utility: prompt detection + quiescence logic
- `electron/ipc/handlers/terminal/__tests__/shellReady.test.ts` — 11 unit tests (fast/slow shell, p10k two-phase, bash/zsh prompts, CR-only separators, exit mid-wait, timeout fallback)
- `electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts` — 7 integration tests covering concurrent terminals and the full spawn-to-inject path

## Testing

Full unit + integration test suite with fake timers and direct event emission. Covers slow-startup scenarios (1000ms+ RC delay), p10k two-phase prompt, exit mid-wait, timeout as a degraded fallback, and concurrent terminals. Typecheck, lint, format, and build all clean.