### PR TITLE
feat(notifications): show DND state on toolbar bell

### DIFF
--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -66,6 +66,7 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
   useEffect(() => {
     const tick = () => forceTick((n) => n + 1);
     const timeouts: ReturnType<typeof setTimeout>[] = [];
+    const intervals: ReturnType<typeof setInterval>[] = [];
 
     if (isSessionMuted) {
       const delay = Math.max(0, quietUntil - Date.now());
@@ -73,14 +74,20 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     }
 
     if (quietHoursEnabled) {
-      // Re-evaluate at the next minute boundary — a single coarse poll keeps
-      // the implementation simple across midnight/DST/weekday rollovers.
+      // Coarse minute-poll re-render. Aligns to the next minute, then repeats.
+      // Simpler than computing exact start/end edges across midnight/DST/weekday rollovers.
       const msToNextMinute = 60_000 - (Date.now() % 60_000);
-      timeouts.push(setTimeout(tick, msToNextMinute + 50));
+      timeouts.push(
+        setTimeout(() => {
+          tick();
+          intervals.push(setInterval(tick, 60_000));
+        }, msToNextMinute + 50)
+      );
     }
 
     return () => {
       for (const t of timeouts) clearTimeout(t);
+      for (const i of intervals) clearInterval(i);
     };
   }, [isSessionMuted, quietUntil, quietHoursEnabled]);
 

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -1,15 +1,21 @@
-import { useRef, useEffect, memo } from "react";
+import { useRef, useEffect, useState, memo } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
-import { Bell } from "lucide-react";
+import { Bell, BellOff } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { NotificationCenter } from "@/components/Notifications/NotificationCenter";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
+import { isScheduledQuietNow } from "@shared/utils/quietHours";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text transition-colors";
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
 
 export const NotificationCenterToolbarButton = memo(function NotificationCenterToolbarButton({
   "data-toolbar-item": dataToolbarItem,
@@ -25,13 +31,76 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
   );
   const notificationCenterButtonRef = useRef<HTMLButtonElement>(null);
   const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
-  const notificationsEnabled = useNotificationSettingsStore((s) => s.enabled);
+  const {
+    enabled: notificationsEnabled,
+    quietUntil,
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+  } = useNotificationSettingsStore(
+    useShallow((s) => ({
+      enabled: s.enabled,
+      quietUntil: s.quietUntil,
+      quietHoursEnabled: s.quietHoursEnabled,
+      quietHoursStartMin: s.quietHoursStartMin,
+      quietHoursEndMin: s.quietHoursEndMin,
+      quietHoursWeekdays: s.quietHoursWeekdays,
+    }))
+  );
+
+  // Force re-render at session-mute expiry and at scheduled quiet-hours
+  // boundaries. Without this the icon stays in its old state until something
+  // else triggers a render.
+  const [, forceTick] = useState(0);
+  const now = Date.now();
+  const isSessionMuted = quietUntil > now;
+  const isScheduledMuted = isScheduledQuietNow({
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+  });
+  const isDndActive = isSessionMuted || isScheduledMuted;
+
+  useEffect(() => {
+    const tick = () => forceTick((n) => n + 1);
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+
+    if (isSessionMuted) {
+      const delay = Math.max(0, quietUntil - Date.now());
+      timeouts.push(setTimeout(tick, delay + 50));
+    }
+
+    if (quietHoursEnabled) {
+      // Re-evaluate at the next minute boundary — a single coarse poll keeps
+      // the implementation simple across midnight/DST/weekday rollovers.
+      const msToNextMinute = 60_000 - (Date.now() % 60_000);
+      timeouts.push(setTimeout(tick, msToNextMinute + 50));
+    }
+
+    return () => {
+      for (const t of timeouts) clearTimeout(t);
+    };
+  }, [isSessionMuted, quietUntil, quietHoursEnabled]);
 
   useEffect(() => {
     if (!notificationsEnabled && notificationCenterOpen) closeNotificationCenter();
   }, [notificationsEnabled, notificationCenterOpen, closeNotificationCenter]);
 
   if (!notificationsEnabled) return null;
+
+  const label = (() => {
+    if (isSessionMuted) {
+      return `Notifications — muted until ${timeFormatter.format(new Date(quietUntil))}`;
+    }
+    if (isScheduledMuted) return "Notifications — scheduled quiet hours";
+    if (notificationUnreadCount > 0) return `Notifications — ${notificationUnreadCount} unread`;
+    return "Notifications";
+  })();
+
+  const Icon = isDndActive ? BellOff : Bell;
+  const dotColor = isDndActive ? "bg-daintree-text/30" : "bg-daintree-text/50";
 
   return (
     <div className="relative">
@@ -43,25 +112,23 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
               variant="ghost"
               size="icon"
               data-toolbar-item={dataToolbarItem}
+              data-dnd-active={isDndActive ? "true" : undefined}
               onClick={toggleNotificationCenter}
               className={toolbarIconButtonClass}
-              aria-label={
-                notificationUnreadCount > 0
-                  ? `Notifications — ${notificationUnreadCount} unread`
-                  : "Notifications"
-              }
+              aria-label={label}
               aria-expanded={notificationCenterOpen}
               aria-haspopup="dialog"
             >
-              <Bell />
+              <Icon />
               {notificationUnreadCount > 0 && (
-                <span className="absolute top-1 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-daintree-accent text-[9px] font-bold tabular-nums text-daintree-bg px-0.5 leading-none">
-                  {notificationUnreadCount > 99 ? "99+" : notificationUnreadCount}
-                </span>
+                <span
+                  data-testid="notification-unread-dot"
+                  className={`absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full ring-1 ring-daintree-bg/60 ${dotColor}`}
+                />
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Notifications</TooltipContent>
+          <TooltipContent side="bottom">{label}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
       <FixedDropdown

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -12,7 +12,7 @@
  *  - aria-label / tooltip describes the muted state with a time-of-day when known
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import { NotificationCenterToolbarButton } from "../NotificationCenterToolbarButton";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -112,6 +112,7 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       const { queryByTestId } = render(<NotificationCenterToolbarButton />);
       expect(queryByTestId("icon-bell-off")).toBeTruthy();
+      expect(queryByTestId("icon-bell")).toBeNull();
     });
 
     it("renders Bell again outside scheduled quiet hours", () => {
@@ -124,6 +125,27 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       const { queryByTestId } = render(<NotificationCenterToolbarButton />);
       expect(queryByTestId("icon-bell")).toBeTruthy();
+      expect(queryByTestId("icon-bell-off")).toBeNull();
+    });
+
+    it("respects weekday filter — Bell on excluded day, BellOff on included day", () => {
+      vi.useFakeTimers();
+      // 2024-01-06 is a Saturday (day 6); 2024-01-08 is a Monday (day 1).
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 23 * 60,
+        quietHoursWeekdays: [1, 2, 3, 4, 5],
+      });
+
+      vi.setSystemTime(new Date(2024, 0, 6, 22, 30));
+      const sat = render(<NotificationCenterToolbarButton />);
+      expect(sat.queryByTestId("icon-bell")).toBeTruthy();
+      sat.unmount();
+
+      vi.setSystemTime(new Date(2024, 0, 8, 22, 30));
+      const mon = render(<NotificationCenterToolbarButton />);
+      expect(mon.queryByTestId("icon-bell-off")).toBeTruthy();
     });
   });
 
