### PR TITLE
fix(sidebar): use live keybinding hint for worktrees overview tooltip

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -13,7 +13,13 @@ import React, {
 import { FolderOpen, FilterX, LayoutGrid, Plus, RefreshCw } from "lucide-react";
 import { BroadcastTerminalIcon } from "@/components/icons";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
-import { useAgentLauncher, useWorktrees, useProjectSettings, useWorktreeActions } from "@/hooks";
+import {
+  useAgentLauncher,
+  useWorktrees,
+  useProjectSettings,
+  useWorktreeActions,
+  useKeybindingDisplay,
+} from "@/hooks";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -291,6 +297,7 @@ interface SidebarContentProps {
 }
 
 function SidebarContent({ onOpenOverview }: SidebarContentProps) {
+  const overviewShortcut = useKeybindingDisplay("worktree.overview");
   const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
@@ -920,7 +927,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  {createTooltipWithShortcut("Open worktrees overview", "Cmd+Shift+O")}
+                  {createTooltipWithShortcut("Open worktrees overview", overviewShortcut)}
                 </TooltipContent>
               </Tooltip>
               <Tooltip>

--- a/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+describe("SidebarContent shortcut tooltips — issue #5843", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  describe("useKeybindingDisplay hooks", () => {
+    it("uses dynamic hook for worktree.overview", () => {
+      expect(source).toContain('useKeybindingDisplay("worktree.overview")');
+    });
+  });
+
+  describe("no hardcoded shortcut strings in tooltips", () => {
+    it("does not hardcode shortcut strings in createTooltipWithShortcut calls", () => {
+      expect(source).not.toMatch(/createTooltipWithShortcut\([^)]*"Cmd\+/);
+      expect(source).not.toMatch(/createTooltipWithShortcut\([^)]*"Ctrl\+/);
+    });
+  });
+
+  describe("createTooltipWithShortcut usage", () => {
+    it("uses createTooltipWithShortcut for Open worktrees overview tooltip", () => {
+      expect(source).toContain(
+        'createTooltipWithShortcut("Open worktrees overview", overviewShortcut)'
+      );
+    });
+  });
+});

--- a/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
@@ -22,6 +22,10 @@ describe("SidebarContent shortcut tooltips — issue #5843", () => {
       expect(source).not.toMatch(/createTooltipWithShortcut\([^)]*"Cmd\+/);
       expect(source).not.toMatch(/createTooltipWithShortcut\([^)]*"Ctrl\+/);
     });
+
+    it("does not assign hardcoded shortcut literals to *Shortcut variables", () => {
+      expect(source).not.toMatch(/const\s+\w*Shortcut\s*=\s*["'](Cmd|Ctrl|Shift|Alt|Option)/);
+    });
   });
 
   describe("createTooltipWithShortcut usage", () => {


### PR DESCRIPTION
## Summary

- The worktrees overview button in `SidebarContent` was hardcoding `"Cmd+Shift+O"` in its tooltip. It now resolves the live shortcut via `useKeybindingDisplay("worktree.overview")`, so the hint stays accurate if the user remaps the keybinding.
- A file-scan test (mirroring the pattern in `PanelHeader` and `PortalToolbar`) guards against regressions where hardcoded shortcut literals get routed through `*Shortcut` variables to sidestep the existing check.

Resolves #5843

## Changes

- `src/components/Sidebar/SidebarContent.tsx` — replace hardcoded `"Cmd+Shift+O"` with `useKeybindingDisplay("worktree.overview")` and pass the result through `createTooltipWithShortcut()`
- `src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts` — new static-analysis test asserting no hardcoded shortcut literals in the sidebar file, with an extra guard against the `*Shortcut` variable pattern

## Audit notes

The other surfaces called out in the issue were checked:

- **Toolbar** — already uses `useKeybindingDisplay` correctly, no changes needed
- **PanelHeader** — same, dynamic pattern already in place; tab-scroll chevrons are UI-only (no action ID) so they correctly have no shortcut hint
- **PortalToolbar** — back/forward/reload have no registered default keybindings, so the existing test correctly asserts they remain plain-text tooltips; no change needed
- Sidebar broadcast/refresh/create buttons have no registered default keybindings, so omitting hints there is correct

## Testing

- `npm test` on the new test file: 4/4 pass
- `npm run check` (typecheck + lint + format): clean