### PR TITLE
perf(persistence): expand SQLite pragma set for write-heavy workload

### DIFF
--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -9,6 +9,8 @@ vi.mock("electron", () => ({
 
 const mockPragma = vi.fn();
 const mockClose = vi.fn();
+const mockExec = vi.fn();
+const mockPrepare = vi.fn(() => ({ run: vi.fn() }));
 const mockDatabaseConstructor = vi.fn();
 
 vi.mock("better-sqlite3", () => {
@@ -21,11 +23,17 @@ vi.mock("better-sqlite3", () => {
       }
       pragma = mockPragma;
       close = mockClose;
+      exec = mockExec;
+      prepare = mockPrepare;
     },
   };
 });
 
-import { probeDb, attemptRecovery, closeSharedDb } from "../db.js";
+vi.mock("drizzle-orm/better-sqlite3", () => ({
+  drizzle: vi.fn(() => ({})),
+}));
+
+import { probeDb, attemptRecovery, closeSharedDb, openDb } from "../db.js";
 
 describe("probeDb", () => {
   let tmpDir: string;
@@ -176,5 +184,33 @@ describe("attemptRecovery", () => {
 describe("closeSharedDb", () => {
   it("does nothing when no shared instance exists", () => {
     expect(() => closeSharedDb({ checkpoint: true })).not.toThrow();
+  });
+});
+
+describe("openDb", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDatabaseConstructor.mockImplementation(() => ({}));
+    mockPragma.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("applies pragmas in the required order, with synchronous after WAL", () => {
+    openDb("/fake/test.db");
+
+    const pragmaCalls = mockPragma.mock.calls.map(([s]) => s as string);
+    // First six pragma calls must be the openDb configuration block.
+    // Migration logic below also calls pragma("table_info(projects)"), which we do not assert order on.
+    expect(pragmaCalls.slice(0, 6)).toEqual([
+      "journal_mode = WAL",
+      "busy_timeout = 3000",
+      "synchronous = NORMAL",
+      "temp_store = MEMORY",
+      "mmap_size = 10737418240",
+      "cache_size = -65536",
+    ]);
   });
 });

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -212,5 +212,11 @@ describe("openDb", () => {
       "mmap_size = 10737418240",
       "cache_size = -65536",
     ]);
+
+    // Schema creation must run after the pragma configuration block, otherwise
+    // CREATE TABLE happens with the wrong journal/cache settings.
+    const sixthPragmaOrder = mockPragma.mock.invocationCallOrder[5];
+    const firstExecOrder = mockExec.mock.invocationCallOrder[0];
+    expect(firstExecOrder).toBeGreaterThan(sixthPragmaOrder);
   });
 });

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -79,6 +79,10 @@ export function openDb(dbPath: string): { sqlite: Database.Database; db: AppDb }
   const sqlite = new Database(dbPath);
   sqlite.pragma("journal_mode = WAL");
   sqlite.pragma("busy_timeout = 3000");
+  sqlite.pragma("synchronous = NORMAL");
+  sqlite.pragma("temp_store = MEMORY");
+  sqlite.pragma("mmap_size = 10737418240");
+  sqlite.pragma("cache_size = -65536");
   sqlite.exec(CREATE_TABLES_SQL);
 
   // Migrate: add pinned column to projects table if it doesn't exist


### PR DESCRIPTION
## Summary

- `openDb()` only set `journal_mode=WAL` and `busy_timeout=3000`, paying fsync-per-commit cost and running with SQLite's tiny default page cache
- Adds the four pragmas the issue identifies: `synchronous=NORMAL`, `temp_store=MEMORY`, `mmap_size=10737418240`, `cache_size=-65536` (64 MiB)
- These pair cleanly with existing behaviour; `DatabaseMaintenanceService` already handles WAL checkpointing so the durability story is unchanged

Resolves #5829

## Changes

- `electron/services/persistence/db.ts` — four new pragma calls after `busy_timeout`, ordered to match the WAL-safe configuration the issue documents
- `electron/services/persistence/__tests__/db.test.ts` — asserts all 6 pragma calls execute in the correct order; also adds a regression test confirming `sqlite.exec()` runs after pragma configuration (a gap where swapping that call before the pragmas would have silently passed)

## Testing

10 tests in `db.test.ts` via vitest, all passing. Typecheck, lint, and format clean.