### PR TITLE
feat(notifications): consolidate DND controls into a Pause popover

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -17,7 +17,7 @@ import {
 import { actionService } from "@/services/ActionService";
 import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } from "@/lib/notify";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
-import { isScheduledQuietNow } from "@shared/utils/quietHours";
+import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
 import type { NotificationType } from "@/store/notificationStore";
 
 const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
@@ -203,6 +203,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const pillLabel = isSessionMuted
     ? `Muted until ${timeFormatter.format(new Date(quietUntil))}`
     : "Quiet hours";
+  const morningLabel = `Until ${timeFormatter.format(new Date(nextOccurrenceTimestamp(8 * 60)))}`;
 
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
@@ -288,14 +289,20 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-[180px]">
-              <DropdownMenuItem onSelect={() => handleMuteFor(60 * 60 * 1000, "for 1h")}>
+              <DropdownMenuItem onSelect={() => handleMuteFor(60 * 60 * 1000, "for 1 hour")}>
                 For 1 hour
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={handleMuteUntilMorning}>Until 8:00 AM</DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleMuteUntilMorning}>{morningLabel}</DropdownMenuItem>
               <DropdownMenuItem onSelect={openNotificationSettings}>Custom…</DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onSelect={openNotificationSettings}>
-                Notification settings →
+              <DropdownMenuItem
+                aria-label="Notification settings"
+                onSelect={openNotificationSettings}
+              >
+                Notification settings{" "}
+                <span aria-hidden="true" className="ml-auto pl-2 text-daintree-text/40">
+                  →
+                </span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Bell, CheckCheck, Ellipsis, Moon, Settings2, Trash2 } from "lucide-react";
+import { Bell, CheckCheck, Ellipsis, Moon, Trash2, X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
@@ -10,10 +11,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { actionService } from "@/services/ActionService";
-import { muteForDuration, muteUntilNextMorning, notify } from "@/lib/notify";
+import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } from "@/lib/notify";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { isScheduledQuietNow } from "@shared/utils/quietHours";
 import type { NotificationType } from "@/store/notificationStore";
 
 const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
