### PR TITLE
fix(toolbar): suppress agent status dot for passive states

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -198,14 +198,15 @@ export function AgentButton({
     void useAgentSettingsStore.getState().updateWorktreePreset(type, activeWorktreeId, presetId);
   };
 
+  const dotColor = dominantState ? agentStateDotColor(dominantState) : null;
   const iconElement = (
     <div className="relative">
       <config.icon brandColor={getBrandColorHex(type)} />
-      {isSessionActive && dominantState && (
+      {isSessionActive && dotColor && (
         <span
           className={cn(
-            "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-1 ring-daintree-sidebar",
-            agentStateDotColor(dominantState)
+            "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
+            dotColor
           )}
           aria-hidden="true"
         />

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -102,12 +102,13 @@ function buildAgentRow(
 }
 
 function RunningDot({ state }: { state: AgentState | null }) {
-  if (!state) return null;
+  const color = state ? agentStateDotColor(state) : null;
+  if (!color) return null;
   return (
     <span
       className={cn(
-        "absolute -bottom-0.5 -right-0.5 h-2 w-2 rounded-full ring-1 ring-daintree-sidebar",
-        agentStateDotColor(state)
+        "absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-sidebar",
+        color
       )}
       aria-hidden="true"
     />

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -67,9 +67,11 @@ vi.mock("@/store/projectPresetsStore", () => ({
   ) => selector({ presetsByAgent: {} }),
 }));
 
+let mockPanelsById: Record<string, unknown> = {};
+let mockPanelIds: string[] = [];
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ panelsById: {}, panelIds: [] }),
+    selector({ panelsById: mockPanelsById, panelIds: mockPanelIds }),
 }));
 
 vi.mock("@/store/worktreeStore", () => ({
@@ -98,9 +100,13 @@ vi.mock("@/lib/colorUtils", () => ({
   getBrandColorHex: (id: string) => `#brand-${id}`,
 }));
 
+// Defaults match the historical "ignore the badge in these tests" stance;
+// individual badge tests override these to drive the indicator render path.
+let mockDominantState: string | null = null;
+let mockDotColor: string | null = "";
 vi.mock("@/components/Worktree/AgentStatusIndicator", () => ({
-  getDominantAgentState: () => null,
-  agentStateDotColor: () => "",
+  getDominantAgentState: () => mockDominantState,
+  agentStateDotColor: () => mockDotColor,
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -188,6 +194,10 @@ describe("AgentButton preset UX", () => {
     mockCcrPresetsByAgent = {};
     mockMergedPresetsFn = () => [];
     mockCliDetails = {};
+    mockDominantState = null;
+    mockDotColor = "";
+    mockPanelsById = {};
+    mockPanelIds = [];
   });
 
   describe("split threshold", () => {
@@ -456,6 +466,68 @@ describe("AgentButton preset UX", () => {
         { tab: "agents", subtab: "claude" },
         { source: "user" }
       );
+    });
+  });
+
+  describe("status dot badge", () => {
+    function activePanel(state: string): Record<string, unknown> {
+      // `detectedAgentId` is what `getRuntimeOrBootAgentId` reads (via
+      // `deriveTerminalChrome`); plain `agentId` on the panel is not used by
+      // the derivation, so the helper would return undefined and the panel
+      // would never enter the active-session set.
+      return {
+        id: "panel-1",
+        kind: "terminal",
+        detectedAgentId: "claude",
+        worktreeId: "wt-1",
+        location: "grid",
+        agentState: state,
+      };
+    }
+
+    it("renders the badge span when an actionable state returns a non-null color", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockPanelsById = { "panel-1": activePanel("waiting") };
+      mockPanelIds = ["panel-1"];
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "waiting";
+      mockDotColor = "bg-state-waiting";
+
+      const { container } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const badge = container.querySelector('.relative span[aria-hidden="true"]');
+      expect(badge).not.toBeNull();
+    });
+
+    it("does not render the badge span when the helper returns null (passive state)", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockPanelsById = { "panel-1": activePanel("working") };
+      mockPanelIds = ["panel-1"];
+      mockActiveWorktreeId = "wt-1";
+      mockDominantState = "working";
+      mockDotColor = null;
+
+      const { container } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const badge = container.querySelector('.relative span[aria-hidden="true"]');
+      expect(badge).toBeNull();
+    });
+
+    it("does not render the badge span when there is no active session", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockDominantState = null;
+      mockDotColor = "bg-state-waiting";
+
+      const { container } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      const badge = container.querySelector('.relative span[aria-hidden="true"]');
+      expect(badge).toBeNull();
     });
   });
 });

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1031,6 +1031,21 @@ describe("AgentTrayButton", () => {
       }
     );
 
+    // `completed` and `exited` are excluded from ACTIVE_AGENT_STATES, so the
+    // panel never enters the dominant-state aggregation in the first place;
+    // the dot is suppressed one layer earlier than for working/idle. Covered
+    // here so the consumer-level contract ("no badge for passive states") is
+    // tested end-to-end regardless of which guard fires.
+    it.each([["completed"], ["exited"]] as const)(
+      "does not render the badge for terminal state %s",
+      (state) => {
+        const availability = arrangeClaudePanel(state);
+        const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+        const row = getByTestId("agent-tray-row-claude");
+        expect(badgeIn(row)).toBeNull();
+      }
+    );
+
     it("does not render the badge when there is no active session", () => {
       const availability = { claude: "ready" } as unknown as CliAvailability;
       mockSettings = settingsWith({ claude: { pinned: false } });

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -983,4 +983,61 @@ describe("AgentTrayButton", () => {
       );
     });
   });
+
+  describe("RunningDot status badge", () => {
+    function arrangeClaudePanel(state: string) {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockSettings = settingsWith({ claude: { pinned: false } });
+      // `detectedAgentId` is what `getRuntimeOrBootAgentId` reads via
+      // `deriveTerminalChrome`; plain `agentId` is ignored by the derivation.
+      mockPanelsById = {
+        "panel-1": {
+          id: "panel-1",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          worktreeId: "wt-1",
+          location: "grid",
+          agentState: state,
+        },
+      };
+      mockPanelIds = ["panel-1"];
+      mockActiveWorktreeId = "wt-1";
+      return availability;
+    }
+
+    function badgeIn(row: HTMLElement): Element | null {
+      // The RunningDot lives inside the icon's relative-positioned wrapper —
+      // the only `aria-hidden` span in a Launch row that uses this scoping.
+      return row.querySelector('span.relative span[aria-hidden="true"]');
+    }
+
+    it.each([["waiting"], ["directing"]] as const)(
+      "renders the badge for actionable state %s",
+      (state) => {
+        const availability = arrangeClaudePanel(state);
+        const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+        const row = getByTestId("agent-tray-row-claude");
+        expect(badgeIn(row)).not.toBeNull();
+      }
+    );
+
+    it.each([["working"], ["idle"]] as const)(
+      "does not render the badge for passive state %s",
+      (state) => {
+        const availability = arrangeClaudePanel(state);
+        const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+        const row = getByTestId("agent-tray-row-claude");
+        expect(badgeIn(row)).toBeNull();
+      }
+    );
+
+    it("does not render the badge when there is no active session", () => {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const row = getByTestId("agent-tray-row-claude");
+      expect(badgeIn(row)).toBeNull();
+    });
+  });
 });

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -145,14 +145,18 @@ export function getDominantAgentState(states: (AgentState | undefined)[]): Agent
   return dominant === "idle" ? null : dominant;
 }
 
