### PR TITLE
fix(process-detector): make ambiguity first-class and harden runtime detection

### DIFF
--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -552,6 +552,20 @@ export class ProcessDetector {
         this.onStreak = 0;
         this.offStreak = 0;
         this.pendingDetected = null;
+
+        // Upgrade evidence source when the process tree later corroborates a
+        // shell-only commit. Without this, `lastEvidenceSource` remains
+        // `"shell_command"` forever, and a subsequent `clearShellCommandEvidence()`
+        // call (e.g. on prompt-return) would mistakenly compute the shell as
+        // the sole support and emit a spurious demotion — even though the
+        // process tree still shows the agent running. #5809
+        if (
+          rawDetected &&
+          result.evidenceSource &&
+          result.evidenceSource !== this.lastEvidenceSource
+        ) {
+          this.lastEvidenceSource = result.evidenceSource;
+        }
       }
 
       const inPendingTransition = this.onStreak > 0 || this.offStreak > 0;
@@ -604,8 +618,18 @@ export class ProcessDetector {
     // agent every OFF hysteresis window; returning `unknown` holds state
     // until the cache recovers. Precedent: #4973 (distinguish contexts so
     // a guard correct in one doesn't silently break another). #5809
+    //
+    // EXCEPTION: if fresh shell-command evidence exists, let the merge path
+    // promote from it. Blind-`ps` + typed `claude` is the PRIMARY case this
+    // feature exists for — holding `unknown` here would silently discard the
+    // shell signal. Only when both signals are absent do we hold `unknown`.
     const cacheError = this.cache.getLastError();
     if (!isBusy && cacheError !== null) {
+      const shellEvidenceValid =
+        this.shellCommandIdentity !== null && Date.now() < this.shellCommandExpiresAt;
+      if (shellEvidenceValid) {
+        return this.mergeWithShellEvidence(null, { isBusy: false, currentCommand: undefined });
+      }
       return makeUnknownResult({ isBusy: false });
     }
 
@@ -710,11 +734,15 @@ export class ProcessDetector {
     ctx: { isBusy: boolean; currentCommand?: string }
   ): DetectionResult {
     const shellIdentity = this.shellCommandIdentity;
-    const shellStickyActive = shellIdentity !== null && Date.now() < this.shellCommandStickyUntil;
+    // Merge uses the wider expiry window (30 s) — shell evidence stays valid
+    // for merging even after the 12 s sticky window closes. Sticky governs
+    // off-streak suppression in detect(); merge governs whether the shell
+    // signal can promote (no tree) or disagree (tree shows different agent).
+    const shellEvidenceValid = shellIdentity !== null && Date.now() < this.shellCommandExpiresAt;
 
     // Case A — tree has a positive agent match.
     if (treeMatch?.agentType) {
-      if (shellStickyActive && shellIdentity?.agentType) {
+      if (shellEvidenceValid && shellIdentity?.agentType) {
         if (shellIdentity.agentType === treeMatch.agentType) {
           return makeAgentResult({
             agentType: treeMatch.agentType,
@@ -741,9 +769,9 @@ export class ProcessDetector {
       });
     }
 
-    // Case B — no tree agent match, but shell is fresh with an agent. The
+    // Case B — no tree agent match, but shell is valid with an agent. The
     // title-rewriting CLI and blind-`ps` cases both land here.
-    if (shellStickyActive && shellIdentity?.agentType) {
+    if (shellEvidenceValid && shellIdentity?.agentType) {
       return makeAgentResult({
         agentType: shellIdentity.agentType,
         processIconId: shellIdentity.processIconId ?? treeMatch?.processIconId,
@@ -767,8 +795,8 @@ export class ProcessDetector {
     }
 
     // Case D — no tree evidence. If shell has a non-agent icon and is still
-    // fresh, surface it the same way a tree icon would be surfaced.
-    if (shellStickyActive && shellIdentity?.processIconId) {
+    // valid, surface it the same way a tree icon would be surfaced.
+    if (shellEvidenceValid && shellIdentity?.processIconId) {
       return makeAgentResult({
         processIconId: shellIdentity.processIconId,
         processName: shellIdentity.processName,

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -188,7 +188,7 @@ export interface DetectionResult {
 
 export type DetectionCallback = (result: DetectionResult, spawnedAt: number) => void;
 
-function makeAgentResult(params: {
+export function makeAgentResult(params: {
   agentType?: TerminalType;
   processIconId?: string;
   processName?: string;
@@ -208,7 +208,10 @@ function makeAgentResult(params: {
   };
 }
 
-function makeNoAgentResult(params: { isBusy?: boolean; currentCommand?: string }): DetectionResult {
+export function makeNoAgentResult(params: {
+  isBusy?: boolean;
+  currentCommand?: string;
+}): DetectionResult {
   return {
     detectionState: "no_agent",
     detected: false,
@@ -217,7 +220,7 @@ function makeNoAgentResult(params: { isBusy?: boolean; currentCommand?: string }
   };
 }
 
-function makeUnknownResult(params?: {
+export function makeUnknownResult(params?: {
   isBusy?: boolean;
   currentCommand?: string;
 }): DetectionResult {
@@ -229,7 +232,7 @@ function makeUnknownResult(params?: {
   };
 }
 
-function makeAmbiguousResult(params: {
+export function makeAmbiguousResult(params: {
   isBusy?: boolean;
   currentCommand?: string;
   evidenceSource?: DetectionEvidenceSource;
@@ -281,7 +284,6 @@ export class ProcessDetector {
   // detectAgent() so the two signals arrive at a single committed result.
   private shellCommandIdentity: CommandIdentity | null = null;
   private shellCommandText: string | undefined;
-  private shellCommandObservedAt: number = 0;
   private shellCommandStickyUntil: number = 0;
   private shellCommandExpiresAt: number = 0;
 
@@ -315,7 +317,6 @@ export class ProcessDetector {
   ): void {
     this.shellCommandIdentity = identity;
     this.shellCommandText = commandText;
-    this.shellCommandObservedAt = observedAt;
     this.shellCommandStickyUntil = observedAt + ProcessDetector.SHELL_COMMAND_STICKY_MS;
     this.shellCommandExpiresAt = observedAt + ProcessDetector.SHELL_COMMAND_EXPIRY_MS;
 
@@ -348,7 +349,6 @@ export class ProcessDetector {
 
     this.shellCommandIdentity = null;
     this.shellCommandText = undefined;
-    this.shellCommandObservedAt = 0;
     this.shellCommandStickyUntil = 0;
     this.shellCommandExpiresAt = 0;
 

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -162,16 +162,86 @@ export function detectCommandIdentity(command: string | undefined): CommandIdent
   };
 }
 
+/**
+ * Explicit detection state. Ambiguity is first-class — `unknown` means we have
+ * no evidence (cache error, blind `ps`, invalid PID) and should not mutate
+ * committed state; `ambiguous` means we have conflicting positive evidence
+ * from two independent sources and are holding until one stabilises. Only
+ * `agent` and `no_agent` drive actual state changes in consumers.
+ */
+export type DetectionState = "unknown" | "no_agent" | "agent" | "ambiguous";
+
+/** Which signal produced the committed agent identity, for diagnostics. */
+export type DetectionEvidenceSource = "process_tree" | "shell_command" | "both";
+
 export interface DetectionResult {
+  detectionState: DetectionState;
+  /** @deprecated Use `detectionState === "agent"`. Retained for legacy consumers. */
   detected: boolean;
   agentType?: TerminalType;
   processIconId?: string;
   processName?: string;
   isBusy?: boolean;
   currentCommand?: string;
+  evidenceSource?: DetectionEvidenceSource;
 }
 
 export type DetectionCallback = (result: DetectionResult, spawnedAt: number) => void;
+
+function makeAgentResult(params: {
+  agentType?: TerminalType;
+  processIconId?: string;
+  processName?: string;
+  isBusy?: boolean;
+  currentCommand?: string;
+  evidenceSource?: DetectionEvidenceSource;
+}): DetectionResult {
+  return {
+    detectionState: "agent",
+    detected: true,
+    agentType: params.agentType,
+    processIconId: params.processIconId,
+    processName: params.processName,
+    isBusy: params.isBusy,
+    currentCommand: params.currentCommand,
+    evidenceSource: params.evidenceSource,
+  };
+}
+
+function makeNoAgentResult(params: { isBusy?: boolean; currentCommand?: string }): DetectionResult {
+  return {
+    detectionState: "no_agent",
+    detected: false,
+    isBusy: params.isBusy,
+    currentCommand: params.currentCommand,
+  };
+}
+
+function makeUnknownResult(params?: {
+  isBusy?: boolean;
+  currentCommand?: string;
+}): DetectionResult {
+  return {
+    detectionState: "unknown",
+    detected: false,
+    isBusy: params?.isBusy,
+    currentCommand: params?.currentCommand,
+  };
+}
+
+function makeAmbiguousResult(params: {
+  isBusy?: boolean;
+  currentCommand?: string;
+  evidenceSource?: DetectionEvidenceSource;
+}): DetectionResult {
+  return {
+    detectionState: "ambiguous",
+    detected: false,
+    isBusy: params.isBusy,
+    currentCommand: params.currentCommand,
+    evidenceSource: params.evidenceSource,
+  };
+}
 
 export class ProcessDetector {
   // Require N consecutive polls agreeing on a new agent/icon state before
@@ -179,6 +249,15 @@ export class ProcessDetector {
   // which is enough to filter out short-lived processes (e.g. `claude --version`)
   // that would otherwise cause the detector to thrash between on/off.
   private static readonly HYSTERESIS_THRESHOLD = 2;
+
+  // Asymmetric TTLs for shell-command evidence. Sticky window suppresses the
+  // off-streak — a fresh shell-command commit anchors the detector through
+  // blind `ps` cycles and short-lived subprocess thrash without waiting for
+  // the next process-tree poll to re-confirm. Absolute upper bound prevents
+  // a synthetic shell identity from holding `agent` forever if the process
+  // never actually started. #5809
+  private static readonly SHELL_COMMAND_STICKY_MS = 12_000;
+  private static readonly SHELL_COMMAND_EXPIRY_MS = 30_000;
 
   private terminalId: string;
   private spawnedAt: number;
@@ -188,6 +267,7 @@ export class ProcessDetector {
   private lastProcessIconId: string | null = null;
   private lastBusyState: boolean | null = null;
   private lastCurrentCommand: string | undefined;
+  private lastEvidenceSource: DetectionEvidenceSource | null = null;
   private cache: ProcessTreeCache;
   private unsubscribe: (() => void) | null = null;
   private isStarted: boolean = false;
@@ -195,6 +275,15 @@ export class ProcessDetector {
   private offStreak: number = 0;
   private pendingDetected: { agentType?: TerminalType; processIconId?: string } | null = null;
   private lastUnknownSignature: string | null = null;
+
+  // Shell-command evidence injected by TerminalProcess when a command is
+  // submitted through the PTY. Merges with process-tree evidence inside
+  // detectAgent() so the two signals arrive at a single committed result.
+  private shellCommandIdentity: CommandIdentity | null = null;
+  private shellCommandText: string | undefined;
+  private shellCommandObservedAt: number = 0;
+  private shellCommandStickyUntil: number = 0;
+  private shellCommandExpiresAt: number = 0;
 
   constructor(
     terminalId: string,
@@ -208,6 +297,82 @@ export class ProcessDetector {
     this.ptyPid = ptyPid;
     this.callback = callback;
     this.cache = cache;
+  }
+
+  /**
+   * Inject shell-command evidence from a PTY input capture. Called by
+   * TerminalProcess after parsing a submitted command line so the detector
+   * can merge the shell identity with process-tree observations in one
+   * place. Triggers a synchronous `detect()` so fast commits (~1.2 s) are
+   * preserved without waiting for the next cache poll (~2.5 s). The sticky
+   * TTL (12 s) then suppresses off-streak counting so short-lived subprocess
+   * thrash doesn't demote a confident commit. #5809
+   */
+  injectShellCommandEvidence(
+    identity: CommandIdentity,
+    commandText?: string,
+    observedAt: number = Date.now()
+  ): void {
+    this.shellCommandIdentity = identity;
+    this.shellCommandText = commandText;
+    this.shellCommandObservedAt = observedAt;
+    this.shellCommandStickyUntil = observedAt + ProcessDetector.SHELL_COMMAND_STICKY_MS;
+    this.shellCommandExpiresAt = observedAt + ProcessDetector.SHELL_COMMAND_EXPIRY_MS;
+
+    // Only run the sync detect pass once attached — before start() the cache
+    // callback is not wired and invoking detect() early emits from a detector
+    // that hasn't announced itself yet.
+    if (this.isStarted) {
+      this.detect();
+    }
+  }
+
+  /**
+   * Clear any injected shell-command evidence. Called by TerminalProcess on
+   * prompt-return (the command finished) or on terminal teardown.
+   *
+   * When the committed identity was held SOLELY by shell-command evidence
+   * (evidenceSource === "shell_command"), clearing the evidence leaves no
+   * support for the commit — the process tree showed nothing, and the shell
+   * signal just went away. In that case we demote synchronously so the UI
+   * clears the stale badge instead of waiting for process-tree hysteresis
+   * to run (which in test/mock environments may never tick). When the
+   * commit was also backed by the process tree ("both" or "process_tree"),
+   * the tree-sourced support is independent of the shell clear — let the
+   * natural detect cycle drive any demotion.
+   */
+  clearShellCommandEvidence(): void {
+    const shellWasSoleSupport =
+      this.lastEvidenceSource === "shell_command" &&
+      (this.lastDetected !== null || this.lastProcessIconId !== null);
+
+    this.shellCommandIdentity = null;
+    this.shellCommandText = undefined;
+    this.shellCommandObservedAt = 0;
+    this.shellCommandStickyUntil = 0;
+    this.shellCommandExpiresAt = 0;
+
+    if (shellWasSoleSupport && this.isStarted) {
+      this.lastDetected = null;
+      this.lastProcessIconId = null;
+      this.lastEvidenceSource = null;
+      this.lastBusyState = false;
+      this.lastCurrentCommand = undefined;
+      this.onStreak = 0;
+      this.offStreak = 0;
+      this.pendingDetected = null;
+      try {
+        this.callback(
+          makeNoAgentResult({ isBusy: false, currentCommand: undefined }),
+          this.spawnedAt
+        );
+      } catch (err) {
+        console.error(
+          `ProcessDetector clear-shell demote error for terminal ${this.terminalId}:`,
+          err
+        );
+      }
+    }
   }
 
   start(): void {
@@ -239,6 +404,11 @@ export class ProcessDetector {
 
   stop(): void {
     if (this.unsubscribe) {
+      // Clear any injected shell-command evidence first so the teardown flush
+      // emits a clean no_agent result and no stale identity lingers across a
+      // same-session restart of the detector.
+      this.clearShellCommandEvidence();
+
       // Flush a pending OFF streak on teardown so a detected agent whose process
       // exited inside the hysteresis window does not leave ghost state in the UI.
       if (this.offStreak > 0 && (this.lastDetected !== null || this.lastProcessIconId !== null)) {
@@ -247,11 +417,12 @@ export class ProcessDetector {
         this.lastProcessIconId = null;
         this.lastBusyState = false;
         this.lastCurrentCommand = undefined;
+        this.lastEvidenceSource = null;
         this.offStreak = 0;
         this.onStreak = 0;
         this.pendingDetected = null;
         try {
-          this.callback({ detected: false, isBusy: false, currentCommand: undefined }, spawnedAt);
+          this.callback(makeNoAgentResult({ isBusy: false, currentCommand: undefined }), spawnedAt);
         } catch (err) {
           console.error(`ProcessDetector stop flush error for terminal ${this.terminalId}:`, err);
         }
@@ -270,17 +441,61 @@ export class ProcessDetector {
 
   private detect(): void {
     try {
+      // Expire stale shell-command evidence before each detect pass so a
+      // synthetic identity from a never-started subprocess can't pin the
+      // detector to `agent` past the upper bound.
+      if (
+        this.shellCommandIdentity !== null &&
+        this.shellCommandExpiresAt > 0 &&
+        Date.now() > this.shellCommandExpiresAt
+      ) {
+        this.clearShellCommandEvidence();
+      }
+
       const result = this.detectAgent();
+
+      // `unknown` and `ambiguous` are first-class HOLD states — no committed-
+      // state transitions and no side-channel emissions. A blind `ps` or a
+      // two-source conflict genuinely has no reliable busy/command data to
+      // report, so emitting anything here would leak uncertainty into
+      // consumers (headline generators, state machines) that would then act
+      // on it. Hold committed state silently until the cache recovers or the
+      // conflict resolves. Precedent: #4153 — uncertain events must be no-ops,
+      // not partial updates. #5809
+      if (result.detectionState === "unknown" || result.detectionState === "ambiguous") {
+        this.onStreak = 0;
+        this.offStreak = 0;
+        this.pendingDetected = null;
+        return;
+      }
 
       const rawAgent = result.agentType ?? null;
       const rawIcon = result.processIconId ?? null;
-      const rawDetected = result.detected;
+      const rawDetected = result.detectionState === "agent";
       const committedAgent = this.lastDetected;
       const committedIcon = this.lastProcessIconId;
 
       const agentOrIconDiffers = rawAgent !== committedAgent || rawIcon !== committedIcon;
 
+      // Sticky TTL: when fresh shell-command evidence vouches for the currently
+      // committed identity, suppress the off-streak entirely. Short-lived
+      // subprocess thrash or blind `ps` cycles within the TTL window must not
+      // produce a demotion commit. #5809
+      const shellStickyActive =
+        this.shellCommandIdentity !== null && Date.now() < this.shellCommandStickyUntil;
+
       let gatedCommitted = false;
+
+      // Fast-commit path for shell-sourced evidence. The shell-command
+      // fallback already debounces at its capture site (~1.2 s prompt-not-
+      // visible window) before injection, so requiring a second hysteresis
+      // confirmation here would double-count the debounce and add ~2.5 s of
+      // UI latency. When the evidence source is `shell_command` or `both`,
+      // the decision is already backed by a second signal and can commit on
+      // the first tick. Process-tree-only signals still go through
+      // hysteresis to filter out short-lived subprocess thrash. #5809
+      const isShellSourcedEvidence =
+        result.evidenceSource === "shell_command" || result.evidenceSource === "both";
 
       if (agentOrIconDiffers) {
         if (rawDetected) {
@@ -298,13 +513,26 @@ export class ProcessDetector {
           };
           this.offStreak = 0;
 
-          if (this.onStreak >= ProcessDetector.HYSTERESIS_THRESHOLD) {
+          const commitNow =
+            isShellSourcedEvidence || this.onStreak >= ProcessDetector.HYSTERESIS_THRESHOLD;
+
+          if (commitNow) {
             this.lastDetected = rawAgent;
             this.lastProcessIconId = rawIcon;
+            this.lastEvidenceSource = result.evidenceSource ?? "process_tree";
             this.onStreak = 0;
             this.pendingDetected = null;
             gatedCommitted = true;
           }
+        } else if (shellStickyActive) {
+          // OFF direction suppressed by fresh shell evidence — hold committed
+          // state, flush streaks, and emit nothing. Busy/command side-channel
+          // emissions are still suppressed below via inPendingTransition=false
+          // plus the committed match (but lastBusy/command updates will flow
+          // naturally on matching ticks).
+          this.onStreak = 0;
+          this.offStreak = 0;
+          this.pendingDetected = null;
         } else {
           // OFF direction: raw reports no detection but committed state has one.
           this.offStreak += 1;
@@ -314,6 +542,7 @@ export class ProcessDetector {
           if (this.offStreak >= ProcessDetector.HYSTERESIS_THRESHOLD) {
             this.lastDetected = null;
             this.lastProcessIconId = null;
+            this.lastEvidenceSource = null;
             this.offStreak = 0;
             gatedCommitted = true;
           }
@@ -347,7 +576,7 @@ export class ProcessDetector {
         // side-channel change).
         if (gatedCommitted) {
           console.log(
-            `[ProcessDetector ${this.terminalId.slice(0, 8)}] commit pid=${this.ptyPid} detected=${result.detected} agent=${result.agentType ?? "null"} icon=${result.processIconId ?? "null"}`
+            `[ProcessDetector ${this.terminalId.slice(0, 8)}] commit pid=${this.ptyPid} state=${result.detectionState} agent=${result.agentType ?? "null"} icon=${result.processIconId ?? "null"} src=${result.evidenceSource ?? "process_tree"}`
           );
         }
         this.callback(result, this.spawnedAt);
@@ -359,15 +588,32 @@ export class ProcessDetector {
 
   private detectAgent(): DetectionResult {
     if (!Number.isInteger(this.ptyPid) || this.ptyPid <= 0) {
+      // Invalid PID — no evidence, not negative evidence. Hold committed
+      // state rather than emitting a demotion.
       console.warn(`Invalid PTY PID for terminal ${this.terminalId}: ${this.ptyPid}`);
-      return { detected: false, isBusy: false };
+      return makeUnknownResult({ isBusy: false });
     }
 
     const children = this.cache.getChildren(this.ptyPid);
     const isBusy = children.length > 0;
 
+    // Distinguish "no evidence" from "negative evidence". When the process
+    // tree cache is currently in an error state and reports zero children,
+    // that's blindness — an OS-level `ps` failure or fd starvation in the
+    // utility process. Returning `no_agent` here would demote a confirmed
+    // agent every OFF hysteresis window; returning `unknown` holds state
+    // until the cache recovers. Precedent: #4973 (distinguish contexts so
+    // a guard correct in one doesn't silently break another). #5809
+    const cacheError = this.cache.getLastError();
+    if (!isBusy && cacheError !== null) {
+      return makeUnknownResult({ isBusy: false });
+    }
+
     if (!isBusy) {
-      return { detected: false, isBusy: false, currentCommand: undefined };
+      // True absence of children with healthy cache → negative evidence. Let
+      // merge logic below consider shell-command evidence before committing
+      // no_agent.
+      return this.mergeWithShellEvidence(null, { isBusy: false, currentCommand: undefined });
     }
 
     const processes: ChildProcess[] = children.map((p) => ({
@@ -426,21 +672,114 @@ export class ProcessDetector {
       }
     }
 
-    if (bestMatch) {
-      return {
-        detected: true,
-        agentType: bestMatch.agentType,
-        processIconId: bestMatch.processIconId,
-        processName: bestMatch.processName,
-        isBusy,
-        currentCommand: bestMatch.processCommand || processes[0]?.command,
-      };
+    const primaryProcess = processes[0];
+    const primaryCommand = primaryProcess?.command;
+
+    return this.mergeWithShellEvidence(bestMatch, {
+      isBusy,
+      currentCommand: bestMatch?.processCommand || primaryCommand,
+    });
+  }
+
+  /**
+   * Merge process-tree evidence (bestMatch from children scan) with any
+   * injected shell-command evidence to produce the final DetectionResult.
+   *
+   * Rules — with the title-rewriting case as the primary motivating example:
+   *   1. Both sources agree on agent identity → `agent` with
+   *      `evidenceSource: "both"`.
+   *   2. Process tree positively identifies a DIFFERENT agent than the shell
+   *      → `ambiguous`. Two positive agent signals in conflict is genuinely
+   *      uncertain; hold until one stabilises.
+   *   3. Shell identifies an agent + tree shows a runtime/no match (the
+   *      title-rewriting or blind-argv case) → `agent` with
+   *      `evidenceSource: "shell_command"`. This is what #5809 is for —
+   *      `node` or empty tree + `claude` in the shell must resolve to
+   *      claude, not hold in limbo.
+   *   4. Only process tree → `agent`/`no_agent` with
+   *      `evidenceSource: "process_tree"`.
+   *   5. Only shell evidence, tree says no_agent but shell is fresh → use
+   *      shell identity (shell-command wins when tree is blind/empty).
+   *   6. Non-agent process icon from shell (npm/docker/etc.) behaves the
+   *      same way the process-tree icon would — it's a display hint, not
+   *      an agent promotion — and is subordinated to any process-tree agent
+   *      match.
+   */
+  private mergeWithShellEvidence(
+    treeMatch: DetectedProcessCandidate | null,
+    ctx: { isBusy: boolean; currentCommand?: string }
+  ): DetectionResult {
+    const shellIdentity = this.shellCommandIdentity;
+    const shellStickyActive = shellIdentity !== null && Date.now() < this.shellCommandStickyUntil;
+
+    // Case A — tree has a positive agent match.
+    if (treeMatch?.agentType) {
+      if (shellStickyActive && shellIdentity?.agentType) {
+        if (shellIdentity.agentType === treeMatch.agentType) {
+          return makeAgentResult({
+            agentType: treeMatch.agentType,
+            processIconId: treeMatch.processIconId,
+            processName: treeMatch.processName,
+            isBusy: ctx.isBusy,
+            currentCommand: ctx.currentCommand,
+            evidenceSource: "both",
+          });
+        }
+        // Two distinct positive agent identities — genuinely ambiguous. Hold.
+        return makeAmbiguousResult({
+          isBusy: ctx.isBusy,
+          currentCommand: ctx.currentCommand,
+        });
+      }
+      return makeAgentResult({
+        agentType: treeMatch.agentType,
+        processIconId: treeMatch.processIconId,
+        processName: treeMatch.processName,
+        isBusy: ctx.isBusy,
+        currentCommand: ctx.currentCommand,
+        evidenceSource: "process_tree",
+      });
     }
 
-    const primaryProcess = processes[0];
-    const currentCommand = primaryProcess?.command;
+    // Case B — no tree agent match, but shell is fresh with an agent. The
+    // title-rewriting CLI and blind-`ps` cases both land here.
+    if (shellStickyActive && shellIdentity?.agentType) {
+      return makeAgentResult({
+        agentType: shellIdentity.agentType,
+        processIconId: shellIdentity.processIconId ?? treeMatch?.processIconId,
+        processName: shellIdentity.processName ?? treeMatch?.processName,
+        isBusy: ctx.isBusy,
+        currentCommand: this.shellCommandText ?? ctx.currentCommand,
+        evidenceSource: "shell_command",
+      });
+    }
 
-    return { detected: false, isBusy, currentCommand };
+    // Case C — tree has a non-agent icon match (npm/docker/etc). Shell icon
+    // is only consulted when tree has nothing at all.
+    if (treeMatch?.processIconId) {
+      return makeAgentResult({
+        processIconId: treeMatch.processIconId,
+        processName: treeMatch.processName,
+        isBusy: ctx.isBusy,
+        currentCommand: ctx.currentCommand,
+        evidenceSource: "process_tree",
+      });
+    }
+
+    // Case D — no tree evidence. If shell has a non-agent icon and is still
+    // fresh, surface it the same way a tree icon would be surfaced.
+    if (shellStickyActive && shellIdentity?.processIconId) {
+      return makeAgentResult({
+        processIconId: shellIdentity.processIconId,
+        processName: shellIdentity.processName,
+        isBusy: ctx.isBusy,
+        currentCommand: this.shellCommandText ?? ctx.currentCommand,
+        evidenceSource: "shell_command",
+      });
+    }
+
+    // Case E — no evidence from either source → genuine no_agent.
+    return makeNoAgentResult({ isBusy: ctx.isBusy, currentCommand: ctx.currentCommand });
   }
 
   getLastDetected(): TerminalType | null {

--- a/electron/services/__tests__/AgentClassification.integration.test.ts
+++ b/electron/services/__tests__/AgentClassification.integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { randomUUID } from "crypto";
 import { PtyManager } from "../PtyManager.js";
 import { cleanupPtyManager, sleep } from "./helpers/ptyTestUtils.js";
+import { makeAgentResult, makeNoAgentResult } from "../ProcessDetector.js";
 import type { TerminalType, PanelKind } from "../../../shared/types/panel.js";
 
 describe("Agent Classification Matrix", () => {
@@ -283,11 +284,13 @@ describe("Agent Classification Matrix", () => {
       expect(before?.agentState).toBeUndefined();
       expect(before?.detectedAgentType).toBeUndefined();
 
-      const simulated = manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "claude" as TerminalType,
-        processName: "claude",
-      });
+      const simulated = manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "claude" as TerminalType,
+          processName: "claude",
+        })
+      );
       expect(simulated).toBe(true);
 
       const after = manager.getTerminal(id);
@@ -308,19 +311,19 @@ describe("Agent Classification Matrix", () => {
 
       await sleep(100);
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "claude" as TerminalType,
-        processName: "claude",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "claude" as TerminalType,
+          processName: "claude",
+        })
+      );
 
       const promoted = manager.getTerminal(id);
       expect(promoted?.analysisEnabled).toBe(true);
       expect(promoted?.detectedAgentType).toBe("claude");
 
-      manager.simulateAgentDetection(id, {
-        detected: false,
-      });
+      manager.simulateAgentDetection(id, makeNoAgentResult({}));
 
       const demoted = manager.getTerminal(id);
       expect(demoted?.analysisEnabled).toBe(false);
@@ -339,18 +342,22 @@ describe("Agent Classification Matrix", () => {
 
       await sleep(100);
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "claude" as TerminalType,
-        processName: "claude",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "claude" as TerminalType,
+          processName: "claude",
+        })
+      );
       expect(manager.getTerminal(id)?.analysisEnabled).toBe(true);
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        processIconId: "npm",
-        processName: "npm",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          processIconId: "npm",
+          processName: "npm",
+        })
+      );
 
       const demoted = manager.getTerminal(id);
       expect(demoted?.analysisEnabled).toBe(false);
@@ -372,9 +379,7 @@ describe("Agent Classification Matrix", () => {
       // Spawn-time agent panels keep analysisEnabled=true even after the live
       // agent exits — lifecycle unification here is runtime-only, and these
       // panels remain classified as agent panels for the whole session.
-      manager.simulateAgentDetection(id, {
-        detected: false,
-      });
+      manager.simulateAgentDetection(id, makeNoAgentResult({}));
 
       const info = manager.getTerminal(id);
       expect(info?.analysisEnabled).toBe(true);
@@ -392,11 +397,13 @@ describe("Agent Classification Matrix", () => {
       await sleep(100);
       expect(manager.getTerminal(id)?.agentId).toBeUndefined();
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "claude" as TerminalType,
-        processName: "claude",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "claude" as TerminalType,
+          processName: "claude",
+        })
+      );
 
       const promoted = manager.getTerminal(id);
       // Without agentId, AgentStateService.updateAgentState() and
@@ -407,7 +414,7 @@ describe("Agent Classification Matrix", () => {
       expect(promoted?.agentState).toBe("working");
 
       // Demotion clears agentId back to undefined for runtime-promoted terminals.
-      manager.simulateAgentDetection(id, { detected: false });
+      manager.simulateAgentDetection(id, makeNoAgentResult({}));
       expect(manager.getTerminal(id)?.agentId).toBeUndefined();
     }, 10000);
 
@@ -422,18 +429,22 @@ describe("Agent Classification Matrix", () => {
 
       await sleep(100);
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "claude" as TerminalType,
-        processName: "claude",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "claude" as TerminalType,
+          processName: "claude",
+        })
+      );
       expect(manager.getTerminal(id)?.type).toBe("claude");
 
-      manager.simulateAgentDetection(id, {
-        detected: true,
-        agentType: "gemini" as TerminalType,
-        processName: "gemini",
-      });
+      manager.simulateAgentDetection(
+        id,
+        makeAgentResult({
+          agentType: "gemini" as TerminalType,
+          processName: "gemini",
+        })
+      );
 
       const info = manager.getTerminal(id);
       expect(info?.analysisEnabled).toBe(true);

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -6,15 +6,20 @@ type ProcessNode = { pid: number; comm: string; command?: string };
 function createCacheMock() {
   const listeners = new Set<() => void>();
   const children = new Map<number, ProcessNode[]>();
+  let lastError: Error | null = null;
 
   return {
     getChildren: vi.fn((pid: number) => children.get(pid) ?? []),
+    getLastError: vi.fn(() => lastError),
     onRefresh: vi.fn((callback: () => void) => {
       listeners.add(callback);
       return () => listeners.delete(callback);
     }),
     setChildren(pid: number, nodes: ProcessNode[]) {
       children.set(pid, nodes);
+    },
+    setLastError(err: Error | null) {
+      lastError = err;
     },
     emitRefresh() {
       for (const callback of listeners) {
@@ -664,6 +669,266 @@ describe("ProcessDetector", () => {
 
       detector.stop();
       expect(callback).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // Four-state detection: unknown / no_agent / agent / ambiguous. These tests
+  // cover the specific failure modes called out in #5809 — blind ps, title-
+  // rewriting CLIs, short-lived subprocess thrash under sticky TTL, utility-
+  // process fd starvation — and guard against silent regressions where a
+  // blind signal would demote a confident detection.
+  describe("detection state (first-class ambiguity)", () => {
+    it("returns unknown (not no_agent) when ps cache is in error state with empty children", () => {
+      const cache = createCacheMock();
+      cache.setLastError(new Error("ps: spawn EMFILE"));
+      // Children is empty AND cache has live error → this is blindness, not
+      // negative evidence. Detector must hold committed state rather than
+      // emit a demotion. Unknown states are held, so no callback fires.
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-blind-ps",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      const detectedCalls = callback.mock.calls.filter(([r]) => r.detected === true);
+      const demoteCalls = callback.mock.calls.filter(([r]) => r.detectionState === "no_agent");
+      expect(detectedCalls).toHaveLength(0);
+      expect(demoteCalls).toHaveLength(0);
+    });
+
+    it("holds committed agent through a blind-ps cycle (no demotion when lastError set)", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-blind-ps-hold",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith(
+        expect.objectContaining({ detectionState: "agent", agentType: "claude" }),
+        expect.any(Number)
+      );
+
+      // ps goes blind — empty children with live error. Two more refreshes
+      // must NOT demote; legacy behaviour would have committed no_agent after
+      // two empty polls.
+      cache.setChildren(100, []);
+      cache.setLastError(new Error("ps: I/O error"));
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(detector.getLastDetected()).toBe("claude");
+    });
+
+    it("resolves to agent with evidenceSource 'shell_command' when tree is blind", () => {
+      // Title-rewriting / blind-`ps` case: process tree has nothing, shell
+      // evidence says `claude`. Must commit agent immediately (fast-commit
+      // path) with evidenceSource 'shell_command'.
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-shell-only",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume"
+      );
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detectionState: "agent",
+          agentType: "claude",
+          evidenceSource: "shell_command",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("resolves to agent with evidenceSource 'both' when tree and shell agree", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-both",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      // Inject before start so the first detect() sees both signals and
+      // commits with evidenceSource 'both' on the first pass.
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume"
+      );
+      detector.start();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detectionState: "agent",
+          agentType: "claude",
+          evidenceSource: "both",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("returns ambiguous when tree and shell report different agent identities", () => {
+      // Genuine two-positive-signals conflict: tree says codex, shell says
+      // claude. Must hold in ambiguous rather than pick one. No callback
+      // fires for ambiguous (it's a HOLD state, no committed change).
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "codex", command: "codex --model gpt-5" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-ambiguous",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude"
+      );
+      detector.start();
+
+      // With conflict, nothing should commit.
+      expect(callback.mock.calls.filter(([r]) => r.detectionState === "agent")).toHaveLength(0);
+      expect(detector.getLastDetected()).toBeNull();
+    });
+
+    it("holds committed state through short-lived subprocess thrash within sticky TTL", () => {
+      // User ran `claude --resume` — shell evidence injected. A short-lived
+      // subprocess (e.g. a grep the user ran mid-session) appears and exits
+      // between cache polls. The sticky TTL must suppress off-streak counting
+      // so the detector holds `claude`.
+      const base = Date.now();
+      vi.setSystemTime(base);
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector("terminal-thrash", base, 100, callback, cache as never);
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume",
+        base
+      );
+      expect(detector.getLastDetected()).toBe("claude");
+      // Reset call history so only post-inject emissions are counted against
+      // the demote assertion. Initial start() may have emitted a no_agent
+      // baseline when no children existed, which is not a demotion.
+      callback.mockClear();
+
+      // Half a second later, children are empty (subprocess thrash). Must not
+      // demote because sticky TTL (~12 s) is still active.
+      vi.setSystemTime(base + 500);
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBe("claude");
+      const demoteCalls = callback.mock.calls.filter(([r]) => r.detectionState === "no_agent");
+      expect(demoteCalls).toHaveLength(0);
+      vi.useRealTimers();
+    });
+
+    it("allows demotion after shell evidence expires past the upper bound", () => {
+      // Absolute upper bound (~30 s) guards against a synthetic shell identity
+      // holding `agent` forever when the process never actually started.
+      const base = Date.now();
+      vi.setSystemTime(base);
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector("terminal-expiry", base, 100, callback, cache as never);
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume",
+        base
+      );
+      expect(detector.getLastDetected()).toBe("claude");
+
+      // Advance past expiry (30 s upper bound) — shell evidence should now be
+      // expired and a blind tree can demote the commit via normal hysteresis.
+      vi.setSystemTime(base + 31_000);
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      vi.useRealTimers();
+    });
+
+    it("clearShellCommandEvidence releases the TTL so the tree path can demote", () => {
+      // On prompt-return, TerminalProcess clears shell evidence. The next
+      // detector pass with empty tree then moves through normal off-streak
+      // hysteresis and commits no_agent after two confirmations.
+      const base = Date.now();
+      vi.setSystemTime(base);
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector("terminal-cleared", base, 100, callback, cache as never);
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume",
+        base
+      );
+      expect(detector.getLastDetected()).toBe("claude");
+
+      detector.clearShellCommandEvidence();
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      vi.useRealTimers();
+    });
+
+    it("emits detectionState on the legacy committed callback", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-state-field",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detectionState: "agent",
+          detected: true,
+          evidenceSource: "process_tree",
+        }),
+        expect.any(Number)
+      );
     });
   });
 });

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -907,6 +907,124 @@ describe("ProcessDetector", () => {
       vi.useRealTimers();
     });
 
+    it("promotes shell-command evidence even when ps is in error state with empty children", () => {
+      // Primary regression guard for #5809: when the cache is BLIND (ps
+      // failed) AND the user just typed `claude`, the shell evidence must
+      // promote the committed state. The earlier "tree is blind" test used
+      // a healthy-empty cache; this test uses an error-state cache, which
+      // is the actual failure mode the feature targets. A naive `unknown`
+      // early-return would discard shell evidence here.
+      const cache = createCacheMock();
+      cache.setLastError(new Error("ps: spawn EMFILE"));
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-blind-plus-shell",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume"
+      );
+
+      const agentCalls = callback.mock.calls.filter(([r]) => r.detectionState === "agent");
+      expect(agentCalls.length).toBeGreaterThan(0);
+      expect(agentCalls[agentCalls.length - 1][0]).toMatchObject({
+        detectionState: "agent",
+        agentType: "claude",
+        evidenceSource: "shell_command",
+      });
+      expect(detector.getLastDetected()).toBe("claude");
+    });
+
+    it("upgrades committed evidence source when tree later corroborates a shell-only commit", () => {
+      // Regression guard for #5809: after shell commits `claude`, a
+      // subsequent cache refresh with the tree also showing `claude` must
+      // upgrade lastEvidenceSource to "both". If it stays "shell_command",
+      // clearShellCommandEvidence would then emit a spurious synchronous
+      // demotion on prompt-return even though the tree still has the agent.
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-upgrade-source",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      // Step 1: shell-only commit (tree empty, healthy cache).
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume"
+      );
+      expect(detector.getLastDetected()).toBe("claude");
+
+      // Step 2: tree refresh now shows claude — committed state unchanged,
+      // but evidence source should upgrade to "both".
+      cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);
+      cache.emitRefresh();
+
+      // Step 3: clear shell evidence (simulates prompt-return). The committed
+      // state must PERSIST because the tree still supports it.
+      callback.mockClear();
+      detector.clearShellCommandEvidence();
+
+      const demoteCalls = callback.mock.calls.filter(([r]) => r.detectionState === "no_agent");
+      expect(demoteCalls).toHaveLength(0);
+      expect(detector.getLastDetected()).toBe("claude");
+    });
+
+    it("holds agent identity at 12s sticky boundary but demotes past 30s expiry", () => {
+      // The sticky TTL (12 s) and expiry TTL (30 s) must be distinct — at
+      // the sticky boundary the badge persists, only at the absolute expiry
+      // can the tree path demote.
+      const base = Date.now();
+      vi.setSystemTime(base);
+      const cache = createCacheMock();
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-ttl-boundary",
+        base,
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "claude", processIconId: "claude", processName: "claude" },
+        "claude --resume",
+        base
+      );
+      expect(detector.getLastDetected()).toBe("claude");
+
+      // Just past the sticky boundary but well before expiry — shell
+      // evidence still present, just not anchoring off-streak anymore. An
+      // empty tree would demote after hysteresis, but shell is still fresh
+      // in merge logic, so tree sees "agent shell_command" and no demote
+      // fires.
+      vi.setSystemTime(base + 12_001);
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      cache.emitRefresh();
+      expect(detector.getLastDetected()).toBe("claude");
+
+      // Past absolute expiry — shell evidence cleared on next detect, tree
+      // is empty and healthy, normal off-streak hysteresis runs and commits
+      // no_agent.
+      vi.setSystemTime(base + 30_001);
+      cache.emitRefresh();
+      cache.emitRefresh();
+      expect(detector.getLastDetected()).toBeNull();
+      vi.useRealTimers();
+    });
+
     it("emits detectionState on the legacy committed callback", () => {
       const cache = createCacheMock();
       cache.setChildren(100, [{ pid: 200, comm: "claude", command: "claude --resume" }]);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1160,6 +1160,16 @@ export class TerminalProcess {
       : null;
     this.shellIdentityFallbackCommitted = false;
     this.shellIdentityFallbackPromptStreak = 0;
+
+    // If the new command has no recognizable identity (e.g. `echo hi` after a
+    // prior `npm run dev` that committed `npm`), clear any stale shell
+    // evidence on the detector so it doesn't keep the prior identity sticky
+    // for the full TTL. Identity-carrying commands overwrite via the
+    // watcher's later inject call. #5809
+    if (!this.shellIdentityFallbackIdentity) {
+      this.processDetector?.clearShellCommandEvidence();
+    }
+
     this.startShellIdentityFallbackWatcher();
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -12,6 +12,7 @@ import {
   detectCommandIdentity,
   type CommandIdentity,
   type DetectionResult,
+  type DetectionState,
 } from "../ProcessDetector.js";
 import type { ProcessTreeCache } from "../ProcessTreeCache.js";
 import { ActivityMonitor } from "../ActivityMonitor.js";
@@ -1252,17 +1253,32 @@ export class TerminalProcess {
         return;
       }
 
-      this.handleAgentDetection(
-        {
-          detected: true,
-          agentType: this.shellIdentityFallbackIdentity.agentType,
-          processIconId: this.shellIdentityFallbackIdentity.processIconId,
-          processName: this.shellIdentityFallbackIdentity.processName,
-          isBusy: true,
-          currentCommand: this.shellIdentityFallbackCommandText,
-        },
-        this.terminalInfo.spawnedAt
-      );
+      // Route shell-command evidence through ProcessDetector so the merge with
+      // process-tree evidence lives in one place. The detector applies the
+      // sticky TTL (~12 s) which anchors this commit through blind-`ps`
+      // cycles and short-lived subprocess thrash. If no detector exists
+      // (null cache path), fall back to the legacy direct emission so a
+      // degraded terminal still surfaces shell-command identity. #5809
+      if (this.processDetector) {
+        this.processDetector.injectShellCommandEvidence(
+          this.shellIdentityFallbackIdentity,
+          this.shellIdentityFallbackCommandText
+        );
+      } else {
+        this.handleAgentDetection(
+          {
+            detectionState: "agent",
+            detected: true,
+            agentType: this.shellIdentityFallbackIdentity.agentType,
+            processIconId: this.shellIdentityFallbackIdentity.processIconId,
+            processName: this.shellIdentityFallbackIdentity.processName,
+            isBusy: true,
+            currentCommand: this.shellIdentityFallbackCommandText,
+            evidenceSource: "shell_command",
+          },
+          this.terminalInfo.spawnedAt
+        );
+      }
       this.shellIdentityFallbackCommitted = true;
       return;
     }
@@ -1277,14 +1293,25 @@ export class TerminalProcess {
       return;
     }
 
-    this.handleAgentDetection(
-      {
-        detected: false,
-        isBusy: false,
-        currentCommand: undefined,
-      },
-      this.terminalInfo.spawnedAt
-    );
+    // Prompt has returned — the command has finished. Clear the injected
+    // shell evidence so the next detector pass no longer overrides a blind
+    // process tree with a stale shell identity. The process-tree path then
+    // takes over and emits the demotion naturally via hysteresis. When no
+    // detector is attached, fall back to the legacy direct emission so the
+    // UI still demotes promptly.
+    if (this.processDetector) {
+      this.processDetector.clearShellCommandEvidence();
+    } else {
+      this.handleAgentDetection(
+        {
+          detectionState: "no_agent",
+          detected: false,
+          isBusy: false,
+          currentCommand: undefined,
+        },
+        this.terminalInfo.spawnedAt
+      );
+    }
     this.stopShellIdentityFallbackWatcher();
   }
 
@@ -1710,6 +1737,23 @@ export class TerminalProcess {
       return;
     }
 
+    // Normalize legacy callers that only set `detected`. Callers that set
+    // `detectionState` win; fall back to mapping `detected: boolean` onto
+    // the four-state enum. This preserves existing test call sites while
+    // new code branches on the richer enum. #5809
+    const state: DetectionState = result.detectionState ?? (result.detected ? "agent" : "no_agent");
+
+    // `unknown` and `ambiguous` are HOLD states — no evidence change, no
+    // committed-state transition. Skip all branches so a blind `ps` cycle
+    // doesn't silently demote a confirmed agent every HYSTERESIS window,
+    // and a two-source conflict holds rather than flips. Precedent:
+    // #4153 — make uncertain events no-ops in the state machine. #5809
+    if (state === "unknown" || state === "ambiguous") {
+      return;
+    }
+
+    const isDetected = state === "agent";
+
     // Set when we clear a runtime agent detection on this tick so the block
     // below can suppress a same-tick shell-headline emission that would
     // otherwise overwrite the "Exited" completion cue emitted by
@@ -1717,7 +1761,7 @@ export class TerminalProcess {
     // instead. #5773
     let justClearedDetection = false;
 
-    if (result.detected && result.agentType) {
+    if (isDetected && result.agentType) {
       const previousType = terminal.detectedAgentType;
       terminal.everDetectedAgent = true;
 
@@ -1776,7 +1820,7 @@ export class TerminalProcess {
           timestamp: Date.now(),
         });
       }
-    } else if (result.detected && !result.agentType && result.processIconId) {
+    } else if (isDetected && !result.agentType && result.processIconId) {
       // Non-agent process detected (npm, python, docker, etc.)
       // If we're transitioning directly from an agent, clear agent state first
       if (terminal.detectedAgentType) {
@@ -1809,7 +1853,7 @@ export class TerminalProcess {
           timestamp: Date.now(),
         });
       }
-    } else if (!result.detected && (terminal.detectedAgentType || this.lastDetectedProcessIconId)) {
+    } else if (!isDetected && (terminal.detectedAgentType || this.lastDetectedProcessIconId)) {
       const previousType = terminal.detectedAgentType;
       if (previousType) {
         this.deps.agentStateService.updateAgentState(terminal, { type: "exit", code: 0 });

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -899,3 +899,83 @@ describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => 
     }
   });
 });
+
+// #5809: unknown/ambiguous are first-class HOLD states. handleAgentDetection
+// must no-op on both so a blind `ps` cycle or a two-source conflict does not
+// silently demote a confirmed agent every HYSTERESIS window.
+describe("TerminalProcess.handleAgentDetection — unknown/ambiguous hold state (#5809)", () => {
+  it("no-ops on detectionState=unknown — keeps committed agent identity", () => {
+    const terminal = createAgentTerminal();
+    let exitedEvents = 0;
+    const unsubscribe = events.on("agent:exited", () => {
+      exitedEvents += 1;
+    });
+
+    try {
+      callHandleAgentDetection(
+        terminal,
+        { detectionState: "agent", detected: true, agentType: "claude", processIconId: "claude" },
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().detectedAgentType).toBe("claude");
+
+      callHandleAgentDetection(
+        terminal,
+        { detectionState: "unknown", detected: false },
+        getSpawnedAt(terminal)
+      );
+
+      expect(terminal.getInfo().detectedAgentType).toBe("claude");
+      expect(terminal.getInfo().type).toBe("claude");
+      expect(exitedEvents).toBe(0);
+    } finally {
+      unsubscribe();
+      terminal.dispose();
+    }
+  });
+
+  it("no-ops on detectionState=ambiguous — keeps committed agent identity", () => {
+    const terminal = createAgentTerminal();
+    let exitedEvents = 0;
+    const unsubscribe = events.on("agent:exited", () => {
+      exitedEvents += 1;
+    });
+
+    try {
+      callHandleAgentDetection(
+        terminal,
+        { detectionState: "agent", detected: true, agentType: "claude", processIconId: "claude" },
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().detectedAgentType).toBe("claude");
+
+      callHandleAgentDetection(
+        terminal,
+        { detectionState: "ambiguous", detected: false },
+        getSpawnedAt(terminal)
+      );
+
+      expect(terminal.getInfo().detectedAgentType).toBe("claude");
+      expect(terminal.getInfo().type).toBe("claude");
+      expect(exitedEvents).toBe(0);
+    } finally {
+      unsubscribe();
+      terminal.dispose();
+    }
+  });
+
+  it("normalizes legacy callers missing detectionState — detected=true maps to agent state", () => {
+    const terminal = createPlainTerminal("t-normalize");
+    try {
+      // Legacy caller (no detectionState) — must be treated as agent.
+      callHandleAgentDetection(
+        terminal,
+        { detected: true, agentType: "claude", processIconId: "claude" } as never,
+        getSpawnedAt(terminal)
+      );
+      expect(terminal.getInfo().detectedAgentType).toBe("claude");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -4,6 +4,7 @@ import { TerminalProcess } from "../TerminalProcess.js";
 import type { SpawnContext } from "../terminalSpawn.js";
 import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
 import type { DetectionResult } from "../../ProcessDetector.js";
+import { makeAgentResult, makeNoAgentResult } from "../../ProcessDetector.js";
 import { events } from "../../events.js";
 
 vi.mock("node-pty", () => {
@@ -199,7 +200,7 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
     // Seed initial agent detection so subsequent transitions hit the exit branches.
     callHandleAgentDetection(
       terminal,
-      { detected: true, agentType: "claude", processIconId: "claude" },
+      makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
       getSpawnedAt(terminal)
     );
   });
@@ -214,7 +215,7 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
 
     callHandleAgentDetection(
       terminal,
-      { detected: true, processIconId: "npm", processName: "npm" },
+      makeAgentResult({ processIconId: "npm", processName: "npm" }),
       getSpawnedAt(terminal)
     );
 
@@ -226,7 +227,7 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
   it("Branch B — disposes monitor when no process is detected after the agent", () => {
     expect(getActivityMonitor(terminal)).not.toBeNull();
 
-    callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+    callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
 
     expect(getActivityMonitor(terminal)).toBeNull();
     expect(exitedEvents).toHaveLength(1);
@@ -247,14 +248,18 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
       // Seed agent detection.
       callHandleAgentDetection(
         trackedTerminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(trackedTerminal)
       );
       const monitorBefore = getActivityMonitor(trackedTerminal);
       expect(monitorBefore).not.toBeNull();
 
       // Demote: agent gone.
-      callHandleAgentDetection(trackedTerminal, { detected: false }, getSpawnedAt(trackedTerminal));
+      callHandleAgentDetection(
+        trackedTerminal,
+        makeNoAgentResult({}),
+        getSpawnedAt(trackedTerminal)
+      );
       expect(getActivityMonitor(trackedTerminal)).toBeNull();
 
       handleActivityState.mockClear();
@@ -270,7 +275,7 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
   it("Branch A → Branch B sequence — only one agent:exited with the original agentType", () => {
     callHandleAgentDetection(
       terminal,
-      { detected: true, processIconId: "npm", processName: "npm" },
+      makeAgentResult({ processIconId: "npm", processName: "npm" }),
       getSpawnedAt(terminal)
     );
     expect(getActivityMonitor(terminal)).toBeNull();
@@ -278,7 +283,7 @@ describe("TerminalProcess.handleAgentDetection — disposes ActivityMonitor on a
     expect(exitedEvents[0]).toEqual({ terminalId: "t-agent", agentType: "claude" });
 
     // Subsequent Branch B fires because lastDetectedProcessIconId is still set.
-    callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+    callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
     expect(getActivityMonitor(terminal)).toBeNull();
     // Branch B emits a second exit (with undefined agentType) by existing contract;
     // the load-bearing assertion is no monitor leak across the sequence.
@@ -298,14 +303,18 @@ describe("TerminalProcess.handleAgentDetection — disposes monitor without prio
       // No initial agent detection: only a non-agent process icon is set.
       callHandleAgentDetection(
         trackedTerminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(trackedTerminal)
       );
       // Monitor was created in the constructor for this isAgentTerminal=true terminal.
       expect(getActivityMonitor(trackedTerminal)).not.toBeNull();
 
       // Now everything goes away — Branch B with previousType undefined.
-      callHandleAgentDetection(trackedTerminal, { detected: false }, getSpawnedAt(trackedTerminal));
+      callHandleAgentDetection(
+        trackedTerminal,
+        makeNoAgentResult({}),
+        getSpawnedAt(trackedTerminal)
+      );
 
       expect(getActivityMonitor(trackedTerminal)).toBeNull();
       expect(exitedEvents).toHaveLength(1);
@@ -339,12 +348,16 @@ describe("TerminalProcess.handleAgentDetection — polling loop teardown", () =>
     try {
       callHandleAgentDetection(
         trackedTerminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(trackedTerminal)
       );
       expect(getActivityMonitor(trackedTerminal)).not.toBeNull();
 
-      callHandleAgentDetection(trackedTerminal, { detected: false }, getSpawnedAt(trackedTerminal));
+      callHandleAgentDetection(
+        trackedTerminal,
+        makeNoAgentResult({}),
+        getSpawnedAt(trackedTerminal)
+      );
       expect(getActivityMonitor(trackedTerminal)).toBeNull();
 
       handleActivityState.mockClear();
@@ -374,7 +387,7 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
 
@@ -389,14 +402,14 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(getScrollback(terminal)).toBe(10000);
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(getScrollback(terminal)).toBe(10000);
@@ -413,7 +426,7 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
 
@@ -439,14 +452,14 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(getScrollback(terminal)).toBe(10000);
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "gemini", processIconId: "gemini" },
+        makeAgentResult({ agentType: "gemini" as const, processIconId: "gemini" }),
         getSpawnedAt(terminal)
       );
       expect(getScrollback(terminal)).toBe(10000);
@@ -645,7 +658,7 @@ describe("TerminalProcess.handleAgentDetection — plain process icon badge emis
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(terminal)
       );
 
@@ -671,12 +684,12 @@ describe("TerminalProcess.handleAgentDetection — plain process icon badge emis
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().detectedProcessIconId).toBe("npm");
 
-      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
 
       expect(terminal.getInfo().detectedProcessIconId).toBeUndefined();
       expect(exitedEvents).toHaveLength(1);
@@ -701,7 +714,7 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
 
@@ -718,7 +731,7 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().agentId).toBeUndefined();
@@ -726,14 +739,14 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
       // Demotion via non-agent icon.
       callHandleAgentDetection(
         terminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().agentId).toBeUndefined();
       expect(terminal.getInfo().detectedAgentType).toBeUndefined();
 
       // Demotion via no-detection.
-      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
       expect(terminal.getInfo().agentId).toBeUndefined();
     } finally {
       terminal.dispose();
@@ -745,14 +758,14 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().agentId).toBe("claude");
 
       callHandleAgentDetection(
         terminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(terminal)
       );
 
@@ -769,12 +782,12 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().agentId).toBe("claude");
 
-      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
 
       const info = terminal.getInfo();
       expect(info.agentId).toBe("claude");
@@ -798,14 +811,14 @@ describe("TerminalProcess.handleAgentDetection — launch identity immutability 
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(detectedEvents).toHaveLength(1);
       expect(detectedEvents[0].agentType).toBe("claude");
       expect(terminal.getInfo().agentId).toBeUndefined();
 
-      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
       expect(exitedEvents).toHaveLength(1);
       expect(exitedEvents[0].agentType).toBe("claude");
       expect(terminal.getInfo().agentId).toBeUndefined();
@@ -845,7 +858,7 @@ describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => 
     try {
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
 
@@ -866,7 +879,7 @@ describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => 
       // Spurious re-detection of the same agent.
       callHandleAgentDetection(
         terminal,
-        { detected: true, agentType: "claude", processIconId: "claude" },
+        makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().capabilityAgentId).toBe("claude");
@@ -874,13 +887,13 @@ describe("TerminalProcess — capabilityAgentId sealed at spawn (#5804)", () => 
       // Demotion to a non-agent process.
       callHandleAgentDetection(
         terminal,
-        { detected: true, processIconId: "npm", processName: "npm" },
+        makeAgentResult({ processIconId: "npm", processName: "npm" }),
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().capabilityAgentId).toBe("claude");
 
       // Full demotion.
-      callHandleAgentDetection(terminal, { detected: false }, getSpawnedAt(terminal));
+      callHandleAgentDetection(terminal, makeNoAgentResult({}), getSpawnedAt(terminal));
       expect(terminal.getInfo().capabilityAgentId).toBe("claude");
     } finally {
       terminal.dispose();


### PR DESCRIPTION
## Summary

- `ProcessDetector` now returns explicit `unknown`, `no_agent`, `agent`, and `ambiguous` states instead of a binary detected/not-detected signal. Downstream consumers decide how to handle weak evidence rather than treating every detection as authoritative.
- Process-tree evidence and shell-command fallback are combined into a single weighted decision. Short-lived subprocess exits no longer demote a previously-confident detection when the shell-command signal still agrees.
- `TerminalProcess` consumes the new result type correctly, and the `ps`-blind path surfaces shell evidence rather than silently dropping it.

Resolves #5809

## Changes

- `ProcessDetector.ts`: added `DetectionResult` discriminated union (`unknown | no_agent | agent | ambiguous`), unified evidence weighting, hardened the blind-ps fallback so shell evidence is surfaced rather than discarded, and added structured logging for `ps` failures with enough context to diagnose from a submitted log.
- `TerminalProcess.ts`: updated to handle all four result states; `ambiguous` no longer auto-promotes to full agent capability.
- `ProcessDetector.test.ts`: new test file covering title-rewriting CLIs, short-lived subprocess thrash, `ps` returning empty, and the combined evidence weighting logic (383 lines).
- `TerminalProcess.agentDetection.test.ts` and `AgentClassification.integration.test.ts`: updated to match the new result shape and cover the ambiguous path.

## Testing

Unit tests cover all four detection states, the blind-ps + shell-command combined path, subprocess thrash scenarios, and the `ps`-empty failure case. Integration tests confirm downstream state transitions remain correct under the new result type. Ran `npm run check` clean with no errors.