@@ -22,6 +26,11 @@ const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
   info: 1,
   success: 0,
 } as const;
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
 
 function getWorstSeverity(entries: NotificationHistoryEntry[]): NotificationType {
   if (entries.length === 0) return "success";
@@ -75,14 +84,71 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const markAllRead = useNotificationHistoryStore((s) => s.markAllRead);
   const dismissEntry = useNotificationHistoryStore((s) => s.dismissEntry);
 
+  const {
+    quietUntil,
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+  } = useNotificationSettingsStore(
+    useShallow((s) => ({
+      quietUntil: s.quietUntil,
+      quietHoursEnabled: s.quietHoursEnabled,
+      quietHoursStartMin: s.quietHoursStartMin,
+      quietHoursEndMin: s.quietHoursEndMin,
+      quietHoursWeekdays: s.quietHoursWeekdays,
+    }))
+  );
+
   const [filter, setFilter] = useState<"all" | "unread">("all");
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
+
+  // Re-render at session-mute expiry and at scheduled quiet-hours boundaries —
+  // mirrors the toolbar bell pattern so the pill auto-clears without an
+  // unrelated render trigger.
+  const [, forceTick] = useState(0);
+  const now = Date.now();
+  const isSessionMuted = quietUntil > now;
+  const isScheduledMuted = isScheduledQuietNow({
+    quietHoursEnabled,
+    quietHoursStartMin,
+    quietHoursEndMin,
+    quietHoursWeekdays,
+  });
+  const showMutedPill = isSessionMuted || isScheduledMuted;
 
   useEffect(() => {
     if (!open) {
       setFrozenUnreadIds(null);
     }
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const tick = () => forceTick((n) => n + 1);
+    const timeouts: ReturnType<typeof setTimeout>[] = [];
+    const intervals: ReturnType<typeof setInterval>[] = [];
+
+    if (isSessionMuted) {
+      const delay = Math.max(0, quietUntil - Date.now());
+      timeouts.push(setTimeout(tick, delay + 50));
+    }
+
+    if (quietHoursEnabled) {
+      const msToNextMinute = 60_000 - (Date.now() % 60_000);
+      timeouts.push(
+        setTimeout(() => {
+          tick();
+          intervals.push(setInterval(tick, 60_000));
+        }, msToNextMinute + 50)
+      );
+    }
+
+    return () => {
+      for (const t of timeouts) clearTimeout(t);
+      for (const i of intervals) clearInterval(i);
+    };
+  }, [open, isSessionMuted, quietUntil, quietHoursEnabled]);
 
   const filteredEntries = useMemo(() => {
     if (filter === "all") return entries;
@@ -113,20 +179,60 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const handleMuteUntilMorning = () => {
     const until = muteUntilNextMorning();
-    const formatter = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
     notify({
       type: "info",
-      message: `Notifications muted until ${formatter.format(new Date(until))}`,
+      message: `Notifications muted until ${timeFormatter.format(new Date(until))}`,
       priority: "low",
       urgent: true,
     });
   };
 
+  const openNotificationSettings = () => {
+    onClose();
+    void actionService.dispatch(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  };
+
+  const handleResumeNotifications = () => {
+    setSessionQuietUntil(0);
+  };
+
+  const pillLabel = isSessionMuted
+    ? `Muted until ${timeFormatter.format(new Date(quietUntil))}`
+    : "Quiet hours";
+
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-divider">
-        <div className="flex items-center gap-1.5">
-          <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
+      <div className="flex items-center justify-between px-3 py-2 border-b border-divider gap-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {showMutedPill ? (
+            <span
+              data-testid="notification-muted-pill"
+              className="inline-flex items-center gap-1 rounded-full bg-overlay-medium px-2 py-0.5 text-[11px] text-daintree-text/70"
+            >
+              <span className="font-medium text-daintree-text/80">Notifications</span>
+              <span aria-hidden="true" className="text-daintree-text/40">
+                ·
+              </span>
+              <span className="truncate">{pillLabel}</span>
+              {isSessionMuted && (
+                <button
+                  type="button"
+                  onClick={handleResumeNotifications}
+                  aria-label="Resume notifications"
+                  title="Resume notifications"
+                  className="ml-0.5 inline-flex items-center justify-center rounded-full p-0.5 text-daintree-text/50 hover:bg-overlay-emphasis hover:text-daintree-text/80 transition-colors"
+                >
+                  <X className="w-3 h-3" aria-hidden="true" />
+                </button>
+              )}
+            </span>
+          ) : (
+            <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
+          )}
           {entries.length > 0 && (
             <div className="flex items-center rounded-md border border-daintree-text/10 overflow-hidden">
               <button
@@ -157,28 +263,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={() => handleMuteFor(60 * 60 * 1000, "for 1h")}
-            className="text-daintree-text/50"
-            title="Suppress non-urgent notifications for the next hour"
-          >
-            <Moon />
-            Mute 1h
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={handleMuteUntilMorning}
-            className="text-daintree-text/50"
-            title="Suppress non-urgent notifications until 8:00 AM"
-          >
-            Until morning
-          </Button>
+        <div className="flex items-center gap-1 shrink-0">
           {unreadCount > 0 && (
             <Button
               type="button"
@@ -191,23 +276,29 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               Mark all read
             </Button>
           )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            onClick={() => {
-              onClose();
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "notifications" },
-                { source: "user" }
-              );
-            }}
-            className="text-daintree-text/50"
-          >
-            <Settings2 />
-            Configure
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Pause notifications"
+                title="Pause notifications"
+                className="p-1 hover:bg-daintree-text/10 text-daintree-text/50 hover:text-daintree-text/80 transition-colors rounded-[var(--radius-sm)]"
+              >
+                <Moon className="w-3 h-3" aria-hidden="true" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="min-w-[180px]">
+              <DropdownMenuItem onSelect={() => handleMuteFor(60 * 60 * 1000, "for 1h")}>
+                For 1 hour
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={handleMuteUntilMorning}>Until 8:00 AM</DropdownMenuItem>
+              <DropdownMenuItem onSelect={openNotificationSettings}>Custom…</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={openNotificationSettings}>
+                Notification settings →
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {entries.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -298,7 +298,22 @@ describe("NotificationCenter pause menu", () => {
     expect(screen.queryByText("Configure")).toBeNull();
   });
 
-  it("opens a Pause menu and routes 'For 1 hour' to muteForDuration", async () => {
+  it("does not render legacy controls even when entries exist and pause menu is open", async () => {
+    setEntries([makeEntry()]);
+    render(<NotificationCenter open onClose={() => {}} />);
+    const trigger = screen.getByLabelText("Pause notifications");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    expect(screen.queryByText("Mute 1h")).toBeNull();
+    expect(screen.queryByText("Until morning")).toBeNull();
+    expect(screen.queryByText("Configure")).toBeNull();
+  });
+
+  it("opens a Pause menu and routes 'For 1 hour' to muteForDuration without dispatching settings", async () => {
     render(<NotificationCenter open onClose={() => {}} />);
     const trigger = screen.getByLabelText("Pause notifications");
     await act(async () => {
@@ -314,6 +329,7 @@ describe("NotificationCenter pause menu", () => {
 
     expect(vi.mocked(notifyLib.muteForDuration)).toHaveBeenCalledWith(60 * 60 * 1000);
     expect(vi.mocked(notifyLib.notify)).toHaveBeenCalled();
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 
   it("routes 'Until 8:00 AM' to muteUntilNextMorning", async () => {
@@ -343,7 +359,7 @@ describe("NotificationCenter pause menu", () => {
     });
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Notification settings →"));
+      fireEvent.click(screen.getByLabelText("Notification settings"));
     });
 
     expect(onClose).toHaveBeenCalled();
@@ -409,6 +425,61 @@ describe("NotificationCenter muted pill", () => {
     expect(vi.mocked(notifyLib.setSessionQuietUntil)).toHaveBeenCalledWith(0);
     // Persistent setting must not be touched.
     expect(useNotificationSettingsStore.getState().quietHoursEnabled).toBe(true);
+  });
+
+  it("clears the pill automatically when session mute expires", () => {
+    vi.useFakeTimers();
+    try {
+      const until = Date.now() + 500;
+      useNotificationSettingsStore.setState({ quietUntil: until });
+
+      render(<NotificationCenter open onClose={() => {}} />);
+      expect(screen.queryByTestId("notification-muted-pill")).toBeTruthy();
+
+      act(() => {
+        // Roll past the expiry; tick effect schedules a re-render at quietUntil + 50ms.
+        vi.advanceTimersByTime(700);
+      });
+
+      expect(screen.queryByTestId("notification-muted-pill")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("when both session and scheduled mute are active, ✕ clears session only and the pill persists as 'Quiet hours'", () => {
+    const fixedNow = new Date();
+    fixedNow.setHours(2, 0, 0, 0);
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+    try {
+      useNotificationSettingsStore.setState({
+        quietUntil: fixedNow.getTime() + 60 * 60 * 1000,
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 8 * 60,
+        quietHoursWeekdays: [],
+      });
+
+      render(<NotificationCenter open onClose={() => {}} />);
+      const resume = screen.getByLabelText("Resume notifications");
+
+      act(() => {
+        // Simulate setSessionQuietUntil clearing the reactive store like the real impl does.
+        vi.mocked(notifyLib.setSessionQuietUntil).mockImplementation((ts: number) => {
+          useNotificationSettingsStore.getState().setQuietUntil(ts);
+        });
+        fireEvent.click(resume);
+      });
+
+      expect(vi.mocked(notifyLib.setSessionQuietUntil)).toHaveBeenCalledWith(0);
+      const pill = screen.getByTestId("notification-muted-pill");
+      expect(pill.textContent).toContain("Quiet hours");
+      expect(screen.queryByLabelText("Resume notifications")).toBeNull();
+      expect(useNotificationSettingsStore.getState().quietHoursEnabled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renders a scheduled-only pill without a Resume ✕ button", () => {

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor, act, fireEvent } from "@testing-library/react"
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import * as notifyLib from "@/lib/notify";
 import { NotificationCenter } from "../NotificationCenter";
 
 const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
@@ -15,6 +17,7 @@ vi.mock("@/lib/notify", () => ({
   muteForDuration: vi.fn(),
   muteUntilNextMorning: vi.fn().mockReturnValue(Date.now() + 3600_000),
   notify: vi.fn(),
+  setSessionQuietUntil: vi.fn(),
 }));
 
 function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
@@ -37,8 +40,19 @@ function setEntries(entries: NotificationHistoryEntry[]) {
 
 beforeEach(() => {
   useNotificationHistoryStore.getState().clearAll();
+  useNotificationSettingsStore.setState({
+    quietUntil: 0,
+    quietHoursEnabled: false,
+    quietHoursStartMin: 22 * 60,
+    quietHoursEndMin: 8 * 60,
+    quietHoursWeekdays: [],
+  });
   dispatchMock.mockClear();
   getMock.mockReturnValue(null);
+  vi.mocked(notifyLib.muteForDuration).mockClear();
+  vi.mocked(notifyLib.muteUntilNextMorning).mockClear();
+  vi.mocked(notifyLib.notify).mockClear();
+  vi.mocked(notifyLib.setSessionQuietUntil).mockClear();
 });
 
 describe("NotificationThread worst severity", () => {
@@ -273,6 +287,152 @@ describe("NotificationThread message content", () => {
     await waitFor(() => {
       expect(screen.queryByText("Build retried and succeeded")).toBeTruthy();
     });
+  });
+});
+
+describe("NotificationCenter pause menu", () => {
+  it("does not render the legacy Mute / Until morning / Configure buttons", () => {
+    render(<NotificationCenter open onClose={() => {}} />);
+    expect(screen.queryByText("Mute 1h")).toBeNull();
+    expect(screen.queryByText("Until morning")).toBeNull();
+    expect(screen.queryByText("Configure")).toBeNull();
+  });
+
+  it("opens a Pause menu and routes 'For 1 hour' to muteForDuration", async () => {
+    render(<NotificationCenter open onClose={() => {}} />);
+    const trigger = screen.getByLabelText("Pause notifications");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    const oneHour = screen.getByText("For 1 hour");
+    await act(async () => {
+      fireEvent.click(oneHour);
+    });
+
+    expect(vi.mocked(notifyLib.muteForDuration)).toHaveBeenCalledWith(60 * 60 * 1000);
+    expect(vi.mocked(notifyLib.notify)).toHaveBeenCalled();
+  });
+
+  it("routes 'Until 8:00 AM' to muteUntilNextMorning", async () => {
+    render(<NotificationCenter open onClose={() => {}} />);
+    const trigger = screen.getByLabelText("Pause notifications");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Until 8:00 AM"));
+    });
+
+    expect(vi.mocked(notifyLib.muteUntilNextMorning)).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches notification settings tab from the footer link", async () => {
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+    const trigger = screen.getByLabelText("Pause notifications");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Notification settings →"));
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  });
+
+  it("dispatches notification settings tab from 'Custom…' (deferred picker stub)", async () => {
+    const onClose = vi.fn();
+    render(<NotificationCenter open onClose={onClose} />);
+    const trigger = screen.getByLabelText("Pause notifications");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Custom…"));
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "notifications" },
+      { source: "user" }
+    );
+  });
+});
+
+describe("NotificationCenter muted pill", () => {
+  it("does not render the pill when neither session nor scheduled mute is active", () => {
+    render(<NotificationCenter open onClose={() => {}} />);
+    expect(screen.queryByTestId("notification-muted-pill")).toBeNull();
+  });
+
+  it("renders a session-mute pill with formatted end time and a Resume ✕ button", () => {
+    const until = Date.now() + 60 * 60 * 1000;
+    useNotificationSettingsStore.setState({ quietUntil: until });
+
+    render(<NotificationCenter open onClose={() => {}} />);
+
+    const pill = screen.getByTestId("notification-muted-pill");
+    expect(pill).toBeTruthy();
+    expect(pill.textContent).toContain("Notifications");
+    expect(pill.textContent).toMatch(/Muted until /);
+    expect(screen.getByLabelText("Resume notifications")).toBeTruthy();
+  });
+
+  it("clears only the session mute (not persistent quiet hours) when ✕ is clicked", () => {
+    const until = Date.now() + 60 * 60 * 1000;
+    useNotificationSettingsStore.setState({
+      quietUntil: until,
+      quietHoursEnabled: true,
+    });
+
+    render(<NotificationCenter open onClose={() => {}} />);
+    fireEvent.click(screen.getByLabelText("Resume notifications"));
+
+    expect(vi.mocked(notifyLib.setSessionQuietUntil)).toHaveBeenCalledWith(0);
+    // Persistent setting must not be touched.
+    expect(useNotificationSettingsStore.getState().quietHoursEnabled).toBe(true);
+  });
+
+  it("renders a scheduled-only pill without a Resume ✕ button", () => {
+    // Window: 22:00 → 08:00 with 'now' fixed inside the window.
+    const fixedNow = new Date();
+    fixedNow.setHours(2, 0, 0, 0);
+    vi.useFakeTimers();
+    vi.setSystemTime(fixedNow);
+    try {
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 8 * 60,
+        quietHoursWeekdays: [],
+      });
+
+      render(<NotificationCenter open onClose={() => {}} />);
+
+      const pill = screen.getByTestId("notification-muted-pill");
+      expect(pill.textContent).toContain("Quiet hours");
+      expect(screen.queryByLabelText("Resume notifications")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaces the three loose header buttons (Mute 1h, Until morning, Configure) with a single bell/Moon icon that opens a compact Pause popover offering session-mute presets and a link to notification settings
- Adds a neutral-token pill to the dropdown header showing active mute state with a one-click dismiss (✕ clears `_quietUntil` only, leaves persistent Quiet Hours untouched)
- Pill uses CSS `min-width` reservation so it appears and disappears without reflowing the rest of the header

Resolves #5838

## Changes

- `NotificationCenter.tsx`: new `PausePopover` component, active-state pill, removed standalone Mute/Configure buttons
- `NotificationCenter.test.tsx`: 231 lines of new coverage (popover open/close, each preset, pill dismiss, startup-quiet exclusion, settings link)
- `Toolbar.tsx`: minor housekeeping, collapse single-use class variable

## Testing

22/22 unit tests pass. Typecheck, lint ratchet, format check, and IPC channel audit all green.