### PR TITLE
feat(notifications): consolidate DND controls into Pause popover with mute state pill

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -144,6 +144,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       message: `Notifications muted ${label}`,
       priority: "low",
       urgent: true,
+      countable: false,
     });
   };
 
@@ -155,6 +156,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       message: `Notifications muted until ${formatTimeOfDay(until)}`,
       priority: "low",
       urgent: true,
+      countable: false,
     });
   };
 

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
-import { Bell, CheckCheck, Moon, Settings2, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useStore } from "zustand";
+import { Bell, CheckCheck, Clock, Moon, Sunrise, Trash2, X } from "lucide-react";
 import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
@@ -7,7 +8,16 @@ import {
 import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { Button } from "@/components/ui/button";
 import { actionService } from "@/services/ActionService";
-import { muteForDuration, muteUntilNextMorning, notify } from "@/lib/notify";
+import {
+  _muteStore,
+  clearSessionMute,
+  isScheduledQuietHours,
+  muteForDuration,
+  muteUntilNextMorning,
+  notify,
+} from "@/lib/notify";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { cn } from "@/lib/utils";
 import type { NotificationType } from "@/store/notificationStore";
 
 const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
@@ -62,21 +72,52 @@ function groupByCorrelationId(entries: NotificationHistoryEntry[]): ThreadGroup[
   });
 }
 
+function formatTimeOfDay(ts: number): string {
+  return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" }).format(
+    new Date(ts)
+  );
+}
+
 export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const entries = useNotificationHistoryStore((s) => s.entries);
   const unreadCount = useNotificationHistoryStore((s) => s.unreadCount);
   const clearAll = useNotificationHistoryStore((s) => s.clearAll);
   const markAllRead = useNotificationHistoryStore((s) => s.markAllRead);
   const dismissEntry = useNotificationHistoryStore((s) => s.dismissEntry);
+  const quietUntil = useStore(_muteStore, (s) => s.quietUntil);
 
   const [filter, setFilter] = useState<"all" | "unread">("all");
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
+  const [pauseOpen, setPauseOpen] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const pauseAnchorRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) {
       setFrozenUnreadIds(null);
+      setPauseOpen(false);
     }
   }, [open]);
