### PR TITLE
refactor(agent-identity): sweep renderer consumers onto resolveEffectiveAgentId

### DIFF
--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -327,6 +327,11 @@ export function AgentTrayButton({
     const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
     for (const pid of panelIds) {
       const p = panelsById[pid];
+      // Launch-intent only: the tray aggregates sessions by the agent they were
+      // launched as, so pre-detection panels still appear under their tray entry.
+      // Using `isRuntimeAgentTerminal` here would silently exclude freshly-spawned
+      // agents during the boot window and demote ex-agents that outlived their
+      // process — neither matches the tray's "sessions grouped by launch agent" model.
       if (!p || !p.agentId || p.location === "trash" || p.location === "background") continue;
       if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
       if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -30,6 +30,7 @@ import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { getTerminalFocusTarget } from "@/components/Terminal/terminalFocus";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
@@ -365,7 +366,9 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const panelPresetColors = useMemo(() => {
     return new Map(
       panels.map((p) => {
-        const fallbackColor = getBrandColorHex(p.detectedAgentId ?? p.agentId ?? p.type);
+        const fallbackColor = getBrandColorHex(
+          resolveEffectiveAgentId(p.detectedAgentId, p.agentId) ?? p.type
+        );
         if (!p.agentPresetId || !p.agentId) return [p.id, fallbackColor] as const;
         const presets = getMergedPresets(
           p.agentId,
@@ -389,7 +392,9 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
   const brandColor =
     panelPresetColors.get(activePanel.id) ??
-    getBrandColorHex(activePanel.detectedAgentId ?? activePanel.agentId ?? activePanel.type);
+    getBrandColorHex(
+      resolveEffectiveAgentId(activePanel.detectedAgentId, activePanel.agentId) ?? activePanel.type
+    );
   const agentState = activePanel.agentState;
   const displayTitle = getBaseTitle(activePanel.title);
   const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -18,6 +18,7 @@ import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { getTerminalFocusTarget } from "@/components/Terminal/terminalFocus";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
@@ -195,7 +196,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   );
   const brandColor = useMemo(() => {
     const fallbackColor = getBrandColorHex(
-      terminal.detectedAgentId ?? terminal.agentId ?? terminal.type
+      resolveEffectiveAgentId(terminal.detectedAgentId, terminal.agentId) ?? terminal.type
     );
     if (!terminal.agentPresetId || !terminal.agentId) return fallbackColor;
     const preset = getMergedPresets(

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -58,6 +58,8 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
   const terminalName = (() => {
     const observed = terminal.lastObservedTitle;
     if (observed && !isUselessTitle(observed)) return observed;
+    // Launch-intent only: trash labels should read the stable launch identity
+    // so a terminal's name doesn't change as runtime detection flips after trashing.
     if (terminal.agentId) {
       if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
       const agentConfig = terminal.agentId ? getEffectiveAgentConfig(terminal.agentId) : undefined;

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -12,6 +12,7 @@ import { actionService } from "@/services/ActionService";
 import { isRegisteredPanelKind, panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import { computeGridSelectedAgentIds } from "./contentGridAgentFilter";
 import {
   ArrowDownFromLine,
@@ -314,9 +315,12 @@ export function TerminalContextMenu({
     [terminal, terminalId]
   );
 
+  // Runtime-detected identity wins over launch-time `agentId`; legacy
+  // `type: "<agent>"` with no `agentId` is kept as a final tail so the
+  // "Convert to" submenu can still highlight the current agent for panels
+  // that predate the identity-normalization pass.
   const currentAgentId =
-    terminal?.detectedAgentId ??
-    terminal?.agentId ??
+    resolveEffectiveAgentId(terminal?.detectedAgentId, terminal?.agentId) ??
     (terminal?.type !== "terminal" ? terminal?.type : null);
   const isPlainTerminal = terminal?.type === "terminal" || terminal?.kind === "terminal";
 

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -6,7 +6,8 @@ import type { TerminalInstance } from "@/store/panelStore";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { cn } from "@/lib/utils";
 import type { WorktreeTerminalCounts } from "@/hooks/useWorktreeTerminals";
-import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
+import { getAgentConfig } from "@/config/agents";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   STATE_LABELS,
   STATE_PRIORITY,
@@ -217,7 +218,7 @@ export function WorktreeTerminalSection({
     if (terminals.length === 0) return null;
     let commonId: string | null = null;
     for (const t of terminals) {
-      const effectiveId = t.agentId ?? (t.type && isRegisteredAgent(t.type) ? t.type : undefined);
+      const effectiveId = resolveEffectiveAgentId(t.detectedAgentId, t.agentId);
       if (!effectiveId) return null;
       if (commonId === null) commonId = effectiveId;
       else if (effectiveId !== commonId) return null;

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -147,12 +147,39 @@ describe("WorktreeTerminalSection summary icon", () => {
     expect(screen.queryByTestId("agent-icon")).toBeNull();
   });
 
-  it("resolves agent from type when agentId is absent (legacy compat)", () => {
-    renderSection({
+  it("does not resolve agent from type alone (identity requires agentId or detectedAgentId)", () => {
+    // Post-#5805 sweep: the summary icon reads through `resolveEffectiveAgentId`,
+    // which looks at `detectedAgentId` and `agentId` only. A terminal whose only
+    // agent signal is a legacy `type: "claude"` (no `agentId`, no detection) no
+    // longer claims an agent identity here — the panel-creation path now
+    // normalizes `type` → `agentId` at launch, so this arrangement shouldn't
+    // occur in live data anyway.
+    const { container } = renderSection({
       terminals: [
         makeTerminal({ agentId: undefined, type: "claude" as TerminalInstance["type"] }),
         makeTerminal({ agentId: undefined, type: "claude" as TerminalInstance["type"] }),
       ],
+    });
+    expect(screen.queryByTestId("agent-icon")).toBeNull();
+    expect(container.querySelector("svg.lucide-square-terminal")).toBeTruthy();
+  });
+
+  it("prefers detectedAgentId over agentId when both are set", () => {
+    renderSection({
+      terminals: [
+        makeTerminal({ agentId: "claude", detectedAgentId: "gemini" }),
+        makeTerminal({ agentId: "claude", detectedAgentId: "gemini" }),
+      ],
+    });
+    // Both terminals resolve to "gemini" via detectedAgentId, so the shared
+    // icon renders.
+    expect(screen.getByTestId("agent-icon")).toBeDefined();
+  });
+
+  it("uses detectedAgentId to classify a plain shell that entered agent mode", () => {
+    renderSection({
+      terminals: [makeTerminal({ agentId: undefined, detectedAgentId: "claude" })],
+      counts: { ...baseCounts, total: 1 },
     });
     expect(screen.getByTestId("agent-icon")).toBeDefined();
   });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -37,15 +37,17 @@ vi.mock("@/components/Terminal/TerminalIcon", () => ({
   ),
 }));
 
-const MockAgentIcon = ({ className }: { className?: string }) => (
-  <svg data-testid="agent-icon" className={className} />
+const MockClaudeIcon = ({ className }: { className?: string }) => (
+  <svg data-testid="agent-icon" data-agent="claude" className={className} />
+);
+const MockGeminiIcon = ({ className }: { className?: string }) => (
+  <svg data-testid="agent-icon" data-agent="gemini" className={className} />
 );
 
 vi.mock("@/config/agents", () => ({
   getAgentConfig: (agentId: string) => {
-    if (agentId === "claude" || agentId === "gemini") {
-      return { icon: MockAgentIcon, color: "#ff0000" };
-    }
+    if (agentId === "claude") return { icon: MockClaudeIcon, color: "#ff0000" };
+    if (agentId === "gemini") return { icon: MockGeminiIcon, color: "#00aaff" };
     return undefined;
   },
   isRegisteredAgent: (id: string) => id === "claude" || id === "gemini",
@@ -171,9 +173,10 @@ describe("WorktreeTerminalSection summary icon", () => {
         makeTerminal({ agentId: "claude", detectedAgentId: "gemini" }),
       ],
     });
-    // Both terminals resolve to "gemini" via detectedAgentId, so the shared
-    // icon renders.
-    expect(screen.getByTestId("agent-icon")).toBeDefined();
+    // Distinct mock icons per agent lock in precedence: a swapped-arg regression
+    // (agentId-wins) would surface the Claude icon instead.
+    const icon = screen.getByTestId("agent-icon");
+    expect(icon.getAttribute("data-agent")).toBe("gemini");
   });
 
   it("uses detectedAgentId to classify a plain shell that entered agent mode", () => {

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -9,6 +9,7 @@ import { terminalClient } from "@/clients";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 import { usePaletteStore } from "@/store/paletteStore";
 import { getAgentConfig } from "@/config/agents";
+import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 
 export interface SendToAgentItem {
   id: string;
@@ -98,7 +99,7 @@ export function useSendToAgentPalette() {
       if (t.kind && !panelKindHasPty(t.kind)) continue;
       if (t.hasPty === false) continue;
 
-      const effectiveAgentId = t.detectedAgentId ?? t.agentId;
+      const effectiveAgentId = resolveEffectiveAgentId(t.detectedAgentId, t.agentId);
       const agentConfig = effectiveAgentId ? getAgentConfig(effectiveAgentId) : null;
       const subtitle = agentConfig ? agentConfig.name : t.type !== "terminal" ? t.type : "Terminal";
 

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -66,7 +66,10 @@ function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
 }
 
 function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
-  // Map kind to RecipeTerminalType
+  // Map kind to RecipeTerminalType.
+  // Launch-intent only: recipes encode what the terminal was launched as, not
+  // what runtime detection observed. Persisting `detectedAgentId` would corrupt
+  // a recipe by baking ephemeral session state into a reusable template.
   const type: RecipeTerminalType =
     terminal.kind === "dev-preview"
       ? "dev-preview"

--- a/src/utils/__tests__/agentIdentity.test.ts
+++ b/src/utils/__tests__/agentIdentity.test.ts
@@ -17,4 +17,19 @@ describe("resolveEffectiveAgentId", () => {
   it("returns undefined when neither is present", () => {
     expect(resolveEffectiveAgentId(undefined, undefined)).toBeUndefined();
   });
+
+  it("preserves empty-string identities (??  only short-circuits on nullish)", () => {
+    // Guards against accidental truthiness-based trimming at call sites:
+    // the helper uses `??`, so "" survives. If a caller wants to treat empty
+    // strings as absent, it must do so explicitly after resolution.
+    expect(resolveEffectiveAgentId("", "claude")).toBe("");
+    expect(resolveEffectiveAgentId(undefined, "")).toBe("");
+  });
+
+  it("ignores the runtime-detected identity when it is explicitly null-ish", () => {
+    // Callers that clear `detectedAgentId` on exit must get the launch-time
+    // fallback back, not a stale detection.
+    expect(resolveEffectiveAgentId(undefined, "claude")).toBe("claude");
+    expect(resolveEffectiveAgentId(null as unknown as undefined, "claude")).toBe("claude");
+  });
 });

--- a/src/utils/agentIdentity.ts
+++ b/src/utils/agentIdentity.ts
@@ -6,9 +6,12 @@ type MaybeAgentId = BuiltInAgentId | AgentId | string | undefined;
 /**
  * Resolve the effective agent identity for panel chrome (icons, badges, labels).
  *
- * Prefers the runtime-detected agent (`detectedAgentId`) over the launch-time
- * intent (`agentId`). Used so chrome stops claiming an agent is live once the
- * process exits — the launch-time field remains for session-capability gates.
+ * Prefers the runtime-detected agent (`detectedAgentId`) so chrome follows
+ * mid-session agent switches (e.g., plain shell starts Claude) and, when
+ * detection clears on exit, falls back to the launch-time `agentId`. This
+ * helper resolves identity only — it does not claim the session is live. Use
+ * `isRuntimeAgentTerminal` (in `terminalType.ts`) when the decision depends on
+ * whether the agent is currently running.
  */
 export function resolveEffectiveAgentId(
   detectedAgentId: MaybeAgentId,

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -41,7 +41,11 @@ export async function validateTerminalConfig(
     }
   }
 
-  // Check agent CLI availability
+  // Check agent CLI availability.
+  // Launch-intent only: this runs before (or just after) launch to verify the CLI
+  // the user asked for is on PATH. `detectedAgentId` doesn't exist yet at that
+  // point, and using it later would validate the wrong binary for runtime-morphed
+  // sessions (e.g., a plain shell that started a different agent).
   const agentId = terminal.agentId ?? terminal.type;
   if (agentId && agentId !== "terminal") {
     try {


### PR DESCRIPTION
## Summary

- Migrated 5 renderer call sites (WorktreeTerminalSection, DockedTerminalItem, DockedTabGroup, useSendToAgentPalette, TerminalContextMenu) off inline `detectedAgentId ?? agentId ?? type` chains onto the shared `resolveEffectiveAgentId()` helper in `src/utils/agentIdentity.ts`.
- Added explicit comments to 4 deliberate-exclusion sites (AgentTrayButton aggregation, TrashBinItem label, recipeStore persistence, pre-launch CLI validation) that correctly read launch-intent fields directly.
- Tightened the helper docstring to separate identity resolution from liveness classification and point runtime-liveness callers at `isRuntimeAgentTerminal`.

Closes #5805

## Changes

- `src/utils/agentIdentity.ts` — improved docstring distinguishing the two concerns
- `src/components/Layout/DockedTabGroup.tsx`, `DockedTerminalItem.tsx` — migrated to `resolveEffectiveAgentId`
- `src/components/Terminal/TerminalContextMenu.tsx` — migrated
- `src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx` — migrated
- `src/hooks/useSendToAgentPalette.ts` — migrated
- `src/utils/terminalValidation.ts`, `src/store/recipeStore.ts` — annotated as intentional launch-intent reads
- `src/components/Layout/AgentTrayButton.tsx`, `TrashBinItem.tsx` — annotated likewise
- Tests updated: removed dead "legacy compat" case, added detected-wins and detected-as-sole-signal coverage; edge cases (empty string, null-ish) added to agentIdentity unit tests

## Testing

91 targeted tests covering agentIdentity, WorktreeTerminalSection, TerminalContextMenu, terminalValidation, and recipeStore all pass. Typecheck, format, and lint clean.