### PR TITLE
refactor(errors): replace ad-hoc Unknown error fallbacks with formatErrorMessage

### DIFF
--- a/e2e/full/core-terminal-isolation.spec.ts
+++ b/e2e/full/core-terminal-isolation.spec.ts
@@ -64,6 +64,7 @@ async function ptySubmit(page: import("@playwright/test").Page, panelId: string,
         await w.electron.terminal.submit(id, payload);
         return { ok: true };
       } catch (err) {
+        // eslint-disable-next-line no-restricted-syntax -- runs inside page.evaluate, cannot import shared helpers.
         return { ok: false, reason: err instanceof Error ? err.message : String(err) };
       }
     },

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -6,6 +6,7 @@ import * as crypto from "node:crypto";
 import * as os from "node:os";
 import { defineIpcNamespace, op } from "../define.js";
 import { CLIPBOARD_METHOD_CHANNELS } from "./clipboard.preload.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 const CLIPBOARD_DIR_NAME = "daintree-clipboard";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -77,7 +78,7 @@ async function handleSaveImage(): Promise<
 
     return { ok: true, filePath, thumbnailDataUrl };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to save clipboard image");
     return { ok: false, error: message };
   }
 }
@@ -101,7 +102,7 @@ async function handleThumbnailFromPath(
 
     return { ok: true, filePath, thumbnailDataUrl };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to generate clipboard thumbnail");
     return { ok: false, error: message };
   }
 }
@@ -118,7 +119,7 @@ async function handleWriteImage(
     clipboard.writeImage(image);
     return { ok: true };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to write clipboard image");
     return { ok: false, error: message };
   }
 }
@@ -131,7 +132,7 @@ function handleWriteText(text: string): { ok: true } | { ok: false; error: strin
     clipboard.writeText(text);
     return { ok: true };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to write clipboard text");
     return { ok: false, error: message };
   }
 }
@@ -152,7 +153,7 @@ function handleWriteSelection(text: string): { ok: true } | { ok: false; error: 
     clipboard.writeText(text, "selection");
     return { ok: true };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to write PRIMARY selection");
     return { ok: false, error: message };
   }
 }
@@ -165,7 +166,7 @@ function handleReadSelection(): { ok: true; text: string } | { ok: false; error:
     const text = clipboard.readText("selection");
     return { ok: true, text };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Failed to read PRIMARY selection");
     return { ok: false, error: message };
   }
 }

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import path from "path";
 import { pathToFileURL } from "url";
 import { CHANNELS } from "../channels.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   broadcastToRenderer,
   checkRateLimit,