+
+  // Refresh once a minute while open so the muted pill auto-clears on expiry
+  // and the "Muted until 8:00" label stays current. Poll-while-open keeps the
+  // cost off the closed-state idle path. Lesson #4595.
+  useEffect(() => {
+    if (!open) return;
+    const id = window.setInterval(() => setNow(Date.now()), 60_000);
+    return () => window.clearInterval(id);
+  }, [open]);
+
+  useEscapeStack(open && pauseOpen, () => setPauseOpen(false));
+
+  const sessionMuted = quietUntil > now;
+  const scheduledQuiet = useMemo(() => isScheduledQuietHours(new Date(now)), [now]);
+  const muteActive = sessionMuted || scheduledQuiet;
+  const muteLabel = sessionMuted
+    ? `Muted until ${formatTimeOfDay(quietUntil)}`
+    : scheduledQuiet
+      ? "Quiet hours"
+      : "";
 
   const filteredEntries = useMemo(() => {
     if (filter === "all") return entries;
@@ -97,6 +138,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const handleMuteFor = (durationMs: number, label: string) => {
     muteForDuration(durationMs);
+    setPauseOpen(false);
     notify({
       type: "info",
       message: `Notifications muted ${label}`,
@@ -107,19 +149,29 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const handleMuteUntilMorning = () => {
     const until = muteUntilNextMorning();
-    const formatter = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
+    setPauseOpen(false);
     notify({
       type: "info",
-      message: `Notifications muted until ${formatter.format(new Date(until))}`,
+      message: `Notifications muted until ${formatTimeOfDay(until)}`,
       priority: "low",
       urgent: true,
     });
   };
 
+  const openSettings = () => {
+    setPauseOpen(false);
+    onClose();
+    void actionService.dispatch(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  };
+
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
       <div className="flex items-center justify-between px-3 py-2 border-b border-divider">
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5 min-w-0">
           <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
           {entries.length > 0 && (
             <div className="flex items-center rounded-md border border-daintree-text/10 overflow-hidden">
@@ -150,29 +202,14 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               </button>
             </div>
           )}
+          <MuteStatePill
+            visible={muteActive}
+            label={muteLabel}
+            canResume={sessionMuted}
+            onResume={clearSessionMute}
+          />
         </div>
         <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={() => handleMuteFor(60 * 60 * 1000, "for 1h")}
-            className="text-daintree-text/50"
-            title="Suppress non-urgent notifications for the next hour"
-          >
-            <Moon />
-            Mute 1h
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={handleMuteUntilMorning}
-            className="text-daintree-text/50"
-            title="Suppress non-urgent notifications until 8:00 AM"
-          >
-            Until morning
-          </Button>
           {unreadCount > 0 && (
             <Button
               type="button"
@@ -185,23 +222,35 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               Mark all read
             </Button>
           )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              onClose();
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "notifications" },
-                { source: "user" }
-              );
-            }}
-            className="text-daintree-text/50"
-          >
-            <Settings2 />
-            Configure
-          </Button>
+          <div className="relative">
+            <Button
+              ref={pauseAnchorRef}
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => setPauseOpen((o) => !o)}
+              className={cn(
+                "text-daintree-text/50",
+                muteActive && "text-daintree-text/80",
+                pauseOpen && "bg-overlay-soft text-daintree-text"
+              )}
+              aria-label="Pause notifications"
+              aria-haspopup="menu"
+              aria-expanded={pauseOpen}
+              title="Pause notifications"
+            >
+              <Moon />
+            </Button>
+            {pauseOpen && (
+              <PausePopover
+                anchorRef={pauseAnchorRef}
+                onClose={() => setPauseOpen(false)}
+                onMuteFor={handleMuteFor}
+                onMuteUntilMorning={handleMuteUntilMorning}
+                onOpenSettings={openSettings}
+              />
+            )}
+          </div>
           {entries.length > 0 && (
             <Button
               type="button"
@@ -251,6 +300,142 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         )}
       </div>
     </div>
+  );
+}
+
+function MuteStatePill({
+  visible,
+  label,
+  canResume,
+  onResume,
+}: {
+  visible: boolean;
+  label: string;
+  canResume: boolean;
+  onResume: () => void;
+}) {
+  // `invisible` keeps the slot reserved so toggling on/off doesn't reflow the
+  // header (filter pills / Pause button stay put). The width cap protects the
+  // row from runaway labels.
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 rounded-md bg-overlay-medium px-1.5 py-0.5 text-[10px] font-medium text-daintree-text/70 max-w-[160px]",
+        visible ? "visible" : "invisible"
+      )}
+      aria-hidden={!visible}
+      data-testid="notification-mute-pill"
+    >
+      <span className="truncate">{label || "—"}</span>
+      {canResume && (
+        <button
+          type="button"
+          onClick={onResume}
+          className="-mr-0.5 rounded-sm p-0.5 text-daintree-text/60 hover:bg-overlay-soft hover:text-daintree-text"
+          aria-label="Resume notifications"
+          tabIndex={visible ? 0 : -1}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PausePopover({
+  anchorRef,
+  onClose,
+  onMuteFor,
+  onMuteUntilMorning,
+  onOpenSettings,
+}: {
+  anchorRef: React.RefObject<HTMLButtonElement | null>;
+  onClose: () => void;
+  onMuteFor: (durationMs: number, label: string) => void;
+  onMuteUntilMorning: () => void;
+  onOpenSettings: () => void;
+}) {
+  // Positioned absolutely inside the NotificationCenter DOM tree (no portal).
+  // `FixedDropdown` guards outside-click via `contentRef.contains()`, so any
+  // portaled popover would close the parent dropdown when clicked. Keeping
+  // the panel inside the same node tree avoids that collision.
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onPointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      if (panelRef.current?.contains(target)) return;
+      // Skip the trigger button — its onClick toggles us closed already, and
+      // closing here would race with the click handler reopening us.
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("touchstart", onPointerDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("touchstart", onPointerDown);
+    };
+  }, [anchorRef, onClose]);
+
+  return (
+    <div
+      ref={panelRef}
+      role="menu"
+      className="absolute right-0 top-full mt-1 z-10 w-[200px] rounded-md surface-overlay shadow-overlay border border-divider py-1 text-xs"
+      data-testid="notification-pause-popover"
+    >
+      <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-daintree-text/40">
+        Pause notifications
+      </div>
+      <PauseOption
+        icon={<Clock className="h-3.5 w-3.5" />}
+        label="For 1 hour"
+        onClick={() => onMuteFor(60 * 60 * 1000, "for 1h")}
+      />
+      <PauseOption
+        icon={<Sunrise className="h-3.5 w-3.5" />}
+        label="Until 8:00 AM"
+        onClick={onMuteUntilMorning}
+      />
+      <PauseOption
+        icon={<Moon className="h-3.5 w-3.5" />}
+        label="Custom…"
+        onClick={onOpenSettings}
+      />
+      <div className="my-1 border-t border-divider" />
+      <button
+        type="button"
+        role="menuitem"
+        onClick={onOpenSettings}
+        className="flex w-full items-center justify-between px-2 py-1.5 text-left text-daintree-text/70 hover:bg-overlay-soft hover:text-daintree-text"
+      >
+        <span>Notification settings</span>
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+  );
+}
+
+function PauseOption({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-2 py-1.5 text-left text-daintree-text/70 hover:bg-overlay-soft hover:text-daintree-text"
+    >
+      <span className="text-daintree-text/50">{icon}</span>
+      <span>{label}</span>
+    </button>
   );
 }
 

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -6,7 +6,7 @@ import type { NotificationHistoryEntry } from "@/store/slices/notificationHistor
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useNotificationStore } from "@/store/notificationStore";
-import { _muteStore, _setQuietUntil } from "@/lib/notify";
+import { _muteStore, _setQuietUntil, setStartupQuietPeriod } from "@/lib/notify";
 import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
 
 const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
