### PR TITLE
feat(notifications): move Clear all into overflow menu

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
-import { Bell, CheckCheck, Moon, Settings2, Trash2 } from "lucide-react";
+import { Bell, CheckCheck, Ellipsis, Moon, Settings2, Trash2 } from "lucide-react";
 import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
 } from "@/store/slices/notificationHistorySlice";
 import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { actionService } from "@/services/ActionService";
 import { muteForDuration, muteUntilNextMorning, notify } from "@/lib/notify";
 import type { NotificationType } from "@/store/notificationStore";
@@ -203,19 +209,30 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             Configure
           </Button>
           {entries.length > 0 && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              onClick={() => {
-                clearAll();
-                onClose();
-              }}
-              className="text-daintree-text/50"
-            >
-              <Trash2 />
-              Clear all
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="p-1 hover:bg-daintree-text/10 text-daintree-text/50 hover:text-daintree-text/80 transition-colors rounded-[var(--radius-sm)]"
+                  aria-label="More notification actions"
+                  title="More notification actions"
+                >
+                  <Ellipsis className="w-3 h-3" aria-hidden="true" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[160px]">
+                <DropdownMenuItem
+                  destructive
+                  onSelect={() => {
+                    clearAll();
+                    onClose();
+                  }}
+                >
+                  <Trash2 className="w-3 h-3 mr-2" aria-hidden="true" />
+                  Clear all
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
       </div>

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
@@ -12,9 +12,9 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 vi.mock("@/lib/notify", () => ({
-  notify: vi.fn(),
   muteForDuration: vi.fn(),
-  muteUntilNextMorning: vi.fn(),
+  muteUntilNextMorning: vi.fn().mockReturnValue(Date.now() + 3600_000),
+  notify: vi.fn(),
 }));
 
 function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
@@ -28,6 +28,11 @@ function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): Notificat
     countable: true,
     ...overrides,
   };
+}
+
+function setEntries(entries: NotificationHistoryEntry[]) {
+  const unreadCount = entries.filter((e) => !e.seenAsToast && e.countable !== false).length;
+  useNotificationHistoryStore.setState({ entries, unreadCount });
 }
 
 beforeEach(() => {
@@ -268,5 +273,40 @@ describe("NotificationThread message content", () => {
     await waitFor(() => {
       expect(screen.queryByText("Build retried and succeeded")).toBeTruthy();
     });
+  });
+});
+
+describe("NotificationCenter overflow menu", () => {
+  it("does not render overflow trigger when there are no entries", () => {
+    render(<NotificationCenter open onClose={() => {}} />);
+    expect(screen.queryByLabelText("More notification actions")).toBeNull();
+  });
+
+  it("renders overflow trigger when entries exist", () => {
+    setEntries([makeEntry()]);
+    render(<NotificationCenter open onClose={() => {}} />);
+    expect(screen.getByLabelText("More notification actions")).toBeTruthy();
+  });
+
+  it("clears entries and closes the panel when 'Clear all' is selected", async () => {
+    setEntries([makeEntry(), makeEntry({ id: "entry-2" })]);
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+
+    const trigger = screen.getByLabelText("More notification actions");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    const clearItem = screen.getByText("Clear all");
+    await act(async () => {
+      fireEvent.click(clearItem);
+    });
+
+    expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -282,15 +282,26 @@ describe("NotificationCenter overflow menu", () => {
     expect(screen.queryByLabelText("More notification actions")).toBeNull();
   });
 
-  it("renders overflow trigger when entries exist", () => {
+  it("renders overflow trigger as a button when entries exist", () => {
     setEntries([makeEntry()]);
     render(<NotificationCenter open onClose={() => {}} />);
-    expect(screen.getByLabelText("More notification actions")).toBeTruthy();
+    const trigger = screen.getByLabelText("More notification actions");
+    expect(trigger.tagName).toBe("BUTTON");
   });
 
-  it("clears entries and closes the panel when 'Clear all' is selected", async () => {
+  it("calls clearAll before onClose and removes the trigger when 'Clear all' is selected", async () => {
+    const callOrder: string[] = [];
+    const originalClearAll = useNotificationHistoryStore.getState().clearAll;
+    const clearAllSpy = vi.fn(() => {
+      callOrder.push("clearAll");
+      originalClearAll();
+    });
+    useNotificationHistoryStore.setState({ clearAll: clearAllSpy });
+
     setEntries([makeEntry(), makeEntry({ id: "entry-2" })]);
-    const onClose = vi.fn();
+    const onClose = vi.fn(() => {
+      callOrder.push("onClose");
+    });
     render(<NotificationCenter open onClose={onClose} />);
 
     const trigger = screen.getByLabelText("More notification actions");
@@ -308,5 +319,7 @@ describe("NotificationCenter overflow menu", () => {
     expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
     expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["clearAll", "onClose"]);
+    expect(screen.queryByLabelText("More notification actions")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Moves the 'Clear all' button out of the notification header strip and into a `⋯` overflow menu, reducing the persistent button count and tucking a destructive, low-frequency action behind one extra click.
- The header row already had four buttons competing for space; a permanent 'Clear all' with no recovery path was the obvious candidate to deprioritise.
- Tests cover the `clearAll` callback ordering (fires before `onClose`) and verifies the overflow trigger appears/disappears correctly with notification count changes.

Resolves #5841

## Changes

- `NotificationCenter.tsx`: replaces the standalone Clear all `<button>` with an overflow `DropdownMenu` component containing the action as a menu item
- `NotificationCenter.test.tsx`: new test file asserting overflow trigger visibility, menu item rendering, callback ordering, and trigger removal when the list empties

## Testing

- Unit tests pass: `clearAll` fires before `onClose`, overflow trigger absent when no notifications, trigger present with notifications, menu item labelled correctly
- Format and lint clean (no errors, warnings pre-existing and unrelated to this change)