-export function agentStateDotColor(state: AgentState): string {
+// Returns null for passive states (working, completed, exited, idle) so the
+// callers skip rendering a badge entirely. Only `waiting` and `directing` —
+// the actionable states a human should attend to — earn a visible dot. Keeping
+// passive sessions unmarked lets the actionable few stand out on a toolbar
+// that may show many running agents at once.
+export function agentStateDotColor(state: AgentState): string | null {
   switch (state) {
-    case "working":
     case "directing":
       return "bg-state-working";
     case "waiting":
       return "bg-state-waiting";
     default:
-      return "bg-daintree-accent";
+      return null;
   }
 }

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -123,18 +123,30 @@ describe("getDominantAgentState", () => {
   it("prefers directing over completed", () => {
     expect(getDominantAgentState(["completed", "directing"])).toBe("directing");
   });
+
+  // Documents the accepted trade-off: when a worktree has both a passive
+  // working session and an actionable waiting session, the dominant state
+  // resolves to working (priority 7 > 3), so agentStateDotColor returns null
+  // and the toolbar dot is suppressed. WorktreeCard's border-flash animation
+  // depends on working outranking waiting; the tray dot rides on the same
+  // priority table. If this priority is ever inverted, this assertion fails
+  // first as a guard.
+  it("returns working when a worktree mixes working and waiting (suppresses tray dot)", () => {
+    expect(getDominantAgentState(["working", "waiting"])).toBe("working");
+  });
 });
 
 describe("agentStateDotColor", () => {
-  it.each([["waiting"], ["directing"]] as const)(
-    "returns a non-null class for actionable state %s",
-    (state) => {
-      const result = agentStateDotColor(state as AgentState);
-      expect(result).not.toBeNull();
-      expect(typeof result).toBe("string");
-      expect(result?.length).toBeGreaterThan(0);
-    }
-  );
+  // Exact class assertions guard the color mapping itself: a swap between
+  // waiting and directing would still return a non-null string, so a
+  // truthiness-only check would let the regression slip past.
+  it("returns bg-state-waiting for waiting", () => {
+    expect(agentStateDotColor("waiting")).toBe("bg-state-waiting");
+  });
+
+  it("returns bg-state-working for directing", () => {
+    expect(agentStateDotColor("directing")).toBe("bg-state-working");
+  });
 
   it.each([["working"], ["completed"], ["exited"], ["idle"]] as const)(
     "returns null for passive state %s (no dot rendered)",

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { act, render, cleanup } from "@testing-library/react";
-import { AgentStatusIndicator, getDominantAgentState } from "../AgentStatusIndicator";
+import {
+  AgentStatusIndicator,
+  agentStateDotColor,
+  getDominantAgentState,
+} from "../AgentStatusIndicator";
 import type { AgentState } from "@/types";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -119,4 +123,23 @@ describe("getDominantAgentState", () => {
   it("prefers directing over completed", () => {
     expect(getDominantAgentState(["completed", "directing"])).toBe("directing");
   });
+});
+
+describe("agentStateDotColor", () => {
+  it.each([["waiting"], ["directing"]] as const)(
+    "returns a non-null class for actionable state %s",
+    (state) => {
+      const result = agentStateDotColor(state as AgentState);
+      expect(result).not.toBeNull();
+      expect(typeof result).toBe("string");
+      expect(result?.length).toBeGreaterThan(0);
+    }
+  );
+
+  it.each([["working"], ["completed"], ["exited"], ["idle"]] as const)(
+    "returns null for passive state %s (no dot rendered)",
+    (state) => {
+      expect(agentStateDotColor(state as AgentState)).toBeNull();
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- `agentStateDotColor()` now returns `null` for passive states (working, completed, exited, idle) and a colour only for actionable ones (waiting, directing). The dot renders only when it actually means something.
- Dot shrunk from 8px to 6px and repositioned to top-right on both `AgentButton` and the `AgentTrayButton` `RunningDot`, so it no longer competes with the split-button chevron in the bottom-right corner.
- Removed the `bg-daintree-accent` fallback that was violating the accent-colour restraint rule in `CLAUDE.md`.

Resolves #5900.

## Changes

- `AgentStatusIndicator.tsx` — `agentStateDotColor` return type narrowed to `string | null`; passive states return `null`; `waiting` maps to `bg-state-waiting`, `directing` to `bg-state-working`
- `AgentButton.tsx` — dot span gated on non-null colour, resized to `h-1.5 w-1.5`, repositioned to `-top-0.5 -right-0.5`
- `AgentTrayButton.tsx` — same size/position change on `RunningDot`
- New unit tests covering exact colour assertions, badge presence/absence per state, and the working > waiting priority trade-off in `getDominantAgentState`

## Testing

Typecheck, lint (359 pre-existing warnings, 0 errors), format, and build all green. 87 unit tests pass, including new direct tests for `agentStateDotColor` and the badge render paths in both button components.