### PR TITLE
perf(pty): stream renderer data as transferable Uint8Array

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -274,8 +274,14 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
     rendererConnections.size > 0 &&
     !isSmokeTestTerminalId(id)
   ) {
-    const dataString = toStringForIpc(data);
-    const byteCount = Buffer.byteLength(dataString, "utf8");
+    // Carry raw bytes on the hot MessagePort path so the renderer receives a
+    // transferred ArrayBuffer instead of a structured-cloned UTF-8 string.
+    // Wrap with `new Uint8Array(...)` to escape node-pty's Buffer pool slab —
+    // each batcher will copy these chunks into a fresh isolated buffer at
+    // flush time before they land in the postMessage transfer list.
+    const chunk =
+      typeof data === "string" ? new Uint8Array(Buffer.from(data, "utf8")) : new Uint8Array(data);
+    const byteCount = chunk.byteLength;
 
     for (const [windowId, conn] of rendererConnections) {
       const windowProject = windowProjectMap.get(windowId) ?? null;
@@ -284,7 +290,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
 
       if (filtered) continue;
 
-      if (conn.batcher.write(id, dataString, byteCount)) {
+      if (conn.batcher.write(id, chunk, byteCount)) {
         visualWritten = true;
       }
     }
@@ -744,7 +750,12 @@ port.on("message", async (rawMsg: any) => {
           const perWindowBatcher = new PortBatcher({
             portQueueManager: perWindowQueueManager,
             postMessage: (id, data, bytes) => {
-              receivedPort.postMessage({ type: "data", id, data, bytes });
+              // Transfer the backing ArrayBuffer to the renderer instead of
+              // structured-cloning. The batcher allocates `data` fresh per
+              // flush, so it is safe to detach here.
+              receivedPort.postMessage({ type: "data", id, data, bytes }, [
+                data.buffer as ArrayBuffer,
+              ]);
             },
             onError: () => {
               disconnectWindow(windowId, "postMessage-error");

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -310,6 +310,48 @@ describe("PortBatcher", () => {
     expect(Array.from(emitted)).toEqual([1, 2, 3, 4]);
   });
 
+  it("multi-byte UTF-8: emitted byteLength matches Buffer.byteLength of the source string", () => {
+    // ACK accounting on the host uses chunk.byteLength (the UTF-8 byte count),
+    // not character count. A regression that confused string.length and
+    // byteLength would silently miscalibrate backpressure for non-ASCII output.
+    const deps = createDeps();
+    const batcher = new PortBatcher(deps);
+
+    const text = "café — 日本語 🚀";
+    const expectedBytes = Buffer.byteLength(text, "utf8");
+    expect(expectedBytes).toBeGreaterThan(text.length);
+
+    batcher.write("t1", bytes(text), expectedBytes);
+    vi.runAllTimers();
+
+    const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+    expect(postMessage).toHaveBeenCalledOnce();
+    const [, emitted, ackBytes] = postMessage.mock.calls[0];
+    expect(ackBytes).toBe(expectedBytes);
+    expect((emitted as Uint8Array).byteLength).toBe(expectedBytes);
+    expect(Buffer.from(emitted as Uint8Array).toString("utf8")).toBe(text);
+  });
+
+  it("byte-count mismatch routes through onError instead of throwing", () => {
+    // mergeChunks runs inside the flush try/catch, so allocation failures
+    // (e.g., a future caller passing a wrong totalBytes) surface via onError
+    // and trigger disconnectWindow rather than aborting the flush loop.
+    const deps = createDeps();
+    const batcher = new PortBatcher(deps);
+
+    // Lie about the byte count: chunk is 4 bytes but we claim 8 bytes.
+    // mergeChunks will allocate Uint8Array(8) and chunks.set(chunk, offset)
+    // succeeds — but offset (4) does not equal totalBytes (8). The actual
+    // failure mode here is benign (trailing zeros), so we use a chunk that
+    // overflows the claimed budget instead.
+    const chunk = bytesOfLength(8);
+    batcher.write("t1", chunk, 4); // claim 4 bytes for an 8-byte chunk
+    vi.runAllTimers();
+
+    expect(deps.onError).toHaveBeenCalledOnce();
+    expect(deps.onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
   it("flush concatenates multiple chunks into a single contiguous Uint8Array", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -3,6 +3,14 @@ import { PortBatcher, type PortBatcherDeps } from "../portBatcher.js";
 import type { PortQueueManager } from "../portQueue.js";
 import { PORT_BATCH_THRESHOLD_BYTES } from "../../services/pty/types.js";
 
+function bytes(text: string): Uint8Array {
+  return new Uint8Array(Buffer.from(text, "utf8"));
+}
+
+function bytesOfLength(len: number, fillChar = "x"): Uint8Array {
+  return new Uint8Array(Buffer.from(fillChar.repeat(len), "utf8"));
+}
+
 function createMockQueueManager() {
   return {
     isAtCapacity: vi.fn(() => false),
@@ -34,14 +42,14 @@ describe("PortBatcher", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    const result = batcher.write("t1", "hello", 5);
+    const result = batcher.write("t1", bytes("hello"), 5);
     expect(result).toBe(true);
     expect(deps.postMessage).not.toHaveBeenCalled();
 
     vi.runAllTimers();
 
     expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "hello", 5);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("hello"), 5);
     expect(deps.portQueueManager.addBytes).toHaveBeenCalledWith("t1", 5);
   });
 
@@ -49,8 +57,8 @@ describe("PortBatcher", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "aaa", 3);
-    batcher.write("t1", "bbb", 3);
+    batcher.write("t1", bytes("aaa"), 3);
+    batcher.write("t1", bytes("bbb"), 3);
 
     // Advance less than 16ms — should not flush yet
     vi.advanceTimersByTime(10);
@@ -59,27 +67,27 @@ describe("PortBatcher", () => {
     // Advance to 16ms — should flush
     vi.advanceTimersByTime(6);
     expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "aaabbb", 6);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("aaabbb"), 6);
   });
 
   it("no double-upgrade: third chunk in throughput mode does not reschedule", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "a", 1);
-    batcher.write("t1", "b", 1); // upgrade to throughput
-    batcher.write("t1", "c", 1); // no reschedule
+    batcher.write("t1", bytes("a"), 1);
+    batcher.write("t1", bytes("b"), 1); // upgrade to throughput
+    batcher.write("t1", bytes("c"), 1); // no reschedule
 
     vi.advanceTimersByTime(16);
     expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "abc", 3);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("abc"), 3);
   });
 
   it("threshold bypass: sync flush when bytes exceed 64KB", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    const bigData = "x".repeat(PORT_BATCH_THRESHOLD_BYTES);
+    const bigData = bytesOfLength(PORT_BATCH_THRESHOLD_BYTES);
     batcher.write("t1", bigData, PORT_BATCH_THRESHOLD_BYTES);
 
     // Should have flushed synchronously — no timer needed
@@ -94,15 +102,15 @@ describe("PortBatcher", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "a1", 2);
-    batcher.write("t2", "b1", 2);
-    batcher.write("t1", "a2", 2);
+    batcher.write("t1", bytes("a1"), 2);
+    batcher.write("t2", bytes("b1"), 2);
+    batcher.write("t1", bytes("a2"), 2);
 
     vi.runAllTimers();
 
     expect(deps.postMessage).toHaveBeenCalledTimes(2);
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "a1a2", 4);
-    expect(deps.postMessage).toHaveBeenCalledWith("t2", "b1", 2);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("a1a2"), 4);
+    expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("b1"), 2);
   });
 
   it("capacity gating: returns false when portQueueManager is at capacity", () => {
@@ -111,7 +119,7 @@ describe("PortBatcher", () => {
     const deps = createDeps({ portQueueManager: qm });
     const batcher = new PortBatcher(deps);
 
-    const result = batcher.write("t1", "data", 4);
+    const result = batcher.write("t1", bytes("data"), 4);
     expect(result).toBe(false);
     expect(deps.postMessage).not.toHaveBeenCalled();
   });
@@ -125,9 +133,9 @@ describe("PortBatcher", () => {
     const batcher = new PortBatcher(deps);
 
     // First write of 80 bytes succeeds (80 <= 100)
-    expect(batcher.write("t1", "x".repeat(80), 80)).toBe(true);
+    expect(batcher.write("t1", bytesOfLength(80), 80)).toBe(true);
     // Second write of 30 bytes should fail (80 + 30 = 110 > 100)
-    expect(batcher.write("t1", "y".repeat(30), 30)).toBe(false);
+    expect(batcher.write("t1", bytesOfLength(30, "y"), 30)).toBe(false);
   });
 
   it("capacity rejection flushes pending data to prevent split-channel delivery", () => {
@@ -139,51 +147,53 @@ describe("PortBatcher", () => {
     const batcher = new PortBatcher(deps);
 
     // Buffer 80 bytes for t1
-    expect(batcher.write("t1", "buffered", 80)).toBe(true);
+    const buffered = bytesOfLength(80, "b");
+    expect(batcher.write("t1", buffered, 80)).toBe(true);
     expect(deps.postMessage).not.toHaveBeenCalled();
 
     // Next write rejected — but pending data should be flushed first
-    expect(batcher.write("t1", "rejected", 30)).toBe(false);
+    const rejected = bytesOfLength(30, "r");
+    expect(batcher.write("t1", rejected, 30)).toBe(false);
     expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "buffered", 80);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", buffered, 80);
   });
 
   it("flushTerminal: flushes only the specified terminal", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "aaa", 3);
-    batcher.write("t2", "bbb", 3);
+    batcher.write("t1", bytes("aaa"), 3);
+    batcher.write("t2", bytes("bbb"), 3);
 
     batcher.flushTerminal("t1");
 
     expect(deps.postMessage).toHaveBeenCalledOnce();
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "aaa", 3);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("aaa"), 3);
 
     // t2 is still buffered, flushes on timer
     vi.runAllTimers();
     expect(deps.postMessage).toHaveBeenCalledTimes(2);
-    expect(deps.postMessage).toHaveBeenCalledWith("t2", "bbb", 3);
+    expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("bbb"), 3);
   });
 
   it("flushTerminal resets mode when buffer empties — next write gets latency mode", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "aaa", 3);
