### PR TITLE
feat(pty): introduce explicit capability mode separating full agent terminals from observed shells

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -205,6 +205,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             everDetectedAgent: terminal.everDetectedAgent,
             detectedAgentId: terminal.detectedAgentId,
             detectedProcessId: terminal.detectedProcessId,
+            capabilityAgentId: terminal.capabilityAgentId,
           });
         }
       }
@@ -255,6 +256,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           everDetectedAgent: t.everDetectedAgent,
           detectedAgentId: t.detectedAgentId,
           detectedProcessId: t.detectedProcessId,
+          capabilityAgentId: t.capabilityAgentId,
         }));
 
       logInfo(`terminal:getAvailable: found ${sanitized.length} available terminals`);
@@ -305,6 +307,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           everDetectedAgent: t.everDetectedAgent,
           detectedAgentId: t.detectedAgentId,
           detectedProcessId: t.detectedProcessId,
+          capabilityAgentId: t.capabilityAgentId,
         }));
 
       logInfo(`terminal:getByState(${state}): found ${sanitized.length} terminals`);
@@ -344,6 +347,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
           everDetectedAgent: t.everDetectedAgent,
           detectedAgentId: t.detectedAgentId,
           detectedProcessId: t.detectedProcessId,
+          capabilityAgentId: t.capabilityAgentId,
         }));
 
       logInfo(`terminal:getAll: found ${sanitized.length} terminals`);
@@ -397,6 +401,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         everDetectedAgent: terminal.everDetectedAgent,
         detectedAgentId: terminal.detectedAgentId,
         detectedProcessId: terminal.detectedProcessId,
+        capabilityAgentId: terminal.capabilityAgentId,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -164,7 +164,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_REPLAY_HISTORY, handleTerminalReplayHistory));
 
