### PR TITLE
feat(terminal): release WebGL context when terminal goes off-screen

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -605,9 +605,13 @@ class TerminalInstanceService {
           }
         });
 
-        // Debounced WebGL restore. Reflow already woke the DOM renderer's
-        // IntersectionObserver above; the addon load happens after a short
-        // delay so rapid hide→show toggles don't thrash addon lifecycle.
+        // Debounced WebGL restore for same-tier transitions. If
+        // applyRendererPolicy above triggers a tier upgrade (e.g.
+        // BACKGROUND→VISIBLE), onTierApplied loads the addon immediately
+        // and this timer becomes a (harmless) idempotent re-apply. The
+        // debounce only meaningfully gates rapid hide→show toggles where
+        // the tier doesn't change, since same-tier applyRendererPolicy
+        // is a no-op.
         managed.webGLRestoreTimer = window.setTimeout(() => {
           const current = this.instances.get(id);
           if (!current) return;
@@ -1305,6 +1309,20 @@ class TerminalInstanceService {
           if (managed.lastAppliedTier === undefined || currentTier !== managed.lastAppliedTier) {
             this.rendererPolicy.applyRendererPolicy(id, currentTier);
           }
+        }
+
+        // Restore WebGL after a same-tier reparent: setVisible(true) above
+        // returned early because isAttaching was set, so no debounce timer
+        // was armed. If tier didn't change either, applyRendererPolicy
+        // above is a no-op. Re-acquire the context here so an agent
+        // terminal that released WebGL on hide doesn't stay on the DOM
+        // renderer permanently after a project switch or grid reflow.
+        if (
+          managed.isVisible &&
+          !this.webGLManager.isActive(id) &&
+          this.shouldRestoreWebGL(managed)
+        ) {
+          this.webGLManager.ensureContext(id, managed);
         }
 
         if (!managed.terminal.element) {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -64,6 +64,11 @@ const REFLOW_THROTTLE_MS = 250;
 // renderer that has no writes, without costing measurable CPU.
 const REFLOW_HEARTBEAT_MS = 3000;
 
+// Debounce on the visibility-driven WebGL restore path. Hide is immediate;
+// show waits this long before re-acquiring so rapid tab/panel toggles don't
+// thrash WebglAddon load/unload (each cycle reallocates GPU resources).
+const WEBGL_RESTORE_DEBOUNCE_MS = 100;
+
 function canAutoInitializeTerminalIngest(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -373,6 +378,26 @@ class TerminalInstanceService {
     }
   }
 
+  /**
+   * Eligibility for visibility-driven WebGL restore. Mirrors the gates in
+   * onTierApplied (agent identity + visible/focused tier) plus liveness
+   * checks (opened, not attaching, not hibernated). Used by the debounced
+   * timer in setVisible() before re-acquiring a context.
+   */
+  private shouldRestoreWebGL(managed: ManagedTerminal): boolean {
+    if (!managed.runtimeAgentId) return false;
+    if (!managed.isOpened) return false;
+    if (!managed.isVisible) return false;
+    if (managed.isAttaching) return false;
+    if (managed.isHibernated) return false;
+    const tier = managed.lastAppliedTier ?? managed.getRefreshTier?.();
+    return (
+      tier === TerminalRefreshTier.FOCUSED ||
+      tier === TerminalRefreshTier.BURST ||
+      tier === TerminalRefreshTier.VISIBLE
+    );
+  }
+
   private onUserInput(id: string, data: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;
@@ -537,6 +562,11 @@ class TerminalInstanceService {
       managed.isVisible = isVisible;
       managed.lastActiveTime = Date.now();
 
+      if (managed.webGLRestoreTimer !== undefined) {
+        clearTimeout(managed.webGLRestoreTimer);
+        managed.webGLRestoreTimer = undefined;
+      }
+
       if (isVisible) {
         // Revealing an on-screen terminal — make sure it doesn't get hibernated.
         // Tier may still be BACKGROUND (non-focused split view), so applying
@@ -574,9 +604,32 @@ class TerminalInstanceService {
             current.terminal.refresh(0, current.terminal.rows - 1);
           }
         });
+
+        // Debounced WebGL restore. Reflow already woke the DOM renderer's
+        // IntersectionObserver above; the addon load happens after a short
+        // delay so rapid hide→show toggles don't thrash addon lifecycle.
+        managed.webGLRestoreTimer = window.setTimeout(() => {
+          const current = this.instances.get(id);
+          if (!current) return;
+          current.webGLRestoreTimer = undefined;
+          if (!this.shouldRestoreWebGL(current)) return;
+          this.webGLManager.ensureContext(id, current);
+          if (current.terminal.rows > 0) {
+            current.terminal.refresh(0, current.terminal.rows - 1);
+          }
+        }, WEBGL_RESTORE_DEBOUNCE_MS);
       } else {
-        // Going offscreen. If we're already in a hibernation-eligible tier,
-        // onTierApplied won't fire to start the timer — do it here instead.
+        // Going offscreen. Release the WebGL context immediately to free a
+        // pool slot — xterm falls back to the DOM renderer until the
+        // terminal becomes visible again.
+        const hadWebGL = this.webGLManager.isActive(id);
+        this.webGLManager.releaseContext(id);
+        if (hadWebGL && managed.terminal.rows > 0) {
+          managed.terminal.refresh(0, managed.terminal.rows - 1);
+        }
+
+        // If we're already in a hibernation-eligible tier, onTierApplied
+        // won't fire to start the timer — do it here instead.
         const tier = managed.lastAppliedTier ?? managed.getRefreshTier?.();
         if (tier !== undefined && this.isHibernationEligible(tier, managed)) {
           this.scheduleHibernation(id, managed);
@@ -2002,6 +2055,10 @@ class TerminalInstanceService {
     if (managed.resizeSuppressionTimer !== undefined) {
       clearTimeout(managed.resizeSuppressionTimer);
       managed.resizeSuppressionTimer = undefined;
+    }
+    if (managed.webGLRestoreTimer !== undefined) {
+      clearTimeout(managed.webGLRestoreTimer);
+      managed.webGLRestoreTimer = undefined;
     }
 
     managed.lastActivityMarker?.dispose();

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -91,7 +91,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     isUserScrolledBack: false,
     isAltBuffer: false,
     isHibernated: false,
-    runtimeAgentId: "claude",
+    runtimeAgentId: "claude" as string | undefined,
     launchAgentId: "claude",
     lastActiveTime: Date.now(),
     lastWidth: 800,

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
+
+const mockTerminalClient = {
+  onData: vi.fn(() => vi.fn()),
+  onExit: vi.fn(() => vi.fn()),
+  setActivityTier: vi.fn(),
+  wake: vi.fn().mockResolvedValue({ state: null }),
+  write: vi.fn(),
+  getSerializedState: vi.fn(),
+  getSharedBuffer: vi.fn(() => null),
+  acknowledgeData: vi.fn(),
+  acknowledgePortData: vi.fn(),
+};
+
+vi.mock("@/clients", () => ({
+  terminalClient: mockTerminalClient,
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn(function () {
+    return {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+  }),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type WebGLVisibilityService = {
+  instances: Map<string, Record<string, unknown>>;
+  setVisible: (id: string, visible: boolean, expectedGeneration?: number) => void;
+  destroy: (id: string) => void;
+  webGLManager: {
+    isActive: (id: string) => boolean;
+    ensureContext: (id: string, managed: unknown) => void;
+    releaseContext: (id: string) => void;
+  };
+};
+
+function makeMockManaged(overrides: Record<string, unknown> = {}) {
+  const terminal = {
+    rows: 24,
+    cols: 80,
+    refresh: vi.fn(),
+    loadAddon: vi.fn(),
+    dispose: vi.fn(),
+    element: document.createElement("div"),
+  };
+
+  const hostElement = document.createElement("div");
+  Object.defineProperty(hostElement, "getBoundingClientRect", {
+    value: () => ({ width: 800, height: 600, top: 0, left: 0, right: 800, bottom: 600 }),
+  });
+
+  const managed = {
+    terminal,
+    type: "terminal",
+    kind: "terminal",
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: null,
+    searchAddon: {},
+    fileLinksDisposable: null,
+    webLinksAddon: null,
+    hostElement,
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isAttaching: false,
+    isUserScrolledBack: false,
+    isAltBuffer: false,
+    isHibernated: false,
+    runtimeAgentId: "claude",
+    launchAgentId: "claude",
+    lastActiveTime: Date.now(),
+    lastWidth: 800,
+    lastHeight: 600,
+    lastAppliedTier: TerminalRefreshTier.FOCUSED as TerminalRefreshTier | undefined,
+    pendingTier: undefined as TerminalRefreshTier | undefined,
+    tierChangeTimer: undefined as number | undefined,
+    getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+    needsWake: false,
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    listeners: [] as Array<() => void>,
+    exitSubscribers: new Set(),
+    latestCols: 80,
+    latestRows: 24,
+    latestWasAtBottom: true,
+    keyHandlerInstalled: false,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [] as Array<string | Uint8Array>,
+    hibernationTimer: undefined as ReturnType<typeof setTimeout> | undefined,
+    webGLRestoreTimer: undefined as number | undefined,
+    isInputLocked: false,
+    ipcListenerCount: 0,
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    scrollbackRestoreState: "none" as const,
+    ...overrides,
+  };
+  return managed;
+}
+
+describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
+  let service: WebGLVisibilityService;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    (window as unknown as Record<string, unknown>).electron = {
+      terminal: { reportTitleState: vi.fn() },
+    };
+
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: WebGLVisibilityService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("setVisible(false) immediately releases the WebGL context", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    service.setVisible("t1", false);
+
+    // No timer advance — release happens synchronously on the hide path
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("setVisible(false) calls terminal.refresh after WebGL release for DOM fallback", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.setVisible("t1", false);
+
+    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+  });
+
+  it("setVisible(false) does not refresh when no WebGL was active", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    // Never acquired WebGL
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.setVisible("t1", false);
+
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("setVisible(true) restores WebGL after the debounce window", () => {
+    const managed = makeMockManaged({ isVisible: false });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    service.setVisible("t1", true);
+
+    // Restore is debounced — not active yet
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    vi.advanceTimersByTime(100);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  it("setVisible(true) calls terminal.refresh after re-acquiring WebGL", () => {
+    const managed = makeMockManaged({ isVisible: false });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+
+    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+  });
+
+  it("rapid hide→show→hide before debounce expires keeps context released", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+
+    service.setVisible("t1", false);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    service.setVisible("t1", true);
+    // Within debounce — not yet restored
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    service.setVisible("t1", false);
+    // Restore timer cancelled, still released
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    vi.advanceTimersByTime(200);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("standard (non-agent) terminal does not acquire WebGL on show", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("show while attaching defers WebGL restore (no addon load)", () => {
+    const managed = makeMockManaged({ isVisible: false, isAttaching: true });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+
+    // setVisible's isAttaching branch returns early — no restore timer scheduled
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("show while in BACKGROUND tier does not restore WebGL", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("destroy clears the pending WebGL restore timer", () => {
+    const managed = makeMockManaged({ isVisible: false });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", true);
+    expect(managed.webGLRestoreTimer).toBeDefined();
+
+    service.destroy("t1");
+
+    // Timer cleared (won't fire and won't crash)
+    vi.advanceTimersByTime(200);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("hibernated terminal short-circuits — no WebGL changes", () => {
+    const managed = makeMockManaged({ isHibernated: true });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", false);
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("stale generation cleanup does not release WebGL", () => {
+    const managed = makeMockManaged({ attachGeneration: 5 });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+
+    // Stale generation from a previous mount — should be ignored entirely
+    service.setVisible("t1", false, 4);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    // Matching generation — release proceeds
+    service.setVisible("t1", false, 5);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -306,4 +306,21 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.setVisible("t1", false, 5);
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
+
+  it("agent demotion during debounce window cancels WebGL restore", () => {
+    const managed = makeMockManaged({ isVisible: false });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.setVisible("t1", true);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    // Demotion happens inside the debounce window — runtimeAgentId clears.
+    managed.runtimeAgentId = undefined;
+
+    vi.advanceTimersByTime(100);
+
+    // shouldRestoreWebGL re-checks runtimeAgentId in the timer callback,
+    // so the deferred restore must not fire after demotion.
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
 });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -144,6 +144,11 @@ export interface ManagedTerminal {
   isHibernated?: boolean;
   hibernationTimer?: ReturnType<typeof setTimeout>;
   ipcListenerCount: number;
+
+  // Visibility-driven WebGL restore debounce. Hide path releases the WebGL
+  // context immediately; show path waits ~100ms before re-acquiring so rapid
+  // tab/panel toggles don't thrash addon load/unload.
+  webGLRestoreTimer?: number;
 }
 
 export const TIER_DOWNGRADE_HYSTERESIS_MS = 500;


### PR DESCRIPTION
## Summary

Chromium enforces a hard limit of 16 active WebGL contexts per renderer process. With 10-30 agent terminals open (a normal parallel workload), the 17th terminal's context gets killed via `webglcontextlost` and xterm 6.0 doesn't auto-fallback to the DOM renderer, leaving blank or stale terminal visuals.

The fix is visibility-driven WebGL leasing. Terminals release their WebGL addon immediately when they go off-screen and re-acquire it (debounced 100ms) when they return to view. PTY data keeps accumulating in xterm's buffer regardless; only the render path changes. This keeps the live context count near the number of visible terminals rather than the total terminal count.

A follow-up fix ensures post-attach reconciliation re-acquires WebGL after a same-tier reparent (project switch, grid reflow), so terminals aren't stranded on the DOM renderer permanently after a layout change.

Resolves #5836

## Changes

- `TerminalWebGLManager.setVisible()` added; hooks into the existing `IntersectionObserver` path in the terminal pane component
- `shouldRestoreWebGL()` helper mirrors `onTierApplied`'s gates (agent identity, visible/focused tier, opened, not attaching/hibernated)
- Post-attach reconciliation now calls `setVisible(true)` after a same-tier reparent to prevent permanent DOM-renderer fallback
- 12 new tests in `TerminalInstanceService.webglVisibility.test.ts` covering hide release, debounced show, rapid toggles, attaching/hibernated guards, agent demotion during debounce, stale generation, and BACKGROUND-tier guard

## Testing

All 574 terminal service tests pass. Typecheck, lint, format, and build are clean. Manual verification: open 20+ agent terminals across a grid layout, confirm WebGL is released on hide and restored on re-show without any `webglcontextlost` events firing.