### PR TITLE
fix(layout): include implicit Default in preset split-UI threshold

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -103,9 +103,10 @@ export function AgentButton({
 
   const entry = agentSettings?.agents?.[type] ?? {};
   const presets = getMergedPresets(type, entry.customPresets, ccrPresets, projectPresets);
-  // Only show the split/chevron UI when there are at least 2 presets; a single
-  // preset is implicitly the default and doesn't warrant a picker.
-  const hasPresets = presets.length >= 2;
+  // Show the split/chevron UI when there is at least one named preset; the
+  // dropdown always renders the implicit "Default" entry alongside it, so one
+  // named preset already gives the user two real launch choices.
+  const hasPresets = presets.length >= 1;
   // Worktree-scoped pick wins over the agent-level default so switching
   // worktrees doesn't silently surface another worktree's selection.
   const savedPresetId = resolveEffectivePresetId(entry, activeWorktreeId);

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -88,7 +88,7 @@ function buildAgentRow(
   const config = getAgentConfig(id);
   if (!config) return null;
   const presets = getMergedPresets(id, customPresets, ccrPresets, projectPresets);
-  const hasPresets = presets.length > 1;
+  const hasPresets = presets.length > 0;
   return {
     id,
     name: config.name,

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -3,7 +3,7 @@
  * AgentButton — toolbar button with optional preset picker.
  *
  * Covers the MRU (most-recently-used) preset launch semantics and the
- * >= 2 threshold for showing the split/chevron UI. These are UX regressions
+ * >= 1 threshold for showing the split/chevron UI. These are UX regressions
  * corrected during the preset PR review:
  *
  *  - Primary-button click launches with the saved `presetId` when present,
@@ -11,8 +11,10 @@
  *    always-default on the primary button contradicts the industry-standard
  *    split-button convention.
  *
- *  - The chevron/dropdown only appears when there are at least 2 presets.
- *    A single preset is implicitly the default and doesn't warrant a picker.
+ *  - The chevron/dropdown appears whenever there is at least one named preset.
+ *    The dropdown always renders the implicit "Default" entry alongside named
+ *    presets, so one named preset already gives the user two real launch
+ *    choices and warrants the picker.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
@@ -197,13 +199,14 @@ describe("AgentButton preset UX", () => {
       expect(queryByTestId("chevron-icon")).toBeNull();
     });
 
-    it("renders plain button (no chevron) when agent has exactly 1 preset", () => {
+    it("renders split button (with chevron) when agent has exactly 1 preset", () => {
       mockMergedPresetsFn = () => [{ id: "only", name: "Only" }];
-      const { queryByTestId } = render(
+      const { getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      // Threshold is >= 2, so a single preset should not trigger the split UI.
-      expect(queryByTestId("chevron-icon")).toBeNull();
+      // The dropdown always includes an implicit Default entry, so a single
+      // named preset already represents two real launch choices.
+      expect(getByTestId("chevron-icon")).toBeTruthy();
     });
 
     it("renders split button (with chevron) when agent has >= 2 presets", () => {
@@ -257,16 +260,17 @@ describe("AgentButton preset UX", () => {
       );
     });
 
-    it("primary click with savedPresetId dispatches presetId even when agent has only 1 preset (no split)", () => {
-      // With < 2 presets we render a plain button, but MRU must still work —
-      // the user picked this preset from Settings and expects it on next click.
+    it("primary click with savedPresetId dispatches presetId when agent has only 1 preset", () => {
+      // With 1 named preset the split UI now renders (Default + the preset),
+      // and the primary button must still honor the saved MRU selection.
       mockSettings = settingsWith({ claude: { presetId: "user-alpha" } });
       mockMergedPresetsFn = () => [{ id: "user-alpha", name: "Alpha" }];
 
-      const { getByRole } = render(
+      const { getAllByRole } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      fireEvent.click(getByRole("button"));
+      const [primaryBtn] = getAllByRole("button") as HTMLElement[];
+      fireEvent.click(primaryBtn!);
 
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -923,6 +923,18 @@ describe("AgentTrayButton", () => {
       expect(queryByText("CCR Routes")).toBeNull();
       expect(queryByText("Custom")).toBeNull();
     });
+
+    it("renders the submenu trigger when agent has exactly 1 preset", () => {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockSettings = settingsWith({ claude: { pinned: false } });
+      mockMergedPresetsFn = () => [{ id: "user-alpha", name: "Alpha" }];
+
+      const { queryAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      // The submenu always includes the implicit Default entry alongside named
+      // presets, so a single named preset already represents two real launch
+      // choices and warrants the submenu picker.
+      expect(queryAllByTestId("submenu-trigger").length).toBeGreaterThan(0);
+    });
   });
 
   describe("worktree-scoped preset persistence", () => {


### PR DESCRIPTION
## Summary

- The preset launch dropdown always renders an implicit "Default" entry alongside any named presets, but the threshold logic in `AgentButton` and `AgentTrayButton` only counted named presets. So a single named preset hid the chevron/split-button UI entirely, even though users actually had two real launch choices (Default + the named preset).
- Fixed by adjusting the threshold: `hasPresets >= 1` in `AgentButton` and `hasPresets > 0` in `AgentTrayButton`, so the split UI appears as soon as there's one named preset (giving two real options).

Resolves #5842

## Changes

- `src/components/Layout/AgentButton.tsx` line 108: `hasPresets >= 2` → `hasPresets >= 1`
- `src/components/Layout/AgentTrayButton.tsx` line 91: `hasPresets > 1` → `hasPresets > 0`
- Updated tests in `AgentButton.test.tsx` and `AgentTrayButton.test.tsx` to cover the corrected thresholds (53 tests pass)

## Testing

Unit tests updated to assert the split UI renders with one named preset. All 53 tests pass. Typecheck, lint, and format clean.