-  const handleTerminalGetForProject = async (projectId: string) => {
+  const handleTerminalGetForProject = async (
+    projectId: string
+  ): Promise<import("../../../../shared/types/ipc.js").BackendTerminalInfo[]> => {
     try {
       if (typeof projectId !== "string" || !projectId) {
         throw new Error("Invalid project ID: must be a non-empty string");
@@ -172,7 +174,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
       const terminalIds = await ptyClient.getTerminalsForProjectAsync(projectId);
 
-      const terminals = [];
+      const terminals: import("../../../../shared/types/ipc.js").BackendTerminalInfo[] = [];
       for (const id of terminalIds) {
         const terminal = await ptyClient.getTerminalAsync(id);
         // Dev preview and help PTYs should not be rehydrated as generic terminal
@@ -190,9 +192,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             agentId: terminal.agentId,
             title: terminal.title,
             cwd: terminal.cwd,
-            worktreeId: terminal.worktreeId,
             agentState: terminal.agentState,
-            waitingReason: terminal.waitingReason,
             lastStateChange: terminal.lastStateChange,
             spawnedAt: terminal.spawnedAt,
             isTrashed: terminal.isTrashed,
@@ -228,7 +228,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_GET_FOR_PROJECT, handleTerminalGetForProject));
 
-  const handleTerminalGetAvailable = async () => {
+  const handleTerminalGetAvailable = async (): Promise<
+    import("../../../../shared/types/ipc.js").BackendTerminalInfo[]
+  > => {
     try {
       const terminals = await ptyClient.getAvailableTerminalsAsync();
 
@@ -268,7 +270,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_GET_AVAILABLE, handleTerminalGetAvailable));
 
-  const handleTerminalGetByState = async (state: string) => {
+  const handleTerminalGetByState = async (
+    state: string
+  ): Promise<import("../../../../shared/types/ipc.js").BackendTerminalInfo[]> => {
     try {
       if (typeof state !== "string" || !state) {
         throw new Error("Invalid state: must be a non-empty string");
@@ -319,7 +323,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_GET_BY_STATE, handleTerminalGetByState));
 
-  const handleTerminalGetAll = async () => {
+  const handleTerminalGetAll = async (): Promise<
+    import("../../../../shared/types/ipc.js").BackendTerminalInfo[]
+  > => {
     try {
       const terminals = await ptyClient.getAllTerminalsAsync();
 
@@ -359,7 +365,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_GET_ALL, handleTerminalGetAll));
 
-  const handleTerminalReconnect = async (terminalId: string) => {
+  const handleTerminalReconnect = async (
+    terminalId: string
+  ): Promise<import("../../../../shared/types/ipc.js").TerminalReconnectResult> => {
     try {
       if (typeof terminalId !== "string" || !terminalId) {
         throw new Error("Invalid terminal ID: must be a non-empty string");
@@ -369,12 +377,12 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
       if (!terminal) {
         logWarn(`terminal:reconnect: Terminal ${terminalId} not found`);
-        return { exists: false, error: "Terminal not found in backend" };
+        return { exists: false };
       }
 
       if (getAgentAvailabilityStore().isHelpTerminal(terminal.id)) {
         logInfo(`terminal:reconnect: Skipping help terminal ${terminalId}`);
-        return { exists: false, error: "Terminal is a help terminal" };
+        return { exists: false };
       }
 
       logInfo(`terminal:reconnect: Reconnecting to ${terminalId}`);
@@ -388,9 +396,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         agentId: terminal.agentId,
         title: terminal.title,
         cwd: terminal.cwd,
-        worktreeId: terminal.worktreeId,
         agentState: terminal.agentState,
-        waitingReason: terminal.waitingReason,
         lastStateChange: terminal.lastStateChange,
         spawnedAt: terminal.spawnedAt,
         activityTier: terminal.activityTier,

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1331,6 +1331,7 @@ port.on("message", async (rawMsg: any) => {
                 everDetectedAgent: terminal.everDetectedAgent,
                 detectedAgentId: narrowDetectedAgentId(terminal.detectedAgentType),
                 detectedProcessId: terminal.detectedProcessIconId,
+                capabilityAgentId: terminal.capabilityAgentId,
               }
             : null,
         });
@@ -1455,6 +1456,7 @@ port.on("message", async (rawMsg: any) => {
             everDetectedAgent: t.everDetectedAgent,
             detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
             detectedProcessId: t.detectedProcessIconId,
+            capabilityAgentId: t.capabilityAgentId,
           })),
         });
         break;
@@ -1487,6 +1489,7 @@ port.on("message", async (rawMsg: any) => {
             everDetectedAgent: t.everDetectedAgent,
             detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
             detectedProcessId: t.detectedProcessIconId,
+            capabilityAgentId: t.capabilityAgentId,
           })),
         });
         break;
@@ -1519,6 +1522,7 @@ port.on("message", async (rawMsg: any) => {
             everDetectedAgent: t.everDetectedAgent,
             detectedAgentId: narrowDetectedAgentId(t.detectedAgentType),
             detectedProcessId: t.detectedProcessIconId,
+            capabilityAgentId: t.capabilityAgentId,
           })),
         });
         break;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -91,6 +91,8 @@ interface TerminalInfoResponse {
   detectedAgentId?: BuiltInAgentId;
   /** Runtime-detected non-agent process icon id (npm, yarn, etc.). Cleared when the process exits. */
   detectedProcessId?: string;
+  /** Capability mode — sealed-at-spawn agent capability surface. Set when the terminal was cold-launched as a built-in agent. */
+  capabilityAgentId?: BuiltInAgentId;
 }
 
 export interface PtyClientConfig {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -518,6 +518,7 @@ export class TerminalProcess {
       detectedAgentType: t.detectedAgentType,
       detectedProcessIconId: t.detectedProcessIconId,
       everDetectedAgent: t.everDetectedAgent,
+      capabilityAgentId: t.capabilityAgentId,
       restartCount: t.restartCount,
       activityTier: this._activityTier,
       hasPty,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -6,6 +6,7 @@ const { Terminal: HeadlessTerminal } = headless;
 import serialize, { type SerializeAddon as SerializeAddonType } from "@xterm/addon-serialize";
 const { SerializeAddon } = serialize;
 import { AGENT_REGISTRY, getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
+import { isBuiltInAgentId } from "../../../shared/config/agentIds.js";
 import {
   ProcessDetector,
   detectCommandIdentity,
@@ -331,6 +332,14 @@ export class TerminalProcess {
     headlessTerminal.loadAddon(serializeAddon);
     this.restoreSessionIfPresent(headlessTerminal);
 
+    // Sealed-at-spawn capability mode (#5804). Derived from launch intent: a
+    // cold-launched agent terminal whose `agentId` is a built-in agent gets
+    // `full` capability; plain shells and non-built-in agents do not. Never
+    // mutated by runtime process detection — `handleAgentDetection` may flip
+    // chrome-facing fields like `detectedAgentType`, but this stays sealed.
+    const capabilityAgentId =
+      this.isAgentTerminal && isBuiltInAgentId(agentId) ? agentId : undefined;
+
     this.terminalInfo = {
       id,
       projectId: options.projectId,
@@ -341,6 +350,7 @@ export class TerminalProcess {
       type: options.type,
       title: options.title,
       agentId,
+      capabilityAgentId,
       spawnedAt,
       agentState: this.isAgentTerminal ? "idle" : undefined,
       lastStateChange: this.isAgentTerminal ? spawnedAt : undefined,

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -886,4 +886,16 @@ describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => 
       terminal.dispose();
     }
   });
+
+  it("getPublicState() emits capabilityAgentId — IPC-safe consumers must see it", () => {
+    const agent = createAgentTerminal();
+    const plain = createPlainTerminal("t-cap-public-plain");
+    try {
+      expect(agent.getPublicState().capabilityAgentId).toBe("claude");
+      expect(plain.getPublicState().capabilityAgentId).toBeUndefined();
+    } finally {
+      agent.dispose();
+      plain.dispose();
+    }
+  });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -816,3 +816,74 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
     }
   });
 });
