### PR TITLE
test(e2e): cover terminal identity and delete legacy type fallbacks

### DIFF
--- a/e2e/core/core-terminal-identity.spec.ts
+++ b/e2e/core/core-terminal-identity.spec.ts
@@ -98,9 +98,9 @@ test.describe.serial("Core: Terminal Identity", () => {
   test("restart preserves capability identity on a full-mode agent panel", async () => {
     const { window } = ctx;
 
-    // Same skip predicate — without Claude there's no full-mode panel to
-    // restart. The test above is the gate that proves the panel exists;
-    // re-check here so this test is independently runnable.
+    // Depends on the cold-launch test above leaving an agent panel in the grid
+    // (serial suite). When Claude isn't on PATH the prior test skipped, so the
+    // capability panel won't be present and we skip too.
     const agentPanel = window.locator(SEL.agent.capabilityPanel("claude")).first();
     if (!(await agentPanel.isVisible({ timeout: T_SHORT }).catch(() => false))) {
       test.skip();

--- a/e2e/core/core-terminal-identity.spec.ts
+++ b/e2e/core/core-terminal-identity.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { getFirstGridPanel, openTerminal, getGridPanelCount } from "../helpers/panels";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_SHORT, T_SETTLE } from "../helpers/timeouts";
+
+// #5812: cross-process terminal identity is the contract that decides
+// whether a panel is treated as a "full" agent (cold-launched: capabilities
+// sealed at spawn) vs an "observational" agent (runtime detection in a plain
+// shell). The DOM discriminator is `data-capability-agent-id` — present only
+// for cold-launched agents, absent for plain shells and observational ones.
+//
+// These tests assert the launch-intent identity at the point users care about:
+// the panel root attribute, plus the absence of the observational chip when
+// the panel is full-mode. Detection-driven UI for non-agent processes is
+// covered by core-process-badge.spec.ts; runtime observational chip behavior
+// requires real Claude and lives in e2e/online/.
+let ctx: AppContext;
+let fixtureDir: string;
+
+test.describe.serial("Core: Terminal Identity", () => {
+  test.beforeAll(async () => {
+    fixtureDir = createFixtureRepo({ name: "terminal-identity" });
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(
+      ctx.app,
+      ctx.window,
+      fixtureDir,
+      "Terminal Identity Test"
+    );
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("plain shell terminal never carries data-capability-agent-id", async () => {
+    const { window } = ctx;
+    await openTerminal(window);
+    const panel = getFirstGridPanel(window);
+    await expect(panel).toBeVisible({ timeout: T_LONG });
+
+    const panelId = await panel.getAttribute("data-panel-id");
+    expect(panelId).toBeTruthy();
+
+    // capabilityAgentId is sealed at spawn — a plain shell never gets it.
+    // Read directly from the DOM so we catch any later mutation too.
+    expect(
+      await window.evaluate(
+        (id) =>
+          document
+            .querySelector(`[data-panel-id="${id}"]`)
+            ?.getAttribute("data-capability-agent-id"),
+        panelId
+      )
+    ).toBeNull();
+
+    // Observational chip belongs only to plain shells where a real agent
+    // process was detected (Claude/Gemini/etc.). A bare shell has neither
+    // launch intent nor detection, so the chip must stay hidden.
+    await expect(panel.locator(SEL.agent.observationalChip)).toHaveCount(0);
+  });
+
+  test("cold-launched Claude agent panel exposes capability identity", async () => {
+    const { window } = ctx;
+
+    // Skip when Claude CLI isn't on PATH — the toolbar surfaces a different
+    // aria-label ("Claude CLI not installed") and routes clicks to settings.
+    const startBtn = window.locator(SEL.agent.startButton);
+    if (!(await startBtn.isVisible({ timeout: T_SHORT }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const initialCount = await getGridPanelCount(window);
+    await startBtn.click();
+
+    // Wait for the new agent panel to land in the grid (panel-count poll
+    // is the deterministic anchor — a sleep would race the spawn).
+    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(initialCount + 1);
+
+    const agentPanel = window.locator(SEL.agent.capabilityPanel("claude")).first();
+    await expect(agentPanel).toBeVisible({ timeout: T_LONG });
+
+    // Cold launch path stamps capabilityAgentId at spawn — assert on the
+    // DOM attribute so we exercise the renderer→panel-store→panel-root
+    // pipeline that real users see.
+    expect(await agentPanel.getAttribute("data-capability-agent-id")).toBe("claude");
+
+    // Full-mode panels never render the observational chip. The chip is
+    // gated on `detectedAgentId && !capabilityAgentId`, so its absence
+    // proves the cold launch sealed capability identity correctly.
+    await expect(agentPanel.locator(SEL.agent.observationalChip)).toHaveCount(0);
+  });
+
+  test("restart preserves capability identity on a full-mode agent panel", async () => {
+    const { window } = ctx;
+
+    // Same skip predicate — without Claude there's no full-mode panel to
+    // restart. The test above is the gate that proves the panel exists;
+    // re-check here so this test is independently runnable.
+    const agentPanel = window.locator(SEL.agent.capabilityPanel("claude")).first();
+    if (!(await agentPanel.isVisible({ timeout: T_SHORT }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const panelId = await agentPanel.getAttribute("data-panel-id");
+    expect(panelId).toBeTruthy();
+
+    // Restart flows through the panel overflow menu; capability identity
+    // must survive PTY teardown + respawn (otherwise hydration regresses to
+    // observational mode).
+    await agentPanel.hover();
+    await agentPanel.locator(SEL.panel.overflowMenu).first().click();
+    const restartBtn = window.locator(SEL.panel.restart).first();
+    await expect(restartBtn).toBeVisible({ timeout: T_SHORT });
+    await restartBtn.click();
+
+    const confirmBtn = window.locator(SEL.panel.restartConfirm).first();
+    await expect(confirmBtn).toBeVisible({ timeout: T_SHORT });
+    await confirmBtn.click();
+
+    // Give the respawn a beat to settle, then re-assert the attribute on
+    // the same panel-id. capabilityAgentId is read from store state at
+    // render time — if respawn dropped it, the attribute disappears.
+    await window.waitForTimeout(T_SETTLE);
+    await expect
+      .poll(
+        async () =>
+          window.evaluate(
+            (id) =>
+              document
+                .querySelector(`[data-panel-id="${id}"]`)
+                ?.getAttribute("data-capability-agent-id"),
+            panelId
+          ),
+        { timeout: T_LONG, intervals: [500] }
+      )
+      .toBe("claude");
+
+    // Restart must not flip the panel into observational mode either.
+    await expect(
+      window.locator(`[data-panel-id="${panelId}"] ${SEL.agent.observationalChip}`)
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/full/core-terminal-identity-recovery.spec.ts
+++ b/e2e/full/core-terminal-identity-recovery.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  mockOpenDialog,
+  refreshActiveWindow,
+  type AppContext,
+} from "../helpers/launch";
+import { createFixtureRepos } from "../helpers/fixtures";
+import { openAndOnboardProject, completeOnboarding } from "../helpers/project";
+import { getFirstGridPanel, openTerminal, getGridPanelCount } from "../helpers/panels";
+import { runTerminalCommand, waitForTerminalText } from "../helpers/terminal";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
+
+// #5812: identity must survive WebContentsView eviction + rebuild. Project
+// switching is the canonical eviction trigger — switching to another project
+// invalidates the current view's renderer reference, and switching back
+// rehydrates from backend state. capabilityAgentId is sealed at spawn and
+// must replay through the rebuild; if hydration drops it, a cold-launched
+// agent silently demotes to observational.
+//
+// Plain shells must also remain identity-clean across this round-trip — no
+// data-capability-agent-id should appear on a terminal that wasn't cold-
+// launched as one.
+let ctx: AppContext;
+const PROJECT_A = "Identity Project A";
+const PROJECT_B = "Identity Project B";
+
+async function getCurrentProjectName(page: typeof ctx.window): Promise<string> {
+  return page.evaluate(async () => {
+    const w = window as unknown as {
+      electron: { project: { getCurrent(): Promise<{ name: string }> } };
+    };
+    const project = await w.electron.project.getCurrent();
+    return project.name;
+  });
+}
+
+async function switchToProject(
+  page: typeof ctx.window,
+  projectName: string
+): Promise<typeof ctx.window> {
+  const current = await getCurrentProjectName(page);
+  if (current === projectName) return page;
+
+  await page.locator(SEL.toolbar.projectSwitcherTrigger).click();
+  const palette = page.locator(SEL.projectSwitcher.palette);
+  await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+  await page.waitForTimeout(T_SETTLE);
+
+  // The palette options can re-render mid-click — evaluate-clicking by text
+  // is the documented pattern in core-project-switch-race.spec.ts.
+  await page.evaluate((name) => {
+    const el = document.querySelector('[data-testid="project-switcher-palette"]');
+    if (!el) throw new Error("Palette not in DOM");
+    const options = el.querySelectorAll('[role="option"]');
+    for (const opt of options) {
+      if (opt.textContent?.includes(name)) {
+        (opt as HTMLElement).click();
+        return;
+      }
+    }
+    throw new Error(`Project "${name}" not found in palette`);
+  }, projectName);
+
+  await expect(palette)
+    .not.toBeVisible({ timeout: T_LONG })
+    .catch(() => undefined);
+
+  // Refresh window after switch — past lessons #5010/#4981: stale ctx.window
+  // throws "Target page has been closed" because the WebContentsView gets
+  // swapped out by the main process.
+  const refreshed = await refreshActiveWindow(ctx.app, page);
+  await refreshed.waitForTimeout(T_SETTLE);
+  ctx.window = refreshed;
+  return refreshed;
+}
+
+test.describe.serial("Full: Terminal Identity Recovery", () => {
+  test.beforeAll(async () => {
+    const [repoA, repoB] = createFixtureRepos(2);
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
+
+    // Add Project B without leaving Project A view chain — needed so the
+    // eviction test has a real second project to swap between.
+    await mockOpenDialog(ctx.app, repoB);
+    await ctx.window.locator(SEL.toolbar.projectSwitcherTrigger).click();
+    const palette = ctx.window.locator(SEL.projectSwitcher.palette);
+    await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+    await ctx.window.locator(SEL.projectSwitcher.addButton).click({ force: true });
+    await completeOnboarding(ctx.window, PROJECT_B);
+    ctx.window = await refreshActiveWindow(ctx.app, ctx.window);
+
+    await switchToProject(ctx.window, PROJECT_A);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("plain shell stays identity-clean across non-agent process churn", async () => {
+    const { window } = ctx;
+    await openTerminal(window);
+    const panel = getFirstGridPanel(window);
+    await expect(panel).toBeVisible({ timeout: T_LONG });
+
+    const panelId = await panel.getAttribute("data-panel-id");
+    expect(panelId).toBeTruthy();
+
+    const readCapability = () =>
+      window.evaluate(
+        (id) =>
+          document
+            .querySelector(`[data-panel-id="${id}"]`)
+            ?.getAttribute("data-capability-agent-id"),
+        panelId
+      );
+
+    // Baseline: no capability before any process runs.
+    expect(await readCapability()).toBeNull();
+
+    // Run a bounded `node` script — this exercises the same detection chain
+    // that fires `agent:detected` for processIconId. Detection of node must
+    // never promote a plain shell to a "full" agent terminal.
+    await runTerminalCommand(
+      window,
+      panel,
+      `node -e "console.log('IDENTITY_SENTINEL'); setTimeout(()=>{}, 4000)"`
+    );
+    await waitForTerminalText(panel, "IDENTITY_SENTINEL", T_LONG);
+
+    // capabilityAgentId is launch-intent-only — no detection event can ever
+    // stamp it. Sample a few times across the process lifetime to catch any
+    // mid-flight mutation.
+    for (let i = 0; i < 4; i++) {
+      expect(await readCapability()).toBeNull();
+      await window.waitForTimeout(800);
+    }
+  });
+
+  test("cold-launched agent capability identity survives view eviction + rebuild", async () => {
+    const { window } = ctx;
+
+    // Need the real Claude CLI for cold-launch — without it the toolbar
+    // surfaces a non-launching button and there is no panel to evict.
+    const startBtn = window.locator(SEL.agent.startButton);
+    if (!(await startBtn.isVisible({ timeout: T_SHORT }).catch(() => false))) {
+      test.skip();
+      return;
+    }
+
+    const initialCount = await getGridPanelCount(window);
+    await startBtn.click();
+    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(initialCount + 1);
+
+    const agentPanel = window.locator(SEL.agent.capabilityPanel("claude")).first();
+    await expect(agentPanel).toBeVisible({ timeout: T_LONG });
+    const agentPanelId = await agentPanel.getAttribute("data-panel-id");
+    expect(agentPanelId).toBeTruthy();
+
+    // Switch away — this evicts (or at least swaps) the current project's
+    // WebContentsView. The page reference becomes stale; switchToProject
+    // refreshes ctx.window via refreshActiveWindow.
+    await switchToProject(window, PROJECT_B);
+    await switchToProject(ctx.window, PROJECT_A);
+
+    // After switch-back, hydration must replay capabilityAgentId on the
+    // same panel id. Use the freshly-refreshed window — referencing the
+    // pre-switch `window` would query the old (closed) view.
+    const restoredPanel = ctx.window.locator(`[data-panel-id="${agentPanelId}"]`);
+    await expect(restoredPanel).toBeVisible({ timeout: T_LONG });
+
+    await expect
+      .poll(
+        async () =>
+          ctx.window.evaluate(
+            (id) =>
+              document
+                .querySelector(`[data-panel-id="${id}"]`)
+                ?.getAttribute("data-capability-agent-id"),
+            agentPanelId
+          ),
+        { timeout: T_LONG, intervals: [500] }
+      )
+      .toBe("claude");
+
+    // And it must come back as full-mode, not observational (the latter
+    // would render the chip and signal a hydration regression).
+    await expect(
+      ctx.window.locator(`[data-panel-id="${agentPanelId}"] ${SEL.agent.observationalChip}`)
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -174,6 +174,8 @@ export const SEL = {
     panel: '[aria-label^="Claude agent:"]',
     startButton: '[aria-label="Start Claude Agent"]',
     trayButton: '[aria-label^="Agent tray"]',
+    observationalChip: '[data-testid="panel-observational-chip"]',
+    capabilityPanel: (agentId: string) => `[data-capability-agent-id="${agentId}"]`,
   },
   opencodeAgent: {
     panel: '[aria-label^="OpenCode agent:"]',

--- a/electron/services/pty/terminalInput.ts
+++ b/electron/services/pty/terminalInput.ts
@@ -38,6 +38,9 @@ export function splitTrailingNewlines(text: string): { body: string; enterCount:
 }
 
 function getEffectiveAgentId(terminal: TerminalInfo): string | undefined {
+  // Pre-migration sessions written before the agentId field existed (where
+  // identity lived only in `terminal.type`) lose bracketed-paste / soft-newline
+  // capability data here until they respawn — acceptable rolloff per #5812.
   return terminal.detectedAgentType ?? terminal.agentId;
 }
 

--- a/electron/services/pty/terminalInput.ts
+++ b/electron/services/pty/terminalInput.ts
@@ -38,7 +38,7 @@ export function splitTrailingNewlines(text: string): { body: string; enterCount:
 }
 
 function getEffectiveAgentId(terminal: TerminalInfo): string | undefined {
-  return terminal.detectedAgentType ?? terminal.agentId ?? terminal.type;
+  return terminal.detectedAgentType ?? terminal.agentId;
 }
 
 export function supportsBracketedPaste(terminal: TerminalInfo): boolean {

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -17,7 +17,7 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
     return <div className={cn("h-full rounded-[var(--radius-lg)] bg-daintree-bg/50", className)} />;
   }
 
-  const { title, type, kind, agentId, detectedAgentId, detectedProcessId } = activeTerminal;
+  const { title, kind, agentId, detectedAgentId, detectedProcessId } = activeTerminal;
 
   return (
     <div
@@ -38,7 +38,6 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
       >
         <span className="shrink-0 flex items-center justify-center text-daintree-accent/80">
           <TerminalIcon
-            type={type}
             kind={kind}
             agentId={agentId}
             detectedAgentId={detectedAgentId}

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -207,7 +207,6 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
                   <div className="flex items-center gap-2 min-w-0 flex-1">
                     <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
                       <TerminalIcon
-                        type={item.terminal.type}
                         kind={item.terminal.kind}
                         agentId={item.terminal.agentId}
                         detectedAgentId={item.terminal.detectedAgentId}
@@ -309,7 +308,6 @@ function BackgroundGroupItem({
                   className="flex items-center gap-2 w-full px-2 py-1 text-[11px] rounded hover:bg-tint/5 text-left"
                 >
                   <TerminalIcon
-                    type={terminal.type}
                     kind={terminal.kind}
                     agentId={terminal.agentId}
                     detectedAgentId={terminal.detectedAgentId}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -441,7 +441,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           >
             <div className="flex items-center justify-center shrink-0">
               <TerminalIcon
-                type={activePanel.type}
                 kind={activePanel.kind}
                 agentId={activePanel.agentId}
                 detectedAgentId={activePanel.detectedAgentId}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -275,7 +275,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           >
             <div className="flex items-center justify-center shrink-0">
               <TerminalIcon
-                type={terminal.type}
                 kind={terminal.kind}
                 agentId={terminal.agentId}
                 detectedAgentId={terminal.detectedAgentId}

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -130,7 +130,6 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
                     <TerminalIcon
-                      type={terminal.type}
                       kind={terminal.kind}
                       agentId={terminal.agentId}
                       detectedAgentId={terminal.detectedAgentId}

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -62,17 +62,16 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
     // so a terminal's name doesn't change as runtime detection flips after trashing.
     if (terminal.agentId) {
       if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
-      const agentConfig = terminal.agentId ? getEffectiveAgentConfig(terminal.agentId) : undefined;
-      return agentConfig?.name ?? terminal.agentId ?? terminal.type ?? "Agent";
+      const agentConfig = getEffectiveAgentConfig(terminal.agentId);
+      return agentConfig?.name ?? terminal.agentId;
     }
-    return terminal.title || terminal.type || "Terminal";
+    return terminal.title || "Terminal";
   })();
 
   return (
     <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors group">
       <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
         <TerminalIcon
-          type={terminal.type}
           kind={terminal.kind}
           agentId={terminal.agentId}
           detectedAgentId={terminal.detectedAgentId}

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -177,7 +177,7 @@ export function TrashGroupItem({
               return 0;
             })
             .map(({ terminal }) => {
-              const terminalName = terminal.title || terminal.type || "Terminal";
+              const terminalName = terminal.title || "Terminal";
               const isActiveTab = groupMetadata.activeTabId === terminal.id;
               return (
                 <div
@@ -185,7 +185,6 @@ export function TrashGroupItem({
                   className="flex items-center gap-2 px-2 py-1 text-[11px] rounded hover:bg-tint/5 group/panel"
                 >
                   <TerminalIcon
-                    type={terminal.type}
                     kind={terminal.kind}
                     agentId={terminal.agentId}
                     detectedAgentId={terminal.detectedAgentId}

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -294,6 +294,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         data-panel-id={id}
         data-panel-location={location}
         data-detected-process-id={detectedProcessId || undefined}
+        data-capability-agent-id={capabilityAgentId || undefined}
         data-selected={isSelected || undefined}
         style={{
           contain: "content",

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -743,7 +743,6 @@ function PanelHeaderComponent({
         <div className="flex items-center gap-2 min-w-0">
           <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5 text-daintree-text">
             <TerminalIcon
-              type={type}
               kind={kind}
               agentId={agentId}
               detectedAgentId={detectedAgentId}

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -264,7 +264,6 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
             )}
             <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5">
               <TerminalIcon
-                type={type}
                 kind={kind}
                 agentId={agentId}
                 detectedAgentId={detectedAgentId}

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -40,7 +40,6 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
       <span className="shrink-0 text-daintree-text/70" aria-hidden="true">
         {item.type === "terminal" ? (
           <TerminalIcon
-            type={item.terminalType}
             kind={item.terminalKind}
             agentId={item.agentId}
             detectedAgentId={item.detectedAgentId}

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -55,7 +55,6 @@ const SendToAgentItemRow = React.memo(function SendToAgentItemRow({
     >
       <span className="shrink-0 text-daintree-text/70" aria-hidden="true">
         <TerminalIcon
-          type={item.terminalType}
           kind={item.terminalKind}
           agentId={item.agentId}
           detectedAgentId={item.detectedAgentId}

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,8 +1,8 @@
 import { SquareTerminal, Globe, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { TerminalType, PanelKind } from "@/types";
+import type { PanelKind } from "@/types";
 import type { ComponentType } from "react";
-import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
+import { getAgentConfig } from "@/config/agents";
 import { resolveEffectiveAgentId } from "@/utils/agentIdentity";
 import {
   NpmIcon,
@@ -51,7 +51,6 @@ const PROCESS_ICON_MAP: Record<string, ComponentType<{ className?: string; size?
 };
 
 export interface TerminalIconProps {
-  type?: TerminalType;
   kind?: PanelKind;
   agentId?: string;
   /**
@@ -65,7 +64,6 @@ export interface TerminalIconProps {
 }
 
 export function TerminalIcon({
-  type,
   kind,
   agentId,
   detectedAgentId,
@@ -88,10 +86,8 @@ export function TerminalIcon({
     return <Monitor {...finalProps} className={cn(finalProps.className, "text-status-info")} />;
   }
 
-  // Prefer runtime-detected identity, then launch-time agentId, then legacy type fallback.
-  const effectiveAgentId =
-    resolveEffectiveAgentId(detectedAgentId, agentId) ??
-    (type && isRegisteredAgent(type) ? type : undefined);
+  // Prefer runtime-detected identity, then launch-time agentId.
+  const effectiveAgentId = resolveEffectiveAgentId(detectedAgentId, agentId);
 
   if (effectiveAgentId) {
     const config = getAgentConfig(effectiveAgentId);

--- a/src/components/Terminal/__tests__/TerminalIcon.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalIcon.test.tsx
@@ -4,15 +4,13 @@ import { render } from "@testing-library/react";
 import { TerminalIcon } from "../TerminalIcon";
 
 function renderDefaultTerminalIcon(): string {
-  return render(<TerminalIcon kind="terminal" type="terminal" />).container.innerHTML;
+  return render(<TerminalIcon kind="terminal" />).container.innerHTML;
 }
 
 describe("TerminalIcon", () => {
   it("renders AI process icons for detected CLI processes in terminal panels", () => {
     const fallback = renderDefaultTerminalIcon();
-    const { container } = render(
-      <TerminalIcon kind="terminal" type="terminal" detectedProcessId="claude" />
-    );
+    const { container } = render(<TerminalIcon kind="terminal" detectedProcessId="claude" />);
 
     expect(container.innerHTML).not.toBe(fallback);
     expect(container.innerHTML).toContain("currentColor");
@@ -20,29 +18,24 @@ describe("TerminalIcon", () => {
 
   it("renders package-manager process icons for detected CLI processes", () => {
     const fallback = renderDefaultTerminalIcon();
-    const { container } = render(
-      <TerminalIcon kind="terminal" type="terminal" detectedProcessId="npm" />
-    );
+    const { container } = render(<TerminalIcon kind="terminal" detectedProcessId="npm" />);
 
     expect(container.innerHTML).not.toBe(fallback);
   });
 
   it("falls back to terminal icon when detected process is unknown", () => {
     const fallback = renderDefaultTerminalIcon();
-    const { container } = render(
-      <TerminalIcon kind="terminal" type="terminal" detectedProcessId="unknown-tool" />
-    );
+    const { container } = render(<TerminalIcon kind="terminal" detectedProcessId="unknown-tool" />);
 
     expect(container.innerHTML).toBe(fallback);
   });
 
   it("prefers explicit agent icon over detected process icon", () => {
-    const npmDetected = render(
-      <TerminalIcon kind="terminal" type="terminal" detectedProcessId="npm" />
-    ).container.innerHTML;
+    const npmDetected = render(<TerminalIcon kind="terminal" detectedProcessId="npm" />).container
+      .innerHTML;
 
     const explicitAgent = render(
-      <TerminalIcon kind="agent" type="claude" agentId="claude" detectedProcessId="npm" />
+      <TerminalIcon kind="agent" agentId="claude" detectedProcessId="npm" />
     ).container.innerHTML;
 
     const fallback = renderDefaultTerminalIcon();

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -101,7 +101,6 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
         >
           <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
             <TerminalIcon
-              type={term.type}
               kind={term.kind}
               agentId={term.agentId}
               detectedAgentId={term.detectedAgentId}

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -71,9 +71,7 @@ function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
   // what runtime detection observed. Persisting `detectedAgentId` would corrupt
   // a recipe by baking ephemeral session state into a reusable template.
   const type: RecipeTerminalType =
-    terminal.kind === "dev-preview"
-      ? "dev-preview"
-      : (terminal.agentId ?? terminal.type ?? "terminal");
+    terminal.kind === "dev-preview" ? "dev-preview" : (terminal.agentId ?? "terminal");
 
   const isAgent = isAgentRecipeType(type);
 

--- a/src/utils/__tests__/terminalValidation.test.ts
+++ b/src/utils/__tests__/terminalValidation.test.ts
@@ -54,7 +54,7 @@ describe("terminalValidation", () => {
     const result = await validateTerminalConfig(
       makeTerminal({
         cwd: "/repo",
-        type: "claude",
+        agentId: "claude",
       }) as never
     );
 
@@ -70,7 +70,7 @@ describe("terminalValidation", () => {
     const result = await validateTerminalConfig(
       makeTerminal({
         cwd: "/missing",
-        type: "codex",
+        agentId: "codex",
       }) as never
     );
 
@@ -123,7 +123,7 @@ describe("terminalValidation", () => {
 
     const result = await validateTerminalConfig(
       makeTerminal({
-        type: "gemini",
+        agentId: "gemini",
       }) as never
     );
 
@@ -150,7 +150,7 @@ describe("terminalValidation", () => {
   it("falls back to agentId when agent is not in registry", async () => {
     const result = await validateTerminalConfig(
       makeTerminal({
-        type: "unknown-agent",
+        agentId: "unknown-agent",
       }) as never
     );
 
@@ -165,7 +165,7 @@ describe("terminalValidation", () => {
     const results = await validateTerminals([
       makeTerminal({ id: "ok", cwd: "/repo", type: "terminal" }) as never,
       makeTerminal({ id: "bad-cwd", cwd: "/missing", type: "terminal" }) as never,
-      makeTerminal({ id: "bad-cli", type: "broken-agent" }) as never,
+      makeTerminal({ id: "bad-cli", agentId: "broken-agent" }) as never,
     ]);
 
     expect(results.has("ok")).toBe(false);

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -207,6 +207,19 @@ describe("buildArgsForBackendTerminal", () => {
     expect(result.cwd).toBe("/project");
   });
 
+  it("falls back to saved.agentId when backend record lost it", () => {
+    // Mirrors buildArgsForReconnectedFallback's saved-agentId recovery so a
+    // PTY-host restart that wiped backend.agentId doesn't strip the panel's
+    // agent identity if the renderer state still has it.
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", agentId: undefined, capabilityAgentId: "claude" },
+      { id: "t1", location: "grid", agentId: "claude" },
+      "/p"
+    );
+    expect(result.agentId).toBe("claude");
+    expect(result.capabilityAgentId).toBe("claude");
+  });
+
   it("includes dev-preview browser fields", () => {
     const result = buildArgsForBackendTerminal(
       { id: "t1", cwd: "/p", kind: "dev-preview" },

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -155,23 +155,19 @@ describe("inferAgentIdFromTitle", () => {
 
 describe("resolveAgentId", () => {
   it("returns primary agentId", () => {
-    expect(resolveAgentId("claude", undefined)).toBe("claude");
+    expect(resolveAgentId("claude")).toBe("claude");
   });
 
-  it("returns primary type when registered", () => {
-    expect(resolveAgentId(undefined, "claude")).toBe("claude");
+  it("returns fallback agentId when primary is undefined", () => {
+    expect(resolveAgentId(undefined, "gemini")).toBe("gemini");
   });
 
-  it("returns fallback agentId", () => {
-    expect(resolveAgentId(undefined, undefined, "gemini")).toBe("gemini");
+  it("prefers primary over fallback", () => {
+    expect(resolveAgentId("claude", "gemini")).toBe("claude");
   });
 
-  it("returns fallback type when registered", () => {
-    expect(resolveAgentId(undefined, undefined, undefined, "codex")).toBe("codex");
-  });
-
-  it("returns undefined when nothing matches", () => {
-    expect(resolveAgentId(undefined, "bash" as never, undefined, "zsh" as never)).toBeUndefined();
+  it("returns undefined when both are undefined", () => {
+    expect(resolveAgentId(undefined, undefined)).toBeUndefined();
   });
 });
 

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -43,6 +43,7 @@ import { reconnectWithTimeout } from "./reconnectManager";
 import {
   inferKind,
   resolveAgentId,
+  inferAgentIdFromTitle,
   buildArgsForBackendTerminal,
   buildArgsForReconnectedFallback,
   buildArgsForRespawn,
@@ -460,10 +461,14 @@ export async function hydrateAppState(
               isPty: taskIsPty,
               execute: async () => {
                 if (backendTerminal) {
-                  // Skip dead agent backend terminals — they create phantom idle panels
+                  // Skip dead agent backend terminals — they create phantom idle panels.
+                  // capabilityAgentId is sealed at spawn for cold-launched agents, so
+                  // a dead PTY with capabilityAgentId set is still an agent backend
+                  // even if agentId got cleared on PTY teardown.
                   const isDeadAgentBackend =
                     backendTerminal.hasPty === false &&
-                    resolveAgentId(backendTerminal.agentId) !== undefined;
+                    (resolveAgentId(backendTerminal.agentId) !== undefined ||
+                      !!backendTerminal.capabilityAgentId);
                   if (isDeadAgentBackend) {
                     logHydrationInfo(`Skipping dead agent backend terminal: ${backendTerminal.id}`);
                     backendTerminalMap.delete(saved.id);
@@ -592,7 +597,16 @@ export async function hydrateAppState(
                       // panels that no longer exist in the backend — they are phantoms.
                       // On cold app restart (_switchId undefined), not_found simply means the
                       // PTY process was killed on quit and needs to be respawned.
-                      const isAgentKind = resolveAgentId(saved.agentId) !== undefined;
+                      // Mirror buildArgsForRespawn's title-inference recovery so legacy
+                      // `kind: "agent"` panels with cleared agentId still skip as phantoms.
+                      const inferredAgentId = inferAgentIdFromTitle(
+                        saved.title,
+                        kind,
+                        resolveAgentId(saved.agentId),
+                        saved.id,
+                        "switch-guard"
+                      );
+                      const isAgentKind = inferredAgentId !== undefined;
                       if (
                         isAgentKind &&
                         reconnectOutcome.status === "not_found" &&

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -463,7 +463,7 @@ export async function hydrateAppState(
                   // Skip dead agent backend terminals — they create phantom idle panels
                   const isDeadAgentBackend =
                     backendTerminal.hasPty === false &&
-                    resolveAgentId(backendTerminal.agentId, backendTerminal.type) !== undefined;
+                    resolveAgentId(backendTerminal.agentId) !== undefined;
                   if (isDeadAgentBackend) {
                     logHydrationInfo(`Skipping dead agent backend terminal: ${backendTerminal.id}`);
                     backendTerminalMap.delete(saved.id);
@@ -592,7 +592,7 @@ export async function hydrateAppState(
                       // panels that no longer exist in the backend — they are phantoms.
                       // On cold app restart (_switchId undefined), not_found simply means the
                       // PTY process was killed on quit and needs to be respawned.
-                      const isAgentKind = resolveAgentId(saved.agentId, saved.type) !== undefined;
+                      const isAgentKind = resolveAgentId(saved.agentId) !== undefined;
                       if (
                         isAgentKind &&
                         reconnectOutcome.status === "not_found" &&

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -172,7 +172,9 @@ export function buildArgsForBackendTerminal(
   projectRoot: string
 ): AddTerminalArgs {
   const cwd = backendTerminal.cwd || projectRoot || "";
-  let agentId = resolveAgentId(backendTerminal.agentId);
+  // Fall back to saved.agentId when the backend record lost it (e.g. PTY-host
+  // restart before persistence flushed) — mirrors buildArgsForReconnectedFallback.
+  let agentId = resolveAgentId(backendTerminal.agentId, saved.agentId);
   agentId = inferAgentIdFromTitle(
     backendTerminal.title,
     backendTerminal.kind,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -4,12 +4,7 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type { PanelExitBehavior } from "@shared/types/panel";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
-import {
-  isRegisteredAgent,
-  getAgentConfig,
-  getMergedPreset,
-  sanitizeAgentEnv,
-} from "@/config/agents";
+import { getAgentConfig, getMergedPreset, sanitizeAgentEnv } from "@/config/agents";
 import {
   generateAgentCommand,
   buildResumeCommand,
@@ -151,14 +146,10 @@ export function inferAgentIdFromTitle(
 
 export function resolveAgentId(
   primaryAgentId: string | undefined,
-  primaryType: TerminalType | undefined,
-  fallbackAgentId?: string | undefined,
-  fallbackType?: TerminalType | undefined
+  fallbackAgentId?: string | undefined
 ): string | undefined {
   if (primaryAgentId) return primaryAgentId;
-  if (primaryType && isRegisteredAgent(primaryType)) return primaryType;
   if (fallbackAgentId) return fallbackAgentId;
-  if (fallbackType && isRegisteredAgent(fallbackType)) return fallbackType;
   return undefined;
 }
 
@@ -181,7 +172,7 @@ export function buildArgsForBackendTerminal(
   projectRoot: string
 ): AddTerminalArgs {
   const cwd = backendTerminal.cwd || projectRoot || "";
-  let agentId = resolveAgentId(backendTerminal.agentId, backendTerminal.type);
+  let agentId = resolveAgentId(backendTerminal.agentId);
   agentId = inferAgentIdFromTitle(
     backendTerminal.title,
     backendTerminal.kind,
@@ -231,12 +222,7 @@ export function buildArgsForReconnectedFallback(
   projectRoot: string
 ): AddTerminalArgs {
   const cwd = reconnectedTerminal.cwd || saved.cwd || projectRoot || "";
-  let agentId = resolveAgentId(
-    reconnectedTerminal.agentId,
-    reconnectedTerminal.type,
-    saved.agentId,
-    saved.type
-  );
+  let agentId = resolveAgentId(reconnectedTerminal.agentId, saved.agentId);
 
   const reconnectedKind = reconnectedTerminal.kind ?? saved.kind;
   agentId = inferAgentIdFromTitle(
@@ -290,7 +276,7 @@ export function buildArgsForRespawn(
   reconnectTimedOut: boolean,
   clipboardDirectory: string | undefined
 ): AddTerminalArgs {
-  let effectiveAgentId = resolveAgentId(saved.agentId, saved.type);
+  let effectiveAgentId = resolveAgentId(saved.agentId);
   effectiveAgentId = inferAgentIdFromTitle(
     saved.title,
     kind,
@@ -470,7 +456,7 @@ export function buildArgsForOrphanedTerminal(
   projectRoot: string
 ): AddTerminalArgs {
   const cwd = terminal.cwd || projectRoot || "";
-  let agentId = resolveAgentId(terminal.agentId, terminal.type);
+  let agentId = resolveAgentId(terminal.agentId);
   agentId = inferAgentIdFromTitle(terminal.title, terminal.kind, agentId, terminal.id, "Orphaned");
 
   return {

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -46,7 +46,7 @@ export async function validateTerminalConfig(
   // the user asked for is on PATH. `detectedAgentId` doesn't exist yet at that
   // point, and using it later would validate the wrong binary for runtime-morphed
   // sessions (e.g., a plain shell that started a different agent).
-  const agentId = terminal.agentId ?? terminal.type;
+  const agentId = terminal.agentId;
   if (agentId && agentId !== "terminal") {
     try {
       const agentConfig = getAgentConfig(agentId);


### PR DESCRIPTION
## Summary

- Adds 2 E2E specs covering cold-launch identity, restart behaviour, plain-shell isolation, and view eviction recovery (core tier gates releases; full tier runs nightly)
- Deletes 8 sites of `terminal.type` agent-identity fallback shims across `resolveAgentId`, `terminalValidation`, `TerminalIcon`, `TrashBinItem`, `TrashGroupItem`, `recipeStore`, `terminalInput`, and `stateHydration`
- Closes 3 hydration regressions surfaced in review: `saved.agentId` fallback in `buildArgsForBackendTerminal`, `capabilityAgentId`-aware `isDeadAgentBackend` guard, and title-inferred phantom-skip

Closes #5812

## Changes

- `e2e/core/core-terminal-identity.spec.ts` — cold-launch identity, restart, plain-shell isolation assertions
- `e2e/full/core-terminal-identity-recovery.spec.ts` — view eviction and recovery scenarios
- `e2e/helpers/selectors.ts` — `data-capability-agent-id` selector additions
- `src/components/Panel/ContentPanel.tsx` — adds `data-capability-agent-id` DOM attribute for full-mode assertion
- `src/utils/stateHydration/statePatcher.ts` + `index.ts` — drops `type`-field fallbacks, adds `saved.agentId` recovery path, tightens `isDeadAgentBackend` guard
- `electron/services/pty/terminalInput.ts` — removes shim branch
- `src/components/Terminal/TerminalIcon.tsx` + `src/store/recipeStore.ts` + Layout components — remaining shim deletions

## Testing

Vitest: 140 unit tests pass, tsc clean, lint clean (2 pre-existing `recipeStore.ts` warnings, untouched). Local E2E blocked by a pre-existing environment issue that affects all `openAndOnboardProject` tests — verified `core-process-badge` and `core-persistence` fail identically, so not introduced here. CI (Linux + macOS) will be the green gate for the new E2E specs.