### PR TITLE
feat(toolbar): redesign agent button preset selection and launch menus

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
@@ -151,6 +152,35 @@ export function AgentButton({
   const panelsById = usePanelStore(useShallow((s) => s.panelsById));
   const panelIds = usePanelStore(useShallow((s) => s.panelIds));
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+
+  // Radix Tooltip reopens on focus restoration. When the chevron's
+  // DropdownMenu closes, Radix returns focus to the chevron trigger and the
+  // tooltip would reopen on top of the freshly-launched action's surfaces.
+  // Gate both halves' tooltips on controlled state and hold suppression open
+  // until the next genuine pointer hover. Same pattern as AgentTrayButton.
+  const [primaryTooltipOpen, setPrimaryTooltipOpen] = useState(false);
+  const [chevronTooltipOpen, setChevronTooltipOpen] = useState(false);
+  const isRestoringFocusRef = useRef(false);
+
+  const handlePrimaryTooltipOpenChange = (open: boolean) => {
+    if (open && isRestoringFocusRef.current) return;
+    setPrimaryTooltipOpen(open);
+  };
+
+  const handleChevronTooltipOpenChange = (open: boolean) => {
+    if (open && isRestoringFocusRef.current) return;
+    setChevronTooltipOpen(open);
+  };
+
+  const suppressTooltipsDuringFocusRestore = () => {
+    setPrimaryTooltipOpen(false);
+    setChevronTooltipOpen(false);
+    isRestoringFocusRef.current = true;
+  };
+
+  const clearFocusRestoreSuppression = () => {
+    isRestoringFocusRef.current = false;
+  };
 
   const activeSession = useMemo(() => {
     const states: (AgentState | undefined)[] = [];
@@ -301,7 +331,7 @@ export function AgentButton({
     return (
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <Tooltip>
+          <Tooltip open={primaryTooltipOpen} onOpenChange={handlePrimaryTooltipOpenChange}>
             <TooltipTrigger asChild>
               <span className="inline-flex">
                 <Button
@@ -310,6 +340,7 @@ export function AgentButton({
                   onClick={handleClick}
                   disabled={isLoading}
                   data-toolbar-item={dataToolbarItem}
+                  onPointerEnter={clearFocusRestoreSuppression}
                   className={cn(
                     "toolbar-agent-button text-daintree-text transition-colors relative",
                     isReady &&
@@ -326,7 +357,7 @@ export function AgentButton({
             <TooltipContent side="bottom">{tooltip}</TooltipContent>
           </Tooltip>
         </ContextMenuTrigger>
-        <ContextMenuContent>
+        <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
           <ContextMenuItem
             disabled={!isReady}
             onSelect={() =>
@@ -354,7 +385,7 @@ export function AgentButton({
           {worktrees.length > 0 && (
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
-              <ContextMenuSubContent>
+              <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
                 <WorktreeMenuItems agentType={type} worktrees={worktrees} />
               </ContextMenuSubContent>
             </ContextMenuSub>
@@ -395,7 +426,7 @@ export function AgentButton({
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <span className="inline-flex">
-          <Tooltip>
+          <Tooltip open={primaryTooltipOpen} onOpenChange={handlePrimaryTooltipOpenChange}>
             <TooltipTrigger asChild>
               <Button
                 variant="ghost"
@@ -403,6 +434,7 @@ export function AgentButton({
                 onClick={handleClick}
                 disabled={isLoading}
                 data-toolbar-item={dataToolbarItem}
+                onPointerEnter={clearFocusRestoreSuppression}
                 className={cn(
                   "toolbar-agent-button text-daintree-text transition-colors rounded-r-none border-r border-transparent relative",
                   isReady &&
@@ -417,29 +449,44 @@ export function AgentButton({
             </TooltipTrigger>
             <TooltipContent side="bottom">{tooltip}</TooltipContent>
           </Tooltip>
-          <DropdownMenu>
-            <Tooltip>
+          <DropdownMenu
+            onOpenChange={(open) => {
+              if (open) {
+                setPrimaryTooltipOpen(false);
+                setChevronTooltipOpen(false);
+              }
+            }}
+          >
+            <Tooltip open={chevronTooltipOpen} onOpenChange={handleChevronTooltipOpenChange}>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
                     disabled={isLoading || !isReady}
                     data-toolbar-item={dataToolbarItem}
+                    onPointerEnter={clearFocusRestoreSuppression}
                     className={cn(
                       "toolbar-agent-button text-daintree-text transition-colors rounded-l-none",
-                      "h-8 w-4 p-0 flex items-center justify-center",
+                      "h-8 w-6 p-0 flex items-center justify-center",
                       "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
                       !isReady && !isLoading && "opacity-60"
                     )}
                     aria-label={chevronTooltip}
                   >
-                    <ChevronDown className="h-3 w-3 opacity-70" />
+                    <ChevronDown className="h-3 w-3" />
                   </Button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
               <TooltipContent side="bottom">{chevronTooltip}</TooltipContent>
             </Tooltip>
-            <DropdownMenuContent align="start" sideOffset={4} className="min-w-[12rem]">
+            <DropdownMenuContent
+              align="start"
+              sideOffset={4}
+              className="min-w-[12rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+              onCloseAutoFocus={() => {
+                suppressTooltipsDuringFocusRestore();
+              }}
+            >
               <DropdownMenuRadioGroup value={savedPresetId ?? ""}>
                 <DropdownMenuRadioItem
                   value=""
@@ -535,11 +582,23 @@ export function AgentButton({
                   </>
                 )}
               </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() =>
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "agents", subtab: type, sectionId: "agents-presets" },
+                    { source: "user" }
+                  )
+                }
+              >
+                Manage Presets...
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </span>
       </ContextMenuTrigger>
-      <ContextMenuContent>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
         <ContextMenuItem
           disabled={!isReady}
           onSelect={() =>
@@ -567,7 +626,10 @@ export function AgentButton({
         {hasPresets && (
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch with Preset</ContextMenuSubTrigger>
-            <ContextMenuSubContent data-testid="context-submenu-content">
+            <ContextMenuSubContent
+              data-testid="context-submenu-content"
+              className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
+            >
               <ContextMenuRadioGroup value={savedPresetId ?? ""}>
                 <ContextMenuRadioItem
                   value=""
@@ -605,7 +667,7 @@ export function AgentButton({
         {worktrees.length > 0 && (
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
-            <ContextMenuSubContent>
+            <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
               <WorktreeMenuItems agentType={type} worktrees={worktrees} />
             </ContextMenuSubContent>
           </ContextMenuSub>

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -278,15 +278,13 @@ export function AgentButton({
 
   const handleClick = () => {
     if (isReady) {
-      // MRU semantics: primary-button click launches with the saved preset if
-      // one is stored (user's last pick), otherwise default (no presetId).
-      // Passing `presetId: null` would force explicit default and override a
-      // saved default — we want undefined fallthrough to useAgentLauncher.
-      void actionService.dispatch(
-        "agent.launch",
-        savedPresetId ? { agentId: type, presetId: savedPresetId } : { agentId: type },
-        { source: "user" }
-      );
+      // Defer all preset resolution to useAgentLauncher. Forwarding the
+      // resolved savedPresetId explicitly would block the launcher's
+      // stale-fallback path: when a worktree-scoped pick references a
+      // deleted preset, an explicit presetId bypasses the agent-level
+      // default and launches preset-free instead. Omitting presetId lets
+      // the launcher run resolveEffectivePresetId + fallback in one place.
+      void actionService.dispatch("agent.launch", { agentId: type }, { source: "user" });
     } else {
       void actionService.dispatch(
         "app.settings.openTab",

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -781,6 +781,31 @@ describe("AgentButton preset UX", () => {
     });
   });
 
+  describe("manage presets dropdown footer", () => {
+    it("dropdown footer dispatches deep-link to the preset editor with source 'user'", () => {
+      // The chevron dropdown carries a footer "Manage Presets..." item that
+      // mirrors the right-click menu's agent-named entry but uses the
+      // shorter label since the agent identity is implicit (the user just
+      // clicked this agent's chevron). Source is "user" because it's a
+      // direct primary-UI dispatch, not a context-menu surface.
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-alpha", name: "Alpha" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("preset-item") as HTMLElement[];
+      const manage = items.find((el) => el.textContent === "Manage Presets...")!;
+      fireEvent.click(manage);
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "app.settings.openTab",
+        { tab: "agents", subtab: "claude", sectionId: "agents-presets" },
+        { source: "user" }
+      );
+    });
+  });
+
   describe("context menu", () => {
     it("exposes Manage Presets that deep-links to the presets section (no-presets branch)", () => {
       mockSettings = settingsWith({ claude: {} });

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -350,7 +350,14 @@ describe("AgentButton preset UX", () => {
       );
     });
 
-    it("primary click with savedPresetId dispatches with that presetId (MRU)", () => {
+    it("primary click never forwards an explicit presetId — launcher resolves it", () => {
+      // The toolbar must NOT forward the resolved savedPresetId. Doing so
+      // bypasses useAgentLauncher's stale-fallback path: when a saved id
+      // points to a deleted preset, an explicit presetId launches
+      // preset-free instead of falling back to the agent-level default.
+      // Omitting presetId lets the launcher run resolveEffectivePresetId +
+      // fallback in one place. Saved-preset display still works because the
+      // launcher reads the same setting internally.
       mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
       mockMergedPresetsFn = () => [
         { id: "user-blue", name: "Blue" },
@@ -360,20 +367,17 @@ describe("AgentButton preset UX", () => {
       const { getAllByRole } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      // Split-button branch — first button is the primary launch button.
       const [primaryBtn] = getAllByRole("button") as HTMLElement[];
       fireEvent.click(primaryBtn!);
 
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
-        { agentId: "claude", presetId: "user-blue" },
+        { agentId: "claude" },
         { source: "user" }
       );
     });
 
-    it("primary click with savedPresetId dispatches presetId when agent has only 1 preset", () => {
-      // With 1 named preset the split UI now renders (Default + the preset),
-      // and the primary button must still honor the saved MRU selection.
+    it("primary click omits presetId even when agent has only 1 preset", () => {
       mockSettings = settingsWith({ claude: { presetId: "user-alpha" } });
       mockMergedPresetsFn = () => [{ id: "user-alpha", name: "Alpha" }];
 
@@ -385,7 +389,35 @@ describe("AgentButton preset UX", () => {
 
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
-        { agentId: "claude", presetId: "user-alpha" },
+        { agentId: "claude" },
+        { source: "user" }
+      );
+    });
+
+    it("primary click with stale worktree-scoped preset still dispatches without presetId so launcher fallback runs", () => {
+      // Regression guard: when the worktree slot points to a deleted preset
+      // and the agent-level default is still valid, the toolbar must not
+      // forward the stale id — it would block useAgentLauncher's fallback
+      // and the click would launch preset-free instead of the global
+      // default. The toolbar passes nothing; the launcher does the rest.
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: {
+          presetId: "user-global",
+          worktreePresets: { "wt-A": "deleted-id" },
+        },
+      });
+      mockMergedPresetsFn = () => [{ id: "user-global", name: "Global" }];
+
+      const { getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const [primaryBtn] = getAllByRole("button") as HTMLElement[];
+      fireEvent.click(primaryBtn!);
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude" },
         { source: "user" }
       );
     });
@@ -424,7 +456,7 @@ describe("AgentButton preset UX", () => {
   });
 
   describe("worktree-scoped preset", () => {
-    it("primary click reads the worktree override when present, not the agent-level default", () => {
+    it("primary click dispatches without presetId when a worktree override is present (launcher resolves)", () => {
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({
         claude: {
@@ -437,20 +469,24 @@ describe("AgentButton preset UX", () => {
         { id: "user-scoped", name: "Scoped" },
       ];
 
-      const { getAllByRole } = render(
+      const { getAllByRole, container } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       const [primaryBtn] = getAllByRole("button") as HTMLElement[];
       fireEvent.click(primaryBtn!);
 
+      // Dispatch carries no presetId — that's the launcher's job. The
+      // tooltip still surfaces the worktree-scoped preset name so the
+      // user sees what the click will run.
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
-        { agentId: "claude", presetId: "user-scoped" },
+        { agentId: "claude" },
         { source: "user" }
       );
+      expect(container.textContent).toContain("Start Claude · Scoped");
     });
 
-    it("primary click falls back to agent-level default when the active worktree has no override", () => {
+    it("primary click dispatches without presetId when active worktree has no override (tooltip shows global)", () => {
       mockActiveWorktreeId = "wt-B";
       mockSettings = settingsWith({
         claude: {
@@ -463,7 +499,7 @@ describe("AgentButton preset UX", () => {
         { id: "user-scoped", name: "Scoped" },
       ];
 
-      const { getAllByRole } = render(
+      const { getAllByRole, container } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       const [primaryBtn] = getAllByRole("button") as HTMLElement[];
@@ -471,9 +507,10 @@ describe("AgentButton preset UX", () => {
 
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
-        { agentId: "claude", presetId: "user-global" },
+        { agentId: "claude" },
         { source: "user" }
       );
+      expect(container.textContent).toContain("Start Claude · Global");
     });
 
     it("dropdown preset selection persists the pick to the worktree slot before dispatch", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -273,6 +273,9 @@ vi.mock("@/components/ui/button", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  Check: ({ className }: { className?: string }) => (
+    <span data-testid="check-icon" data-classname={className} />
+  ),
   Plug: () => <span data-testid="plug-icon" />,
   Pin: ({ className }: { className?: string; strokeWidth?: number }) => (
     <span data-testid="pin-icon" data-classname={className} />


### PR DESCRIPTION
## Summary

- Fixes 5 interconnected UX problems with the toolbar agent button (active preset visibility, chevron affordance, inconsistent saved-preset indicators, no preset management entry point, and a 3-deep worktree picker) from #5903, which consolidates #5901 and #5902
- Critical correctness fix: the primary button click no longer forwards an explicit `presetId` to `agent.launch` — it defers to `useAgentLauncher`'s stale-fallback resolution path, which handles deleted/sanitised presets gracefully
- 21 unit tests in `AgentButton.test.tsx` (14 existing kept, 6 new scenarios, 1 stale-preset regression guard)

Resolves #5903

## Changes

- **Tooltip names the active preset.** Shows `Start Claude Code · <preset name> (⌥⌘C)` scoped to the current worktree. Falls back to "Default" when the saved preset has been deleted or sanitised away
- **Chevron is a proper affordance.** Wider hit target (~24px), persistent when presets exist, with its own tooltip. Dropdown includes a "Manage Presets..." footer item that deep-links to the preset editor via the existing `app.settings.openTab` action
- **Unified Check indicator.** Single trailing check icon with muted text colour (no accent per CLAUDE.md) across the chevron dropdown, right-click submenu, and `SplitLaunchItem` in `AgentTrayButton` — replaces the three inconsistent treatments (bold text, `" ✓"` suffix, nothing)
- **"Manage Presets..." in right-click menu.** Added to both the with-presets and no-presets branches of the context menu
- **Worktree picker is 1 hover deep.** Inline trailing Dock button on each worktree row replaces the 3-level flyout. Grid is the row click; Dock is the trailing button on hover
- **No `presetId` forwarded on primary click.** `resolvedPresetId` was previously passed into `agent.launch` which bypassed the launcher's stale-preset handling. Primary click now passes no `presetId`, letting the launcher resolve it via its own fallback logic
- Includes a small pre-existing prettier fix to `Toolbar.tsx` (format drift on develop that would have blocked CI)

## Testing

- 21 unit tests covering: tooltip label resolution (active/default/deleted preset), chevron presence/absence, Check indicator rendering across surfaces, Manage Presets entry, stale-preset regression guard, worktree picker structure
- `npm run check` passes (0 errors, warnings are pre-existing on develop)