### PR TITLE
fix(notifications): reduce unread row to a single signal

### DIFF
--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -45,12 +45,7 @@ export function NotificationCenterEntry({
   const Icon = config.icon;
 
   return (
-    <div
-      className={cn(
-        "group flex items-start gap-2.5 px-3 py-2 hover:bg-overlay-medium transition-colors border-l-2",
-        isNew ? "border-daintree-accent bg-daintree-accent/[0.04]" : "border-transparent"
-      )}
-    >
+    <div className="group flex items-start gap-2.5 px-3 py-2 hover:bg-overlay-medium transition-colors">
       <div className={cn("mt-0.5 shrink-0", config.className)}>
         <Icon className="h-3.5 w-3.5" />
       </div>

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -72,3 +72,26 @@ describe("NotificationCenterEntry overflow menu", () => {
     expect(screen.getByLabelText("Notification options")).toBeTruthy();
   });
 });
+
+describe("NotificationCenterEntry unread signal", () => {
+  it("renders the unread dot when isNew=true", () => {
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    expect(container.querySelector(".bg-daintree-accent.rounded-full")).not.toBeNull();
+  });
+
+  it("does not render the unread dot when isNew is omitted or false", () => {
+    const { container, rerender } = render(<NotificationCenterEntry entry={makeEntry()} />);
+    expect(container.querySelector(".bg-daintree-accent.rounded-full")).toBeNull();
+
+    rerender(<NotificationCenterEntry entry={makeEntry()} isNew={false} />);
+    expect(container.querySelector(".bg-daintree-accent.rounded-full")).toBeNull();
+  });
+
+  it("does not apply legacy unread row treatments (border or background tint)", () => {
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    const row = container.firstElementChild as HTMLElement;
+    expect(row.className).not.toMatch(/border-l-2/);
+    expect(row.className).not.toMatch(/border-daintree-accent/);
+    expect(row.className).not.toMatch(/bg-daintree-accent\/\[0\.04\]/);
+  });
+});


### PR DESCRIPTION
## Summary

- Unread notification rows were applying the accent colour three times: a left border, a background tint, and a right-side dot. This violates the accent-restraint rule (accent as a scarce resource, not applied to multiple elements at once).
- Removed `border-l-2 border-daintree-accent` and `bg-daintree-accent/[0.04]` from `NotificationCenterEntry.tsx`, keeping only the right-side dot as the sole unread signal.
- The change brings the notification centre in line with how Linear, Vercel, and GitHub Inbox handle unread state: one clear indicator, no visual shouting.

Resolves #5840

## Changes

- `src/components/Notifications/NotificationCenterEntry.tsx` — stripped the left border and background tint from the unread conditional classes
- `src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx` — three new regression tests: dot present when `isNew=true`, dot absent when `isNew=false` or omitted, and the removed border/tint classes are not rendered

## Testing

All 7 tests in `NotificationCenterEntry.test.tsx` pass. `npm run check` is clean — typecheck passes, lint-ratchet improved by 6 warnings, format check clean.