@@ -51,6 +51,7 @@ beforeEach(() => {
     quietHoursWeekdays: [],
   });
   _setQuietUntil(0);
+  setStartupQuietPeriod(0);
   resetEscapeStack();
   dispatchMock.mockClear();
   getMock.mockReturnValue(null);
@@ -326,6 +327,16 @@ describe("NotificationCenter — Pause popover", () => {
     vi.useRealTimers();
   });
 
+  it("mute confirmation toast does not increment the unread badge", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    fireEvent.click(screen.getByText("For 1 hour"));
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+    vi.useRealTimers();
+  });
+
   it('"Until 8:00 AM" mutes until next 08:00', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
@@ -389,6 +400,14 @@ describe("NotificationCenter — muted-state pill", () => {
     expect(_muteStore.getState().quietUntil).toBe(0);
     const pill = screen.getByTestId("notification-mute-pill");
     expect(pill.className).toContain("invisible");
+  });
+
+  it("startup quiet period does not surface as a session-mute pill", () => {
+    setStartupQuietPeriod(5000);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    const pill = screen.getByTestId("notification-mute-pill");
+    expect(pill.className).toContain("invisible");
+    expect(screen.queryByLabelText("Resume notifications")).toBeNull();
   });
 
   it("scheduled quiet hours show a pill without a Resume button", () => {

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,20 +1,18 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationCenter } from "../NotificationCenter";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
-import { NotificationCenter } from "../NotificationCenter";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import { _muteStore, _setQuietUntil } from "@/lib/notify";
+import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
 
 const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
 const getMock = vi.hoisted(() => vi.fn());
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: dispatchMock, get: getMock },
-}));
-
-vi.mock("@/lib/notify", () => ({
-  notify: vi.fn(),
-  muteForDuration: vi.fn(),
-  muteUntilNextMorning: vi.fn(),
 }));
 
 function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
