### PR TITLE
fix(ui): add next-step affordances to empty states

### DIFF
--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -15,7 +15,7 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
   const mac = isMac();
 
   const handleAddPortalLink = useCallback(() => {
-    void actionService.dispatch("portal.links.add", undefined, { source: "user" });
+    void actionService.dispatch("app.settings.openTab", { tab: "portal" }, { source: "user" });
   }, []);
 
   if (links.length === 0) {

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -1,7 +1,10 @@
-import { Globe } from "lucide-react";
+import { Globe, Plus } from "lucide-react";
+import { useCallback } from "react";
 import type { PortalLink } from "@shared/types";
 import { PortalIcon } from "./PortalIcon";
 import { isMac } from "@/lib/platform";
+import { actionService } from "@/services/ActionService";
+import { Button } from "@/components/ui/button";
 
 interface PortalLaunchpadProps {
   links: PortalLink[];
@@ -10,11 +13,29 @@ interface PortalLaunchpadProps {
 
 export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
   const mac = isMac();
+
+  const handleAddPortalLink = useCallback(() => {
+    void actionService.dispatch("portal.links.add", undefined, { source: "user" });
+  }, []);
+
   if (links.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-start pt-8 text-muted-foreground px-6">
-        <Globe className="w-12 h-12 mb-4 opacity-50" />
-        <p className="text-sm">No AI agents configured</p>
+      <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
+        <Globe className="w-12 h-12 mb-2 opacity-50" />
+        <p className="text-sm text-daintree-text/50">No AI agents configured</p>
+        <p className="text-xs text-daintree-text/40">
+          Add a portal link to use as your AI agent web client.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleAddPortalLink}
+          className="gap-1.5"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          <span>Add agent link</span>
+        </Button>
       </div>
     );
   }

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -386,7 +386,7 @@ function ProjectListContent({
               ) : mode === "modal" ? (
                 "No active projects"
               ) : (
-                "No projects available"
+                "No projects available — add one below"
               )}
             </div>
           </div>

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -102,8 +102,10 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
   }, [closeQuickCreate, palette]);
 
   const handleOpenRecipeEditor = useCallback(() => {
-    void actionService.dispatch("recipe.editor.open", undefined, { source: "user" });
-  }, []);
+    closeQuickCreate();
+    palette.close();
+    void actionService.dispatch("recipe.manager.open", undefined, { source: "user" });
+  }, [closeQuickCreate, palette]);
 
   const showAssignToggle =
     palette.selectedRecipe && getAutoAssign(palette.selectedRecipe) === "prompt";

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -6,6 +6,8 @@ import { getAutoAssign } from "@shared/types/project";
 import type { TerminalRecipe } from "@/types";
 import { Settings2 } from "lucide-react";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { actionService } from "@/services/ActionService";
+import { Button } from "@/components/ui/button";
 
 const TYPE_BADGES: Record<string, string> = {
   terminal: "Terminal",
@@ -99,6 +101,10 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
     palette.close();
   }, [closeQuickCreate, palette]);
 
+  const handleOpenRecipeEditor = useCallback(() => {
+    void actionService.dispatch("recipe.editor.open", undefined, { source: "user" });
+  }, []);
+
   const showAssignToggle =
     palette.selectedRecipe && getAutoAssign(palette.selectedRecipe) === "prompt";
 
@@ -130,7 +136,24 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
       searchAriaLabel="Search recipes"
       listId="quick-create-palette-list"
       itemIdPrefix="quick-create-option"
-      emptyMessage="No recipes yet — create one in the recipe editor"
+      emptyMessage="No recipes yet"
+      emptyContent={
+        <div className="flex flex-col items-center gap-3 mt-4">
+          <p className="text-xs text-daintree-text/40">
+            Create a recipe in the recipe editor to get started.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleOpenRecipeEditor}
+            className="gap-1.5"
+          >
+            <Settings2 className="w-3.5 h-3.5" />
+            <span>Open recipe editor</span>
+          </Button>
+        </div>
+      }
       noMatchMessage={`No recipes match "${palette.query}"`}
       totalResults={palette.totalResults}
       afterList={

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -39,10 +39,13 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
   const [isPending, startTransition] = useTransition();
   const [assignToSelf, setAssignToSelf] = useState(true);
 
-  const items: QuickCreateItem[] = [
-    ...recipes.map((r): QuickCreateItem => ({ ...r, _kind: "recipe" })),
-    { _kind: "customize", id: "__customize__", name: "Customize…" },
-  ];
+  const hasRecipes = recipes.length > 0;
+  const items: QuickCreateItem[] = hasRecipes
+    ? [
+        ...recipes.map((r): QuickCreateItem => ({ ...r, _kind: "recipe" })),
+        { _kind: "customize", id: "__customize__", name: "Customize…" },
+      ]
+    : [];
 
   const filterItems = useCallback(
     (allItems: QuickCreateItem[], query: string): QuickCreateItem[] => {
@@ -82,6 +85,13 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
     (item: QuickCreateItem | null) => {
       if (isPending) return;
       if (!item) {
+        if (palette.results.length === 0) {
+          // No recipes at all — open recipe manager so user can create one
+          closeQuickCreate();
+          palette.close();
+          void actionService.dispatch("recipe.manager.open", undefined, { source: "user" });
+          return;
+        }
         palette.close();
         return;
       }


### PR DESCRIPTION
## Summary
Three empty states in PortalLaunchpad, ProjectSwitcherPalette, and QuickCreatePalette stopped at "you have nothing here" with no path forward. Added CTA buttons or directional text so users know what to do next.

The template already existed in HelpAgentPicker. PortalLaunchpad and QuickCreatePalette follow that pattern with CTA buttons. ProjectSwitcherPalette uses the lighter approach, pointing to the existing "Add Project" footer button.

Resolves #5853

## Changes
- PortalLaunchpad: added "Add agent link" button that opens portal settings, centred the empty state layout
- ProjectSwitcherPalette: changed empty message to point users to the "Add Project" footer button
- QuickCreatePalette: added "Open recipe editor" CTA button, plus conditionally hides the "Customize..." item when there are no recipes
- useQuickCreatePalette: pressing Enter with no results opens the recipe manager instead of silently closing

## Testing
Verified each empty state renders the CTA, the button dispatches the correct action, and the "Customize..." item is hidden when the recipe list is empty.