### PR TITLE
fix(settings): replace weak and empty placeholders with concrete examples

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -929,7 +929,6 @@ export function AgentSettings({
                           suggestions={getAgentConfig(activeAgent.id)?.envSuggestions ?? []}
                           datalistId="env-key-suggestions-global"
                           contextKey={`global-${activeAgent.id}`}
-                          valuePlaceholder="value"
                           data-testid="global-env-editor"
                         />
                       </div>

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -246,7 +246,7 @@ export function EnvironmentSettingsTab() {
                           "w-full bg-daintree-sidebar border border-border-strong rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-none focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30",
                           isSensitive && "pr-8"
                         )}
-                        placeholder="value"
+                        placeholder="e.g. /usr/local/bin"
                         aria-label="Environment variable value"
                       />
                       {isSensitive && (

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -410,7 +410,7 @@ export function PortalSettingsTab() {
           <div className="flex gap-2">
             <input
               type="text"
-              placeholder="Name"
+              placeholder="e.g. My portal"
               value={newLinkName}
               onChange={(e) => {
                 setNewLinkName(e.target.value);
@@ -420,7 +420,7 @@ export function PortalSettingsTab() {
             />
             <input
               type="text"
-              placeholder="https://..."
+              placeholder="e.g. https://github.com/owner/repo"
               value={newLinkUrl}
               onChange={(e) => {
                 setNewLinkUrl(e.target.value);

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -210,14 +210,14 @@ export function PortalSettingsTab() {
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
             className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text w-32 focus:border-daintree-accent focus:outline-none"
-            placeholder="Name"
+            placeholder="e.g. My portal"
           />
           <input
             type="text"
             value={editUrl}
             onChange={(e) => setEditUrl(e.target.value)}
             className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text flex-1 focus:border-daintree-accent focus:outline-none"
-            placeholder="URL"
+            placeholder="e.g. https://github.com/owner/repo"
           />
           <button
             onClick={handleSaveEdit}

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -515,7 +515,7 @@ export function ResourceEnvironmentsSection({
               type="text"
               value={env.status ?? ""}
               onChange={(e) => updateEnv({ status: e.target.value || undefined })}
-              placeholder="e.g. docker inspect container"
+              placeholder="e.g. docker compose ps --format json"
               spellCheck={false}
               className="w-full px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-none focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
             />

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -476,7 +476,7 @@ export function ResourceEnvironmentsSection({
           <CommandList
             commands={env.provision ?? []}
             onChange={(provision) => updateEnv({ provision })}
-            placeholder=""
+            placeholder="e.g. docker compose up -d"
             label="Provision Commands"
             helpText="Commands to run when provisioning a remote environment"
           />
@@ -485,7 +485,7 @@ export function ResourceEnvironmentsSection({
           <CommandList
             commands={env.teardown ?? []}
             onChange={(teardown) => updateEnv({ teardown })}
-            placeholder=""
+            placeholder="e.g. docker compose down"
             label="Teardown Commands"
             helpText="Commands to run when destroying the environment"
           />
@@ -494,7 +494,7 @@ export function ResourceEnvironmentsSection({
           <CommandList
             commands={env.resume ?? []}
             onChange={(resume) => updateEnv({ resume })}
-            placeholder=""
+            placeholder="e.g. docker unpause container"
             label="Resume Commands"
             helpText="Commands to resume a paused environment without destroying"
           />
@@ -503,7 +503,7 @@ export function ResourceEnvironmentsSection({
           <CommandList
             commands={env.pause ?? []}
             onChange={(pause) => updateEnv({ pause })}
-            placeholder=""
+            placeholder="e.g. docker pause container"
             label="Pause Commands"
             helpText="Commands to pause the environment while preserving state"
           />
@@ -515,7 +515,7 @@ export function ResourceEnvironmentsSection({
               type="text"
               value={env.status ?? ""}
               onChange={(e) => updateEnv({ status: e.target.value || undefined })}
-              placeholder=""
+              placeholder="e.g. docker inspect container"
               spellCheck={false}
               className="w-full px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-none focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
             />
@@ -531,7 +531,7 @@ export function ResourceEnvironmentsSection({
               type="text"
               value={env.connect ?? ""}
               onChange={(e) => updateEnv({ connect: e.target.value || undefined })}
-              placeholder=""
+              placeholder="e.g. docker exec -it container /bin/bash"
               spellCheck={false}
               className="w-full px-3 py-1.5 text-sm bg-surface-inset border border-border-default rounded-[var(--radius-md)] text-daintree-text font-mono focus:outline-none focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
             />

--- a/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
+++ b/src/components/Settings/__tests__/ResourceEnvironmentsSection.test.tsx
@@ -35,37 +35,41 @@ describe("ResourceEnvironmentsSection", () => {
       (input as HTMLInputElement).value.includes("up -d")
     );
     expect(provisionInputs).toHaveLength(1);
-    expect(provisionInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(provisionInputs[0]?.getAttribute("placeholder")).toBe("e.g. docker compose up -d");
 
     const teardownInputs = inputs.filter((input) =>
       (input as HTMLInputElement).value.includes("down -v")
     );
     expect(teardownInputs).toHaveLength(1);
-    expect(teardownInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(teardownInputs[0]?.getAttribute("placeholder")).toBe("e.g. docker compose down");
 
     const resumeInputs = inputs.filter((input) =>
       (input as HTMLInputElement).value.includes("start")
     );
     expect(resumeInputs).toHaveLength(1);
-    expect(resumeInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(resumeInputs[0]?.getAttribute("placeholder")).toBe("e.g. docker unpause container");
 
     const pauseInputs = inputs.filter((input) =>
       (input as HTMLInputElement).value.includes("stop")
     );
     expect(pauseInputs).toHaveLength(1);
-    expect(pauseInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(pauseInputs[0]?.getAttribute("placeholder")).toBe("e.g. docker pause container");
 
     const statusInputs = inputs.filter((input) =>
       (input as HTMLInputElement).value.includes("ps --format json")
     );
     expect(statusInputs).toHaveLength(1);
-    expect(statusInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(statusInputs[0]?.getAttribute("placeholder")).toBe(
+      "e.g. docker compose ps --format json"
+    );
 
     const connectInputs = inputs.filter((input) =>
       (input as HTMLInputElement).value.includes("exec app bash")
     );
     expect(connectInputs).toHaveLength(1);
-    expect(connectInputs[0]?.getAttribute("placeholder")).toBe("");
+    expect(connectInputs[0]?.getAttribute("placeholder")).toBe(
+      "e.g. docker exec -it container /bin/bash"
+    );
   });
 
   it("preserves help text for all command fields", () => {


### PR DESCRIPTION
## Summary
- Replaced label-echo and empty placeholders across Settings tabs with example values that actually hint at what to type
- Covered PortalSettingsTab, EnvironmentSettingsTab, ResourceEnvironmentsSection, and removed a weak override in AgentSettings
- Updated test assertions to match the new placeholders

Resolves #5846

## Changes
**PortalSettingsTab** -- "Name" / "URL" replaced with "e.g. My portal" / "e.g. https://github.com/owner/repo" for both edit and add-row inputs

**EnvironmentSettingsTab** -- "value" replaced with "e.g. /usr/local/bin" so the placeholder adds signal instead of echoing the column label

**ResourceEnvironmentsSection** -- six empty placeholders filled with docker examples:
- Provision: `e.g. docker compose up -d`
- Teardown: `e.g. docker compose down`
- Resume: `e.g. docker unpause container`
- Pause: `e.g. docker pause container`
- Status: `e.g. docker compose ps --format json`
- Connect: `e.g. docker exec -it container /bin/bash`

**AgentSettings** -- removed `valuePlaceholder="value"` override, letting the default "e.g. /usr/local/bin" show through

**Tests** -- ResourceEnvironmentsSection assertions updated for the new placeholder values

## Testing
- Unit tests updated and passing
- Verified each input renders its example placeholder text