@@ -175,8 +197,8 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       const btn = container.querySelector("button")!;
       const label = btn.getAttribute("aria-label") ?? "";
       expect(label.startsWith("Notifications — muted until ")).toBe(true);
-      // Locale-dependent formatting — match the time portion loosely.
-      expect(label).toMatch(/2:30/);
+      // Match either 12h ("2:30") or 24h ("14:30") locale outputs.
+      expect(label).toMatch(/(?:^|[^0-9])(?:14|2):30/);
     });
 
     it("says 'scheduled quiet hours' during the configured window", () => {
@@ -217,6 +239,55 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       useNotificationSettingsStore.setState({ enabled: false });
       const { container } = render(<NotificationCenterToolbarButton />);
       expect(container.querySelector("button")).toBeNull();
+    });
+  });
+
+  describe("boundary timers — auto re-render at expiry / minute boundary", () => {
+    it("flips BellOff back to Bell when the session mute expires", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      useNotificationSettingsStore.setState({
+        quietUntil: new Date(2024, 0, 1, 12, 0, 30).getTime(),
+      });
+
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell-off")).toBeTruthy();
+
+      // Advance past the expiry timestamp + the 50ms safety pad.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31_000);
+      });
+
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+      expect(queryByTestId("icon-bell-off")).toBeNull();
+    });
+
+    it("re-arms the minute poll so scheduled quiet hours flip Bell at the end boundary", async () => {
+      vi.useFakeTimers();
+      // Start at 22:59:30 — quiet starts at 23:00 and ends at 23:01.
+      vi.setSystemTime(new Date(2024, 0, 1, 22, 59, 30));
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 23 * 60,
+        quietHoursEndMin: 23 * 60 + 1,
+      });
+
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      // Outside the window initially.
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+
+      // Cross 23:00 — first re-arm via initial setTimeout fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31_000);
+      });
+      expect(queryByTestId("icon-bell-off")).toBeTruthy();
+
+      // Cross 23:01 — interval must re-arm and tick again.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+      expect(queryByTestId("icon-bell-off")).toBeNull();
     });
   });
 });

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+/**
+ * NotificationCenterToolbarButton — DND state surfaced on the toolbar bell.
+ *
+ * Issue #5839: the bell must reflect Do-Not-Disturb (session mute or scheduled
+ * quiet hours) so users aren't confused about whether their notifications are
+ * being suppressed.
+ *
+ *  - Bell icon swaps to BellOff while DND is active
+ *  - Numeric accent badge collapses to a plain dot (always — accent restraint)
+ *  - The dot uses a non-accent color and dims further when DND is active
+ *  - aria-label / tooltip describes the muted state with a time-of-day when known
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { NotificationCenterToolbarButton } from "../NotificationCenterToolbarButton";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { useUIStore } from "@/store/uiStore";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+  } & React.HTMLAttributes<HTMLButtonElement>) => (
+    <button onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/fixed-dropdown", () => ({
+  FixedDropdown: () => null,
+}));
+
+vi.mock("@/components/Notifications/NotificationCenter", () => ({
+  NotificationCenter: () => null,
+}));
+
+vi.mock("lucide-react", () => ({
+  Bell: () => <span data-testid="icon-bell" />,
+  BellOff: () => <span data-testid="icon-bell-off" />,
+}));
+
+function resetStores() {
+  useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+  useNotificationSettingsStore.setState({
+    enabled: true,
+    hydrated: true,
+    quietHoursEnabled: false,
+    quietHoursStartMin: 22 * 60,
+    quietHoursEndMin: 8 * 60,
+    quietHoursWeekdays: [],
+    quietUntil: 0,
+  });
+  useUIStore.setState({
+    notificationCenterOpen: false,
+  });
+}
+
+describe("NotificationCenterToolbarButton — DND state surface", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("icon", () => {
+    it("renders Bell when no DND and no unreads", () => {
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+      expect(queryByTestId("icon-bell-off")).toBeNull();
+    });
+
+    it("renders Bell when only unreads are present", () => {
+      useNotificationHistoryStore.setState({ unreadCount: 3 });
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+      expect(queryByTestId("icon-bell-off")).toBeNull();
+    });
+
+    it("renders BellOff when session-muted", () => {
+      useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60 * 60 * 1000 });
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell-off")).toBeTruthy();
+      expect(queryByTestId("icon-bell")).toBeNull();
+    });
+
+    it("renders BellOff during scheduled quiet hours", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 6 * 60,
+      });
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell-off")).toBeTruthy();
+    });
+
+    it("renders Bell again outside scheduled quiet hours", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 14, 0));
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 6 * 60,
+      });
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("icon-bell")).toBeTruthy();
+    });
+  });
+
+  describe("unread dot", () => {
+    it("does not render when unreadCount is 0", () => {
+      const { queryByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(queryByTestId("notification-unread-dot")).toBeNull();
+    });
+
+    it("renders a plain dot (no number) when unreadCount > 0 and DND is off", () => {
+      useNotificationHistoryStore.setState({ unreadCount: 5 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const dot = getByTestId("notification-unread-dot");
+      expect(dot).toBeTruthy();
+      expect(dot.textContent).toBe("");
+      expect(dot.className).not.toContain("bg-daintree-accent");
+    });
+
+    it("uses a dimmer non-accent color when DND is active and there are unreads", () => {
+      useNotificationHistoryStore.setState({ unreadCount: 2 });
+      useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60 * 1000 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const dot = getByTestId("notification-unread-dot");
+      expect(dot.className).toContain("bg-daintree-text/30");
+      expect(dot.className).not.toContain("bg-daintree-accent");
+    });
+  });
+
+  describe("aria-label / tooltip", () => {
+    it('says "Notifications" when idle', () => {
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      expect(btn.getAttribute("aria-label")).toBe("Notifications");
+    });
+
+    it("includes the unread count when not muted", () => {
+      useNotificationHistoryStore.setState({ unreadCount: 4 });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      expect(btn.getAttribute("aria-label")).toBe("Notifications — 4 unread");
+    });
+
+    it("includes a formatted end time when session-muted", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      const until = new Date(2024, 0, 1, 14, 30).getTime();
+      useNotificationSettingsStore.setState({ quietUntil: until });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      const label = btn.getAttribute("aria-label") ?? "";
+      expect(label.startsWith("Notifications — muted until ")).toBe(true);
+      // Locale-dependent formatting — match the time portion loosely.
+      expect(label).toMatch(/2:30/);
+    });
+
+    it("says 'scheduled quiet hours' during the configured window", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 6 * 60,
+      });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      expect(btn.getAttribute("aria-label")).toBe("Notifications — scheduled quiet hours");
+    });
+
+    it("session mute label takes priority over unread count", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      useNotificationHistoryStore.setState({ unreadCount: 7 });
+      useNotificationSettingsStore.setState({
+        quietUntil: new Date(2024, 0, 1, 13, 15).getTime(),
+      });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      expect(btn.getAttribute("aria-label")).toMatch(/^Notifications — muted until /);
+    });
+
+    it("button carries data-dnd-active='true' while DND is active", () => {
+      useNotificationSettingsStore.setState({ quietUntil: Date.now() + 30 * 1000 });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const btn = container.querySelector("button")!;
+      expect(btn.getAttribute("data-dnd-active")).toBe("true");
+    });
+  });
+
+  describe("master toggle", () => {
+    it("renders nothing when notifications are globally disabled", () => {
+      useNotificationSettingsStore.setState({ enabled: false });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      expect(container.querySelector("button")).toBeNull();
+    });
+  });
+});

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1483,6 +1483,29 @@ describe("notify()", () => {
       vi.useRealTimers();
     });
 
+    it("muteForDuration mirrors the timestamp into the settings store", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      const until = muteForDuration(30 * 60 * 1000);
+      expect(useNotificationSettingsStore.getState().quietUntil).toBe(until);
+      vi.useRealTimers();
+    });
+
+    it("muteUntilNextMorning mirrors the timestamp into the settings store", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
+      const until = muteUntilNextMorning();
+      expect(useNotificationSettingsStore.getState().quietUntil).toBe(until);
+      vi.useRealTimers();
+    });
+
+    it("_setQuietUntil (startup path) does NOT mirror to the settings store", () => {
+      // Startup quiet windows must not flip the toolbar to BellOff during boot.
+      useNotificationSettingsStore.setState({ quietUntil: 0 });
+      _setQuietUntil(Date.now() + 5_000);
+      expect(useNotificationSettingsStore.getState().quietUntil).toBe(0);
+    });
+
     it("muteUntilNextMorning mirrors the timestamp to the main process", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2024, 0, 1, 23, 0));

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -110,6 +110,9 @@ export function _setQuietUntil(ts: number): void {
 /** Session-only mute helper used by the notification-center quick actions. */
 export function setSessionQuietUntil(ts: number): void {
   _quietUntil = ts;
+  // Mirror to the renderer store so the toolbar bell can react. Module-level
+  // _quietUntil stays the hot-path cache for notify().
+  useNotificationSettingsStore.getState().setQuietUntil(ts);
   // Mirror to main so completion watch notifications and working-pulse sounds
   // are also suppressed until the timestamp.
   if (typeof window !== "undefined") {

--- a/src/store/notificationSettingsStore.ts
+++ b/src/store/notificationSettingsStore.ts
@@ -7,12 +7,16 @@ interface NotificationSettingsState {
   quietHoursStartMin: number;
   quietHoursEndMin: number;
   quietHoursWeekdays: number[];
+  // Reactive mirror of session-mute timestamp (epoch ms). Drives toolbar
+  // DND indicator. In-memory only — meaningless across restarts.
+  quietUntil: number;
   hydrate(): Promise<void>;
   setEnabled(value: boolean): void;
   setQuietHoursEnabled(value: boolean): void;
   setQuietHoursStartMin(value: number): void;
   setQuietHoursEndMin(value: number): void;
   setQuietHoursWeekdays(value: number[]): void;
+  setQuietUntil(ts: number): void;
 }
 
 export const useNotificationSettingsStore = create<NotificationSettingsState>((set, get) => ({
@@ -22,6 +26,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 8 * 60,
   quietHoursWeekdays: [],
+  quietUntil: 0,
 
   async hydrate() {
     if (get().hydrated) return;
@@ -90,5 +95,9 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
     window.electron?.notification?.setSettings({ quietHoursWeekdays: cleaned }).catch(() => {
       set({ quietHoursWeekdays: prev });
     });
+  },
+
+  setQuietUntil(ts: number) {
+    set({ quietUntil: Number.isFinite(ts) ? ts : 0 });
   },
 }));


### PR DESCRIPTION
## Summary

- Swaps `Bell` to `BellOff` on the toolbar when session mute or scheduled quiet hours is active, giving users a persistent visual signal that DND is on
- Replaces the numeric accent badge with a small neutral dot — \"you have unread\" without spending accent on a low-signal count
- Adds a reactive `quietUntil` field to `useNotificationSettingsStore` so the component can respond to mute changes without polling, with boundary timers for both session-mute expiry and quiet-hours minute transitions

Resolves #5839

## Changes

- `src/store/notificationSettingsStore.ts` — adds `quietUntil` field and `setQuietUntil` action
- `src/lib/notify.ts` — mirrors `setSessionQuietUntil` writes into the store (session mute path only, not startup)
- `src/components/Layout/NotificationCenterToolbarButton.tsx` — DND-aware icon, neutral unread dot, unified `aria-label`/tooltip string
- `src/lib/__tests__/notify.test.ts` — 3 new tests covering the store mirror
- `src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx` — 18 new tests covering session mute, quiet hours, weekday filter, locale-tolerant time format, and minute-boundary re-arm

## Testing

Unit tests cover session-mute auto-expiry, quiet-hours minute-boundary re-arm, weekday filtering, and the store mirror. Visual parity confirmed: bell stays in position, layout unchanged across states.