@@ -357,7 +358,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
       return result;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to copy context file");
       console.error(`[${traceId}] Failed to save/copy context file:`, errorMessage);
       return {
         ...result,

--- a/electron/ipc/handlers/git-read.ts
+++ b/electron/ipc/handlers/git-read.ts
@@ -5,6 +5,7 @@ import { checkRateLimit, typedHandle, typedHandleWithContext } from "../utils.js
 import type { HandlerDependencies } from "../types.js";
 import type { PulseRangeDays, ProjectPulse } from "../../../shared/types/pulse.js";
 import { taskWorktreeService } from "../../services/TaskWorktreeService.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -73,7 +74,7 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
     try {
       return await deps.worktreeService.getFileDiff(cwd, filePath, status);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get file diff");
       console.error("[Git] Failed to get file diff via WorkspaceClient:", errorMessage);
       throw new Error(`Failed to get file diff: ${errorMessage}`, { cause: error });
     }

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -23,6 +23,7 @@ import {
   classifyGitError,
   getGitRecoveryAction,
 } from "../../../shared/utils/gitOperationErrors.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -339,7 +340,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
         } catch (pushErr) {
           // Keep the narrow upstream-missing auto-retry via substring match —
           // classifier's `config-missing` also covers unrelated config errors.
-          const msg = pushErr instanceof Error ? pushErr.message : String(pushErr);
+          const msg = formatErrorMessage(pushErr, "git push failed");
           if (msg.includes("no upstream branch") || msg.includes("has no upstream")) {
             await git.push(["--set-upstream", "origin", branchName]);
           } else {
@@ -355,7 +356,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
         soundService.play("git-push-error");
       }
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "git push failed");
       const gitReason = classifyGitError(error);
       return {
         success: false,

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../types/index.js";
 import { gitHubRateLimitService, gitHubTokenHealthService } from "../../services/github/index.js";
 import { getWorkspaceClient } from "../../services/WorkspaceClient.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 export function buildGitHubSearchQuery(
   searchText: string | undefined,
@@ -126,7 +127,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "Failed to fetch GitHub repo stats");
       return {
         commitCount: 0,
         issueCount: null,
@@ -194,7 +195,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         error: result.error,
       };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "Failed to fetch GitHub project health");
       return {
         ciStatus: "none",
         issueCount: 0,
@@ -304,7 +305,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         throw new Error(`Only https:// or http:// PR URLs are allowed, got ${url.protocol}`);
       }
     } catch (error) {
-      throw new Error(`Invalid PR URL: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(formatErrorMessage(error, "Invalid PR URL"));
     }
     await shell.openExternal(prUrl);
   };

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -6,6 +6,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -196,7 +197,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       console.error(`[IPC] project:close: Failed to close project ${projectId}:`, error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: formatErrorMessage(error, "Failed to close project"),
         processesKilled: 0,
         terminalsKilled: 0,
       };

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -13,6 +13,7 @@ import type {
   CloneRepoResult,
   CloneRepoProgressEvent,
 } from "../../../../shared/types/ipc/gitClone.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerGitCloneHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -137,7 +138,7 @@ export function registerGitCloneHandlers(): () => void {
         return { success: false, cancelled: true, error: "Clone cancelled" };
       }
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to clone repository");
       emitProgress("error", 0, `Clone failed: ${errorMessage}`);
       return { success: false, error: errorMessage };
     } finally {

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -13,6 +13,7 @@ import type {
   GitInitResult,
   GitInitProgressEvent,
 } from "../../../../shared/types/ipc/gitInit.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerGitInitHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -136,7 +137,7 @@ export function registerGitInitHandlers(): () => void {
           completedSteps.push("commit");
           emitProgress("commit", "success", `Committed: ${initialCommitMessage}`);
         } catch (commitError) {
-          const errorMsg = commitError instanceof Error ? commitError.message : String(commitError);
+          const errorMsg = formatErrorMessage(commitError, "Failed to create initial commit");
           if (errorMsg.includes("user.email") || errorMsg.includes("user.name")) {
             emitProgress(
               "commit",
@@ -157,7 +158,7 @@ export function registerGitInitHandlers(): () => void {
       emitProgress("complete", "success", "Git initialization complete");
       return { success: true, completedSteps };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Git initialization failed");
       emitProgress("error", "error", "Git initialization failed", errorMessage);
       return {
         success: false,

--- a/electron/ipc/handlers/terminal/artifacts.ts
+++ b/electron/ipc/handlers/terminal/artifacts.ts
@@ -8,6 +8,7 @@ import path from "path";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 import { typedHandle, typedHandleWithContext } from "../../utils.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerArtifactHandlers(deps: HandlerDependencies): () => void {
   const mainWindow = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
@@ -73,7 +74,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
         success: true,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to save artifact");
       console.error("[Artifact] Failed to save to file:", errorMessage);
       throw new Error(`Failed to save artifact: ${errorMessage}`);
     }
@@ -142,7 +143,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       } catch (error) {
         return {
           success: false,
-          error: `Invalid cwd: ${error instanceof Error ? error.message : String(error)}`,
+          error: formatErrorMessage(error, "Invalid cwd"),
         };
       }
 
@@ -172,7 +173,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
         await fs.unlink(tmpPatchPath).catch(() => {});
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to apply patch");
       console.error("[Artifact] Failed to apply patch:", errorMessage);
       return {
         success: false,

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -10,6 +10,7 @@ import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 import { typedHandle } from "../../utils.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerTerminalIOHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -93,7 +94,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       }
       ptyClient.submit(id, text);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to submit to terminal");
       throw new Error(`Failed to submit to terminal: ${errorMessage}`);
     }
   };
@@ -215,7 +216,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       ptyClient.forceResume(id);
       return { success: true };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to force resume terminal");
       console.error(`[IPC] Failed to force resume terminal ${id}:`, errorMessage);
       return { success: false, error: errorMessage };
     }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -15,6 +15,7 @@ import {
   clearAgentSessions,
 } from "../../../services/pty/agentSessionHistory.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
@@ -242,7 +243,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
       return id;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to spawn terminal");
       throw new Error(`Failed to spawn terminal: ${errorMessage}`);
     }
   };
@@ -255,7 +256,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       }
       ptyClient.kill(id);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to kill terminal");
       throw new Error(`Failed to kill terminal: ${errorMessage}`);
     }
   };
@@ -276,7 +277,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       }
       ptyClient.trash(id);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to trash terminal");
       throw new Error(`Failed to trash terminal: ${errorMessage}`);
     }
   };
@@ -289,7 +290,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       }
       return ptyClient.restore(id);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to restore terminal");
       throw new Error(`Failed to restore terminal: ${errorMessage}`);
     }
   };

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -8,6 +8,7 @@ import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn, logError } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
 import { typedHandle } from "../../utils.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -25,7 +26,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       }
       return await ptyClient.wakeTerminal(id);
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to wake terminal");
       throw new Error(`Failed to wake terminal: ${errorMessage}`);
     }
   };
@@ -46,7 +47,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       }
       return serializedState;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get serialized terminal state");
       throw new Error(`Failed to get serialized terminal state: ${errorMessage}`);
     }
   };
@@ -110,7 +111,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
       return terminalInfo;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get terminal info");
       throw new Error(`Failed to get terminal info: ${errorMessage}`);
     }
   };
@@ -158,7 +159,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       logInfo(`terminal:replayHistory(${terminalId}): replayed ${replayed} lines`);
       return { replayed };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to replay terminal history");
       throw new Error(`Failed to replay terminal history: ${errorMessage}`);
     }
   };
@@ -224,7 +225,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       );
       return terminals;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get terminals for project");
       throw new Error(`Failed to get terminals for project: ${errorMessage}`);
     }
   };
@@ -268,7 +269,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       logInfo(`terminal:getAvailable: found ${sanitized.length} available terminals`);
       return sanitized;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get available terminals");
       throw new Error(`Failed to get available terminals: ${errorMessage}`);
     }
   };
@@ -323,7 +324,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       logInfo(`terminal:getByState(${state}): found ${sanitized.length} terminals`);
       return sanitized;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get terminals by state");
       throw new Error(`Failed to get terminals by state: ${errorMessage}`);
     }
   };
@@ -367,7 +368,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       logInfo(`terminal:getAll: found ${sanitized.length} terminals`);
       return sanitized;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to get all terminals");
       throw new Error(`Failed to get all terminals: ${errorMessage}`);
     }
   };
@@ -420,7 +421,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         detectedProcessId: terminal.detectedProcessId,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to reconnect to terminal");
       throw new Error(`Failed to reconnect to terminal: ${errorMessage}`);
     }
   };

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -12,6 +12,7 @@ import type {
   SerializedConsoleRow,
   CdpPropertyDescriptor,
 } from "../../../shared/types/ipc/webviewConsole.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 interface CdpSession {
   runtimeEnabled: boolean;
@@ -236,7 +237,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         state: frozen ? "frozen" : "active",
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "CDP lifecycle state failed");
       const isExpected =
         message.includes("Target closed") ||
         message.includes("Inspected target navigated") ||
@@ -342,7 +343,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         wc.debugger.on("detach", detachListener);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "CDP console capture start failed");
       const isExpected =
         message.includes("Target closed") ||
         message.includes("Cannot attach") ||
@@ -506,7 +507,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
 
       return { properties };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "Failed to get object properties");
       if (message.includes("Could not find object")) {
         return { properties: [] };
       }
@@ -754,7 +755,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         });
       });
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatErrorMessage(err, "CDP setup failed");
       console.error("[OAuthLoopback] CDP setup failed:", msg);
       // Still try to navigate even without interception — might work for providers
       // that don't enforce strict redirect_uri matching at token exchange

--- a/electron/ipc/handlers/worktree/task.ts
+++ b/electron/ipc/handlers/worktree/task.ts
@@ -19,6 +19,7 @@ import {
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { taskWorktreeService } from "../../../services/TaskWorktreeService.js";
 import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 
 export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -303,7 +304,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
       allStates = await deps.worktreeService.getAllStatesAsync(senderWindowCleanup?.id);
     } catch (error) {
       logDebug("Could not fetch worktree states for cleanup pre-check", {
-        error: error instanceof Error ? error.message : String(error),
+        error: formatErrorMessage(error, "Could not fetch worktree states"),
         taskId,
       });
     }
@@ -335,7 +336,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
         // Remove from tracking after successful deletion
         taskWorktreeService.removeTaskWorktreeMapping(currentProjectId, taskId, worktreeId);
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = formatErrorMessage(error, "Failed to cleanup worktree");
 
         // If worktree not found, treat as success and remove mapping (idempotent)
         if (errorMessage.includes("not found") || errorMessage.includes("does not exist")) {

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -10,6 +10,7 @@ import { autoUpdaterService } from "./services/AutoUpdaterService.js";
 import { getPluginMenuItems } from "./services/pluginMenuRegistry.js";
 import { getAppWebContents } from "./window/webContentsRegistry.js";
 import { PRODUCT_NAME, PRODUCT_WEBSITE, PRODUCT_COPYRIGHT_ORG } from "./utils/productBranding.js";
+import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 app.setAboutPanelOptions({
   applicationName: PRODUCT_NAME,
@@ -351,7 +352,7 @@ export function createApplicationMenu(
               }
               createApplicationMenu(mainWindow, cliAvailabilityService);
             } catch (err) {
-              const message = err instanceof Error ? err.message : String(err);
+              const message = formatErrorMessage(err, "Failed to install CLI");
               if (targetWin && !targetWin.isDestroyed()) {
                 const wc = getAppWebContents(targetWin);
                 if (!wc.isDestroyed()) {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -56,6 +56,7 @@ import {
   BACKPRESSURE_SAFETY_TIMEOUT_MS,
 } from "./pty-host/index.js";
 import { isSmokeTestTerminalId } from "../shared/utils/smokeTestTerminals.js";
+import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -85,7 +86,7 @@ process.on("unhandledRejection", (reason) => {
     sendEvent({
       type: "error",
       id: "system",
-      error: String(reason instanceof Error ? reason.message : reason),
+      error: formatErrorMessage(reason, "Unhandled rejection in PTY host"),
     });
   } catch {
     // ignore

--- a/electron/services/AppAgentService.ts
+++ b/electron/services/AppAgentService.ts
@@ -1,5 +1,6 @@
 import { store } from "../store.js";
 import type { AppAgentConfig } from "../../shared/types/appAgent.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 
@@ -79,7 +80,7 @@ export class AppAgentService {
 
       return {
         valid: false,
-        error: error instanceof Error ? error.message : "Failed to connect to API",
+        error: formatErrorMessage(error, "Failed to connect to API"),
       };
     }
   }
@@ -148,7 +149,7 @@ export class AppAgentService {
 
       return {
         valid: false,
-        error: error instanceof Error ? error.message : "Failed to connect to API",
+        error: formatErrorMessage(error, "Failed to connect to API"),
       };
     }
   }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -115,6 +115,7 @@ export class CliAvailabilityService {
             }
           });
         } catch (error) {
+          // eslint-disable-next-line no-restricted-syntax -- diagnostic console.warn passes the raw error if not an Error; not a user-visible string.
           console.warn("[CliAvailabilityService]", error instanceof Error ? error.message : error);
           outcomeEntries = entries.map(([id]) => [
             id,

--- a/electron/services/CommandService.ts
+++ b/electron/services/CommandService.ts
@@ -13,6 +13,7 @@ import type {
 } from "../../shared/types/commands.js";
 import { projectStore } from "./ProjectStore.js";
 import { substituteTemplateVariables } from "../../shared/utils/promptTemplate.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
@@ -374,7 +375,7 @@ class CommandServiceImpl {
       const result = await command.execute(context, effectiveArgs);
       return result as CommandResult<TResult>;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "Command execution failed");
       // Only include stack traces in development mode
       const isDev = process.env.NODE_ENV === "development";
       return {

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as fs from "fs/promises";
 import type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress } from "../types/index.js";
 import { logWarn } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress };
 
@@ -201,7 +202,7 @@ class CopyTreeService {
         includedFiles: 0,
         includedSize: 0,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: formatErrorMessage(error, "Failed to generate context"),
       };
     }
   }

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -17,6 +17,7 @@ import type {
 import type { DevServerError } from "../../shared/utils/devServerErrors.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { markPerformance } from "../utils/performance.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 interface DevPreviewSession extends DevPreviewSessionState {
   cwd: string;
@@ -236,7 +237,7 @@ export class DevPreviewSessionService {
       try {
         this.ptyClient.kill(terminalId, "dev-preview:dispose");
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = formatErrorMessage(err, "Failed to kill dev preview terminal");
         if (!this.isBenignMissingTerminalError(message)) {
           console.warn("[DevPreviewSessionService] Failed to kill terminal during dispose:", err);
         }
@@ -405,7 +406,7 @@ export class DevPreviewSessionService {
             this.releasePort(key);
             this.restoreWorktreeMapping(session.worktreeId, key);
           } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
+            const message = formatErrorMessage(err, "Failed to stop dev preview");
             this.updateSession(session, {
               status: "error",
               url: null,
@@ -447,7 +448,7 @@ export class DevPreviewSessionService {
             this.releasePort(key);
             this.restoreWorktreeMapping(session.worktreeId, key);
           } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
+            const message = formatErrorMessage(err, "Failed to stop dev preview");
             console.warn("[DevPreviewSessionService] stopByProject failed for session", {
               panelId: session.panelId,
               projectId: session.projectId,
@@ -685,7 +686,7 @@ export class DevPreviewSessionService {
     } catch (err) {
       console.warn("[DevPreviewSessionService] replayRecentOutput failed for terminal:", {
         terminalId,
-        error: err instanceof Error ? err.message : String(err),
+        error: formatErrorMessage(err, "Failed to replay terminal history"),
       });
     }
   }
@@ -737,7 +738,7 @@ export class DevPreviewSessionService {
         terminalId,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to start dev server");
       this.detachTerminal(session);
       this.updateSession(session, {
         status: "error",
@@ -848,7 +849,7 @@ export class DevPreviewSessionService {
     try {
       this.ptyClient.kill(terminalId, `dev-preview:${context}`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = formatErrorMessage(err, "Failed to kill dev preview terminal");
       if (!this.isBenignMissingTerminalError(message)) {
         throw new Error(`Failed to kill terminal (${context}): ${message}`);
       }
@@ -1049,7 +1050,7 @@ export class DevPreviewSessionService {
       });
     } catch (error) {
       session.isRunningInstall = false;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to start dependency install");
       this.detachTerminal(session);
       this.updateSession(session, {
         status: "error",
@@ -1128,7 +1129,7 @@ export class DevPreviewSessionService {
         session.pendingUrl = null;
         session.readinessAbort = null;
 
-        const message = err instanceof Error ? err.message : String(err);
+        const message = formatErrorMessage(err, "Dev server readiness check failed");
         console.warn("[DevPreviewSessionService] Readiness poll error:", {
           url,
           panelId: session.panelId,

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -33,6 +33,7 @@ import {
 } from "./github/index.js";
 import type { RollupContextNode } from "./github/index.js";
 import { getLastAuthMetadata } from "./github/GitHubAuth.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 import type {
   RepoContext,
@@ -196,7 +197,7 @@ export async function getRepoContext(cwd: string): Promise<RepoContext | null> {
 }
 
 function isRepoNotFoundError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatErrorMessage(error, "Failed to access GitHub repository");
   const lower = message.toLowerCase();
   // Broad pattern match - includes both repo-level and resource-level "not found" errors.
   // This is acceptable because withRepoContextRetry only retries when repo context actually
@@ -996,7 +997,7 @@ export function parseGitHubError(error: unknown): string {
   if (error instanceof GitHubRateLimitError) {
     return rateLimitMessage(error.kind, error.resumeAt);
   }
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatErrorMessage(error, "GitHub request failed");
   const isTimeout = error instanceof Error && error.name === "TimeoutError";
 
   if (
@@ -1779,7 +1780,7 @@ export async function getIssueByNumber(
       return parseIssueNode(issue as Record<string, unknown>);
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatErrorMessage(error, "Failed to fetch GitHub issue");
     if (message === "Not a GitHub repository") {
       throw error;
     }
@@ -1813,7 +1814,7 @@ export async function getPRByNumber(cwd: string, prNumber: number): Promise<GitH
       return parsePRNode(pr as Record<string, unknown>);
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatErrorMessage(error, "Failed to fetch GitHub pull request");
     if (message === "Not a GitHub repository") {
       throw error;
     }

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -7,6 +7,7 @@ import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
 import { WorktreeRemovedError, GitError, toGitOperationError } from "../utils/errorTypes.js";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/types/ipc/git.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -487,7 +488,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     try {
       return await operation();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, `Git operation failed: ${context}`);
 
       if (
         errorMessage.includes("ENOENT") ||

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -13,6 +13,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/types/actions.js";
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const DISCOVERY_DIR = path.join(os.homedir(), ".daintree");
 const DISCOVERY_FILE = path.join(DISCOVERY_DIR, "mcp.json");
@@ -414,7 +415,7 @@ export class McpServerService {
           content: [
             {
               type: "text" as const,
-              text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+              text: `Error: ${formatErrorMessage(err, "Action dispatch failed")}`,
             },
           ],
           isError: true,

--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -2,6 +2,7 @@ import { events } from "./events.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import type { SnapshotInfo } from "../../shared/types/ipc/git.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const STASH_PREFIX = "daintree:pre-agent:";
 const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
@@ -50,7 +51,7 @@ class PreAgentSnapshotService {
       this.snapshots.delete(worktreeId);
       logWarn("[PreAgentSnapshot] Failed to create snapshot", {
         worktreeId,
-        error: err instanceof Error ? err.message : String(err),
+        error: formatErrorMessage(err, "Failed to create pre-agent snapshot"),
       });
       events.emit("ui:notify", {
         type: "warning",
@@ -228,7 +229,7 @@ class PreAgentSnapshotService {
         } catch (err) {
           logWarn("[PreAgentSnapshot] Failed to prune snapshot", {
             worktreeId,
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "Failed to prune pre-agent snapshot"),
           });
         }
       }

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -2,6 +2,7 @@ import type { SimpleGit } from "simple-git";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { existsSync } from "fs";
 import { logDebug, logError } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import type {
   ProjectPulse,
   HeatCell,
@@ -107,7 +108,7 @@ export class ProjectPulseService {
         return pulse;
       } catch (error) {
         logError("ProjectPulse computation failed", {
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Failed to compute project pulse"),
           stack: error instanceof Error ? error.stack : undefined,
           worktreeId: options.worktreeId,
           worktreePath: options.worktreePath,
@@ -156,7 +157,7 @@ export class ProjectPulseService {
     try {
       headSha = (await git.raw(["rev-parse", "--verify", "HEAD"])).trim() || undefined;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to read git HEAD");
       const noCommitsPatterns = [
         "fatal: ambiguous argument 'HEAD'",
         "unknown revision",

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -14,6 +14,7 @@ import { app } from "electron";
 import { GitService } from "./GitService.js";
 import { isDaintreeError } from "../utils/errorTypes.js";
 import { logError } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { store } from "../store.js";
 import { getSharedDb } from "./persistence/db.js";
 import {
@@ -131,7 +132,8 @@ export class ProjectStore {
     try {
       gitRoot = await this.getGitRoot(projectPath);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to add project");
+      // eslint-disable-next-line no-restricted-syntax -- typed extraction of optional Daintree error cause; undefined fallback is required so the join below skips it.
       const causeMessage =
         isDaintreeError(error) && error.cause instanceof Error ? error.cause.message : undefined;
       const combined = [message, causeMessage].filter(Boolean).join("\n");

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -13,6 +13,7 @@ import { store } from "../store.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { markPerformance, withPerformanceSpan } from "../utils/performance.js";
 import { buildSwitchHydrateResult } from "./AppHydrationService.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export class ProjectSwitchService {
   private deps: HandlerDependencies;
@@ -230,7 +231,7 @@ export class ProjectSwitchService {
       return {};
     } catch (err) {
       console.error("[ProjectSwitch] Failed to load worktrees for project:", err);
-      return { error: err instanceof Error ? err.message : "Failed to load worktrees" };
+      return { error: formatErrorMessage(err, "Failed to load worktrees") };
     }
   }
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -8,6 +8,7 @@ import {
 import { gitHubRateLimitService } from "./github/index.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
 
@@ -148,7 +149,7 @@ class PullRequestService {
         logDebug("Running debounced PR check", { candidateCount: this.candidates.size });
         void this.checkForPRs().catch((err) =>
           logWarn("Debounced PR check failed", {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "Debounced PR check failed"),
           })
         );
 
@@ -267,7 +268,7 @@ class PullRequestService {
           this.consecutiveErrors = 0;
           this.nextRetryAt = 0;
           void this.checkForPRs()
-            .catch((err) => this.handleError(err instanceof Error ? err.message : String(err)))
+            .catch((err) => this.handleError(formatErrorMessage(err, "PR check failed")))
             .finally(() => this.scheduleNextPoll());
         }, delay);
       }
@@ -289,7 +290,7 @@ class PullRequestService {
     this.pollTimer = setTimeout(() => {
       this.pollTimer = null;
       void this.checkForPRs()
-        .catch((err) => this.handleError(err instanceof Error ? err.message : String(err)))
+        .catch((err) => this.handleError(formatErrorMessage(err, "PR check failed")))
         .finally(() => this.scheduleNextPoll());
     }, interval);
   }
@@ -328,7 +329,7 @@ class PullRequestService {
       void this.revalidateResolvedPRs()
         .catch((err) =>
           logWarn("Revalidation unexpected error", {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "PR revalidation failed"),
           })
         )
         .finally(() => this.scheduleRevalidation());
@@ -439,7 +440,7 @@ class PullRequestService {
       }
     } catch (error) {
       logWarn("Revalidation check error", {
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: formatErrorMessage(error, "PR revalidation failed"),
       });
     }
   }
@@ -530,7 +531,7 @@ class PullRequestService {
         }
       }
     } catch (error) {
-      this.handleError(error instanceof Error ? error.message : "Unknown error");
+      this.handleError(formatErrorMessage(error, "PR check failed"));
     }
   }
 

--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -16,6 +16,7 @@ import type { PtyClient } from "./PtyClient.js";
 import type { AgentState } from "../../shared/types/agent.js";
 import type { DaintreeEventMap } from "./events.js";
 import type { TaskRoutingHints } from "../../shared/types/task.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 /**
  * Check if an agent is available to receive a new task.
@@ -186,7 +187,7 @@ export class TaskOrchestrator {
 
           console.warn(
             `[TaskOrchestrator] Failed to mark task ${task.id} as running:`,
-            error instanceof Error ? error.message : String(error)
+            formatErrorMessage(error, "Failed to mark task running")
           );
           break; // Don't try to assign more tasks if we hit an error
         }
@@ -385,7 +386,7 @@ export class TaskOrchestrator {
     } catch (error) {
       console.error(
         `[TaskOrchestrator] Failed to mark task ${taskId} as completed:`,
-        error instanceof Error ? error.message : String(error)
+        formatErrorMessage(error, "Failed to mark task completed")
       );
     }
 
@@ -434,7 +435,7 @@ export class TaskOrchestrator {
     } catch (err) {
       console.error(
         `[TaskOrchestrator] Failed to cancel task ${taskId} after agent kill:`,
-        err instanceof Error ? err.message : String(err)
+        formatErrorMessage(err, "Failed to cancel task")
       );
     }
 
@@ -491,7 +492,7 @@ export class TaskOrchestrator {
       } catch (err) {
         console.error(
           `[TaskOrchestrator] Failed to mark task ${taskId} completed after agent exit:`,
-          err instanceof Error ? err.message : String(err)
+          formatErrorMessage(err, "Failed to mark task completed")
         );
       }
     }
@@ -541,7 +542,7 @@ export class TaskOrchestrator {
         // Task may already be in a terminal state
         console.warn(
           `[TaskOrchestrator] Failed to cancel task ${task.id} on worktree removal:`,
-          error instanceof Error ? error.message : String(error)
+          formatErrorMessage(error, "Failed to cancel task on worktree removal")
         );
       }
     }

--- a/electron/services/UserAgentRegistryService.ts
+++ b/electron/services/UserAgentRegistryService.ts
@@ -2,6 +2,7 @@ import { store } from "../store.js";
 import type { UserAgentRegistry, UserAgentConfig } from "../../shared/types/index.js";
 import { UserAgentConfigSchema, UserAgentRegistrySchema } from "../../shared/types/index.js";
 import { setUserRegistry, isBuiltInAgent } from "../../shared/config/agentRegistry.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const RESERVED_REGISTRY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 const SAFE_AGENT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
@@ -71,7 +72,7 @@ export class UserAgentRegistryService {
       this.syncToSharedRegistry();
       return { success: true };
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unknown error";
+      const message = formatErrorMessage(error, "Failed to save user agent registry");
       console.error("[UserAgentRegistryService] Failed to save registry:", error);
       return { success: false, error: `Failed to save: ${message}` };
     }

--- a/electron/services/VoiceCorrectionService.ts
+++ b/electron/services/VoiceCorrectionService.ts
@@ -7,6 +7,7 @@ import {
   buildMicroCorrectionSystemPrompt,
   type CorrectionPromptContext,
 } from "../../shared/config/voiceCorrection.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export { CORE_CORRECTION_PROMPT, buildCorrectionSystemPrompt };
 
@@ -160,7 +161,7 @@ export class VoiceCorrectionService {
         confirmedText,
       };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Voice correction failed");
       logWarn(`${P} Correction failed, using raw text`, { error: msg });
       return {
         action: "no_change",
@@ -272,7 +273,7 @@ export class VoiceCorrectionService {
 
       return { ...result, confirmedText };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Voice micro-correction failed");
       logWarn(`${P} Micro-correction failed, using raw text`, { error: msg });
       return {
         action: "no_change",
@@ -332,7 +333,7 @@ export class VoiceCorrectionService {
 
       return parsed.file_references.filter((r) => r.description.trim().length > 0);
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Voice file link detection failed");
       logWarn(`${P} File link detection failed`, { error: msg });
       return [];
     }

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -1,5 +1,6 @@
 import { logDebug, logWarn } from "../utils/logger.js";
 import { fileSearchService } from "./FileSearchService.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const P = "[VoiceFileLinkResolver]";
 const NL_CONFIDENCE_THRESHOLD = 0.67;
@@ -50,7 +51,7 @@ export class VoiceFileLinkResolver {
 
       return await this.aiRerank(description, candidates, apiKey);
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Voice file link resolution failed");
       logWarn(`${P} Resolution failed`, { error: msg });
       return null;
     }
@@ -161,7 +162,7 @@ export class VoiceFileLinkResolver {
 
       return null;
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Voice AI rerank failed");
       logWarn(`${P} AI rerank failed, using top candidate`, { error: msg });
       return candidates[0];
     }

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -2,6 +2,7 @@ import { createClient, LiveTranscriptionEvents } from "@deepgram/sdk";
 import type { ListenLiveClient, LiveTranscriptionEvent } from "@deepgram/sdk";
 import type { VoiceInputSettings, VoiceInputStatus } from "../../shared/types/ipc/api.js";
 import { CONFIDENCE_TAG_THRESHOLD } from "../../shared/config/voiceCorrection.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { logDebug, logInfo, logWarn, logError } from "../utils/logger.js";
 
 const P = "[VoiceTranscription]";
@@ -247,11 +248,8 @@ export class VoiceTranscriptionService {
       connection.on(LiveTranscriptionEvents.Error, (err: Error) => {
         this.clearConnectTimeout();
         if (this.sessionId !== mySessionId) return;
-        const errObj = err as { message?: string; error?: string };
-        const message =
-          err instanceof Error
-            ? err.message
-            : (errObj?.message ?? errObj?.error ?? "Deepgram error");
+        const errObj = err as { error?: string };
+        const message = formatErrorMessage(err, errObj?.error ?? "Deepgram error");
         logError(`${P} Connection error`, { message });
         this.cleanupConnection();
         this.emit({ type: "error", message });

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -16,6 +16,7 @@ import { broadcastToRenderer } from "../ipc/utils.js";
 import { gitHubRateLimitService } from "./github/index.js";
 import { store } from "../store.js";
 import { isValidLogOverrideLevel } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 import { WorkspaceHostProcess } from "./WorkspaceHostProcess.js";
 import type {
@@ -1094,7 +1095,7 @@ export class WorkspaceClient extends EventEmitter {
         includedFiles: 0,
         includedSize: 0,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: formatErrorMessage(error, "Failed to generate context"),
       };
     }
   }

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../shared/types/workspace-host.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
 import { createLogger } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const logger = createLogger("main:WorkspaceHost");
 const logInfo = (msg: string, ctx?: Record<string, unknown>) =>
@@ -425,7 +426,7 @@ export class WorkspaceHostProcess extends EventEmitter {
     } catch (error) {
       console.error(`[WorkspaceHost:${this.serviceName}] Failed to fork:`, error);
       if (this.readyReject) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = formatErrorMessage(error, "Workspace host failed to fork");
         this.readyReject(new Error(`Workspace host failed to fork: ${errorMessage}`));
         this.readyReject = null;
       }

--- a/electron/services/__tests__/AppAgentService.adversarial.test.ts
+++ b/electron/services/__tests__/AppAgentService.adversarial.test.ts
@@ -73,16 +73,28 @@ describe("AppAgentService adversarial", () => {
     expect(result).toEqual({ valid: true });
   });
 
-  it("testApiKey returns a stable friendly message when fetch rejects with a non-Error value", async () => {
+  it("testApiKey returns a stable friendly message when fetch rejects with an opaque value", async () => {
     mockFetch(
       vi.fn(async () => {
-        throw "string rejection" as unknown as Error;
+        throw 42 as unknown as Error;
       }) as unknown as typeof fetch
     );
 
     const result = await new AppAgentService().testApiKey("k");
     expect(result.valid).toBe(false);
     expect(result.error).toBe("Failed to connect to API");
+  });
+
+  it("testApiKey surfaces a thrown string verbatim (formatErrorMessage treats strings as messages)", async () => {
+    mockFetch(
+      vi.fn(async () => {
+        throw "rate limit exceeded" as unknown as Error;
+      }) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("rate limit exceeded");
   });
 
   it("testApiKey 401 maps to 'Invalid API key'", async () => {

--- a/electron/services/commands/githubCreateIssue.ts
+++ b/electron/services/commands/githubCreateIssue.ts
@@ -1,6 +1,7 @@
 import type { DaintreeCommand, CommandResult } from "../../../shared/types/commands.js";
 import { getGitHubToken, getRepoContext, clearGitHubCaches } from "../GitHubService.js";
 import { GITHUB_API_TIMEOUT_MS } from "../github/index.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 interface CreateIssueArgs {
   title?: string;
@@ -120,7 +121,7 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
     try {
       repoContext = await getRepoContext(cwd);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to determine repository context");
       return {
         success: false,
         error: {
@@ -258,7 +259,7 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
         },
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to create GitHub issue");
 
       if (
         message.includes("ENOTFOUND") ||

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -23,6 +23,7 @@ import { getWorkspaceClient } from "../WorkspaceClient.js";
 import { GitService } from "../GitService.js";
 import { generateWorktreePath, validatePathPattern } from "../../../shared/utils/pathPattern.js";
 import { resolveWorktreePattern } from "../../utils/worktreePattern.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 /** Arguments for the github:work-issue command */
 export interface GitHubWorkIssueArgs {
@@ -109,7 +110,7 @@ async function fetchIssueDetails(cwd: string, issueNumber: number): Promise<Issu
     })) as GraphQlQueryResponseData;
   } catch (error) {
     // Handle GraphQL errors (auth, rate limit, network)
-    const message = error instanceof Error ? error.message : String(error);
+    const message = formatErrorMessage(error, "Failed to fetch GitHub issue");
     if (message.includes("401") || message.includes("Unauthorized")) {
       throw new Error("GitHub authentication failed. Check your token.");
     }
@@ -291,7 +292,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       const gitService = new GitService(cwd);
       rootPath = await gitService.getRepositoryRoot(cwd);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Not a git repository");
       return {
         success: false,
         error: {
@@ -317,7 +318,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
     try {
       issue = await fetchIssueDetails(rootPath, issueNumber);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to fetch issue");
 
       if (message.includes("not found")) {
         return {
@@ -388,7 +389,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
         fromRemote = detected.fromRemote;
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to detect base branch");
       return {
         success: false,
         error: {
@@ -406,7 +407,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
     try {
       finalBranchName = await gitService.findAvailableBranchName(branchName);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to validate branch name");
       return {
         success: false,
         error: {
@@ -439,7 +440,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       try {
         await mkdir(parentDir, { recursive: true });
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatErrorMessage(error, "Failed to create worktree directory");
         return {
           success: false,
           error: {
@@ -472,7 +473,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
         fromRemote,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to create worktree");
       return {
         success: false,
         error: {
@@ -488,7 +489,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       await workspaceClient.setActiveWorktree(worktreeId);
     } catch (error) {
       // Non-fatal - worktree was created, just couldn't switch
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to switch worktree");
       switchWarning = `Worktree created but failed to switch: ${errorMessage}`;
       console.warn("Failed to switch to new worktree:", errorMessage);
     }
@@ -501,7 +502,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
         issueUrl = resolvedIssueUrl;
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to resolve issue URL");
       console.warn(`Failed to resolve issue URL for #${issueNumber}: ${message}`);
     }
 

--- a/electron/services/gemini/GeminiConfigService.ts
+++ b/electron/services/gemini/GeminiConfigService.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile } from "node:fs/promises";
 import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import { homedir } from "node:os";
 import path from "node:path";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 export interface GeminiConfig {
   ui?: {
@@ -43,7 +44,7 @@ export class GeminiConfigService {
       const content = await readFile(this.configPath, "utf8");
       return JSON.parse(content) as GeminiConfig;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to read Gemini config");
       throw new Error(`Failed to read Gemini config: ${message}`);
     }
   }
@@ -63,7 +64,7 @@ export class GeminiConfigService {
         alternateBufferEnabled: config.ui?.useAlternateBuffer === true,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to read Gemini config");
       return { exists: true, alternateBufferEnabled: false, error: message };
     }
   }
