### PR TITLE
feat(agent-button): improve right-click context menu

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useMemo, useRef, type PointerEvent as ReactPointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
@@ -66,19 +66,25 @@ const stopPointer = (e: ReactPointerEvent) => {
 interface WorktreeMenuItemsProps {
   agentType: AgentType;
   worktrees: ReturnType<typeof useWorktrees>["worktrees"];
-  closeMenu: () => void;
 }
 
 // Flattens the worktree picker from a nested 3-deep submenu (worktree →
-// Grid/Dock) into one row per worktree. Default click (and keyboard
-// Enter) launches in grid; the inline Dock affordance gives mouse users
-// the secondary location without a second submenu hop, mirroring the pin
-// button pattern in AgentTrayButton. The pointer/click stopPropagation
-// guards keep the parent ContextMenuItem from also firing the row's
-// grid onSelect — but stopping the onClick also cuts Radix's
-// handleSelect → onClose chain, so we close the menu explicitly via
-// the controlled closeMenu callback.
-function WorktreeMenuItems({ agentType, worktrees, closeMenu }: WorktreeMenuItemsProps) {
+// Grid/Dock) into one row per worktree. Row click (and keyboard Enter)
+// launches in grid; the inline Dock affordance gives mouse users the
+// secondary location without a second submenu hop, mirroring the pin
+// button pattern in AgentTrayButton.
+//
+// Closing-the-menu mechanics: Radix ContextMenu Root has no `open` prop,
+// so we can't use a controlled-state shortcut. Instead, the inline Dock
+// click is allowed to bubble to the parent ContextMenuItem so Radix's
+// normal handleSelect → onClose chain still fires (which is what closes
+// the menu). To avoid double-firing the row's grid dispatch on top of
+// the dock dispatch, the inline button sets a ref before bubbling; the
+// row's onSelect honors the ref and skips the grid dispatch when set.
+// pointerDown/pointerUp still stopPropagation to keep Radix from
+// treating the icon press as the row's primary selection event.
+function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
+  const dockClickedRef = useRef(false);
   return (
     <>
       {worktrees.map((wt) => {
@@ -88,13 +94,17 @@ function WorktreeMenuItems({ agentType, worktrees, closeMenu }: WorktreeMenuItem
             key={wt.id}
             className="group/wt-row pr-1"
             data-testid={`agent-context-worktree-${wt.id}`}
-            onSelect={() =>
+            onSelect={() => {
+              if (dockClickedRef.current) {
+                dockClickedRef.current = false;
+                return;
+              }
               void actionService.dispatch(
                 "agent.launch",
                 { agentId: agentType, worktreeId: wt.id, location: "grid" },
                 { source: "context-menu" }
-              )
-            }
+              );
+            }}
           >
             <span className="flex-1 truncate">{label}</span>
             <span
@@ -104,14 +114,13 @@ function WorktreeMenuItems({ agentType, worktrees, closeMenu }: WorktreeMenuItem
               title="Launch in dock"
               onPointerDown={stopPointer}
               onPointerUp={stopPointer}
-              onClick={(e) => {
-                e.stopPropagation();
+              onClick={() => {
+                dockClickedRef.current = true;
                 void actionService.dispatch(
                   "agent.launch",
                   { agentId: agentType, worktreeId: wt.id, location: "dock" },
                   { source: "context-menu" }
                 );
-                closeMenu();
               }}
               className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
             >
@@ -130,11 +139,6 @@ export function AgentButton({
   "data-toolbar-item": dataToolbarItem,
 }: AgentButtonProps) {
   const { worktrees } = useWorktrees();
-  // Controlled open state lets WorktreeMenuItems' inline Dock button close the
-  // menu manually after dispatching, since stopPropagation on the inline
-  // button's onClick also cuts Radix's normal handleSelect → onClose path.
-  const [contextMenuOpen, setContextMenuOpen] = useState(false);
-  const closeContextMenu = () => setContextMenuOpen(false);
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const cliDetail = useCliAvailabilityStore((s) => s.details[type]);
@@ -286,7 +290,7 @@ export function AgentButton({
 
   if (!hasPresets) {
     return (
-      <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
+      <ContextMenu>
         <ContextMenuTrigger asChild>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -342,11 +346,7 @@ export function AgentButton({
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
               <ContextMenuSubContent>
-                <WorktreeMenuItems
-                  agentType={type}
-                  worktrees={worktrees}
-                  closeMenu={closeContextMenu}
-                />
+                <WorktreeMenuItems agentType={type} worktrees={worktrees} />
               </ContextMenuSubContent>
             </ContextMenuSub>
           )}
@@ -383,7 +383,7 @@ export function AgentButton({
   }
 
   return (
-    <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
+    <ContextMenu>
       <ContextMenuTrigger asChild>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -575,11 +575,7 @@ export function AgentButton({
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
             <ContextMenuSubContent>
-              <WorktreeMenuItems
-                agentType={type}
-                worktrees={worktrees}
-                closeMenu={closeContextMenu}
-              />
+              <WorktreeMenuItems agentType={type} worktrees={worktrees} />
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type PointerEvent as ReactPointerEvent } from "react";
+import { useMemo, useState, type PointerEvent as ReactPointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
@@ -26,7 +26,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { ChevronDown, LayoutGrid, PanelBottom, Unplug } from "lucide-react";
+import { ChevronDown, PanelBottom, Unplug } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
@@ -66,16 +66,19 @@ const stopPointer = (e: ReactPointerEvent) => {
 interface WorktreeMenuItemsProps {
   agentType: AgentType;
   worktrees: ReturnType<typeof useWorktrees>["worktrees"];
+  closeMenu: () => void;
 }
 
 // Flattens the worktree picker from a nested 3-deep submenu (worktree →
-// Grid/Dock) into a single row per worktree. Default click (and keyboard
-// Enter) launches in grid; the inline Dock affordance, mirroring the pin
-// button pattern in AgentTrayButton, gives mouse users the secondary
-// location without a second submenu hop. Both onPointerDown and onClick
-// must stopPropagation — Radix selects the parent ContextMenuItem at
-// pointerdown, so stopping only onClick lets the wrong action fire first.
-function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
+// Grid/Dock) into one row per worktree. Default click (and keyboard
+// Enter) launches in grid; the inline Dock affordance gives mouse users
+// the secondary location without a second submenu hop, mirroring the pin
+// button pattern in AgentTrayButton. The pointer/click stopPropagation
+// guards keep the parent ContextMenuItem from also firing the row's
+// grid onSelect — but stopping the onClick also cuts Radix's
+// handleSelect → onClose chain, so we close the menu explicitly via
+// the controlled closeMenu callback.
+function WorktreeMenuItems({ agentType, worktrees, closeMenu }: WorktreeMenuItemsProps) {
   return (
     <>
       {worktrees.map((wt) => {
@@ -97,25 +100,6 @@ function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
             <span
               role="presentation"
               aria-hidden="true"
-              data-testid={`agent-context-worktree-grid-${wt.id}`}
-              title="Launch in grid"
-              onPointerDown={stopPointer}
-              onPointerUp={stopPointer}
-              onClick={(e) => {
-                e.stopPropagation();
-                void actionService.dispatch(
-                  "agent.launch",
-                  { agentId: agentType, worktreeId: wt.id, location: "grid" },
-                  { source: "context-menu" }
-                );
-              }}
-              className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
-            >
-              <LayoutGrid className="h-3 w-3" />
-            </span>
-            <span
-              role="presentation"
-              aria-hidden="true"
               data-testid={`agent-context-worktree-dock-${wt.id}`}
               title="Launch in dock"
               onPointerDown={stopPointer}
@@ -127,8 +111,9 @@ function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
                   { agentId: agentType, worktreeId: wt.id, location: "dock" },
                   { source: "context-menu" }
                 );
+                closeMenu();
               }}
-              className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
+              className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
             >
               <PanelBottom className="h-3 w-3" />
             </span>
@@ -145,6 +130,11 @@ export function AgentButton({
   "data-toolbar-item": dataToolbarItem,
 }: AgentButtonProps) {
   const { worktrees } = useWorktrees();
+  // Controlled open state lets WorktreeMenuItems' inline Dock button close the
+  // menu manually after dispatching, since stopPropagation on the inline
+  // button's onClick also cuts Radix's normal handleSelect → onClose path.
+  const [contextMenuOpen, setContextMenuOpen] = useState(false);
+  const closeContextMenu = () => setContextMenuOpen(false);
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const cliDetail = useCliAvailabilityStore((s) => s.details[type]);
@@ -296,7 +286,7 @@ export function AgentButton({
 
   if (!hasPresets) {
     return (
-      <ContextMenu>
+      <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
         <ContextMenuTrigger asChild>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -352,7 +342,11 @@ export function AgentButton({
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
               <ContextMenuSubContent>
-                <WorktreeMenuItems agentType={type} worktrees={worktrees} />
+                <WorktreeMenuItems
+                  agentType={type}
+                  worktrees={worktrees}
+                  closeMenu={closeContextMenu}
+                />
               </ContextMenuSubContent>
             </ContextMenuSub>
           )}
@@ -389,7 +383,7 @@ export function AgentButton({
   }
 
   return (
-    <ContextMenu>
+    <ContextMenu open={contextMenuOpen} onOpenChange={setContextMenuOpen}>
       <ContextMenuTrigger asChild>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -581,7 +575,11 @@ export function AgentButton({
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
             <ContextMenuSubContent>
-              <WorktreeMenuItems agentType={type} worktrees={worktrees} />
+              <WorktreeMenuItems
+                agentType={type}
+                worktrees={worktrees}
+                closeMenu={closeContextMenu}
+              />
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type PointerEvent as ReactPointerEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
@@ -26,7 +26,7 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { ChevronDown, Unplug } from "lucide-react";
+import { ChevronDown, LayoutGrid, PanelBottom, Unplug } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
@@ -57,6 +57,86 @@ interface AgentButtonProps {
   type: AgentType;
   availability?: AgentAvailabilityState;
   "data-toolbar-item"?: string;
+}
+
+const stopPointer = (e: ReactPointerEvent) => {
+  e.stopPropagation();
+};
+
+interface WorktreeMenuItemsProps {
+  agentType: AgentType;
+  worktrees: ReturnType<typeof useWorktrees>["worktrees"];
+}
+
+// Flattens the worktree picker from a nested 3-deep submenu (worktree →
+// Grid/Dock) into a single row per worktree. Default click (and keyboard
+// Enter) launches in grid; the inline Dock affordance, mirroring the pin
+// button pattern in AgentTrayButton, gives mouse users the secondary
+// location without a second submenu hop. Both onPointerDown and onClick
+// must stopPropagation — Radix selects the parent ContextMenuItem at
+// pointerdown, so stopping only onClick lets the wrong action fire first.
+function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
+  return (
+    <>
+      {worktrees.map((wt) => {
+        const label = wt.isMainWorktree ? wt.name : wt.branch?.trim() || wt.name;
+        return (
+          <ContextMenuItem
+            key={wt.id}
+            className="group/wt-row pr-1"
+            data-testid={`agent-context-worktree-${wt.id}`}
+            onSelect={() =>
+              void actionService.dispatch(
+                "agent.launch",
+                { agentId: agentType, worktreeId: wt.id, location: "grid" },
+                { source: "context-menu" }
+              )
+            }
+          >
+            <span className="flex-1 truncate">{label}</span>
+            <span
+              role="presentation"
+              aria-hidden="true"
+              data-testid={`agent-context-worktree-grid-${wt.id}`}
+              title="Launch in grid"
+              onPointerDown={stopPointer}
+              onPointerUp={stopPointer}
+              onClick={(e) => {
+                e.stopPropagation();
+                void actionService.dispatch(
+                  "agent.launch",
+                  { agentId: agentType, worktreeId: wt.id, location: "grid" },
+                  { source: "context-menu" }
+                );
+              }}
+              className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
+            >
+              <LayoutGrid className="h-3 w-3" />
+            </span>
+            <span
+              role="presentation"
+              aria-hidden="true"
+              data-testid={`agent-context-worktree-dock-${wt.id}`}
+              title="Launch in dock"
+              onPointerDown={stopPointer}
+              onPointerUp={stopPointer}
+              onClick={(e) => {
+                e.stopPropagation();
+                void actionService.dispatch(
+                  "agent.launch",
+                  { agentId: agentType, worktreeId: wt.id, location: "dock" },
+                  { source: "context-menu" }
+                );
+              }}
+              className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]/wt-row:opacity-100"
+            >
+              <PanelBottom className="h-3 w-3" />
+            </span>
+          </ContextMenuItem>
+        );
+      })}
+    </>
+  );
 }
 
 export function AgentButton({
@@ -272,38 +352,7 @@ export function AgentButton({
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
               <ContextMenuSubContent>
-                {worktrees.map((wt) => {
-                  const label = wt.isMainWorktree ? wt.name : wt.branch?.trim() || wt.name;
-                  return (
-                    <ContextMenuSub key={wt.id}>
-                      <ContextMenuSubTrigger>{label}</ContextMenuSubTrigger>
-                      <ContextMenuSubContent>
-                        <ContextMenuItem
-                          onSelect={() =>
-                            void actionService.dispatch(
-                              "agent.launch",
-                              { agentId: type, worktreeId: wt.id, location: "grid" },
-                              { source: "context-menu" }
-                            )
-                          }
-                        >
-                          Grid
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          onSelect={() =>
-                            void actionService.dispatch(
-                              "agent.launch",
-                              { agentId: type, worktreeId: wt.id, location: "dock" },
-                              { source: "context-menu" }
-                            )
-                          }
-                        >
-                          Dock
-                        </ContextMenuItem>
-                      </ContextMenuSubContent>
-                    </ContextMenuSub>
-                  );
-                })}
+                <WorktreeMenuItems agentType={type} worktrees={worktrees} />
               </ContextMenuSubContent>
             </ContextMenuSub>
           )}
@@ -311,6 +360,17 @@ export function AgentButton({
           <ContextMenuItem onSelect={handleUnpinFromToolbar}>
             <Unplug className="mr-2 h-3.5 w-3.5" />
             Unpin from Toolbar
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() =>
+              void actionService.dispatch(
+                "app.settings.openTab",
+                { tab: "agents", subtab: type, sectionId: "agents-presets" },
+                { source: "context-menu" }
+              )
+            }
+          >
+            Manage {config.name} Presets...
           </ContextMenuItem>
           <ContextMenuItem
             onSelect={() =>
@@ -521,38 +581,7 @@ export function AgentButton({
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
             <ContextMenuSubContent>
-              {worktrees.map((wt) => {
-                const label = wt.isMainWorktree ? wt.name : wt.branch?.trim() || wt.name;
-                return (
-                  <ContextMenuSub key={wt.id}>
-                    <ContextMenuSubTrigger>{label}</ContextMenuSubTrigger>
-                    <ContextMenuSubContent>
-                      <ContextMenuItem
-                        onSelect={() =>
-                          void actionService.dispatch(
-                            "agent.launch",
-                            { agentId: type, worktreeId: wt.id, location: "grid" },
-                            { source: "context-menu" }
-                          )
-                        }
-                      >
-                        Grid
-                      </ContextMenuItem>
-                      <ContextMenuItem
-                        onSelect={() =>
-                          void actionService.dispatch(
-                            "agent.launch",
-                            { agentId: type, worktreeId: wt.id, location: "dock" },
-                            { source: "context-menu" }
-                          )
-                        }
-                      >
-                        Dock
-                      </ContextMenuItem>
-                    </ContextMenuSubContent>
-                  </ContextMenuSub>
-                );
-              })}
+              <WorktreeMenuItems agentType={type} worktrees={worktrees} />
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}
@@ -560,6 +589,17 @@ export function AgentButton({
         <ContextMenuItem onSelect={handleUnpinFromToolbar}>
           <Unplug className="mr-2 h-3.5 w-3.5" />
           Unpin from Toolbar
+        </ContextMenuItem>
+        <ContextMenuItem
+          onSelect={() =>
+            void actionService.dispatch(
+              "app.settings.openTab",
+              { tab: "agents", subtab: type, sectionId: "agents-presets" },
+              { source: "context-menu" }
+            )
+          }
+        >
+          Manage {config.name} Presets...
         </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -171,24 +171,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("@/components/ui/context-menu", () => ({
-  ContextMenu: ({
-    children,
-    open,
-    onOpenChange,
-  }: {
-    children: React.ReactNode;
-    open?: boolean;
-    onOpenChange?: (next: boolean) => void;
-  }) => (
-    <div data-testid="context-menu-root" data-open={String(open ?? false)}>
-      {/* Test-only opener — Radix's right-click trigger isn't observable in the
-          minimal mock, so this lets tests transition the controlled menu to the
-          open state before exercising item interactions. Rendered as a div to
-          stay out of getByRole("button") queries used by other tests. */}
-      <div data-testid="__open-context-menu" onClick={() => onOpenChange?.(true)} />
-      {children}
-    </div>
-  ),
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="context-menu-content">{children}</div>
@@ -702,28 +685,6 @@ describe("AgentButton preset UX", () => {
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       expect(queryByText("Launch in Worktree")).toBeNull();
-    });
-
-    it("closes the context menu after clicking the inline Dock icon", () => {
-      // Regression for the Radix close-chain bug: stopPropagation on the
-      // inline button cuts handleSelect → onClose, so the implementation
-      // must call closeMenu explicitly.
-      mockSettings = settingsWith({ claude: {} });
-      mockMergedPresetsFn = () => [];
-      mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
-
-      const { getAllByTestId, getByTestId } = render(
-        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
-      );
-
-      // Open the controlled menu first so we can observe the close transition.
-      const openers = getAllByTestId("__open-context-menu");
-      fireEvent.click(openers[0]!);
-      const roots = getAllByTestId("context-menu-root");
-      expect(roots[0]!.getAttribute("data-open")).toBe("true");
-
-      fireEvent.click(getByTestId("agent-context-worktree-dock-wt-1"));
-      expect(getAllByTestId("context-menu-root")[0]!.getAttribute("data-open")).toBe("false");
     });
   });
 });

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -171,7 +171,24 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("@/components/ui/context-menu", () => ({
-  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenu: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (next: boolean) => void;
+  }) => (
+    <div data-testid="context-menu-root" data-open={String(open ?? false)}>
+      {/* Test-only opener — Radix's right-click trigger isn't observable in the
+          minimal mock, so this lets tests transition the controlled menu to the
+          open state before exercising item interactions. Rendered as a div to
+          stay out of getByRole("button") queries used by other tests. */}
+      <div data-testid="__open-context-menu" onClick={() => onOpenChange?.(true)} />
+      {children}
+    </div>
+  ),
   ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="context-menu-content">{children}</div>
@@ -224,7 +241,6 @@ vi.mock("@/components/ui/context-menu", () => ({
 
 vi.mock("lucide-react", () => ({
   ChevronDown: () => <span data-testid="chevron-icon" />,
-  LayoutGrid: () => <span data-testid="layout-grid-icon" />,
   PanelBottom: () => <span data-testid="panel-bottom-icon" />,
   Unplug: () => <span data-testid="unplug-icon" />,
 }));
@@ -686,6 +702,28 @@ describe("AgentButton preset UX", () => {
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       expect(queryByText("Launch in Worktree")).toBeNull();
+    });
+
+    it("closes the context menu after clicking the inline Dock icon", () => {
+      // Regression for the Radix close-chain bug: stopPropagation on the
+      // inline button cuts handleSelect → onClose, so the implementation
+      // must call closeMenu explicitly.
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+      mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
+
+      const { getAllByTestId, getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      // Open the controlled menu first so we can observe the close transition.
+      const openers = getAllByTestId("__open-context-menu");
+      fireEvent.click(openers[0]!);
+      const roots = getAllByTestId("context-menu-root");
+      expect(roots[0]!.getAttribute("data-open")).toBe("true");
+
+      fireEvent.click(getByTestId("agent-context-worktree-dock-wt-1"));
+      expect(getAllByTestId("context-menu-root")[0]!.getAttribute("data-open")).toBe("false");
     });
   });
 });

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -79,8 +79,15 @@ vi.mock("@/store/worktreeStore", () => ({
     selector({ activeWorktreeId: mockActiveWorktreeId }),
 }));
 
+let mockWorktrees: Array<{
+  id: string;
+  name: string;
+  branch?: string | null;
+  isMainWorktree?: boolean;
+}> = [];
+
 vi.mock("@/hooks/useWorktrees", () => ({
-  useWorktrees: () => ({ worktrees: [] }),
+  useWorktrees: () => ({ worktrees: mockWorktrees }),
 }));
 
 vi.mock("@/hooks", () => ({
@@ -166,16 +173,59 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 vi.mock("@/components/ui/context-menu", () => ({
   ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ContextMenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+    className,
+    "data-testid": dataTestId,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    disabled?: boolean;
+    className?: string;
+    "data-testid"?: string;
+  }) => (
+    <div
+      role="menuitem"
+      data-testid={dataTestId ?? "context-menu-item"}
+      data-disabled={disabled ? "true" : undefined}
+      className={className}
+      onClick={(e) => {
+        if (disabled) return;
+        onSelect?.(e as unknown as Event);
+      }}
+    >
+      {children}
+    </div>
+  ),
   ContextMenuSeparator: () => null,
   ContextMenuSub: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuSubTrigger: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => (
+    <div
+      role="menuitem"
+      data-testid="context-menu-sub-trigger"
+      data-disabled={disabled ? "true" : undefined}
+    >
+      {children}
+    </div>
+  ),
 }));
 
 vi.mock("lucide-react", () => ({
   ChevronDown: () => <span data-testid="chevron-icon" />,
+  LayoutGrid: () => <span data-testid="layout-grid-icon" />,
+  PanelBottom: () => <span data-testid="panel-bottom-icon" />,
   Unplug: () => <span data-testid="unplug-icon" />,
 }));
 
@@ -198,6 +248,7 @@ describe("AgentButton preset UX", () => {
     mockDotColor = "";
     mockPanelsById = {};
     mockPanelIds = [];
+    mockWorktrees = [];
   });
 
   describe("split threshold", () => {
@@ -528,6 +579,113 @@ describe("AgentButton preset UX", () => {
 
       const badge = container.querySelector('.relative span[aria-hidden="true"]');
       expect(badge).toBeNull();
+    });
+  });
+
+  describe("context menu", () => {
+    it("exposes Manage Presets that deep-links to the presets section (no-presets branch)", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+
+      const { getByText } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      fireEvent.click(getByText("Manage Claude Presets..."));
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "app.settings.openTab",
+        { tab: "agents", subtab: "claude", sectionId: "agents-presets" },
+        { source: "context-menu" }
+      );
+    });
+
+    it("exposes Manage Presets that deep-links to the presets section (with-presets branch)", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-alpha", name: "Alpha" }];
+
+      const { getByText } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      fireEvent.click(getByText("Manage Claude Presets..."));
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "app.settings.openTab",
+        { tab: "agents", subtab: "claude", sectionId: "agents-presets" },
+        { source: "context-menu" }
+      );
+    });
+
+    it("renders one flat row per worktree (no nested Grid/Dock submenus)", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+      mockWorktrees = [
+        { id: "wt-1", name: "Main", isMainWorktree: true },
+        { id: "wt-2", name: "feat/x", branch: "feat/x" },
+      ];
+
+      const { getAllByTestId, queryByText } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      expect(getAllByTestId(/^agent-context-worktree-(wt-1|wt-2)$/)).toHaveLength(2);
+      // No nested Grid/Dock leaf items — only inline buttons.
+      expect(queryByText("Grid")).toBeNull();
+      expect(queryByText("Dock")).toBeNull();
+    });
+
+    it("clicking a worktree row launches in grid (default)", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+      mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
+
+      const { getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      fireEvent.click(getByTestId("agent-context-worktree-wt-1"));
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", worktreeId: "wt-1", location: "grid" },
+        { source: "context-menu" }
+      );
+    });
+
+    it("clicking the inline Dock icon launches in dock without firing grid", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+      mockWorktrees = [{ id: "wt-1", name: "Main", isMainWorktree: true }];
+
+      const { getByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      fireEvent.click(getByTestId("agent-context-worktree-dock-wt-1"));
+
+      // The inline button must stop propagation so the row's onSelect
+      // (which would launch grid) does not also fire.
+      const dockCalls = dispatchMock.mock.calls.filter(
+        (c) => c[0] === "agent.launch" && (c[1] as { location?: string }).location === "dock"
+      );
+      const gridCalls = dispatchMock.mock.calls.filter(
+        (c) => c[0] === "agent.launch" && (c[1] as { location?: string }).location === "grid"
+      );
+      expect(dockCalls).toHaveLength(1);
+      expect(gridCalls).toHaveLength(0);
+      expect(dockCalls[0]).toEqual([
+        "agent.launch",
+        { agentId: "claude", worktreeId: "wt-1", location: "dock" },
+        { source: "context-menu" },
+      ]);
+    });
+
+    it("hides the Launch in Worktree submenu when no worktrees exist", () => {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [];
+      mockWorktrees = [];
+
+      const { queryByText } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      expect(queryByText("Launch in Worktree")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a "Manage {agent} Presets..." entry to the right-click context menu that deep-links directly to the presets section of agent settings (`sectionId=agents-presets`), so users can get there without wading through the generic settings tab.
- Flattens the three-deep "Launch in Worktree" submenu to a single flat list. Each worktree row clicks through to the grid (default), with an inline Dock icon on the row for mouse users who want the secondary location — mirrors the pin button pattern already in `AgentTrayButton`.
- Adds a ref guard so the inline Dock click doesn't bubble up and double-fire the row's grid dispatch. Both the with-presets and no-presets branches of the menu are updated identically.

Resolves #5902.

## Changes

- `src/components/Layout/AgentButton.tsx` — new "Manage Presets" entry, flattened worktree submenu with inline Dock icon, ref-guard to prevent double dispatch
- `src/components/Layout/__tests__/AgentButton.test.tsx` — 5 new tests covering Manage Presets dispatch in both branches, flat row rendering, row-default grid dispatch, dock-only inline click, and hidden submenu when no worktrees
- `src/components/Layout/Toolbar.tsx` — drive-by prettier fix to keep CI format check green

## Testing

20 vitest tests pass. Typecheck, lint, and format all clean. The three-deep hover cascade is gone; the Dock icon click fires exactly once per action.