-    batcher.write("t1", "bbb", 3); // upgrade to throughput
+    batcher.write("t1", bytes("aaa"), 3);
+    batcher.write("t1", bytes("bbb"), 3); // upgrade to throughput
 
     // Flush t1 — buffer is now empty, mode should reset to idle
     batcher.flushTerminal("t1");
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "aaabbb", 6);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("aaabbb"), 6);
 
     // Next write should use latency mode (setImmediate), not stale throughput (setTimeout 16)
     (deps.postMessage as ReturnType<typeof vi.fn>).mockClear();
-    batcher.write("t2", "ccc", 3);
+    batcher.write("t2", bytes("ccc"), 3);
 
     // setImmediate fires immediately via runAllTimers, not delayed by 16ms
     vi.advanceTimersByTime(2);
-    expect(deps.postMessage).toHaveBeenCalledWith("t2", "ccc", 3);
+    expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("ccc"), 3);
   });
 
   it("flushTerminal on non-existent id is a no-op", () => {
@@ -201,7 +211,7 @@ describe("PortBatcher", () => {
     });
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "data", 4);
+    batcher.write("t1", bytes("data"), 4);
     vi.runAllTimers();
 
     expect(deps.onError).toHaveBeenCalledOnce();
@@ -220,11 +230,11 @@ describe("PortBatcher", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "data", 4);
+    batcher.write("t1", bytes("data"), 4);
     batcher.dispose();
 
     expect(vi.getTimerCount()).toBe(0);
-    expect(batcher.write("t1", "more", 4)).toBe(false);
+    expect(batcher.write("t1", bytes("more"), 4)).toBe(false);
   });
 
   it("dispose is safe to call twice", () => {
@@ -240,22 +250,21 @@ describe("PortBatcher", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "data", 4);
+    batcher.write("t1", bytes("data"), 4);
     expect(deps.portQueueManager.addBytes).not.toHaveBeenCalled();
 
     vi.runAllTimers();
     expect(deps.portQueueManager.addBytes).toHaveBeenCalledWith("t1", 4);
   });
 
