### PR TITLE
feat(palette): show disabled action reasons inline in action palette

### DIFF
--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActionPaletteItem } from "./ActionPaletteItem";
+import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/config/categoryColors", () => ({
+  ACTION_CATEGORY_COLORS: {
+    terminal: "bg-cat-blue/15 text-cat-blue",
+  },
+  ACTION_CATEGORY_DEFAULT_COLOR: "bg-tint/[0.06] text-daintree-text/50",
+}));
+
+function makeItem(overrides: Partial<ActionPaletteItemType> = {}): ActionPaletteItemType {
+  return {
+    id: "action-1",
+    title: "Test Action",
+    description: "Test description",
+    category: "terminal",
+    enabled: true,
+    kind: "command",
+    titleLower: "test action",
+    categoryLower: "terminal",
+    descriptionLower: "test description",
+    titleAcronym: "TA",
+    keywordsLower: [],
+    ...overrides,
+  };
+}
+
+describe("ActionPaletteItem", () => {
+  const onSelect = vi.fn();
+
+  it("renders enabled action without disabled reason", () => {
+    render(
+      <ActionPaletteItem
+        item={makeItem({ enabled: true })}
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getByText("Test Action")).toBeTruthy();
+    expect(screen.getByText("Test description")).toBeTruthy();
+    expect(screen.queryByText("No focused terminal")).toBeNull();
+  });
+
+  it("renders disabled action with inline disabled reason", () => {
+    render(
+      <ActionPaletteItem
+        item={makeItem({ enabled: false, disabledReason: "No focused terminal" })}
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getByText("Test Action")).toBeTruthy();
+    expect(screen.getByText("Test description")).toBeTruthy();
+    expect(screen.getByText("No focused terminal")).toBeTruthy();
+
+    const reasonElement = screen.getByText("No focused terminal");
+    expect(reasonElement.className).toContain("italic");
+  });
+
+  it("does not render disabled reason for disabled actions without a reason", () => {
+    const { container } = render(
+      <ActionPaletteItem
+        item={makeItem({ enabled: false })}
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getByText("Test Action")).toBeTruthy();
+    expect(screen.getByText("Test description")).toBeTruthy();
+    expect(container.querySelector("button")?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("does not render disabled reason for enabled actions with disabledReason", () => {
+    const { container } = render(
+      <ActionPaletteItem
+        item={makeItem({ enabled: true, disabledReason: "Should not show" })}
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getByText("Test Action")).toBeTruthy();
+    expect(screen.queryByText("Should not show")).toBeNull();
+    expect(container.querySelector("button")?.getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("renders keybinding when present", () => {
+    render(
+      <ActionPaletteItem
+        item={makeItem({ keybinding: "⌘K" })}
+        isSelected={false}
+        onSelect={onSelect}
+      />
+    );
+
+    expect(screen.getByText("⌘K")).toBeTruthy();
+  });
+
+  it("applies selected styling", () => {
+    const { container } = render(
+      <ActionPaletteItem item={makeItem()} isSelected={true} onSelect={onSelect} />
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -106,7 +106,7 @@ describe("ActionPaletteItem", () => {
     expect(screen.getByText("⌘K")).toBeTruthy();
   });
 
-  it("applies selected styling", () => {
+  it("applies selected styling with aria-selected and accent indicator", () => {
     const { container } = render(
       <ActionPaletteItem item={makeItem()} isSelected={true} onSelect={onSelect} />
     );
@@ -114,5 +114,6 @@ describe("ActionPaletteItem", () => {
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
     expect(button?.getAttribute("aria-selected")).toBe("true");
+    expect(button?.className).toContain("bg-overlay-soft");
   });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -16,7 +16,7 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
 
-  const buttonContent = (
+  return (
     <button
       id={`action-option-${item.id}`}
       tabIndex={-1}
@@ -24,6 +24,7 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
       role="option"
       aria-selected={isSelected}
       aria-disabled={!item.enabled}
+      disabled={!item.enabled}
       className={cn(
         "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
         !item.enabled && "opacity-40 cursor-not-allowed",
@@ -31,7 +32,7 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
           ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
           : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
       )}
-      onClick={() => onSelect(item)}
+      onClick={() => item.enabled && onSelect(item)}
     >
       <span
         className={cn(
@@ -48,7 +49,9 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
           <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
         )}
         {!item.enabled && item.disabledReason && (
-          <div className="text-[10px] text-daintree-text/40 italic">{item.disabledReason}</div>
+          <div className="text-[10px] text-daintree-text/40 italic truncate">
+            {item.disabledReason}
+          </div>
         )}
       </div>
 
@@ -59,6 +62,4 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
       )}
     </button>
   );
-
-  return buttonContent;
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
 
 interface ActionPaletteItemProps {
@@ -48,6 +47,9 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
         {item.description && (
           <div className="text-xs text-daintree-text/50 truncate">{item.description}</div>
         )}
+        {!item.enabled && item.disabledReason && (
+          <div className="text-[10px] text-daintree-text/40 italic">{item.disabledReason}</div>
+        )}
       </div>
 
       {item.keybinding && (
@@ -57,19 +59,6 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
       )}
     </button>
   );
-
-  if (!item.enabled && item.disabledReason) {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex w-full">{buttonContent}</span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{item.disabledReason}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
 
   return buttonContent;
 });


### PR DESCRIPTION
## Summary
- Disabled actions in the action palette now show their reason as an inline subtitle, matching the CommandPicker pattern
- Removes the Radix Tooltip wrapper that only worked on hover, leaving keyboard users in the dark
- Adds a test suite covering the enabled/disabled/reason states

Resolves #5849

## Changes
- Replaced Tooltip wrapping with inline `text-[10px] italic truncate` subtitle below the description
- Added `disabled` HTML attribute and `item.enabled` onClick guard to the button element
- Removed unused Tooltip, TooltipContent, TooltipTrigger, TooltipProvider imports
- Added `ActionPaletteItem.test.tsx` with 6 test cases covering enabled, disabled, reason visibility, keybinding, and selection styling

## Testing
- All 6 unit tests pass in vitest
- Manual verification: opened the action palette with a disabled action, confirmed the reason appears inline and is visible without hover