@@ -113,7 +114,7 @@ export class GeminiConfigService {
       const content = JSON.stringify(config, null, 2);
       await resilientAtomicWriteFile(this.configPath, content, "utf8");
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to write Gemini config");
       throw new Error(`Failed to write Gemini config: ${message}`);
     }
   }

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -1,5 +1,6 @@
 import { graphql } from "@octokit/graphql";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 export const GITHUB_API_TIMEOUT_MS = 15_000;
 export const GITHUB_AUTH_TIMEOUT_MS = 10_000;
@@ -336,7 +337,7 @@ export class GitHubAuth {
         avatarUrl: userData.avatar_url,
       };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to validate GitHub token");
       const isTimeout = error instanceof Error && error.name === "TimeoutError";
       if (
         isTimeout ||

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -3,6 +3,7 @@ import type {
   GitHubRateLimitPayload,
 } from "../../../shared/types/ipc/github.js";
 import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 // Buffer applied to GitHub's `x-ratelimit-reset` to absorb clock skew between
 // the local host and api.github.com, and to avoid a poll slipping in a tick
@@ -157,7 +158,7 @@ class GitHubRateLimitServiceImpl {
       } catch (err) {
         // A misbehaving transport must not break rate-limit bookkeeping.
         logWarn("GitHub rate-limit listener threw", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Rate-limit listener failed"),
         });
       }
     }

--- a/electron/services/github/GitHubTokenHealthService.ts
+++ b/electron/services/github/GitHubTokenHealthService.ts
@@ -4,6 +4,7 @@ import type {
 } from "../../../shared/types/ipc/github.js";
 import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
 import { GitHubAuth, captureAuthMetadata, getLastAuthMetadata } from "./GitHubAuth.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 /** How often background probes run when the app is actively used. */
 export const HEALTH_CHECK_INTERVAL_MS = 30 * 60 * 1000;
@@ -230,7 +231,7 @@ class GitHubTokenHealthServiceImpl {
         // Network failures (`ENOTFOUND`, `ETIMEDOUT`, `AbortError`, etc.) are
         // not authoritative token-dead signals — don't flip state.
         logDebug("GitHub token health: probe failed (network/transport)", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Token health probe failed"),
           reason: context.reason,
         });
       }
@@ -267,7 +268,7 @@ class GitHubTokenHealthServiceImpl {
       } catch (err) {
         // A misbehaving transport must not break health-check bookkeeping.
         logWarn("GitHub token-health listener threw", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Token-health listener failed"),
         });
       }
     }

