### PR TITLE
fix(notifications): protect error toasts from eviction by fast successors

### DIFF
--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -232,6 +232,51 @@ describe("notificationStore — error-protected eviction", () => {
 
     expect(onDismiss).not.toHaveBeenCalled();
   });
+
+  it("admits an incoming error by evicting the oldest non-error from a full cap", () => {
+    const successId1 = addToast({ type: "success", message: "ok-1" });
+    addToast({ type: "success", message: "ok-2" });
+    addToast({ type: "success", message: "ok-3" });
+    addToast({ type: "error", message: "boom" });
+
+    const notifications = getState().notifications;
+    expect(notifications.find((n) => n.id === successId1)?.dismissed).toBe(true);
+
+    const active = notifications.filter((n) => !n.dismissed);
+    expect(active.map((n) => n.message)).toEqual(["ok-2", "ok-3", "boom"]);
+  });
+
+  it("flips only the evicted toast's history entry — bystanders stay seen", () => {
+    const evictedEntry = useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "evicted-history",
+      seenAsToast: true,
+    });
+    const survivorEntry = useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "survivor-history",
+      seenAsToast: true,
+    });
+
+    addToast({ type: "error", message: "err" });
+    addToast({ type: "info", message: "info-1", historyEntryId: evictedEntry });
+    addToast({ type: "info", message: "info-2", historyEntryId: survivorEntry });
+    addToast({ type: "success", message: "ok" });
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === evictedEntry)?.seenAsToast).toBe(false);
+    expect(entries.find((e) => e.id === survivorEntry)?.seenAsToast).toBe(true);
+  });
+
+  it("does not invoke onDismiss in the all-errors FIFO fallback path", () => {
+    const onDismiss = vi.fn();
+    addToast({ type: "error", message: "err-1", onDismiss });
+    addToast({ type: "error", message: "err-2" });
+    addToast({ type: "error", message: "err-3" });
+    addToast({ type: "error", message: "err-4" });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
 });
 
 describe("notificationStore — correlationId collapse", () => {

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useNotificationStore, MAX_VISIBLE_TOASTS, type Notification } from "../notificationStore";
 import { useNotificationHistoryStore } from "../slices/notificationHistorySlice";
 
@@ -143,6 +143,94 @@ describe("notificationStore — toast cap", () => {
     const active = getState().notifications.filter((n) => !n.dismissed);
     expect(active).toHaveLength(3);
     expect(active.map((n) => n.message)).toEqual(["toast-2", "toast-3", "toast-4"]);
+  });
+});
+
+describe("notificationStore — error-protected eviction", () => {
+  beforeEach(() => {
+    useNotificationStore.setState({ notifications: [] });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+  });
+
+  it("keeps the error visible when three rapid successes follow it (#5861)", () => {
+    const errorId = addToast({ type: "error", message: "boom" });
+    const successId1 = addToast({ type: "success", message: "ok-1" });
+    addToast({ type: "success", message: "ok-2" });
+    addToast({ type: "success", message: "ok-3" });
+
+    const notifications = getState().notifications;
+    expect(notifications).toHaveLength(4);
+
+    expect(notifications.find((n) => n.id === errorId)?.dismissed).toBeFalsy();
+    expect(notifications.find((n) => n.id === successId1)?.dismissed).toBe(true);
+
+    const active = notifications.filter((n) => !n.dismissed);
+    expect(active.map((n) => n.message)).toEqual(["boom", "ok-2", "ok-3"]);
+  });
+
+  it("falls back to oldest-first FIFO when every visible toast is an error", () => {
+    const id1 = addToast({ type: "error", message: "err-1" });
+    addToast({ type: "error", message: "err-2" });
+    addToast({ type: "error", message: "err-3" });
+    addToast({ type: "error", message: "err-4" });
+
+    const notifications = getState().notifications;
+    expect(notifications.find((n) => n.id === id1)?.dismissed).toBe(true);
+
+    const active = notifications.filter((n) => !n.dismissed);
+    expect(active.map((n) => n.message)).toEqual(["err-2", "err-3", "err-4"]);
+  });
+
+  it("treats warning as evictable (warnings are not protected like errors)", () => {
+    const warnId = addToast({ type: "warning", message: "warn" });
+    addToast({ type: "info", message: "info-1" });
+    addToast({ type: "info", message: "info-2" });
+    addToast({ type: "success", message: "ok" });
+
+    const notifications = getState().notifications;
+    expect(notifications.find((n) => n.id === warnId)?.dismissed).toBe(true);
+
+    const active = notifications.filter((n) => !n.dismissed);
+    expect(active.map((n) => n.message)).toEqual(["info-1", "info-2", "ok"]);
+  });
+
+  it("evicts the oldest non-error from a mixed-severity set", () => {
+    addToast({ type: "error", message: "err" });
+    const warnId = addToast({ type: "warning", message: "warn" });
+    addToast({ type: "info", message: "info" });
+    addToast({ type: "success", message: "ok" });
+
+    const notifications = getState().notifications;
+    expect(notifications.find((n) => n.id === warnId)?.dismissed).toBe(true);
+
+    const active = notifications.filter((n) => !n.dismissed);
+    expect(active.map((n) => n.message)).toEqual(["err", "info", "ok"]);
+  });
+
+  it("marks the evicted non-error's history entry as unseen even when an error is present", () => {
+    const entryId = useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "history-for-info",
+      seenAsToast: true,
+    });
+
+    addToast({ type: "error", message: "err" });
+    addToast({ type: "info", message: "info-1", historyEntryId: entryId });
+    addToast({ type: "info", message: "info-2" });
+    addToast({ type: "success", message: "ok" });
+
+    const entry = useNotificationHistoryStore.getState().entries.find((e) => e.id === entryId);
+    expect(entry?.seenAsToast).toBe(false);
+  });
+
+  it("does not invoke onDismiss when a non-error toast is evicted", () => {
+    const onDismiss = vi.fn();
+    addToast({ type: "error", message: "err" });
+    addToast({ type: "info", message: "info-1", onDismiss });
+    addToast({ type: "info", message: "info-2" });
+    addToast({ type: "success", message: "ok" });
+
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -136,12 +136,18 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
       if (notification.placement !== "grid-bar") {
         const active = notifications.filter((n) => !n.dismissed && n.placement !== "grid-bar");
         if (active.length >= MAX_VISIBLE_TOASTS) {
-          const oldest = active[0]!;
+          // Prefer evicting the oldest non-error toast so an error stays
+          // visible when fast successes/infos arrive after it (#5861). Falls
+          // back to oldest-of-any-type when the visible set is all errors.
+          // Relies on `notifications` being append-only — `active` is therefore
+          // insertion-ordered oldest-first, so `find` returns the oldest
+          // non-error without sorting.
+          const evictCandidate = active.find((n) => n.type !== "error") ?? active[0]!;
           notifications = notifications.map((n) =>
-            n.id === oldest.id ? { ...n, dismissed: true } : n
+            n.id === evictCandidate.id ? { ...n, dismissed: true } : n
           );
-          if (oldest.historyEntryId) {
-            useNotificationHistoryStore.getState().markUnseenAsToast(oldest.historyEntryId);
+          if (evictCandidate.historyEntryId) {
+            useNotificationHistoryStore.getState().markUnseenAsToast(evictCandidate.historyEntryId);
           }
         }
       }


### PR DESCRIPTION
## Summary

- When the toast cap (`MAX_VISIBLE_TOASTS = 3`) was reached, eviction picked the oldest active toast regardless of type. An error that arrived first could be bumped off screen by three rapid successes, losing the most important signal before the user ever saw it.
- Fix: prefer evicting the oldest non-error toast first; fall back to FIFO only when every visible toast is an error. One-line change in `src/store/notificationStore.ts` — `const evictCandidate = active.find((n) => n.type !== "error") ?? active[0]!`.
- Only `type === "error"` is protected. Warnings, infos, and successes stay evictable. `NotificationPriority` is untouched (severity and priority remain orthogonal). The `correlationId` collapse path, `markUnseenAsToast` history call, and the "onDismiss does not fire on eviction" contract are all preserved.

Resolves #5861

## Changes

- `src/store/notificationStore.ts` — eviction candidate selection uses `find(n => n.type !== "error") ?? active[0]` instead of `active[0]` directly
- `src/store/__tests__/notificationStore.test.ts` — 9 new tests covering: core regression, FIFO fallback when all visible are errors, warning evictability, mixed-severity ordering, history-unseen marking, `onDismiss` invariant in both eviction paths, inverted arrival (incoming error admitted from a full success cap), and bystander history entries staying seen

## Testing

Ran the full notification store test suite locally. All 9 new cases pass alongside the existing suite. Typecheck, lint, format, and build all clean.