### PR TITLE
fix(notifications): cap coalesced toast lifetime (#5863)

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -243,7 +243,7 @@ describe("Toast accessibility", () => {
     expect(toast.className).toContain("motion-reduce:duration-0");
   });
 
-  it("resets auto-dismiss timer when updatedAt changes", async () => {
+  it("resets auto-dismiss timer when the message changes", async () => {
     render(<Toaster />);
     let toastId: string;
     await act(async () => {
@@ -257,7 +257,7 @@ describe("Toast accessibility", () => {
     });
     expect(screen.getByText("Initial")).toBeTruthy();
 
-    // Update the notification — timer should reset
+    // Update with a NEW message — contentKey bumps, timer resets
     await act(async () => {
       useNotificationStore.getState().updateNotification(toastId!, {
         message: "Updated",
@@ -275,6 +275,83 @@ describe("Toast accessibility", () => {
       vi.advanceTimersByTime(1500);
     });
     expect(screen.queryByText("Updated")).toBeNull();
+  });
+
+  it("does NOT reset auto-dismiss timer on count-only coalesce (issue #5863)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 3000,
+        message: "Same message",
+        correlationId: "entity-a",
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Advance 2s into the 3s timer
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByText("Same message")).toBeTruthy();
+
+    // Coalesce with the SAME message — count bumps but contentKey does not,
+    // so the auto-dismiss timer must NOT restart.
+    await act(async () => {
+      addToast({
+        duration: 3000,
+        message: "Same message",
+        correlationId: "entity-a",
+      });
+    });
+
+    // Advance past the original deadline. If the timer had reset, the toast
+    // would still be visible. With the fix it dismisses on schedule.
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.queryByText("Same message")).toBeNull();
+  });
+
+  it("hard cap eventually dismisses toasts updated faster than their duration", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 3000,
+        message: "msg-0",
+        correlationId: "entity-a",
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Hard cap = min(3000 * 3, 15000) = 9000ms after firstShownAt. Drive four
+    // message-changing coalesces 2000ms apart; each resets the per-update
+    // timer (without the cap, the toast would live forever).
+    for (let i = 1; i <= 4; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      await act(async () => {
+        addToast({
+          duration: 3000,
+          message: `msg-${i}`,
+          correlationId: "entity-a",
+        });
+      });
+    }
+
+    // After the 4th coalesce (~8016ms in), the capped delay collapses to
+    // ~984ms instead of resetting to a fresh 3000ms.
+    expect(screen.getByText("msg-4")).toBeTruthy();
+
+    // Cross the cap; timer fires, then 300ms fade-out removes the toast.
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.queryByText(/msg-/)).toBeNull();
   });
 
   it("fires onDismiss when the user clicks the close button", async () => {

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -312,6 +312,45 @@ describe("Toast accessibility", () => {
     expect(screen.queryByText("Same message")).toBeNull();
   });
 
+  it("persistent (duration:0) toast stays for full new duration when promoted to auto-dismiss", async () => {
+    render(<Toaster />);
+    let toastId: string;
+    await act(async () => {
+      toastId = addToast({ duration: 0, message: "Copying context…" });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Simulate a long async operation while the toast is persistent.
+    await act(async () => {
+      vi.advanceTimersByTime(20000);
+    });
+    expect(screen.getByText("Copying context…")).toBeTruthy();
+
+    // Operation completes; promote to auto-dismiss with a fresh duration.
+    await act(async () => {
+      useNotificationStore.getState().updateNotification(toastId!, {
+        message: "Copied 12 files",
+        duration: 3000,
+      });
+    });
+
+    // The toast must remain visible for the new duration, not dismiss
+    // immediately because firstShownAt was set 20s ago.
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(screen.getByText("Copied 12 files")).toBeTruthy();
+
+    // It does dismiss after the new duration elapses.
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.queryByText("Copied 12 files")).toBeNull();
+  });
+
   it("hard cap eventually dismisses toasts updated faster than their duration", async () => {
     render(<Toaster />);
     await act(async () => {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -39,6 +39,14 @@ const TYPE_ICON_CONFIG: Record<string, IconConfig> = {
   warning: { Icon: AlertTriangle, className: "text-status-warning" },
 };
 
+/**
+ * Hard cap on total visible time for any toast, regardless of how many
+ * coalesced updates restart its timer. Bounds chatty same-entity bursts
+ * (e.g. agent state churn under #5863).
+ */
+const MAX_VISIBLE_DURATION_MS = 15000;
+const VISIBLE_DURATION_MULTIPLIER = 3;
+
 function Toast({ notification }: { notification: Notification }) {
   const { dismissNotification, removeNotification } = useNotificationStore(
     useShallow((state) => ({
@@ -103,14 +111,26 @@ function Toast({ notification }: { notification: Notification }) {
     }
   }, [notification.dismissed, notification.id, isVisible, removeNotification, restoreFocus]);
 
+  // Latest-ref for handleDismiss so the auto-dismiss effect doesn't restart
+  // every time the callback identity changes — the effect should restart only
+  // on contentKey (true message change) or when pause/duration toggles.
+  const dismissRef = useRef(handleDismiss);
+  useLayoutEffect(() => {
+    dismissRef.current = handleDismiss;
+  });
+
   useEffect(() => {
-    // duration === 0 is sticky; undefined would mean a direct addNotification
-    // caller bypassed notify()'s severity defaults — leave it sticky rather
-    // than silently auto-dismissing at 0ms.
+    // !notification.duration is sticky (covers both 0 and undefined): a direct
+    // addNotification caller bypassing notify()'s severity defaults stays
+    // sticky rather than silently auto-dismissing at 0ms.
     if (!notification.duration || isPaused) return;
-    const timer = setTimeout(handleDismiss, notification.duration);
+    const duration = notification.duration;
+    const cap = Math.min(duration * VISIBLE_DURATION_MULTIPLIER, MAX_VISIBLE_DURATION_MS);
+    const deadline = (notification.firstShownAt ?? Date.now()) + cap;
+    const delay = Math.min(duration, Math.max(0, deadline - Date.now()));
+    const timer = setTimeout(() => dismissRef.current(), delay);
     return () => clearTimeout(timer);
-  }, [notification.duration, notification.updatedAt, handleDismiss, isPaused]);
+  }, [notification.duration, notification.contentKey, notification.firstShownAt, isPaused]);
 
   const accentClass = ACCENT_CLASS[notification.type] ?? "border-l-status-info";
   const { Icon, className: iconClassName } =

--- a/src/store/__tests__/notificationStore.adversarial.test.ts
+++ b/src/store/__tests__/notificationStore.adversarial.test.ts
@@ -156,6 +156,35 @@ describe("notificationStore adversarial", () => {
     expect(after.updatedAt).toBe(5000);
   });
 
+  it("updateNotification resets firstShownAt when promoting duration:0 to auto-dismiss", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const id = addToast({ message: "Copying…", duration: 0 });
+    expect(
+      useNotificationStore.getState().notifications.find((x) => x.id === id)!.firstShownAt
+    ).toBe(1000);
+
+    // Long-running async operation completes 30s later; toast is promoted.
+    vi.spyOn(Date, "now").mockReturnValue(31000);
+    useNotificationStore.getState().updateNotification(id, { message: "Done", duration: 3000 });
+
+    const after = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(after.firstShownAt).toBe(31000);
+  });
+
+  it("updateNotification does NOT reset firstShownAt when patching auto-dismiss → auto-dismiss", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const id = addToast({ message: "m", duration: 3000 });
+    expect(
+      useNotificationStore.getState().notifications.find((x) => x.id === id)!.firstShownAt
+    ).toBe(1000);
+
+    vi.spyOn(Date, "now").mockReturnValue(2000);
+    useNotificationStore.getState().updateNotification(id, { message: "m2", duration: 5000 });
+
+    const after = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(after.firstShownAt).toBe(1000);
+  });
+
   it("updateNotification on a missing id is a pure no-op", () => {
     const id = addToast({ title: "keep" });
     const before = JSON.parse(JSON.stringify(useNotificationStore.getState().notifications));

--- a/src/store/__tests__/notificationStore.adversarial.test.ts
+++ b/src/store/__tests__/notificationStore.adversarial.test.ts
@@ -119,6 +119,43 @@ describe("notificationStore adversarial", () => {
     expect(n?.updatedAt).toBe(2000);
   });
 
+  it("updateNotification does not bump contentKey for non-message patches", () => {
+    const id = addToast({ message: "msg" });
+    const initial = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(initial.contentKey).toBe(1);
+
+    useNotificationStore.getState().updateNotification(id, { title: "new-title" });
+    expect(useNotificationStore.getState().notifications.find((x) => x.id === id)!.contentKey).toBe(
+      1
+    );
+
+    useNotificationStore.getState().updateNotification(id, { message: "msg" }); // unchanged
+    expect(useNotificationStore.getState().notifications.find((x) => x.id === id)!.contentKey).toBe(
+      1
+    );
+
+    useNotificationStore.getState().updateNotification(id, { message: "new-msg" });
+    expect(useNotificationStore.getState().notifications.find((x) => x.id === id)!.contentKey).toBe(
+      2
+    );
+  });
+
+  it("updateNotification preserves firstShownAt even when patch tries to overwrite it", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    const id = addToast({ message: "m" });
+    const initial = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(initial.firstShownAt).toBe(1000);
+
+    vi.spyOn(Date, "now").mockReturnValue(5000);
+    useNotificationStore
+      .getState()
+      .updateNotification(id, { firstShownAt: 9999, message: "changed" });
+
+    const after = useNotificationStore.getState().notifications.find((x) => x.id === id)!;
+    expect(after.firstShownAt).toBe(1000);
+    expect(after.updatedAt).toBe(5000);
+  });
+
   it("updateNotification on a missing id is a pure no-op", () => {
     const id = addToast({ title: "keep" });
     const before = JSON.parse(JSON.stringify(useNotificationStore.getState().notifications));

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -312,7 +312,7 @@ describe("notificationStore — correlationId collapse", () => {
     expect(active[0]!.message).toBe("m-4");
   });
 
-  it("bumps updatedAt when collapsing so auto-dismiss timers reset", () => {
+  it("bumps updatedAt when collapsing so accessibility re-announce fires", () => {
     const originalNow = Date.now;
     let mockNow = 1000;
     Date.now = () => mockNow;
@@ -326,6 +326,46 @@ describe("notificationStore — correlationId collapse", () => {
 
       const after = getState().notifications.find((n) => n.id === id)!;
       expect(after.updatedAt).toBe(2500);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("bumps contentKey only when the displayed message actually changes", () => {
+    const id = addToast({ correlationId: "entity-a", message: "same" });
+    const initial = getState().notifications.find((n) => n.id === id)!;
+    expect(initial.contentKey).toBe(1);
+
+    // Same message — contentKey must NOT bump (issue #5863 fix).
+    addToast({ correlationId: "entity-a", message: "same" });
+    expect(getState().notifications.find((n) => n.id === id)!.contentKey).toBe(1);
+
+    // New message — contentKey bumps.
+    addToast({ correlationId: "entity-a", message: "different" });
+    expect(getState().notifications.find((n) => n.id === id)!.contentKey).toBe(2);
+
+    // Same message again — no bump.
+    addToast({ correlationId: "entity-a", message: "different" });
+    expect(getState().notifications.find((n) => n.id === id)!.contentKey).toBe(2);
+  });
+
+  it("preserves firstShownAt across coalesces", () => {
+    const originalNow = Date.now;
+    let mockNow = 1000;
+    Date.now = () => mockNow;
+    try {
+      const id = addToast({ correlationId: "entity-a", message: "first" });
+      const first = getState().notifications.find((n) => n.id === id)!;
+      expect(first.firstShownAt).toBe(1000);
+
+      mockNow = 2500;
+      addToast({ correlationId: "entity-a", message: "second" });
+      mockNow = 4000;
+      addToast({ correlationId: "entity-a", message: "third" });
+
+      const after = getState().notifications.find((n) => n.id === id)!;
+      expect(after.firstShownAt).toBe(1000);
+      expect(after.updatedAt).toBe(4000);
     } finally {
       Date.now = originalNow;
     }

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -187,15 +187,20 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
     set((state) => ({
       notifications: state.notifications.map((n) => {
         if (n.id !== id) return n;
+        const now = Date.now();
         const messageInPatch = "message" in patch;
         const messageChanged = messageInPatch && !messagesEqual(patch.message, n.message);
+        // A transition from "persistent" (duration: 0) to "auto-dismissing"
+        // (duration > 0) is the start of a new visibility window — typically
+        // an async operation completing. Reset firstShownAt so the cap is
+        // measured from this point, not from when the spinner first appeared.
+        const becomingAutoDismiss =
+          n.duration === 0 && typeof patch.duration === "number" && patch.duration > 0;
         return {
           ...n,
           ...patch,
-          updatedAt: Date.now(),
-          // firstShownAt is set once at creation; never overwrite (even if a
-          // caller passes it in the patch).
-          firstShownAt: n.firstShownAt,
+          updatedAt: now,
+          firstShownAt: becomingAutoDismiss ? now : n.firstShownAt,
           contentKey: messageChanged ? (n.contentKey ?? 1) + 1 : (n.contentKey ?? 1),
         };
       }),

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -35,6 +35,15 @@ export interface Notification {
   dismissed?: boolean;
   /** Bumped on each coalesced update so useEffect deps can detect changes */
   updatedAt?: number;
+  /** Wall-clock time the toast first became visible. Preserved across coalesces and updates. */
+  firstShownAt?: number;
+  /**
+   * Bumped only when the displayed message text actually changes (not on
+   * every count bump or metadata-only update). The Toast auto-dismiss timer
+   * resets on this key, so chatty same-message coalesces no longer keep the
+   * toast alive forever (issue #5863).
+   */
+  contentKey?: number;
   /** Links this toast to its notification history entry for overflow tracking */
   historyEntryId?: string;
   /**
@@ -76,6 +85,17 @@ interface NotificationStore {
 
 export const MAX_VISIBLE_TOASTS = 3;
 
+/**
+ * Compare two notification messages for the purpose of contentKey bumping.
+ * Plain strings compare by value; any ReactNode message is treated as
+ * "changed" because referential equality on JSX is unreliable and false
+ * positives are safer than false negatives (a missed timer reset would let a
+ * truly-updated toast dismiss too early).
+ */
+function messagesEqual(a: Notification["message"], b: Notification["message"]): boolean {
+  return typeof a === "string" && typeof b === "string" && a === b;
+}
+
 export const useNotificationStore = create<NotificationStore>((set) => ({
   notifications: [],
   addNotification: (notification) => {
@@ -108,6 +128,7 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
           // onto a downloading-again state. Unset keys still preserve the
           // existing action (the default "missing = preserve" semantic).
           const actionResolved = "action" in notification ? notification.action : liveMatch.action;
+          const messageChanged = !messagesEqual(notification.message, liveMatch.message);
           return {
             notifications: state.notifications.map((n) =>
               n.id === liveMatch.id
@@ -125,6 +146,7 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
                     historyEntryId: notification.historyEntryId ?? n.historyEntryId,
                     count: (n.count ?? 1) + 1,
                     updatedAt: Date.now(),
+                    contentKey: messageChanged ? (n.contentKey ?? 1) + 1 : (n.contentKey ?? 1),
                   }
                 : n
             ),
@@ -151,17 +173,32 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
           }
         }
       }
+      const now = Date.now();
       return {
-        notifications: [...notifications, { ...notification, id, updatedAt: Date.now() }],
+        notifications: [
+          ...notifications,
+          { ...notification, id, updatedAt: now, firstShownAt: now, contentKey: 1 },
+        ],
       };
     });
     return collapsedOntoId ?? id;
   },
   updateNotification: (id, patch) =>
     set((state) => ({
-      notifications: state.notifications.map((n) =>
-        n.id === id ? { ...n, ...patch, updatedAt: Date.now() } : n
-      ),
+      notifications: state.notifications.map((n) => {
+        if (n.id !== id) return n;
+        const messageInPatch = "message" in patch;
+        const messageChanged = messageInPatch && !messagesEqual(patch.message, n.message);
+        return {
+          ...n,
+          ...patch,
+          updatedAt: Date.now(),
+          // firstShownAt is set once at creation; never overwrite (even if a
+          // caller passes it in the patch).
+          firstShownAt: n.firstShownAt,
+          contentKey: messageChanged ? (n.contentKey ?? 1) + 1 : (n.contentKey ?? 1),
+        };
+      }),
     })),
   dismissNotification: (id) =>
     set((state) => ({


### PR DESCRIPTION
## Summary

- Coalesced toasts could stay visible indefinitely because every count-bump reset the auto-dismiss timer. A chatty source (e.g. an agent cycling through states every 4s with a 5s duration) would keep a toast alive forever.
- Two fixes: `contentKey` (a stable hash of the message text) so the timer only resets on genuine content changes, not on count-only coalesces; and `firstShownAt` (set once, reset only when a persistent toast is promoted to auto-dismiss) to hard-cap total visible time at `min(duration × 3, 15000ms)`.
- `updatedAt` is still bumped on every coalesce so screen-reader re-announcements keep working.

Resolves #5863

## Changes

- `src/store/notificationStore.ts` — adds `contentKey` and `firstShownAt` to the `Notification` type; coalesce logic sets `contentKey` on first add and only bumps it when the message text actually changes; `firstShownAt` is set once per toast lifetime.
- `src/components/ui/toaster.tsx` — auto-dismiss effect now keys off `contentKey` instead of `updatedAt`, and clamps the remaining duration against the hard cap.
- Tests updated across `notificationStore.test.ts`, `notificationStore.adversarial.test.ts`, and `toaster.test.tsx` to cover count-only coalesces, content changes, cap enforcement, and the persistent-to-auto-dismiss promotion path.

## Testing

- Unit tests cover the main coalesce paths: count-only bumps don't extend the timer, real message changes do reset it, total lifetime is capped, and accessibility re-announcements still fire.
- Adversarial test confirms a source emitting 20 rapid updates still results in a bounded visible duration.