@@ -31,9 +29,36 @@ function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): Notificat
 }
 
 beforeEach(() => {
-  useNotificationHistoryStore.getState().clearAll();
+  Object.defineProperty(window, "electron", {
+    value: {
+      notification: {
+        showNative: vi.fn(),
+        setSettings: vi.fn().mockResolvedValue(undefined),
+        setSessionMuteUntil: vi.fn(),
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+  useNotificationStore.setState({ notifications: [] });
+  useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+  useNotificationSettingsStore.setState({
+    enabled: true,
+    hydrated: true,
+    quietHoursEnabled: false,
+    quietHoursStartMin: 22 * 60,
+    quietHoursEndMin: 8 * 60,
+    quietHoursWeekdays: [],
+  });
+  _setQuietUntil(0);
+  resetEscapeStack();
   dispatchMock.mockClear();
   getMock.mockReturnValue(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("NotificationThread worst severity", () => {
@@ -268,5 +293,170 @@ describe("NotificationThread message content", () => {
     await waitFor(() => {
       expect(screen.queryByText("Build retried and succeeded")).toBeTruthy();
     });
+  });
+});
+
+describe("NotificationCenter — Pause popover", () => {
+  it("Pause trigger renders, Mute 1h / Until morning / Configure buttons do not", () => {
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.getByLabelText("Pause notifications")).toBeTruthy();
+    expect(screen.queryByText("Mute 1h")).toBeNull();
+    expect(screen.queryByText("Until morning")).toBeNull();
+    expect(screen.queryByText("Configure")).toBeNull();
+  });
+
+  it("clicking the Pause trigger opens the popover", () => {
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    expect(screen.getByTestId("notification-pause-popover")).toBeTruthy();
+    expect(screen.getByText("For 1 hour")).toBeTruthy();
+    expect(screen.getByText("Until 8:00 AM")).toBeTruthy();
+    expect(screen.getByText("Custom…")).toBeTruthy();
+    expect(screen.getByText("Notification settings")).toBeTruthy();
+  });
+
+  it('"For 1 hour" sets a session mute and closes the popover', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    fireEvent.click(screen.getByText("For 1 hour"));
+    expect(_muteStore.getState().quietUntil).toBe(Date.now() + 60 * 60 * 1000);
+    expect(screen.queryByTestId("notification-pause-popover")).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('"Until 8:00 AM" mutes until next 08:00', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    fireEvent.click(screen.getByText("Until 8:00 AM"));
+    const until = _muteStore.getState().quietUntil;
+    expect(new Date(until).getHours()).toBe(8);
+    vi.useRealTimers();
+  });
+
+  it('"Custom…" closes the center and dispatches openTab(notifications)', () => {
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    fireEvent.click(screen.getByText("Custom…"));
+    expect(onClose).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  });
+
+  it('"Notification settings" footer link dispatches openTab(notifications)', () => {
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    fireEvent.click(screen.getByText("Notification settings"));
+    expect(onClose).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  });
+});
+
+describe("NotificationCenter — muted-state pill", () => {
+  it("pill is invisible when no mute is active (preserves layout)", () => {
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    const pill = screen.getByTestId("notification-mute-pill");
+    expect(pill.className).toContain("invisible");
+    expect(pill.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("pill becomes visible when session mute is active", () => {
+    _setQuietUntil(Date.now() + 60 * 60 * 1000);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    const pill = screen.getByTestId("notification-mute-pill");
+    expect(pill.className).toContain("visible");
+    expect(pill.getAttribute("aria-hidden")).toBe("false");
+    expect(pill.textContent).toMatch(/Muted until/);
+    expect(screen.getByLabelText("Resume notifications")).toBeTruthy();
+  });
+
+  it("clicking ✕ resumes notifications by clearing the session mute", () => {
+    _setQuietUntil(Date.now() + 60 * 60 * 1000);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText("Resume notifications"));
+    expect(_muteStore.getState().quietUntil).toBe(0);
+    const pill = screen.getByTestId("notification-mute-pill");
+    expect(pill.className).toContain("invisible");
+  });
+
+  it("scheduled quiet hours show a pill without a Resume button", () => {
+    vi.useFakeTimers();
+    // Force a time inside the default 22:00–08:00 window.
+    vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
+    useNotificationSettingsStore.setState({
+      quietHoursEnabled: true,
+      quietHoursStartMin: 22 * 60,
+      quietHoursEndMin: 8 * 60,
+      quietHoursWeekdays: [],
+    });
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    const pill = screen.getByTestId("notification-mute-pill");
+    expect(pill.className).toContain("visible");
+    expect(pill.textContent).toMatch(/Quiet hours/);
+    expect(screen.queryByLabelText("Resume notifications")).toBeNull();
+    vi.useRealTimers();
+  });
+});
+
+describe("NotificationCenter — frozen unread regression", () => {
+  it("Mark all read keeps items visible while Unread filter is active", () => {
+    useNotificationHistoryStore.setState({
+      entries: [
+        {
+          id: "n1",
+          type: "info",
+          message: "first",
+          timestamp: Date.now(),
+          seenAsToast: false,
+          summarized: false,
+          countable: true,
+        },
+        {
+          id: "n2",
+          type: "info",
+          message: "second",
+          timestamp: Date.now(),
+          seenAsToast: false,
+          summarized: false,
+          countable: true,
+        },
+      ],
+      unreadCount: 2,
+    });
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByText("Unread"));
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(screen.getByText("second")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Mark all read"));
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(screen.getByText("second")).toBeTruthy();
+  });
+});
+
+describe("NotificationCenter — Escape ordering", () => {
+  it("first Escape closes the Pause popover, dropdown stays open", async () => {
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Pause notifications"));
+    expect(screen.getByTestId("notification-pause-popover")).toBeTruthy();
+
+    await act(async () => {
+      dispatchEscape();
+    });
+    expect(screen.queryByTestId("notification-pause-popover")).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -5,8 +5,10 @@ import {
   _resetCoalesceMap,
   _resetComboMap,
   _setQuietUntil,
+  _muteStore,
   muteForDuration,
   muteUntilNextMorning,
+  clearSessionMute,
   isScheduledQuietHours,
 } from "../notify";
 import { useNotificationStore } from "../../store/notificationStore";
@@ -1507,6 +1509,35 @@ describe("notify()", () => {
       expect(new Date(until).getHours()).toBe(8);
       expect(new Date(until).getDate()).toBe(2);
       vi.useRealTimers();
+    });
+
+    it("_muteStore reflects writes from setSession/mute helpers", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      muteForDuration(60 * 60 * 1000);
+      expect(_muteStore.getState().quietUntil).toBe(Date.now() + 60 * 60 * 1000);
+      vi.useRealTimers();
+    });
+
+    it("clearSessionMute resets quietUntil to 0 and lifts the mute gate", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      muteForDuration(60 * 60 * 1000);
+      expect(_muteStore.getState().quietUntil).toBeGreaterThan(Date.now());
+
+      clearSessionMute();
+      expect(_muteStore.getState().quietUntil).toBe(0);
+
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "info", message: "Now visible", priority: "high" });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      vi.useRealTimers();
+    });
+
+    it("clearSessionMute mirrors the cleared timestamp to the main process", () => {
+      mockSetSessionMute.mockClear();
+      clearSessionMute();
+      expect(mockSetSessionMute).toHaveBeenCalledWith(0);
     });
   });
 });

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -95,19 +95,23 @@ export function _resetComboMap(): void {
 }
 
 /**
- * Vanilla Zustand store wrapping the session quiet-until timestamp so the
- * renderer UI (notification center pill, Pause popover) can subscribe
- * reactively. Internal `notify()` reads still go through `getState()` for the
- * synchronous gate.
+ * Vanilla Zustand store wrapping the user-initiated session mute timestamp.
+ * The notification-center pill and Pause popover subscribe to this for
+ * reactive display. Kept separate from the startup quiet period so the pill
+ * never reflects the silent app-boot suppression window.
  */
 export const _muteStore = createStore<{ quietUntil: number }>(() => ({ quietUntil: 0 }));
 
+// Startup quiet is an internal app-boot guard, not a user-facing mute. The
+// pill must not flash during this window, so it lives outside `_muteStore`.
+let _startupQuietUntil = 0;
+
 export function setStartupQuietPeriod(durationMs: number): void {
-  _muteStore.setState({ quietUntil: Date.now() + durationMs });
+  _startupQuietUntil = Date.now() + durationMs;
 }
 
 export function getQuietPeriodRemaining(): number {
-  return Math.max(0, _muteStore.getState().quietUntil - Date.now());
+  return Math.max(0, _startupQuietUntil - Date.now());
 }
 
 export function _setQuietUntil(ts: number): void {
@@ -199,8 +203,10 @@ export function notify(payload: NotifyPayload): string {
     }));
 
   const notificationsEnabled = useNotificationSettingsStore.getState().enabled;
+  const now = Date.now();
   const isQuiet =
-    !payload.urgent && (Date.now() < _muteStore.getState().quietUntil || isScheduledQuietHours());
+    !payload.urgent &&
+    (now < _muteStore.getState().quietUntil || now < _startupQuietUntil || isScheduledQuietHours());
 
   if (placement === "grid-bar") {
     const entryId = historyMessage

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -110,10 +110,6 @@ export function setStartupQuietPeriod(durationMs: number): void {
   _startupQuietUntil = Date.now() + durationMs;
 }
 
-export function getQuietPeriodRemaining(): number {
-  return Math.max(0, _startupQuietUntil - Date.now());
-}
-
 export function _setQuietUntil(ts: number): void {
   _muteStore.setState({ quietUntil: ts });
 }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { createStore } from "zustand/vanilla";
 import {
   useNotificationStore,
   type NotificationPriority,
@@ -93,23 +94,29 @@ export function _resetComboMap(): void {
   _comboCounts.clear();
 }
 
-let _quietUntil = 0;
+/**
+ * Vanilla Zustand store wrapping the session quiet-until timestamp so the
+ * renderer UI (notification center pill, Pause popover) can subscribe
+ * reactively. Internal `notify()` reads still go through `getState()` for the
+ * synchronous gate.
+ */
+export const _muteStore = createStore<{ quietUntil: number }>(() => ({ quietUntil: 0 }));
 
 export function setStartupQuietPeriod(durationMs: number): void {
-  _quietUntil = Date.now() + durationMs;
+  _muteStore.setState({ quietUntil: Date.now() + durationMs });
 }
 
 export function getQuietPeriodRemaining(): number {
-  return Math.max(0, _quietUntil - Date.now());
+  return Math.max(0, _muteStore.getState().quietUntil - Date.now());
 }
 
 export function _setQuietUntil(ts: number): void {
-  _quietUntil = ts;
+  _muteStore.setState({ quietUntil: ts });
 }
 
 /** Session-only mute helper used by the notification-center quick actions. */
 export function setSessionQuietUntil(ts: number): void {
-  _quietUntil = ts;
+  _muteStore.setState({ quietUntil: ts });
   // Mirror to main so completion watch notifications and working-pulse sounds
   // are also suppressed until the timestamp.
   if (typeof window !== "undefined") {
@@ -128,6 +135,11 @@ export function muteUntilNextMorning(morningMin = 8 * 60): number {
   const until = nextOccurrenceTimestamp(morningMin);
   setSessionQuietUntil(until);
   return until;
+}
+
+/** Clears the session mute. Used by the resume (✕) affordance on the muted-state pill. */
+export function clearSessionMute(): void {
+  setSessionQuietUntil(0);
 }
 
 export function isScheduledQuietHours(now: Date = new Date()): boolean {
@@ -187,7 +199,8 @@ export function notify(payload: NotifyPayload): string {
     }));
 
   const notificationsEnabled = useNotificationSettingsStore.getState().enabled;
-  const isQuiet = !payload.urgent && (Date.now() < _quietUntil || isScheduledQuietHours());
+  const isQuiet =
+    !payload.urgent && (Date.now() < _muteStore.getState().quietUntil || isScheduledQuietHours());
 
   if (placement === "grid-bar") {
     const entryId = historyMessage


### PR DESCRIPTION
## Summary

- Replaces the three separate header buttons (Mute 1h, Until morning, Configure) with a single Moon trigger that opens an inline Pause popover offering session mute presets and a settings footer link.
- Adds a layout-stable muted-state pill in the header that shows "Muted until {time}" with a ✕ to clear the session mute, without causing reflow as it appears and disappears. Scheduled quiet hours are reflected without the ✕.
- Session mute state is backed by a vanilla Zustand `_muteStore` for reactive updates; startup quiet period is kept off the store so the pill never flashes during the 5s app-boot suppression window.

Resolves #5838

## Changes

- `NotificationCenter.tsx`: replaced mute/configure header buttons with Moon trigger + inline Pause popover; added muted-state pill using `invisible` for layout stability; wired `useEscapeStack` for LIFO Escape (popover first, then dropdown).
- `notify.ts`: added `_muteStore` Zustand store, `clearSessionMute()` helper, and kept `_startupQuietUntil` as a module-level variable separate from the store.
- Mute confirmation toasts marked `countable: false` so they don't bump the unread badge.

## Testing

- `src/lib/__tests__/notify.test.ts`: added `_muteStore` reactivity and `clearSessionMute()` coverage (2 new tests, all 117 pass).
- `src/components/Notifications/__tests__/NotificationCenter.test.tsx`: new file with 14 tests covering the Pause popover, mute pill (visible/invisible states, scheduled quiet hours, startup quiet non-leakage), Escape ordering, frozen-unread regression, and mute confirmation no-badge behaviour.