### PR TITLE
feat(actions): surface toast when a disabled action is dispatched

### DIFF
--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -196,8 +196,11 @@ describe("useActionPalette", () => {
       result.current.executeAction(result.current.results[0]!);
     });
 
+    // Dispatch still runs so ActionService can surface the disabled-reason toast,
+    // but MRU stays clean — repeated attempts on a disabled item must not promote
+    // it to the top of the palette.
     expect(useActionMruStore.getState().getSortedActionMruList().length).toBe(0);
-    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
   });
 
   it("uses frecency as tiebreaker in non-empty query results", async () => {

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -132,7 +132,12 @@ export function useActionPalette(): UseActionPaletteReturn {
 
   const executeAction = useCallback(
     (item: ActionPaletteItem) => {
-      useActionMruStore.getState().recordActionMru(item.id);
+      // Only record frecency for enabled items so disabled actions don't get
+      // promoted to the top from repeated attempts. Dispatch still runs for
+      // disabled items so ActionService can surface the disabled-reason toast.
+      if (item.enabled) {
+        useActionMruStore.getState().recordActionMru(item.id);
+      }
       close();
       void actionService
         .dispatch(

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -132,7 +132,6 @@ export function useActionPalette(): UseActionPaletteReturn {
 
   const executeAction = useCallback(
     (item: ActionPaletteItem) => {
-      if (!item.enabled) return;
       useActionMruStore.getState().recordActionMru(item.id);
       close();
       void actionService
@@ -144,7 +143,7 @@ export function useActionPalette(): UseActionPaletteReturn {
           }
         )
         .then((result) => {
-          if (!result.ok) {
+          if (!result.ok && result.error.code !== "DISABLED") {
             notify({
               type: "error",
               title: "Action Failed",

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../shared/types/actions.js";
 import type { AnyActionDefinition } from "./actions/actionTypes";
 import { logWarn } from "@/utils/logger";
+import { notify } from "@/lib/notify";
 import { keybindingService } from "./KeybindingService";
 import { shortcutHintStore } from "../store/shortcutHintStore";
 
@@ -157,7 +158,15 @@ export class ActionService {
 
     const isEnabled = definition.isEnabled?.(context) ?? true;
     if (!isEnabled) {
-      const disabledReason = definition.disabledReason?.(context) ?? "Action is currently disabled";
+      const reasonText = definition.disabledReason?.(context);
+      const disabledReason = reasonText ?? "Action is currently disabled";
+      if (reasonText) {
+        notify({
+          type: "warning",
+          title: "Action Disabled",
+          message: reasonText,
+        });
+      }
       const error: ActionError = {
         code: "DISABLED",
         message: disabledReason,

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -28,6 +28,9 @@ vi.mock("../KeybindingService", () => ({
   },
 }));
 
+const notifyMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
 import { ActionService } from "../ActionService";
 import type { ActionDefinition, ActionId } from "@shared/types/actions";
 
@@ -36,6 +39,7 @@ describe("ActionService", () => {
 
   beforeEach(() => {
     service = new ActionService();
+    notifyMock.mockClear();
   });
 
   describe("register", () => {
@@ -260,6 +264,73 @@ describe("ActionService", () => {
         expect(result.error.message).toContain("disabled for testing");
       }
       expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it("should show warning toast when disabled action has disabledReason", async () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        isEnabled: () => false,
+        disabledReason: () => "No focused terminal",
+        run: vi.fn(),
+      };
+
+      service.register(action);
+      const result = await service.dispatch("actions.list");
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("DISABLED");
+      }
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith({
+        type: "warning",
+        title: "Action Disabled",
+        message: "No focused terminal",
+      });
+    });
+
+    it("should NOT show toast when disabled action has no disabledReason", async () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        isEnabled: () => false,
+        run: vi.fn(),
+      };
+
+      service.register(action);
+      const result = await service.dispatch("actions.list");
+
+      expect(result.ok).toBe(false);
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("should NOT show toast for enabled actions", async () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+
+      service.register(action);
+      await service.dispatch("actions.list");
+
+      expect(notifyMock).not.toHaveBeenCalled();
     });
 
     it("should reject restricted actions", async () => {

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -315,6 +315,34 @@ describe("ActionService", () => {
       expect(notifyMock).not.toHaveBeenCalled();
     });
 
+    it("should show toast for disabled action from any source", async () => {
+      const action: ActionDefinition = {
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description: "A test action",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        isEnabled: () => false,
+        disabledReason: () => "Disabled for test",
+        run: vi.fn(),
+      };
+
+      service.register(action);
+
+      for (const source of ["keybinding", "menu", "context-menu", "user", "agent"] as const) {
+        notifyMock.mockClear();
+        const result = await service.dispatch("actions.list", undefined, { source });
+        expect(result.ok).toBe(false);
+        expect(notifyMock).toHaveBeenCalledWith({
+          type: "warning",
+          title: "Action Disabled",
+          message: "Disabled for test",
+        });
+      }
+    });
+
     it("should NOT show toast for enabled actions", async () => {
       const action: ActionDefinition = {
         id: "actions.list" as ActionId,


### PR DESCRIPTION
## Summary
- When a disabled action is dispatched (palette, menu, keybinding, agent), and the action has a `disabledReason` callback, a warning toast now surfaces the reason text.
- The dispatch still returns a `DISABLED` error, so existing error handling works as before. The toast is additive, not a replacement.
- Actions without a `disabledReason` callback stay silent when disabled, preserving the no-op behaviour for simple guard cases.

Resolves #5851

## Changes
- `ActionService.ts`: added `notify` call with the `disabledReason` text when a disabled action is dispatched
- `useActionPalette.ts`: removed the early-return for disabled items so the toast fires, and suppressed the "Action Failed" error toast for the `DISABLED` code
- `ActionService.test.ts`: 4 new test cases covering toast behaviour, no-toast for enabled actions, and source coverage

## Testing
- Unit tests cover: toast fires when disabledReason is present, no toast when absent, no toast for enabled actions, all action sources produce the toast