--- a/electron/services/smokeTest.ts
+++ b/electron/services/smokeTest.ts
@@ -8,6 +8,7 @@ import type { ProjectState, TerminalSnapshot } from "../types/index.js";
 import type { PtyClient } from "./PtyClient.js";
 import { projectStore } from "./ProjectStore.js";
 import { getAppWebContents } from "../window/webContentsRegistry.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -328,10 +329,7 @@ async function runSmokeProjectPersistenceChecks(window: BrowserWindow): Promise<
 }
 
 function logSmokeFailure(context: string, error: unknown): void {
-  console.error(
-    `[SMOKE] FAILED — ${context}:`,
-    error instanceof Error ? error.message : String(error)
-  );
+  console.error(`[SMOKE] FAILED — ${context}:`, formatErrorMessage(error, "Smoke test failed"));
 }
 
 export async function runSmokeFunctionalChecks(

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -307,6 +307,7 @@ export async function refreshPath(): Promise<void> {
             shellEnvFailed = true;
             console.warn(
               "[refreshPath] shell-env failed:",
+              // eslint-disable-next-line no-restricted-syntax -- diagnostic console.warn passes the raw error if not an Error; not a user-visible string.
               err instanceof Error ? err.message : err
             );
           }

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -15,6 +15,7 @@ export function _resetHandlingFatalForTesting(): void {
 }
 
 function buildFatalAppError(kind: string, error: unknown): AppError {
+  // eslint-disable-next-line no-restricted-syntax -- top-level fatal handler with no operation context; the kind ("UNCAUGHT_EXCEPTION" / "UNHANDLED_REJECTION") supplies the domain.
   const message = error instanceof Error ? error.message : String(error ?? "Unknown error");
   const id = `fatal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -6,6 +6,7 @@ import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { store } from "../store.js";
 import type { AppError } from "../../shared/types/ipc/errors.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 let handlingFatal = false;
 
@@ -15,8 +16,7 @@ export function _resetHandlingFatalForTesting(): void {
 }
 
 function buildFatalAppError(kind: string, error: unknown): AppError {
-  // eslint-disable-next-line no-restricted-syntax -- top-level fatal handler with no operation context; the kind ("UNCAUGHT_EXCEPTION" / "UNHANDLED_REJECTION") supplies the domain.
-  const message = error instanceof Error ? error.message : String(error ?? "Unknown error");
+  const message = formatErrorMessage(error, "Unknown fatal error");
   const id = `fatal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
   return {

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -5,6 +5,7 @@ import {
   WorktreeRemovedError,
   DaintreeError,
   toGitOperationError,
+  getUserMessage,
 } from "../errorTypes.js";
 
 describe("GitOperationError", () => {
@@ -69,5 +70,31 @@ describe("toGitOperationError", () => {
     const wrapped = toGitOperationError("fatal: unable to read config file '/etc/gitconfig'");
     expect(wrapped).toBeInstanceOf(GitOperationError);
     expect(wrapped.reason).toBe("config-missing");
+  });
+});
+
+describe("getUserMessage", () => {
+  it("returns the Daintree error's own message when given a DaintreeError", () => {
+    const err = new GitOperationError("auth-failed", "permission denied", { op: "push" });
+    expect(getUserMessage(err)).toBe("permission denied");
+  });
+
+  it("returns the message of a plain Error", () => {
+    expect(getUserMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns a string error verbatim", () => {
+    expect(getUserMessage("plain string")).toBe("plain string");
+  });
+
+  it("duck-types IPC-stripped error objects (Electron structured clone case)", () => {
+    expect(getUserMessage({ message: "remote failure", name: "Error" })).toBe("remote failure");
+  });
+
+  it("falls back to 'An unknown error occurred' for opaque values", () => {
+    expect(getUserMessage(42)).toBe("An unknown error occurred");
+    expect(getUserMessage(null)).toBe("An unknown error occurred");
+    expect(getUserMessage(undefined)).toBe("An unknown error occurred");
+    expect(getUserMessage({ code: "EFAIL" })).toBe("An unknown error occurred");
   });
 });

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export interface AppProtocolHeaders extends Record<string, string> {
   "Content-Type": string;
@@ -99,7 +100,7 @@ export function resolveAppUrlToDistPath(
   } catch (error) {
     return {
       filePath: "",
-      error: error instanceof Error ? error.message : "Unknown error",
+      error: formatErrorMessage(error, "Failed to resolve app protocol path"),
     };
   }
 }

--- a/electron/utils/colorSchemeImporter.ts
+++ b/electron/utils/colorSchemeImporter.ts
@@ -1,5 +1,6 @@
 import { readFile } from "fs/promises";
 import path from "path";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 interface ImportedSchemeColors {
   background?: string;
@@ -365,7 +366,7 @@ export async function parseColorSchemeFile(filePath: string): Promise<ImportResu
   } catch (err) {
     return {
       ok: false,
-      errors: [`Failed to read file: ${err instanceof Error ? err.message : String(err)}`],
+      errors: [formatErrorMessage(err, "Failed to read color scheme file")],
     };
   }
 }

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -1,5 +1,6 @@
 import { classifyGitError, extractGitErrorMessage } from "../../shared/utils/gitOperationErrors.js";
 import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export class DaintreeError extends Error {
   constructor(
@@ -131,11 +132,7 @@ export function getUserMessage(error: unknown): string {
     return error.message;
   }
 
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  return String(error);
+  return formatErrorMessage(error, "An unknown error occurred");
 }
 
 /**

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -6,6 +6,7 @@ import { WorktreeRemovedError, toGitOperationError } from "./errorTypes.js";
 import { logWarn, logError } from "./logger.js";
 import { Cache } from "./cache.js";
 import { createHardenedGit } from "./hardenedGit.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const GIT_WORKTREE_CHANGES_CACHE = new Cache<string, WorktreeChanges>({
   maxSize: 100,
@@ -444,7 +445,7 @@ export async function getWorktreeChangesWithStats(
         throw error;
       }
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Git worktree changes failed");
       if (
         errorMessage.includes("ENOENT") ||
         errorMessage.includes("no such file or directory") ||

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -84,6 +84,7 @@ import {
   finalizeDeferredRegistration,
   resetDeferredQueue,
 } from "./deferredInitQueue.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const DEFAULT_TERMINAL_ID = "default";
 
@@ -257,7 +258,7 @@ export async function setupWindowServices(
       markPerformance(PERF_MARKS.SERVICE_INIT_MIGRATIONS_DONE);
     } catch (error) {
       console.error("[MAIN] Store migration failed:", error);
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Store migration failed");
       dialog
         .showMessageBox(win, {
           type: "error",

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -23,6 +23,7 @@ import type { WorkspaceHostRequest, WorkspaceHostEvent } from "../shared/types/w
 import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
 import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
+import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {
@@ -209,7 +210,7 @@ process.on("unhandledRejection", (reason) => {
   console.error("[WorkspaceHost] Unhandled Rejection:", reason);
   sendEvent({
     type: "error",
-    error: String(reason instanceof Error ? reason.message : reason),
+    error: formatErrorMessage(reason, "Unhandled rejection in workspace host"),
   });
 });
 
@@ -220,7 +221,7 @@ function sendEvent(event: WorkspaceHostEvent): void {
   } catch (error) {
     console.error(
       `[WorkspaceHost] Failed to send event type "${(event as any).type}":`,
-      error instanceof Error ? error.message : String(error)
+      formatErrorMessage(error, "Failed to send workspace event")
     );
 
     try {
@@ -230,7 +231,7 @@ function sendEvent(event: WorkspaceHostEvent): void {
     } catch (sanitizeError) {
       console.error(
         `[WorkspaceHost] Failed to sanitize event, sending error event instead:`,
-        sanitizeError instanceof Error ? sanitizeError.message : String(sanitizeError)
+        formatErrorMessage(sanitizeError, "Failed to sanitize workspace event")
       );
       port.postMessage({
         type: "error",

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -28,6 +28,7 @@ import { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService } from "./PRIntegrationService.js";
 import { waitForPathExists } from "../utils/fs.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 // Configuration
 const DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS = 2000;
@@ -542,7 +543,7 @@ export class WorkspaceService {
     } catch (error) {
       console.warn(
         "[WorkspaceHost] Resource config initialization failed (continuing without resources):",
-        error instanceof Error ? error.message : String(error)
+        formatErrorMessage(error, "Resource config initialization failed")
       );
     }
   }
@@ -2172,7 +2173,7 @@ ${connectCommand} "$@"
 
       await writeFile(wrapperPath, scriptContent, { mode: 0o755 });
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      const msg = formatErrorMessage(error, "Failed to generate daintree-remote wrapper");
       console.warn("[WorkspaceService] Failed to generate daintree-remote wrapper:", msg);
     }
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,26 +128,24 @@ export default tseslint.config(
     },
   },
 
-  // Scaffold: no-restricted-syntax — uncomment and adapt to block a retired
-  // identifier (module export, global name, or property access) during a
-  // flag burn-down. Uses ESLint AST selectors.
-  // {
-  //   rules: {
-  //     "no-restricted-syntax": [
-  //       "error",
-  //       {
-  //         // why: <identifier> was retired in <version> — see <issue>.
-  //         selector: "Identifier[name='RetiredName']",
-  //         message: "RetiredName is retired. Use ReplacementName instead.",
-  //       },
-  //       {
-  //         // why: property access on a removed global.
-  //         selector: "MemberExpression[object.name='legacyGlobal']",
-  //         message: "legacyGlobal is retired. Use currentAPI instead.",
-  //       },
-  //     ],
-  //   },
-  // },
+  // Ban the ad-hoc `err instanceof Error ? err.message : <fallback>` ternary —
+  // use formatErrorMessage(err, "domain fallback") from shared/utils/errorMessage
+  // so every call site supplies its own operation-specific fallback string.
+  // See issue #5845.
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "ConditionalExpression[test.type='BinaryExpression'][test.operator='instanceof'][test.right.name='Error'][consequent.type='MemberExpression'][consequent.property.name='message']",
+          message:
+            "Use formatErrorMessage(err, 'operation-specific fallback') from @shared/utils/errorMessage instead of the inline `instanceof Error ? .message : ...` ternary.",
+        },
+      ],
+    },
+  },
 
   // Prevent UI components from importing main-process types
   {

--- a/shared/utils/__tests__/errorMessage.test.ts
+++ b/shared/utils/__tests__/errorMessage.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { formatErrorMessage } from "../errorMessage.js";
+
+describe("formatErrorMessage", () => {
+  const FALLBACK = "Couldn't load thing";
+
+  describe("Error instances", () => {
+    it("returns the message of a real Error", () => {
+      expect(formatErrorMessage(new Error("boom"), FALLBACK)).toBe("boom");
+    });
+
+    it("returns the message of a TypeError subclass", () => {
+      expect(formatErrorMessage(new TypeError("bad type"), FALLBACK)).toBe("bad type");
+    });
+
+    it("returns the empty string for an Error with empty message (does NOT fall back)", () => {
+      expect(formatErrorMessage(new Error(""), FALLBACK)).toBe("");
+    });
+  });
+
+  describe("string errors", () => {
+    it("returns the string as-is", () => {
+      expect(formatErrorMessage("plain string error", FALLBACK)).toBe("plain string error");
+    });
+
+    it("returns the empty string when error is empty string", () => {
+      expect(formatErrorMessage("", FALLBACK)).toBe("");
+    });
+  });
+
+  describe("IPC duck-typed errors", () => {
+    it("returns message from a plain { message: string } object (Electron IPC strip case)", () => {
+      const ipcError = { message: "remote failure", name: "Error", stack: "..." };
+      expect(formatErrorMessage(ipcError, FALLBACK)).toBe("remote failure");
+    });
+
+    it("falls back when message is a non-string", () => {
+      expect(formatErrorMessage({ message: 42 }, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back when message is null", () => {
+      expect(formatErrorMessage({ message: null }, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back when message is undefined", () => {
+      expect(formatErrorMessage({ message: undefined }, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back when message is an object", () => {
+      expect(formatErrorMessage({ message: { nested: "thing" } }, FALLBACK)).toBe(FALLBACK);
+    });
+  });
+
+  describe("opaque values fall back", () => {
+    it("falls back for null", () => {
+      expect(formatErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for undefined", () => {
+      expect(formatErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for a number", () => {
+      expect(formatErrorMessage(42, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for a boolean", () => {
+      expect(formatErrorMessage(true, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for an object without message", () => {
+      expect(formatErrorMessage({ code: "EFAIL" }, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for an array", () => {
+      expect(formatErrorMessage(["error", "list"], FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back for a Symbol", () => {
+      expect(formatErrorMessage(Symbol("err"), FALLBACK)).toBe(FALLBACK);
+    });
+  });
+
+  describe("contract", () => {
+    it("does not stringify opaque objects (no [object Object] leakage)", () => {
+      expect(formatErrorMessage({ foo: "bar" }, FALLBACK)).not.toContain("[object Object]");
+    });
+  });
+});

--- a/shared/utils/__tests__/errorMessage.test.ts
+++ b/shared/utils/__tests__/errorMessage.test.ts
@@ -85,5 +85,26 @@ describe("formatErrorMessage", () => {
     it("does not stringify opaque objects (no [object Object] leakage)", () => {
       expect(formatErrorMessage({ foo: "bar" }, FALLBACK)).not.toContain("[object Object]");
     });
+
+    it("falls back when the message getter throws", () => {
+      const hostile = {
+        get message(): string {
+          throw new Error("getter blew up");
+        },
+      };
+      expect(formatErrorMessage(hostile, FALLBACK)).toBe(FALLBACK);
+    });
+
+    it("falls back when a Proxy has-trap throws", () => {
+      const hostile = new Proxy(
+        {},
+        {
+          has() {
+            throw new Error("has-trap blew up");
+          },
+        }
+      );
+      expect(formatErrorMessage(hostile, FALLBACK)).toBe(FALLBACK);
+    });
   });
 });

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract a human-readable message from an unknown caught error, falling back
+ * to a caller-supplied domain string for opaque or non-Error values.
+ *
+ * The fallback is required (no default) so every call site supplies its own
+ * operation context — replacing the ad-hoc `err instanceof Error ? err.message
+ * : "Unknown error"` ternary that produced uninformative UI copy.
+ *
+ * Duck-types `{ message: string }` because Electron's structured clone strips
+ * the Error prototype across IPC, leaving plain objects that fail
+ * `instanceof Error` but still carry the original message.
+ */
+export function formatErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { message: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return fallback;
+}

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -13,9 +13,15 @@
 export function formatErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof Error) return error.message;
   if (typeof error === "string") return error;
-  if (typeof error === "object" && error !== null && "message" in error) {
-    const message = (error as { message: unknown }).message;
-    if (typeof message === "string") return message;
+  if (typeof error === "object" && error !== null) {
+    try {
+      if ("message" in error) {
+        const message = (error as { message: unknown }).message;
+        if (typeof message === "string") return message;
+      }
+    } catch {
+      // Proxies with throwing `has` traps or accessor errors fall back.
+    }
   }
   return fallback;
 }

--- a/shared/utils/serialization.ts
+++ b/shared/utils/serialization.ts
@@ -1,3 +1,5 @@
+import { formatErrorMessage } from "./errorMessage.js";
+
 /**
  * Utilities for ensuring data is safe for structured clone serialization (IPC transport).
  *
@@ -28,9 +30,7 @@ export function ensureSerializable<T>(data: T): unknown {
   try {
     return JSON.parse(JSON.stringify(data));
   } catch (error) {
-    throw new Error(
-      `Failed to serialize data: ${error instanceof Error ? error.message : String(error)}`
-    );
+    throw new Error(formatErrorMessage(error, "Failed to serialize data"));
   }
 }
 
@@ -49,10 +49,9 @@ export function validateSerializable(
     JSON.stringify(data);
     return { valid: true };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
     return {
       valid: false,
-      error: message,
+      error: formatErrorMessage(error, "Failed to serialize data"),
     };
   }
 }

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface ActiveRecording {
   captureId: string;
@@ -79,7 +80,7 @@ export function DemoCaptureBridge() {
             audio: false,
           });
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = formatErrorMessage(err, "getDisplayMedia failed");
           api.sendCommandDone(requestId, `getDisplayMedia failed: ${message}`);
           return;
         }
@@ -93,7 +94,7 @@ export function DemoCaptureBridge() {
           recorder = new MediaRecorder(stream, { mimeType });
         } catch (err) {
           stream.getTracks().forEach((t) => t.stop());
-          const message = err instanceof Error ? err.message : String(err);
+          const message = formatErrorMessage(err, "MediaRecorder init failed");
           api.sendCommandDone(requestId, `MediaRecorder init failed: ${message}`);
           return;
         }
@@ -120,7 +121,7 @@ export function DemoCaptureBridge() {
             api.sendCaptureChunk(active.captureId, new Uint8Array(ab));
           } catch (err) {
             if (!active.stopError) {
-              active.stopError = err instanceof Error ? err.message : String(err);
+              active.stopError = formatErrorMessage(err, "Failed to send capture chunk");
             }
           } finally {
             active.pendingChunks -= 1;
@@ -148,7 +149,7 @@ export function DemoCaptureBridge() {
           recorder.start(1000);
           api.sendCommandDone(requestId);
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = formatErrorMessage(err, "recorder.start failed");
           stopAndCleanup(active, message);
           api.sendCommandDone(requestId, `recorder.start failed: ${message}`);
         }
@@ -180,7 +181,7 @@ export function DemoCaptureBridge() {
             maybeSendStop(active);
           }
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
+          const message = formatErrorMessage(err, "Failed to stop recorder");
           active.stopError = message;
           active.stopped = true;
           maybeSendStop(active);

--- a/src/components/GitHub/CommitList.tsx
+++ b/src/components/GitHub/CommitList.tsx
@@ -7,6 +7,7 @@ import { CommitListItem } from "./CommitListItem";
 import type { GitCommit, GitCommitListResponse } from "@shared/types/github";
 import { actionService } from "@/services/ActionService";
 import { CommitListSkeleton } from "./GitHubDropdownSkeletons";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface CommitListProps {
   projectPath: string;
@@ -94,7 +95,7 @@ export function CommitList({ projectPath, branch, onClose, initialCount }: Commi
         setHasMore(result.hasMore);
       } catch (err) {
         if (abortSignal?.aborted) return;
-        const message = err instanceof Error ? err.message : "Failed to fetch commits";
+        const message = formatErrorMessage(err, "Failed to fetch commits");
         if (append) {
           setLoadMoreError(message);
         } else {

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -32,6 +32,7 @@ import {
   MAX_SKELETON_ITEMS,
   RESOURCE_ITEM_HEIGHT_PX,
 } from "./GitHubDropdownSkeletons";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 type StateFilter = IssueStateFilter | PRStateFilter;
 
@@ -265,7 +266,7 @@ export function GitHubResourceList({
         }
       } catch (err) {
         if (abortSignal?.aborted) return;
-        const message = err instanceof Error ? err.message : "Failed to fetch data";
+        const message = formatErrorMessage(err, "Failed to fetch data");
         if (append) {
           setLoadMoreError(message);
         } else {
@@ -410,7 +411,7 @@ export function GitHubResourceList({
         }
       } catch (err) {
         if (abortController.signal.aborted) return;
-        const message = err instanceof Error ? err.message : "Failed to fetch data";
+        const message = formatErrorMessage(err, "Failed to fetch data");
         setError(message);
       } finally {
         if (!abortController.signal.aborted) {

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -5,6 +5,7 @@ import { Check, AlertCircle, FolderOpen } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
 
 interface CloneRepoDialogProps {
@@ -140,7 +141,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         setError(result.error || "Clone failed");
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Unknown error");
+      setError(formatErrorMessage(err, "Failed to clone repository"));
     } finally {
       setIsCloning(false);
     }

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { copyTreeClient } from "@/clients/copyTreeClient";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { CopyTreeSettings, CopyTreeTestConfigResult, Worktree } from "@/types";
 
 function formatBytes(bytes: number): string {
@@ -114,7 +115,7 @@ export function ContextTab({
         includedFiles: 0,
         includedSize: 0,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-        error: error instanceof Error ? error.message : "Failed to test configuration",
+        error: formatErrorMessage(error, "Failed to test configuration"),
       });
     } finally {
       setIsTestingConfig(false);

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -4,6 +4,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { FolderPlus, FolderOpen } from "lucide-react";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface CreateProjectFolderDialogProps {
   isOpen: boolean;
@@ -95,7 +96,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
       onClose();
     } catch (err) {
       // Show error inline — keep dialog open so user can retry or correct input
-      setError(err instanceof Error ? err.message : "Failed to create folder");
+      setError(formatErrorMessage(err, "Failed to create folder"));
     } finally {
       setIsCreating(false);
     }

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Key, Lock, ShieldAlert, Eye, EyeOff, Plus, Trash2, Save, Globe } from "lucide-react";
 import { isSensitiveEnvKey } from "@shared/utils/envVars";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { EnvVar } from "./projectSettingsDirty";
 import type { ProjectSettings } from "@shared/types/project";
 
@@ -133,7 +134,7 @@ export function EnvironmentVariablesEditor({
         await onFlush();
       }
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to save environment variables");
+      setSaveError(formatErrorMessage(err, "Failed to save environment variables"));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -8,6 +8,7 @@ import { getProjectGradient, isValidHexColor } from "@/lib/colorUtils";
 import { cn } from "@/lib/utils";
 import { sanitizeSvg, svgToDataUrl } from "@/lib/svg";
 import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { Project } from "@shared/types/project";
 
 const PRESET_SWATCHES = [
@@ -219,7 +220,7 @@ export function GeneralTab({
         setInRepoExpanded(false);
       }
     } catch (err) {
-      setInRepoError(err instanceof Error ? err.message : "Failed to enable in-repo settings");
+      setInRepoError(formatErrorMessage(err, "Failed to enable in-repo settings"));
     } finally {
       setInRepoEnabling(false);
     }
@@ -232,7 +233,7 @@ export function GeneralTab({
     try {
       await disableInRepoSettings(projectId);
     } catch (err) {
-      setInRepoError(err instanceof Error ? err.message : "Failed to disable in-repo settings");
+      setInRepoError(formatErrorMessage(err, "Failed to disable in-repo settings"));
     } finally {
       setInRepoEnabling(false);
     }

--- a/src/components/Project/GitHubTab.tsx
+++ b/src/components/Project/GitHubTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { RemoteInfo } from "@shared/types/ipc/github";
 
 interface GitHubTabProps {
@@ -29,7 +30,7 @@ export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: G
       })
       .catch((err) => {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : String(err));
+          setError(formatErrorMessage(err, "Failed to load git remotes"));
           setLoading(false);
         }
       });

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -5,6 +5,7 @@ import { Check, AlertCircle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
 
 interface GitInitDialogProps {
@@ -82,8 +83,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
         setError(result.error || "Initialization failed");
       }
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      setError(errorMessage);
+      setError(formatErrorMessage(err, "Failed to initialize git repository"));
     } finally {
       setIsInitializing(false);
     }

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -18,6 +18,7 @@ import { useProjectSettings } from "@/hooks";
 import { useProjectStore } from "@/store/projectStore";
 import type { RunCommand } from "@/types";
 import { getProjectGradient } from "@/lib/colorUtils";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const CURATED_EMOJIS = [
   "🌲",
@@ -127,7 +128,7 @@ export function ProjectOnboardingWizard({
       onClose();
       onFinish?.(projectId);
     } catch (error) {
-      setSaveError(error instanceof Error ? error.message : "Failed to save settings");
+      setSaveError(formatErrorMessage(error, "Failed to save settings"));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -10,6 +10,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import type { TerminalRecipe, Worktree } from "@/types";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface RecipesTabProps {
   projectId: string;
@@ -114,7 +115,7 @@ export function RecipesTab({
       setRecipeToDelete(null);
     } catch (err) {
       console.error("Failed to delete recipe:", err);
-      setDeleteError(err instanceof Error ? err.message : "Failed to delete recipe");
+      setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
     }
   };
 
@@ -135,7 +136,7 @@ export function RecipesTab({
         }, 2000);
       } catch (err) {
         console.error("Failed to copy to clipboard:", err);
-        setExportError(err instanceof Error ? err.message : "Failed to copy to clipboard");
+        setExportError(formatErrorMessage(err, "Failed to copy to clipboard"));
       }
     }
   };
@@ -151,7 +152,7 @@ export function RecipesTab({
       setShowImportDialog(false);
       setImportJson("");
     } catch (err) {
-      setImportError(err instanceof Error ? err.message : "Failed to import recipe");
+      setImportError(formatErrorMessage(err, "Failed to import recipe"));
     }
   };
 

--- a/src/components/Project/__tests__/ProjectSettingsDialog.inRepoSettings.test.ts
+++ b/src/components/Project/__tests__/ProjectSettingsDialog.inRepoSettings.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { GITIGNORE_SNIPPET } from "../projectSettingsConstants";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 describe("GITIGNORE_SNIPPET", () => {
   it("includes project.json path as safe to commit", () => {
@@ -56,7 +57,7 @@ describe("In-repo settings — enable/disable UI logic", () => {
     try {
       throw new Error("EACCES: permission denied, mkdir '.daintree'");
     } catch (err) {
-      inRepoError = err instanceof Error ? err.message : "Failed to enable in-repo settings";
+      inRepoError = formatErrorMessage(err, "Failed to enable in-repo settings");
     } finally {
       inRepoEnabling = false;
     }

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -7,6 +7,7 @@ import { cliAvailabilityClient } from "@/clients";
 import type { AgentHelpResult } from "@shared/types/ipc/agent";
 import type { AgentAvailabilityState } from "@shared/types";
 import { isAgentInstalled, isAgentMissing } from "../../../shared/utils/agentAvailability";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface AgentHelpOutputProps {
   agentId: string;
@@ -81,7 +82,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
         const result = await agentHelpClient.get({ agentId, refresh });
         setHelpResult(result);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load help output");
+        setError(formatErrorMessage(err, "Failed to load help output"));
       } finally {
         setIsLoading(false);
       }

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -5,6 +5,7 @@ import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { editorClient } from "@/clients/editorClient";
 import type { EditorConfig, DiscoveredEditor, KnownEditorId } from "@shared/types/editor";
 import { useProjectStore } from "@/store";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const EDITOR_LABELS: Record<KnownEditorId, string> = {
   vscode: "VS Code",
@@ -110,7 +111,7 @@ export function EditorIntegrationTab() {
       setPreferredEditor(editor);
     } catch (err) {
       if (!isMountedRef.current) return;
-      setSaveError(err instanceof Error ? err.message : "Failed to save");
+      setSaveError(formatErrorMessage(err, "Failed to save editor preference"));
     } finally {
       if (isMountedRef.current) setIsSaving(false);
     }

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { SettingsSection } from "./SettingsSection";
 import { isSensitiveEnvKey } from "@shared/utils/envVars";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 interface EnvVar {
@@ -173,7 +174,7 @@ export function EnvironmentSettingsTab() {
       setSavedSnapshot(record);
       setIsDirty(false);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to save");
+      setSaveError(formatErrorMessage(err, "Failed to save environment variables"));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -35,6 +35,7 @@ import {
 import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const GENERAL_SUBTABS: SettingsSubtabItem[] = [
   { id: "overview", label: "Overview" },
@@ -185,7 +186,7 @@ export function GeneralTab({
         clearTimeout(timer);
         if (cancelled) return;
         console.error("Failed to load hibernation config:", error);
-        setConfigError(error instanceof Error ? error.message : "Failed to load settings");
+        setConfigError(formatErrorMessage(error, "Failed to load hibernation settings"));
       });
 
     actionService

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Image } from "lucide-react";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { useProjectStore } from "@/store";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 type ImageViewerMode = "os" | "custom";
 
@@ -93,7 +94,7 @@ export function ImageViewerTab() {
       setSaved(true);
     } catch (err) {
       if (!isMountedRef.current) return;
-      setSaveError(err instanceof Error ? err.message : "Failed to save");
+      setSaveError(formatErrorMessage(err, "Failed to save image viewer preference"));
     } finally {
       if (isMountedRef.current) setIsSaving(false);
     }

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -4,6 +4,7 @@ import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface McpServerStatus {
   enabled: boolean;
@@ -42,7 +43,7 @@ export function McpServerSettingsTab() {
       })
       .catch((err) => {
         if (settled) return;
-        setError(err instanceof Error ? err.message : "Failed to load MCP status");
+        setError(formatErrorMessage(err, "Failed to load MCP status"));
       })
       .finally(() => {
         settled = true;
@@ -59,7 +60,7 @@ export function McpServerSettingsTab() {
       const newStatus = await window.electron.mcpServer.setEnabled(!status.enabled);
       setStatus(newStatus);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update MCP server");
+      setError(formatErrorMessage(err, "Failed to update MCP server"));
     }
   }, [status.enabled]);
 
@@ -70,7 +71,7 @@ export function McpServerSettingsTab() {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to copy config");
+      setError(formatErrorMessage(err, "Failed to copy config"));
     }
   }, []);
 
@@ -87,7 +88,7 @@ export function McpServerSettingsTab() {
       setStatus(newStatus);
       setPortInput(newStatus.configuredPort?.toString() ?? "");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update port");
+      setError(formatErrorMessage(err, "Failed to update port"));
     }
   }, [portInput]);
 
@@ -98,7 +99,7 @@ export function McpServerSettingsTab() {
       setStatus((prev) => ({ ...prev, apiKey: key }));
       setShowApiKey(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to generate API key");
+      setError(formatErrorMessage(err, "Failed to generate API key"));
     }
   }, []);
 
@@ -108,7 +109,7 @@ export function McpServerSettingsTab() {
       const newStatus = await window.electron.mcpServer.setApiKey("");
       setStatus(newStatus);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to clear API key");
+      setError(formatErrorMessage(err, "Failed to clear API key"));
     }
   }, []);
 

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -22,6 +22,7 @@ import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function SystemHealthSection() {
   const [result, setResult] = useState<SystemHealthCheckResult | null>(null);
@@ -35,7 +36,7 @@ function SystemHealthSection() {
       const data = await systemClient.healthCheck();
       setResult(data);
     } catch (err) {
-      setCheckError(err instanceof Error ? err.message : "Health check failed");
+      setCheckError(formatErrorMessage(err, "Health check failed"));
     } finally {
       setIsChecking(false);
     }
@@ -104,7 +105,7 @@ function DownloadDiagnosticsSection() {
       setReviewPayload(payload);
       setReviewOpen(true);
     } catch (err) {
-      setDownloadError(err instanceof Error ? err.message : "Failed to collect diagnostics");
+      setDownloadError(formatErrorMessage(err, "Failed to collect diagnostics"));
     } finally {
       setIsCollecting(false);
     }
@@ -124,7 +125,7 @@ function DownloadDiagnosticsSection() {
           setReviewOpen(false);
         }
       } catch (err) {
-        setDownloadError(err instanceof Error ? err.message : "Failed to save diagnostics bundle");
+        setDownloadError(formatErrorMessage(err, "Failed to save diagnostics bundle"));
       } finally {
         setIsSaving(false);
       }

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -12,6 +12,7 @@ import {
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const PATTERN_PRESETS = [
   {
@@ -77,7 +78,7 @@ export function WorktreeSettingsTab() {
       .catch((err) => {
         settled = true;
         clearTimeout(timer);
-        setError(err instanceof Error ? err.message : "Failed to load settings");
+        setError(formatErrorMessage(err, "Failed to load worktree settings"));
       })
       .finally(() => {
         setIsLoading(false);
@@ -126,7 +127,7 @@ export function WorktreeSettingsTab() {
       const timeout = setTimeout(() => setSavedMessage(false), 2000);
       setSavedMessageTimeout(timeout);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save pattern");
+      setError(formatErrorMessage(err, "Failed to save pattern"));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -19,6 +19,7 @@ import { CopyableCommand } from "./InstallBlock";
 import { AGENT_DESCRIPTIONS } from "@/config/agents";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled } from "@shared/utils/agentAvailability";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
 
@@ -135,7 +136,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
         setCardStatuses((prev) => ({ ...prev, [agentId]: "error" }));
         setCardErrors((prev) => ({
           ...prev,
-          [agentId]: err instanceof Error ? err.message : "Installation failed",
+          [agentId]: formatErrorMessage(err, "Installation failed"),
         }));
       } finally {
         installingRef.current.delete(agentId);

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { systemClient } from "@/clients";
 import type { PrerequisiteCheckResult, PrerequisiteSpec } from "@shared/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const POOL_CONCURRENCY = 3;
 
@@ -80,7 +81,7 @@ export function useSystemHealthCheck(): SystemHealthCheckState {
         }
       });
     } catch (err) {
-      if (activeRef.current) setError(err instanceof Error ? err.message : "Health check failed");
+      if (activeRef.current) setError(formatErrorMessage(err, "Health check failed"));
     } finally {
       isCheckingRef.current = false;
       if (activeRef.current) setIsChecking(false);

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -5,6 +5,7 @@ import { Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface TerminalInfoDialogProps {
   isOpen: boolean;
@@ -148,7 +149,7 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
           setInfo(result.result as TerminalInfoPayload);
         }
       } catch (err) {
-        const message = err instanceof Error ? err.message : "Unknown error";
+        const message = formatErrorMessage(err, "Failed to load terminal info");
         if (isMounted) {
           setError(message);
         }

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -18,6 +18,7 @@ import type {
   AtTerminalContext,
   AtSelectionContext,
 } from "../hybridInputParsing";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface LatestRefShape {
   terminalId: string;
@@ -120,7 +121,7 @@ export function useTokenResolution({
                 replacement = `No ${labels[token.diffType]} changes.`;
               }
             } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
+              const msg = formatErrorMessage(err, "Failed to fetch diff");
               replacement = `[Error fetching diff: ${msg}]`;
             }
             replacements.push({ start: token.start, end: token.end, replacement });

--- a/src/components/Terminal/terminalSearchUtils.ts
+++ b/src/components/Terminal/terminalSearchUtils.ts
@@ -1,4 +1,5 @@
 import type { ISearchOptions } from "@xterm/addon-search";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type SearchStatus = "idle" | "found" | "none" | "invalidRegex";
 
@@ -21,7 +22,7 @@ export function validateRegexTerm(
   } catch (e) {
     return {
       isValid: false,
-      error: e instanceof Error ? e.message : "Invalid regex pattern",
+      error: formatErrorMessage(e, "Invalid regex pattern"),
     };
   }
 }

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -6,6 +6,7 @@ import { useRecipeStore } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function cloneTerminal(t: RecipeTerminal): RecipeTerminal {
   return { ...t, env: t.env ? { ...t.env } : {} };
@@ -239,7 +240,7 @@ export function RecipeEditor({
 
       onClose();
     } catch (error) {
-      setError(error instanceof Error ? error.message : "Failed to save recipe");
+      setError(formatErrorMessage(error, "Failed to save recipe"));
     } finally {
       setIsSaving(false);
     }

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -24,6 +24,7 @@ import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import type { TerminalRecipe } from "@/types";
 import { useRef } from "react";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface RecipeManagerProps {
   isOpen: boolean;
@@ -84,7 +85,7 @@ export function RecipeManager({
       setRecipeToDelete(null);
     } catch (err) {
       console.error("Failed to delete recipe:", err);
-      setDeleteError(err instanceof Error ? err.message : "Failed to delete recipe");
+      setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
     }
   };
 
@@ -118,7 +119,7 @@ export function RecipeManager({
       setRecipeToSave(null);
       setRecipeToDeleteAfterSave(savedId);
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : "Failed to save recipe to repo");
+      setSaveError(formatErrorMessage(err, "Failed to save recipe to repo"));
     } finally {
       setIsSaving(false);
     }
@@ -146,7 +147,7 @@ export function RecipeManager({
       setShowImportDialog(false);
       setImportJson("");
     } catch (err) {
-      setImportError(err instanceof Error ? err.message : "Failed to import recipe");
+      setImportError(formatErrorMessage(err, "Failed to import recipe"));
     }
   };
 

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -8,6 +8,7 @@ import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "@shared/types/i
 import { DiffViewer } from "./DiffViewer";
 import { WorktreeSelector } from "./WorktreeSelector";
 import { sortWorktreesForComparison } from "./crossWorktreeDiffUtils";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface CrossWorktreeDiffProps {
   isOpen: boolean;
@@ -101,7 +102,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
       setResult(res);
     } catch (err) {
       if (token !== compareTokenRef.current) return;
-      setError(err instanceof Error ? err.message : "Failed to compare worktrees");
+      setError(formatErrorMessage(err, "Failed to compare worktrees"));
     } finally {
       if (token === compareTokenRef.current) setLoading(false);
     }

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
 import type { WorktreeState } from "@/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface IssuePickerDialogProps {
   isOpen: boolean;
@@ -50,7 +51,7 @@ export function IssuePickerDialog({
         setIssues(result.items);
         setSelectedIndex(0);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to load issues");
+        setError(formatErrorMessage(e, "Failed to load issues"));
         setIssues([]);
       } finally {
         setIsLoading(false);

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -46,6 +46,7 @@ import { useBranchPicker } from "./hooks/useBranchPicker";
 import { usePrefixPicker } from "./hooks/usePrefixPicker";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "./hooks/useRecipePicker";
 import { usePanelStore } from "@/store/panelStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 type BranchMode = "new" | "existing";
 
@@ -609,8 +610,7 @@ export function NewWorktreeDialog({
                 .generateRecipeFromActiveTerminals(sourceWorktreeId);
               await cloneLayoutPanels(terminals, worktreeId, worktreePath.trim());
             } catch (cloneErr) {
-              const message =
-                cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+              const message = formatErrorMessage(cloneErr, "Failed to clone layout");
               notify({
                 type: "warning",
                 title: "Could not clone layout",
@@ -624,8 +624,7 @@ export function NewWorktreeDialog({
                 branchName: selectedExistingBranch,
               });
             } catch (recipeErr) {
-              const message =
-                recipeErr instanceof Error ? recipeErr.message : "Failed to run recipe";
+              const message = formatErrorMessage(recipeErr, "Failed to run recipe");
               const recipeId = selectedRecipe.id;
               const recipePath = worktreePath.trim();
               notify({
@@ -653,7 +652,7 @@ export function NewWorktreeDialog({
           setSelectedExistingBranch(null);
           setWorktreePath("");
         } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : "Failed to create worktree";
+          const message = formatErrorMessage(err, "Failed to create worktree");
           setCreationError(mapCreationError(message, onClose));
         }
       });
@@ -761,8 +760,7 @@ export function NewWorktreeDialog({
           try {
             await githubClient.assignIssue(rootPath, selectedIssue.number, currentUser);
           } catch (assignErr) {
-            const message =
-              assignErr instanceof Error ? assignErr.message : "Failed to assign issue";
+            const message = formatErrorMessage(assignErr, "Failed to assign issue");
             const issueUrl = selectedIssue.url;
             notify({
               type: "warning",
@@ -787,7 +785,7 @@ export function NewWorktreeDialog({
               .generateRecipeFromActiveTerminals(sourceWorktreeId);
             await cloneLayoutPanels(terminals, worktreeId, worktreePath.trim());
           } catch (cloneErr) {
-            const message = cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+            const message = formatErrorMessage(cloneErr, "Failed to clone layout");
             notify({
               type: "warning",
               title: "Could not clone layout",
@@ -804,7 +802,7 @@ export function NewWorktreeDialog({
               branchName: fullBranchName,
             });
           } catch (recipeErr) {
-            const message = recipeErr instanceof Error ? recipeErr.message : "Failed to run recipe";
+            const message = formatErrorMessage(recipeErr, "Failed to run recipe");
             const recipeId = selectedRecipe.id;
             const recipePath = worktreePath.trim();
             const recipeWorktreeId = worktreeId;
@@ -839,7 +837,7 @@ export function NewWorktreeDialog({
         setWorktreePath("");
         setFromRemote(false);
       } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : "Failed to create worktree";
+        const message = formatErrorMessage(err, "Failed to create worktree");
         setCreationError(mapCreationError(message, onClose));
       }
     });
@@ -1435,7 +1433,7 @@ export function NewWorktreeDialog({
                         }
                       } catch (err: unknown) {
                         console.error("Failed to open directory picker:", err);
-                        const message = err instanceof Error ? err.message : "Unknown error";
+                        const message = formatErrorMessage(err, "Failed to open directory picker");
                         setValidationError(`Failed to open directory picker: ${message}`);
                         setErrorField(null);
                       }

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -27,6 +27,7 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useShallow } from "zustand/react/shallow";
 import { githubClient } from "@/clients/githubClient";
 import { actionService } from "@/services/ActionService";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface ReviewHubProps {
   isOpen: boolean;
@@ -159,7 +160,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       }
     } catch (err) {
       if (refreshIdRef.current === requestId) {
-        setLoadError(err instanceof Error ? err.message : String(err));
+        setLoadError(formatErrorMessage(err, "Failed to load staging status"));
       }
     } finally {
       if (refreshIdRef.current === requestId) {
@@ -214,7 +215,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       setBaseBranchFiles(res.files);
     } catch (err) {
       if (baseBranchRequestRef.current !== requestId) return;
-      setBaseBranchError(err instanceof Error ? err.message : "Failed to load base branch diff");
+      setBaseBranchError(formatErrorMessage(err, "Failed to load base branch diff"));
     } finally {
       if (baseBranchRequestRef.current === requestId) setBaseBranchLoading(false);
     }
@@ -280,7 +281,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         await window.electron.git.stageFile(worktreePath, filePath);
         await refresh();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(formatErrorMessage(err, "Failed to stage file"));
       }
     },
     [worktreePath, refresh]
@@ -294,7 +295,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         await window.electron.git.unstageFile(worktreePath, filePath);
         await refresh();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(formatErrorMessage(err, "Failed to unstage file"));
       }
     },
     [worktreePath, refresh]
@@ -307,7 +308,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       await window.electron.git.stageAll(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
+      setActionError(formatErrorMessage(err, "Failed to stage all files"));
     }
   }, [worktreePath, refresh]);
 
@@ -318,7 +319,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       await window.electron.git.unstageAll(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
+      setActionError(formatErrorMessage(err, "Failed to unstage all files"));
     }
   }, [worktreePath, refresh]);
 
@@ -330,7 +331,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         await window.electron.git.commit(worktreePath, message);
         await refresh();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(formatErrorMessage(err, "Failed to commit changes"));
         throw err;
       }
     },
@@ -344,7 +345,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       await window.electron.git.abortRepositoryOperation(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
+      setActionError(formatErrorMessage(err, "Failed to abort repository operation"));
       throw err;
     }
   }, [worktreePath, refresh]);
@@ -356,7 +357,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       await window.electron.git.continueRepositoryOperation(worktreePath);
       await refresh();
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : String(err));
+      setActionError(formatErrorMessage(err, "Failed to continue repository operation"));
       throw err;
     }
   }, [worktreePath, refresh]);
@@ -369,7 +370,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         const tail = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
         await window.electron.system.openInEditor({ path: `${base}/${tail}` });
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(formatErrorMessage(err, "Failed to open file in editor"));
       }
     },
     [worktreePath]
@@ -389,7 +390,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     } catch (err) {
       setPushError({
         reason: "unknown",
-        rawMessage: err instanceof Error ? err.message : String(err),
+        rawMessage: formatErrorMessage(err, "Failed to push"),
       });
     }
   }, [worktreePath]);
@@ -402,7 +403,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       try {
         await window.electron.git.commit(worktreePath, message);
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(formatErrorMessage(err, "Failed to commit changes"));
         throw err;
       }
       await refresh();

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -7,6 +7,7 @@ import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
 import { usePanelStore } from "@/store";
 import { actionService } from "@/services/ActionService";
 import type { WorktreeState } from "@/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface WorktreeDeleteDialogProps {
   isOpen: boolean;
@@ -106,7 +107,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       }
       onClose();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = formatErrorMessage(err, "Failed to delete worktree");
       setError(msg);
     } finally {
       setIsDeleting(false);

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -6,6 +6,7 @@ import { notify } from "@/lib/notify";
 import { useNotificationStore } from "@/store/notificationStore";
 import { detectCloudSyncService, type Platform } from "@/utils/cloudSyncDetection";
 import { isMac, isLinux } from "@/lib/platform";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function getPlatform(): Platform {
   if (isMac()) return "mac";
@@ -67,7 +68,7 @@ export function useCloudSyncWarning(homeDir?: string) {
               notify({
                 type: "error",
                 title: "Failed to save preference",
-                message: err instanceof Error ? err.message : "Unknown error",
+                message: formatErrorMessage(err, "Failed to save cloud sync warning preference"),
                 duration: 6000,
               });
               lastNotifiedProjectRef.current = null;

--- a/src/hooks/app/useContextFilesOffer.tsx
+++ b/src/hooks/app/useContextFilesOffer.tsx
@@ -4,6 +4,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { notify } from "@/lib/notify";
 import { useNotificationStore } from "@/store/notificationStore";
 import { projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function formatFileList(files: string[]): string {
   if (files.length === 1) return files[0]!;
@@ -110,7 +111,7 @@ export function useContextFilesOffer() {
                 notify({
                   type: "error",
                   title: "Failed to enable project context",
-                  message: err instanceof Error ? err.message : "Unknown error",
+                  message: formatErrorMessage(err, "Failed to enable project context"),
                   duration: 6000,
                 });
                 // Allow a retry next time the effect runs for this project.
@@ -135,7 +136,7 @@ export function useContextFilesOffer() {
                 notify({
                   type: "error",
                   title: "Failed to save preference",
-                  message: err instanceof Error ? err.message : "Unknown error",
+                  message: formatErrorMessage(err, "Failed to dismiss context files offer"),
                   duration: 6000,
                 });
                 if (inFlightProjectRef.current === targetProjectId) {

--- a/src/hooks/useArtifacts.ts
+++ b/src/hooks/useArtifacts.ts
@@ -10,6 +10,7 @@ import { artifactClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { logDebug } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const artifactStore = new Map<string, Artifact[]>();
 const listeners = new Set<(terminalId: string, artifacts: Artifact[]) => void>();
@@ -212,7 +213,7 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
         });
         return {
           success: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Failed to apply patch"),
         };
       } finally {
         setActionInProgress(null);
@@ -331,7 +332,7 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
           result.failed++;
           result.failures.push({
             artifact,
-            error: error instanceof Error ? error.message : String(error),
+            error: formatErrorMessage(error, "Failed to save artifact"),
           });
         }
       }
@@ -402,7 +403,7 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
           result.failed++;
           result.failures.push({
             artifact,
-            error: error instanceof Error ? error.message : String(error),
+            error: formatErrorMessage(error, "Failed to apply patch"),
           });
         }
       }

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -7,6 +7,7 @@ import { copyTreeClient } from "@/clients";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 import { logDebug, logError } from "@/utils/logger";
 import { isAgentTerminal } from "@/utils/terminalType";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type InjectionStatus = "idle" | "waiting" | "injecting";
 
@@ -260,7 +261,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
           });
         } catch (e) {
           // Injection was cancelled while waiting
-          const message = e instanceof Error ? e.message : "Injection cancelled";
+          const message = formatErrorMessage(e, "Injection cancelled");
           if (message !== "Injection cancelled") {
             setError(message);
           }
@@ -355,7 +356,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
           currentErrorIdRef.current = null;
         }
       } catch (e) {
-        const message = e instanceof Error ? e.message : "Failed to inject context";
+        const message = formatErrorMessage(e, "Failed to inject context");
         const details = e instanceof Error ? e.stack : undefined;
 
         setError(message);

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useProjectStore } from "@/store/projectStore";
 import type { DevServerErrorType } from "../../shared/utils/devServerErrors";
 import type { DevPreviewSessionState } from "../../shared/types/ipc/devPreview";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type DevPreviewStatus = "stopped" | "starting" | "installing" | "running" | "error";
 
@@ -168,7 +169,7 @@ export function useDevServer({
 
   const applyInvokeError = useCallback((err: unknown) => {
     if (!isMountedRef.current) return;
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatErrorMessage(err, "Dev server request failed");
     latestSessionRef.current = {
       status: "error",
       url: null,

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
 import type { ActionId } from "@shared/types/actions";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 /**
  * Sets up the renderer-side MCP bridge.
@@ -37,7 +38,7 @@ export function useMcpBridge(): void {
               ok: false,
               error: {
                 code: "EXECUTION_ERROR",
-                message: err instanceof Error ? err.message : String(err),
+                message: formatErrorMessage(err, "Action dispatch failed"),
               },
             },
           });

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { ProjectHealthData } from "../types";
 import { githubClient, projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -86,7 +87,7 @@ export function useProjectHealth(): UseProjectHealthReturn {
       }
     } catch (err) {
       if (mountedRef.current) {
-        const errorMessage = err instanceof Error ? err.message : "Failed to fetch project health";
+        const errorMessage = formatErrorMessage(err, "Failed to fetch project health");
         setError(errorMessage);
         lastErrorRef.current = errorMessage;
       }

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -4,6 +4,7 @@ import { advanceMruIndex, getMruProjects } from "@/lib/projectMru";
 import { notify } from "@/lib/notify";
 import { useProjectStore } from "@/store/projectStore";
 import type { Project } from "@shared/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 import { useEscapeStack } from "./useEscapeStack";
 
@@ -87,7 +88,7 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
       notify({
         type: "error",
         title: "Failed to switch project",
-        message: error instanceof Error ? error.message : "Unknown error",
+        message: formatErrorMessage(error, "Failed to switch project"),
         duration: 5000,
       });
     });

--- a/src/hooks/useProjectSettings.ts
+++ b/src/hooks/useProjectSettings.ts
@@ -4,6 +4,7 @@ import { useProjectStore } from "../store/projectStore";
 import { useProjectSettingsStore } from "../store/projectSettingsStore";
 import { projectClient } from "@/clients";
 import { updateBrandingCache } from "./useProjectBranding";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface UseProjectSettingsReturn {
   settings: ProjectSettings | null;
@@ -76,7 +77,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
     } catch (err) {
       console.error("Failed to load project settings:", err);
       if (requestedProjectId === latestTargetIdRef.current) {
-        setLocalError(err instanceof Error ? err.message : "Unknown error");
+        setLocalError(formatErrorMessage(err, "Failed to load project settings"));
         setLocalSettings({ runCommands: [] });
         setLocalDetectedRunners([]);
         setLocalAllDetectedRunners([]);
@@ -146,7 +147,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
         setLocalError(null);
       } catch (err) {
         console.error("Failed to save project settings:", err);
-        const errorMsg = err instanceof Error ? err.message : "Unknown error";
+        const errorMsg = formatErrorMessage(err, "Failed to save project settings");
         setLocalError(errorMsg);
         throw err;
       }
@@ -201,7 +202,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
         setLocalError(null);
       } catch (err) {
         console.error("Failed to promote command:", err);
-        setLocalError(err instanceof Error ? err.message : "Unknown error");
+        setLocalError(formatErrorMessage(err, "Failed to promote command"));
         throw err;
       }
     },
@@ -263,7 +264,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
         setLocalError(null);
       } catch (err) {
         console.error("Failed to remove command:", err);
-        setLocalError(err instanceof Error ? err.message : "Unknown error");
+        setLocalError(formatErrorMessage(err, "Failed to remove command"));
         throw err;
       }
     },

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -15,6 +15,7 @@ import type { ProjectTerminalSettings, ResourceEnvironment } from "@shared/types
 import type { CommandOverride } from "@shared/types/commands";
 import type { NotificationSettings } from "@shared/types/ipc/api";
 import { SCROLLBACK_MIN, SCROLLBACK_MAX } from "@shared/config/scrollback";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface UseProjectSettingsFormParams {
   projectId: string | null;
@@ -404,7 +405,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       }
     } catch (err) {
       console.error("Failed to auto-save project settings:", err);
-      setProjectAutoSaveError(err instanceof Error ? err.message : "Failed to save settings");
+      setProjectAutoSaveError(formatErrorMessage(err, "Failed to save settings"));
     }
   };
 

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -6,6 +6,7 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { notify } from "@/lib/notify";
 import type { Project } from "@shared/types";
 import { projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type ProjectSwitcherMode = "modal" | "dropdown";
 
@@ -251,7 +252,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           notify({
             type: "error",
             title: "Failed to reopen project",
-            message: error instanceof Error ? error.message : "Unknown error",
+            message: formatErrorMessage(error, "Failed to reopen project"),
             duration: 5000,
           });
         }
@@ -262,7 +263,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           notify({
             type: "error",
             title: "Failed to switch project",
-            message: error instanceof Error ? error.message : "Unknown error",
+            message: formatErrorMessage(error, "Failed to switch project"),
             duration: 5000,
           });
         }
@@ -305,7 +306,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         notify({
           type: "error",
           title: "Failed to update project",
-          message: error instanceof Error ? error.message : "Unknown error",
+          message: formatErrorMessage(error, "Failed to update project"),
           duration: 5000,
         });
       }
@@ -332,7 +333,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       notify({
         type: "error",
         title: "Failed to stop project",
-        message: error instanceof Error ? error.message : "Unknown error",
+        message: formatErrorMessage(error, "Failed to stop project"),
         duration: 5000,
       });
     } finally {
@@ -370,7 +371,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         title: removeConfirmProject.isActive
           ? "Failed to close project"
           : "Failed to remove project",
-        message: error instanceof Error ? error.message : "Unknown error",
+        message: formatErrorMessage(
+          error,
+          removeConfirmProject.isActive ? "Failed to close project" : "Failed to remove project"
+        ),
         duration: 5000,
       });
     } finally {

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -9,6 +9,7 @@ import { getAutoAssign } from "@shared/types/project";
 import { detectPrefixFromIssue, buildBranchName } from "@/components/Worktree/branchPrefixUtils";
 import { generateBranchSlug } from "@/utils/textParsing";
 import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type QuickCreateItem =
   | (TerminalRecipe & { _kind: "recipe" })
@@ -182,7 +183,7 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
           notify({
             type: "error",
             title: "Creation Failed",
-            message: error instanceof Error ? error.message : "Unknown error",
+            message: formatErrorMessage(error, "Failed to create worktree"),
           });
         } finally {
           closeQuickCreate();

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import type { GitHubRateLimitKind, RepositoryStats } from "../types";
 import { githubClient, projectClient } from "@/clients";
 import { isTokenRelatedError } from "@/lib/githubErrors";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -176,8 +177,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       }
     } catch (err) {
       if (mountedRef.current) {
-        const errorMessage =
-          err instanceof Error ? err.message : "Failed to fetch repository stats";
+        const errorMessage = formatErrorMessage(err, "Failed to fetch repository stats");
         setError(errorMessage);
         lastErrorRef.current = errorMessage;
       }

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -5,6 +5,7 @@ import { useRecipeStore } from "@/store/recipeStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { formatBytes } from "@/lib/formatBytes";
 import { actionService } from "@/services/ActionService";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export function formatCopyResultMessage(payload: {
   fileCount: number;
@@ -67,7 +68,7 @@ export async function copyContextWithFeedback(
       dismissed: false,
     });
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Failed to copy context to clipboard";
+    const message = formatErrorMessage(e, "Failed to copy context to clipboard");
     store.updateNotification(toastId, {
       type: "error",
       message: `Copy context failed: ${message}`,
@@ -139,7 +140,7 @@ export function useWorktreeActions({
         };
         return formatCopyResultMessage(payload);
       } catch (e) {
-        const message = e instanceof Error ? e.message : "Failed to copy context to clipboard";
+        const message = formatErrorMessage(e, "Failed to copy context to clipboard");
         const details = e instanceof Error ? e.stack : undefined;
 
         let errorType: AppError["type"] = "process";

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -13,6 +13,7 @@ import type { AnyActionDefinition } from "./actions/actionTypes";
 import { logWarn } from "@/utils/logger";
 import { keybindingService } from "./KeybindingService";
 import { shortcutHintStore } from "../store/shortcutHintStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 /** Fields that should be redacted from event payloads to prevent secret leakage */
 const SENSITIVE_ARG_FIELDS = new Set(["token", "password", "secret", "key", "auth", "credential"]);
@@ -213,7 +214,7 @@ export class ActionService {
     } catch (err) {
       const error: ActionError = {
         code: "EXECUTION_ERROR",
-        message: err instanceof Error ? err.message : String(err),
+        message: formatErrorMessage(err, `Action "${actionId}" failed`),
         details: err,
       };
       return { ok: false, error };

--- a/src/services/SemanticAnalysisService.ts
+++ b/src/services/SemanticAnalysisService.ts
@@ -12,6 +12,7 @@ import type {
   WorkerInboundMessage,
 } from "../../shared/types/worker-messages.js";
 import { logDebug, logWarn, logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 /** Event handlers for semantic analysis events */
 export interface SemanticAnalysisEventHandlers {
@@ -101,7 +102,7 @@ class SemanticAnalysisService {
     } catch (error) {
       logError("[SemanticAnalysisService] Failed to get analysis buffer", error);
       this.handlers.onError?.(
-        error instanceof Error ? error.message : String(error),
+        formatErrorMessage(error, "Failed to initialize semantic analysis worker"),
         "initialization"
       );
 
@@ -192,7 +193,7 @@ class SemanticAnalysisService {
     try {
       await this.initialize(this.handlers);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to restart semantic analysis worker");
       logError("[SemanticAnalysisService] Worker restart failed", undefined, { message });
       this.handlers.onError?.(message, "restart");
       return;

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -4,6 +4,7 @@ import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { getMruProjects } from "@/lib/projectMru";
 import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 async function runMruFallbackSwitch(direction: "older" | "newer"): Promise<void> {
   const state = useProjectStore.getState();
@@ -25,7 +26,7 @@ async function runMruFallbackSwitch(direction: "older" | "newer"): Promise<void>
     notify({
       type: "error",
       title: "Failed to switch project",
-      message: error instanceof Error ? error.message : "Unknown error",
+      message: formatErrorMessage(error, "Failed to switch project"),
       duration: 5000,
     });
   }
@@ -258,7 +259,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
         notify({
           type: "error",
           title: "Failed to mute notifications",
-          message: error instanceof Error ? error.message : "Unknown error",
+          message: formatErrorMessage(error, "Failed to mute project notifications"),
           duration: 5000,
         });
       }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -36,6 +36,7 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isUselessTitle, normalizeObservedTitle } from "@shared/utils/isUselessTitle";
 import { usePanelStore } from "@/store/panelStore";
 import { isNonKeyboardInput } from "./inputUtils";
@@ -937,14 +938,14 @@ class TerminalInstanceService {
           window.electron.terminal.updateObservedTitle(id, pending);
         } catch (err) {
           logWarn("[TerminalInstanceService] updateObservedTitle failed", {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "Failed to update observed title"),
           });
         }
         try {
           usePanelStore.getState().updateLastObservedTitle(id, pending);
         } catch (err) {
           logWarn("[TerminalInstanceService] panel store title update failed", {
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "Failed to update panel store observed title"),
           });
         }
       }, 150);

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -6,6 +6,7 @@ import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
 import { isAgentPinned } from "../../shared/utils/agentPinned";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 /**
  * In-memory normalization with two distinct paths:
@@ -136,7 +137,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
           return;
         }
         set({
-          error: e instanceof Error ? e.message : "Failed to load agent settings",
+          error: formatErrorMessage(e, "Failed to load agent settings"),
           isLoading: false,
           isInitialized: true,
         });
@@ -166,7 +167,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       // owns the error surface now, and fire-and-forget callers should not
       // see spurious unhandled rejections from an invalidated attempt.
       if (myEpoch !== normalizeEpoch) return;
-      set({ error: e instanceof Error ? e.message : "Failed to refresh agent settings" });
+      set({ error: formatErrorMessage(e, "Failed to refresh agent settings") });
       throw e;
     }
   },
@@ -195,7 +196,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
     } catch (e) {
       if (myEpoch !== normalizeEpoch) return;
       if (previous) set({ settings: previous });
-      set({ error: e instanceof Error ? e.message : `Failed to update ${agentId} settings` });
+      set({ error: formatErrorMessage(e, `Failed to update ${agentId} settings`) });
       throw e;
     }
   },
@@ -232,7 +233,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       set({ settings });
     } catch (e) {
       if (myEpoch !== normalizeEpoch) return;
-      set({ error: e instanceof Error ? e.message : "Failed to reset agent settings" });
+      set({ error: formatErrorMessage(e, "Failed to reset agent settings") });
       throw e;
     }
   },

--- a/src/store/appAgentStore.ts
+++ b/src/store/appAgentStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { AppAgentConfig } from "@shared/types";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface AppAgentState {
   hasApiKey: boolean;
@@ -41,7 +42,7 @@ export const useAppAgentStore = create<AppAgentStore>()((set, get) => ({
         set({ hasApiKey, config, enabled: config.enabled !== false, isInitialized: true });
       } catch (e) {
         set({
-          error: e instanceof Error ? e.message : "Failed to initialize app agent",
+          error: formatErrorMessage(e, "Failed to initialize app agent"),
           isInitialized: true,
         });
       }
@@ -56,7 +57,7 @@ export const useAppAgentStore = create<AppAgentStore>()((set, get) => ({
       const hasApiKey = await window.electron.appAgent.hasApiKey();
       set({ config, hasApiKey, enabled: config.enabled !== false, error: null });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : "Failed to set API key" });
+      set({ error: formatErrorMessage(e, "Failed to set API key") });
       throw e;
     }
   },
@@ -66,7 +67,7 @@ export const useAppAgentStore = create<AppAgentStore>()((set, get) => ({
       const config = await window.electron.appAgent.setConfig({ model });
       set({ config, enabled: config.enabled !== false, error: null });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : "Failed to set model" });
+      set({ error: formatErrorMessage(e, "Failed to set model") });
       throw e;
     }
   },
@@ -76,7 +77,7 @@ export const useAppAgentStore = create<AppAgentStore>()((set, get) => ({
       const config = await window.electron.appAgent.setConfig({ enabled });
       set({ config, enabled, error: null });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : "Failed to update enabled state" });
+      set({ error: formatErrorMessage(e, "Failed to update enabled state") });
       throw e;
     }
   },

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -5,6 +5,7 @@ import { cliAvailabilityClient } from "@/clients";
 import { getAgentIds } from "@/config/agents";
 import { isElectronAvailable } from "@/hooks/useElectron";
 import { safeJSONParse } from "./persistence/safeStorage";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface CliAvailabilityState {
   availability: CliAvailability;
@@ -207,7 +208,7 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
         } catch (e) {
           if (epoch === myEpoch) {
             set({
-              error: e instanceof Error ? e.message : "Failed to check CLI availability",
+              error: formatErrorMessage(e, "Failed to check CLI availability"),
               isLoading: false,
               isInitialized: true,
             });
@@ -262,7 +263,7 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
         } catch (e) {
           if (epoch === myEpoch) {
             set({
-              error: e instanceof Error ? e.message : "Failed to refresh CLI availability",
+              error: formatErrorMessage(e, "Failed to refresh CLI availability"),
               isRefreshing: false,
             });
           }

--- a/src/store/commandStore.ts
+++ b/src/store/commandStore.ts
@@ -6,6 +6,7 @@ import type {
   BuilderStep,
 } from "@shared/types/commands";
 import { commandsClient } from "@/clients/commandsClient";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface CommandStore {
   // Picker state
@@ -78,7 +79,7 @@ export const useCommandStore = create<CommandStore>()((set, get) => ({
           }
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Failed to load builder";
+        const message = formatErrorMessage(error, "Failed to load builder");
         console.error("Failed to fetch builder steps:", error);
         const currentCommandId = get().activeCommandId;
         if (currentCommandId === commandId) {
@@ -119,7 +120,7 @@ export const useCommandStore = create<CommandStore>()((set, get) => ({
 
       return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Command execution failed";
+      const message = formatErrorMessage(error, "Command execution failed");
       set({ executionError: message });
       return {
         success: false,

--- a/src/store/githubConfigStore.ts
+++ b/src/store/githubConfigStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { GitHubTokenConfig } from "@/types";
 import { githubClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface GitHubConfigState {
   config: GitHubTokenConfig | null;
@@ -37,7 +38,7 @@ export const useGitHubConfigStore = create<GitHubConfigStore>()((set, get) => ({
         set({ config, isLoading: false, isInitialized: true });
       } catch (e) {
         set({
-          error: e instanceof Error ? e.message : "Failed to load GitHub config",
+          error: formatErrorMessage(e, "Failed to load GitHub config"),
           isLoading: false,
           isInitialized: true,
         });
@@ -53,7 +54,7 @@ export const useGitHubConfigStore = create<GitHubConfigStore>()((set, get) => ({
       const config = await githubClient.getConfig();
       set({ config });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : "Failed to refresh GitHub config" });
+      set({ error: formatErrorMessage(e, "Failed to refresh GitHub config") });
     }
   },
 

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -1,5 +1,6 @@
 import type { PersistStorage, StateStorage, StorageValue } from "zustand/middleware";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const fallbackStorageData = new Map<string, string>();
 
@@ -151,7 +152,7 @@ export function safeJSONParse<T>(
   } catch (error) {
     console.warn("[safeStorage] JSON parse failed", {
       ...context,
-      error: error instanceof Error ? error.message : String(error),
+      error: formatErrorMessage(error, "JSON parse failed"),
     });
     return fallback;
   }
@@ -170,7 +171,7 @@ export function createSafeJSONStorage<T>(): PersistStorage<T> {
       } catch (error) {
         console.warn("[safeStorage] corrupt persisted state, resetting to defaults", {
           key: name,
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Corrupt persisted state"),
         });
         return null;
       }

--- a/src/store/projectSettingsStore.ts
+++ b/src/store/projectSettingsStore.ts
@@ -1,6 +1,7 @@
 import { create, type StateCreator } from "zustand";
 import type { ProjectSettings, RunCommand } from "@shared/types";
 import { projectClient } from "@/clients";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface ProjectSettingsState {
   /** Cached settings for the current project */
@@ -114,7 +115,7 @@ const createProjectSettingsStore: StateCreator<ProjectSettingsState & ProjectSet
       }
 
       set({
-        error: err instanceof Error ? err.message : "Unknown error",
+        error: formatErrorMessage(err, "Failed to load project settings"),
         settings: { runCommands: [] },
         detectedRunners: [],
         allDetectedRunners: [],

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -12,6 +12,7 @@ import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistence";
 import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import type { TerminalInstance, TabGroup } from "@shared/types";
 
@@ -191,13 +192,13 @@ function getProjectStoreListenerState(): ProjectStoreListenerState {
 }
 
 function isDubiousOwnershipError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatErrorMessage(error, "");
   const lower = message.toLowerCase();
   return lower.includes("dubious ownership") || lower.includes("safe.directory");
 }
 
 function getProjectOpenErrorMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatErrorMessage(error, "");
   const lower = message.toLowerCase();
 
   if (lower.includes("spawn git enoent") || lower.includes("git: not found")) {
@@ -289,7 +290,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         component: "projectStore",
         details: { path: resolvedPath || path },
       });
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to add project");
 
       // Absolute-path check: POSIX (/...), Windows drive letter (C:\... / C:/...),
       // and Windows UNC (\\server\share...) are all "absolute" here.
@@ -324,8 +325,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                   try {
                     await window.electron.git.markSafeDirectory(targetPath);
                   } catch (markError) {
-                    const markMessage =
-                      markError instanceof Error ? markError.message : String(markError);
+                    const markMessage = formatErrorMessage(
+                      markError,
+                      "Failed to mark directory as safe"
+                    );
                     notify({
                       type: "error",
                       title: "Failed to mark as safe",

--- a/src/store/pulseStore.ts
+++ b/src/store/pulseStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { ProjectPulse, PulseRangeDays } from "@shared/types";
 import { actionService } from "@/services/ActionService";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY = 2000;
@@ -132,8 +133,7 @@ export const usePulseStore = create<PulseStore>()((set, get) => ({
 
       return null;
     } catch (error) {
-      const technicalMessage =
-        error instanceof Error ? error.message : "Failed to fetch pulse data";
+      const technicalMessage = formatErrorMessage(error, "Failed to fetch pulse data");
       const userMessage = getUserFriendlyError(technicalMessage);
       const currentRetries = get().retryCount.get(worktreeId) ?? 0;
       const currentState = get();

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -7,6 +7,7 @@ import { generateAgentCommand } from "@shared/types";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export interface RecipeSpawnResult {
   index: number;
@@ -593,7 +594,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           results.failed.push({ index, error: "Panel limit reached" });
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatErrorMessage(error, "Failed to spawn terminal");
         console.error(`Failed to spawn terminal for recipe ${recipeId}:`, error);
         results.failed.push({ index, error: message });
       }

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -28,6 +28,7 @@ import {
   resolveAgentRuntimeSettings,
   type AgentRuntimeSettingsResolution,
 } from "@/utils/agentRuntimeSettings";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 // Lazy accessor to break circular dependency: restart -> projectStore -> panelPersistence -> core.
 let _cachedProjectStore: typeof import("@/store/projectStore").useProjectStore | null = null;
@@ -199,7 +200,7 @@ export const createRestartActions = (
         recoverable: false,
         context: {
           failedCwd: terminal.cwd,
-          validationError: error instanceof Error ? error.message : String(error),
+          validationError: formatErrorMessage(error, "Failed to validate terminal configuration"),
         },
       };
 
@@ -501,7 +502,7 @@ export const createRestartActions = (
       unmarkTerminalRestarting(id);
       set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to restart terminal");
       const errorCode = (error as { code?: string })?.code;
 
       let phase = "unknown";
@@ -693,7 +694,7 @@ export const createRestartActions = (
                   ...t,
                   isRestarting: false,
                   restartError: {
-                    message: err instanceof Error ? err.message : String(err),
+                    message: formatErrorMessage(err, "Failed to move terminal to new worktree"),
                     timestamp: Date.now(),
                     recoverable: false,
                     context: {
@@ -949,7 +950,7 @@ export const createRestartActions = (
       set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
       return { success: true };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = formatErrorMessage(error, "Failed to restart terminal");
       unmarkTerminalRestarting(id);
       set((state) =>
         updateTerminal(state, id, (t) => ({

--- a/src/store/userAgentRegistryStore.ts
+++ b/src/store/userAgentRegistryStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { UserAgentRegistry, UserAgentConfig } from "@shared/types";
 import { userAgentRegistryClient } from "@/clients/userAgentRegistryClient";
 import { setUserRegistry } from "../../shared/config/agentRegistry";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 interface UserAgentRegistryState {
   registry: UserAgentRegistry | null;
@@ -44,7 +45,7 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, 
         set({ registry, isLoading: false, isInitialized: true });
       } catch (e) {
         set({
-          error: e instanceof Error ? e.message : "Failed to load user agent registry",
+          error: formatErrorMessage(e, "Failed to load user agent registry"),
           isLoading: false,
           isInitialized: false,
         });
@@ -69,7 +70,7 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, 
       }
       return result;
     } catch (e) {
-      const error = e instanceof Error ? e.message : "Failed to add agent";
+      const error = formatErrorMessage(e, "Failed to add agent");
       set({ error });
       return { success: false, error };
     }
@@ -88,7 +89,7 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, 
       }
       return result;
     } catch (e) {
-      const error = e instanceof Error ? e.message : "Failed to update agent";
+      const error = formatErrorMessage(e, "Failed to update agent");
       set({ error });
       return { success: false, error };
     }
@@ -107,7 +108,7 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, 
       }
       return result;
     } catch (e) {
-      const error = e instanceof Error ? e.message : "Failed to remove agent";
+      const error = formatErrorMessage(e, "Failed to remove agent");
       set({ error });
       return { success: false, error };
     }
@@ -120,7 +121,7 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, 
       setUserRegistry(registry);
       set({ registry });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : "Failed to refresh user agent registry" });
+      set({ error: formatErrorMessage(e, "Failed to refresh user agent registry") });
       throw e;
     }
   },

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -7,6 +7,7 @@ import { logErrorWithContext } from "@/utils/errorContext";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { setWorktreeSelectionStoreGetter } from "./projectStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 // Getter injected by fleetArmingStore at module init to break the import
 // cycle (fleetArmingStore imports worktreeStore). Returns the current armed
@@ -177,7 +178,7 @@ function loadClientsModule(): Promise<ClientsModule> {
           module: "@/clients",
           durationMs: Number((now - startedAt).toFixed(3)),
           ok: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Failed to load @/clients module"),
         });
         throw error;
       });
@@ -205,7 +206,7 @@ function loadTerminalStoreModule(): Promise<TerminalStoreModule> {
           module: "@/store/panelStore",
           durationMs: Number((now - startedAt).toFixed(3)),
           ok: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Failed to load @/store/panelStore module"),
         });
         throw error;
       });

--- a/src/utils/reactRootErrorCallbacks.ts
+++ b/src/utils/reactRootErrorCallbacks.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from "@/utils/errorContext";
 export function onCaughtError(error: unknown, errorInfo: { componentStack?: string }): void {
   try {
     logWarn("[React] Caught render error", {
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
       componentStack: errorInfo.componentStack,
     });
   } catch {
@@ -55,7 +55,7 @@ export function onUncaughtError(error: unknown, errorInfo: { componentStack?: st
 export function onRecoverableError(error: unknown, errorInfo: { componentStack?: string }): void {
   try {
     logDebug("[React] Recoverable render error", {
-      error: error instanceof Error ? error.message : String(error),
+      error: getErrorMessage(error),
       componentStack: errorInfo.componentStack,
     });
   } catch {

--- a/src/utils/renderBootstrapError.ts
+++ b/src/utils/renderBootstrapError.ts
@@ -1,5 +1,7 @@
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
 export function renderBootstrapError(rootEl: HTMLElement, error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = formatErrorMessage(error, "Renderer failed to initialize");
   const stack = error instanceof Error ? error.stack : undefined;
 
   rootEl.innerHTML = "";

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -1,6 +1,7 @@
 import type { TerminalInstance } from "@/types";
 import { systemClient } from "@/clients/systemClient";
 import { getAgentConfig } from "@/config/agents";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export interface ValidationError {
   type: "cwd" | "cli" | "config";
@@ -32,7 +33,7 @@ export async function validateTerminalConfig(
         });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to check directory");
       errors.push({
         type: "config",
         message: `Failed to validate working directory "${terminal.cwd}": ${message}`,
@@ -60,7 +61,7 @@ export async function validateTerminalConfig(
         });
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = formatErrorMessage(error, "Failed to check CLI");
       errors.push({
         type: "config",
         message: `Failed to validate CLI "${agentId}": ${message}`,
@@ -88,7 +89,7 @@ export async function validateTerminals(
           results.set(terminal.id, result);
         }
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatErrorMessage(error, "Failed to validate terminal");
         results.set(terminal.id, {
           valid: false,
           errors: [

--- a/src/workers/semantic.worker.ts
+++ b/src/workers/semantic.worker.ts
@@ -19,6 +19,7 @@ import type {
   WorkerOutboundMessage,
   WorkerTerminalState,
 } from "../../shared/types/worker-messages.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const ACTIVE_POLL_MS = 20; // 50Hz when receiving data
 const IDLE_INTERVALS = [50, 100, 250] as const; // Progressive backoff when idle
@@ -71,7 +72,7 @@ async function processPacket(terminalId: string, data: string): Promise<void> {
   } catch (error) {
     postTypedMessage({
       type: "ERROR",
-      error: error instanceof Error ? error.message : String(error),
+      error: formatErrorMessage(error, "Artifact extraction failed"),
       context: "artifact extraction",
     });
   }
@@ -149,7 +150,7 @@ async function pollBuffer(): Promise<void> {
   } catch (error) {
     postTypedMessage({
       type: "ERROR",
-      error: error instanceof Error ? error.message : String(error),
+      error: formatErrorMessage(error, "Polling loop failed"),
       context: "polling loop",
     });
   } finally {
@@ -161,7 +162,7 @@ async function pollBuffer(): Promise<void> {
 self.onunhandledrejection = (event: PromiseRejectionEvent) => {
   postTypedMessage({
     type: "ERROR",
-    error: event.reason instanceof Error ? event.reason.message : String(event.reason),
+    error: formatErrorMessage(event.reason, "Unhandled promise rejection"),
     context: "unhandled rejection",
   });
 };
@@ -192,7 +193,7 @@ self.onmessage = (event: MessageEvent<WorkerInboundMessage>) => {
       } catch (error) {
         postTypedMessage({
           type: "ERROR",
-          error: error instanceof Error ? error.message : String(error),
+          error: formatErrorMessage(error, "Failed to initialize ring buffer"),
           context: "buffer initialization",
         });
       }


### PR DESCRIPTION
## Summary

- ~290 catch sites across the codebase used `err instanceof Error ? err.message : "Unknown error"`, producing uninformative fallbacks whenever the error was non-standard or IPC-stripped. Users saw "Unknown error" with no context; the string gave future debuggers nothing to search for.
- New `shared/utils/errorMessage.ts` exports `formatErrorMessage(error, fallback)` with a required positional fallback. It duck-types `{message: string}` objects so IPC-deserialized errors are handled correctly. Every call site now carries a domain-specific fallback derived from the surrounding catch context.
- A new ESLint `no-restricted-syntax` rule bans the raw `instanceof Error ? .message : ...` ternary going forward, so the pattern can't sneak back in.

Resolves #5845

## Changes

- `shared/utils/errorMessage.ts` — new helper with required fallback, duck-type support, and Proxy-safe handling
- `shared/utils/__tests__/errorMessage.test.ts` — 18+ cases covering Error, string, IPC duck-type, opaque objects, and Proxy edges
- 124 files migrated across `electron/`, `src/` — all 290 sites converted to domain-specific fallbacks
- `eslint.config.mjs` — `no-restricted-syntax` rule banning the old ternary pattern
- 5 `eslint-disable` sites retained with rationale comments: typed `Daintree error.cause` extraction (undefined fallback is load-bearing), 2 console.warn diagnostics, 1 top-level fatal shape check, 1 `page.evaluate` context that can't import shared helpers
- `getUserMessage` tests updated; `AppAgentService` adversarial test split into opaque vs string passthrough cases

## Testing

- `npm run check` passes clean (0 errors, warnings only on pre-existing patterns)
- All 18+ new `formatErrorMessage` unit tests pass
- 5 new `getUserMessage` tests pass
- ESLint rule verified to catch the banned pattern and accept `formatErrorMessage` in its place