### PR TITLE
fix(worktree): reduce accent colour usage in worktree cards

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -681,21 +681,14 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               "bg-surface-panel-elevated shadow-[var(--theme-shadow-ambient)]",
             !isActive &&
               variant === "grid" &&
-              "hover:bg-[var(--sidebar-hover-bg,var(--theme-overlay-hover))]",
+              "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]",
             variant === "sidebar" && !isActive && "bg-transparent",
-            variant === "grid" &&
-              isActive &&
-              "border-accent-primary/70 shadow-[var(--theme-shadow-floating)]",
-            variant === "grid" &&
-              !isActive &&
-              "hover:border-accent-primary/50 hover:shadow-[var(--theme-shadow-floating)]",
-            isFocused &&
-              !isActive &&
-              variant === "grid" &&
-              "bg-[var(--sidebar-hover-bg,var(--theme-overlay-hover))]",
+            isFocused && !isActive && variant === "grid" && "bg-overlay-soft",
             isOver &&
               !isActive &&
-              "ring-2 ring-accent-primary bg-accent-primary/10 border-accent-primary/50 transition-colors duration-200"
+              "ring-2 ring-overlay bg-overlay-soft border-overlay transition-colors duration-200",
+            worktree.isCurrent &&
+              "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
           )}
           data-active={isActive && variant === "sidebar" ? "true" : undefined}
           data-hoverable={!isActive && variant === "sidebar" ? "true" : undefined}
@@ -721,7 +714,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
           {isOver && !isActive && (
             <div
               className={cn(
-                "absolute inset-0 z-50 bg-accent-primary/10 border-2 border-accent-primary pointer-events-none animate-in fade-in duration-150",
+                "absolute inset-0 z-50 bg-overlay-soft border-2 border-overlay pointer-events-none animate-in fade-in duration-150",
                 variant === "grid" && "rounded-lg"
               )}
             />
@@ -730,7 +723,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
             <div
               key={flashKey}
               className={cn(
-                "absolute inset-0 z-20 pointer-events-none border border-accent-primary animate-border-flash",
+                "absolute inset-0 z-20 pointer-events-none border border-overlay animate-border-flash",
                 variant === "grid" && "rounded-lg"
               )}
               aria-hidden="true"

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -6,7 +6,7 @@
 
 .sidebar-worktree-card[data-active="true"] {
   background: var(--sidebar-active-bg, rgba(255, 255, 255, 0.03));
-  box-shadow: inset 2px 0 0 var(--theme-accent-primary);
+  box-shadow: inset 2px 0 0 var(--theme-overlay-selected);
 }
 
 .sidebar-worktree-card[data-hoverable="true"]:hover,


### PR DESCRIPTION
## Summary
Worktree cards were leaning on the brand accent across too many roles at once — selected borders, hover borders, shadows, the drop indicator, and the flash border. With multiple cards visible in grid view, the accent stopped carrying meaning as a focal anchor. This strips it back to one load-bearing signal per card.

Resolves #5856.

## Changes
- Replaced accent-coloured borders and shadows in hover, selected, and focused states with neutral overlay tokens (`bg-overlay-subtle`, `bg-overlay-soft`, `border-overlay`)
- Replaced the drop indicator's accent ring/border with overlay tokens
- Replaced the flash border animation from accent to overlay
- Changed the sidebar active card's left-edge indicator from `--theme-accent-primary` to `--theme-overlay-selected`
- Added a thin 2px accent left-edge marker (via `before:`) on the current worktree card — the single focal signal

## Testing
Manual verification across sidebar and grid variants. The "this is current" marker is now the only accent usage on the card, making it actually readable as a focal anchor.