+
+// #5804: capability mode is sealed at spawn time from launch intent. Cold-launched
+// built-in agents get `capabilityAgentId`; plain shells do not, even when an agent
+// is later detected at runtime. Runtime detection (and the bridge-write violation
+// in `handleAgentDetection` that mutates `agentId`) must never touch this field.
+describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => {
+  it("cold-launched built-in agent terminal has capabilityAgentId set to its agentId", () => {
+    const terminal = createAgentTerminal();
+    try {
+      expect(terminal.getInfo().capabilityAgentId).toBe("claude");
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("plain terminal has no capabilityAgentId at construction", () => {
+    const terminal = createPlainTerminal("t-cap-plain");
+    try {
+      expect(terminal.getInfo().capabilityAgentId).toBeUndefined();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("runtime promotion to a detected agent does not set capabilityAgentId on a plain shell", () => {
+    const terminal = createPlainTerminal("t-cap-promotion");
+    try {
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, agentType: "claude", processIconId: "claude" },
+        getSpawnedAt(terminal)
+      );
+
+      const info = terminal.getInfo();
+      // Live identity flows through detectedAgentType. Capability mode does not.
+      expect(info.detectedAgentType).toBe("claude");
+      expect(info.capabilityAgentId).toBeUndefined();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("runtime detection events on a cold-launched agent do not change capabilityAgentId", () => {
+    const terminal = createAgentTerminal();
+    try {
+      expect(terminal.getInfo().capabilityAgentId).toBe("claude");
+
+      // Spurious re-detection of the same agent.
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, agentType: "claude", processIconId: "claude" },
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().capabilityAgentId).toBe("claude");
+
+      // Demotion to a non-agent process.
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, processIconId: "npm", processName: "npm" },
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().capabilityAgentId).toBe("claude");
+
+      // Full demotion.
+      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      expect(terminal.getInfo().capabilityAgentId).toBe("claude");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -74,9 +74,12 @@ export interface TerminalPublicState {
   everDetectedAgent?: boolean;
   /**
    * Capability mode — the agent capability surface this terminal is allowed to
-   * participate in. Currently expected to follow launch intent (`agentId`);
-   * derived at read time; not persisted; not written by any production code
-   * yet. See `docs/architecture/terminal-identity.md`.
+   * participate in (fleet membership, hybrid input, orchestration). Sealed at
+   * spawn time from launch intent (`agentId` narrowed to `BuiltInAgentId`);
+   * never written by runtime detection. Absent on plain shells and on agent
+   * terminals launched with a non-built-in `agentId`. Not persisted — re-derived
+   * on every spawn from the same launch context. See
+   * `docs/architecture/terminal-identity.md`.
    */
   capabilityAgentId?: BuiltInAgentId;
   restartCount: number;

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -63,6 +63,13 @@ export interface AddPanelOptionsBase {
   detectedAgentId?: BuiltInAgentId;
   /** Runtime-detected non-agent process icon id (npm, yarn, etc.) at hydration time; cleared when the process exits. */
   detectedProcessId?: string;
+  /**
+   * Capability mode — sealed-at-spawn agent capability surface. See
+   * `PtyPanelData.capabilityAgentId` for the full contract. Carried here so
+   * hydration paths (project switch, reconnect, orphaned terminal recovery) can
+   * preserve the backend-written value without re-deriving it from `agentId`.
+   */
+  capabilityAgentId?: BuiltInAgentId;
   /** Preset ID selected at launch time for per-panel preset selection */
   agentPresetId?: string;
   /** Preset brand color (hex) captured at launch time for per-panel icon tinting */

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -209,9 +209,9 @@ export interface BackendTerminalInfo {
    */
   detectedAgentId?: BuiltInAgentId;
   /**
-   * Capability mode — the agent capability surface this terminal is allowed
-   * to participate in. Currently expected to follow launch intent; reserved
-   * for future consumers. Not populated by any writer yet.
+   * Capability mode — sealed-at-spawn agent capability surface. Set when the
+   * terminal was cold-launched as a built-in agent. See
+   * `docs/architecture/terminal-identity.md`.
    */
   capabilityAgentId?: BuiltInAgentId;
   /** Runtime-detected non-agent process icon id (npm, yarn, etc.). Cleared when the process exits. */
@@ -258,8 +258,10 @@ export interface TerminalReconnectResult {
    */
   detectedAgentId?: BuiltInAgentId;
   /**
-   * Capability mode — reserved for future consumers. Currently expected to
-   * follow launch intent; no production writer exists yet.
+   * Capability mode — sealed-at-spawn agent capability surface. Carried on
+   * reconnect so the renderer can re-derive session-capability gates without
+   * waiting for a fresh snapshot. See
+   * `docs/architecture/terminal-identity.md`.
    */
   capabilityAgentId?: BuiltInAgentId;
   /** Runtime-detected non-agent process icon id (npm, yarn, etc.). Cleared when the process exits. */
@@ -270,8 +272,10 @@ export interface TerminalReconnectResult {
  * Terminal information payload for diagnostic display.
  *
  * Consumed exclusively by `TerminalInfoDialog.tsx`. Intentionally omits
- * `capabilityAgentId` — no runtime writer exists yet, and adding a third
- * identity field with no value to display would only confuse diagnostics.
+ * `capabilityAgentId` — capability mode is sealed-at-spawn from `agentId`
+ * (narrowed to `BuiltInAgentId`), so the dialog does not need to render it
+ * separately. Diagnostic readers that need the value should consume it via
+ * `BackendTerminalInfo` / `TerminalReconnectResult`.
  * See `docs/architecture/terminal-identity.md`.
  */
 export interface TerminalInfoPayload {

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -281,12 +281,12 @@ export interface PtyPanelData extends BasePanelData {
   detectedAgentId?: BuiltInAgentId;
   /**
    * Capability mode — the agent capability surface this terminal is allowed to
-   * participate in (fleet membership, orchestration, hybrid input).
-   *
-   * Currently expected to follow launch intent (`agentId`). Derived at read
-   * time; not persisted; reserved for future consumers. No production code
-   * writes this field yet — the slot exists so consumers can migrate without
-   * further IPC contract churn.
+   * participate in (fleet membership, orchestration, hybrid input). Sealed at
+   * spawn time from launch intent (`agentId` narrowed to `BuiltInAgentId`);
+   * never touched by runtime detection. Absent on plain shells and on
+   * terminals where an agent was only runtime-detected. Not persisted —
+   * re-derived on every spawn from the same launch context. See
+   * `docs/architecture/terminal-identity.md`.
    */
   capabilityAgentId?: BuiltInAgentId;
   /** Captured agent session ID from graceful shutdown (used for session resume) */
@@ -476,8 +476,8 @@ export interface TerminalInstance {
    */
   detectedAgentId?: BuiltInAgentId;
   /**
-   * Capability mode slot. See `PtyPanelData.capabilityAgentId` for full contract.
-   * Not yet populated by any writer.
+   * Capability mode — sealed-at-spawn agent capability surface. See
+   * `PtyPanelData.capabilityAgentId` for the full contract.
    */
   capabilityAgentId?: BuiltInAgentId;
   /** Captured agent session ID from graceful shutdown (used for session resume) */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -300,6 +300,15 @@ export interface PtyHostTerminalInfo {
   detectedAgentId?: BuiltInAgentId;
   /** Runtime-detected non-agent process icon id (npm, yarn, etc.). Cleared when the process exits. */
   detectedProcessId?: string;
+  /**
+   * Capability mode — the agent capability surface this terminal is allowed to
+   * participate in (fleet membership, hybrid input, orchestration). Sealed at
+   * spawn time from launch intent (`agentId` narrowed to `BuiltInAgentId`); never
+   * touched by runtime detection. Absent on plain shells and on agent terminals
+   * launched with a non-built-in `agentId`. See
+   * `docs/architecture/terminal-identity.md`.
+   */
+  capabilityAgentId?: BuiltInAgentId;
 }
 
 /** Payload for agent:spawned event */

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -30,7 +30,6 @@ import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { getTerminalFocusTarget } from "@/components/Terminal/terminalFocus";
-import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
@@ -510,7 +509,11 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           const focusTarget = getTerminalFocusTarget({
-            isAgentTerminal: isRuntimeAgentTerminal(activePanel),
+            // #5804: capability mode (sealed at spawn) — not the broader
+            // runtime-detect predicate. The HybridInputBar only renders for
+            // cold-launched built-in agents, so observational shells must
+            // fall through to xterm focus to keep clicks responsive.
+            hasFullAgentCapability: activePanel.capabilityAgentId !== undefined,
             isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
             hybridInputEnabled,
             hybridInputAutoFocus,

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -18,7 +18,6 @@ import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { getTerminalFocusTarget } from "@/components/Terminal/terminalFocus";
-import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
@@ -344,7 +343,11 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           const focusTarget = getTerminalFocusTarget({
-            isAgentTerminal: isRuntimeAgentTerminal(terminal),
+            // #5804: capability mode (sealed at spawn) — not the broader
+            // runtime-detect predicate. The HybridInputBar only renders for
+            // cold-launched built-in agents, so observational shells must
+            // fall through to xterm focus to keep clicks responsive.
+            hasFullAgentCapability: terminal.capabilityAgentId !== undefined,
             isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
             hybridInputEnabled,
             hybridInputAutoFocus,

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -68,6 +68,8 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
       a.kind !== b.kind ||
       a.type !== b.type ||
       a.agentId !== b.agentId ||
+      a.detectedAgentId !== b.detectedAgentId ||
+      a.capabilityAgentId !== b.capabilityAgentId ||
       a.cwd !== b.cwd ||
       a.agentState !== b.agentState ||
       a.activityHeadline !== b.activityHeadline ||

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -270,6 +270,7 @@ function TerminalPaneComponent({
   const hybridInputAutoFocus = useTerminalInputStore((state) => state.hybridInputAutoFocus);
   const effectiveAgentId = (resolveEffectiveAgentId(detectedAgentId, agentId) ??
     (type && isRegisteredAgent(type) ? type : undefined)) as BuiltInAgentId | undefined;
+  // @ts-expect-error kept for clarity about capability mode logic (#5804)
   const isAgentTerminal = effectiveAgentId !== undefined;
   // HybridInputBar is gated on capability mode (#5804), not on
   // `effectiveAgentId`. Cold-launched agent terminals get the bar; plain shells
@@ -600,7 +601,7 @@ function TerminalPaneComponent({
       if (!xtermElement) return;
 
       const focusTarget = getTerminalFocusTarget({
-        isAgentTerminal,
+        hasFullAgentCapability: capabilityAgentId !== undefined,
         isInputDisabled: isBackendDisconnected || isBackendRecovering || isInputLocked,
         hybridInputEnabled,
         hybridInputAutoFocus,
@@ -630,7 +631,7 @@ function TerminalPaneComponent({
     [
       id,
       location,
-      isAgentTerminal,
+      capabilityAgentId,
       hybridInputEnabled,
       hybridInputAutoFocus,
       isBackendDisconnected,
@@ -664,7 +665,7 @@ function TerminalPaneComponent({
     if (!isFocused) return;
 
     const focusTarget = getTerminalFocusTarget({
-      isAgentTerminal,
+      hasFullAgentCapability: capabilityAgentId !== undefined,
       isInputDisabled: isBackendDisconnected || isBackendRecovering || isInputLocked,
       hybridInputEnabled,
       hybridInputAutoFocus,
@@ -688,7 +689,7 @@ function TerminalPaneComponent({
   }, [
     id,
     isFocused,
-    isAgentTerminal,
+    capabilityAgentId,
     hybridInputEnabled,
     hybridInputAutoFocus,
     isBackendDisconnected,
@@ -700,7 +701,7 @@ function TerminalPaneComponent({
     if (!showHybridInputBar) return;
     return registerPanelFocusHandler(id, () => {
       const focusTarget = getTerminalFocusTarget({
-        isAgentTerminal,
+        hasFullAgentCapability: capabilityAgentId !== undefined,
         isInputDisabled: isBackendDisconnected || isBackendRecovering || isInputLocked,
         hybridInputEnabled,
         hybridInputAutoFocus,
@@ -711,7 +712,7 @@ function TerminalPaneComponent({
   }, [
     id,
     showHybridInputBar,
-    isAgentTerminal,
+    capabilityAgentId,
     isBackendDisconnected,
     isBackendRecovering,
     isInputLocked,

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -78,6 +78,14 @@ export interface TerminalPaneProps {
   agentId?: string;
   /** Runtime-detected agent identity (cleared on agent exit). Drives panel chrome (icons, badges). */
   detectedAgentId?: BuiltInAgentId;
+  /**
+   * Sealed-at-spawn capability mode (#5804). Set when the terminal was
+   * cold-launched as a built-in agent; absent on plain shells and on terminals
+   * where an agent was only runtime-detected. Drives session-capability gates
+   * (HybridInputBar, fleet membership) — distinct from `detectedAgentId`,
+   * which only drives chrome.
+   */
+  capabilityAgentId?: BuiltInAgentId;
   agentPresetId?: string;
   presetColor?: string;
   worktreeId?: string;
@@ -121,6 +129,7 @@ function TerminalPaneComponent({
   type,
   agentId,
   detectedAgentId,
+  capabilityAgentId,
   agentPresetId,
   presetColor,
   worktreeId,
@@ -262,7 +271,13 @@ function TerminalPaneComponent({
   const effectiveAgentId = (resolveEffectiveAgentId(detectedAgentId, agentId) ??
     (type && isRegisteredAgent(type) ? type : undefined)) as BuiltInAgentId | undefined;
   const isAgentTerminal = effectiveAgentId !== undefined;
-  const showHybridInputBar = isAgentTerminal && hybridInputEnabled;
+  // HybridInputBar is gated on capability mode (#5804), not on
+  // `effectiveAgentId`. Cold-launched agent terminals get the bar; plain shells
+  // where an agent was merely detected at runtime do not — those terminals lack
+  // the spawn-time env/pool/scrollback shaping the bar's submit semantics
+  // assume. Chrome (icons/badges) still uses `effectiveAgentId` so live
+  // detection drives visual feedback.
+  const showHybridInputBar = capabilityAgentId !== undefined && hybridInputEnabled;
 
   const queueCount = usePanelStore((state) => state.commandQueueCountById[id] ?? 0);
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -268,10 +268,12 @@ function TerminalPaneComponent({
   }, [isRestartingService]);
   const hybridInputEnabled = useTerminalInputStore((state) => state.hybridInputEnabled);
   const hybridInputAutoFocus = useTerminalInputStore((state) => state.hybridInputAutoFocus);
+  // Effective agent identity for chrome (icons, badges, presets) — prefers
+  // runtime-detected over launch-intent so chrome reflects what's actually
+  // running. Distinct from `capabilityAgentId`, which gates session-only
+  // features and never includes runtime-detected agents.
   const effectiveAgentId = (resolveEffectiveAgentId(detectedAgentId, agentId) ??
     (type && isRegisteredAgent(type) ? type : undefined)) as BuiltInAgentId | undefined;
-  // @ts-expect-error kept for clarity about capability mode logic (#5804)
-  const isAgentTerminal = effectiveAgentId !== undefined;
   // HybridInputBar is gated on capability mode (#5804), not on
   // `effectiveAgentId`. Cold-launched agent terminals get the bar; plain shells
   // where an agent was merely detected at runtime do not — those terminals lack

--- a/src/components/Terminal/__tests__/terminalFocus.test.ts
+++ b/src/components/Terminal/__tests__/terminalFocus.test.ts
@@ -5,7 +5,7 @@ describe("getTerminalFocusTarget", () => {
   it("focuses hybrid input for enabled agent terminals", () => {
     expect(
       getTerminalFocusTarget({
-        isAgentTerminal: true,
+        hasFullAgentCapability: true,
         isInputDisabled: false,
         hybridInputEnabled: true,
         hybridInputAutoFocus: true,
@@ -16,7 +16,7 @@ describe("getTerminalFocusTarget", () => {
   it("falls back to xterm when input is disabled", () => {
     expect(
       getTerminalFocusTarget({
-        isAgentTerminal: true,
+        hasFullAgentCapability: true,
         isInputDisabled: true,
         hybridInputEnabled: true,
         hybridInputAutoFocus: true,
@@ -27,7 +27,23 @@ describe("getTerminalFocusTarget", () => {
   it("focuses xterm for non-agent terminals", () => {
     expect(
       getTerminalFocusTarget({
-        isAgentTerminal: false,
+        hasFullAgentCapability: false,
+        isInputDisabled: false,
+        hybridInputEnabled: true,
+        hybridInputAutoFocus: true,
+      })
+    ).toBe("xterm");
+  });
+
+  // #5804 regression: an observational shell (plain terminal where an agent
+  // was runtime-detected) must NOT focus the hybrid input — the bar isn't
+  // rendered for it, so suppressing xterm focus would swallow clicks with no
+  // effect. Capability mode is sealed at spawn; runtime detection can flip
+  // chrome-facing fields (icon, badge) but not capability.
+  it("focuses xterm for observational shells with no full capability", () => {
+    expect(
+      getTerminalFocusTarget({
+        hasFullAgentCapability: false,
         isInputDisabled: false,
         hybridInputEnabled: true,
         hybridInputAutoFocus: true,
@@ -38,7 +54,7 @@ describe("getTerminalFocusTarget", () => {
   it("focuses xterm when hybrid input is disabled", () => {
     expect(
       getTerminalFocusTarget({
-        isAgentTerminal: true,
+        hasFullAgentCapability: true,
         isInputDisabled: false,
         hybridInputEnabled: false,
         hybridInputAutoFocus: true,
@@ -49,7 +65,7 @@ describe("getTerminalFocusTarget", () => {
   it("focuses xterm when hybrid input auto-focus is disabled", () => {
     expect(
       getTerminalFocusTarget({
-        isAgentTerminal: true,
+        hasFullAgentCapability: true,
         isInputDisabled: false,
         hybridInputEnabled: true,
         hybridInputAutoFocus: false,

--- a/src/components/Terminal/terminalFocus.ts
+++ b/src/components/Terminal/terminalFocus.ts
@@ -1,13 +1,25 @@
 export type TerminalFocusTarget = "hybridInput" | "xterm";
 
+/**
+ * Resolve which child component should receive focus when the terminal pane
+ * gains focus.
+ *
+ * `hasFullAgentCapability` must be the capability-mode predicate (#5804) —
+ * `capabilityAgentId !== undefined` — NOT the broader runtime-detect
+ * predicate. The HybridInputBar only renders for cold-launched built-in
+ * agents, so observational shells (plain terminals where an agent was
+ * runtime-detected) must fall through to xterm. Otherwise the unfocused-click
+ * suppression at the call site would swallow clicks with no visible effect:
+ * the bar isn't there to receive focus, and xterm focus is suppressed.
+ */
 export function getTerminalFocusTarget(options: {
-  isAgentTerminal: boolean;
+  hasFullAgentCapability: boolean;
   isInputDisabled: boolean;
   hybridInputEnabled: boolean;
   hybridInputAutoFocus: boolean;
 }): TerminalFocusTarget {
   if (
-    options.isAgentTerminal &&
+    options.hasFullAgentCapability &&
     !options.isInputDisabled &&
     options.hybridInputEnabled &&
     options.hybridInputAutoFocus

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -542,22 +542,25 @@ describe("fleetArmingStore", () => {
       expect(isAgentFleetActionEligible(terminal)).toBe(true);
     });
 
-    it("treats observational shells with no capabilityAgentId as non-agent-capable", () => {
-      // Plain shell where Claude was runtime-detected (e.g., user typed `claude`
-      // in a regular shell). The bridge-write violation in `handleAgentDetection`
-      // can promote `agentId` to "claude" — but capability mode is sealed at
-      // spawn time and remains undefined. Capability gate must follow that.
+    it("treats observational shells without explicit capabilityAgentId as non-agent-capable when agentId is also unset", () => {
+      // Plain shell where Claude was runtime-detected (e.g., user typed
+      // `claude` in a regular shell), and capability was never sealed at spawn.
+      // `agentId` is undefined here (not yet polluted by the bridge-write
+      // violation in `handleAgentDetection`). Eligibility paths must reject.
       const observedShell = makeAgentTerminal("a", {
-        agentId: "claude",
+        agentId: undefined,
         capabilityAgentId: undefined,
         detectedAgentId: "claude",
         everDetectedAgent: true,
       });
-      // Fallback path still grants agent capability (compat for older payloads),
-      // but a future tightening that drops the agentId fallback would expose
-      // observational shells. The capabilityAgentId field is the load-bearing
-      // signal once #5804 lands across the IPC pipeline.
       expect(observedShell.capabilityAgentId).toBeUndefined();
+      expect(resolveFleetAgentCapabilityId(observedShell)).toBeUndefined();
+      expect(isAgentFleetActionEligible(observedShell)).toBe(false);
+      expect(isFleetWaitingAgentEligible({ ...observedShell, agentState: "waiting" })).toBe(false);
+      expect(isFleetInterruptAgentEligible({ ...observedShell, agentState: "working" })).toBe(
+        false
+      );
+      expect(isFleetRestartAgentEligible(observedShell)).toBe(false);
     });
 
     it("keeps runtime-detected plain shells out of Fleet membership and actions", () => {

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -533,13 +533,31 @@ describe("fleetArmingStore", () => {
       expect(isFleetRestartAgentEligible(terminal)).toBe(true);
     });
 
-    it("uses explicit capabilityAgentId when #5804 starts writing it", () => {
+    it("prefers explicit capabilityAgentId over launch-time agentId fallback", () => {
       const terminal = makeAgentTerminal("a", {
         agentId: undefined,
         capabilityAgentId: "codex",
       });
       expect(resolveFleetAgentCapabilityId(terminal)).toBe("codex");
       expect(isAgentFleetActionEligible(terminal)).toBe(true);
+    });
+
+    it("treats observational shells with no capabilityAgentId as non-agent-capable", () => {
+      // Plain shell where Claude was runtime-detected (e.g., user typed `claude`
+      // in a regular shell). The bridge-write violation in `handleAgentDetection`
+      // can promote `agentId` to "claude" — but capability mode is sealed at
+      // spawn time and remains undefined. Capability gate must follow that.
+      const observedShell = makeAgentTerminal("a", {
+        agentId: "claude",
+        capabilityAgentId: undefined,
+        detectedAgentId: "claude",
+        everDetectedAgent: true,
+      });
+      // Fallback path still grants agent capability (compat for older payloads),
+      // but a future tightening that drops the agentId fallback would expose
+      // observational shells. The capabilityAgentId field is the load-bearing
+      // signal once #5804 lands across the IPC pipeline.
+      expect(observedShell.capabilityAgentId).toBeUndefined();
     });
 
     it("keeps runtime-detected plain shells out of Fleet membership and actions", () => {

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -18,8 +18,10 @@ export function isTerminalFleetEligible(t: TerminalInstance | undefined): t is T
 
 /**
  * Agent capability for Fleet actions that depend on a full agent session
- * (accept/reject/interrupt/restart). Until #5804 installs a real writer,
- * launch-time built-in agent identity is the compatibility fallback.
+ * (accept/reject/interrupt/restart). Prefers the sealed-at-spawn
+ * `capabilityAgentId` (#5804); falls back to launch-time built-in `agentId`
+ * for terminals reconnected from older backend payloads that predate the
+ * writer.
  */
 export function resolveFleetAgentCapabilityId(
   t: TerminalInstance | undefined

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -411,14 +411,22 @@ export const createCorePanelActions = (
       everDetectedAgent: options.everDetectedAgent,
       detectedAgentId: options.detectedAgentId,
       detectedProcessId: options.detectedProcessId,
-      // Capability mode (#5804). For reconnects/hydration the value comes from
-      // the backend payload via `options.capabilityAgentId`. For fresh agent
-      // spawns, mirror the backend's spawn-time derivation so the renderer can
-      // gate features (HybridInputBar, fleet membership) immediately, before
-      // the post-spawn snapshot lands. The backend writes the same value into
-      // its `TerminalPublicState` from the same launch intent.
-      capabilityAgentId:
-        options.capabilityAgentId ?? (isAgent && isBuiltInAgentId(agentId) ? agentId : undefined),
+      // Capability mode (#5804). On reconnect/hydration, trust the backend
+      // payload directly — it's the source of truth for sealed-at-spawn
+      // identity. We must NOT re-derive from `agentId` here, because the
+      // `handleAgentDetection` bridge-write violation can rewrite `agentId`
+      // (and the legacy `type` field carried in IPC snapshots) to a runtime-
+      // detected agent on observed shells; deriving from that would mint
+      // false `full` capability and expose features (HybridInputBar, fleet
+      // membership) to terminals that were never cold-launched as the agent.
+      // For fresh spawns (no `existingId`), mirror the backend's spawn-time
+      // derivation so the renderer can gate features immediately, before the
+      // post-spawn snapshot lands; the backend writes the same value from the
+      // same launch intent.
+      capabilityAgentId: isReconnect
+        ? options.capabilityAgentId
+        : (options.capabilityAgentId ??
+          (isAgent && isBuiltInAgentId(agentId) ? agentId : undefined)),
       agentPresetId: options.agentPresetId,
       agentPresetColor: options.agentPresetColor,
       originalPresetId: options.originalPresetId ?? options.agentPresetId,

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -10,6 +10,7 @@ import { terminalClient, projectClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { isRegisteredAgent } from "@/config/agents";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
 import {
   panelKindHasPty,
   panelKindUsesTerminalUi,
@@ -410,6 +411,14 @@ export const createCorePanelActions = (
       everDetectedAgent: options.everDetectedAgent,
       detectedAgentId: options.detectedAgentId,
       detectedProcessId: options.detectedProcessId,
+      // Capability mode (#5804). For reconnects/hydration the value comes from
+      // the backend payload via `options.capabilityAgentId`. For fresh agent
+      // spawns, mirror the backend's spawn-time derivation so the renderer can
+      // gate features (HybridInputBar, fleet membership) immediately, before
+      // the post-spawn snapshot lands. The backend writes the same value into
+      // its `TerminalPublicState` from the same launch intent.
+      capabilityAgentId:
+        options.capabilityAgentId ?? (isAgent && isBuiltInAgentId(agentId) ? agentId : undefined),
       agentPresetId: options.agentPresetId,
       agentPresetColor: options.agentPresetColor,
       originalPresetId: options.originalPresetId ?? options.agentPresetId,
@@ -444,6 +453,9 @@ export const createCorePanelActions = (
                 // live detection (live IPC event may have landed before reconnect flush).
                 detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
                 detectedProcessId: terminal.detectedProcessId ?? existing.detectedProcessId,
+                // Capability is sealed at spawn — values should match — but
+                // preserve the existing entry if a partial reconnect omits it.
+                capabilityAgentId: terminal.capabilityAgentId ?? existing.capabilityAgentId,
               }
             : terminal;
         return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
@@ -469,6 +481,9 @@ export const createCorePanelActions = (
                 // live detection (live IPC event may have landed before reconnect flush).
                 detectedAgentId: terminal.detectedAgentId ?? existing.detectedAgentId,
                 detectedProcessId: terminal.detectedProcessId ?? existing.detectedProcessId,
+                // Capability is sealed at spawn — values should match — but
+                // preserve the existing entry if a partial reconnect omits it.
+                capabilityAgentId: terminal.capabilityAgentId ?? existing.capabilityAgentId,
               }
             : terminal;
           const newById = { ...state.panelsById, [id]: preservedTerminal };

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -67,6 +67,7 @@ export function buildPanelProps({
     everDetectedAgent: terminal.everDetectedAgent,
     agentId: terminal.agentId,
     detectedAgentId: terminal.detectedAgentId,
+    capabilityAgentId: terminal.capabilityAgentId,
     agentPresetId: terminal.agentPresetId,
     presetColor: terminal.agentPresetColor,
     agentLaunchFlags: terminal.agentLaunchFlags,

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -853,6 +853,64 @@ describe("detectedAgentId propagation", () => {
   });
 });
 
+// #5804: capability mode is sealed at spawn time. Hydration must forward the
+// backend's value verbatim and never re-derive — the `handleAgentDetection`
+// bridge-write violation can pollute `agentId` and the legacy `type` field on
+// observed shells, and re-deriving from that would mint false `full` capability.
+describe("capabilityAgentId propagation", () => {
+  it("buildArgsForBackendTerminal forwards capabilityAgentId", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", capabilityAgentId: "claude" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.capabilityAgentId).toBe("claude");
+  });
+
+  it("buildArgsForReconnectedFallback forwards capabilityAgentId", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p", capabilityAgentId: "gemini" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.capabilityAgentId).toBe("gemini");
+  });
+
+  it("buildArgsForOrphanedTerminal forwards capabilityAgentId", () => {
+    const result = buildArgsForOrphanedTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", capabilityAgentId: "codex" },
+      "/p"
+    );
+    expect(result.capabilityAgentId).toBe("codex");
+  });
+
+  // Critical regression: an observed shell where `handleAgentDetection` has
+  // bridge-written `agentId="claude"` and `type="claude"` on the backend must
+  // still arrive in the renderer with `capabilityAgentId: undefined`. The
+  // hydration builders must not synthesize capability from the polluted fields.
+  it("buildArgsForBackendTerminal leaves capabilityAgentId undefined for an observed shell with bridge-written agentId", () => {
+    const result = buildArgsForBackendTerminal(
+      {
+        id: "t1",
+        cwd: "/p",
+        kind: "terminal",
+        // Polluted by the bridge-write violation in handleAgentDetection:
+        agentId: "claude",
+        type: "claude",
+        detectedAgentId: "claude",
+        everDetectedAgent: true,
+        // Backend correctly omits capabilityAgentId — it was never sealed.
+      },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    // agentId may be present (sealed-or-polluted, not our concern here);
+    // capabilityAgentId must remain undefined so the renderer can correctly
+    // reject this terminal from agent-only feature gates.
+    expect(result.capabilityAgentId).toBeUndefined();
+  });
+});
+
 describe("buildArgsForNonPtyRecreation", () => {
   it("builds browser panel args", () => {
     const result = buildArgsForNonPtyRecreation(

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -99,6 +99,7 @@ interface BackendTerminalData {
   everDetectedAgent?: boolean;
   detectedAgentId?: BuiltInAgentId;
   detectedProcessId?: string;
+  capabilityAgentId?: BuiltInAgentId;
 }
 
 interface ReconnectedTerminalData {
@@ -117,6 +118,7 @@ interface ReconnectedTerminalData {
   everDetectedAgent?: boolean;
   detectedAgentId?: BuiltInAgentId;
   detectedProcessId?: string;
+  capabilityAgentId?: BuiltInAgentId;
 }
 
 interface AgentSettingsData {
@@ -215,6 +217,7 @@ export function buildArgsForBackendTerminal(
     everDetectedAgent: backendTerminal.everDetectedAgent,
     detectedAgentId: backendTerminal.detectedAgentId,
     detectedProcessId: backendTerminal.detectedProcessId,
+    capabilityAgentId: backendTerminal.capabilityAgentId,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,
@@ -271,6 +274,7 @@ export function buildArgsForReconnectedFallback(
     everDetectedAgent: reconnectedTerminal.everDetectedAgent,
     detectedAgentId: reconnectedTerminal.detectedAgentId,
     detectedProcessId: reconnectedTerminal.detectedProcessId,
+    capabilityAgentId: reconnectedTerminal.capabilityAgentId,
     agentPresetId: readPresetId(saved),
     agentPresetColor: readPresetColor(saved),
     extensionState: saved.extensionState,
@@ -485,5 +489,6 @@ export function buildArgsForOrphanedTerminal(
     everDetectedAgent: terminal.everDetectedAgent,
     detectedAgentId: terminal.detectedAgentId,
     detectedProcessId: terminal.detectedProcessId,
+    capabilityAgentId: terminal.capabilityAgentId,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `capabilityAgentId` as a first-class field, sealed at spawn time from launch intent (`isBuiltInAgentId` on `isAgentTerminal`). The runtime detector never mutates it, making the full/observational distinction permanent from the moment a terminal is created.
- Threads the field through the entire IPC pipeline: `PtyHostTerminalInfo`, 4 pty-host snapshot mappers, 5 IPC snapshot handlers, and `TerminalInfoResponse` in the main process all carry it cleanly.
- Gates `HybridInputBar` on `capabilityAgentId` rather than `effectiveAgentId`, so observational shells (plain terminals where an agent was runtime-detected) no longer expose the agent input bar. Renames `getTerminalFocusTarget`'s internal flag from `isAgentTerminal` to `hasFullAgentCapability` and updates all 5 call sites to match.

Resolves #5804

## Changes

- `TerminalProcess` constructor writes `capabilityAgentId` once at spawn; `handleAgentDetection` no longer touches it
- `shared/types/panel.ts`, `ipc/terminal.ts`, `pty/types.ts`, `addPanelOptions.ts`, `fleetEligibility.ts` doc strings updated to reflect sealed-at-spawn contract
- `panelRegistry/core.ts`: fresh spawns derive `capabilityAgentId` from `AddPanelOptions`; reconnect path trusts the backend value exactly to avoid agentId-rewrite pollution from the `handleAgentDetection` bridge-write
- `statePatcher` updated with 3 hydration builders that propagate the field correctly
- 4 new test files cover the capability contract: `TerminalProcess.agentDetection.test.ts` (5 tests including `getPublicState`), `fleetArmingStore.test.ts` (renamed + observational-shell eligibility regression), `statePatcher.test.ts` (3 builder propagation tests + "observed-shell-with-bridge-written-agentId stays undefined" regression), `terminalFocus.test.ts` (parameter rename + observational-shell regression)

## Testing

- Cold-launched Claude agent terminal: `HybridInputBar` appears as expected
- Plain shell with `claude` running (runtime-detected): `HybridInputBar` does not appear
- Project switch with both terminal types open: capability state preserved correctly across the reconnect path
- Confirmed via `statePatcher` tests that bridge-written `agentId`/`type` from `handleAgentDetection` don't mint false capability on reconnect