-  it("single chunk optimization: avoids join for single-chunk flush", () => {
+  it("single chunk flush emits the same bytes", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
-    batcher.write("t1", "single", 6);
+    batcher.write("t1", bytes("single"), 6);
     vi.runAllTimers();
 
-    // Verify the exact string passed (not a joined array)
-    expect(deps.postMessage).toHaveBeenCalledWith("t1", "single", 6);
+    expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("single"), 6);
   });
 
   it("threshold accumulation: multiple small writes trigger sync flush at threshold", () => {
@@ -263,7 +272,7 @@ describe("PortBatcher", () => {
     const batcher = new PortBatcher(deps);
 
     const chunkSize = 32 * 1024;
-    const chunk = "x".repeat(chunkSize);
+    const chunk = bytesOfLength(chunkSize);
 
     batcher.write("t1", chunk, chunkSize); // 32KB — latency mode
     expect(deps.postMessage).not.toHaveBeenCalled();
@@ -271,5 +280,51 @@ describe("PortBatcher", () => {
     batcher.write("t1", chunk, chunkSize); // 64KB — triggers sync flush
     expect(deps.postMessage).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("flush emits a transferable Uint8Array — backing buffer is not aliased to the input chunk", () => {
+    // Slab-escape regression for PR #4639: node-pty Buffers under 4KB share an
+    // 8KB pool slab, so the flush output must be a fresh ArrayBuffer that the
+    // postMessage closure can safely place in a transfer list. The batcher's
+    // output buffer must not be aliased to any input chunk.
+    const deps = createDeps();
+    const batcher = new PortBatcher(deps);
+
+    // Simulate a node-pty chunk: a 4-byte view into an 8KB slab.
+    const slab = new ArrayBuffer(8192);
+    new Uint8Array(slab).fill(0xab); // pre-fill so we can detect aliasing
+    const chunk = new Uint8Array(slab, 16, 4);
+    chunk.set([1, 2, 3, 4]);
+
+    batcher.write("t1", chunk, 4);
+    vi.runAllTimers();
+
+    const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+    expect(postMessage).toHaveBeenCalledOnce();
+    const emitted = postMessage.mock.calls[0][1] as Uint8Array;
+
+    expect(emitted.byteLength).toBe(4);
+    // The emitted buffer must NOT be the slab — that would detach the slab on transfer.
+    expect(emitted.buffer).not.toBe(slab);
+    expect(emitted.buffer.byteLength).toBe(4);
+    expect(Array.from(emitted)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("flush concatenates multiple chunks into a single contiguous Uint8Array", () => {
+    const deps = createDeps();
+    const batcher = new PortBatcher(deps);
+
+    batcher.write("t1", bytes("foo"), 3);
+    batcher.write("t1", bytes("bar"), 3);
+    batcher.write("t1", bytes("baz"), 3);
+    vi.runAllTimers();
+
+    const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+    expect(postMessage).toHaveBeenCalledOnce();
+    const emitted = postMessage.mock.calls[0][1] as Uint8Array;
+
+    expect(emitted.byteLength).toBe(9);
+    expect(emitted.buffer.byteLength).toBe(9);
+    expect(Buffer.from(emitted).toString("utf8")).toBe("foobarbaz");
   });
 });

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -78,8 +78,8 @@ export class PortBatcher {
     this.mode = "idle";
 
     for (const [id, { chunks, bytes }] of snapshot) {
-      const data = mergeChunks(chunks, bytes);
       try {
+        const data = mergeChunks(chunks, bytes);
         this.deps.postMessage(id, data, bytes);
         this.deps.portQueueManager.addBytes(id, bytes);
         this.deps.portQueueManager.applyBackpressure(
@@ -106,8 +106,8 @@ export class PortBatcher {
       this.mode = "idle";
     }
 
-    const data = mergeChunks(entry.chunks, entry.bytes);
     try {
+      const data = mergeChunks(entry.chunks, entry.bytes);
       this.deps.postMessage(id, data, entry.bytes);
       this.deps.portQueueManager.addBytes(id, entry.bytes);
       this.deps.portQueueManager.applyBackpressure(

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -6,12 +6,12 @@ import type { PortQueueManager } from "./portQueue.js";
 
 export interface PortBatcherDeps {
   portQueueManager: PortQueueManager;
-  postMessage: (id: string, data: string, bytes: number) => void;
+  postMessage: (id: string, data: Uint8Array, bytes: number) => void;
   onError: (error: unknown) => void;
 }
 
 interface PendingTerminal {
-  chunks: string[];
+  chunks: Uint8Array[];
   bytes: number;
 }
 
@@ -27,7 +27,7 @@ export class PortBatcher {
 
   constructor(private readonly deps: PortBatcherDeps) {}
 
-  write(id: string, data: string, byteCount: number): boolean {
+  write(id: string, data: Uint8Array, byteCount: number): boolean {
     if (this.disposed) return false;
 
     const terminalPending = this.pendingChunks.get(id)?.bytes ?? 0;
@@ -78,7 +78,7 @@ export class PortBatcher {
     this.mode = "idle";
 
     for (const [id, { chunks, bytes }] of snapshot) {
-      const data = chunks.length === 1 ? chunks[0] : chunks.join("");
+      const data = mergeChunks(chunks, bytes);
       try {
         this.deps.postMessage(id, data, bytes);
         this.deps.portQueueManager.addBytes(id, bytes);
@@ -106,7 +106,7 @@ export class PortBatcher {
       this.mode = "idle";
     }
 
-    const data = entry.chunks.length === 1 ? entry.chunks[0] : entry.chunks.join("");
+    const data = mergeChunks(entry.chunks, entry.bytes);
     try {
       this.deps.postMessage(id, data, entry.bytes);
       this.deps.portQueueManager.addBytes(id, entry.bytes);
@@ -137,4 +137,19 @@ export class PortBatcher {
       this.timeoutHandle = null;
     }
   }
+}
+
+// Concatenate chunks into a freshly-allocated Uint8Array whose ArrayBuffer is
+// not aliased by any other Buffer. This is required so the caller can place
+// `merged.buffer` in a postMessage transfer list — node-pty Buffers under 4KB
+// share an 8KB pool slab, and transferring a slab-backed buffer would detach
+// the slab and corrupt every other Buffer that aliases it (PR #4639).
+function mergeChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
 }

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -455,7 +455,12 @@ export type RendererToPtyHostMessage =
  * Messages sent from Pty Host → Renderer via MessagePort (direct channel).
  * These bypass the Main process for low-latency terminal output.
  */
-export type PtyHostToRendererMessage = { type: "data"; id: string; data: string; bytes: number };
+export type PtyHostToRendererMessage = {
+  type: "data";
+  id: string;
+  data: Uint8Array;
+  bytes: number;
+};
 
 /** Per-process resource breakdown entry */
 export interface TerminalResourceProcess {


### PR DESCRIPTION
## Summary

- PTY output was decoded to string before batching, then crossed the MessagePort boundary via structured-clone. On sustained AI agent output (10-30 MB/s bursts) that's a TextDecoder pass plus a memcpy-equivalent per chunk, per window.
- Chunks now accumulate as `Uint8Array[]` in `PortBatcher`, flushed via a single `mergeChunks` allocation, and posted with the backing `ArrayBuffer` in the transfer list for zero-copy transfer. The IPC-mirror and IPC-fallback cold paths keep their own decode.
- ACK byte accounting is unchanged: the `bytes` field travels separately and still reflects the raw byte count.

Resolves #5826

## Changes

- `shared/types/pty-host.ts` — `PtyHostToRendererMessage.data` typed as `Uint8Array` instead of `string`
- `electron/pty-host/portBatcher.ts` — accumulate chunks as `Uint8Array[]`; `mergeChunks` helper allocates one output buffer per flush; wrapped in try/catch so allocation errors route through `onError`
- `electron/pty-host.ts` — encode string to `Uint8Array` at the MessagePort write site; postMessage passes `[data.buffer]` as the transfer list
- `electron/pty-host/__tests__/portBatcher.test.ts` — new fixtures and tests covering slab-escape safety, multi-chunk concat, UTF-8 ACK accounting, and the byte-count mismatch error path

## Testing

Unit tests updated and passing. The renderer's `terminalClient.ts` and xterm's `terminal.write()` both already accept `Uint8Array`, so no renderer changes were needed.