### PR TITLE
fix(notifications): show worst severity icon in grouped threads

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -8,6 +8,21 @@ import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { Button } from "@/components/ui/button";
 import { actionService } from "@/services/ActionService";
 import { muteForDuration, muteUntilNextMorning, notify } from "@/lib/notify";
+import type { NotificationType } from "@/store/notificationStore";
+
+const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+  success: 0,
+} as const;
+
+function getWorstSeverity(entries: NotificationHistoryEntry[]): NotificationType {
+  if (entries.length === 0) return "success";
+  return entries.reduce((highest, current) =>
+    SEVERITY_WEIGHTS[current.type] > SEVERITY_WEIGHTS[highest.type] ? current : highest
+  ).type;
+}
 
 interface NotificationCenterProps {
   open: boolean;
@@ -251,10 +266,13 @@ function NotificationThread({
 
   if (!latest) return null;
 
+  const displayType = getWorstSeverity(group.entries);
+
   return (
     <div className="relative">
       <NotificationCenterEntry
         entry={latest}
+        displayType={displayType}
         threadCount={group.entries.length}
         isNew={isNew}
         onDismiss={() => onDismiss(latest.id)}

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { actionService } from "@/services/ActionService";
 import type { ActionId } from "@shared/types/actions";
+import type { NotificationType } from "@/store/notificationStore";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,6 +31,7 @@ function formatRelativeTime(timestamp: number): string {
 
 interface NotificationCenterEntryProps {
   entry: NotificationHistoryEntry;
+  displayType?: NotificationType;
   threadCount?: number;
   isNew?: boolean;
   onDismiss?: () => void;
@@ -37,11 +39,12 @@ interface NotificationCenterEntryProps {
 
 export function NotificationCenterEntry({
   entry,
+  displayType,
   threadCount,
   isNew = false,
   onDismiss,
 }: NotificationCenterEntryProps) {
-  const config = TYPE_CONFIG[entry.type];
+  const config = TYPE_CONFIG[displayType ?? entry.type];
   const Icon = config.icon;
 
   return (

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,272 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { NotificationCenter } from "../NotificationCenter";
+
+const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
+const getMock = vi.hoisted(() => vi.fn());
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock, get: getMock },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+  muteForDuration: vi.fn(),
+  muteUntilNextMorning: vi.fn(),
+}));
+
+function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
+  return {
+    id: `entry-${Math.random()}`,
+    type: "info",
+    message: "Notification message",
+    timestamp: Date.now(),
+    seenAsToast: true,
+    summarized: false,
+    countable: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useNotificationHistoryStore.getState().clearAll();
+  dispatchMock.mockClear();
+  getMock.mockReturnValue(null);
+});
+
+describe("NotificationThread worst severity", () => {
+  it("shows error icon for thread with [error, success] entries", async () => {
+    const correlationId = "thread-1";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "error-entry",
+        type: "error",
+        message: "Failed to deploy",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry",
+        type: "success",
+        message: "Deploy successful",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Deploy successful")).toBeTruthy();
+    });
+
+    const errorIcon = container.querySelector(".text-status-error");
+    expect(errorIcon).toBeTruthy();
+  });
+
+  it("shows error icon for thread with [info, warning, error] entries", async () => {
+    const correlationId = "thread-2";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "info-entry",
+        type: "info",
+        message: "Starting build",
+        correlationId,
+        timestamp: Date.now() - 3000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "warning-entry",
+        type: "warning",
+        message: "Slow dependency",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "error-entry",
+        type: "error",
+        message: "Build failed",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Build failed")).toBeTruthy();
+    });
+
+    const errorIcon = container.querySelector(".text-status-error");
+    expect(errorIcon).toBeTruthy();
+  });
+
+  it("shows warning icon for thread with [success, warning, info] entries", async () => {
+    const correlationId = "thread-3";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry",
+        type: "success",
+        message: "Step 1 complete",
+        correlationId,
+        timestamp: Date.now() - 3000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "info-entry",
+        type: "info",
+        message: "Step 2 complete",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "warning-entry",
+        type: "warning",
+        message: "Lint warnings found",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Lint warnings found")).toBeTruthy();
+    });
+
+    const warningIcon = container.querySelector(".text-status-warning");
+    expect(warningIcon).toBeTruthy();
+  });
+
+  it("shows info icon for thread with [success, success, info] entries", async () => {
+    const correlationId = "thread-4";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry-1",
+        type: "success",
+        message: "Part 1 done",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry-2",
+        type: "success",
+        message: "Part 2 done",
+        correlationId,
+        timestamp: Date.now() - 1500,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "info-entry",
+        type: "info",
+        message: "Build complete",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Build complete")).toBeTruthy();
+    });
+
+    const infoIcon = container.querySelector(".text-status-info");
+    expect(infoIcon).toBeTruthy();
+  });
+
+  it("shows success icon for thread with all success entries", async () => {
+    const correlationId = "thread-5";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry-1",
+        type: "success",
+        message: "Step 1 done",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry-2",
+        type: "success",
+        message: "Step 2 done",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Step 2 done")).toBeTruthy();
+    });
+
+    const successIcon = container.querySelector(".text-status-success");
+    expect(successIcon).toBeTruthy();
+  });
+});
+
+describe("NotificationThread with single entry", () => {
+  it("displays single-entry notification without thread count", async () => {
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "solo-entry",
+        type: "error",
+        message: "Single error",
+        correlationId: "solo-1",
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Single error")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/events$/)).toBeNull();
+  });
+});
+
+describe("NotificationThread message content", () => {
+  it("shows latest entry message even when worst severity is different", async () => {
+    const correlationId = "thread-6";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "error-entry",
+        type: "error",
+        message: "Build failed",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "success-entry",
+        type: "success",
+        message: "Build retried and succeeded",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Build retried and succeeded")).toBeTruthy();
+    });
+  });
+});

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";


### PR DESCRIPTION
## Summary
- Notification thread groups now display the worst severity icon across all entries, not just the latest one
- An error followed by a recovery success now correctly shows the error icon, matching how Linear and GitHub render collapsed activity
- Added comprehensive test coverage for the severity resolution

Resolves #5862

## Changes
- `getWorstSeverity()` computes the highest-severity type from all entries in a thread group
- `NotificationCenterEntry` accepts an optional `displayType` prop that overrides the entry's own type for icon rendering
- New test file covers 5 severity combinations, single-entry display, and message content correctness

## Testing
- Unit tests cover error > warning > info > success priority ordering
- Verified single-entry notifications are unaffected (no thread count badge)
- Confirmed the latest entry's message text is still shown even when the icon reflects an earlier error