### PR TITLE
feat(layout): surface active preset on agent toolbar buttons

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -5,8 +5,9 @@ import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -20,6 +21,8 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubContent,
@@ -185,6 +188,10 @@ export function AgentButton({
   // Worktree-scoped pick wins over the agent-level default so switching
   // worktrees doesn't silently surface another worktree's selection.
   const savedPresetId = resolveEffectivePresetId(entry, activeWorktreeId);
+  const activePreset = savedPresetId ? presets.find((p) => p.id === savedPresetId) : undefined;
+  // CCR presets carry the routing prefix in their stored name; strip it for
+  // display so the tooltip and menu surfaces show the same human label.
+  const activePresetName = activePreset ? activePreset.name.replace(/^CCR:\s*/, "") : null;
   // Group by source. Project presets are identified by membership so that a
   // project preset whose id happens to start with "ccr-" still lands in
   // "Project Shared" rather than being stolen by the CCR group. Everything
@@ -219,15 +226,17 @@ export function AgentButton({
   // because the CLI itself will prompt for sign-in on first run.
   const signInUnconfirmed = isReady && cliDetail?.authConfirmed === false;
 
+  const presetSegment = activePresetName ? ` · ${activePresetName}` : "";
   const tooltip = isLoading
     ? `Checking ${config.name} CLI availability...`
     : isReady
       ? signInUnconfirmed
-        ? `Start ${config.name} — sign-in not detected${shortcut}`
-        : `Start ${config.name}${tooltipDetails}${shortcut}`
+        ? `Start ${config.name}${presetSegment} — sign-in not detected${shortcut}`
+        : `Start ${config.name}${presetSegment}${tooltipDetails}${shortcut}`
       : needsSetup
         ? `${config.name} needs setup. Click to configure.`
         : `${config.name} CLI not found. Click to install.`;
+  const chevronTooltip = `Choose ${config.name} preset`;
 
   const ariaLabel = isLoading
     ? `Checking ${config.name} availability`
@@ -385,9 +394,9 @@ export function AgentButton({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
+        <span className="inline-flex">
+          <Tooltip>
+            <TooltipTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
@@ -405,7 +414,12 @@ export function AgentButton({
                 {iconElement}
                 <ShortcutRevealChip actionId={`agent.${type}`} />
               </Button>
-              <DropdownMenu>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{tooltip}</TooltipContent>
+          </Tooltip>
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
@@ -417,111 +431,113 @@ export function AgentButton({
                       "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
                       !isReady && !isLoading && "opacity-60"
                     )}
-                    aria-label={`Choose ${config.name} preset`}
+                    aria-label={chevronTooltip}
                   >
                     <ChevronDown className="h-3 w-3 opacity-70" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="start" sideOffset={4} className="min-w-[12rem]">
-                  <DropdownMenuItem
-                    className={cn(!savedPresetId && "font-medium")}
-                    onSelect={() => {
-                      persistWorktreePick(undefined);
-                      void actionService.dispatch(
-                        "agent.launch",
-                        { agentId: type, presetId: null },
-                        { source: "user" }
-                      );
-                    }}
-                  >
-                    <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                      <config.icon brandColor={getBrandColorHex(type)} />
-                    </span>
-                    Default
-                  </DropdownMenuItem>
-                  {ccrPresetGroup.length > 0 && (
-                    <>
-                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                      {hasMultiplePresetGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
-                      {ccrPresetGroup.map((preset) => (
-                        <DropdownMenuItem
-                          key={preset.id}
-                          className={cn(savedPresetId === preset.id && "font-medium")}
-                          onSelect={() => {
-                            persistWorktreePick(preset.id);
-                            void actionService.dispatch(
-                              "agent.launch",
-                              { agentId: type, presetId: preset.id },
-                              { source: "user" }
-                            );
-                          }}
-                        >
-                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                          </span>
-                          {preset.name.replace(/^CCR:\s*/, "")}
-                        </DropdownMenuItem>
-                      ))}
-                    </>
-                  )}
-                  {projectPresetGroup.length > 0 && (
-                    <>
-                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                      {hasMultiplePresetGroups && (
-                        <DropdownMenuLabel>Project Shared</DropdownMenuLabel>
-                      )}
-                      {projectPresetGroup.map((preset) => (
-                        <DropdownMenuItem
-                          key={preset.id}
-                          className={cn(savedPresetId === preset.id && "font-medium")}
-                          onSelect={() => {
-                            persistWorktreePick(preset.id);
-                            void actionService.dispatch(
-                              "agent.launch",
-                              { agentId: type, presetId: preset.id },
-                              { source: "user" }
-                            );
-                          }}
-                        >
-                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                          </span>
-                          {preset.name}
-                        </DropdownMenuItem>
-                      ))}
-                    </>
-                  )}
-                  {customPresetGroup.length > 0 && (
-                    <>
-                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                      {hasMultiplePresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
-                      {customPresetGroup.map((preset) => (
-                        <DropdownMenuItem
-                          key={preset.id}
-                          className={cn(savedPresetId === preset.id && "font-medium")}
-                          onSelect={() => {
-                            persistWorktreePick(preset.id);
-                            void actionService.dispatch(
-                              "agent.launch",
-                              { agentId: type, presetId: preset.id },
-                              { source: "user" }
-                            );
-                          }}
-                        >
-                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                          </span>
-                          {preset.name}
-                        </DropdownMenuItem>
-                      ))}
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{tooltip}</TooltipContent>
-        </Tooltip>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{chevronTooltip}</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="start" sideOffset={4} className="min-w-[12rem]">
+              <DropdownMenuRadioGroup value={savedPresetId ?? ""}>
+                <DropdownMenuRadioItem
+                  value=""
+                  onSelect={() => {
+                    persistWorktreePick(undefined);
+                    void actionService.dispatch(
+                      "agent.launch",
+                      { agentId: type, presetId: null },
+                      { source: "user" }
+                    );
+                  }}
+                >
+                  <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                    <config.icon brandColor={getBrandColorHex(type)} />
+                  </span>
+                  Default
+                </DropdownMenuRadioItem>
+                {ccrPresetGroup.length > 0 && (
+                  <>
+                    {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                    {hasMultiplePresetGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
+                    {ccrPresetGroup.map((preset) => (
+                      <DropdownMenuRadioItem
+                        key={preset.id}
+                        value={preset.id}
+                        onSelect={() => {
+                          persistWorktreePick(preset.id);
+                          void actionService.dispatch(
+                            "agent.launch",
+                            { agentId: type, presetId: preset.id },
+                            { source: "user" }
+                          );
+                        }}
+                      >
+                        <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                          <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                        </span>
+                        {preset.name.replace(/^CCR:\s*/, "")}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </>
+                )}
+                {projectPresetGroup.length > 0 && (
+                  <>
+                    {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                    {hasMultiplePresetGroups && (
+                      <DropdownMenuLabel>Project Shared</DropdownMenuLabel>
+                    )}
+                    {projectPresetGroup.map((preset) => (
+                      <DropdownMenuRadioItem
+                        key={preset.id}
+                        value={preset.id}
+                        onSelect={() => {
+                          persistWorktreePick(preset.id);
+                          void actionService.dispatch(
+                            "agent.launch",
+                            { agentId: type, presetId: preset.id },
+                            { source: "user" }
+                          );
+                        }}
+                      >
+                        <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                          <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                        </span>
+                        {preset.name}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </>
+                )}
+                {customPresetGroup.length > 0 && (
+                  <>
+                    {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                    {hasMultiplePresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
+                    {customPresetGroup.map((preset) => (
+                      <DropdownMenuRadioItem
+                        key={preset.id}
+                        value={preset.id}
+                        onSelect={() => {
+                          persistWorktreePick(preset.id);
+                          void actionService.dispatch(
+                            "agent.launch",
+                            { agentId: type, presetId: preset.id },
+                            { source: "user" }
+                          );
+                        }}
+                      >
+                        <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                          <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                        </span>
+                        {preset.name}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </>
+                )}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </span>
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem
@@ -552,22 +568,37 @@ export function AgentButton({
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch with Preset</ContextMenuSubTrigger>
             <ContextMenuSubContent data-testid="context-submenu-content">
-              {presets.map((preset) => (
-                <ContextMenuItem
-                  key={preset.id}
+              <ContextMenuRadioGroup value={savedPresetId ?? ""}>
+                <ContextMenuRadioItem
+                  value=""
                   onSelect={() => {
-                    persistWorktreePick(preset.id);
+                    persistWorktreePick(undefined);
                     void actionService.dispatch(
                       "agent.launch",
-                      { agentId: type, presetId: preset.id },
+                      { agentId: type, presetId: null },
                       { source: "context-menu" }
                     );
                   }}
                 >
-                  {preset.name}
-                  {savedPresetId === preset.id ? " ✓" : ""}
-                </ContextMenuItem>
-              ))}
+                  Default
+                </ContextMenuRadioItem>
+                {presets.map((preset) => (
+                  <ContextMenuRadioItem
+                    key={preset.id}
+                    value={preset.id}
+                    onSelect={() => {
+                      persistWorktreePick(preset.id);
+                      void actionService.dispatch(
+                        "agent.launch",
+                        { agentId: type, presetId: preset.id },
+                        { source: "context-menu" }
+                      );
+                    }}
+                  >
+                    {preset.name.replace(/^CCR:\s*/, "")}
+                  </ContextMenuRadioItem>
+                ))}
+              </ContextMenuRadioGroup>
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -17,6 +17,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
@@ -44,6 +46,7 @@ import { useKeybindingDisplay } from "@/hooks";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
+import { resolveEffectivePresetId } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import {
@@ -67,6 +70,7 @@ type AgentRow = {
   isNew: boolean;
   presets?: AgentPreset[];
   projectPresetIds: Set<string>;
+  savedPresetId?: string;
 };
 
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
@@ -83,7 +87,8 @@ function buildAgentRow(
   isNew: boolean,
   customPresets?: AgentPreset[],
   ccrPresets?: AgentPreset[],
-  projectPresets?: AgentPreset[]
+  projectPresets?: AgentPreset[],
+  savedPresetId?: string
 ): AgentRow | null {
   const config = getAgentConfig(id);
   if (!config) return null;
@@ -98,6 +103,7 @@ function buildAgentRow(
     isNew,
     presets: hasPresets ? presets : undefined,
     projectPresetIds: new Set((projectPresets ?? []).map((f) => f.id)),
+    savedPresetId,
   };
 }
 
@@ -187,54 +193,68 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
         </span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent data-testid="submenu-content">
-        <DropdownMenuItem onSelect={() => onLaunch(row.id, null)}>
-          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-            <row.Icon brandColor={getBrandColorHex(row.id)} />
-          </span>
-          Default
-        </DropdownMenuItem>
-        {ccrPresets.length > 0 && (
-          <>
-            {hasMultipleGroups && <DropdownMenuSeparator />}
-            {hasMultipleGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
-            {ccrPresets.map((preset) => (
-              <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
-                <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                  <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
-                </span>
-                {preset.name.replace(/^CCR:\s*/, "")}
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
-        {projectPresets.length > 0 && (
-          <>
-            {hasMultipleGroups && <DropdownMenuSeparator />}
-            {hasMultipleGroups && <DropdownMenuLabel>Project Shared</DropdownMenuLabel>}
-            {projectPresets.map((preset) => (
-              <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
-                <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                  <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
-                </span>
-                {preset.name}
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
-        {customPresets.length > 0 && (
-          <>
-            {hasMultipleGroups && <DropdownMenuSeparator />}
-            {hasMultipleGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
-            {customPresets.map((preset) => (
-              <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
-                <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                  <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
-                </span>
-                {preset.name}
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
+        <DropdownMenuRadioGroup value={row.savedPresetId ?? ""}>
+          <DropdownMenuRadioItem value="" onSelect={() => onLaunch(row.id, null)}>
+            <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+              <row.Icon brandColor={getBrandColorHex(row.id)} />
+            </span>
+            Default
+          </DropdownMenuRadioItem>
+          {ccrPresets.length > 0 && (
+            <>
+              {hasMultipleGroups && <DropdownMenuSeparator />}
+              {hasMultipleGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
+              {ccrPresets.map((preset) => (
+                <DropdownMenuRadioItem
+                  key={preset.id}
+                  value={preset.id}
+                  onSelect={() => onLaunch(row.id, preset.id)}
+                >
+                  <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                    <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
+                  </span>
+                  {preset.name.replace(/^CCR:\s*/, "")}
+                </DropdownMenuRadioItem>
+              ))}
+            </>
+          )}
+          {projectPresets.length > 0 && (
+            <>
+              {hasMultipleGroups && <DropdownMenuSeparator />}
+              {hasMultipleGroups && <DropdownMenuLabel>Project Shared</DropdownMenuLabel>}
+              {projectPresets.map((preset) => (
+                <DropdownMenuRadioItem
+                  key={preset.id}
+                  value={preset.id}
+                  onSelect={() => onLaunch(row.id, preset.id)}
+                >
+                  <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                    <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
+                  </span>
+                  {preset.name}
+                </DropdownMenuRadioItem>
+              ))}
+            </>
+          )}
+          {customPresets.length > 0 && (
+            <>
+              {hasMultipleGroups && <DropdownMenuSeparator />}
+              {hasMultipleGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
+              {customPresets.map((preset) => (
+                <DropdownMenuRadioItem
+                  key={preset.id}
+                  value={preset.id}
+                  onSelect={() => onLaunch(row.id, preset.id)}
+                >
+                  <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                    <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
+                  </span>
+                  {preset.name}
+                </DropdownMenuRadioItem>
+              ))}
+            </>
+          )}
+        </DropdownMenuRadioGroup>
       </DropdownMenuSubContent>
     </DropdownMenuSub>
   );
@@ -379,9 +399,11 @@ export function AgentTrayButton({
     for (const id of BUILT_IN_AGENT_IDS) {
       const pinned = isAgentPinned(agentSettings?.agents?.[id]);
       const dominant = agentDominantStates.get(id) ?? null;
-      const customPresets = agentSettings?.agents?.[id]?.customPresets;
+      const entry = agentSettings?.agents?.[id];
+      const customPresets = entry?.customPresets;
       const ccrPresets = ccrPresetsByAgent[id];
       const projectPresets = projectPresetsByAgent[id];
+      const savedPresetId = resolveEffectivePresetId(entry, activeWorktreeId);
       const row = buildAgentRow(
         id,
         pinned,
@@ -389,7 +411,8 @@ export function AgentTrayButton({
         newAgentIds.has(id),
         customPresets,
         ccrPresets,
-        projectPresets
+        projectPresets,
+        savedPresetId
       );
       if (!row) continue;
 
@@ -438,6 +461,7 @@ export function AgentTrayButton({
     newAgentIds,
     ccrPresetsByAgent,
     projectPresetsByAgent,
+    activeWorktreeId,
   ]);
 
   const handleLaunch = useCallback(

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -587,8 +587,12 @@ describe("AgentButton preset UX", () => {
       const { getAllByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      // No `·` segment when nothing is armed.
-      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude");
+      const texts = tooltipTexts(getAllByTestId);
+      expect(texts).toContain("Start Claude");
+      // No `·` segment leaks in via the launch tooltip when nothing is armed.
+      const launchTooltip = texts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toBeDefined();
+      expect(launchTooltip).not.toContain("·");
     });
 
     it("omits the preset segment when the saved id no longer matches a preset", () => {
@@ -600,7 +604,10 @@ describe("AgentButton preset UX", () => {
       const { getAllByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude");
+      const texts = tooltipTexts(getAllByTestId);
+      expect(texts).toContain("Start Claude");
+      const launchTooltip = texts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).not.toContain("·");
     });
 
     it("renders a chevron-specific tooltip distinct from the launch tooltip", () => {
@@ -611,6 +618,23 @@ describe("AgentButton preset UX", () => {
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       expect(tooltipTexts(getAllByTestId)).toContain("Choose Claude preset");
+    });
+
+    it("preserves the preset segment when the sign-in probe is unconfirmed", () => {
+      // Edge case: agent is `ready` but the auth probe came back empty.
+      // The user still has an armed preset that will fire on click — the
+      // tooltip should surface it rather than silently dropping the segment.
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      mockCliDetails = { claude: { authConfirmed: false } };
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const texts = tooltipTexts(getAllByTestId);
+      const launchTooltip = texts.find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toContain("· Blue");
+      expect(launchTooltip).toContain("sign-in not detected");
     });
   });
 
@@ -638,6 +662,42 @@ describe("AgentButton preset UX", () => {
       // The Default radio item is rendered with value="" so the group
       // resolves to that item when nothing is saved.
       expect(getByTestId("preset-radio-group").getAttribute("data-value")).toBe("");
+    });
+
+    it("context-menu radio group reflects the saved preset id", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [
+        { id: "user-blue", name: "Blue" },
+        { id: "user-red", name: "Red" },
+      ];
+
+      const { getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(getByTestId("context-radio-group").getAttribute("data-value")).toBe("user-blue");
+    });
+
+    it("context-menu preset selection dispatches with source 'context-menu'", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [
+        { id: "user-blue", name: "Blue" },
+        { id: "user-red", name: "Red" },
+      ];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("context-radio-item") as HTMLElement[];
+      const blueItem = items.find((el) => el.textContent?.includes("Blue"))!;
+      fireEvent.click(blueItem);
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", "user-blue");
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: "user-blue" },
+        { source: "context-menu" }
+      );
     });
   });
 

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -135,7 +135,9 @@ vi.mock("@/components/ui/button", () => ({
 
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -158,6 +160,32 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     <div
       role="menuitem"
       data-testid="preset-item"
+      className={className}
+      onClick={(e) => onSelect?.(e as unknown as Event)}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuRadioGroup: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="preset-radio-group" data-value={value ?? ""}>
+      {children}
+    </div>
+  ),
+  DropdownMenuRadioItem: ({
+    children,
+    onSelect,
+    value,
+    className,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    value: string;
+    className?: string;
+  }) => (
+    <div
+      role="menuitemradio"
+      data-testid="preset-item"
+      data-value={value}
       className={className}
       onClick={(e) => onSelect?.(e as unknown as Event)}
     >
@@ -198,6 +226,29 @@ vi.mock("@/components/ui/context-menu", () => ({
         if (disabled) return;
         onSelect?.(e as unknown as Event);
       }}
+    >
+      {children}
+    </div>
+  ),
+  ContextMenuRadioGroup: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="context-radio-group" data-value={value ?? ""}>
+      {children}
+    </div>
+  ),
+  ContextMenuRadioItem: ({
+    children,
+    onSelect,
+    value,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    value: string;
+  }) => (
+    <div
+      role="menuitemradio"
+      data-testid="context-radio-item"
+      data-value={value}
+      onClick={(e) => onSelect?.(e as unknown as Event)}
     >
       {children}
     </div>
@@ -498,6 +549,95 @@ describe("AgentButton preset UX", () => {
         { agentId: "claude", presetId: "user-alpha" },
         { source: "user" }
       );
+    });
+  });
+
+  describe("tooltip surfaces active preset", () => {
+    function tooltipTexts(getAllByTestId: (id: string) => HTMLElement[]): string[] {
+      return getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+    }
+
+    it("appends the saved preset name to the launch tooltip", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [
+        { id: "user-blue", name: "Blue" },
+        { id: "user-red", name: "Red" },
+      ];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude · Blue");
+    });
+
+    it("strips the CCR routing prefix from the saved preset name", () => {
+      mockSettings = settingsWith({ claude: { presetId: "ccr-sonnet" } });
+      mockMergedPresetsFn = () => [{ id: "ccr-sonnet", name: "CCR: Sonnet 4.5" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude · Sonnet 4.5");
+    });
+
+    it("omits the preset segment when no preset is saved", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      // No `·` segment when nothing is armed.
+      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude");
+    });
+
+    it("omits the preset segment when the saved id no longer matches a preset", () => {
+      // Stale id (preset deleted) — fall back to plain tooltip rather than
+      // surfacing a phantom name.
+      mockSettings = settingsWith({ claude: { presetId: "ghost" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(tooltipTexts(getAllByTestId)).toContain("Start Claude");
+    });
+
+    it("renders a chevron-specific tooltip distinct from the launch tooltip", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(tooltipTexts(getAllByTestId)).toContain("Choose Claude preset");
+    });
+  });
+
+  describe("radio indicator", () => {
+    it("dropdown radio group reflects the saved preset id", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [
+        { id: "user-blue", name: "Blue" },
+        { id: "user-red", name: "Red" },
+      ];
+
+      const { getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(getByTestId("preset-radio-group").getAttribute("data-value")).toBe("user-blue");
+    });
+
+    it("dropdown radio group falls back to empty string when no preset is saved", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      // The Default radio item is rendered with value="" so the group
+      // resolves to that item when nothing is saved.
+      expect(getByTestId("preset-radio-group").getAttribute("data-value")).toBe("");
     });
   });
 

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -186,6 +186,32 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="menu-label">{children}</div>
   ),
+  DropdownMenuRadioGroup: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="preset-radio-group" data-value={value ?? ""}>
+      {children}
+    </div>
+  ),
+  DropdownMenuRadioItem: ({
+    children,
+    onSelect,
+    value,
+    className,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    value: string;
+    className?: string;
+  }) => (
+    <div
+      role="menuitemradio"
+      data-testid="preset-radio-item"
+      data-value={value}
+      className={className}
+      onClick={(e) => onSelect?.(e as unknown as Event)}
+    >
+      {children}
+    </div>
+  ),
   DropdownMenuSeparator: () => <hr data-testid="menu-separator" />,
   DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => (
     <span data-testid="menu-shortcut">{children}</span>
@@ -1053,6 +1079,59 @@ describe("AgentTrayButton", () => {
       const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
       const row = getByTestId("agent-tray-row-claude");
       expect(badgeIn(row)).toBeNull();
+    });
+  });
+
+  describe("SplitLaunchItem saved-preset indicator", () => {
+    function arrangeAgentWithPresets() {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockMergedPresetsFn = (agentId: string) =>
+        agentId === "claude"
+          ? [
+              { id: "user-alpha", name: "Alpha" },
+              { id: "user-beta", name: "Beta" },
+            ]
+          : [];
+      return availability;
+    }
+
+    it("threads the worktree-scoped saved preset id into the submenu radio group", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: {
+          presetId: "user-alpha",
+          worktreePresets: { "wt-A": "user-beta" },
+        } as unknown as { pinned?: boolean },
+      });
+      const availability = arrangeAgentWithPresets();
+
+      const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const groups = getAllByTestId("preset-radio-group");
+      // The worktree-scoped pick wins over the agent-level default — the
+      // submenu radio group resolves to "user-beta".
+      expect(groups[0]!.getAttribute("data-value")).toBe("user-beta");
+    });
+
+    it("falls back to the agent-level preset when no worktree override exists", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: { presetId: "user-alpha" } as unknown as { pinned?: boolean },
+      });
+      const availability = arrangeAgentWithPresets();
+
+      const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const groups = getAllByTestId("preset-radio-group");
+      expect(groups[0]!.getAttribute("data-value")).toBe("user-alpha");
+    });
+
+    it("resolves to empty string when nothing is saved (Default armed)", () => {
+      mockActiveWorktreeId = null;
+      mockSettings = settingsWith({ claude: { pinned: false } });
+      const availability = arrangeAgentWithPresets();
+
+      const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const groups = getAllByTestId("preset-radio-group");
+      expect(groups[0]!.getAttribute("data-value")).toBe("");
     });
   });
 });

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -171,12 +171,38 @@ const ContextMenuCheckboxItem = React.forwardRef<
 ));
 ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
 
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] py-1.5 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-overlay-emphasis data-[highlighted]:bg-overlay-emphasis data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
 export {
   ContextMenu,
   ContextMenuTrigger,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuCheckboxItem,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuLabel,
   ContextMenuShortcut,


### PR DESCRIPTION
## Summary

- Tooltips now include the active preset name so you can see what will launch without opening the chevron menu (e.g. "Start Claude Code · Sonnet 4.5 (⌥⌘C)")
- Split the launch and chevron tooltips apart so the chevron describes its actual job ("Switch preset")
- Unified the saved-preset indicator across the chevron dropdown, right-click context submenu, and agent tray — all three now use `DropdownMenuRadioGroup` / `ContextMenuRadioGroup` for consistent, native-feeling selection state instead of ad-hoc bolding and checkmark suffixes

Resolves #5901

## Changes

- `AgentButton.tsx` — preset-aware launch tooltip; two sibling `Tooltip`s under one `TooltipProvider`; chevron-specific tooltip; `DropdownMenuRadioGroup`/`RadioItem` in dropdown; `ContextMenuRadioGroup`/`RadioItem` in context submenu with a new Default item for parity; preset segment retained on the `signInUnconfirmed` path
- `AgentTrayButton.tsx` — `savedPresetId` threaded through `buildAgentRow`; `SplitLaunchItem` submenu migrated to `DropdownMenuRadioGroup`/`RadioItem`
- `context-menu.tsx` — added `ContextMenuRadioGroup` and `ContextMenuRadioItem` wrappers (were missing from the UI primitives)
- `Toolbar.tsx` — single-line formatting fix (prettier)
- `AgentButton.test.tsx` / `AgentTrayButton.test.tsx` — mocks updated for radio primitives + `tooltip-content` testid; 12 new tests covering preset label display, chevron tooltip, and radio selection state

## Testing

66 vitest tests pass. `tsc --noEmit`, eslint, and prettier all clean. Lint ratchet improved by 4 warnings vs develop.