### PR TITLE
feat(panel): observational chip for runtime-detected agent terminals

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -6,6 +6,7 @@ import { TitleEditingProvider, useTitleEditing } from "./TitleEditingContext";
 import { TerminalHeaderContent } from "@/components/Terminal/TerminalHeaderContent";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import type { PanelKind, TerminalType, AgentState } from "@/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import type { TabInfo } from "./TabButton";
 import { useDockBlockedState } from "@/components/Layout/useDockBlockedState";
@@ -57,6 +58,8 @@ export interface ContentPanelProps extends BasePanelProps {
   agentId?: string;
   /** Runtime-detected agent identity (cleared on agent exit). Drives panel chrome. */
   detectedAgentId?: string;
+  /** Sealed at spawn for full-mode agent terminals. Absent for runtime-detected agents in plain shells. */
+  capabilityAgentId?: BuiltInAgentId;
   detectedProcessId?: string;
   presetColor?: string;
   agentLaunchFlags?: string[];
@@ -131,6 +134,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     type,
     agentId,
     detectedAgentId,
+    capabilityAgentId,
     detectedProcessId,
     presetColor,
     agentLaunchFlags,
@@ -333,6 +337,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           type={type}
           agentId={agentId}
           detectedAgentId={detectedAgentId}
+          capabilityAgentId={capabilityAgentId}
           detectedProcessId={detectedProcessId}
           presetColor={presetColor}
           agentLaunchFlags={agentLaunchFlags}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   CopyPlus,
   Ellipsis,
+  Eye,
   Info,
   Lock,
   Pencil,
@@ -65,6 +66,8 @@ import { TabButton, type TabInfo } from "./TabButton";
 import { SortableTabButton } from "./SortableTabButton";
 import { useShallow } from "zustand/react/shallow";
 import { panelKindCanRestart, panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isRegisteredAgent } from "@shared/config/agentRegistry";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { actionService } from "@/services/ActionService";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
@@ -77,6 +80,12 @@ export interface PanelHeaderProps {
   agentId?: string;
   /** Runtime-detected agent identity (cleared when the agent exits). Drives icons and the watch button. */
   detectedAgentId?: string;
+  /**
+   * Agent identity sealed at spawn for full-mode terminals. Absent when an
+   * agent was started inside a plain shell — the chip uses this gap to offer
+   * a one-click respawn into a proper agent terminal.
+   */
+  capabilityAgentId?: BuiltInAgentId;
   detectedProcessId?: string;
   presetColor?: string;
   worktreeAccentColor?: string;
@@ -143,6 +152,7 @@ function PanelHeaderComponent({
   type,
   agentId,
   detectedAgentId,
+  capabilityAgentId,
   detectedProcessId,
   presetColor,
   worktreeAccentColor,
@@ -266,6 +276,17 @@ function PanelHeaderComponent({
   const terminal = usePanelStore(useShallow((state) => state.panelsById[id]));
   const isInputLocked = terminal?.isInputLocked ?? false;
   const hasPty = panelKindHasPty(kind);
+
+  // Observational mode: an agent is running inside a plain shell that wasn't
+  // launched as an agent terminal. `capabilityAgentId` is sealed at spawn for
+  // full-mode terminals; its absence alongside a live `detectedAgentId` is the
+  // gap we surface — calmly, with a one-click respawn into the proper agent
+  // terminal. We only show the CTA for agents the registry can spawn.
+  const isObservationalAgent =
+    !!detectedAgentId &&
+    !capabilityAgentId &&
+    isRegisteredAgent(detectedAgentId) &&
+    !terminal?.isRestarting;
 
   // Whether the overflow "..." menu has any items to show
   const showMoveToDock = !!onMinimize && !isMaximized && location !== "dock";
@@ -809,6 +830,36 @@ function PanelHeaderComponent({
                 <TooltipContent side="bottom">
                   Last fleet broadcast failed here — click to dismiss. Run "Fleet: Retry failed
                   broadcast" from the command palette to resend.
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+
+          {isObservationalAgent && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void actionService.dispatch(
+                        "terminal.convertType",
+                        { terminalId: id, type: detectedAgentId },
+                        { source: "menu" }
+                      );
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    aria-label={`Restart as ${detectedAgentId} agent terminal`}
+                    data-testid="panel-observational-chip"
+                    className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium leading-none select-none bg-overlay-subtle text-daintree-text/70 hover:text-daintree-text hover:bg-daintree-text/10 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                  >
+                    <Eye className="w-3 h-3" aria-hidden="true" />
+                    <span>Observing · Restart as agent</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {`${detectedAgentId} is running inside a plain shell. Restart to give it the full agent terminal — managed environment, scrollback, and fleet membership.`}
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -532,6 +532,67 @@ describe("PanelHeader", () => {
     });
   });
 
+  describe("observational agent chip", () => {
+    it("renders the chip when an agent is detected without capability seal", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "claude" })} />);
+      const chip = screen.getByTestId("panel-observational-chip");
+      expect(chip).toBeDefined();
+      expect(chip.textContent).toContain("Observing");
+      expect(chip.textContent).toContain("Restart as agent");
+      expect(chip.getAttribute("aria-label")).toBe("Restart as claude agent terminal");
+    });
+
+    it("does not render the chip when capabilityAgentId is set (full-mode terminal)", () => {
+      render(
+        <PanelHeader {...makeProps({ detectedAgentId: "claude", capabilityAgentId: "claude" })} />
+      );
+      expect(screen.queryByTestId("panel-observational-chip")).toBeNull();
+    });
+
+    it("does not render the chip when no agent is detected", () => {
+      render(<PanelHeader {...makeProps()} />);
+      expect(screen.queryByTestId("panel-observational-chip")).toBeNull();
+    });
+
+    it("does not render the chip while the terminal is restarting", () => {
+      mockStoreState = {
+        ...mockStoreState,
+        panelsById: { "test-panel": { id: "test-panel", isRestarting: true } },
+        panelIds: ["test-panel"],
+      };
+      render(<PanelHeader {...makeProps({ detectedAgentId: "claude" })} />);
+      expect(screen.queryByTestId("panel-observational-chip")).toBeNull();
+    });
+
+    it("does not render the chip for an unregistered detected agent id", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "not-a-real-agent" })} />);
+      expect(screen.queryByTestId("panel-observational-chip")).toBeNull();
+    });
+
+    it("dispatches terminal.convertType with the detected agent id when clicked", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "claude" })} />);
+      const chip = screen.getByTestId("panel-observational-chip");
+      chip.click();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        "terminal.convertType",
+        { terminalId: "test-panel", type: "claude" },
+        { source: "menu" }
+      );
+    });
+
+    it("uses neutral surface tokens, not warning or accent colors", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "claude" })} />);
+      const chip = screen.getByTestId("panel-observational-chip");
+      // Honest UX: chip is informational, not alarming. No warning orange,
+      // no accent on the resting surface — accent is reserved for one
+      // load-bearing signal per view (per CLAUDE.md).
+      expect(chip.className).toContain("bg-overlay-subtle");
+      expect(chip.className).not.toContain("bg-status-warning");
+      expect(chip.className).not.toContain("bg-status-danger");
+      expect(chip.className).not.toContain("text-accent-primary");
+    });
+  });
+
   describe("dangerous flags indicator", () => {
     it("shows red dot indicator when agentLaunchFlags contain dangerous flag", () => {
       render(

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -591,6 +591,36 @@ describe("PanelHeader", () => {
       expect(chip.className).not.toContain("bg-status-danger");
       expect(chip.className).not.toContain("text-accent-primary");
     });
+
+    it("threads the detected agent id through label and dispatch (not hardcoded to claude)", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "gemini" })} />);
+      const chip = screen.getByTestId("panel-observational-chip");
+      expect(chip.getAttribute("aria-label")).toBe("Restart as gemini agent terminal");
+
+      chip.click();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        "terminal.convertType",
+        { terminalId: "test-panel", type: "gemini" },
+        { source: "menu" }
+      );
+    });
+
+    it("does not render the chip when capability is sealed for a different agent", () => {
+      // Any seal suppresses observational mode — we trust capabilityAgentId
+      // as the authoritative full-mode predicate, even if detection sees a
+      // different live process.
+      render(
+        <PanelHeader {...makeProps({ detectedAgentId: "gemini", capabilityAgentId: "claude" })} />
+      );
+      expect(screen.queryByTestId("panel-observational-chip")).toBeNull();
+    });
+
+    it("does not bubble to the header double-click handler when the chip is clicked", () => {
+      render(<PanelHeader {...makeProps({ detectedAgentId: "claude" })} />);
+      const chip = screen.getByTestId("panel-observational-chip");
+      chip.click();
+      expect(mockDispatch).not.toHaveBeenCalledWith("nav.toggleFocusMode");
+    });
   });
 
   describe("dangerous flags indicator", () => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -763,6 +763,7 @@ function TerminalPaneComponent({
       type={type}
       agentId={agentId}
       detectedAgentId={detectedAgentId}
+      capabilityAgentId={capabilityAgentId}
       presetColor={livePresetColor}
       isFocused={isFocused}
       isMaximized={isMaximized}

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -737,6 +737,22 @@ export const createRestartActions = (
       }
     }
 
+    // Snapshot pre-mutation identity for rollback on spawn failure. If the
+    // spawn rejects after we kill the old PTY, leaving the optimistic write
+    // in place would falsely mark the panel as fleet-eligible (via the
+    // capability-id fallback to `agentId`) while the PTY is actually dead.
+    const previousIdentity = {
+      kind: terminal.kind,
+      type: terminal.type,
+      agentId: terminal.agentId,
+      title: terminal.title,
+      agentState: terminal.agentState,
+      lastStateChange: terminal.lastStateChange,
+      stateChangeTrigger: terminal.stateChangeTrigger,
+      stateChangeConfidence: terminal.stateChangeConfidence,
+      command: terminal.command,
+    };
+
     try {
       const managedInstance = terminalInstanceService.get(id);
       let spawnCols = terminal.cols || 80;
@@ -841,6 +857,7 @@ export const createRestartActions = (
       set((state) =>
         updateTerminal(state, id, (t) => ({
           ...t,
+          ...previousIdentity,
           isRestarting: false,
           restartError,
         }))


### PR DESCRIPTION
## Summary

- The previous "degraded mode" banner for runtime-promoted agent terminals was removed (correctly) but nothing replaced it. Users running Claude in a plain shell had no indication the app had detected an agent, and no clear path to a proper managed terminal.
- This adds a low-key "Observing · Restart as agent" chip in the panel header for runtime-detected agents. One click dispatches `terminal.convertType` and respawns the terminal as a full fleet-managed agent terminal with proper scrollback, managed env, and fleet membership.
- While wiring this up, a latent bug in `convertTerminalType` surfaced: a failed respawn left the panel in a half-mutated state (identity fields already overwritten, PTY dead). Fixed by snapshotting pre-mutation state and restoring it in the catch block.

Resolves #5806.

## Changes

- `PanelHeader.tsx` — derives `isObservationalAgent` from `detectedAgentId`, `capabilityAgentId`, and `isRestarting`; renders the chip in the single-panel (no-tabs) branch using neutral surface tokens (`bg-overlay-subtle`), no warning colour, no accent. Tooltip explains the value of a proper respawn without alarming language.
- `ContentPanel.tsx` — threads `capabilityAgentId` through `ContentPanelProps` → `PanelHeaderProps`.
- `TerminalPane.tsx` — passes `capabilityAgentId` down into `ContentPanel`.
- `restart.ts` — snapshots panel identity fields before the optimistic mutation; restores them in the catch block alongside `restartError`. Prevents false fleet eligibility after a failed spawn.
- `PanelHeader.test.tsx` — 10 new unit tests covering render conditions, suppression during restart, dispatch wiring, neutral token assertions, parameterised agent IDs, the capability-seal path, and click-bubble suppression.

## Testing

Manual:
- Run `claude` in a plain terminal panel. The "Observing · Restart as agent" chip should appear in the header once agent output is detected.
- Click the chip. Panel should respawn as a full Claude agent terminal (managed env, scrollback configured, fleet entry added).
- Cold-launch a terminal via the agent panel kind. No chip should appear (capability seal suppresses it).
- During a restart, the chip should disappear until the new PTY is healthy.

Unit: 53 Vitest tests passing, tsc clean, lint at baseline (364 warnings, 0 errors), build 12s.