### PR TITLE
docs(themes): document canonical interaction state recipes

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -6,7 +6,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 
 - **Never use `transition-all`** — forces Chromium to interpolate every computed property on every frame. Use specific transitions: `transition-colors`, `transition-opacity`, `transition-transform`, or explicit property lists like `transition-[width,height]`. (See lesson #4738)
 - **Never use `text-text-inverse` for hover states** — renders invisible in dark themes. Use theme-aware text colors like `text-daintree-text` or `text-canopy-text` instead. (See lesson #4630)
-- **Use `outline` utilities, not `ring`** — `outline` is truly transparent and supports Windows High Contrast Mode. `ring` uses box-shadow which fails in HCM.
+- **Prefer `outline` for focus rings** — `outline` is transparent and supports Windows High Contrast Mode. `ring` (box-shadow-based) is acceptable for active/dock states (e.g., `ring-1 ring-daintree-accent/30`), but for keyboard focus, always use `focus-visible:outline-*`.
 - **Always use `:focus-visible`** — `:focus` shows rings on mouse clicks; `:focus-visible` only shows for keyboard navigation.
 - **Never use accent color as default hover** — it's a scarce resource reserved for one load-bearing signal per component.
 
@@ -34,7 +34,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 "hover:bg-overlay-subtle hover:text-daintree-text";
 ```
 
-**Usage:** For selected state, use `bg-overlay-soft` with `border-daintree-accent` left accent edge. Used in `QuickSwitcherItem.tsx` (line 31).
+**Usage:** For selected state, use `bg-overlay-soft border-overlay` with a `before:` pseudo-element for the 2px accent rail (`before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent`). Used in `QuickSwitcherItem.tsx` (line 31).
 
 ---
 
@@ -43,10 +43,10 @@ This document maps each interactive component role to its canonical Tailwind cla
 **Role:** Worktree cards (grid variant), settings cards. Use elevation or border change rather than large background shifts.
 
 ```tsx
-"hover:border-border-default hover:shadow-[var(--theme-shadow-ambient)]";
+"hover:border-accent-primary/50 hover:shadow-[var(--theme-shadow-floating)]";
 ```
 
-**Usage:** Prefer border/shadow changes for elevation; avoid large background fills that feel heavy. Used in `WorktreeCard.tsx` grid variant (line 691).
+**Usage:** Accent-tinged border and floating shadow create elevation without heavy background fills. Used in `WorktreeCard.tsx` grid variant (line 691).
 
 ---
 
@@ -74,18 +74,15 @@ This document maps each interactive component role to its canonical Tailwind cla
 
 ---
 
-### Selected + Hover Combo
+### Selected State (List Item)
 
-**Role:** Selected items that also receive hover. Use pseudo-element overlay to avoid "color jump."
+**Role:** Selected list item in a picker. Uses background fill with accent rail via pseudo-element.
 
 ```tsx
-// Base selected state
-"bg-overlay-soft border-daintree-accent";
-// Hover overlay added via :after pseudo-element
-"hover:after:absolute hover:after:inset-0 hover:after:bg-white/10";
+"bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent";
 ```
 
-**Usage:** Pseudo-element overlay adds brightness on hover while maintaining selection indicator. Prevents jarring color transitions when user hovers over selected item. Pattern derived from QuickSwitcherItem (lines 29-31).
+**Usage:** Selected items do not add hover overlay — the background fill and accent rail provide sufficient state distinction. Unselected items get `hover:bg-overlay-subtle`. Used in `QuickSwitcherItem.tsx` (line 30).
 
 ---
 
@@ -96,10 +93,10 @@ This document maps each interactive component role to its canonical Tailwind cla
 **Role:** Standard focus indicator for buttons, cards, form controls.
 
 ```tsx
-"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+"focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 ```
 
-**Usage:** 2px outline with 2px offset satisfies WCAG 2.2 SC 2.4.13 (3:1 contrast ratio and size requirements). Used in `SettingsInput.tsx` (line 7).
+**Usage:** 2px outline with 2px offset satisfies WCAG 2.2 SC 2.4.13 (3:1 contrast ratio and size requirements). Requires `focus-visible:outline` base class to enable outline rendering. Used in `SettingsInput.tsx` (line 7).
 
 ---
 
@@ -108,22 +105,34 @@ This document maps each interactive component role to its canonical Tailwind cla
 **Role:** Flush list items, tree nodes, or elements with no gaps where outline shouldn't overlap adjacent items.
 
 ```tsx
-"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]";
+"focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]";
 ```
 
 **Usage:** Negative offset keeps indicator inside element bounds. Use when elements are packed tightly (e.g., list items, file tree rows) where default offset would bleed into neighbors.
 
 ---
 
-### Input Focus
+### Input Focus (Outline)
 
 **Role:** Text inputs, textareas. Pre-allocate border width; only change color to avoid layout shifts.
 
 ```tsx
-"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+"focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 ```
 
 **Usage:** Base state includes `border-border-strong`. On focus, outline is added — do NOT change `border-width`. Changing width causes layout jitter. Used in `SettingsInput.tsx` (line 7) and `SettingsTextarea.tsx` (line 7).
+
+---
+
+### Input Focus (Border Shift)
+
+**Role:** Standard form inputs where outline treatment is not desired. Shifts border color on focus without adding extra ring.
+
+```tsx
+"border border-border-strong focus:border-daintree-accent focus:outline-none transition-colors";
+```
+
+**Usage:** Border-shift is the lighter-weight alternative to outline-based focus. Base state must always have a visible border (`border-border-strong` or equivalent). On focus, only the border color changes — no outline or ring is added. Suitable for simple text inputs within constrained UIs. Used in `GitHubSettingsTab.tsx` (line 213) and `NotificationSettingsTab.tsx` (lines 217, 282, 415).
 
 ---
 
@@ -153,17 +162,23 @@ The overlay ladder drives most hover/fill states. See `theme-tokens.md` for full
 
 ---
 
+## Usage Pattern
+
+Each recipe is a class fragment to apply to a suitable base component, not a standalone implementation. When a canonical example is cited, prefer extending it over recreating the pattern. All recipes document current app behavior — if a pattern changes in a component, update this document to match.
+
 ## Canonical Examples
 
-| Component           | File                      | Key Pattern                                  |
-| ------------------- | ------------------------- | -------------------------------------------- |
-| Quick Switcher Item | `QuickSwitcherItem.tsx`   | Selected + hover with pseudo-element overlay |
-| Settings Input      | `SettingsInput.tsx`       | Input focus with outline ring                |
-| Settings Textarea   | `SettingsTextarea.tsx`    | Input focus with outline ring                |
-| Button Ghost        | `button.tsx` (line 21)    | Ghost button hover with overlay-soft         |
-| Button Pill         | `HelpAgentDockButton.tsx` | Dock item active with border + ring combo    |
-| Settings Subtab     | `SettingsSubtabBar.tsx`   | Active tab with bottom border accent         |
-| Worktree Card       | `WorktreeCard.tsx`        | Card hover with border/shadow elevation      |
+| Component             | File                                     | Key Pattern                                      |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Quick Switcher Item   | `QuickSwitcherItem.tsx`                  | Selected state with accent rail via `before:`    |
+| Settings Input        | `SettingsInput.tsx`                      | Input focus with outline ring                    |
+| Settings Textarea     | `SettingsTextarea.tsx`                   | Input focus with outline ring                    |
+| Button Ghost          | `button.tsx` (line 21)                   | Ghost button hover with overlay-soft             |
+| Button Pill           | `HelpAgentDockButton.tsx`                | Dock item active with border + ring combo        |
+| Settings Subtab       | `SettingsSubtabBar.tsx`                  | Active tab with bottom border accent             |
+| Worktree Card         | `WorktreeCard.tsx`                       | Card hover with accent-tinged border + elevation |
+| GitHub Settings Tab   | `GitHubSettingsTab.tsx` (line 213)       | Input focus with border-shift (no outline)       |
+| Notification Settings | `NotificationSettingsTab.tsx` (line 217) | Input focus with border-shift (no outline)       |
 
 ---
 

--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -1,0 +1,174 @@
+# Canonical Interaction State Recipes
+
+This document maps each interactive component role to its canonical Tailwind class string. Use these patterns as a single reference point so new components converge on established treatments instead of inventing variations.
+
+## Critical Rules
+
+- **Never use `transition-all`** — forces Chromium to interpolate every computed property on every frame. Use specific transitions: `transition-colors`, `transition-opacity`, `transition-transform`, or explicit property lists like `transition-[width,height]`. (See lesson #4738)
+- **Never use `text-text-inverse` for hover states** — renders invisible in dark themes. Use theme-aware text colors like `text-daintree-text` or `text-canopy-text` instead. (See lesson #4630)
+- **Use `outline` utilities, not `ring`** — `outline` is truly transparent and supports Windows High Contrast Mode. `ring` uses box-shadow which fails in HCM.
+- **Always use `:focus-visible`** — `:focus` shows rings on mouse clicks; `:focus-visible` only shows for keyboard navigation.
+- **Never use accent color as default hover** — it's a scarce resource reserved for one load-bearing signal per component.
+
+---
+
+## Hover States
+
+### Ghost Button Hover
+
+**Role:** Secondary toolbar buttons, icon-only buttons where minimal visual weight needed.
+
+```tsx
+"hover:bg-overlay-soft hover:text-daintree-text focus-visible:text-daintree-text";
+```
+
+**Usage:** Combine with `transition-colors` for smooth transitions. Add `focus-visible:` variant for keyboard parity. Used in `button.tsx` ghost variant (line 21).
+
+---
+
+### List Row Hover
+
+**Role:** File trees, quick switcher items, settings lists. Entire row highlights with subtle background tint.
+
+```tsx
+"hover:bg-overlay-subtle hover:text-daintree-text";
+```
+
+**Usage:** For selected state, use `bg-overlay-soft` with `border-daintree-accent` left accent edge. Used in `QuickSwitcherItem.tsx` (line 31).
+
+---
+
+### Card Hover
+
+**Role:** Worktree cards (grid variant), settings cards. Use elevation or border change rather than large background shifts.
+
+```tsx
+"hover:border-border-default hover:shadow-[var(--theme-shadow-ambient)]";
+```
+
+**Usage:** Prefer border/shadow changes for elevation; avoid large background fills that feel heavy. Used in `WorktreeCard.tsx` grid variant (line 691).
+
+---
+
+### Settings Nav Active
+
+**Role:** Active tab in settings subtabs, navigation bars with bottom-border indicators.
+
+```tsx
+"border-b-2 border-daintree-accent text-daintree-text";
+```
+
+**Usage:** Hover state: `hover:border-daintree-border hover:text-daintree-text`. Always use `border-b-2` for consistent 2px active indicator height. Used in `SettingsSubtabBar.tsx` (line 77).
+
+---
+
+### Dock Item Active
+
+**Role:** Active dock button. Use border + ring combo for clear active state without heavy background.
+
+```tsx
+"bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30";
+```
+
+**Usage:** Semi-transparent accent at 30-40% creates subtle glow without overwhelming adjacent elements. Used in `HelpAgentDockButton.tsx` (line 27).
+
+---
+
+### Selected + Hover Combo
+
+**Role:** Selected items that also receive hover. Use pseudo-element overlay to avoid "color jump."
+
+```tsx
+// Base selected state
+"bg-overlay-soft border-daintree-accent";
+// Hover overlay added via :after pseudo-element
+"hover:after:absolute hover:after:inset-0 hover:after:bg-white/10";
+```
+
+**Usage:** Pseudo-element overlay adds brightness on hover while maintaining selection indicator. Prevents jarring color transitions when user hovers over selected item. Pattern derived from QuickSwitcherItem (lines 29-31).
+
+---
+
+## Focus States
+
+### Default Focus Ring
+
+**Role:** Standard focus indicator for buttons, cards, form controls.
+
+```tsx
+"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+```
+
+**Usage:** 2px outline with 2px offset satisfies WCAG 2.2 SC 2.4.13 (3:1 contrast ratio and size requirements). Used in `SettingsInput.tsx` (line 7).
+
+---
+
+### Inset Focus Ring
+
+**Role:** Flush list items, tree nodes, or elements with no gaps where outline shouldn't overlap adjacent items.
+
+```tsx
+"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]";
+```
+
+**Usage:** Negative offset keeps indicator inside element bounds. Use when elements are packed tightly (e.g., list items, file tree rows) where default offset would bleed into neighbors.
+
+---
+
+### Input Focus
+
+**Role:** Text inputs, textareas. Pre-allocate border width; only change color to avoid layout shifts.
+
+```tsx
+"focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
+```
+
+**Usage:** Base state includes `border-border-strong`. On focus, outline is added — do NOT change `border-width`. Changing width causes layout jitter. Used in `SettingsInput.tsx` (line 7) and `SettingsTextarea.tsx` (line 7).
+
+---
+
+## Transition Patterns
+
+| Need                    | Use Instead                                     | Why                                                                        |
+| ----------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| Color/bg/border changes | `transition-colors`                             | Covers color, background-color, border-color for most interactive states   |
+| Width/height changes    | `transition-[width]` / `transition-[height]`    | Layout-impacting properties should be explicit                             |
+| Opacity changes         | `transition-opacity`                            | Visual fades only                                                          |
+| Transform changes       | `transition-transform`                          | Animations, scale effects                                                  |
+| Multiple props          | `transition-[color,background-color,transform]` | Explicit is better than `transition-all` — forces all props to interpolate |
+
+---
+
+## Token Ladder Reference
+
+The overlay ladder drives most hover/fill states. See `theme-tokens.md` for full token definitions.
+
+| Token              | Opacity (Dark) | Opacity (Light) | Usage                           |
+| ------------------ | -------------- | --------------- | ------------------------------- |
+| `overlay-subtle`   | base 2%        | base 2%         | Lightest interactive tint       |
+| `overlay-soft`     | base 3%        | base 3%         | Hover state on list items       |
+| `overlay-medium`   | base 4%        | base 5%         | Active/selected items           |
+| `overlay-strong`   | base 6%        | base 8%         | Stronger fills, secondary hover |
+| `overlay-emphasis` | base 10%       | base 12%        | Maximum-contrast fill           |
+
+---
+
+## Canonical Examples
+
+| Component           | File                      | Key Pattern                                  |
+| ------------------- | ------------------------- | -------------------------------------------- |
+| Quick Switcher Item | `QuickSwitcherItem.tsx`   | Selected + hover with pseudo-element overlay |
+| Settings Input      | `SettingsInput.tsx`       | Input focus with outline ring                |
+| Settings Textarea   | `SettingsTextarea.tsx`    | Input focus with outline ring                |
+| Button Ghost        | `button.tsx` (line 21)    | Ghost button hover with overlay-soft         |
+| Button Pill         | `HelpAgentDockButton.tsx` | Dock item active with border + ring combo    |
+| Settings Subtab     | `SettingsSubtabBar.tsx`   | Active tab with bottom border accent         |
+| Worktree Card       | `WorktreeCard.tsx`        | Card hover with border/shadow elevation      |
+
+---
+
+## See Also
+
+- [Theme Token Reference](./theme-tokens.md) — Full token documentation including overlay ladder and focus tokens
+- [Theme System](./theme-system.md) — Three-layer theming pipeline and component overrides
+- [Visual Design Guide](./visual-guide.md) — Complete surface-by-surface visual description

--- a/docs/themes/theme-system.md
+++ b/docs/themes/theme-system.md
@@ -74,6 +74,8 @@ Component-specific styling does not belong in this layer.
 
 ## Component Overrides
 
+**See [Canonical Interaction State Recipes](./interaction-state-recipes.md)** for hover/focus implementation patterns when working with component overrides.
+
 Component CSS owns the public override surface. Themes can target specific UI regions through `extensions` without expanding the global semantic contract.
 
 | Component          | File                                 | Variable prefix                                    |

--- a/docs/themes/theme-tokens.md
+++ b/docs/themes/theme-tokens.md
@@ -135,6 +135,8 @@ A single-knob color input (`overlay-base`) drives the entire opacity ladder.
 | `overlay-selected` | Selected state                    | tint 4%      | tint 5%       |
 | `overlay-elevated` | Elevated hover                    | tint 6%      | tint 8%       |
 
+**See [Canonical Interaction State Recipes](./interaction-state-recipes.md)** for hover/focus implementation patterns using these overlay tokens.
+
 Set `overlay-base` to a hued color to tint all hover and fill states (e.g. Fiordland: icy blue `#B4DCF0`, Arashiyama: warm cream `#FFECE6`).
 
 ## Wash Tokens


### PR DESCRIPTION
## Summary
- Added a single reference page mapping every interactive component role to its canonical Tailwind class string, so new components converge on established patterns instead of inventing fresh variations.
- Cross-linked from the existing theme-system and theme-tokens docs so people working on component overrides find it naturally.
- Covers hover states (ghost button, list row, card), active states (settings nav, dock item), focus rings (default with offset, inset for flush items), input focus, and the layered selected+hover combo.

Resolves #5858

## Changes
- New `docs/themes/interaction-state-recipes.md` with critical rules, canonical class strings per role, and references to existing well-built primitives as examples.
- Added cross-references in `docs/themes/theme-system.md` and `docs/themes/theme-tokens.md`.

## Testing
- Verified all referenced class strings are valid Tailwind tokens that exist in the current config.
- Confirmed the referenced component examples (QuickSwitcherItem, SettingsInput, SettingsTextarea, toolbar buttons) use the documented patterns.