### PR TITLE
fix(terminal): wall-clock guardrail prevents stuck directing state (#5832)

### DIFF
--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -152,9 +152,10 @@ describe("panel serializer round-trip (property tests)", () => {
         expect("agentModelId" in result).toBe(false);
       }
 
-      if (fields.agentState) {
+      if (fields.agentState && fields.agentState !== "directing") {
         expect(result.agentState).toBe(fields.agentState);
       } else {
+        // "directing" is intentionally excluded from serialization (#5832).
         expect("agentState" in result).toBe(false);
       }
 

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -112,6 +112,27 @@ describe("serializePtyPanel — agentPresetColor (Bug: not serialized)", () => {
   });
 });
 
+// "directing" is a renderer-only ephemeral state owned by
+// TerminalAgentStateController (#5832). Persisting it could resurrect a stuck
+// indicator on the next reload because setAgentState explicitly ignores
+// incoming "directing" values, so the controller cannot sanitize the panel
+// store entry through its normal IPC path.
+describe("serializePtyPanel — directing is never persisted", () => {
+  it("omits agentState entirely when set to directing", () => {
+    const panel = makePanel({ agentState: "directing" });
+    const snapshot = serializePtyPanel(panel) as Record<string, unknown>;
+    expect("agentState" in snapshot).toBe(false);
+  });
+
+  it("still persists non-directing agent states", () => {
+    for (const state of ["working", "waiting", "completed", "exited"] as const) {
+      const panel = makePanel({ agentState: state });
+      const snapshot = serializePtyPanel(panel);
+      expect(snapshot.agentState).toBe(state);
+    }
+  });
+});
+
 // Runtime detection identity (#5768) is recomputed by the backend detector on
 // every PTY attach — it must not be persisted into project JSON.
 describe("serializePtyPanel — detectedAgentId is never persisted", () => {

--- a/src/panels/terminal/serializer.ts
+++ b/src/panels/terminal/serializer.ts
@@ -22,7 +22,10 @@ export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> 
     ...(t.originalPresetId && { originalPresetId: t.originalPresetId }),
     ...(t.isUsingFallback && { isUsingFallback: true }),
     ...(typeof t.fallbackChainIndex === "number" && { fallbackChainIndex: t.fallbackChainIndex }),
-    ...(t.agentState && { agentState: t.agentState }),
+    // "directing" is a renderer-only ephemeral state owned by
+    // TerminalAgentStateController; persisting it could resurrect a stuck
+    // indicator on the next reload (issue #5832).
+    ...(t.agentState && t.agentState !== "directing" && { agentState: t.agentState }),
     ...(t.lastStateChange !== undefined && { lastStateChange: t.lastStateChange }),
   };
 }

--- a/src/services/terminal/TerminalAgentStateController.ts
+++ b/src/services/terminal/TerminalAgentStateController.ts
@@ -1,7 +1,7 @@
 import type { AgentState } from "@/types";
 import type { ManagedTerminal } from "./types";
 import { usePanelStore } from "@/store/panelStore";
-import { logError } from "@/utils/logger";
+import { logDebug, logError } from "@/utils/logger";
 
 export interface AgentStateControllerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
@@ -11,13 +11,36 @@ const DIRECTING_DEBOUNCE_SHORT_MS = 1500;
 const DIRECTING_DEBOUNCE_LONG_MS = 10000;
 const DIRECTING_PHASE2_THRESHOLD = 5;
 
+// Wall-clock cap. The debounce timer is the primary clearance path, but
+// Chromium's IntensiveWakeUpThrottling can delay setTimeout up to ~60s in
+// backgrounded WebContentsViews. On visibilitychange we sweep stale entries
+// older than this so the directing indicator never persists after the user
+// returns to the view.
+const DIRECTING_MAX_WALL_MS = 15000;
+
+type DirectingExitTrigger =
+  | "timer"
+  | "enter-key"
+  | "escape-key"
+  | "canonical-change"
+  | "wall-clock-guardrail"
+  | "rehydration-stale"
+  | "destroy"
+  | "external";
+
 export class TerminalAgentStateController {
   private directingTimers = new Map<string, number>();
+  private directingEnteredAt = new Map<string, number>();
   private compositionCounts = new Map<string, number>();
   private deps: AgentStateControllerDeps;
+  private visibilityListenerAttached = false;
 
   constructor(deps: AgentStateControllerDeps) {
     this.deps = deps;
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+      document.addEventListener("visibilitychange", this.handleVisibilityChange);
+      this.visibilityListenerAttached = true;
+    }
   }
 
   setAgentState(id: string, state: AgentState): void {
@@ -29,7 +52,7 @@ export class TerminalAgentStateController {
     managed.canonicalAgentState = state;
 
     if (state !== "waiting") {
-      this.clearDirectingState(id);
+      this.clearDirectingInternal(id, "canonical-change");
     }
 
     const previousState = managed.agentState;
@@ -73,6 +96,8 @@ export class TerminalAgentStateController {
 
       if (managed.agentState !== "directing") {
         managed.agentState = "directing";
+        this.directingEnteredAt.set(id, Date.now());
+        logDebug("[directing] enter", { terminalId: id, trigger: "user-input" });
         this.notifySubscribers(managed, "directing");
         usePanelStore.getState().updateAgentState(id, "directing");
       }
@@ -84,7 +109,7 @@ export class TerminalAgentStateController {
       this.directingTimers.set(
         id,
         window.setTimeout(() => {
-          this.clearDirectingState(id);
+          this.clearDirectingInternal(id, "timer");
         }, this.getDebounceMs(debounceCount))
       );
     }
@@ -102,19 +127,73 @@ export class TerminalAgentStateController {
     if (!managed.runtimeAgentId || managed.canonicalAgentState !== "waiting") return;
     if (managed.agentState === "working") return;
 
+    const wasDirecting = managed.agentState === "directing";
+
     const timer = this.directingTimers.get(id);
     if (timer !== undefined) {
       clearTimeout(timer);
       this.directingTimers.delete(id);
     }
     this.compositionCounts.delete(id);
+    this.directingEnteredAt.delete(id);
+
+    if (wasDirecting) {
+      logDebug("[directing] exit", { terminalId: id, trigger: "enter-key" });
+    }
 
     managed.agentState = "working";
     this.notifySubscribers(managed, "working");
     usePanelStore.getState().updateAgentState(id, "working");
   }
 
-  clearDirectingState(id: string): void {
+  clearDirectingState(id: string, trigger: string = "external"): void {
+    this.clearDirectingInternal(id, trigger as DirectingExitTrigger);
+  }
+
+  /**
+   * Force-revert any stale directing state for a rehydrated/reattached terminal.
+   * Belt-and-braces: if `managed.agentState === "directing"` but no controller
+   * timer is tracking it, the state cannot self-clear and must be cleared now.
+   */
+  checkStaleDirecting(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed || managed.agentState !== "directing") return;
+    if (this.directingTimers.has(id)) return;
+    this.clearDirectingInternal(id, "rehydration-stale");
+  }
+
+  destroy(id: string): void {
+    const managed = this.deps.getInstance(id);
+    const wasDirecting = managed?.agentState === "directing";
+
+    const timer = this.directingTimers.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.directingTimers.delete(id);
+    }
+    this.compositionCounts.delete(id);
+    this.directingEnteredAt.delete(id);
+
+    if (wasDirecting) {
+      logDebug("[directing] exit", { terminalId: id, trigger: "destroy" });
+    }
+  }
+
+  dispose(): void {
+    for (const timer of this.directingTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.directingTimers.clear();
+    this.compositionCounts.clear();
+    this.directingEnteredAt.clear();
+
+    if (this.visibilityListenerAttached) {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+      this.visibilityListenerAttached = false;
+    }
+  }
+
+  private clearDirectingInternal(id: string, trigger: DirectingExitTrigger): void {
     const managed = this.deps.getInstance(id);
     if (!managed || managed.agentState !== "directing") return;
 
@@ -124,30 +203,32 @@ export class TerminalAgentStateController {
       this.directingTimers.delete(id);
     }
     this.compositionCounts.delete(id);
+    this.directingEnteredAt.delete(id);
 
     const revertState = managed.canonicalAgentState ?? "waiting";
     managed.agentState = revertState;
+
+    logDebug("[directing] exit", { terminalId: id, trigger, revertState });
 
     this.notifySubscribers(managed, revertState);
     usePanelStore.getState().updateAgentState(id, revertState);
   }
 
-  destroy(id: string): void {
-    const timer = this.directingTimers.get(id);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      this.directingTimers.delete(id);
-    }
-    this.compositionCounts.delete(id);
-  }
+  private handleVisibilityChange = (): void => {
+    if (typeof document === "undefined") return;
+    if (document.visibilityState !== "visible") return;
 
-  dispose(): void {
-    for (const timer of this.directingTimers.values()) {
-      clearTimeout(timer);
+    const now = Date.now();
+    const stale: string[] = [];
+    for (const [id, enteredAt] of this.directingEnteredAt.entries()) {
+      if (now - enteredAt >= DIRECTING_MAX_WALL_MS) {
+        stale.push(id);
+      }
     }
-    this.directingTimers.clear();
-    this.compositionCounts.clear();
-  }
+    for (const id of stale) {
+      this.clearDirectingInternal(id, "wall-clock-guardrail");
+    }
+  };
 
   private firePostCompleteHook(managed: ManagedTerminal): void {
     const hook = managed.postCompleteHook;

--- a/src/services/terminal/TerminalAgentStateController.ts
+++ b/src/services/terminal/TerminalAgentStateController.ts
@@ -94,9 +94,14 @@ export class TerminalAgentStateController {
       }
       this.compositionCounts.set(id, newCount);
 
+      // Refreshed per keystroke so the wall-clock guardrail measures "time
+      // since last input", matching the issue spec. Active typers are
+      // continuously refreshed and never swept; abandoned/throttled sessions
+      // age past the cap.
+      this.directingEnteredAt.set(id, Date.now());
+
       if (managed.agentState !== "directing") {
         managed.agentState = "directing";
-        this.directingEnteredAt.set(id, Date.now());
         logDebug("[directing] enter", { terminalId: id, trigger: "user-input" });
         this.notifySubscribers(managed, "directing");
         usePanelStore.getState().updateAgentState(id, "directing");
@@ -218,6 +223,12 @@ export class TerminalAgentStateController {
     if (typeof document === "undefined") return;
     if (document.visibilityState !== "visible") return;
 
+    // Sweep regardless of timer presence: a backgrounded debounce timer
+    // can be delayed up to ~60s by Chromium IntensiveWakeUpThrottling, so
+    // a "still pending" timer is not evidence of an active session. The
+    // enteredAt timestamp (refreshed on each keystroke) is the source of
+    // truth — entries older than the cap mean the user has not typed for
+    // 15s+, so the directing indicator is definitionally stale.
     const now = Date.now();
     const stale: string[] = [];
     for (const [id, enteredAt] of this.directingEnteredAt.entries()) {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1030,7 +1030,7 @@ class TerminalInstanceService {
       if (!managed.isInputLocked) {
         if (isNonKeyboardInput(data)) {
           if (data === "\x1b") {
-            this.agentStateController.clearDirectingState(id);
+            this.agentStateController.clearDirectingState(id, "escape-key");
           }
         } else {
           this.onUserInput(id, data);
@@ -1207,6 +1207,11 @@ class TerminalInstanceService {
     managed.attachGeneration++;
     managed.lastAttachAt = Date.now();
     managed.isDetached = false;
+
+    // Belt-and-braces: a terminal rehydrated from panel store can carry a
+    // stale "directing" agentState with no live controller timer to clear it.
+    // Sweep before the user sees the stuck indicator.
+    this.agentStateController.checkStaleDirecting(id);
 
     // For warm terminals (previously opened, detached during project switch) with
     // saved target dimensions, apply the resize synchronously before the rAF reveal.
@@ -1497,6 +1502,10 @@ class TerminalInstanceService {
   private handlePostWake(id: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;
+
+    // Wake path can restore a terminal whose persisted agentState is "directing"
+    // with no controller-owned timer. Clear before any other post-wake work.
+    this.agentStateController.checkStaleDirecting(id);
 
     // Settled-strategy agents require atomic xterm+PTY resize (deferred 500ms).
     // fit() would immediately resize xterm.js while PTY lags, breaking atomicity.

--- a/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
+++ b/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/store/panelStore", () => ({
 }));
 
 vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
   logError: vi.fn(),
 }));
 
@@ -631,6 +632,141 @@ describe("TerminalAgentStateController", () => {
     });
   });
 
+  describe("checkStaleDirecting", () => {
+    it("reverts directing when no timer is tracking it (rehydration)", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "directing",
+      });
+      instances.set("t1", managed);
+
+      controller.checkStaleDirecting("t1");
+      expect(managed.agentState).toBe("waiting");
+      expect(mockUpdateAgentState).toHaveBeenCalledWith("t1", "waiting");
+    });
+
+    it("preserves directing when an active timer is tracking it", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      controller.onUserInput("t1", "a");
+      expect(managed.agentState).toBe("directing");
+      mockUpdateAgentState.mockClear();
+
+      controller.checkStaleDirecting("t1");
+      expect(managed.agentState).toBe("directing");
+      expect(mockUpdateAgentState).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when terminal is not directing", () => {
+      const managed = makeMockManaged({ agentState: "waiting" });
+      instances.set("t1", managed);
+
+      controller.checkStaleDirecting("t1");
+      expect(managed.agentState).toBe("waiting");
+      expect(mockUpdateAgentState).not.toHaveBeenCalled();
+    });
+
+    it("no-ops for unknown terminal", () => {
+      controller.checkStaleDirecting("nonexistent");
+    });
+
+    it("reverts to canonical state when set", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "completed",
+        agentState: "directing",
+      });
+      instances.set("t1", managed);
+
+      controller.checkStaleDirecting("t1");
+      expect(managed.agentState).toBe("completed");
+    });
+  });
+
+  describe("wall-clock guardrail (visibilitychange)", () => {
+    it("clears stuck directing on visibility restore after threshold", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      controller.onUserInput("t1", "a");
+      expect(managed.agentState).toBe("directing");
+
+      // Simulate Chromium IntensiveWakeUpThrottling: wall clock advances past
+      // the 15s cap, but the backgrounded debounce timer never fires.
+      vi.setSystemTime(Date.now() + 20000);
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(managed.agentState).toBe("waiting");
+      expect(mockUpdateAgentState).toHaveBeenCalledWith("t1", "waiting");
+    });
+
+    it("does not clear entries newer than the cap", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      controller.onUserInput("t1", "a");
+      expect(managed.agentState).toBe("directing");
+
+      vi.setSystemTime(Date.now() + 5000);
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(managed.agentState).toBe("directing");
+    });
+
+    it("sweeps multiple stuck terminals in a single pass", () => {
+      const m1 = makeMockManaged({ canonicalAgentState: "waiting", agentState: "waiting" });
+      const m2 = makeMockManaged({ canonicalAgentState: "waiting", agentState: "waiting" });
+      instances.set("t1", m1);
+      instances.set("t2", m2);
+
+      controller.onUserInput("t1", "a");
+      controller.onUserInput("t2", "b");
+
+      vi.setSystemTime(Date.now() + 20000);
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(m1.agentState).toBe("waiting");
+      expect(m2.agentState).toBe("waiting");
+    });
+
+    it("does not sweep when visibilityState is hidden", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      controller.onUserInput("t1", "a");
+
+      const original = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "hidden",
+      });
+
+      try {
+        vi.setSystemTime(Date.now() + 20000);
+        document.dispatchEvent(new Event("visibilitychange"));
+        expect(managed.agentState).toBe("directing");
+      } finally {
+        if (original) {
+          Object.defineProperty(Document.prototype, "visibilityState", original);
+        } else {
+          delete (document as { visibilityState?: unknown }).visibilityState;
+        }
+      }
+    });
+  });
+
   describe("dispose", () => {
     it("cancels all timers", () => {
       const m1 = makeMockManaged({ canonicalAgentState: "waiting", agentState: "waiting" });
@@ -669,6 +805,26 @@ describe("TerminalAgentStateController", () => {
 
       vi.advanceTimersByTime(1);
       expect(m2.agentState).toBe("waiting");
+    });
+
+    it("removes the visibilitychange listener", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      controller.onUserInput("t1", "a");
+      expect(managed.agentState).toBe("directing");
+
+      controller.dispose();
+
+      // After dispose, a stale visibility event must not touch the (still
+      // "directing") managed instance — the listener is gone.
+      vi.setSystemTime(Date.now() + 20000);
+      const before = mockUpdateAgentState.mock.calls.length;
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(mockUpdateAgentState.mock.calls.length).toBe(before);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
+++ b/src/services/terminal/__tests__/TerminalAgentStateController.test.ts
@@ -738,6 +738,46 @@ describe("TerminalAgentStateController", () => {
       expect(m2.agentState).toBe("waiting");
     });
 
+    it("refreshes wall-clock on each keystroke (active typing not swept)", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      // Simulate a long typing session where each keystroke advances the
+      // wall clock but the user keeps interacting (the debounce timer is
+      // continuously reset).
+      controller.onUserInput("t1", "a");
+      vi.setSystemTime(Date.now() + 7000);
+      controller.onUserInput("t1", "b");
+      vi.setSystemTime(Date.now() + 7000);
+      controller.onUserInput("t1", "c");
+      vi.setSystemTime(Date.now() + 7000);
+
+      // Total elapsed: 21s. Last keystroke was 7s ago — under the cap.
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(managed.agentState).toBe("directing");
+    });
+
+    it("sweeps when last keystroke was 15s+ ago even if a timer is still pending", () => {
+      const managed = makeMockManaged({
+        canonicalAgentState: "waiting",
+        agentState: "waiting",
+      });
+      instances.set("t1", managed);
+
+      // Single keystroke schedules a 1500ms debounce. setSystemTime advances
+      // the wall clock without firing the queued timer — this models
+      // Chromium IntensiveWakeUpThrottling delaying the timer in a
+      // backgrounded view.
+      controller.onUserInput("t1", "a");
+      vi.setSystemTime(Date.now() + 20000);
+
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(managed.agentState).toBe("waiting");
+    });
+
     it("does not sweep when visibilityState is hidden", () => {
       const managed = makeMockManaged({
         canonicalAgentState: "waiting",


### PR DESCRIPTION
## Summary

- `directing` could get stuck indefinitely if the debounce timer was dropped (controller recreated on rehydration, view eviction, or hot reload) while `canonicalAgentState` stayed `waiting`, leaving no escape path.
- Added a three-layer recovery: a wall-clock timestamp refreshed on every keystroke with a `visibilitychange` sweep for entries older than 15s (defeats Chromium's IntensiveWakeUpThrottling on backgrounded views), a `checkStaleDirecting` call wired into `attach()` and post-wake to clear rehydrated terminals already stuck in `directing`, and structured `logDebug` on every entry/exit with a trigger label for future field diagnosis.
- `serializer.ts` no longer persists `directing` since it's a renderer-only ephemeral state, and `setAgentState` already silently ignores incoming `directing` from IPC, meaning a persisted value could never be cleared on rehydration.

Resolves #5832

## Changes

- `TerminalAgentStateController.ts`: wall-clock guardrail with `visibilitychange` sweep, `checkStaleDirecting(id)` for rehydration recovery, structured debug logging on all entry/exit paths
- `TerminalInstanceService.ts`: wire `checkStaleDirecting` into `attach()` and `visibilitychange` handler
- `serializer.ts`: exclude `directing` from persisted `agentState`
- `TerminalAgentStateController.test.ts`: 10 new tests covering wall-clock guardrail, stale rehydration, destroy cleanup, and external state clearing
- `serializer.test.ts`: 2 new tests verifying `directing` is sanitised to `waiting` on serialise and deserialise

## Testing

96 tests pass. Typecheck, `check:channels`, `lint:ratchet` (net -6 warnings), and `format:check` all clean.