### PR TITLE
feat(panel): add alternate-pane keybinding for tmux-style last-pane toggle

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -87,6 +87,7 @@ export type BuiltInKeyAction =
   | "terminal.inject"
   | "terminal.focusNext"
   | "terminal.focusPrevious"
+  | "terminal.focusAlternate"
   | "terminal.focusUp"
   | "terminal.focusDown"
   | "terminal.focusLeft"
@@ -268,6 +269,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "terminal.inject",
   "terminal.focusNext",
   "terminal.focusPrevious",
+  "terminal.focusAlternate",
   "terminal.focusUp",
   "terminal.focusDown",
   "terminal.focusLeft",

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -66,6 +66,7 @@ const CURATED_SHORTCUTS = [
       "terminal.new",
       "terminal.focusNext",
       "terminal.focusPrevious",
+      "terminal.focusAlternate",
     ],
   },
   {

--- a/src/services/actions/definitions/terminalNavigationActions.ts
+++ b/src/services/actions/definitions/terminalNavigationActions.ts
@@ -35,6 +35,21 @@ export function registerTerminalNavigationActions(
     },
   }));
 
+  actions.set("terminal.focusAlternate", () => ({
+    id: "terminal.focusAlternate",
+    title: "Focus Alternate Panel",
+    description: "Toggle focus between the current panel and the previously focused one",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    nonRepeatable: true,
+    keywords: ["last", "previous", "swap", "toggle", "tmux", "back"],
+    run: async () => {
+      usePanelStore.getState().focusAlternate();
+    },
+  }));
+
   actions.set("terminal.focusUp", () => ({
     id: "terminal.focusUp",
     title: "Focus Terminal Up",

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -178,6 +178,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
+    actionId: "terminal.focusAlternate",
+    combo: "Cmd+Alt+`",
+    scope: "global",
+    priority: 0,
+    description: "Toggle focus between current and previously focused panel",
+    category: "Terminal",
+  },
+  {
     actionId: "tab.next",
     combo: "Cmd+Shift+]",
     scope: "global",

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -132,7 +132,7 @@ export const usePanelStore = create<PanelGridState>()(
       (id) => get().moveTerminalToDock(id),
       (id) => get().moveTerminalToGrid(id),
       () => get().focusedId,
-      (id) => set({ focusedId: id }),
+      (id) => get().activateTerminal(id),
       getActiveWorktreeId
     )(set, get, api);
 
@@ -159,7 +159,12 @@ export const usePanelStore = create<PanelGridState>()(
         // focus also isn't meaningful during restore — focus is resolved elsewhere once
         // the active worktree is set.
         if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
-          set({ focusedId: id });
+          const previousFocusedId = get().focusedId;
+          if (previousFocusedId !== id) {
+            set({ focusedId: id, previousFocusedId });
+          } else {
+            set({ focusedId: id });
+          }
         }
         return id;
       },
@@ -184,6 +189,13 @@ export const usePanelStore = create<PanelGridState>()(
               gridTerminals.push(t);
           }
           updates.focusedId = gridTerminals[0]?.id ?? null;
+          // Auto-fallback focus from a moved-to-dock panel isn't a user
+          // navigation event — clear the alternate pointer to avoid round-
+          // tripping into a panel the user didn't choose.
+          updates.previousFocusedId = null;
+        }
+        if (state.previousFocusedId === id) {
+          updates.previousFocusedId = null;
         }
 
         if (state.maximizedId) {
@@ -203,7 +215,12 @@ export const usePanelStore = create<PanelGridState>()(
       moveTerminalToGrid: (id: string) => {
         const moveSucceeded = registrySlice.moveTerminalToGrid(id);
         if (moveSucceeded) {
-          set({ focusedId: id, activeDockTerminalId: null });
+          const previousFocusedId = get().focusedId;
+          set({
+            focusedId: id,
+            activeDockTerminalId: null,
+            ...(previousFocusedId !== id && { previousFocusedId }),
+          });
         }
         return moveSucceeded;
       },
@@ -215,6 +232,7 @@ export const usePanelStore = create<PanelGridState>()(
 
         if (location === "grid") {
           const activeDockTerminalId = get().activeDockTerminalId;
+          const previousFocusedId = get().focusedId;
           const nextFocusedId = groupBeforeMove.panelIds.includes(groupBeforeMove.activeTabId)
             ? groupBeforeMove.activeTabId
             : (groupBeforeMove.panelIds[0] ?? null);
@@ -225,11 +243,20 @@ export const usePanelStore = create<PanelGridState>()(
           set({
             focusedId: nextFocusedId,
             ...(shouldClearDock && { activeDockTerminalId: null }),
+            ...(nextFocusedId !== previousFocusedId && { previousFocusedId }),
           });
         } else {
           const focusedId = get().focusedId;
           if (focusedId && groupBeforeMove.panelIds.includes(focusedId)) {
-            set({ focusedId: null, activeDockTerminalId: groupBeforeMove.activeTabId });
+            // The previously focused panel is now in the dock and `focusedId`
+            // is being cleared as a side effect of the move, not a user
+            // navigation. Clear the alternate pointer to keep round-trip
+            // semantics tied to explicit focus changes.
+            set({
+              focusedId: null,
+              activeDockTerminalId: groupBeforeMove.activeTabId,
+              previousFocusedId: null,
+            });
           }
         }
 
@@ -272,6 +299,9 @@ export const usePanelStore = create<PanelGridState>()(
             ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
             : undefined;
           updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+          updates.previousFocusedId = null;
+        } else if (state.previousFocusedId === id) {
+          updates.previousFocusedId = null;
         }
 
         if (state.maximizedId === id) {
@@ -326,6 +356,12 @@ export const usePanelStore = create<PanelGridState>()(
             ? gridTerminals.find((t) => isRuntimeAgentTerminal(t))
             : undefined;
           updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+          updates.previousFocusedId = null;
+        } else if (
+          state.previousFocusedId !== null &&
+          panelIdsInGroup.includes(state.previousFocusedId)
+        ) {
+          updates.previousFocusedId = null;
         }
 
         if (state.maximizedId && panelIdsInGroup.includes(state.maximizedId)) {
@@ -343,7 +379,12 @@ export const usePanelStore = create<PanelGridState>()(
 
       restoreTerminal: (id: string, targetWorktreeId?: string) => {
         registrySlice.restoreTerminal(id, targetWorktreeId);
-        set({ focusedId: id, activeDockTerminalId: null });
+        const previousFocusedId = get().focusedId;
+        set({
+          focusedId: id,
+          activeDockTerminalId: null,
+          ...(previousFocusedId !== id && { previousFocusedId }),
+        });
       },
 
       restoreTrashedGroup: (groupRestoreId: string, targetWorktreeId?: string) => {
@@ -369,7 +410,12 @@ export const usePanelStore = create<PanelGridState>()(
           groupPanelIds.includes(anchorPanel.groupMetadata.activeTabId)
             ? anchorPanel.groupMetadata.activeTabId
             : groupPanelIds[0]!;
-        set({ focusedId: focusId, activeDockTerminalId: null });
+        const previousFocusedId = get().focusedId;
+        set({
+          focusedId: focusId,
+          activeDockTerminalId: null,
+          ...(previousFocusedId !== focusId && { previousFocusedId }),
+        });
 
         const group = get().getPanelGroup(focusId);
         if (group) {
@@ -402,7 +448,12 @@ export const usePanelStore = create<PanelGridState>()(
         registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
 
         if (location === "grid") {
-          set({ focusedId: id, activeDockTerminalId: null });
+          const previousFocusedId = state.focusedId;
+          set({
+            focusedId: id,
+            activeDockTerminalId: null,
+            ...(previousFocusedId !== id && { previousFocusedId }),
+          });
         } else if (state.focusedId === id) {
           const activeWt = getActiveWorktreeId() ?? undefined;
           const gridTerminals: TerminalInstance[] = [];
@@ -416,7 +467,9 @@ export const usePanelStore = create<PanelGridState>()(
             )
               gridTerminals.push(t);
           }
-          set({ focusedId: gridTerminals[0]?.id ?? null });
+          // Auto-fallback focus when the focused panel is moved to dock —
+          // not a user navigation, so the alternate pointer becomes stale.
+          set({ focusedId: gridTerminals[0]?.id ?? null, previousFocusedId: null });
         }
       },
 
@@ -473,6 +526,7 @@ export const usePanelStore = create<PanelGridState>()(
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),
           focusedId: null,
+          previousFocusedId: null,
           maximizedId: null,
           activeDockTerminalId: null,
           pingedId: null,
@@ -516,6 +570,7 @@ export const usePanelStore = create<PanelGridState>()(
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),
           focusedId: null,
+          previousFocusedId: null,
           maximizedId: null,
           activeDockTerminalId: null,
           pingedId: null,
@@ -561,6 +616,7 @@ export const usePanelStore = create<PanelGridState>()(
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),
           focusedId: null,
+          previousFocusedId: null,
           maximizedId: null,
           activeDockTerminalId: null,
           pingedId: null,

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -605,6 +605,9 @@ export function setupTerminalStoreListeners() {
                 (t.worktreeId ?? undefined) === activeWt
             );
           updates.focusedId = gridTerminals[0]?.id ?? null;
+          updates.previousFocusedId = null;
+        } else if (state.previousFocusedId === id) {
+          updates.previousFocusedId = null;
         }
         if (state.maximizedId === id) {
           updates.maximizedId = null;
@@ -624,7 +627,11 @@ export function setupTerminalStoreListeners() {
       terminalRegistryController.onRestored((data: { id: string }) => {
         const { id } = data;
         usePanelStore.getState().markAsRestored(id);
-        usePanelStore.setState({ focusedId: id });
+        const previousFocusedId = usePanelStore.getState().focusedId;
+        usePanelStore.setState({
+          focusedId: id,
+          ...(previousFocusedId !== id && { previousFocusedId }),
+        });
       })
     )
   );

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -630,6 +630,7 @@ export function setupTerminalStoreListeners() {
         const previousFocusedId = usePanelStore.getState().focusedId;
         usePanelStore.setState({
           focusedId: id,
+          activeDockTerminalId: null,
           ...(previousFocusedId !== id && { previousFocusedId }),
         });
       })

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
+    wake: vi.fn(),
   },
 }));
 

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -916,3 +916,222 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
     expect(pingSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {
+  beforeAll(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        electron: {
+          notification: { acknowledgeWaiting: vi.fn(), acknowledgeWorkingPulse: vi.fn() },
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  const makeTerminal = (
+    id: string,
+    location: "grid" | "dock" | "trash" | "background" = "grid",
+    worktreeId = "worktree-1"
+  ): TerminalInstance =>
+    ({
+      id,
+      title: id,
+      cwd: "/test",
+      location,
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId,
+    }) as TerminalInstance;
+
+  let terminals: TerminalInstance[];
+  let state: TerminalFocusSlice;
+
+  const setup = () => {
+    const getTerminals = vi.fn(() => terminals);
+    const getState = vi.fn((): TerminalFocusSlice => state);
+    const setState = vi.fn(
+      (
+        updater:
+          | Partial<TerminalFocusSlice>
+          | ((s: TerminalFocusSlice) => Partial<TerminalFocusSlice>)
+      ) => {
+        const currentState = getState();
+        const updates = typeof updater === "function" ? updater(currentState) : updater;
+        state = { ...currentState, ...updates };
+      }
+    );
+    return { getTerminals, setState, getState };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminals = [
+      makeTerminal("a"),
+      makeTerminal("b"),
+      makeTerminal("c"),
+      makeTerminal("dock-1", "dock"),
+    ];
+    const { getTerminals, setState, getState } = setup();
+    state = createTerminalFocusSlice(getTerminals, mockGetActiveWorktreeId)(
+      setState as never,
+      getState as never,
+      {} as never
+    );
+  });
+
+  it("initializes previousFocusedId to null", () => {
+    expect(state.previousFocusedId).toBeNull();
+  });
+
+  it("setFocused records the prior focus as previousFocusedId on a real change", () => {
+    state.setFocused("a");
+    expect(state.focusedId).toBe("a");
+    expect(state.previousFocusedId).toBeNull();
+
+    state.setFocused("b");
+    expect(state.focusedId).toBe("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("setFocused does not corrupt previousFocusedId when re-focusing the active panel", () => {
+    state.setFocused("a");
+    state.setFocused("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    // Re-focusing the already-active panel must not overwrite the alternate
+    // pointer with itself — that would break A↔B round-tripping.
+    state.setFocused("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("activateTerminal records the prior focus as previousFocusedId on a real change", () => {
+    state.activateTerminal("a");
+    expect(state.previousFocusedId).toBeNull();
+
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("activateTerminal does not corrupt previousFocusedId when re-activating the active panel", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("focusAlternate is a no-op when previousFocusedId is null", () => {
+    state.activateTerminal("a");
+    expect(state.previousFocusedId).toBeNull();
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("a");
+  });
+
+  it("focusAlternate swaps to the previous panel and back (A↔B round-trip)", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+    expect(state.focusedId).toBe("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("a");
+    expect(state.previousFocusedId).toBe("b");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("b");
+    expect(state.previousFocusedId).toBe("a");
+  });
+
+  it("focusAlternate ignores trashed targets", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    // Simulate the panel being trashed in place (without going through
+    // handleTerminalRemoved, which would null the pointer itself).
+    terminals = terminals.map((t) => (t.id === "a" ? { ...t, location: "trash" } : t));
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("b");
+  });
+
+  it("focusAlternate ignores background (hibernated) targets", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+
+    terminals = terminals.map((t) => (t.id === "a" ? { ...t, location: "background" } : t));
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("b");
+  });
+
+  it("focusAlternate is a no-op when the previous panel was removed entirely", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+
+    terminals = terminals.filter((t) => t.id !== "a");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("b");
+  });
+
+  it("works across grid and dock panels", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("dock-1");
+    expect(state.focusedId).toBe("dock-1");
+    expect(state.activeDockTerminalId).toBe("dock-1");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("a");
+    expect(state.activeDockTerminalId).toBeNull();
+    expect(state.previousFocusedId).toBe("dock-1");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("dock-1");
+    expect(state.activeDockTerminalId).toBe("dock-1");
+  });
+
+  it("handleTerminalRemoved clears previousFocusedId when the removed panel was the alternate", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.handleTerminalRemoved(
+      "a",
+      terminals.filter((t) => t.id !== "a"),
+      0
+    );
+    expect(state.previousFocusedId).toBeNull();
+    expect(state.focusedId).toBe("b");
+  });
+
+  it("handleTerminalRemoved clears previousFocusedId when the focused panel is removed (auto-fallback)", () => {
+    state.activateTerminal("a");
+    state.activateTerminal("b");
+    expect(state.previousFocusedId).toBe("a");
+
+    // b is currently focused; removing b reassigns focusedId to a fallback,
+    // and the old previousFocusedId is no longer the user's preceding choice.
+    state.handleTerminalRemoved(
+      "b",
+      terminals.filter((t) => t.id !== "b"),
+      1
+    );
+    expect(state.previousFocusedId).toBeNull();
+  });
+});

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1134,4 +1134,29 @@ describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {
     );
     expect(state.previousFocusedId).toBeNull();
   });
+
+  it("openDockTerminal records the prior focus as previousFocusedId", () => {
+    // Most dock-focus entry points (clicks in DockedTerminalItem, focusDock
+    // action, navigateTab dock branch, focusNextBlockedDock) route through
+    // openDockTerminal — the alternate chain must include them.
+    state.activateTerminal("a");
+
+    state.openDockTerminal("dock-1");
+    expect(state.focusedId).toBe("dock-1");
+    expect(state.activeDockTerminalId).toBe("dock-1");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.focusAlternate();
+    expect(state.focusedId).toBe("a");
+    expect(state.previousFocusedId).toBe("dock-1");
+  });
+
+  it("openDockTerminal does not corrupt previousFocusedId when reopening the same dock panel", () => {
+    state.activateTerminal("a");
+    state.openDockTerminal("dock-1");
+    expect(state.previousFocusedId).toBe("a");
+
+    state.openDockTerminal("dock-1");
+    expect(state.previousFocusedId).toBe("a");
+  });
 });

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+    wake: vi.fn(),
   },
 }));
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -42,6 +42,14 @@ export type MaximizeTarget = { type: "panel"; id: string } | { type: "group"; id
 
 export interface TerminalFocusSlice {
   focusedId: string | null;
+  /**
+   * Most recent panel that held focus before `focusedId`. Used by
+   * `focusAlternate` for tmux-style A↔B toggling. Updated atomically alongside
+   * `focusedId` only when the focused panel actually changes — re-focusing the
+   * already-active panel must not corrupt the toggle. Cleared when the
+   * referenced panel is removed or when focus state is reset.
+   */
+  previousFocusedId: string | null;
   maximizedId: string | null;
   /** Tracks whether maximize is for a single panel or a tab group */
   maximizeTarget: MaximizeTarget;
@@ -67,6 +75,11 @@ export interface TerminalFocusSlice {
   clearPreMaximizeLayout: () => void;
   focusNext: () => void;
   focusPrevious: () => void;
+  /**
+   * Toggles focus between the current panel and the previously focused panel
+   * (tmux `last-pane` semantics). No-op when no valid alternate exists.
+   */
+  focusAlternate: () => void;
   focusDirection: (
     direction: NavigationDirection,
     findNearest: (id: string, dir: NavigationDirection) => string | null
@@ -112,6 +125,7 @@ export const createTerminalFocusSlice =
 
     return {
       focusedId: null,
+      previousFocusedId: null,
       maximizedId: null,
       maximizeTarget: null,
       activeDockTerminalId: null,
@@ -120,11 +134,20 @@ export const createTerminalFocusSlice =
       setFocused: (id, shouldPing = false) => {
         if (id) {
           const previousFocusedId = get().focusedId;
+          const focusActuallyChanged = id !== previousFocusedId;
           const terminal = getTerminals().find((t) => t.id === id);
           if (terminal?.location === "dock") {
-            set({ focusedId: id, activeDockTerminalId: id });
+            set({
+              focusedId: id,
+              activeDockTerminalId: id,
+              ...(focusActuallyChanged && { previousFocusedId }),
+            });
           } else {
-            set({ focusedId: id, activeDockTerminalId: null });
+            set({
+              focusedId: id,
+              activeDockTerminalId: null,
+              ...(focusActuallyChanged && { previousFocusedId }),
+            });
           }
           // Wake-on-focus: sync terminal state from backend when focused.
           // Skip wake for non-PTY panels - they don't have backend PTY processes.
@@ -133,7 +156,7 @@ export const createTerminalFocusSlice =
           }
           // Only ping when selection actually changes — re-focusing the already
           // selected terminal should be a no-op visually (no 1.6s ping loop).
-          if (shouldPing && id !== previousFocusedId) {
+          if (shouldPing && focusActuallyChanged) {
             get().pingTerminal(id);
           }
         } else {
@@ -367,6 +390,9 @@ export const createTerminalFocusSlice =
           terminalInstanceService.wake(id);
         }
 
+        const previousFocusedId = get().focusedId;
+        const focusActuallyChanged = id !== previousFocusedId;
+
         if (terminal.location === "dock") {
           if (terminal.agentState === "waiting") {
             window.electron?.notification?.acknowledgeWaiting(id);
@@ -374,10 +400,31 @@ export const createTerminalFocusSlice =
           if (terminal.agentState === "working") {
             window.electron?.notification?.acknowledgeWorkingPulse(id);
           }
-          set({ activeDockTerminalId: id, focusedId: id });
+          set({
+            activeDockTerminalId: id,
+            focusedId: id,
+            ...(focusActuallyChanged && { previousFocusedId }),
+          });
         } else {
-          set({ focusedId: id, activeDockTerminalId: null });
+          set({
+            focusedId: id,
+            activeDockTerminalId: null,
+            ...(focusActuallyChanged && { previousFocusedId }),
+          });
         }
+      },
+
+      focusAlternate: () => {
+        const { previousFocusedId, focusedId, activateTerminal } = get();
+        if (!previousFocusedId || previousFocusedId === focusedId) return;
+        const target = getTerminals().find((t) => t.id === previousFocusedId);
+        if (!target) return;
+        // Skip targets that are no longer reachable: trashed panels are
+        // pending TTL cleanup and background panels are hibernated mirrors,
+        // not user-visible. Activating either would surface a panel the user
+        // didn't expect or fail outright.
+        if (target.location === "trash" || target.location === "background") return;
+        activateTerminal(previousFocusedId);
       },
 
       focusNextWaiting: (isInTrash, validWorktreeIds) => {
@@ -546,6 +593,12 @@ export const createTerminalFocusSlice =
             } else {
               updates.focusedId = null;
             }
+            // Auto-fallback focus is not a user navigation event, so the round-
+            // trip semantic doesn't apply — clear the alternate pointer rather
+            // than letting it point at a panel that wasn't the user's previous.
+            updates.previousFocusedId = null;
+          } else if (state.previousFocusedId === removedId) {
+            updates.previousFocusedId = null;
           }
 
           // Clear maximize state if the removed panel was maximized, or if it was in a maximized group

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -374,7 +374,13 @@ export const createTerminalFocusSlice =
         if (terminal?.agentState === "working") {
           window.electron?.notification?.acknowledgeWorkingPulse(id);
         }
-        set({ activeDockTerminalId: id, focusedId: id });
+        const previousFocusedId = get().focusedId;
+        const focusActuallyChanged = id !== previousFocusedId;
+        set({
+          activeDockTerminalId: id,
+          focusedId: id,
+          ...(focusActuallyChanged && { previousFocusedId }),
+        });
       },
 
       closeDockTerminal: () => set({ activeDockTerminalId: null }),

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -93,7 +93,7 @@ export interface TerminalFocusSlice {
   // Dock terminal activation
   openDockTerminal: (id: string) => void;
   closeDockTerminal: () => void;
-  activateTerminal: (id: string) => void;
+  activateTerminal: (id: string | null) => void;
 
   // Agent state navigation
   focusNextWaiting: (isInTrash: (id: string) => boolean, validWorktreeIds: Set<string>) => void;
@@ -386,6 +386,10 @@ export const createTerminalFocusSlice =
       closeDockTerminal: () => set({ activeDockTerminalId: null }),
 
       activateTerminal: (id) => {
+        if (!id) {
+          set({ focusedId: null });
+          return;
+        }
         const terminals = getTerminals();
         const terminal = terminals.find((t) => t.id === id);
         if (!terminal) return;


### PR DESCRIPTION
## Summary

- Adds a `terminal.focusAlternate` action (default `Cmd+Alt+\``) that swaps focus between the current panel and the previously focused one, giving the same round-trip primitive as tmux's `last-pane`.
- Tracks a `previousFocusedId` pointer in `terminalFocusSlice`, updated atomically through every focus entry path (setFocused, activateTerminal, and now openDockTerminal) with a same-id guard to preserve the A↔B cycle.
- Clears the pointer cleanly on panel removal, trash, group trash, dock fallback, and all reset paths so stale targets never show up.

Resolves #5833

## Changes

- `terminalFocusSlice.ts` — `previousFocusedId` field, `focusAlternate()` action, null-safe `activateTerminal` signature
- `panelStore.ts` — `previousFocusedId` wired into removal and reset paths
- `panelStoreListeners.ts` — `openDockTerminal` now records the outgoing id before switching
- `terminalNavigationActions.ts` — `terminal.focusAlternate` action definition
- `defaultKeybindings.ts` — `Cmd+Alt+\`` default binding
- `GeneralTab.tsx` — binding surfaced in the keybindings settings list
- `terminalFocusSlice.test.ts` — 219-line unit test suite covering round-trip, same-id guard, deletion cleanup, and dock-grid cross-section

## Testing

Unit tests cover the core toggle contract, the same-id guard, deletion cleanup, and the `openDockTerminal` dock entry path. All pass. Typecheck clean.