### PR TITLE
fix(tooltip): hoist single TooltipProvider to App root for unified delay group

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ import { QuickSwitcher } from "./components/QuickSwitcher";
 import { SendToAgentPalette } from "./components/Terminal/SendToAgentPalette";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
+import { TooltipProvider } from "./components/ui/tooltip";
 import { PanelLimitConfirmDialog } from "./components/Terminal/PanelLimitConfirmDialog";
 import { ThemePalette } from "./components/ThemePalette";
 import { LogLevelPalette } from "./components/LogLevelPalette";
@@ -476,336 +477,338 @@ function App() {
   return (
     <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
       <ErrorBoundary variant="fullscreen" componentName="App">
-        <E2EFaultInjector />
-        {isSafeMode && <SafeModeBanner />}
-        <DndProvider>
-          <VoiceRecordingAnnouncer />
-          <AccessibilityAnnouncer />
-          <Profiler id="app-layout" onRender={onLayoutRender}>
-            <AppLayout
-              sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
-              onLaunchAgent={handleLaunchAgent}
-              onSettings={handleSettings}
-              onPreloadSettings={handlePreloadSettings}
-              onRetry={handleErrorRetry}
-              onCancelRetry={handleCancelRetry}
-              agentAvailability={availability}
-              agentSettings={agentSettings}
-              isHydrated={isStateLoaded}
-              projectSwitcherPalette={projectSwitcherPalette}
-            >
-              <Profiler id="content-grid" onRender={onContentGridRender}>
-                <ContentGrid
-                  className="h-full w-full"
-                  agentAvailability={availability}
-                  defaultCwd={defaultTerminalCwd}
-                  emptyContent={
-                    currentProject === null ? (
-                      <WelcomeScreen gettingStarted={gettingStarted} />
-                    ) : undefined
-                  }
-                />
-              </Profiler>
-            </AppLayout>
-          </Profiler>
-        </DndProvider>
+        <TooltipProvider delayDuration={500} skipDelayDuration={150}>
+          <E2EFaultInjector />
+          {isSafeMode && <SafeModeBanner />}
+          <DndProvider>
+            <VoiceRecordingAnnouncer />
+            <AccessibilityAnnouncer />
+            <Profiler id="app-layout" onRender={onLayoutRender}>
+              <AppLayout
+                sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
+                onLaunchAgent={handleLaunchAgent}
+                onSettings={handleSettings}
+                onPreloadSettings={handlePreloadSettings}
+                onRetry={handleErrorRetry}
+                onCancelRetry={handleCancelRetry}
+                agentAvailability={availability}
+                agentSettings={agentSettings}
+                isHydrated={isStateLoaded}
+                projectSwitcherPalette={projectSwitcherPalette}
+              >
+                <Profiler id="content-grid" onRender={onContentGridRender}>
+                  <ContentGrid
+                    className="h-full w-full"
+                    agentAvailability={availability}
+                    defaultCwd={defaultTerminalCwd}
+                    emptyContent={
+                      currentProject === null ? (
+                        <WelcomeScreen gettingStarted={gettingStarted} />
+                      ) : undefined
+                    }
+                  />
+                </Profiler>
+              </AppLayout>
+            </Profiler>
+          </DndProvider>
 
-        <QuickSwitcher
-          isOpen={quickSwitcher.isOpen}
-          query={quickSwitcher.query}
-          results={quickSwitcher.results}
-          totalResults={quickSwitcher.totalResults}
-          selectedIndex={quickSwitcher.selectedIndex}
-          close={quickSwitcher.close}
-          setQuery={quickSwitcher.setQuery}
-          selectPrevious={quickSwitcher.selectPrevious}
-          selectNext={quickSwitcher.selectNext}
-          selectItem={quickSwitcher.selectItem}
-          confirmSelection={quickSwitcher.confirmSelection}
-        />
-        <SendToAgentPalette
-          isOpen={sendToAgentPalette.isOpen}
-          query={sendToAgentPalette.query}
-          results={sendToAgentPalette.results}
-          totalResults={sendToAgentPalette.totalResults}
-          selectedIndex={sendToAgentPalette.selectedIndex}
-          close={sendToAgentPalette.close}
-          setQuery={sendToAgentPalette.setQuery}
-          selectPrevious={sendToAgentPalette.selectPrevious}
-          selectNext={sendToAgentPalette.selectNext}
-          selectItem={sendToAgentPalette.selectItem}
-          confirmSelection={sendToAgentPalette.confirmSelection}
-        />
-        <NewTerminalPalette
-          isOpen={newTerminalPalette.isOpen}
-          query={newTerminalPalette.query}
-          results={newTerminalPalette.results}
-          totalResults={newTerminalPalette.totalResults}
-          selectedIndex={newTerminalPalette.selectedIndex}
-          onQueryChange={newTerminalPalette.setQuery}
-          onSelectPrevious={newTerminalPalette.selectPrevious}
-          onSelectNext={newTerminalPalette.selectNext}
-          onSelect={newTerminalPalette.handleSelect}
-          onConfirm={newTerminalPalette.confirmSelection}
-          onClose={newTerminalPalette.close}
-        />
-        <WorktreePalette
-          isOpen={worktreePalette.isOpen}
-          query={worktreePalette.query}
-          results={worktreePalette.results}
-          totalResults={worktreePalette.totalResults}
-          activeWorktreeId={worktreePalette.activeWorktreeId}
-          selectedIndex={worktreePalette.selectedIndex}
-          onQueryChange={worktreePalette.setQuery}
-          onSelectPrevious={worktreePalette.selectPrevious}
-          onSelectNext={worktreePalette.selectNext}
-          onSelect={worktreePalette.selectWorktree}
-          onConfirm={worktreePalette.confirmSelection}
-          onClose={worktreePalette.close}
-        />
-        <QuickCreatePalette palette={quickCreatePalette} />
-        <PanelPalette
-          isOpen={panelPalette.isOpen}
-          query={panelPalette.query}
-          results={panelPalette.results}
-          totalResults={panelPalette.totalResults}
-          selectedIndex={panelPalette.selectedIndex}
-          matchesById={panelPalette.matchesById}
-          onQueryChange={panelPalette.setQuery}
-          onSelectPrevious={panelPalette.selectPrevious}
-          onSelectNext={panelPalette.selectNext}
-          onSelect={(kind) => {
-            const result = panelPalette.handleSelect(kind);
-            if (!result) return;
-            if (result.resumeSession) {
-              const session = result.resumeSession;
-              const agentConfig = getEffectiveAgentConfig(session.agentId);
-              const command = buildResumeCommand(
-                session.agentId,
-                session.sessionId,
-                session.agentLaunchFlags
-              );
-              if (command && agentConfig) {
+          <QuickSwitcher
+            isOpen={quickSwitcher.isOpen}
+            query={quickSwitcher.query}
+            results={quickSwitcher.results}
+            totalResults={quickSwitcher.totalResults}
+            selectedIndex={quickSwitcher.selectedIndex}
+            close={quickSwitcher.close}
+            setQuery={quickSwitcher.setQuery}
+            selectPrevious={quickSwitcher.selectPrevious}
+            selectNext={quickSwitcher.selectNext}
+            selectItem={quickSwitcher.selectItem}
+            confirmSelection={quickSwitcher.confirmSelection}
+          />
+          <SendToAgentPalette
+            isOpen={sendToAgentPalette.isOpen}
+            query={sendToAgentPalette.query}
+            results={sendToAgentPalette.results}
+            totalResults={sendToAgentPalette.totalResults}
+            selectedIndex={sendToAgentPalette.selectedIndex}
+            close={sendToAgentPalette.close}
+            setQuery={sendToAgentPalette.setQuery}
+            selectPrevious={sendToAgentPalette.selectPrevious}
+            selectNext={sendToAgentPalette.selectNext}
+            selectItem={sendToAgentPalette.selectItem}
+            confirmSelection={sendToAgentPalette.confirmSelection}
+          />
+          <NewTerminalPalette
+            isOpen={newTerminalPalette.isOpen}
+            query={newTerminalPalette.query}
+            results={newTerminalPalette.results}
+            totalResults={newTerminalPalette.totalResults}
+            selectedIndex={newTerminalPalette.selectedIndex}
+            onQueryChange={newTerminalPalette.setQuery}
+            onSelectPrevious={newTerminalPalette.selectPrevious}
+            onSelectNext={newTerminalPalette.selectNext}
+            onSelect={newTerminalPalette.handleSelect}
+            onConfirm={newTerminalPalette.confirmSelection}
+            onClose={newTerminalPalette.close}
+          />
+          <WorktreePalette
+            isOpen={worktreePalette.isOpen}
+            query={worktreePalette.query}
+            results={worktreePalette.results}
+            totalResults={worktreePalette.totalResults}
+            activeWorktreeId={worktreePalette.activeWorktreeId}
+            selectedIndex={worktreePalette.selectedIndex}
+            onQueryChange={worktreePalette.setQuery}
+            onSelectPrevious={worktreePalette.selectPrevious}
+            onSelectNext={worktreePalette.selectNext}
+            onSelect={worktreePalette.selectWorktree}
+            onConfirm={worktreePalette.confirmSelection}
+            onClose={worktreePalette.close}
+          />
+          <QuickCreatePalette palette={quickCreatePalette} />
+          <PanelPalette
+            isOpen={panelPalette.isOpen}
+            query={panelPalette.query}
+            results={panelPalette.results}
+            totalResults={panelPalette.totalResults}
+            selectedIndex={panelPalette.selectedIndex}
+            matchesById={panelPalette.matchesById}
+            onQueryChange={panelPalette.setQuery}
+            onSelectPrevious={panelPalette.selectPrevious}
+            onSelectNext={panelPalette.selectNext}
+            onSelect={(kind) => {
+              const result = panelPalette.handleSelect(kind);
+              if (!result) return;
+              if (result.resumeSession) {
+                const session = result.resumeSession;
+                const agentConfig = getEffectiveAgentConfig(session.agentId);
+                const command = buildResumeCommand(
+                  session.agentId,
+                  session.sessionId,
+                  session.agentLaunchFlags
+                );
+                if (command && agentConfig) {
+                  addPanel({
+                    kind: "terminal",
+                    launchAgentId: session.agentId,
+                    title: agentConfig.name,
+                    cwd: defaultTerminalCwd,
+                    worktreeId: activeWorktreeId ?? undefined,
+                    command,
+                    location: "grid",
+                  });
+                }
+              } else if (result.id.startsWith("agent:")) {
+                const agentId = result.id.slice("agent:".length);
+                if (agentId) {
+                  launchAgent(agentId);
+                }
+              } else {
                 addPanel({
-                  kind: "terminal",
-                  launchAgentId: session.agentId,
-                  title: agentConfig.name,
+                  kind: result.id as BuiltInPanelKind,
                   cwd: defaultTerminalCwd,
                   worktreeId: activeWorktreeId ?? undefined,
-                  command,
                   location: "grid",
                 });
               }
-            } else if (result.id.startsWith("agent:")) {
-              const agentId = result.id.slice("agent:".length);
-              if (agentId) {
-                launchAgent(agentId);
-              }
-            } else {
-              addPanel({
-                kind: result.id as BuiltInPanelKind,
-                cwd: defaultTerminalCwd,
-                worktreeId: activeWorktreeId ?? undefined,
-                location: "grid",
-              });
-            }
-          }}
-          onConfirm={() => {
-            const selected = panelPalette.confirmSelection();
-            if (!selected) return;
-            if (selected.id === MORE_AGENTS_PANEL_ID) return;
-            if (selected.resumeSession) {
-              const session = selected.resumeSession;
-              const agentConfig = getEffectiveAgentConfig(session.agentId);
-              const command = buildResumeCommand(
-                session.agentId,
-                session.sessionId,
-                session.agentLaunchFlags
-              );
-              if (command && agentConfig) {
+            }}
+            onConfirm={() => {
+              const selected = panelPalette.confirmSelection();
+              if (!selected) return;
+              if (selected.id === MORE_AGENTS_PANEL_ID) return;
+              if (selected.resumeSession) {
+                const session = selected.resumeSession;
+                const agentConfig = getEffectiveAgentConfig(session.agentId);
+                const command = buildResumeCommand(
+                  session.agentId,
+                  session.sessionId,
+                  session.agentLaunchFlags
+                );
+                if (command && agentConfig) {
+                  addPanel({
+                    kind: "terminal",
+                    launchAgentId: session.agentId,
+                    title: agentConfig.name,
+                    cwd: defaultTerminalCwd,
+                    worktreeId: activeWorktreeId ?? undefined,
+                    command,
+                    location: "grid",
+                  });
+                }
+              } else if (selected.id.startsWith("agent:")) {
+                const agentId = selected.id.slice("agent:".length);
+                if (agentId) {
+                  launchAgent(agentId);
+                }
+              } else {
                 addPanel({
-                  kind: "terminal",
-                  launchAgentId: session.agentId,
-                  title: agentConfig.name,
+                  kind: selected.id as BuiltInPanelKind,
                   cwd: defaultTerminalCwd,
                   worktreeId: activeWorktreeId ?? undefined,
-                  command,
                   location: "grid",
                 });
               }
-            } else if (selected.id.startsWith("agent:")) {
-              const agentId = selected.id.slice("agent:".length);
-              if (agentId) {
-                launchAgent(agentId);
-              }
-            } else {
-              addPanel({
-                kind: selected.id as BuiltInPanelKind,
-                cwd: defaultTerminalCwd,
-                worktreeId: activeWorktreeId ?? undefined,
-                location: "grid",
-              });
-            }
-          }}
-          onClose={panelPalette.close}
-        />
-        <ProjectMruSwitcherOverlay
-          isVisible={mruSwitcher.isVisible}
-          projects={mruSwitcher.projects}
-          selectedIndex={mruSwitcher.selectedIndex}
-        />
-        <ProjectSwitcherPalette
-          isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
-          query={projectSwitcherPalette.query}
-          results={projectSwitcherPalette.results}
-          selectedIndex={projectSwitcherPalette.selectedIndex}
-          onQueryChange={projectSwitcherPalette.setQuery}
-          onSelectPrevious={projectSwitcherPalette.selectPrevious}
-          onSelectNext={projectSwitcherPalette.selectNext}
-          onSelect={projectSwitcherPalette.selectProject}
-          onClose={projectSwitcherPalette.close}
-          onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
-          onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}
-          removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
-          onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
-          onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
-          isRemovingProject={projectSwitcherPalette.isRemovingProject}
-          onSelectNewWindow={(project) => {
-            projectSwitcherPalette.close();
-            void actionService.dispatch(
-              "app.newWindow",
-              { projectPath: project.path },
-              { source: "user" }
-            );
-          }}
-        />
-        <ConfirmDialog
-          isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
-          onClose={() => {
-            if (projectSwitcherPalette.isStoppingProject) return;
-            projectSwitcherPalette.setStopConfirmProjectId(null);
-          }}
-          title={`Stop project?`}
-          description="This will terminate all running sessions in this project. This can't be undone."
-          confirmLabel="Stop project"
-          cancelLabel="Cancel"
-          onConfirm={projectSwitcherPalette.confirmStopProject}
-          isConfirmLoading={projectSwitcherPalette.isStoppingProject}
-          variant="destructive"
-        />
+            }}
+            onClose={panelPalette.close}
+          />
+          <ProjectMruSwitcherOverlay
+            isVisible={mruSwitcher.isVisible}
+            projects={mruSwitcher.projects}
+            selectedIndex={mruSwitcher.selectedIndex}
+          />
+          <ProjectSwitcherPalette
+            isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
+            query={projectSwitcherPalette.query}
+            results={projectSwitcherPalette.results}
+            selectedIndex={projectSwitcherPalette.selectedIndex}
+            onQueryChange={projectSwitcherPalette.setQuery}
+            onSelectPrevious={projectSwitcherPalette.selectPrevious}
+            onSelectNext={projectSwitcherPalette.selectNext}
+            onSelect={projectSwitcherPalette.selectProject}
+            onClose={projectSwitcherPalette.close}
+            onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
+            onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}
+            removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
+            onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
+            onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
+            isRemovingProject={projectSwitcherPalette.isRemovingProject}
+            onSelectNewWindow={(project) => {
+              projectSwitcherPalette.close();
+              void actionService.dispatch(
+                "app.newWindow",
+                { projectPath: project.path },
+                { source: "user" }
+              );
+            }}
+          />
+          <ConfirmDialog
+            isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
+            onClose={() => {
+              if (projectSwitcherPalette.isStoppingProject) return;
+              projectSwitcherPalette.setStopConfirmProjectId(null);
+            }}
+            title={`Stop project?`}
+            description="This will terminate all running sessions in this project. This can't be undone."
+            confirmLabel="Stop project"
+            cancelLabel="Cancel"
+            onConfirm={projectSwitcherPalette.confirmStopProject}
+            isConfirmLoading={projectSwitcherPalette.isStoppingProject}
+            variant="destructive"
+          />
 
-        <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
+          <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
 
-        <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
+          <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
 
-        <ActionPalette
-          isOpen={actionPalette.isOpen}
-          query={actionPalette.query}
-          results={actionPalette.results}
-          totalResults={actionPalette.totalResults}
-          selectedIndex={actionPalette.selectedIndex}
-          close={actionPalette.close}
-          setQuery={actionPalette.setQuery}
-          selectPrevious={actionPalette.selectPrevious}
-          selectNext={actionPalette.selectNext}
-          executeAction={actionPalette.executeAction}
-          confirmSelection={actionPalette.confirmSelection}
-        />
+          <ActionPalette
+            isOpen={actionPalette.isOpen}
+            query={actionPalette.query}
+            results={actionPalette.results}
+            totalResults={actionPalette.totalResults}
+            selectedIndex={actionPalette.selectedIndex}
+            close={actionPalette.close}
+            setQuery={actionPalette.setQuery}
+            selectPrevious={actionPalette.selectPrevious}
+            selectNext={actionPalette.selectNext}
+            executeAction={actionPalette.executeAction}
+            confirmSelection={actionPalette.confirmSelection}
+          />
 
-        <WorktreeOverviewModal
-          isOpen={isWorktreeOverviewOpen}
-          onClose={closeWorktreeOverview}
-          worktrees={worktrees}
-          activeWorktreeId={activeWorktreeId}
-          focusedWorktreeId={focusedWorktreeId}
-          onSelectWorktree={selectWorktree}
-          onCopyTree={overviewWorktreeActions.handleCopyTree}
-          onOpenEditor={overviewWorktreeActions.handleOpenEditor}
-          onSaveLayout={undefined}
-          onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
-          agentAvailability={availability}
-          agentSettings={agentSettings}
-          homeDir={homeDir}
-        />
+          <WorktreeOverviewModal
+            isOpen={isWorktreeOverviewOpen}
+            onClose={closeWorktreeOverview}
+            worktrees={worktrees}
+            activeWorktreeId={activeWorktreeId}
+            focusedWorktreeId={focusedWorktreeId}
+            onSelectWorktree={selectWorktree}
+            onCopyTree={overviewWorktreeActions.handleCopyTree}
+            onOpenEditor={overviewWorktreeActions.handleOpenEditor}
+            onSaveLayout={undefined}
+            onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
+            agentAvailability={availability}
+            agentSettings={agentSettings}
+            homeDir={homeDir}
+          />
 
-        <CrossWorktreeDiff
-          isOpen={crossDiffDialog.isOpen}
-          onClose={closeCrossWorktreeDiff}
-          initialWorktreeId={crossDiffDialog.initialWorktreeId}
-        />
+          <CrossWorktreeDiff
+            isOpen={crossDiffDialog.isOpen}
+            onClose={closeCrossWorktreeDiff}
+            initialWorktreeId={crossDiffDialog.initialWorktreeId}
+          />
 
-        {(isSettingsOpen || hasOpenedSettings) && (
-          <Suspense fallback={null}>
-            <LazySettingsDialog
-              isOpen={isSettingsOpen}
-              onClose={() => setIsSettingsOpen(false)}
-              defaultTab={settingsTab}
-              defaultSubtab={settingsSubtab}
-              defaultSectionId={settingsSectionId}
-              onSettingsChange={refreshSettings}
-              projectId={currentProject?.id ?? null}
+          {(isSettingsOpen || hasOpenedSettings) && (
+            <Suspense fallback={null}>
+              <LazySettingsDialog
+                isOpen={isSettingsOpen}
+                onClose={() => setIsSettingsOpen(false)}
+                defaultTab={settingsTab}
+                defaultSubtab={settingsSubtab}
+                defaultSectionId={settingsSectionId}
+                onSettingsChange={refreshSettings}
+                projectId={currentProject?.id ?? null}
+              />
+            </Suspense>
+          )}
+
+          <ShortcutReferenceDialog
+            isOpen={isShortcutsOpen}
+            onClose={() => setIsShortcutsOpen(false)}
+          />
+
+          <TerminalInfoDialogHost />
+          <FileViewerModalHost />
+
+          {gitInitDirectoryPath && (
+            <GitInitDialog
+              isOpen={gitInitDialogOpen}
+              directoryPath={gitInitDirectoryPath}
+              onSuccess={handleGitInitSuccess}
+              onCancel={closeGitInitDialog}
             />
-          </Suspense>
-        )}
+          )}
 
-        <ShortcutReferenceDialog
-          isOpen={isShortcutsOpen}
-          onClose={() => setIsShortcutsOpen(false)}
-        />
+          {onboardingProjectId && (
+            <ProjectOnboardingWizard
+              isOpen={onboardingWizardOpen}
+              projectId={onboardingProjectId}
+              onClose={closeOnboardingWizard}
+              onFinish={handleWizardFinish}
+            />
+          )}
 
-        <TerminalInfoDialogHost />
-        <FileViewerModalHost />
-
-        {gitInitDirectoryPath && (
-          <GitInitDialog
-            isOpen={gitInitDialogOpen}
-            directoryPath={gitInitDirectoryPath}
-            onSuccess={handleGitInitSuccess}
-            onCancel={closeGitInitDialog}
+          <CreateProjectFolderDialog
+            isOpen={createFolderDialogOpen}
+            onClose={closeCreateFolderDialog}
           />
-        )}
 
-        {onboardingProjectId && (
-          <ProjectOnboardingWizard
-            isOpen={onboardingWizardOpen}
-            projectId={onboardingProjectId}
-            onClose={closeOnboardingWizard}
-            onFinish={handleWizardFinish}
+          <CloneRepoDialog
+            isOpen={cloneRepoDialogOpen}
+            onSuccess={handleCloneSuccess}
+            onCancel={closeCloneRepoDialog}
           />
-        )}
 
-        <CreateProjectFolderDialog
-          isOpen={createFolderDialogOpen}
-          onClose={closeCreateFolderDialog}
-        />
+          <PanelTransitionOverlay />
+          <PanelLimitConfirmDialog />
 
-        <CloneRepoDialog
-          isOpen={cloneRepoDialogOpen}
-          onSuccess={handleCloneSuccess}
-          onCancel={closeCloneRepoDialog}
-        />
-
-        <PanelTransitionOverlay />
-        <PanelLimitConfirmDialog />
-
-        <Toaster />
-        <ShortcutHint />
-        <ReEntrySummary state={reEntrySummary} />
-        <OnboardingFlow
-          availability={availability}
-          onRefreshSettings={refreshSettings}
-          onComplete={gettingStarted.notifyOnboardingComplete}
-        />
-        {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
-          <GettingStartedChecklist
-            checklist={gettingStarted.checklist}
-            collapsed={gettingStarted.collapsed}
-            onDismiss={gettingStarted.dismiss}
-            onToggleCollapse={gettingStarted.toggleCollapse}
-            onMarkItem={gettingStarted.markItem}
+          <Toaster />
+          <ShortcutHint />
+          <ReEntrySummary state={reEntrySummary} />
+          <OnboardingFlow
+            availability={availability}
+            onRefreshSettings={refreshSettings}
+            onComplete={gettingStarted.notifyOnboardingComplete}
           />
-        )}
-        {gettingStarted.showCelebration && <CelebrationConfetti />}
+          {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
+            <GettingStartedChecklist
+              checklist={gettingStarted.checklist}
+              collapsed={gettingStarted.collapsed}
+              onDismiss={gettingStarted.dismiss}
+              onToggleCollapse={gettingStarted.toggleCollapse}
+              onMarkItem={gettingStarted.markItem}
+            />
+          )}
+          {gettingStarted.showCelebration && <CelebrationConfetti />}
+        </TooltipProvider>
       </ErrorBoundary>
     </MotionConfig>
   );

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -19,7 +19,7 @@ import { cn } from "@/lib/utils";
 import { normalizeBrowserUrl, getDisplayUrl } from "./browserUtils";
 import { actionService } from "@/services/ActionService";
 import { useUrlHistoryStore, getFrecencySuggestions } from "@/store/urlHistoryStore";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ViewportPresetId } from "@shared/types/panel";
 import { VIEWPORT_PRESET_LIST, getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 
@@ -275,165 +275,151 @@ export function BrowserToolbar({
   return (
     <div className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay">
       {/* Navigation buttons */}
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <button
-                type="button"
-                onClick={onBack}
-                disabled={!canGoBack}
-                className={buttonClass}
-                aria-label="Go back"
-                data-testid="browser-back"
-              >
-                <ArrowLeft className="w-4 h-4" />
-              </button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Go back</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <button
-                type="button"
-                onClick={onForward}
-                disabled={!canGoForward}
-                className={buttonClass}
-                aria-label="Go forward"
-                data-testid="browser-forward"
-              >
-                <ArrowRight className="w-4 h-4" />
-              </button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Go forward</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
             <button
               type="button"
-              onClick={(e) => {
-                if (e.shiftKey && onHardReload) {
-                  onHardReload();
-                } else {
-                  onReload();
-                }
-              }}
-              className={cn(buttonClass, isLoading && "animate-spin")}
-              aria-label="Reload"
-              data-testid="browser-reload"
+              onClick={onBack}
+              disabled={!canGoBack}
+              className={buttonClass}
+              aria-label="Go back"
+              data-testid="browser-back"
             >
-              <RotateCw className="w-4 h-4" />
+              <ArrowLeft className="w-4 h-4" />
             </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {onHardReload ? "Reload (Shift+click for hard reload)" : "Reload"}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Go back</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <button
+              type="button"
+              onClick={onForward}
+              disabled={!canGoForward}
+              className={buttonClass}
+              aria-label="Go forward"
+              data-testid="browser-forward"
+            >
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Go forward</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              if (e.shiftKey && onHardReload) {
+                onHardReload();
+              } else {
+                onReload();
+              }
+            }}
+            className={cn(buttonClass, isLoading && "animate-spin")}
+            aria-label="Reload"
+            data-testid="browser-reload"
+          >
+            <RotateCw className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {onHardReload ? "Reload (Shift+click for hard reload)" : "Reload"}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Zoom controls */}
       {onZoomChange && (
         <div className="flex items-center gap-0.5">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <button
-                    type="button"
-                    onClick={() => handleZoomStep("out")}
-                    disabled={!canZoomOut}
-                    className={buttonClass}
-                    aria-label="Zoom out"
-                  >
-                    <ZoomOut className="w-3.5 h-3.5" />
-                  </button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Zoom out</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <button
-                    type="button"
-                    onClick={handleZoomReset}
-                    disabled={!isNonDefaultZoom}
-                    className={cn(
-                      "px-1.5 py-1 rounded text-xs font-medium transition-colors",
-                      "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed",
-                      isNonDefaultZoom ? "text-status-info" : "text-daintree-text/60"
-                    )}
-                    aria-label="Reset zoom"
-                  >
-                    {currentZoomLabel}
-                  </button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Reset zoom to 100%</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <button
-                    type="button"
-                    onClick={() => handleZoomStep("in")}
-                    disabled={!canZoomIn}
-                    className={buttonClass}
-                    aria-label="Zoom in"
-                  >
-                    <ZoomIn className="w-3.5 h-3.5" />
-                  </button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Zoom in</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={() => handleZoomStep("out")}
+                  disabled={!canZoomOut}
+                  className={buttonClass}
+                  aria-label="Zoom out"
+                >
+                  <ZoomOut className="w-3.5 h-3.5" />
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Zoom out</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={handleZoomReset}
+                  disabled={!isNonDefaultZoom}
+                  className={cn(
+                    "px-1.5 py-1 rounded text-xs font-medium transition-colors",
+                    "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed",
+                    isNonDefaultZoom ? "text-status-info" : "text-daintree-text/60"
+                  )}
+                  aria-label="Reset zoom"
+                >
+                  {currentZoomLabel}
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reset zoom to 100%</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={() => handleZoomStep("in")}
+                  disabled={!canZoomIn}
+                  className={buttonClass}
+                  aria-label="Zoom in"
+                >
+                  <ZoomIn className="w-3.5 h-3.5" />
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Zoom in</TooltipContent>
+          </Tooltip>
         </div>
       )}
 
       {/* Viewport preset selector (dev-preview only) */}
       {onViewportPresetChange && (
         <div className="flex items-center">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (viewportPreset) {
-                      onViewportPresetChange(undefined);
-                    } else {
-                      onViewportPresetChange("iphone");
-                    }
-                  }}
-                  className={cn(
-                    buttonClass,
-                    viewportPreset && "bg-overlay-emphasis text-daintree-text"
-                  )}
-                  aria-label="Viewport preset"
-                  aria-pressed={!!viewportPreset}
-                >
-                  <Smartphone className="w-4 h-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {viewportPreset
-                  ? `Viewport: ${getViewportPreset(viewportPreset).label}`
-                  : "Responsive viewport"}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  if (viewportPreset) {
+                    onViewportPresetChange(undefined);
+                  } else {
+                    onViewportPresetChange("iphone");
+                  }
+                }}
+                className={cn(
+                  buttonClass,
+                  viewportPreset && "bg-overlay-emphasis text-daintree-text"
+                )}
+                aria-label="Viewport preset"
+                aria-pressed={!!viewportPreset}
+              >
+                <Smartphone className="w-4 h-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {viewportPreset
+                ? `Viewport: ${getViewportPreset(viewportPreset).label}`
+                : "Responsive viewport"}
+            </TooltipContent>
+          </Tooltip>
           {viewportPreset && (
             <div className="flex items-center ml-0.5">
               {VIEWPORT_PRESET_LIST.map((preset) => (
@@ -467,16 +453,14 @@ export function BrowserToolbar({
           <div className="relative flex items-center">
             <Globe className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none" />
             {urlMightBeStale && !isEditing && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="absolute left-6 w-1.5 h-1.5 rounded-full bg-status-warning/60" />
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    URL may differ from page shown (in-page navigation)
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="absolute left-6 w-1.5 h-1.5 rounded-full bg-status-warning/60" />
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  URL may differ from page shown (in-page navigation)
+                </TooltipContent>
+              </Tooltip>
             )}
             <input
               ref={inputRef}
@@ -589,93 +573,80 @@ export function BrowserToolbar({
       </div>
 
       {/* Action buttons */}
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button type="button" onClick={handleCopy} className={buttonClass}>
-              {copied ? (
-                <Check className="w-4 h-4 text-status-success" />
-              ) : (
-                <Copy className="w-4 h-4" />
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Copy URL</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" onClick={handleCopy} className={buttonClass}>
+            {copied ? (
+              <Check className="w-4 h-4 text-status-success" />
+            ) : (
+              <Copy className="w-4 h-4" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Copy URL</TooltipContent>
+      </Tooltip>
 
       {onCaptureScreenshot && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onCaptureScreenshot}
-                disabled={!isWebviewReady}
-                className={buttonClass}
-                aria-label="Capture screenshot"
-              >
-                <Camera className="w-4 h-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Copy screenshot to clipboard</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onCaptureScreenshot}
+              disabled={!isWebviewReady}
+              className={buttonClass}
+              aria-label="Capture screenshot"
+            >
+              <Camera className="w-4 h-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Copy screenshot to clipboard</TooltipContent>
+        </Tooltip>
       )}
 
       {onToggleConsole && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onToggleConsole}
-                className={cn(
-                  buttonClass,
-                  isConsoleOpen && "bg-overlay-emphasis text-daintree-text"
-                )}
-                aria-label="Toggle console"
-                aria-pressed={isConsoleOpen}
-              >
-                <SquareTerminal className="w-4 h-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {isConsoleOpen ? "Hide console" : "Show console"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onToggleConsole}
+              className={cn(buttonClass, isConsoleOpen && "bg-overlay-emphasis text-daintree-text")}
+              aria-label="Toggle console"
+              aria-pressed={isConsoleOpen}
+            >
+              <SquareTerminal className="w-4 h-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isConsoleOpen ? "Hide console" : "Show console"}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {onToggleDevTools && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onToggleDevTools}
-                disabled={!isWebviewReady}
-                className={buttonClass}
-                aria-label="Toggle DevTools"
-              >
-                <Code className="w-4 h-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Open DevTools</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )}
-
-      <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <button type="button" onClick={onOpenExternal} className={buttonClass}>
-              <ExternalLink className="w-4 h-4" />
+            <button
+              type="button"
+              onClick={onToggleDevTools}
+              disabled={!isWebviewReady}
+              className={buttonClass}
+              aria-label="Toggle DevTools"
+            >
+              <Code className="w-4 h-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Open in browser</TooltipContent>
+          <TooltipContent side="bottom">Open DevTools</TooltipContent>
         </Tooltip>
-      </TooltipProvider>
+      )}
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" onClick={onOpenExternal} className={buttonClass}>
+            <ExternalLink className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open in browser</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Browser/ConsolePanel.tsx
+++ b/src/components/Browser/ConsolePanel.tsx
@@ -7,7 +7,7 @@ import {
   type ConsoleMessage,
   EMPTY_MESSAGES,
 } from "@/store/consoleCaptureStore";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ObjectInspector } from "./ObjectInspector";
 import { StackTrace } from "./StackTrace";
 
@@ -297,38 +297,34 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
 
         {/* Scroll to bottom */}
         {!isAtBottom && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleScrollToBottom}
-                  className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
-                >
-                  <ChevronDown className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Scroll to bottom</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-
-        {/* Clear */}
-        <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 type="button"
-                onClick={() => clearMessages(paneId)}
+                onClick={handleScrollToBottom}
                 className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
-                aria-label="Clear console"
               >
-                <Trash2 className="w-3.5 h-3.5" />
+                <ChevronDown className="w-3.5 h-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">Clear console</TooltipContent>
+            <TooltipContent side="bottom">Scroll to bottom</TooltipContent>
           </Tooltip>
-        </TooltipProvider>
+        )}
+
+        {/* Clear */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => clearMessages(paneId)}
+              className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
+              aria-label="Clear console"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Clear console</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Message list */}

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -3,6 +3,13 @@ import { render, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BrowserToolbar } from "../BrowserToolbar";
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 const mockRemoveUrl = vi.fn();
 
 vi.mock("@/store/urlHistoryStore", () => ({

--- a/src/components/Commands/CommandPickerButton.tsx
+++ b/src/components/Commands/CommandPickerButton.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { SquareTerminal } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface CommandPickerButtonProps {
   onClick: () => void;
@@ -13,33 +13,31 @@ interface CommandPickerButtonProps {
 export const CommandPickerButton = forwardRef<HTMLButtonElement, CommandPickerButtonProps>(
   ({ onClick, disabled = false, className }, ref) => {
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              ref={ref}
-              type="button"
-              onClick={onClick}
-              disabled={disabled}
-              className={cn(
-                "flex items-center justify-center",
-                "h-6 w-6 rounded-[var(--radius-sm)]",
-                "text-daintree-text/50 hover:text-daintree-text/80 hover:bg-tint/[0.06]",
-                "transition-colors",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent",
-                disabled && "opacity-50 cursor-not-allowed",
-                className
-              )}
-              aria-label="Open command picker"
-            >
-              <SquareTerminal className="h-3.5 w-3.5" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {createTooltipWithShortcut("Open command picker", "Cmd+K")}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={ref}
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={cn(
+              "flex items-center justify-center",
+              "h-6 w-6 rounded-[var(--radius-sm)]",
+              "text-daintree-text/50 hover:text-daintree-text/80 hover:bg-tint/[0.06]",
+              "transition-colors",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent",
+              disabled && "opacity-50 cursor-not-allowed",
+              className
+            )}
+            aria-label="Open command picker"
+          >
+            <SquareTerminal className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {createTooltipWithShortcut("Open command picker", "Cmd+K")}
+        </TooltipContent>
+      </Tooltip>
     );
   }
 );

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -2,7 +2,7 @@ import { Suspense, useState, useCallback, useEffect } from "react";
 import { ChevronUp, RotateCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { XtermAdapter } from "../Terminal/XtermAdapter";
 import { terminalInstanceService } from "../../services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -116,28 +116,26 @@ export function ConsoleDrawer({
         </div>
 
         {onHardRestart && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <button
-                    type="button"
-                    onClick={onHardRestart}
-                    disabled={hardRestartDisabled}
-                    className={cn(
-                      "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed transition-colors",
-                      isRestarting && "animate-spin"
-                    )}
-                    aria-label={restartTooltip}
-                    aria-busy={isRestarting}
-                  >
-                    <RotateCw className="h-3.5 w-3.5" />
-                  </button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{restartTooltip}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={onHardRestart}
+                  disabled={hardRestartDisabled}
+                  className={cn(
+                    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed transition-colors",
+                    isRestarting && "animate-spin"
+                  )}
+                  aria-label={restartTooltip}
+                  aria-busy={isRestarting}
+                >
+                  <RotateCw className="h-3.5 w-3.5" />
+                </button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{restartTooltip}</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
@@ -25,6 +25,13 @@ vi.mock("../../Terminal/XtermAdapter", () => ({
   )),
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 describe("ConsoleDrawer", () => {
   const mockTerminalId = "test-terminal-id";
   const getToggleButton = () => screen.getByRole("button", { name: /(?:show|hide) terminal/i });

--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useLogsStore, useErrorStore } from "@/store";
 import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 import { actionService } from "@/services/ActionService";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export function ProblemsActions() {
   const hasActiveErrors = useErrorStore((state) => state.errors.some((e) => !e.dismissed));
@@ -14,35 +14,31 @@ export function ProblemsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="subtle" size="xs" onClick={handleOpenLogs}>
-              Open Logs
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="subtle" size="xs" onClick={handleOpenLogs}>
+            Open Logs
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open log file</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <Button
+              variant="subtle"
+              size="xs"
+              onClick={() =>
+                void actionService.dispatch("errors.clearAll", undefined, { source: "user" })
+              }
+              disabled={!hasActiveErrors}
+            >
+              Clear All
             </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Open log file</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <Button
-                variant="subtle"
-                size="xs"
-                onClick={() =>
-                  void actionService.dispatch("errors.clearAll", undefined, { source: "user" })
-                }
-                disabled={!hasActiveErrors}
-              >
-                Clear All
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Clear all errors</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear all errors</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -61,42 +57,36 @@ export function LogsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={autoScroll ? "info" : "subtle"}
-              size="xs"
-              onClick={() => setAutoScroll(!autoScroll)}
-            >
-              Auto-scroll
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="subtle" size="xs" onClick={handleOpenFile}>
-              Open File
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Open log file</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="subtle" size="xs" onClick={handleClearLogs}>
-              Clear
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Clear logs</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={autoScroll ? "info" : "subtle"}
+            size="xs"
+            onClick={() => setAutoScroll(!autoScroll)}
+          >
+            Auto-scroll
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="subtle" size="xs" onClick={handleOpenFile}>
+            Open File
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Open log file</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="subtle" size="xs" onClick={handleClearLogs}>
+            Clear
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear logs</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -115,37 +105,33 @@ export function TelemetryActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={active ? "info" : "subtle"}
-              size="xs"
-              onClick={handleToggle}
-              aria-pressed={active}
-            >
-              {active ? "Preview On" : "Preview Off"}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={active ? "info" : "subtle"}
+            size="xs"
+            onClick={handleToggle}
+            aria-pressed={active}
+          >
+            {active ? "Preview On" : "Preview Off"}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {active
+            ? "Stop mirroring outbound telemetry payloads"
+            : "Start mirroring outbound telemetry payloads"}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <Button variant="subtle" size="xs" onClick={handleClear} disabled={!hasEvents}>
+              Clear
             </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {active
-              ? "Stop mirroring outbound telemetry payloads"
-              : "Start mirroring outbound telemetry payloads"}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <Button variant="subtle" size="xs" onClick={handleClear} disabled={!hasEvents}>
-                Clear
-              </Button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Clear captured events</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear captured events</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -159,16 +145,14 @@ export function EventsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="subtle" size="xs" onClick={handleClearEvents}>
-              Clear
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Clear all events</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="subtle" size="xs" onClick={handleClearEvents}>
+            Clear
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Clear all events</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState, useEffect, memo } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   useDiagnosticsStore,
   type DiagnosticsTab,
@@ -232,20 +232,18 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
           {activeTab === "events" && <EventsActions />}
           {activeTab === "telemetry" && <TelemetryActions />}
 
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={closeDock}
-                  className="p-1.5 hover:bg-tint/[0.06] rounded-[var(--radius-md)] transition-colors text-daintree-text/60 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                  aria-label="Close diagnostics dock"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Close diagnostics dock</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={closeDock}
+                className="p-1.5 hover:bg-tint/[0.06] rounded-[var(--radius-md)] transition-colors text-daintree-text/60 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                aria-label="Close diagnostics dock"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Close diagnostics dock</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -3,7 +3,6 @@ import { useShallow } from "zustand/react/shallow";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { useLogsStore, filterLogs, collapseConsecutiveDuplicates } from "@/store";
 import { LogEntry, type LogEntryCopyMeta } from "../Logs/LogEntry";
 import { LogFilters } from "../Logs/LogFilters";
@@ -204,70 +203,68 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
   }, [setAutoScroll]);
 
   return (
-    <TooltipProvider>
-      <div className={cn("flex flex-col h-full", className)}>
-        <LogFilters
-          filters={filters}
-          onFiltersChange={setFilters}
-          onClear={clearFilters}
-          availableSources={sources}
-          levelCounts={levelCounts}
-        />
+    <div className={cn("flex flex-col h-full", className)}>
+      <LogFilters
+        filters={filters}
+        onFiltersChange={setFilters}
+        onClear={clearFilters}
+        availableSources={sources}
+        levelCounts={levelCounts}
+      />
 
-        {previousSessionEntry && !filters?.search && (
-          <div className="shrink-0 max-h-48 overflow-y-auto overflow-x-hidden border-b border-daintree-border bg-surface-panel/50 p-3">
-            <div className="flex items-center gap-2 text-text-secondary text-xs font-medium mb-2">
-              <div className="w-2 h-2 rounded-full bg-text-secondary/40" />
-              <span>Previous session</span>
-            </div>
-            <pre className="text-xs text-text-muted whitespace-pre-wrap break-all font-mono">
-              {String(previousSessionEntry.context?.tail || "")}
-            </pre>
+      {previousSessionEntry && !filters?.search && (
+        <div className="shrink-0 max-h-48 overflow-y-auto overflow-x-hidden border-b border-daintree-border bg-surface-panel/50 p-3">
+          <div className="flex items-center gap-2 text-text-secondary text-xs font-medium mb-2">
+            <div className="w-2 h-2 rounded-full bg-text-secondary/40" />
+            <span>Previous session</span>
           </div>
+          <pre className="text-xs text-text-muted whitespace-pre-wrap break-all font-mono">
+            {String(previousSessionEntry.context?.tail || "")}
+          </pre>
+        </div>
+      )}
+
+      <div className="flex-1 relative min-h-0">
+        {displayEntries.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
+            {logs.length === 0 && !previousSessionEntry
+              ? "No logs yet"
+              : logs.length === 0
+                ? "No new logs this session"
+                : "No logs match filters"}
+          </div>
+        ) : (
+          <Virtuoso
+            ref={virtuosoRef}
+            data={displayEntries}
+            followOutput={autoScroll ? "smooth" : false}
+            atBottomStateChange={handleAtBottomChange}
+            computeItemKey={(_index, display) => display.entry.id}
+            itemContent={(_index, display) => (
+              <LogEntry
+                entry={display.entry}
+                count={display.count}
+                copyMeta={copyMeta}
+                isExpanded={expandedIds.has(display.entry.id)}
+                onToggle={() => toggleExpanded(display.entry.id)}
+              />
+            )}
+            className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"
+          />
         )}
 
-        <div className="flex-1 relative min-h-0">
-          {displayEntries.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
-              {logs.length === 0 && !previousSessionEntry
-                ? "No logs yet"
-                : logs.length === 0
-                  ? "No new logs this session"
-                  : "No logs match filters"}
-            </div>
-          ) : (
-            <Virtuoso
-              ref={virtuosoRef}
-              data={displayEntries}
-              followOutput={autoScroll ? "smooth" : false}
-              atBottomStateChange={handleAtBottomChange}
-              computeItemKey={(_index, display) => display.entry.id}
-              itemContent={(_index, display) => (
-                <LogEntry
-                  entry={display.entry}
-                  count={display.count}
-                  copyMeta={copyMeta}
-                  isExpanded={expandedIds.has(display.entry.id)}
-                  onToggle={() => toggleExpanded(display.entry.id)}
-                />
-              )}
-              className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"
-            />
-          )}
-
-          {!atBottom && displayEntries.length > 0 && (
-            <Button
-              variant="info"
-              size="sm"
-              className="absolute bottom-4 right-4 rounded-full shadow-[var(--theme-shadow-floating)] tabular-nums"
-              onClick={scrollToBottom}
-              aria-label={newCount > 0 ? `Resume tail, ${newCount} new` : "Scroll to bottom"}
-            >
-              {newCount > 0 ? `↓ ${newCount} new` : "Scroll to bottom"}
-            </Button>
-          )}
-        </div>
+        {!atBottom && displayEntries.length > 0 && (
+          <Button
+            variant="info"
+            size="sm"
+            className="absolute bottom-4 right-4 rounded-full shadow-[var(--theme-shadow-floating)] tabular-nums"
+            onClick={scrollToBottom}
+            aria-label={newCount > 0 ? `Resume tail, ${newCount} new` : "Scroll to bottom"}
+          >
+            {newCount > 0 ? `↓ ${newCount} new` : "Scroll to bottom"}
+          </Button>
+        )}
       </div>
-    </TooltipProvider>
+    </div>
   );
 }

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -2,7 +2,7 @@ import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useErrorStore, type AppError, type RetryAction } from "@/store";
 import { Copy, Check, Lightbulb } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const ERROR_TYPE_LABELS: Record<string, string> = {
   git: "Git",
@@ -183,29 +183,25 @@ function ErrorRow({
               <pre className="text-xs text-daintree-text/60 whitespace-pre-wrap break-all font-mono max-h-40 overflow-y-auto flex-1 select-text">
                 {error.details}
               </pre>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={handleCopyDetails}
-                      className="shrink-0 p-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 rounded transition-colors"
-                      aria-label={
-                        copied ? "Copied to clipboard" : "Copy error details to clipboard"
-                      }
-                    >
-                      {copied ? (
-                        <Check className="w-4 h-4 text-status-success" />
-                      ) : (
-                        <Copy className="w-4 h-4" />
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {copied ? "Copied!" : "Copy error details"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={handleCopyDetails}
+                    className="shrink-0 p-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 rounded transition-colors"
+                    aria-label={copied ? "Copied to clipboard" : "Copy error details to clipboard"}
+                  >
+                    {copied ? (
+                      <Check className="w-4 h-4 text-status-success" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {copied ? "Copied!" : "Copy error details"}
+                </TooltipContent>
+              </Tooltip>
             </div>
             {error.context && Object.keys(error.context).length > 0 && (
               <div className="mt-2 text-xs text-daintree-text/60">

--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { useEventStore, type EventRecord, type EventFilterOptions } from "@/store/eventStore";
 import { Copy, Check, ChevronDown, ChevronRight, Filter, X } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface EventDetailProps {
   event: EventRecord | null;
@@ -24,35 +24,33 @@ function ContextPill({ label, value, filterKey, currentFilters, onToggle }: Cont
   return (
     <div className="grid grid-cols-[100px_1fr] gap-2 items-center">
       <span className="text-muted-foreground">{label}:</span>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onToggle(filterKey, value);
-              }}
-              className={cn(
-                "group flex items-center gap-2 px-2 py-1 rounded text-xs font-mono text-left w-fit transition max-w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                isActive
-                  ? "bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25"
-                  : "hover:bg-muted border border-transparent hover:border-border text-foreground"
-              )}
-              aria-pressed={isActive}
-            >
-              <span className="truncate">{strValue}</span>
-              {isActive ? (
-                <X className="w-3 h-3 flex-shrink-0 opacity-70" />
-              ) : (
-                <Filter className="w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-30" />
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {isActive ? "Click to clear filter" : `Filter by ${label}`}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(filterKey, value);
+            }}
+            className={cn(
+              "group flex items-center gap-2 px-2 py-1 rounded text-xs font-mono text-left w-fit transition max-w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isActive
+                ? "bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25"
+                : "hover:bg-muted border border-transparent hover:border-border text-foreground"
+            )}
+            aria-pressed={isActive}
+          >
+            <span className="truncate">{strValue}</span>
+            {isActive ? (
+              <X className="w-3 h-3 flex-shrink-0 opacity-70" />
+            ) : (
+              <Filter className="w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-30" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {isActive ? "Click to clear filter" : `Filter by ${label}`}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -149,23 +147,21 @@ export function EventDetail({ event, className }: EventDetailProps) {
               <span className="capitalize">{event.source}</span>
             </div>
           </div>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={copyPayload}
-                  className="flex-shrink-0 p-2 hover:bg-muted rounded transition-colors"
-                >
-                  {copied ? (
-                    <Check className="w-4 h-4 text-status-success" />
-                  ) : (
-                    <Copy className="w-4 h-4" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Copy payload</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={copyPayload}
+                className="flex-shrink-0 p-2 hover:bg-muted rounded transition-colors"
+              >
+                {copied ? (
+                  <Check className="w-4 h-4 text-status-success" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Copy payload</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -185,14 +181,12 @@ export function EventDetail({ event, className }: EventDetailProps) {
           <div className="px-4 pb-3 space-y-2 text-sm">
             <div className="grid grid-cols-[100px_1fr] gap-2">
               <span className="text-muted-foreground">Event ID:</span>
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="font-mono text-xs truncate">{event.id}</span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{event.id}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="font-mono text-xs truncate">{event.id}</span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{event.id}</TooltipContent>
+              </Tooltip>
             </div>
             <div className="grid grid-cols-[100px_1fr] gap-2">
               <span className="text-muted-foreground">Type:</span>
@@ -209,14 +203,12 @@ export function EventDetail({ event, className }: EventDetailProps) {
             {event.payload?.traceId && (
               <div className="grid grid-cols-[100px_1fr] gap-2">
                 <span className="text-muted-foreground">Trace ID:</span>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="font-mono text-xs truncate">{event.payload.traceId}</span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{event.payload.traceId}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="font-mono text-xs truncate">{event.payload.traceId}</span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{event.payload.traceId}</TooltipContent>
+                </Tooltip>
               </div>
             )}
           </div>

--- a/src/components/EventInspector/EventTimeline.tsx
+++ b/src/components/EventInspector/EventTimeline.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import type { EventRecord, EventCategory } from "@/store/eventStore";
 import { Circle } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { EVENT_CATEGORY_STYLES } from "@/config/categoryColors";
 
 interface EventTimelineProps {
@@ -112,21 +112,19 @@ export function EventTimeline({
         )}
       >
         <div className="flex items-start gap-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className={cn(
-                    "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-[11px] font-medium border",
-                    categoryStyle.color
-                  )}
-                >
-                  {categoryStyle.label}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{event.category}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className={cn(
+                  "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-[11px] font-medium border",
+                  categoryStyle.color
+                )}
+              >
+                {categoryStyle.label}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{event.category}</TooltipContent>
+          </Tooltip>
           <div className="flex-1 min-w-0 space-y-1">
             <div className="flex items-center gap-2">
               <span className="font-mono text-xs text-muted-foreground">

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -10,7 +10,7 @@ import { ExternalLink, Copy, Check, Image as ImageIcon } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 
@@ -264,22 +264,20 @@ export function FileViewerModal({
     >
       <AppDialog.Header className="py-3">
         <div className="flex items-center gap-3 min-w-0">
-          <TooltipProvider>
-            <Tooltip>
-              <AppDialog.Title className="text-sm font-medium min-w-0">
-                <TooltipTrigger asChild>
-                  <span className="truncate cursor-default">
-                    {branch && <span className="text-muted-foreground/70 mr-1.5">{branch}</span>}
-                    {relativeDir && <span className="text-muted-foreground">{relativeDir}</span>}
-                    <span className="text-daintree-text">{fileName}</span>
-                  </span>
-                </TooltipTrigger>
-              </AppDialog.Title>
-              <TooltipContent side="bottom" className="max-w-lg break-all">
-                {filePath}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <AppDialog.Title className="text-sm font-medium min-w-0">
+              <TooltipTrigger asChild>
+                <span className="truncate cursor-default">
+                  {branch && <span className="text-muted-foreground/70 mr-1.5">{branch}</span>}
+                  {relativeDir && <span className="text-muted-foreground">{relativeDir}</span>}
+                  <span className="text-daintree-text">{fileName}</span>
+                </span>
+              </TooltipTrigger>
+            </AppDialog.Title>
+            <TooltipContent side="bottom" className="max-w-lg break-all">
+              {filePath}
+            </TooltipContent>
+          </Tooltip>
 
           {/* Show view/diff toggle only when both are potentially available */}
           {hasDiff && !imageFile && (canShowView || loadState !== "loading") && (
@@ -346,23 +344,21 @@ export function FileViewerModal({
 
           {/* Copy diff — only visible in diff mode */}
           {mode === "diff" && hasDiff && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={handleCopyDiff}
-                    aria-label={diffCopied ? "Copied!" : "Copy diff to clipboard"}
-                    className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
-                  >
-                    {diffCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {diffCopied ? "Copied!" : "Copy diff to clipboard"}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleCopyDiff}
+                  aria-label={diffCopied ? "Copied!" : "Copy diff to clipboard"}
+                  className="p-1.5 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
+                >
+                  {diffCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {diffCopied ? "Copied!" : "Copy diff to clipboard"}
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {imageFile ? (

--- a/src/components/GitHub/CommitListItem.tsx
+++ b/src/components/GitHub/CommitListItem.tsx
@@ -4,7 +4,7 @@ import { GitCommitHorizontal, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import type { GitCommit } from "@shared/types/github";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { parseConventionalCommit } from "./commitListUtils";
 
 interface CommitListItemProps {
@@ -88,60 +88,52 @@ export function CommitListItem({ commit, optionId, isActive }: CommitListItemPro
         <div className="flex-1 min-w-0">
           {/* Title row: message + trailing #hash copy */}
           <div className="flex items-center gap-1.5 min-w-0">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>{renderMessage()}</TooltipTrigger>
-                <TooltipContent side="bottom">{commit.message}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>{renderMessage()}</TooltipTrigger>
+              <TooltipContent side="bottom">{commit.message}</TooltipContent>
+            </Tooltip>
 
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={handleCopyHash}
-                    className={cn(
-                      "shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1",
-                      copied && "text-status-success"
-                    )}
-                    aria-label={`Copy hash ${commit.shortHash}`}
-                  >
-                    {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
-                    <span>{commit.shortHash}</span>
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {copied ? "Copied!" : "Click to copy hash"}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleCopyHash}
+                  className={cn(
+                    "shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 font-mono focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1",
+                    copied && "text-status-success"
+                  )}
+                  aria-label={`Copy hash ${commit.shortHash}`}
+                >
+                  {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
+                  <span>{commit.shortHash}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {copied ? "Copied!" : "Click to copy hash"}
+              </TooltipContent>
+            </Tooltip>
           </div>
 
           {/* Metadata row: author · time */}
           <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>{commit.author.name}</span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{commit.author.email}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{commit.author.name}</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{commit.author.email}</TooltipContent>
+            </Tooltip>
             <span>&middot;</span>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>{formatTimeAgo(commit.date)}</span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {(() => {
-                    const d = new Date(commit.date);
-                    return isNaN(d.getTime()) ? "Unknown" : d.toLocaleString();
-                  })()}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>{formatTimeAgo(commit.date)}</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {(() => {
+                  const d = new Date(commit.date);
+                  return isNaN(d.getTime()) ? "Unknown" : d.toLocaleString();
+                })()}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -23,7 +23,7 @@ import type {
   GitHubPRCIStatus,
   GitHubPRCISummary,
 } from "@shared/types/github";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -241,42 +241,38 @@ export function GitHubListItem({
               (() => {
                 const ciInfo = getCIStatusInfo(item.ciStatus, item.ciSummary);
                 return (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="shrink-0" aria-label={ciInfo.tooltip}>
-                          {ciInfo.icon ? (
-                            <ciInfo.icon className={cn("w-3 h-3", ciInfo.color)} />
-                          ) : (
-                            <span className={cn("block w-2 h-2 rounded-full", ciInfo.color)} />
-                          )}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">{ciInfo.tooltip}</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="shrink-0" aria-label={ciInfo.tooltip}>
+                        {ciInfo.icon ? (
+                          <ciInfo.icon className={cn("w-3 h-3", ciInfo.color)} />
+                        ) : (
+                          <span className={cn("block w-2 h-2 rounded-full", ciInfo.color)} />
+                        )}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{ciInfo.tooltip}</TooltipContent>
+                  </Tooltip>
                 );
               })()}
 
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleCopyNumber();
-                    }}
-                    className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
-                    aria-label={`Copy number ${item.number}`}
-                  >
-                    {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
-                    <span>{item.number}</span>
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{copied ? "Copied!" : "Copy number"}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void handleCopyNumber();
+                  }}
+                  className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+                  aria-label={`Copy number ${item.number}`}
+                >
+                  {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
+                  <span>{item.number}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{copied ? "Copied!" : "Copy number"}</TooltipContent>
+            </Tooltip>
           </div>
 
           {/* Metadata row: author, time, branch/labels, worktree, menu */}
@@ -322,28 +318,26 @@ export function GitHubListItem({
             {!isItemPR && "linkedPR" in item && item.linkedPR && (
               <>
                 <span className="shrink-0">&middot;</span>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          void actionService.dispatch(
-                            "system.openExternal",
-                            { url: item.linkedPR!.url },
-                            { source: "user" }
-                          );
-                        }}
-                        className="shrink-0 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                        aria-label={`Linked PR #${item.linkedPR.number}`}
-                      >
-                        <GitPullRequest className="w-3 h-3" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">PR #{item.linkedPR.number}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void actionService.dispatch(
+                          "system.openExternal",
+                          { url: item.linkedPR!.url },
+                          { source: "user" }
+                        );
+                      }}
+                      className="shrink-0 text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+                      aria-label={`Linked PR #${item.linkedPR.number}`}
+                    >
+                      <GitPullRequest className="w-3 h-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">PR #{item.linkedPR.number}</TooltipContent>
+                </Tooltip>
               </>
             )}
 
@@ -359,59 +353,55 @@ export function GitHubListItem({
             )}
 
             {hasWorktree ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    {isActiveWorktree ? (
-                      <span className="shrink-0 text-daintree-accent">
-                        <WorktreeIcon className="w-3.5 h-3.5" />
-                      </span>
-                    ) : onSwitchToWorktree && matchedWorktree ? (
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onSwitchToWorktree(matchedWorktree.id);
-                        }}
-                        className="shrink-0 text-github-open hover:text-github-open/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                        aria-label="Switch to worktree"
-                      >
-                        <WorktreeIcon className="w-3.5 h-3.5" />
-                      </button>
-                    ) : (
-                      <span className="shrink-0 text-github-open">
-                        <WorktreeIcon className="w-3.5 h-3.5" />
-                      </span>
-                    )}
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {isActiveWorktree
-                      ? "Active worktree"
-                      : onSwitchToWorktree && matchedWorktree
-                        ? "Switch to worktree"
-                        : "Has worktree"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ) : item.state === "OPEN" && onCreateWorktree ? (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {isActiveWorktree ? (
+                    <span className="shrink-0 text-daintree-accent">
+                      <WorktreeIcon className="w-3.5 h-3.5" />
+                    </span>
+                  ) : onSwitchToWorktree && matchedWorktree ? (
                     <button
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
-                        onCreateWorktree(item);
+                        onSwitchToWorktree(matchedWorktree.id);
                       }}
-                      className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                      aria-label="Create worktree"
+                      className="shrink-0 text-github-open hover:text-github-open/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+                      aria-label="Switch to worktree"
                     >
                       <WorktreeIcon className="w-3.5 h-3.5" />
                     </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Create worktree</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                  ) : (
+                    <span className="shrink-0 text-github-open">
+                      <WorktreeIcon className="w-3.5 h-3.5" />
+                    </span>
+                  )}
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {isActiveWorktree
+                    ? "Active worktree"
+                    : onSwitchToWorktree && matchedWorktree
+                      ? "Switch to worktree"
+                      : "Has worktree"}
+                </TooltipContent>
+              </Tooltip>
+            ) : item.state === "OPEN" && onCreateWorktree ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCreateWorktree(item);
+                    }}
+                    className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+                    aria-label="Create worktree"
+                  >
+                    <WorktreeIcon className="w-3.5 h-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Create worktree</TooltipContent>
+              </Tooltip>
             ) : null}
 
             <DropdownMenu>

--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -6,7 +6,7 @@ import { githubClient } from "@/clients/githubClient";
 import type { GitHubIssue } from "@shared/types/github";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { GitHubResourceRowsSkeleton } from "./GitHubDropdownSkeletons";
 
 interface IssueSelectorProps {
@@ -92,27 +92,25 @@ export function IssueSelector({
           )}
           <div className="flex items-center gap-1 shrink-0">
             {selectedIssue && !disabled && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      role="button"
-                      tabIndex={0}
-                      onClick={handleClear}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          handleClear(e as unknown as React.MouseEvent);
-                        }
-                      }}
-                      className="p-0.5 hover:bg-daintree-border rounded cursor-pointer"
-                    >
-                      <X className="h-3.5 w-3.5 text-muted-foreground hover:text-daintree-text" />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Clear selection</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={handleClear}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleClear(e as unknown as React.MouseEvent);
+                      }
+                    }}
+                    className="p-0.5 hover:bg-daintree-border rounded cursor-pointer"
+                  >
+                    <X className="h-3.5 w-3.5 text-muted-foreground hover:text-daintree-text" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Clear selection</TooltipContent>
+              </Tooltip>
             )}
             <ChevronsUpDown className="h-4 w-4 opacity-50" />
           </div>

--- a/src/components/GitHub/__tests__/GitHubListItem.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubListItem.test.tsx
@@ -33,6 +33,13 @@ vi.mock("@/utils/timeAgo", () => ({
   formatTimeAgo: (date: number | string) => `time:${date}`,
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 const baseIssue: GitHubIssue = {
   number: 42,
   title: "Fix the thing",

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   DropdownMenu,
@@ -217,32 +217,30 @@ export function AgentButton({
     return (
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handleClick}
-                    disabled={isLoading}
-                    data-toolbar-item={dataToolbarItem}
-                    className={cn(
-                      "toolbar-agent-button text-daintree-text transition-colors relative",
-                      isReady &&
-                        "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
-                      needsSetup && "opacity-70"
-                    )}
-                    aria-label={ariaLabel}
-                  >
-                    {iconElement}
-                    <ShortcutRevealChip actionId={`agent.${type}`} />
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{tooltip}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleClick}
+                  disabled={isLoading}
+                  data-toolbar-item={dataToolbarItem}
+                  className={cn(
+                    "toolbar-agent-button text-daintree-text transition-colors relative",
+                    isReady &&
+                      "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
+                    needsSetup && "opacity-70"
+                  )}
+                  aria-label={ariaLabel}
+                >
+                  {iconElement}
+                  <ShortcutRevealChip actionId={`agent.${type}`} />
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{tooltip}</TooltipContent>
+          </Tooltip>
         </ContextMenuTrigger>
         <ContextMenuContent>
           <ContextMenuItem
@@ -332,147 +330,143 @@ export function AgentButton({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleClick}
-                  disabled={isLoading}
-                  data-toolbar-item={dataToolbarItem}
-                  className={cn(
-                    "toolbar-agent-button text-daintree-text transition-colors rounded-r-none border-r border-transparent relative",
-                    isReady &&
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleClick}
+                disabled={isLoading}
+                data-toolbar-item={dataToolbarItem}
+                className={cn(
+                  "toolbar-agent-button text-daintree-text transition-colors rounded-r-none border-r border-transparent relative",
+                  isReady &&
+                    "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
+                  needsSetup && "opacity-70"
+                )}
+                aria-label={ariaLabel}
+              >
+                {iconElement}
+                <ShortcutRevealChip actionId={`agent.${type}`} />
+              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    disabled={isLoading || !isReady}
+                    data-toolbar-item={dataToolbarItem}
+                    className={cn(
+                      "toolbar-agent-button text-daintree-text transition-colors rounded-l-none",
+                      "h-8 w-4 p-0 flex items-center justify-center",
                       "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
-                    needsSetup && "opacity-70"
+                      !isReady && !isLoading && "opacity-60"
+                    )}
+                    aria-label={`Choose ${config.name} preset`}
+                  >
+                    <ChevronDown className="h-3 w-3 opacity-70" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" sideOffset={4} className="min-w-[12rem]">
+                  <DropdownMenuItem
+                    className={cn(!savedPresetId && "font-medium")}
+                    onSelect={() => {
+                      persistWorktreePick(undefined);
+                      void actionService.dispatch(
+                        "agent.launch",
+                        { agentId: type, presetId: null },
+                        { source: "user" }
+                      );
+                    }}
+                  >
+                    <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                      <config.icon brandColor={getBrandColorHex(type)} />
+                    </span>
+                    Default
+                  </DropdownMenuItem>
+                  {ccrPresetGroup.length > 0 && (
+                    <>
+                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                      {hasMultiplePresetGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
+                      {ccrPresetGroup.map((preset) => (
+                        <DropdownMenuItem
+                          key={preset.id}
+                          className={cn(savedPresetId === preset.id && "font-medium")}
+                          onSelect={() => {
+                            persistWorktreePick(preset.id);
+                            void actionService.dispatch(
+                              "agent.launch",
+                              { agentId: type, presetId: preset.id },
+                              { source: "user" }
+                            );
+                          }}
+                        >
+                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                          </span>
+                          {preset.name.replace(/^CCR:\s*/, "")}
+                        </DropdownMenuItem>
+                      ))}
+                    </>
                   )}
-                  aria-label={ariaLabel}
-                >
-                  {iconElement}
-                  <ShortcutRevealChip actionId={`agent.${type}`} />
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      disabled={isLoading || !isReady}
-                      data-toolbar-item={dataToolbarItem}
-                      className={cn(
-                        "toolbar-agent-button text-daintree-text transition-colors rounded-l-none",
-                        "h-8 w-4 p-0 flex items-center justify-center",
-                        "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
-                        !isReady && !isLoading && "opacity-60"
+                  {projectPresetGroup.length > 0 && (
+                    <>
+                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                      {hasMultiplePresetGroups && (
+                        <DropdownMenuLabel>Project Shared</DropdownMenuLabel>
                       )}
-                      aria-label={`Choose ${config.name} preset`}
-                    >
-                      <ChevronDown className="h-3 w-3 opacity-70" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" sideOffset={4} className="min-w-[12rem]">
-                    <DropdownMenuItem
-                      className={cn(!savedPresetId && "font-medium")}
-                      onSelect={() => {
-                        persistWorktreePick(undefined);
-                        void actionService.dispatch(
-                          "agent.launch",
-                          { agentId: type, presetId: null },
-                          { source: "user" }
-                        );
-                      }}
-                    >
-                      <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                        <config.icon brandColor={getBrandColorHex(type)} />
-                      </span>
-                      Default
-                    </DropdownMenuItem>
-                    {ccrPresetGroup.length > 0 && (
-                      <>
-                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                        {hasMultiplePresetGroups && (
-                          <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>
-                        )}
-                        {ccrPresetGroup.map((preset) => (
-                          <DropdownMenuItem
-                            key={preset.id}
-                            className={cn(savedPresetId === preset.id && "font-medium")}
-                            onSelect={() => {
-                              persistWorktreePick(preset.id);
-                              void actionService.dispatch(
-                                "agent.launch",
-                                { agentId: type, presetId: preset.id },
-                                { source: "user" }
-                              );
-                            }}
-                          >
-                            <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                              <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                            </span>
-                            {preset.name.replace(/^CCR:\s*/, "")}
-                          </DropdownMenuItem>
-                        ))}
-                      </>
-                    )}
-                    {projectPresetGroup.length > 0 && (
-                      <>
-                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                        {hasMultiplePresetGroups && (
-                          <DropdownMenuLabel>Project Shared</DropdownMenuLabel>
-                        )}
-                        {projectPresetGroup.map((preset) => (
-                          <DropdownMenuItem
-                            key={preset.id}
-                            className={cn(savedPresetId === preset.id && "font-medium")}
-                            onSelect={() => {
-                              persistWorktreePick(preset.id);
-                              void actionService.dispatch(
-                                "agent.launch",
-                                { agentId: type, presetId: preset.id },
-                                { source: "user" }
-                              );
-                            }}
-                          >
-                            <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                              <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                            </span>
-                            {preset.name}
-                          </DropdownMenuItem>
-                        ))}
-                      </>
-                    )}
-                    {customPresetGroup.length > 0 && (
-                      <>
-                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
-                        {hasMultiplePresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
-                        {customPresetGroup.map((preset) => (
-                          <DropdownMenuItem
-                            key={preset.id}
-                            className={cn(savedPresetId === preset.id && "font-medium")}
-                            onSelect={() => {
-                              persistWorktreePick(preset.id);
-                              void actionService.dispatch(
-                                "agent.launch",
-                                { agentId: type, presetId: preset.id },
-                                { source: "user" }
-                              );
-                            }}
-                          >
-                            <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                              <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
-                            </span>
-                            {preset.name}
-                          </DropdownMenuItem>
-                        ))}
-                      </>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{tooltip}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                      {projectPresetGroup.map((preset) => (
+                        <DropdownMenuItem
+                          key={preset.id}
+                          className={cn(savedPresetId === preset.id && "font-medium")}
+                          onSelect={() => {
+                            persistWorktreePick(preset.id);
+                            void actionService.dispatch(
+                              "agent.launch",
+                              { agentId: type, presetId: preset.id },
+                              { source: "user" }
+                            );
+                          }}
+                        >
+                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                          </span>
+                          {preset.name}
+                        </DropdownMenuItem>
+                      ))}
+                    </>
+                  )}
+                  {customPresetGroup.length > 0 && (
+                    <>
+                      {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                      {hasMultiplePresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
+                      {customPresetGroup.map((preset) => (
+                        <DropdownMenuItem
+                          key={preset.id}
+                          className={cn(savedPresetId === preset.id && "font-medium")}
+                          onSelect={() => {
+                            persistWorktreePick(preset.id);
+                            void actionService.dispatch(
+                              "agent.launch",
+                              { agentId: type, presetId: preset.id },
+                              { source: "user" }
+                            );
+                          }}
+                        >
+                          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                            <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                          </span>
+                          {preset.name}
+                        </DropdownMenuItem>
+                      ))}
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{tooltip}</TooltipContent>
+        </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -11,7 +11,7 @@ import {
 import { Plug, Pin, Settings2, ChevronRight } from "lucide-react";
 import { DaintreeAgentIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -539,34 +539,32 @@ export function AgentTrayButton({
         handleOpenChange(o);
       }}
     >
-      <TooltipProvider>
-        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                data-toolbar-item={dataToolbarItem}
-                className="toolbar-agent-button text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] transition-colors"
-                aria-label={showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"}
-                onPointerEnter={clearFocusRestoreSuppression}
-              >
-                <span className="relative inline-flex items-center justify-center">
-                  <Plug />
-                  {showDiscoveryBadge && (
-                    <span
-                      data-testid="agent-tray-discovery-badge"
-                      className="absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
-                      aria-hidden="true"
-                    />
-                  )}
-                </span>
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Agent Tray</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              className="toolbar-agent-button text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] transition-colors"
+              aria-label={showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"}
+              onPointerEnter={clearFocusRestoreSuppression}
+            >
+              <span className="relative inline-flex items-center justify-center">
+                <Plug />
+                {showDiscoveryBadge && (
+                  <span
+                    data-testid="agent-tray-discovery-badge"
+                    className="absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+                    aria-hidden="true"
+                  />
+                )}
+              </span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Agent Tray</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent
         align="start"
         sideOffset={4}

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -4,7 +4,7 @@ import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortabl
 import { useDroppable } from "@dnd-kit/core";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   usePanelStore,
   useProjectStore,
@@ -188,25 +188,23 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             {/* Left Scroll Chevron - Overlay */}
             {canScrollLeft && (
               <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={scrollLeft}
-                        className={cn(
-                          "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
-                          "rounded-[var(--radius-md)] transition-colors",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                        )}
-                        aria-label="Scroll left"
-                      >
-                        <ChevronLeft className="w-4 h-4" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Scroll left</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={scrollLeft}
+                      className={cn(
+                        "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
+                        "rounded-[var(--radius-md)] transition-colors",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                      )}
+                      aria-label="Scroll left"
+                    >
+                      <ChevronLeft className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Scroll left</TooltipContent>
+                </Tooltip>
               </div>
             )}
 
@@ -261,25 +259,23 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             {/* Right Scroll Chevron - Overlay */}
             {canScrollRight && (
               <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={scrollRight}
-                        className={cn(
-                          "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
-                          "rounded-[var(--radius-md)] transition-colors",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                        )}
-                        aria-label="Scroll right"
-                      >
-                        <ChevronRight className="w-4 h-4" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Scroll right</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={scrollRight}
+                      className={cn(
+                        "pointer-events-auto p-1.5 text-daintree-text/60 hover:text-daintree-text",
+                        "rounded-[var(--radius-md)] transition-colors",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                      )}
+                      aria-label="Scroll right"
+                    >
+                      <ChevronRight className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Scroll right</TooltipContent>
+                </Tooltip>
               </div>
             )}
           </div>

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -49,7 +49,7 @@ import type { TabGroup } from "@/types";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTabGroupProps {
   group: TabGroup;
@@ -464,42 +464,38 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             {isActive && commandText && (
               <>
                 <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                        {commandText}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{commandText}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                      {commandText}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{commandText}</TooltipContent>
+                </Tooltip>
               </>
             )}
 
             {showStateIcon && StateIcon && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={cn(
+                      "flex items-center shrink-0",
+                      getEffectiveStateColor(agentState, activePanel.waitingReason)
+                    )}
+                  >
+                    <StateIcon
                       className={cn(
-                        "flex items-center shrink-0",
-                        getEffectiveStateColor(agentState, activePanel.waitingReason)
+                        "w-3.5 h-3.5",
+                        agentState === "working" && "animate-spin-slow",
+                        "motion-reduce:animate-none"
                       )}
-                    >
-                      <StateIcon
-                        className={cn(
-                          "w-3.5 h-3.5",
-                          agentState === "working" && "animate-spin-slow",
-                          "motion-reduce:animate-none"
-                        )}
-                        aria-hidden="true"
-                      />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                      aria-hidden="true"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
+              </Tooltip>
             )}
           </button>
         </PopoverTrigger>
@@ -573,25 +569,23 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   />
                 );
               })}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleAddTab();
-                      }}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                      aria-label="Duplicate panel as new tab"
-                      type="button"
-                    >
-                      <Plus className="w-3 h-3" aria-hidden="true" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleAddTab();
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                    aria-label="Duplicate panel as new tab"
+                    type="button"
+                  >
+                    <Plus className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+              </Tooltip>
             </div>
           </SortableContext>
         </DndContext>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -29,7 +29,7 @@ import { useDockPanelPortal } from "./DockPanelOffscreenContainer";
 import { getDockDisplayAgentState, useDockBlockedState } from "./useDockBlockedState";
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTerminalItemProps {
   terminal: TerminalInstance;
@@ -331,43 +331,39 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
             {isActive && commandText && (
               <>
                 <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                        {commandText}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{commandText}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                      {commandText}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{commandText}</TooltipContent>
+                </Tooltip>
               </>
             )}
 
             {/* State icon (compact spacing from title) */}
             {showStateIcon && StateIcon && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={cn(
+                      "flex items-center shrink-0",
+                      getEffectiveStateColor(agentState, terminal.waitingReason)
+                    )}
+                  >
+                    <StateIcon
                       className={cn(
-                        "flex items-center shrink-0",
-                        getEffectiveStateColor(agentState, terminal.waitingReason)
+                        "w-3.5 h-3.5",
+                        agentState === "working" && "animate-spin-slow",
+                        "motion-reduce:animate-none"
                       )}
-                    >
-                      <StateIcon
-                        className={cn(
-                          "w-3.5 h-3.5",
-                          agentState === "working" && "animate-spin-slow",
-                          "motion-reduce:animate-none"
-                        )}
-                        aria-hidden="true"
-                      />
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                      aria-hidden="true"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
+              </Tooltip>
             )}
           </button>
         </PopoverTrigger>

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -13,7 +13,7 @@ import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
 import { CircleDot, GitPullRequest, GitCommit } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { actionService } from "@/services/ActionService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -219,66 +219,64 @@ export const GitHubStatsToolbarButton = memo(
             "var(--toolbar-stats-divider,var(--theme-border-subtle))",
         }}
       >
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                ref={issuesButtonRef}
-                variant="ghost"
-                data-toolbar-item=""
-                onClick={() => {
-                  setPrsOpen(false);
-                  setPrSearchQuery("");
-                  setCommitsOpen(false);
-                  if (isTokenError) {
-                    setIssuesOpen(false);
-                    setIssueSearchQuery("");
-                    void actionService.dispatch(
-                      "app.settings.openTab",
-                      { tab: "github", sectionId: "github-token" },
-                      { source: "user" }
-                    );
-                    return;
-                  }
-                  const willOpen = !issuesOpen;
-                  setIssuesOpen(willOpen);
-                  if (!willOpen) setIssueSearchQuery("");
-                  if (willOpen) refreshStats({ force: true });
-                }}
-                className={cn(
-                  "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
-                  isTokenError && "opacity-40",
-                  !isTokenError && stats?.issueCount === 0 && "opacity-50",
-                  !isTokenError && isStale && "opacity-60",
-                  issuesOpen &&
-                    "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-open/20"
-                )}
-                aria-label={
-                  isTokenError
-                    ? "Configure GitHub token to see issues"
-                    : `${stats?.issueCount ?? "\u2014"} open issues${isStale ? " (cached)" : ""}`
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              ref={issuesButtonRef}
+              variant="ghost"
+              data-toolbar-item=""
+              onClick={() => {
+                setPrsOpen(false);
+                setPrSearchQuery("");
+                setCommitsOpen(false);
+                if (isTokenError) {
+                  setIssuesOpen(false);
+                  setIssueSearchQuery("");
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github", sectionId: "github-token" },
+                    { source: "user" }
+                  );
+                  return;
                 }
-              >
-                <CircleDot
-                  className={cn(
-                    "h-4 w-4",
-                    isTokenError ? "text-muted-foreground" : "text-github-open"
-                  )}
-                />
-                <span className="text-xs font-medium tabular-nums">
-                  {stats?.issueCount ?? "\u2014"}
-                </span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {isTokenError
-                ? "Configure GitHub token to see issues"
-                : isStale
-                  ? `${stats?.issueCount ?? "\u2014"} open issues (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
-                  : "Browse GitHub Issues"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                const willOpen = !issuesOpen;
+                setIssuesOpen(willOpen);
+                if (!willOpen) setIssueSearchQuery("");
+                if (willOpen) refreshStats({ force: true });
+              }}
+              className={cn(
+                "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
+                isTokenError && "opacity-40",
+                !isTokenError && stats?.issueCount === 0 && "opacity-50",
+                !isTokenError && isStale && "opacity-60",
+                issuesOpen &&
+                  "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-open/20"
+              )}
+              aria-label={
+                isTokenError
+                  ? "Configure GitHub token to see issues"
+                  : `${stats?.issueCount ?? "\u2014"} open issues${isStale ? " (cached)" : ""}`
+              }
+            >
+              <CircleDot
+                className={cn(
+                  "h-4 w-4",
+                  isTokenError ? "text-muted-foreground" : "text-github-open"
+                )}
+              />
+              <span className="text-xs font-medium tabular-nums">
+                {stats?.issueCount ?? "\u2014"}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isTokenError
+              ? "Configure GitHub token to see issues"
+              : isStale
+                ? `${stats?.issueCount ?? "\u2014"} open issues (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
+                : "Browse GitHub Issues"}
+          </TooltipContent>
+        </Tooltip>
         <FixedDropdown
           open={issuesOpen}
           onOpenChange={(open) => {
@@ -309,66 +307,62 @@ export const GitHubStatsToolbarButton = memo(
             />
           </Suspense>
         </FixedDropdown>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                ref={prsButtonRef}
-                variant="ghost"
-                data-toolbar-item=""
-                onClick={() => {
-                  setIssuesOpen(false);
-                  setIssueSearchQuery("");
-                  setCommitsOpen(false);
-                  if (isTokenError) {
-                    setPrsOpen(false);
-                    setPrSearchQuery("");
-                    void actionService.dispatch(
-                      "app.settings.openTab",
-                      { tab: "github", sectionId: "github-token" },
-                      { source: "user" }
-                    );
-                    return;
-                  }
-                  const willOpen = !prsOpen;
-                  setPrsOpen(willOpen);
-                  if (!willOpen) setPrSearchQuery("");
-                  if (willOpen) refreshStats({ force: true });
-                }}
-                className={cn(
-                  "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
-                  isTokenError && "opacity-40",
-                  !isTokenError && stats?.prCount === 0 && "opacity-50",
-                  !isTokenError && isStale && "opacity-60",
-                  prsOpen &&
-                    "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-merged/20"
-                )}
-                aria-label={
-                  isTokenError
-                    ? "Configure GitHub token to see pull requests"
-                    : `${stats?.prCount ?? "\u2014"} open pull requests${isStale ? " (cached)" : ""}`
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              ref={prsButtonRef}
+              variant="ghost"
+              data-toolbar-item=""
+              onClick={() => {
+                setIssuesOpen(false);
+                setIssueSearchQuery("");
+                setCommitsOpen(false);
+                if (isTokenError) {
+                  setPrsOpen(false);
+                  setPrSearchQuery("");
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github", sectionId: "github-token" },
+                    { source: "user" }
+                  );
+                  return;
                 }
-              >
-                <GitPullRequest
-                  className={cn(
-                    "h-4 w-4",
-                    isTokenError ? "text-muted-foreground" : "text-github-merged"
-                  )}
-                />
-                <span className="text-xs font-medium tabular-nums">
-                  {stats?.prCount ?? "\u2014"}
-                </span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {isTokenError
-                ? "Configure GitHub token to see pull requests"
-                : isStale
-                  ? `${stats?.prCount ?? "\u2014"} open PRs (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
-                  : "Browse GitHub Pull Requests"}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                const willOpen = !prsOpen;
+                setPrsOpen(willOpen);
+                if (!willOpen) setPrSearchQuery("");
+                if (willOpen) refreshStats({ force: true });
+              }}
+              className={cn(
+                "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
+                isTokenError && "opacity-40",
+                !isTokenError && stats?.prCount === 0 && "opacity-50",
+                !isTokenError && isStale && "opacity-60",
+                prsOpen &&
+                  "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-merged/20"
+              )}
+              aria-label={
+                isTokenError
+                  ? "Configure GitHub token to see pull requests"
+                  : `${stats?.prCount ?? "\u2014"} open pull requests${isStale ? " (cached)" : ""}`
+              }
+            >
+              <GitPullRequest
+                className={cn(
+                  "h-4 w-4",
+                  isTokenError ? "text-muted-foreground" : "text-github-merged"
+                )}
+              />
+              <span className="text-xs font-medium tabular-nums">{stats?.prCount ?? "\u2014"}</span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isTokenError
+              ? "Configure GitHub token to see pull requests"
+              : isStale
+                ? `${stats?.prCount ?? "\u2014"} open PRs (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
+                : "Browse GitHub Pull Requests"}
+          </TooltipContent>
+        </Tooltip>
         <FixedDropdown
           open={prsOpen}
           onOpenChange={(open) => {
@@ -396,37 +390,35 @@ export const GitHubStatsToolbarButton = memo(
             />
           </Suspense>
         </FixedDropdown>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                ref={commitsButtonRef}
-                variant="ghost"
-                data-toolbar-item=""
-                onClick={() => {
-                  setIssuesOpen(false);
-                  setIssueSearchQuery("");
-                  setPrsOpen(false);
-                  setPrSearchQuery("");
-                  setCommitsOpen(!commitsOpen);
-                }}
-                className={cn(
-                  "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
-                  stats?.commitCount === 0 && "opacity-50",
-                  commitsOpen &&
-                    "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-border-strong"
-                )}
-                aria-label={`${stats?.commitCount ?? "\u2014"} commits`}
-              >
-                <GitCommit className="h-4 w-4" />
-                <span className="text-xs font-medium tabular-nums">
-                  {stats?.commitCount ?? "\u2014"}
-                </span>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Browse Git Commits</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              ref={commitsButtonRef}
+              variant="ghost"
+              data-toolbar-item=""
+              onClick={() => {
+                setIssuesOpen(false);
+                setIssueSearchQuery("");
+                setPrsOpen(false);
+                setPrSearchQuery("");
+                setCommitsOpen(!commitsOpen);
+              }}
+              className={cn(
+                "h-full gap-2 rounded-none px-3 text-daintree-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
+                stats?.commitCount === 0 && "opacity-50",
+                commitsOpen &&
+                  "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-border-strong"
+              )}
+              aria-label={`${stats?.commitCount ?? "\u2014"} commits`}
+            >
+              <GitCommit className="h-4 w-4" />
+              <span className="text-xs font-medium tabular-nums">
+                {stats?.commitCount ?? "\u2014"}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Browse Git Commits</TooltipContent>
+        </Tooltip>
         <FixedDropdown
           open={commitsOpen}
           onOpenChange={(open) => {
@@ -454,29 +446,27 @@ export const GitHubStatsToolbarButton = memo(
           onTransitionEnd={handleGitHubStatusTransitionEnd}
         />
         {rateLimitActive && rateLimitLabel ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  role="status"
-                  aria-live="polite"
-                  aria-label={
-                    rateLimitKind === "secondary"
-                      ? `GitHub secondary rate limit — resuming in ${rateLimitCountdown}`
-                      : `GitHub rate limit — resets in ${rateLimitCountdown}`
-                  }
-                  className="flex h-full items-center px-2 text-[10px] font-medium text-muted-foreground opacity-60"
-                >
-                  {rateLimitLabel}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {rateLimitKind === "secondary"
-                  ? "GitHub triggered a secondary (abuse) rate limit — polling paused until it clears."
-                  : "GitHub API quota exhausted — polling paused until the quota resets."}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                role="status"
+                aria-live="polite"
+                aria-label={
+                  rateLimitKind === "secondary"
+                    ? `GitHub secondary rate limit — resuming in ${rateLimitCountdown}`
+                    : `GitHub rate limit — resets in ${rateLimitCountdown}`
+                }
+                className="flex h-full items-center px-2 text-[10px] font-medium text-muted-foreground opacity-60"
+              >
+                {rateLimitLabel}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {rateLimitKind === "secondary"
+                ? "GitHub triggered a secondary (abuse) rate limit — polling paused until it clears."
+                : "GitHub API quota exhausted — polling paused until the quota resets."}
+            </TooltipContent>
+          </Tooltip>
         ) : null}
       </div>
     );

--- a/src/components/Layout/HelpAgentDockButton.tsx
+++ b/src/components/Layout/HelpAgentDockButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
@@ -14,29 +14,24 @@ export function HelpAgentDockButton() {
   }, [toggle]);
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="pill"
-            size="sm"
-            className={cn(
-              "px-2",
-              isOpen &&
-                "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
-            )}
-            onClick={handleClick}
-            aria-label="Help Agent"
-            aria-expanded={isOpen}
-          >
-            <DaintreeIcon className="w-3.5 h-3.5 text-daintree-text/50" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          {isOpen ? "Close help panel" : "Open help panel"}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="pill"
+          size="sm"
+          className={cn(
+            "px-2",
+            isOpen && "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
+          )}
+          onClick={handleClick}
+          aria-label="Help Agent"
+          aria-expanded={isOpen}
+        >
+          <DaintreeIcon className="w-3.5 h-3.5 text-daintree-text/50" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{isOpen ? "Close help panel" : "Open help panel"}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState, memo } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
 import { Bell, BellOff } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { NotificationCenter } from "@/components/Notifications/NotificationCenter";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -111,33 +111,31 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
 
   return (
     <div className="relative">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              ref={notificationCenterButtonRef}
-              variant="ghost"
-              size="icon"
-              data-toolbar-item={dataToolbarItem}
-              data-dnd-active={isDndActive ? "true" : undefined}
-              onClick={toggleNotificationCenter}
-              className={toolbarIconButtonClass}
-              aria-label={label}
-              aria-expanded={notificationCenterOpen}
-              aria-haspopup="dialog"
-            >
-              <Icon />
-              {notificationUnreadCount > 0 && (
-                <span
-                  data-testid="notification-unread-dot"
-                  className={`absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full ring-1 ring-daintree-bg/60 ${dotColor}`}
-                />
-              )}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{label}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            ref={notificationCenterButtonRef}
+            variant="ghost"
+            size="icon"
+            data-toolbar-item={dataToolbarItem}
+            data-dnd-active={isDndActive ? "true" : undefined}
+            onClick={toggleNotificationCenter}
+            className={toolbarIconButtonClass}
+            aria-label={label}
+            aria-expanded={notificationCenterOpen}
+            aria-haspopup="dialog"
+          >
+            <Icon />
+            {notificationUnreadCount > 0 && (
+              <span
+                data-testid="notification-unread-dot"
+                className={`absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full ring-1 ring-daintree-bg/60 ${dotColor}`}
+              />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
       <FixedDropdown
         open={notificationCenterOpen}
         onOpenChange={(open) => {

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -5,7 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -147,18 +147,16 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
                     aria-label={config.statusAriaLabel}
                   />
 
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <div className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors">
-                          {getLocationIcon(terminal.location)}
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {terminal.location === "dock" ? "Docked" : "On Grid"}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors">
+                        {getLocationIcon(terminal.location)}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {terminal.location === "dock" ? "Docked" : "On Grid"}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </button>
             ))}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -26,7 +26,7 @@ import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { isMac, isLinux, createTooltipWithShortcut } from "@/lib/platform";
 import { AgentButton } from "./AgentButton";
 import { AgentTrayButton } from "./AgentTrayButton";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   DropdownMenu,
@@ -73,8 +73,7 @@ const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
-const toolbarIconButtonClass =
-  "toolbar-icon-button text-daintree-text transition-colors relative";
+const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text transition-colors relative";
 
 export function PluginToolbarButton({
   pluginId,
@@ -88,30 +87,28 @@ export function PluginToolbarButton({
   const hover = useShortcutHintHover(config.actionId as string);
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            {...hover}
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            onClick={() => {
-              void actionService.dispatch(
-                config.actionId as Parameters<typeof actionService.dispatch>[0],
-                undefined,
-                { source: "user" }
-              );
-            }}
-            className={toolbarIconButtonClass}
-            aria-label={config?.label ?? pluginId}
-          >
-            <McpServerIcon />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{config?.label ?? pluginId}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          {...hover}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
+          onClick={() => {
+            void actionService.dispatch(
+              config.actionId as Parameters<typeof actionService.dispatch>[0],
+              undefined,
+              { source: "user" }
+            );
+          }}
+          className={toolbarIconButtonClass}
+          aria-label={config?.label ?? pluginId}
+        >
+          <McpServerIcon />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{config?.label ?? pluginId}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -376,31 +373,29 @@ export function Toolbar({
     () => ({
       "sidebar-toggle": {
         render: () => (
-          <TooltipProvider key="sidebar-toggle">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  {...sidebarHintHover}
-                  variant="ghost"
-                  size="icon"
-                  data-toolbar-item=""
-                  onClick={onToggleFocusMode}
-                  className={toolbarIconButtonClass}
-                  aria-label="Toggle Sidebar"
-                  aria-pressed={!isFocusMode}
-                >
-                  {isFocusMode ? <PanelLeftOpen /> : <PanelLeftClose />}
-                  <ShortcutRevealChip actionId="nav.toggleSidebar" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {createTooltipWithShortcut(
-                  isFocusMode ? "Show Sidebar" : "Hide Sidebar",
-                  sidebarShortcut
-                )}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                {...sidebarHintHover}
+                variant="ghost"
+                size="icon"
+                data-toolbar-item=""
+                onClick={onToggleFocusMode}
+                className={toolbarIconButtonClass}
+                aria-label="Toggle Sidebar"
+                aria-pressed={!isFocusMode}
+              >
+                {isFocusMode ? <PanelLeftOpen /> : <PanelLeftClose />}
+                <ShortcutRevealChip actionId="nav.toggleSidebar" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut(
+                isFocusMode ? "Show Sidebar" : "Hide Sidebar",
+                sidebarShortcut
+              )}
+            </TooltipContent>
+          </Tooltip>
         ),
         isAvailable: true,
       },
@@ -456,26 +451,24 @@ export function Toolbar({
       },
       "dev-server": {
         render: () => (
-          <TooltipProvider key="dev-server">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  {...devServerHintHover}
-                  variant="ghost"
-                  size="icon"
-                  data-toolbar-item=""
-                  onClick={() =>
-                    actionService.dispatch("devServer.start", undefined, { source: "user" })
-                  }
-                  className={toolbarIconButtonClass}
-                  aria-label="Open Dev Preview"
-                >
-                  <Monitor />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open Dev Preview</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                {...devServerHintHover}
+                variant="ghost"
+                size="icon"
+                data-toolbar-item=""
+                onClick={() =>
+                  actionService.dispatch("devServer.start", undefined, { source: "user" })
+                }
+                className={toolbarIconButtonClass}
+                aria-label="Open Dev Preview"
+              >
+                <Monitor />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open Dev Preview</TooltipContent>
+          </Tooltip>
         ),
         isAvailable: !!currentProject,
       },
@@ -502,45 +495,43 @@ export function Toolbar({
       },
       "copy-tree": {
         render: () => (
-          <TooltipProvider key="copy-tree">
-            <Tooltip open={treeCopied || undefined} delayDuration={treeCopied ? 0 : 300}>
-              <TooltipTrigger asChild>
-                <Button
-                  {...copyTreeHintHover}
-                  variant="ghost"
-                  size="icon"
-                  data-toolbar-item=""
-                  onClick={handleCopyTreeClick}
-                  disabled={isCopyingTree || !activeWorktree}
-                  className={cn(
-                    "toolbar-icon-button transition-colors relative",
-                    treeCopied ? "text-status-success bg-status-success/10" : "text-daintree-text",
-                    isCopyingTree && "cursor-wait opacity-70",
-                    !activeWorktree && "opacity-50"
-                  )}
-                  aria-label={
-                    isCopyingTree ? "Copying…" : treeCopied ? "Context Copied" : "Copy Context"
-                  }
-                >
-                  {isCopyingTree ? <Spinner /> : treeCopied ? <Check /> : <CopyTreeIcon />}
-                  {!treeCopied && !isCopyingTree && (
-                    <ShortcutRevealChip actionId="worktree.copyTree" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="font-medium">
-                {isCopyingTree ? (
-                  "Copying…"
-                ) : treeCopied ? (
-                  <span role="status" aria-live="polite">
-                    {copyFeedback}
-                  </span>
-                ) : (
-                  createTooltipWithShortcut("Copy Context", copyTreeShortcut)
+          <Tooltip open={treeCopied || undefined} delayDuration={treeCopied ? 0 : 300}>
+            <TooltipTrigger asChild>
+              <Button
+                {...copyTreeHintHover}
+                variant="ghost"
+                size="icon"
+                data-toolbar-item=""
+                onClick={handleCopyTreeClick}
+                disabled={isCopyingTree || !activeWorktree}
+                className={cn(
+                  "toolbar-icon-button transition-colors relative",
+                  treeCopied ? "text-status-success bg-status-success/10" : "text-daintree-text",
+                  isCopyingTree && "cursor-wait opacity-70",
+                  !activeWorktree && "opacity-50"
                 )}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+                aria-label={
+                  isCopyingTree ? "Copying…" : treeCopied ? "Context Copied" : "Copy Context"
+                }
+              >
+                {isCopyingTree ? <Spinner /> : treeCopied ? <Check /> : <CopyTreeIcon />}
+                {!treeCopied && !isCopyingTree && (
+                  <ShortcutRevealChip actionId="worktree.copyTree" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="font-medium">
+              {isCopyingTree ? (
+                "Copying…"
+              ) : treeCopied ? (
+                <span role="status" aria-live="polite">
+                  {copyFeedback}
+                </span>
+              ) : (
+                createTooltipWithShortcut("Copy Context", copyTreeShortcut)
+              )}
+            </TooltipContent>
+          </Tooltip>
         ),
         isAvailable: true,
       },
@@ -787,24 +778,22 @@ export function Toolbar({
     if (overflowIds.length === 0) return null;
     return (
       <DropdownMenu>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  data-toolbar-item=""
-                  className={toolbarIconButtonClass}
-                  aria-label={`${overflowIds.length} more toolbar items`}
-                >
-                  <Ellipsis />
-                </Button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">More items</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                data-toolbar-item=""
+                className={toolbarIconButtonClass}
+                aria-label={`${overflowIds.length} more toolbar items`}
+              >
+                <Ellipsis />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">More items</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent align={side === "left" ? "start" : "end"} sideOffset={4}>
           {overflowIds.flatMap((id, idx) => {
             if (id === "github-stats") {

--- a/src/components/Layout/ToolbarLauncherButton.tsx
+++ b/src/components/Layout/ToolbarLauncherButton.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { SquareTerminal, Globe } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
@@ -55,26 +55,24 @@ export const ToolbarLauncherButton = memo(function ToolbarLauncherButton({
   const Icon = config.icon;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            {...launcherHover}
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            onClick={handleClick}
-            className={toolbarIconButtonClass}
-            aria-label={config.label}
-          >
-            <Icon />
-            <ShortcutRevealChip actionId={config.keybindingAction} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {createTooltipWithShortcut(config.tooltipLabel, shortcut)}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          {...launcherHover}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
+          onClick={handleClick}
+          className={toolbarIconButtonClass}
+          aria-label={config.label}
+        >
+          <Icon />
+          <ShortcutRevealChip actionId={config.keybindingAction} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {createTooltipWithShortcut(config.tooltipLabel, shortcut)}
+      </TooltipContent>
+    </Tooltip>
   );
 });

--- a/src/components/Layout/ToolbarPortalButton.tsx
+++ b/src/components/Layout/ToolbarPortalButton.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { Button } from "@/components/ui/button";
 import { PanelRightOpen, PanelRightClose } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
@@ -20,34 +20,32 @@ export const ToolbarPortalButton = memo(function ToolbarPortalButton({
   const portalHintHover = useShortcutHintHover("panel.togglePortal");
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            {...portalHintHover}
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            onClick={togglePortal}
-            className={toolbarIconButtonClass}
-            aria-label={portalOpen ? "Close context portal" : "Open context portal"}
-            aria-pressed={portalOpen}
-          >
-            {portalOpen ? (
-              <PanelRightClose aria-hidden="true" />
-            ) : (
-              <PanelRightOpen aria-hidden="true" />
-            )}
-            <ShortcutRevealChip actionId="panel.togglePortal" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {createTooltipWithShortcut(
-            portalOpen ? "Close Context Portal" : "Open Context Portal",
-            portalShortcut
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          {...portalHintHover}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
+          onClick={togglePortal}
+          className={toolbarIconButtonClass}
+          aria-label={portalOpen ? "Close context portal" : "Open context portal"}
+          aria-pressed={portalOpen}
+        >
+          {portalOpen ? (
+            <PanelRightClose aria-hidden="true" />
+          ) : (
+            <PanelRightOpen aria-hidden="true" />
           )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          <ShortcutRevealChip actionId="panel.togglePortal" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {createTooltipWithShortcut(
+          portalOpen ? "Close Context Portal" : "Open Context Portal",
+          portalShortcut
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 });

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Button } from "@/components/ui/button";
 import { AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
@@ -24,33 +24,27 @@ export const ToolbarProblemsButton = memo(function ToolbarProblemsButton({
   const diagnosticsHover = useShortcutHintHover("panel.toggleDiagnostics");
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            {...diagnosticsHover}
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            onClick={onToggleProblems}
-            className={cn(
-              toolbarIconButtonClass,
-              "relative",
-              errorCount > 0 && "text-status-error"
-            )}
-            aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
-          >
-            <AlertCircle />
-            {errorCount > 0 && (
-              <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-status-error rounded-full" />
-            )}
-            <ShortcutRevealChip actionId="panel.toggleDiagnostics" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {createTooltipWithShortcut("Show Problems Panel", diagnosticsShortcut)}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          {...diagnosticsHover}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
+          onClick={onToggleProblems}
+          className={cn(toolbarIconButtonClass, "relative", errorCount > 0 && "text-status-error")}
+          aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
+        >
+          <AlertCircle />
+          {errorCount > 0 && (
+            <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-status-error rounded-full" />
+          )}
+          <ShortcutRevealChip actionId="panel.toggleDiagnostics" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {createTooltipWithShortcut("Show Problems Panel", diagnosticsShortcut)}
+      </TooltipContent>
+    </Tooltip>
   );
 });

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { Button } from "@/components/ui/button";
 import { SlidersHorizontal } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
   ContextMenu,
@@ -42,32 +42,30 @@ export const ToolbarSettingsButton = memo(function ToolbarSettingsButton({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                data-toolbar-item={dataToolbarItem}
-                onClick={onSettings}
-                onPointerEnter={(e) => {
-                  onPreloadSettings?.();
-                  settingsHover.onPointerEnter(e);
-                }}
-                onPointerLeave={settingsHover.onPointerLeave}
-                onPointerDown={settingsHover.onPointerDown}
-                className={toolbarIconButtonClass}
-                aria-label="Open settings"
-              >
-                <SlidersHorizontal />
-                <ShortcutRevealChip actionId="app.settings" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {createTooltipWithShortcut("Open Settings", settingsShortcut)}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              onClick={onSettings}
+              onPointerEnter={(e) => {
+                onPreloadSettings?.();
+                settingsHover.onPointerEnter(e);
+              }}
+              onPointerLeave={settingsHover.onPointerLeave}
+              onPointerDown={settingsHover.onPointerDown}
+              className={toolbarIconButtonClass}
+              aria-label="Open settings"
+            >
+              <SlidersHorizontal />
+              <ShortcutRevealChip actionId="app.settings" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {createTooltipWithShortcut("Open Settings", settingsShortcut)}
+          </TooltipContent>
+        </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent>
         {SETTINGS_CONTEXT_MENU_TABS.map(({ tab, label }) => (

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -6,7 +6,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TrashedTerminal } from "@/store/slices";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 
@@ -96,51 +96,47 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
       </div>
 
       <div className="flex gap-1">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  variant="ghost-success"
-                  size="icon-sm"
-                  onClick={handleRestore}
-                  disabled={!canRestore}
-                  aria-label={
-                    isOrphan
-                      ? canRestore
-                        ? `Adopt ${terminalName} to current worktree`
-                        : "No active worktree to restore to"
-                      : `Restore ${terminalName}`
-                  }
-                >
-                  <RotateCcw aria-hidden="true" />
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {isOrphan
-                ? canRestore
-                  ? "Adopt to current worktree"
-                  : "No active worktree - select a worktree first"
-                : `Restore ${terminalName}`}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
               <Button
-                variant="ghost-danger"
+                variant="ghost-success"
                 size="icon-sm"
-                onClick={handleKill}
-                aria-label={`Remove ${terminalName} permanently`}
+                onClick={handleRestore}
+                disabled={!canRestore}
+                aria-label={
+                  isOrphan
+                    ? canRestore
+                      ? `Adopt ${terminalName} to current worktree`
+                      : "No active worktree to restore to"
+                    : `Restore ${terminalName}`
+                }
               >
-                <X aria-hidden="true" />
+                <RotateCcw aria-hidden="true" />
               </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{`Remove ${terminalName} permanently`}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isOrphan
+              ? canRestore
+                ? "Adopt to current worktree"
+                : "No active worktree - select a worktree first"
+              : `Restore ${terminalName}`}
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost-danger"
+              size="icon-sm"
+              onClick={handleKill}
+              aria-label={`Remove ${terminalName} permanently`}
+            >
+              <X aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{`Remove ${terminalName} permanently`}</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -6,7 +6,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface TrashGroupItemProps {
   groupRestoreId: string;
@@ -112,51 +112,47 @@ export function TrashGroupItem({
         </div>
 
         <div className="flex gap-1">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <Button
-                    variant="ghost-success"
-                    size="icon-sm"
-                    onClick={handleRestoreGroup}
-                    disabled={!canRestore}
-                    aria-label={
-                      isOrphan
-                        ? canRestore
-                          ? `Restore group to current worktree`
-                          : "No active worktree to restore to"
-                        : `Restore tab group (${tabCount} tabs)`
-                    }
-                  >
-                    <RotateCcw aria-hidden="true" />
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {isOrphan
-                  ? canRestore
-                    ? "Restore group to current worktree"
-                    : "No active worktree - select a worktree first"
-                  : `Restore tab group (${tabCount} tabs)`}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
                 <Button
-                  variant="ghost-danger"
+                  variant="ghost-success"
                   size="icon-sm"
-                  onClick={handleRemoveAll}
-                  aria-label={`Remove all ${tabCount} tabs permanently`}
+                  onClick={handleRestoreGroup}
+                  disabled={!canRestore}
+                  aria-label={
+                    isOrphan
+                      ? canRestore
+                        ? `Restore group to current worktree`
+                        : "No active worktree to restore to"
+                      : `Restore tab group (${tabCount} tabs)`
+                  }
                 >
-                  <X aria-hidden="true" />
+                  <RotateCcw aria-hidden="true" />
                 </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{`Remove all ${tabCount} tabs permanently`}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {isOrphan
+                ? canRestore
+                  ? "Restore group to current worktree"
+                  : "No active worktree - select a worktree first"
+                : `Restore tab group (${tabCount} tabs)`}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost-danger"
+                size="icon-sm"
+                onClick={handleRemoveAll}
+                aria-label={`Remove all ${tabCount} tabs permanently`}
+              >
+                <X aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{`Remove all ${tabCount} tabs permanently`}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -197,47 +193,43 @@ export function TrashGroupItem({
                     {isActiveTab && <span className="ml-1 text-daintree-text/40">(active)</span>}
                   </span>
                   <div className="flex gap-0.5 opacity-0 group-hover/panel:opacity-100 transition-opacity">
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <Button
-                              variant="ghost-success"
-                              size="icon-sm"
-                              className="h-4 w-4"
-                              onClick={() => {
-                                if (isOrphan && activeWorktreeId) {
-                                  restoreTerminal(terminal.id, activeWorktreeId);
-                                } else {
-                                  restoreTerminal(terminal.id);
-                                }
-                              }}
-                              disabled={!canRestore}
-                              aria-label={`Restore ${terminalName} only`}
-                            >
-                              <RotateCcw className="w-2.5 h-2.5" aria-hidden="true" />
-                            </Button>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">{`Restore ${terminalName} only`}</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
                           <Button
-                            variant="ghost-danger"
+                            variant="ghost-success"
                             size="icon-sm"
                             className="h-4 w-4"
-                            onClick={() => removePanel(terminal.id)}
-                            aria-label={`Remove ${terminalName} permanently`}
+                            onClick={() => {
+                              if (isOrphan && activeWorktreeId) {
+                                restoreTerminal(terminal.id, activeWorktreeId);
+                              } else {
+                                restoreTerminal(terminal.id);
+                              }
+                            }}
+                            disabled={!canRestore}
+                            aria-label={`Restore ${terminalName} only`}
                           >
-                            <X className="w-2.5 h-2.5" aria-hidden="true" />
+                            <RotateCcw className="w-2.5 h-2.5" aria-hidden="true" />
                           </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">{`Remove ${terminalName} permanently`}</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{`Restore ${terminalName} only`}</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost-danger"
+                          size="icon-sm"
+                          className="h-4 w-4"
+                          onClick={() => removePanel(terminal.id)}
+                          aria-label={`Remove ${terminalName} permanently`}
+                        >
+                          <X className="w-2.5 h-2.5" aria-hidden="true" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">{`Remove ${terminalName} permanently`}</TooltipContent>
+                    </Tooltip>
                   </div>
                 </div>
               );

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -1,7 +1,7 @@
 import { Mic } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { cn } from "@/lib/utils";
 import { useKeybindingDisplay } from "@/hooks";
@@ -53,51 +53,49 @@ export function VoiceRecordingToolbarButton({
     .join(" \u00B7 ");
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            onClick={() => {
-              void voiceRecordingService.focusActiveTarget();
-            }}
-            className={cn(
-              "toolbar-icon-button relative transition-colors mr-0.5",
-              isRecording
-                ? "text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
-                : status === "connecting"
-                  ? "text-daintree-text/60 hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
-                  : "text-daintree-accent hover:text-daintree-accent"
-            )}
-            aria-label={tooltipTitle}
-          >
-            {status === "finishing" ? (
-              <Spinner size="md" />
-            ) : (
-              <div className="relative">
-                <Mic className="h-4 w-4" />
-                <span
-                  className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full transition-colors"
-                  style={{
-                    backgroundColor:
-                      status === "connecting"
-                        ? "rgba(var(--theme-accent-rgb), 0.4)"
-                        : `rgba(var(--theme-accent-rgb), ${0.3 + audioLevel * 0.7})`,
-                    transitionDuration: "80ms",
-                  }}
-                />
-              </div>
-            )}
-            <ShortcutRevealChip actionId="voiceInput.toggle" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="text-center">
-          <div className="font-medium">{tooltipTitle}</div>
-          {tooltipExtra && <div className="text-[11px] text-daintree-text/60">{tooltipExtra}</div>}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
+          onClick={() => {
+            void voiceRecordingService.focusActiveTarget();
+          }}
+          className={cn(
+            "toolbar-icon-button relative transition-colors mr-0.5",
+            isRecording
+              ? "text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
+              : status === "connecting"
+                ? "text-daintree-text/60 hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
+                : "text-daintree-accent hover:text-daintree-accent"
+          )}
+          aria-label={tooltipTitle}
+        >
+          {status === "finishing" ? (
+            <Spinner size="md" />
+          ) : (
+            <div className="relative">
+              <Mic className="h-4 w-4" />
+              <span
+                className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full transition-colors"
+                style={{
+                  backgroundColor:
+                    status === "connecting"
+                      ? "rgba(var(--theme-accent-rgb), 0.4)"
+                      : `rgba(var(--theme-accent-rgb), ${0.3 + audioLevel * 0.7})`,
+                  transitionDuration: "80ms",
+                }}
+              />
+            </div>
+          )}
+          <ShortcutRevealChip actionId="voiceInput.toggle" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="text-center">
+        <div className="font-medium">{tooltipTitle}</div>
+        {tooltipExtra && <div className="text-[11px] text-daintree-text/60">{tooltipExtra}</div>}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -25,6 +25,13 @@ vi.mock("@/components/ui/button", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 function makeTrashedItem(id: string): {
   terminal: TerminalInstance;
   trashedInfo: TrashedTerminal;

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -41,7 +41,7 @@ import { LayoutGroup } from "framer-motion";
 import type { PanelKind } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { formatShortcutForTooltip, createTooltipWithShortcut } from "@/lib/platform";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { MoveToDockIcon, MoveToGridIcon, WatchAlertIcon, WorktreeIcon } from "@/components/icons";
@@ -571,30 +571,28 @@ function PanelHeaderComponent({
                         />
                       ))}
                       {onAddTab && (
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  onAddTab();
-                                }}
-                                onPointerDown={(e) => e.stopPropagation()}
-                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                                aria-label="Duplicate panel as new tab"
-                                type="button"
-                              >
-                                <Plus className="w-3 h-3" aria-hidden="true" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">
-                              {createTooltipWithShortcut(
-                                "Duplicate panel as new tab",
-                                duplicateShortcut
-                              )}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onAddTab();
+                              }}
+                              onPointerDown={(e) => e.stopPropagation()}
+                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                              aria-label="Duplicate panel as new tab"
+                              type="button"
+                            >
+                              <Plus className="w-3 h-3" aria-hidden="true" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {createTooltipWithShortcut(
+                              "Duplicate panel as new tab",
+                              duplicateShortcut
+                            )}
+                          </TooltipContent>
+                        </Tooltip>
                       )}
                     </div>
                   </LayoutGroup>
@@ -670,30 +668,25 @@ function PanelHeaderComponent({
                     />
                   ))}
                   {onAddTab && (
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onAddTab();
-                            }}
-                            onPointerDown={(e) => e.stopPropagation()}
-                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                            aria-label="Duplicate panel as new tab"
-                            type="button"
-                          >
-                            <Plus className="w-3 h-3" aria-hidden="true" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">
-                          {createTooltipWithShortcut(
-                            "Duplicate panel as new tab",
-                            duplicateShortcut
-                          )}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onAddTab();
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                          aria-label="Duplicate panel as new tab"
+                          type="button"
+                        >
+                          <Plus className="w-3 h-3" aria-hidden="true" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
               </LayoutGroup>
@@ -742,73 +735,67 @@ function PanelHeaderComponent({
             />
           ) : (
             <div className="flex items-center gap-2 min-w-0">
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className={cn(
-                        "text-xs font-medium font-sans select-none transition-colors",
-                        isFocused || isSelected ? "text-daintree-text" : "text-daintree-text/70",
-                        onTitleChange && "cursor-text hover:text-daintree-text",
-                        isPinged &&
-                          !isMaximized &&
-                          (wasJustSelected ? "animate-eco-title-select" : "animate-eco-title")
-                      )}
-                      onDoubleClick={onTitleDoubleClick}
-                      onKeyDown={onTitleKeyDown}
-                      tabIndex={onTitleChange ? 0 : undefined}
-                      role={onTitleChange ? "button" : undefined}
-                      aria-label={onTitleChange ? getTitleAriaLabel() : undefined}
-                    >
-                      {displayTitle}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {onTitleChange ? `${title} — Double-click to edit` : title}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className={cn(
+                      "text-xs font-medium font-sans select-none transition-colors",
+                      isFocused || isSelected ? "text-daintree-text" : "text-daintree-text/70",
+                      onTitleChange && "cursor-text hover:text-daintree-text",
+                      isPinged &&
+                        !isMaximized &&
+                        (wasJustSelected ? "animate-eco-title-select" : "animate-eco-title")
+                    )}
+                    onDoubleClick={onTitleDoubleClick}
+                    onKeyDown={onTitleKeyDown}
+                    tabIndex={onTitleChange ? 0 : undefined}
+                    role={onTitleChange ? "button" : undefined}
+                    aria-label={onTitleChange ? getTitleAriaLabel() : undefined}
+                  >
+                    {displayTitle}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {onTitleChange ? `${title} — Double-click to edit` : title}
+                </TooltipContent>
+              </Tooltip>
             </div>
           )}
 
           {hasDangerousFlags && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="w-2 h-2 rounded-full bg-status-danger shrink-0"
-                    aria-label="Launched with dangerous permissions"
-                  />
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  Launched with dangerous permissions — agent can modify files without prompting
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                  aria-label="Launched with dangerous permissions"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Launched with dangerous permissions — agent can modify files without prompting
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {isFleetFailed && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      dismissFleetFailure(id);
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    aria-label="Last fleet broadcast failed on this terminal — click to acknowledge"
-                    data-testid="panel-fleet-failure-dot"
-                    className="w-2 h-2 rounded-full bg-status-error shrink-0 hover:scale-125 transition-transform"
-                  />
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  Last fleet broadcast failed here — click to dismiss. Run "Fleet: Retry failed
-                  broadcast" from the command palette to resend.
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    dismissFleetFailure(id);
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  aria-label="Last fleet broadcast failed on this terminal — click to acknowledge"
+                  data-testid="panel-fleet-failure-dot"
+                  className="w-2 h-2 rounded-full bg-status-error shrink-0 hover:scale-125 transition-transform"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Last fleet broadcast failed here — click to dismiss. Run "Fleet: Retry failed
+                broadcast" from the command palette to resend.
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {/* Watch status indicator — non-interactive, shown when actively watching */}
@@ -824,27 +811,25 @@ function PanelHeaderComponent({
 
           {/* Add tab button for single panels */}
           {onAddTab && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAddTab();
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                    aria-label="Duplicate panel as new tab"
-                    type="button"
-                  >
-                    <Plus className="w-3.5 h-3.5" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddTab();
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                  aria-label="Duplicate panel as new tab"
+                  type="button"
+                >
+                  <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
+              </TooltipContent>
+            </Tooltip>
           )}
 
           {/* Worktree branch badge — shown when multiple worktrees are active */}
@@ -894,213 +879,228 @@ function PanelHeaderComponent({
       <div className="flex items-center gap-1">
         {/* Overflow menu — panel management actions */}
         {hasOverflowItems && (
-          <TooltipProvider>
-            <DropdownMenu
-              onOpenChange={(open) => {
-                if (open) setOverflowTooltipOpen(false);
-              }}
-            >
-              <Tooltip open={overflowTooltipOpen} onOpenChange={setOverflowTooltipOpen}>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="p-1.5 hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                      aria-label="More panel actions"
-                    >
-                      <Ellipsis className="w-3 h-3" aria-hidden="true" />
-                    </button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">More panel actions</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end" className="min-w-[160px]">
-                {/* Session group */}
-                {canRestart && onRestart && (
-                  <DropdownMenuItem
-                    onSelect={handleRestartSelect}
-                    className={cn(
-                      armedRestartId === id && "bg-status-warning/10 text-status-warning"
-                    )}
-                    data-testid={armedRestartId === id ? "panel-restart-confirm" : "panel-restart"}
-                    aria-label={
-                      armedRestartId === id
-                        ? `Armed — click again to confirm restart. ${countdown !== null ? `${countdown} seconds remaining` : ""}`
-                        : "Restart Session"
-                    }
+          <DropdownMenu
+            onOpenChange={(open) => {
+              if (open) setOverflowTooltipOpen(false);
+            }}
+          >
+            <Tooltip open={overflowTooltipOpen} onOpenChange={setOverflowTooltipOpen}>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="p-1.5 hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
+                    aria-label="More panel actions"
                   >
-                    <RotateCcw className="w-3 h-3 mr-2" aria-hidden="true" />
-                    {armedRestartId === id
-                      ? `Confirm Restart (${countdown ?? 0}s)`
-                      : "Restart Session"}
-                  </DropdownMenuItem>
-                )}
+                    <Ellipsis className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">More panel actions</TooltipContent>
+            </Tooltip>
+            <DropdownMenuContent align="end" className="min-w-[160px]">
+              {/* Session group */}
+              {canRestart && onRestart && (
+                <DropdownMenuItem
+                  onSelect={handleRestartSelect}
+                  className={cn(
+                    armedRestartId === id && "bg-status-warning/10 text-status-warning"
+                  )}
+                  data-testid={armedRestartId === id ? "panel-restart-confirm" : "panel-restart"}
+                  aria-label={
+                    armedRestartId === id
+                      ? `Armed — click again to confirm restart. ${countdown !== null ? `${countdown} seconds remaining` : ""}`
+                      : "Restart Session"
+                  }
+                >
+                  <RotateCcw className="w-3 h-3 mr-2" aria-hidden="true" />
+                  {armedRestartId === id
+                    ? `Confirm Restart (${countdown ?? 0}s)`
+                    : "Restart Session"}
+                </DropdownMenuItem>
+              )}
 
-                {agentId && (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      void actionService.dispatch(
-                        "terminal.moveToNewWorktree",
-                        { terminalId: id },
-                        { source: "menu" }
-                      )
-                    }
-                  >
-                    <WorktreeIcon className="w-3 h-3 mr-2" aria-hidden="true" />
-                    Move to New Worktree…
-                  </DropdownMenuItem>
-                )}
-
-                {/* Management group */}
-                {((canRestart && onRestart) || agentId) && <DropdownMenuSeparator />}
-                {location === "dock" && onRestore && (
-                  <DropdownMenuItem onSelect={() => onRestore()}>
-                    <MoveToGridIcon className="w-3 h-3 mr-2" aria-hidden="true" />
-                    Restore to Grid
-                  </DropdownMenuItem>
-                )}
+              {agentId && (
                 <DropdownMenuItem
                   onSelect={() =>
                     void actionService.dispatch(
-                      "terminal.rename",
+                      "terminal.moveToNewWorktree",
                       { terminalId: id },
                       { source: "menu" }
                     )
                   }
                 >
-                  <Pencil className="w-3 h-3 mr-2" aria-hidden="true" />
-                  Rename
+                  <WorktreeIcon className="w-3 h-3 mr-2" aria-hidden="true" />
+                  Move to New Worktree…
                 </DropdownMenuItem>
+              )}
+
+              {/* Management group */}
+              {((canRestart && onRestart) || agentId) && <DropdownMenuSeparator />}
+              {location === "dock" && onRestore && (
+                <DropdownMenuItem onSelect={() => onRestore()}>
+                  <MoveToGridIcon className="w-3 h-3 mr-2" aria-hidden="true" />
+                  Restore to Grid
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                onSelect={() =>
+                  void actionService.dispatch(
+                    "terminal.rename",
+                    { terminalId: id },
+                    { source: "menu" }
+                  )
+                }
+              >
+                <Pencil className="w-3 h-3 mr-2" aria-hidden="true" />
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() =>
+                  void actionService.dispatch(
+                    "terminal.duplicate",
+                    { terminalId: id },
+                    { source: "menu" }
+                  )
+                }
+              >
+                <CopyPlus className="w-3 h-3 mr-2" aria-hidden="true" />
+                Duplicate
+              </DropdownMenuItem>
+              {hasPty && (
                 <DropdownMenuItem
                   onSelect={() =>
                     void actionService.dispatch(
-                      "terminal.duplicate",
+                      "terminal.toggleInputLock",
                       { terminalId: id },
                       { source: "menu" }
                     )
                   }
                 >
-                  <CopyPlus className="w-3 h-3 mr-2" aria-hidden="true" />
-                  Duplicate
+                  {isInputLocked ? (
+                    <Unlock className="w-3 h-3 mr-2" aria-hidden="true" />
+                  ) : (
+                    <Lock className="w-3 h-3 mr-2" aria-hidden="true" />
+                  )}
+                  {isInputLocked ? "Unlock Input" : "Lock Input"}
                 </DropdownMenuItem>
-                {hasPty && (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      void actionService.dispatch(
-                        "terminal.toggleInputLock",
-                        { terminalId: id },
-                        { source: "menu" }
-                      )
-                    }
-                  >
-                    {isInputLocked ? (
-                      <Unlock className="w-3 h-3 mr-2" aria-hidden="true" />
-                    ) : (
-                      <Lock className="w-3 h-3 mr-2" aria-hidden="true" />
-                    )}
-                    {isInputLocked ? "Unlock Input" : "Lock Input"}
-                  </DropdownMenuItem>
-                )}
-                {showWatchButton && (
-                  <DropdownMenuItem onSelect={handleWatchToggle}>
-                    {isWatched ? (
-                      <BellOff className="w-3 h-3 mr-2" aria-hidden="true" />
-                    ) : (
-                      <Bell className="w-3 h-3 mr-2" aria-hidden="true" />
-                    )}
-                    {isWatched ? "Cancel Watch" : "Watch"}
-                  </DropdownMenuItem>
-                )}
-                {hasPty && (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      void actionService.dispatch(
-                        "terminal.viewInfo",
-                        { terminalId: id },
-                        { source: "menu" }
-                      )
-                    }
-                  >
-                    <Info className="w-3 h-3 mr-2" aria-hidden="true" />
-                    View Terminal Info
-                  </DropdownMenuItem>
-                )}
-
-                {/* Header actions slot */}
-                {headerActions && <DropdownMenuSeparator />}
-                {headerActions}
-
-                {/* Destructive group */}
-                <DropdownMenuSeparator />
+              )}
+              {showWatchButton && (
+                <DropdownMenuItem onSelect={handleWatchToggle}>
+                  {isWatched ? (
+                    <BellOff className="w-3 h-3 mr-2" aria-hidden="true" />
+                  ) : (
+                    <Bell className="w-3 h-3 mr-2" aria-hidden="true" />
+                  )}
+                  {isWatched ? "Cancel Watch" : "Watch"}
+                </DropdownMenuItem>
+              )}
+              {hasPty && (
                 <DropdownMenuItem
-                  destructive
                   onSelect={() =>
                     void actionService.dispatch(
-                      "terminal.trash",
+                      "terminal.viewInfo",
                       { terminalId: id },
                       { source: "menu" }
                     )
                   }
                 >
-                  <Trash2 className="w-3 h-3 mr-2" aria-hidden="true" />
-                  Trash
+                  <Info className="w-3 h-3 mr-2" aria-hidden="true" />
+                  View Terminal Info
                 </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </TooltipProvider>
+              )}
+
+              {/* Header actions slot */}
+              {headerActions && <DropdownMenuSeparator />}
+              {headerActions}
+
+              {/* Destructive group */}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                destructive
+                onSelect={() =>
+                  void actionService.dispatch(
+                    "terminal.trash",
+                    { terminalId: id },
+                    { source: "menu" }
+                  )
+                }
+              >
+                <Trash2 className="w-3 h-3 mr-2" aria-hidden="true" />
+                Trash
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
 
         {/* Move to Dock — visible button for grid panels */}
         {showMoveToDock && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onMinimize!();
-                  }}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                  aria-label="Move to Dock"
-                  data-testid="panel-move-to-dock"
-                >
-                  <MoveToDockIcon className="w-3 h-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {createTooltipWithShortcut("Move to Dock", moveToDockShortcut)}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMinimize!();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
+                aria-label="Move to Dock"
+                data-testid="panel-move-to-dock"
+              >
+                <MoveToDockIcon className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut("Move to Dock", moveToDockShortcut)}
+            </TooltipContent>
+          </Tooltip>
         )}
 
         {/* Middle control: Collapse-to-Dock / Maximize / Exit Focus */}
         {location === "dock" && onMinimize ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onMinimize();
-                  }}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                  aria-label="Collapse to Dock"
-                  data-testid="panel-collapse-to-dock"
-                >
-                  <MoveToDockIcon className="w-3 h-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {createTooltipWithShortcut("Collapse to Dock", toggleDockShortcut)}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMinimize();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
+                aria-label="Collapse to Dock"
+                data-testid="panel-collapse-to-dock"
+              >
+                <MoveToDockIcon className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut("Collapse to Dock", toggleDockShortcut)}
+            </TooltipContent>
+          </Tooltip>
         ) : onToggleMaximize && isMaximized ? (
-          <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onFocus();
+                  onToggleMaximize();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="flex items-center gap-1.5 px-2 py-1 bg-daintree-accent/10 text-daintree-accent hover:bg-daintree-accent/20 rounded transition-colors mr-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                aria-label="Exit Focus mode and restore grid view"
+              >
+                <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" />
+                <span className="font-medium">Exit Focus</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut("Restore Grid View", maximizeShortcut)}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          onToggleMaximize && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -1110,77 +1110,50 @@ function PanelHeaderComponent({
                     onToggleMaximize();
                   }}
                   onPointerDown={(e) => e.stopPropagation()}
-                  className="flex items-center gap-1.5 px-2 py-1 bg-daintree-accent/10 text-daintree-accent hover:bg-daintree-accent/20 rounded transition-colors mr-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                  aria-label="Exit Focus mode and restore grid view"
+                  className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
+                  aria-label="Maximize"
                 >
-                  <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" />
-                  <span className="font-medium">Exit Focus</span>
+                  <Maximize2 className="w-3 h-3" aria-hidden="true" />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                {createTooltipWithShortcut("Restore Grid View", maximizeShortcut)}
+                {createTooltipWithShortcut("Maximize", maximizeShortcut)}
               </TooltipContent>
             </Tooltip>
-          </TooltipProvider>
-        ) : (
-          onToggleMaximize && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onFocus();
-                      onToggleMaximize();
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    className="p-1.5 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                    aria-label="Maximize"
-                  >
-                    <Maximize2 className="w-3 h-3" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {createTooltipWithShortcut("Maximize", maximizeShortcut)}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
           )
         )}
 
         {/* Close button */}
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                onClick={(e) => {
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose(e.altKey);
+              }}
+              onKeyDown={(e) => {
+                if ((e.key === "Enter" || e.key === " ") && e.altKey) {
+                  e.preventDefault();
                   e.stopPropagation();
-                  onClose(e.altKey);
-                }}
-                onKeyDown={(e) => {
-                  if ((e.key === "Enter" || e.key === " ") && e.altKey) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onClose(true);
-                  }
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                className="p-1.5 hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-status-error focus-visible:outline-offset-2 text-daintree-text/60 hover:text-status-error transition-colors"
-                data-testid="panel-close"
-                aria-label={formatShortcutForTooltip(
-                  "Close session. Hold Alt and click to force close without recovery."
-                )}
-              >
-                <X className="w-3 h-3" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {createTooltipWithShortcut("Close Session", closeShortcut) +
-                " · " +
-                formatShortcutForTooltip("Alt+Click to force close")}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                  onClose(true);
+                }
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className="p-1.5 hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-status-error focus-visible:outline-offset-2 text-daintree-text/60 hover:text-status-error transition-colors"
+              data-testid="panel-close"
+              aria-label={formatShortcutForTooltip(
+                "Close session. Hold Alt and click to force close without recovery."
+              )}
+            >
+              <X className="w-3 h-3" aria-hidden="true" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {createTooltipWithShortcut("Close Session", closeShortcut) +
+              " · " +
+              formatShortcutForTooltip("Alt+Click to force close")}
+          </TooltipContent>
+        </Tooltip>
 
         {/* Kind-specific header content slot */}
         {headerContent}

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -5,7 +5,7 @@ import { X, AlertTriangle } from "lucide-react";
 import type { PanelKind, AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import {
   getEffectiveStateIcon,
@@ -221,145 +221,136 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
   const StateIcon = showStateIcon ? getEffectiveStateIcon(agentState, waitingReason) : null;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            ref={ref}
-            role="tab"
-            aria-selected={isActive}
-            tabIndex={isActive ? 0 : -1}
-            onClick={handleClick}
-            onKeyDown={handleKeyDown}
-            onPointerDown={handlePointerDown}
-            className={cn(
-              "relative flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
-              "border-r border-divider transition-colors",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
-              isActive
-                ? "bg-tint/[0.04] text-daintree-text"
-                : "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-subtle"
-            )}
-            data-tab-id={id}
-            {...mergedAttributes}
-            {...sortableListeners}
-          >
-            {isActive && (
-              <motion.div
-                layoutId="panel-tab-indicator"
-                layout="position"
-                className="absolute inset-x-0 bottom-0 h-0.5 bg-daintree-accent pointer-events-none"
-                transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
-                aria-hidden="true"
-              />
-            )}
-            <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5">
-              <TerminalIcon
-                kind={kind}
-                chrome={chrome}
-                className="w-3.5 h-3.5"
-                brandColor={presetColor ?? chrome.color}
-              />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          ref={ref}
+          role="tab"
+          aria-selected={isActive}
+          tabIndex={isActive ? 0 : -1}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          onPointerDown={handlePointerDown}
+          className={cn(
+            "relative flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
+            "border-r border-divider transition-colors",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+            isActive
+              ? "bg-tint/[0.04] text-daintree-text"
+              : "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-subtle"
+          )}
+          data-tab-id={id}
+          {...mergedAttributes}
+          {...sortableListeners}
+        >
+          {isActive && (
+            <motion.div
+              layoutId="panel-tab-indicator"
+              layout="position"
+              className="absolute inset-x-0 bottom-0 h-0.5 bg-daintree-accent pointer-events-none"
+              transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+              aria-hidden="true"
+            />
+          )}
+          <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5">
+            <TerminalIcon
+              kind={kind}
+              chrome={chrome}
+              className="w-3.5 h-3.5"
+              brandColor={presetColor ?? chrome.color}
+            />
+          </span>
+
+          {isEditing ? (
+            <input
+              ref={inputRef}
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleInputKeyDown}
+              onBlur={handleInputBlur}
+              onClick={handleInputClick}
+              onDoubleClick={handleInputDoubleClick}
+              onPointerDown={handleInputPointerDown}
+              className="text-xs bg-daintree-bg/80 border border-daintree-accent/50 px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent"
+              aria-label={`Rename tab ${title}`}
+            />
+          ) : (
+            <span
+              className={cn("truncate max-w-[100px]", onRename && "cursor-text")}
+              onDoubleClick={handleDoubleClick}
+            >
+              {title}
             </span>
+          )}
 
-            {isEditing ? (
-              <input
-                ref={inputRef}
-                type="text"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleInputKeyDown}
-                onBlur={handleInputBlur}
-                onClick={handleInputClick}
-                onDoubleClick={handleInputDoubleClick}
-                onPointerDown={handleInputPointerDown}
-                className="text-xs bg-daintree-bg/80 border border-daintree-accent/50 px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent"
-                aria-label={`Rename tab ${title}`}
-              />
-            ) : (
-              <span
-                className={cn("truncate max-w-[100px]", onRename && "cursor-text")}
-                onDoubleClick={handleDoubleClick}
-              >
-                {title}
-              </span>
-            )}
+          {showStateIcon && StateIcon && (
+            <StateIcon
+              className={cn(
+                "w-3 h-3 shrink-0",
+                getEffectiveStateColor(agentState, waitingReason),
+                agentState === "working" && "animate-spin-slow",
+                "motion-reduce:animate-none"
+              )}
+              aria-hidden="true"
+            />
+          )}
 
-            {showStateIcon && StateIcon && (
-              <StateIcon
+          {isUsingFallback && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <AlertTriangle
+                  className="w-3 h-3 shrink-0 text-status-warning"
+                  aria-label="Running on fallback preset"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {fallbackTooltip ?? "Running on fallback preset — original provider unavailable"}
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {hasDangerousFlags && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="w-2 h-2 rounded-full bg-status-danger shrink-0"
+                  aria-label="Launched with dangerous permissions"
+                />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                Launched with dangerous permissions — agent can modify files without prompting
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {/* Close button - visible on hover */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleClose}
+                onKeyDown={handleCloseKeyDown}
                 className={cn(
-                  "w-3 h-3 shrink-0",
-                  getEffectiveStateColor(agentState, waitingReason),
-                  agentState === "working" && "animate-spin-slow",
-                  "motion-reduce:animate-none"
+                  "shrink-0 p-0.5 -mr-1 rounded transition-colors",
+                  "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
+                  "hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)]",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
+                  "text-daintree-text/40 hover:text-status-error"
                 )}
-                aria-hidden="true"
-              />
-            )}
-
-            {isUsingFallback && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <AlertTriangle
-                      className="w-3 h-3 shrink-0 text-status-warning"
-                      aria-label="Running on fallback preset"
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {fallbackTooltip ??
-                      "Running on fallback preset — original provider unavailable"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {hasDangerousFlags && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span
-                      className="w-2 h-2 rounded-full bg-status-danger shrink-0"
-                      aria-label="Launched with dangerous permissions"
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    Launched with dangerous permissions — agent can modify files without prompting
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
-
-            {/* Close button - visible on hover */}
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={handleClose}
-                    onKeyDown={handleCloseKeyDown}
-                    className={cn(
-                      "shrink-0 p-0.5 -mr-1 rounded transition-colors",
-                      "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
-                      "hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)]",
-                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
-                      "text-daintree-text/40 hover:text-status-error"
-                    )}
-                    aria-label={`Close ${title}`}
-                    type="button"
-                  >
-                    <X className="w-3 h-3" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Close tab</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {onRename ? `${title} — Double-click to rename` : title}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+                aria-label={`Close ${title}`}
+                type="button"
+              >
+                <X className="w-3 h-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Close tab</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {onRename ? `${title} — Double-click to rename` : title}
+      </TooltipContent>
+    </Tooltip>
   );
 });
 

--- a/src/components/Portal/PortalToolbar.tsx
+++ b/src/components/Portal/PortalToolbar.tsx
@@ -19,7 +19,7 @@ import { CSS } from "@dnd-kit/utilities";
 import type { PortalTab, PortalLink } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { createTooltipWithShortcut } from "@/lib/platform";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePortalStore } from "@/store/portalStore";
 import { PortalIcon } from "./PortalIcon";
 import { useKeybindingDisplay } from "@/hooks";
@@ -235,100 +235,88 @@ export function PortalToolbar({
       {/* Top Row: Navigation Controls */}
       <div className="flex items-center justify-between px-2 py-1.5">
         <div className="flex items-center gap-0.5">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onGoBack}
-                  disabled={!activeTabId}
-                  aria-label="Go back"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ArrowLeft className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Go back</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onGoForward}
-                  disabled={!activeTabId}
-                  aria-label="Go forward"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Go forward</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onReload}
-                  disabled={!activeTabId}
-                  aria-label="Reload"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <RotateCw className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Reload</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onCopyUrl}
-                  disabled={!activeTabId || !hasActiveUrl}
-                  aria-label="Copy URL"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <Link2 className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Copy URL</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onOpenExternal}
-                  disabled={!activeTabId || !hasActiveUrl}
-                  aria-label="Open in external browser"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Open in external browser</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onGoBack}
+                disabled={!activeTabId}
+                aria-label="Go back"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ArrowLeft className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Go back</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onGoForward}
+                disabled={!activeTabId}
+                aria-label="Go forward"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ArrowRight className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Go forward</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onReload}
+                disabled={!activeTabId}
+                aria-label="Reload"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <RotateCw className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reload</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onCopyUrl}
+                disabled={!activeTabId || !hasActiveUrl}
+                aria-label="Copy URL"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <Link2 className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Copy URL</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onOpenExternal}
+                disabled={!activeTabId || !hasActiveUrl}
+                aria-label="Open in external browser"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in external browser</TooltipContent>
+          </Tooltip>
         </div>
 
         <div className="flex items-center gap-1">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onClose}
-                  aria-label="Close portal"
-                  className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors ml-1"
-                >
-                  <X className="w-4 h-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {createTooltipWithShortcut("Close portal", closePortalShortcut)}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onClose}
+                aria-label="Close portal"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors ml-1"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut("Close portal", closePortalShortcut)}
+            </TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -374,33 +362,31 @@ export function PortalToolbar({
                   tabIndex={index}
                 />
               ))}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={onNewTab}
-                      onContextMenu={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        void window.electron.portal.showNewTabMenu({
-                          x: e.screenX,
-                          y: e.screenY,
-                          links: enabledLinks.map((link) => ({ title: link.title, url: link.url })),
-                          defaultNewTabUrl,
-                        });
-                      }}
-                      className="flex items-center justify-center w-8 h-[26px] rounded-full bg-overlay-subtle hover:bg-overlay-soft text-daintree-text/70 hover:text-daintree-text border border-divider transition"
-                      aria-label="New Tab"
-                      aria-haspopup="menu"
-                    >
-                      <Plus className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {createTooltipWithShortcut("New Tab", newTabShortcut)}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={onNewTab}
+                    onContextMenu={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      void window.electron.portal.showNewTabMenu({
+                        x: e.screenX,
+                        y: e.screenY,
+                        links: enabledLinks.map((link) => ({ title: link.title, url: link.url })),
+                        defaultNewTabUrl,
+                      });
+                    }}
+                    className="flex items-center justify-center w-8 h-[26px] rounded-full bg-overlay-subtle hover:bg-overlay-soft text-daintree-text/70 hover:text-daintree-text border border-divider transition"
+                    aria-label="New Tab"
+                    aria-haspopup="menu"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {createTooltipWithShortcut("New Tab", newTabShortcut)}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </SortableContext>
         </DndContext>

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -5,7 +5,7 @@ import { getProjectGradient } from "@/lib/colorUtils";
 import { useProjectStore } from "@/store/projectStore";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { useProjectSwitcherPalette } from "@/hooks";
 import { actionService } from "@/services/ActionService";
@@ -234,57 +234,51 @@ export function ProjectSwitcher() {
         onConfirmRemove={projectSwitcher.confirmRemoveProject}
         isRemovingProject={projectSwitcher.isRemovingProject}
       >
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                className={cn(
-                  "relative w-full justify-between h-12 px-2.5",
-                  "rounded-[var(--radius-lg)]",
-                  "border border-border-subtle",
-                  "bg-surface-panel-elevated shadow-[inset_0_1px_0_var(--color-overlay-soft)]",
-                  "hover:bg-surface-panel-elevated transition-colors",
-                  "active:scale-100"
-                )}
-                disabled={isLoading}
-                onClick={() => projectSwitcher.open("dropdown")}
-              >
-                <div className="flex items-center gap-3 text-left min-w-0">
-                  {renderIcon(
-                    currentProject.emoji || "🌲",
-                    currentProject.color,
-                    "h-9 w-9 text-xl"
-                  )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              className={cn(
+                "relative w-full justify-between h-12 px-2.5",
+                "rounded-[var(--radius-lg)]",
+                "border border-border-subtle",
+                "bg-surface-panel-elevated shadow-[inset_0_1px_0_var(--color-overlay-soft)]",
+                "hover:bg-surface-panel-elevated transition-colors",
+                "active:scale-100"
+              )}
+              disabled={isLoading}
+              onClick={() => projectSwitcher.open("dropdown")}
+            >
+              <div className="flex items-center gap-3 text-left min-w-0">
+                {renderIcon(currentProject.emoji || "🌲", currentProject.color, "h-9 w-9 text-xl")}
 
-                  <div className="flex flex-col min-w-0 gap-0.5">
-                    <span className="truncate font-semibold text-daintree-text text-sm leading-none">
-                      {currentProject.name}
-                    </span>
-                    <span className="truncate font-mono text-xs text-text-secondary">
-                      {currentProject.path.split(/[/\\]/).pop()}
-                    </span>
-                  </div>
+                <div className="flex flex-col min-w-0 gap-0.5">
+                  <span className="truncate font-semibold text-daintree-text text-sm leading-none">
+                    {currentProject.name}
+                  </span>
+                  <span className="truncate font-mono text-xs text-text-secondary">
+                    {currentProject.path.split(/[/\\]/).pop()}
+                  </span>
                 </div>
-                <ChevronsUpDown className="shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
-                {badgeStatus && (
-                  <span
-                    role="status"
-                    aria-label={`${badgeStatus.count} background agent${badgeStatus.count === 1 ? "" : "s"} ${badgeStatus.pulse ? "working" : "waiting"}`}
-                    className={cn(
-                      "absolute top-1 right-1 h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
-                      badgeStatus.color,
-                      badgeStatus.pulse && "animate-activity-pulse"
-                    )}
-                  />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              Switch project{projectSwitcherShortcut ? ` (${projectSwitcherShortcut})` : ""}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+              </div>
+              <ChevronsUpDown className="shrink-0 text-text-muted transition-colors group-hover:text-text-secondary" />
+              {badgeStatus && (
+                <span
+                  role="status"
+                  aria-label={`${badgeStatus.count} background agent${badgeStatus.count === 1 ? "" : "s"} ${badgeStatus.pulse ? "working" : "waiting"}`}
+                  className={cn(
+                    "absolute top-1 right-1 h-2 w-2 rounded-full ring-2 ring-[var(--color-surface-panel-elevated)]",
+                    badgeStatus.color,
+                    badgeStatus.pulse && "animate-activity-pulse"
+                  )}
+                />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            Switch project{projectSwitcherShortcut ? ` (${projectSwitcherShortcut})` : ""}
+          </TooltipContent>
+        </Tooltip>
       </ProjectSwitcherPalette>
     </>
   );

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -17,7 +17,6 @@ import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -598,7 +597,7 @@ function ProjectPaletteInner({
   const activeResult = results[selectedIndex];
 
   return (
-    <TooltipProvider>
+    <>
       <AppPaletteDialog.Header
         label="Switch Project"
         keyHint={projectSwitcherShortcut}
@@ -703,7 +702,7 @@ function ProjectPaletteInner({
       <AppPaletteDialog.Footer>
         <ProjectSwitcherFooter mode={mode} />
       </AppPaletteDialog.Footer>
-    </TooltipProvider>
+    </>
   );
 }
 

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -16,7 +16,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { RunCommand } from "@/types";
 import { RunningTaskList } from "./RunningTaskList";
 
@@ -426,88 +426,82 @@ export function QuickRun({ projectId }: QuickRunProps) {
                 {/* Right Side Controls */}
                 <div className="flex items-center pr-1.5 gap-1">
                   {/* Auto-Restart Toggle */}
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={handleToggleAutoRestart}
-                          className={cn(
-                            "p-1.5 rounded-[var(--radius-sm)] transition",
-                            autoRestart
-                              ? "bg-daintree-accent/20 text-daintree-accent"
-                              : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
-                          )}
-                          aria-label={autoRestart ? "Disable auto-restart" : "Enable auto-restart"}
-                          aria-pressed={autoRestart}
-                        >
-                          <RefreshCw className="h-3.5 w-3.5" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {autoRestart ? "Auto-restart: On" : "Auto-restart: Off"}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={handleToggleAutoRestart}
+                        className={cn(
+                          "p-1.5 rounded-[var(--radius-sm)] transition",
+                          autoRestart
+                            ? "bg-daintree-accent/20 text-daintree-accent"
+                            : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
+                        )}
+                        aria-label={autoRestart ? "Disable auto-restart" : "Enable auto-restart"}
+                        aria-pressed={autoRestart}
+                      >
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {autoRestart ? "Auto-restart: On" : "Auto-restart: Off"}
+                    </TooltipContent>
+                  </Tooltip>
 
                   {/* Location Toggle */}
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => setRunAsDocked(!runAsDocked)}
-                          className={cn(
-                            "p-1.5 rounded-[var(--radius-sm)] transition",
-                            runAsDocked
-                              ? "bg-daintree-accent/20 text-daintree-accent"
-                              : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
-                          )}
-                          aria-label={
-                            runAsDocked
-                              ? "Send output to Dock (background task)"
-                              : "Send output to Grid (interactive terminal)"
-                          }
-                        >
-                          {runAsDocked ? (
-                            <PanelBottom className="h-3.5 w-3.5" />
-                          ) : (
-                            <LayoutGrid className="h-3.5 w-3.5" />
-                          )}
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {runAsDocked
-                          ? "Output: Dock (Background Task)"
-                          : "Output: Grid (Interactive Terminal)"}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => setRunAsDocked(!runAsDocked)}
+                        className={cn(
+                          "p-1.5 rounded-[var(--radius-sm)] transition",
+                          runAsDocked
+                            ? "bg-daintree-accent/20 text-daintree-accent"
+                            : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
+                        )}
+                        aria-label={
+                          runAsDocked
+                            ? "Send output to Dock (background task)"
+                            : "Send output to Grid (interactive terminal)"
+                        }
+                      >
+                        {runAsDocked ? (
+                          <PanelBottom className="h-3.5 w-3.5" />
+                        ) : (
+                          <LayoutGrid className="h-3.5 w-3.5" />
+                        )}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {runAsDocked
+                        ? "Output: Dock (Background Task)"
+                        : "Output: Grid (Interactive Terminal)"}
+                    </TooltipContent>
+                  </Tooltip>
 
                   {/* Enter Button */}
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex">
-                          <button
-                            type="button"
-                            onClick={() => handleRun(input)}
-                            disabled={!input.trim()}
-                            className={cn(
-                              "p-1.5 rounded-[var(--radius-sm)] transition",
-                              input.trim()
-                                ? "text-accent-primary hover:bg-accent-soft"
-                                : "cursor-not-allowed text-text-muted/50"
-                            )}
-                            aria-label="Run command"
-                          >
-                            <CornerDownLeft className="h-3.5 w-3.5" />
-                          </button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Run Command (Enter)</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <button
+                          type="button"
+                          onClick={() => handleRun(input)}
+                          disabled={!input.trim()}
+                          className={cn(
+                            "p-1.5 rounded-[var(--radius-sm)] transition",
+                            input.trim()
+                              ? "text-accent-primary hover:bg-accent-soft"
+                              : "cursor-not-allowed text-text-muted/50"
+                          )}
+                          aria-label="Run command"
+                        >
+                          <CornerDownLeft className="h-3.5 w-3.5" />
+                        </button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Run Command (Enter)</TooltipContent>
+                  </Tooltip>
                 </div>
 
                 {/* Autocomplete Menu */}

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -7,7 +7,7 @@ import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalRecipe, Worktree } from "@/types";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -171,7 +171,7 @@ export function RecipesTab({
   };
 
   return (
-    <TooltipProvider delayDuration={400} skipDelayDuration={300}>
+    <>
       <div className="mb-6">
         <h3 className="text-sm font-semibold text-daintree-text/80 mb-2 flex items-center gap-2">
           <TerminalRecipeIcon className="h-4 w-4" />
@@ -399,6 +399,6 @@ export function RecipesTab({
           </Button>
         </AppDialog.Footer>
       </AppDialog>
-    </TooltipProvider>
+    </>
   );
 }

--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import type { CSSProperties } from "react";
 import type { HeatCell, PulseRangeDays } from "@shared/types";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 interface PulseHeatmapProps {
   cells: HeatCell[];
@@ -126,65 +126,63 @@ export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmap
   const rowWidth = columns > 0 ? cellSize * columns + gap * (columns - 1) : 0;
 
   return (
-    <TooltipProvider delayDuration={0} skipDelayDuration={0}>
-      <div
-        className="flex flex-col"
-        style={{ gap: `${gap}px`, width: `${rowWidth}px` }}
-        role="group"
-        aria-label={`Activity over the last ${rangeDays} days`}
-        data-testid="pulse-heatmap"
-      >
-        {rows.map((row, rowIndex) => (
-          <div
-            key={rowIndex}
-            className={cn(
-              "flex",
-              rowIndex === 0 && rows.length > 1 && row.length < columns && "justify-end"
-            )}
-            style={{ gap: `${gap}px` }}
-          >
-            {row.map((cell) => {
-              const date = new Date(cell.date);
-              const formatted = date.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-              });
+    <div
+      className="flex flex-col"
+      style={{ gap: `${gap}px`, width: `${rowWidth}px` }}
+      role="group"
+      aria-label={`Activity over the last ${rangeDays} days`}
+      data-testid="pulse-heatmap"
+    >
+      {rows.map((row, rowIndex) => (
+        <div
+          key={rowIndex}
+          className={cn(
+            "flex",
+            rowIndex === 0 && rows.length > 1 && row.length < columns && "justify-end"
+          )}
+          style={{ gap: `${gap}px` }}
+        >
+          {row.map((cell) => {
+            const date = new Date(cell.date);
+            const formatted = date.toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+            });
 
-              const ringStyle = (
-                cell.isMostRecentActive
-                  ? { "--tw-ring-offset-color": "var(--pulse-ring-offset, var(--pulse-card-bg))" }
-                  : {}
-              ) as CSSProperties;
+            const ringStyle = (
+              cell.isMostRecentActive
+                ? { "--tw-ring-offset-color": "var(--pulse-ring-offset, var(--pulse-card-bg))" }
+                : {}
+            ) as CSSProperties;
 
-              return (
-                <Tooltip key={cell.date} delayDuration={0}>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      style={{
-                        width: `${cellSize}px`,
-                        height: `${cellSize}px`,
-                        ...getCellStyle(cell),
-                        ...ringStyle,
-                      }}
-                      className={cn(
-                        "rounded-[2px] shrink-0 border-0 p-0 cursor-default transition-[transform,background-color,box-shadow] duration-150",
-                        cell.isMostRecentActive && "ring-1 ring-daintree-accent/45 ring-offset-1"
-                      )}
-                      aria-label={`${formatted}: ${getTooltipText(cell)}`}
-                      tabIndex={0}
-                    />
-                  </TooltipTrigger>
-                  <TooltipContent side="top" className="text-xs">
-                    <span className="font-medium">{formatted}</span>
-                    <span className="ml-1 text-daintree-text/60">{getTooltipText(cell)}</span>
-                  </TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </div>
-        ))}
-      </div>
-    </TooltipProvider>
+            return (
+              <Tooltip key={cell.date} delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    style={{
+                      width: `${cellSize}px`,
+                      height: `${cellSize}px`,
+                      ...getCellStyle(cell),
+                      ...ringStyle,
+                    }}
+                    className={cn(
+                      "rounded-[2px] shrink-0 border-0 p-0 cursor-default transition-[transform,background-color,box-shadow] duration-150",
+                      cell.isMostRecentActive && "ring-1 ring-daintree-accent/45 ring-offset-1"
+                    )}
+                    aria-label={`${formatted}: ${getTooltipText(cell)}`}
+                    tabIndex={0}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  <span className="font-medium">{formatted}</span>
+                  <span className="ml-1 text-daintree-text/60">{getTooltipText(cell)}</span>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </div>
+      ))}
+    </div>
   );
 }

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { WorktreeIcon } from "@/components/icons";
 import type { QuickSwitcherItem as QuickSwitcherItemData } from "@/hooks/useQuickSwitcher";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface QuickSwitcherItemProps {
   item: QuickSwitcherItemData;
@@ -60,14 +60,12 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
           </span>
         </div>
         {item.subtitle && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="text-xs text-daintree-text/50 truncate">{item.subtitle}</div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{item.subtitle}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="text-xs text-daintree-text/50 truncate">{item.subtitle}</div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{item.subtitle}</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </button>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { commandsClient } from "@/clients/commandsClient";
 import type { CommandManifestEntry, CommandOverride } from "@shared/types/commands";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { extractTemplateVariables, validatePromptTemplate } from "@shared/utils/promptTemplate";
 
 interface CommandOverridesTabProps {
@@ -372,50 +372,46 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
 
                 <div className="flex items-center gap-1 shrink-0">
                   {hasOverride(command.id) && (
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => resetToDefaults(command.id)}
-                            className="h-7 px-2"
-                            aria-label="Reset to defaults"
-                          >
-                            <RotateCcw />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">Reset to defaults</TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )}
-                  <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
-                          onClick={() => toggleDisabled(command.id)}
-                          className={cn(
-                            "p-1.5 rounded transition-colors",
-                            isDisabled
-                              ? "text-status-error hover:bg-status-error/10"
-                              : "text-status-success hover:bg-status-success/10"
-                          )}
-                          aria-label={
-                            isDisabled ? "Command disabled for this project" : "Command enabled"
-                          }
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => resetToDefaults(command.id)}
+                          className="h-7 px-2"
+                          aria-label="Reset to defaults"
                         >
-                          {isDisabled ? (
-                            <PowerOff className="h-4 w-4" />
-                          ) : (
-                            <Power className="h-4 w-4" />
-                          )}
-                        </button>
+                          <RotateCcw />
+                        </Button>
                       </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {isDisabled ? "Command disabled for this project" : "Command enabled"}
-                      </TooltipContent>
+                      <TooltipContent side="bottom">Reset to defaults</TooltipContent>
                     </Tooltip>
-                  </TooltipProvider>
+                  )}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => toggleDisabled(command.id)}
+                        className={cn(
+                          "p-1.5 rounded transition-colors",
+                          isDisabled
+                            ? "text-status-error hover:bg-status-error/10"
+                            : "text-status-success hover:bg-status-success/10"
+                        )}
+                        aria-label={
+                          isDisabled ? "Command disabled for this project" : "Command enabled"
+                        }
+                      >
+                        {isDisabled ? (
+                          <PowerOff className="h-4 w-4" />
+                        ) : (
+                          <Power className="h-4 w-4" />
+                        )}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {isDisabled ? "Command disabled for this project" : "Command enabled"}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
 
@@ -560,28 +556,26 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
             <p className="text-xs font-medium text-daintree-text/70 mb-1.5">Available variables:</p>
             <div className="flex flex-wrap gap-1.5">
               {args.map((arg) => (
-                <TooltipProvider key={arg.name}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={() => onChange(value + `{${arg.name}}`)}
-                        className={cn(
-                          "text-[11px] px-2 py-0.5 rounded font-mono transition-colors",
-                          usedVariables.includes(arg.name)
-                            ? "bg-daintree-accent/20 text-daintree-accent border border-daintree-accent/30"
-                            : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border border border-daintree-border"
-                        )}
-                      >
-                        {"{"}
-                        {arg.name}
-                        {"}"}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {arg.description || `Insert {${arg.name}}`}
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => onChange(value + `{${arg.name}}`)}
+                      className={cn(
+                        "text-[11px] px-2 py-0.5 rounded font-mono transition-colors",
+                        usedVariables.includes(arg.name)
+                          ? "bg-daintree-accent/20 text-daintree-accent border border-daintree-accent/30"
+                          : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border border border-daintree-border"
+                      )}
+                    >
+                      {"{"}
+                      {arg.name}
+                      {"}"}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {arg.description || `Insert {${arg.name}}`}
+                  </TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -556,7 +556,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
             <p className="text-xs font-medium text-daintree-text/70 mb-1.5">Available variables:</p>
             <div className="flex flex-wrap gap-1.5">
               {args.map((arg) => (
-                <Tooltip>
+                <Tooltip key={arg.name}>
                   <TooltipTrigger asChild>
                     <button
                       onClick={() => onChange(value + `{${arg.name}}`)}

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 import { keybindingService, KeybindingConfig } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { KeybindingProfileActions } from "./KeybindingProfileActions";
 import { SettingsShortcutCapture } from "@/components/KeyboardShortcuts";
 
@@ -69,20 +69,18 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
           Edit
         </button>
         {binding.isOverridden && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={onReset}
-                  className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover:opacity-100 transition-opacity"
-                  aria-label="Reset to default"
-                >
-                  <RotateCcw className="w-3 h-3" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Reset to default</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onReset}
+                className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Reset to default"
+              >
+                <RotateCcw className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reset to default</TooltipContent>
+          </Tooltip>
         )}
       </div>
     </div>

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -1,7 +1,7 @@
 import { useId, useState } from "react";
 import { Plus, Trash2, Globe, Check, X, Search, PanelRight, Link } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePortalStore } from "@/store/portalStore";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
@@ -245,16 +245,14 @@ export function PortalSettingsTab() {
           <div className="flex flex-col">
             <span className="text-sm text-daintree-text">{link.title}</span>
             {!allowDelete && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-[11px] font-mono text-daintree-text/50 truncate min-w-0">
-                      {link.url}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{link.url}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-[11px] font-mono text-daintree-text/50 truncate min-w-0">
+                    {link.url}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{link.url}</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, Check, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   validatePathPattern,
   previewPathPattern,
@@ -180,20 +180,18 @@ export function WorktreeSettingsTab() {
                 )}
                 placeholder="{parent-dir}/{base-folder}-worktrees/{branch-slug}"
               />
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={handleReset}
-                      className="px-3 py-1.5 border border-daintree-border rounded-[var(--radius-md)] text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors"
-                      aria-label="Reset to default"
-                    >
-                      <RotateCcw className="w-4 h-4" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Reset to default</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleReset}
+                    className="px-3 py-1.5 border border-daintree-border rounded-[var(--radius-md)] text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors"
+                    aria-label="Reset to default"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Reset to default</TooltipContent>
+              </Tooltip>
             </div>
 
             {!validation.valid && validation.error && (
@@ -239,24 +237,22 @@ export function WorktreeSettingsTab() {
             <span className="block text-xs font-medium text-daintree-text/70">Presets:</span>
             <div className="flex flex-wrap gap-2">
               {PATTERN_PRESETS.map((preset) => (
-                <TooltipProvider key={preset.label}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={() => handlePresetClick(preset.pattern)}
-                        className={cn(
-                          "px-3 py-1.5 text-xs rounded-[var(--radius-md)] border transition-colors",
-                          pattern === preset.pattern
-                            ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
-                            : "border-daintree-border text-daintree-text/70 hover:bg-daintree-border/50"
-                        )}
-                      >
-                        {preset.label}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{preset.description}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => handlePresetClick(preset.pattern)}
+                      className={cn(
+                        "px-3 py-1.5 text-xs rounded-[var(--radius-md)] border transition-colors",
+                        pattern === preset.pattern
+                          ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                          : "border-daintree-border text-daintree-text/70 hover:bg-daintree-border/50"
+                      )}
+                    >
+                      {preset.label}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{preset.description}</TooltipContent>
+                </Tooltip>
               ))}
             </div>
           </div>

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -237,7 +237,7 @@ export function WorktreeSettingsTab() {
             <span className="block text-xs font-medium text-daintree-text/70">Presets:</span>
             <div className="flex flex-wrap gap-2">
               {PATTERN_PRESETS.map((preset) => (
-                <Tooltip>
+                <Tooltip key={preset.label}>
                   <TooltipTrigger asChild>
                     <button
                       onClick={() => handlePresetClick(preset.pattern)}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -21,7 +21,7 @@ import {
   useKeybindingDisplay,
 } from "@/hooks";
 import { createTooltipWithShortcut } from "@/lib/platform";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   WorktreeCard,
   type WorktreeCardProps,
@@ -892,269 +892,267 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   );
 
   return (
-    <TooltipProvider delayDuration={400} skipDelayDuration={300}>
-      <div className="flex flex-col h-full">
-        {/* Header Section */}
-        <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
-          <div className="flex items-baseline gap-1.5">
-            <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
-            <span className="text-daintree-text/50 text-xs">
-              {hasFilters && visibleCount !== deferredWorktrees.length
-                ? `(${visibleCount} of ${deferredWorktrees.length})`
-                : `(${deferredWorktrees.length})`}
+    <div className="flex flex-col h-full">
+      {/* Header Section */}
+      <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
+        <div className="flex items-baseline gap-1.5">
+          <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+          <span className="text-daintree-text/50 text-xs">
+            {hasFilters && visibleCount !== deferredWorktrees.length
+              ? `(${visibleCount} of ${deferredWorktrees.length})`
+              : `(${deferredWorktrees.length})`}
+          </span>
+          {isReconnecting && (
+            <span
+              role="status"
+              aria-live="polite"
+              className="flex items-center gap-1 text-daintree-text/60 text-xs"
+            >
+              <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
+              Reconnecting…
             </span>
-            {isReconnecting && (
-              <span
-                role="status"
-                aria-live="polite"
-                className="flex items-center gap-1 text-daintree-text/60 text-xs"
-              >
-                <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
-                Reconnecting…
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={onOpenOverview}
-                    className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
-                    aria-label="Open worktrees overview"
-                  >
-                    <LayoutGrid className="w-3.5 h-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {createTooltipWithShortcut("Open worktrees overview", overviewShortcut)}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={() =>
-                      actionService.dispatch("terminal.bulkCommand", undefined, {
-                        source: "user",
-                      })
-                    }
-                    className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
-                    aria-label="Broadcast to armed agents"
-                  >
-                    <BroadcastTerminalIcon className="w-3.5 h-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Broadcast to agents</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={handleRefreshAll}
-                    disabled={isRefreshing}
-                    className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                    aria-label="Refresh sidebar"
-                  >
-                    <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Refresh sidebar</TooltipContent>
-              </Tooltip>
-            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onOpenOverview}
+                  className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
+                  aria-label="Open worktrees overview"
+                >
+                  <LayoutGrid className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {createTooltipWithShortcut("Open worktrees overview", overviewShortcut)}
+              </TooltipContent>
+            </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   onClick={() =>
-                    actionService.dispatch("worktree.createDialog.open", undefined, {
+                    actionService.dispatch("terminal.bulkCommand", undefined, {
                       source: "user",
                     })
                   }
                   className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
-                  aria-label="Create new worktree"
+                  aria-label="Broadcast to armed agents"
                 >
-                  <Plus className="w-3.5 h-3.5" />
+                  <BroadcastTerminalIcon className="w-3.5 h-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Create new worktree</TooltipContent>
+              <TooltipContent side="bottom">Broadcast to agents</TooltipContent>
             </Tooltip>
-          </div>
-        </div>
-
-        {/* Inline search bar — only when there are non-main worktrees */}
-        {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
-
-        {/* Arm all terminals matching the active filter — only when a filter narrows the list */}
-        {hasNonMainWorktrees && hasFilters && filteredWorktrees.length > 0 && (
-          <div className="shrink-0 px-4 py-1.5 border-b border-divider">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
-                  type="button"
-                  onClick={() =>
-                    actionService.dispatch(
-                      "fleet.armMatchingFilter",
-                      { worktreeIds: filteredWorktrees.map((w) => w.id) },
-                      { source: "user" }
-                    )
-                  }
-                  className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
-                  aria-label={`Arm ${filteredWorktrees.length} matching worktrees`}
+                  onClick={handleRefreshAll}
+                  disabled={isRefreshing}
+                  className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  aria-label="Refresh sidebar"
                 >
-                  <BroadcastTerminalIcon className="w-3 h-3" />
-                  Arm {filteredWorktrees.length} matching
+                  <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">
-                Arm all eligible terminals in the {filteredWorktrees.length} worktrees visible below
-              </TooltipContent>
+              <TooltipContent side="bottom">Refresh sidebar</TooltipContent>
             </Tooltip>
           </div>
-        )}
-
-        {/* Main worktree — visible unless excluded by text search */}
-        {mainMatchesQuery && (
-          <div
-            className="shrink-0"
-            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
-          >
-            <StaticWorktreeRow
-              key={mainWorktree.id}
-              worktreeId={mainWorktree.id}
-              activeWorktreeId={activeWorktreeId}
-              focusedWorktreeId={focusedWorktreeId}
-              totalWorktreeCount={deferredWorktrees.length}
-              selectWorktree={selectWorktree}
-              worktreeActions={worktreeActions}
-              availability={availability}
-              agentSettings={agentSettings}
-              homeDir={homeDir}
-              aggregateCounts={mainWorktreeAggregateCounts}
-            />
-          </div>
-        )}
-
-        {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
-        {integrationMatchesQuery && (
-          <div
-            className="shrink-0"
-            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
-          >
-            {renderWorktreeCard(integrationWorktree)}
-          </div>
-        )}
-
-        {/* Strong divider between pinned worktrees and scrollable list */}
-        {hasNonMainWorktrees && <div className="shrink-0 border-b border-border-default" />}
-
-        {/* Non-main worktree list */}
-        <div className="relative flex-1 min-h-0">
-          <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
-            <div ref={scrollContentRef}>
-              {hasNonMainWorktrees && (
-                <QuickStateFilterBar
-                  value={quickStateFilter}
-                  onChange={setQuickStateFilter}
-                  counts={quickStateCounts}
-                />
-              )}
-              {filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
-                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                  <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
-                  <p className="text-sm text-daintree-text/60 mb-3">
-                    No worktrees match your filters
-                  </p>
-                  <button
-                    onClick={clearAllFilters}
-                    className="text-xs px-3 py-1.5 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
-                  >
-                    Clear filters
-                  </button>
-                </div>
-              ) : groupedSections ? (
-                <div className="flex flex-col">
-                  {groupedSections.map((section) => (
-                    <div key={section.type}>
-                      <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide bg-daintree-sidebar border-b border-divider">
-                        {section.displayName} ({section.worktrees.length})
-                      </div>
-                      {section.worktrees.map(renderWorktreeCard)}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                  <div className="flex flex-col">
-                    {filteredWorktrees.map((worktree) => {
-                      const isPinned = pinnedWorktrees.includes(worktree.id);
-                      return (
-                        <SidebarWorktreeRow
-                          key={worktree.id}
-                          worktreeId={worktree.id}
-                          activeWorktreeId={activeWorktreeId}
-                          focusedWorktreeId={focusedWorktreeId}
-                          totalWorktreeCount={deferredWorktrees.length}
-                          selectWorktree={selectWorktree}
-                          worktreeActions={worktreeActions}
-                          availability={availability}
-                          agentSettings={agentSettings}
-                          homeDir={homeDir}
-                          dragStartOrder={dragStartOrder}
-                          isSortDisabled={isSortDisabled}
-                          isPinned={isPinned}
-                        />
-                      );
-                    })}
-                  </div>
-                </SortableContext>
-              )}
-            </div>
-          </div>
-          <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
-          <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() =>
+                  actionService.dispatch("worktree.createDialog.open", undefined, {
+                    source: "user",
+                  })
+                }
+                className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
+                aria-label="Create new worktree"
+              >
+                <Plus className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Create new worktree</TooltipContent>
+          </Tooltip>
         </div>
-
-        <RecipeEditor
-          recipe={recipeManagerEdit}
-          worktreeId={recipeEditorWorktreeId}
-          initialTerminals={recipeEditorInitialTerminals}
-          defaultScope={recipeEditorDefaultScope}
-          isOpen={isRecipeEditorOpen}
-          onClose={handleCloseRecipeEditor}
-        />
-
-        <RecipeManager
-          isOpen={isRecipeManagerOpen}
-          onClose={handleCloseRecipeManager}
-          onEditRecipe={handleRecipeManagerEdit}
-          onCreateRecipe={handleRecipeManagerCreate}
-        />
-
-        {rootPath && (createDialog.isOpen || hasOpenedNewWorktree) && (
-          <Suspense fallback={null}>
-            <LazyNewWorktreeDialog
-              isOpen={createDialog.isOpen}
-              onClose={closeCreateDialog}
-              rootPath={rootPath}
-              onWorktreeCreated={(worktreeId) => {
-                refresh();
-                createDialog.onCreated?.(worktreeId);
-              }}
-              initialIssue={createDialog.initialIssue}
-              initialPR={createDialog.initialPR}
-              initialRecipeId={createDialog.initialRecipeId}
-            />
-          </Suspense>
-        )}
-
-        <BulkCreateWorktreeDialog
-          isOpen={bulkCreateDialog.isOpen}
-          onClose={closeBulkCreateDialog}
-          mode={bulkCreateDialog.mode}
-          selectedIssues={bulkCreateDialog.selectedIssues}
-          selectedPRs={bulkCreateDialog.selectedPRs}
-          onComplete={closeBulkCreateDialog}
-        />
       </div>
-    </TooltipProvider>
+
+      {/* Inline search bar — only when there are non-main worktrees */}
+      {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
+
+      {/* Arm all terminals matching the active filter — only when a filter narrows the list */}
+      {hasNonMainWorktrees && hasFilters && filteredWorktrees.length > 0 && (
+        <div className="shrink-0 px-4 py-1.5 border-b border-divider">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() =>
+                  actionService.dispatch(
+                    "fleet.armMatchingFilter",
+                    { worktreeIds: filteredWorktrees.map((w) => w.id) },
+                    { source: "user" }
+                  )
+                }
+                className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
+                aria-label={`Arm ${filteredWorktrees.length} matching worktrees`}
+              >
+                <BroadcastTerminalIcon className="w-3 h-3" />
+                Arm {filteredWorktrees.length} matching
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              Arm all eligible terminals in the {filteredWorktrees.length} worktrees visible below
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
+      {/* Main worktree — visible unless excluded by text search */}
+      {mainMatchesQuery && (
+        <div
+          className="shrink-0"
+          style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+        >
+          <StaticWorktreeRow
+            key={mainWorktree.id}
+            worktreeId={mainWorktree.id}
+            activeWorktreeId={activeWorktreeId}
+            focusedWorktreeId={focusedWorktreeId}
+            totalWorktreeCount={deferredWorktrees.length}
+            selectWorktree={selectWorktree}
+            worktreeActions={worktreeActions}
+            availability={availability}
+            agentSettings={agentSettings}
+            homeDir={homeDir}
+            aggregateCounts={mainWorktreeAggregateCounts}
+          />
+        </div>
+      )}
+
+      {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
+      {integrationMatchesQuery && (
+        <div
+          className="shrink-0"
+          style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+        >
+          {renderWorktreeCard(integrationWorktree)}
+        </div>
+      )}
+
+      {/* Strong divider between pinned worktrees and scrollable list */}
+      {hasNonMainWorktrees && <div className="shrink-0 border-b border-border-default" />}
+
+      {/* Non-main worktree list */}
+      <div className="relative flex-1 min-h-0">
+        <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
+          <div ref={scrollContentRef}>
+            {hasNonMainWorktrees && (
+              <QuickStateFilterBar
+                value={quickStateFilter}
+                onChange={setQuickStateFilter}
+                counts={quickStateCounts}
+              />
+            )}
+            {filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
+              <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
+                <p className="text-sm text-daintree-text/60 mb-3">
+                  No worktrees match your filters
+                </p>
+                <button
+                  onClick={clearAllFilters}
+                  className="text-xs px-3 py-1.5 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
+                >
+                  Clear filters
+                </button>
+              </div>
+            ) : groupedSections ? (
+              <div className="flex flex-col">
+                {groupedSections.map((section) => (
+                  <div key={section.type}>
+                    <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide bg-daintree-sidebar border-b border-divider">
+                      {section.displayName} ({section.worktrees.length})
+                    </div>
+                    {section.worktrees.map(renderWorktreeCard)}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                <div className="flex flex-col">
+                  {filteredWorktrees.map((worktree) => {
+                    const isPinned = pinnedWorktrees.includes(worktree.id);
+                    return (
+                      <SidebarWorktreeRow
+                        key={worktree.id}
+                        worktreeId={worktree.id}
+                        activeWorktreeId={activeWorktreeId}
+                        focusedWorktreeId={focusedWorktreeId}
+                        totalWorktreeCount={deferredWorktrees.length}
+                        selectWorktree={selectWorktree}
+                        worktreeActions={worktreeActions}
+                        availability={availability}
+                        agentSettings={agentSettings}
+                        homeDir={homeDir}
+                        dragStartOrder={dragStartOrder}
+                        isSortDisabled={isSortDisabled}
+                        isPinned={isPinned}
+                      />
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            )}
+          </div>
+        </div>
+        <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
+        <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
+      </div>
+
+      <RecipeEditor
+        recipe={recipeManagerEdit}
+        worktreeId={recipeEditorWorktreeId}
+        initialTerminals={recipeEditorInitialTerminals}
+        defaultScope={recipeEditorDefaultScope}
+        isOpen={isRecipeEditorOpen}
+        onClose={handleCloseRecipeEditor}
+      />
+
+      <RecipeManager
+        isOpen={isRecipeManagerOpen}
+        onClose={handleCloseRecipeManager}
+        onEditRecipe={handleRecipeManagerEdit}
+        onCreateRecipe={handleRecipeManagerCreate}
+      />
+
+      {rootPath && (createDialog.isOpen || hasOpenedNewWorktree) && (
+        <Suspense fallback={null}>
+          <LazyNewWorktreeDialog
+            isOpen={createDialog.isOpen}
+            onClose={closeCreateDialog}
+            rootPath={rootPath}
+            onWorktreeCreated={(worktreeId) => {
+              refresh();
+              createDialog.onCreated?.(worktreeId);
+            }}
+            initialIssue={createDialog.initialIssue}
+            initialPR={createDialog.initialPR}
+            initialRecipeId={createDialog.initialRecipeId}
+          />
+        </Suspense>
+      )}
+
+      <BulkCreateWorktreeDialog
+        isOpen={bulkCreateDialog.isOpen}
+        onClose={closeBulkCreateDialog}
+        mode={bulkCreateDialog.mode}
+        selectedIssues={bulkCreateDialog.selectedIssues}
+        selectedPRs={bulkCreateDialog.selectedPRs}
+        onComplete={closeBulkCreateDialog}
+      />
+    </div>
   );
 }
 

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useArtifacts } from "@/hooks/useArtifacts";
 import type { Artifact } from "@shared/types";
 
@@ -160,28 +160,26 @@ function ArtifactItem({
               Save to File
             </button>
             {artifact.type === "patch" && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex">
-                      <button
-                        onClick={handleApplyPatch}
-                        disabled={isProcessing || !canApplyPatch}
-                        className={cn(
-                          "px-3 py-1 text-xs rounded transition-colors",
-                          "bg-status-success hover:brightness-110 text-daintree-bg",
-                          "disabled:opacity-50 disabled:cursor-not-allowed"
-                        )}
-                      >
-                        Apply Patch
-                      </button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {!canApplyPatch ? "No worktree context available" : "Apply patch to worktree"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <button
+                      onClick={handleApplyPatch}
+                      disabled={isProcessing || !canApplyPatch}
+                      className={cn(
+                        "px-3 py-1 text-xs rounded transition-colors",
+                        "bg-status-success hover:brightness-110 text-daintree-bg",
+                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                      )}
+                    >
+                      Apply Patch
+                    </button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {!canApplyPatch ? "No worktree context available" : "Apply patch to worktree"}
+                </TooltipContent>
+              </Tooltip>
             )}
             {feedback && (
               <span
@@ -389,32 +387,30 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                     >
                       Copy All
                     </button>
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <button
-                              type="button"
-                              onClick={() => setIncludeAllTypes((v) => !v)}
-                              disabled={isBulkActionRunning}
-                              className={cn(
-                                "px-2 py-1 text-xs rounded transition-colors",
-                                includeAllTypes
-                                  ? "bg-daintree-border text-daintree-text"
-                                  : "bg-daintree-sidebar text-daintree-text/60",
-                                "hover:brightness-110",
-                                "disabled:opacity-50 disabled:cursor-not-allowed"
-                              )}
-                            >
-                              {includeAllTypes ? "All" : "Code"}
-                            </button>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">
-                          {includeAllTypes ? "Copying all types" : "Copying code only"}
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <button
+                            type="button"
+                            onClick={() => setIncludeAllTypes((v) => !v)}
+                            disabled={isBulkActionRunning}
+                            className={cn(
+                              "px-2 py-1 text-xs rounded transition-colors",
+                              includeAllTypes
+                                ? "bg-daintree-border text-daintree-text"
+                                : "bg-daintree-sidebar text-daintree-text/60",
+                              "hover:brightness-110",
+                              "disabled:opacity-50 disabled:cursor-not-allowed"
+                            )}
+                          >
+                            {includeAllTypes ? "All" : "Code"}
+                          </button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {includeAllTypes ? "Copying all types" : "Copying code only"}
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                 )}
                 {showSaveAll && (
@@ -432,29 +428,27 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   </button>
                 )}
                 {showApplyAll && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex">
-                          <button
-                            type="button"
-                            onClick={handleApplyAllPatches}
-                            disabled={isBulkActionRunning || !canApplyAll}
-                            className={cn(
-                              "px-3 py-1 text-xs rounded transition-colors",
-                              "bg-status-success hover:brightness-110 text-daintree-bg",
-                              "disabled:opacity-50 disabled:cursor-not-allowed"
-                            )}
-                          >
-                            Apply All Patches
-                          </button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {!canApplyAll ? "No worktree context available" : "Apply all patches"}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <button
+                          type="button"
+                          onClick={handleApplyAllPatches}
+                          disabled={isBulkActionRunning || !canApplyAll}
+                          className={cn(
+                            "px-3 py-1 text-xs rounded transition-colors",
+                            "bg-status-success hover:brightness-110 text-daintree-bg",
+                            "disabled:opacity-50 disabled:cursor-not-allowed"
+                          )}
+                        >
+                          Apply All Patches
+                        </button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {!canApplyAll ? "No worktree context available" : "Apply all patches"}
+                    </TooltipContent>
+                  </Tooltip>
                 )}
                 {bulkProgress && (
                   <span className="text-xs tabular-nums text-daintree-text/60 ml-auto">

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 function getDescriptionSnippet(description: string, maxLength = 60): string {
   const cleaned = description.replace(/\s+/g, " ").trim();
@@ -59,42 +59,38 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
               : undefined;
 
             return (
-              <TooltipProvider key={item.key}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      role="option"
-                      aria-selected={idx === selectedIndex}
-                      className={cn(
-                        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
-                        idx === selectedIndex
-                          ? "bg-daintree-accent/20 text-daintree-text"
-                          : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
-                      )}
-                      onMouseDown={(e) => e.preventDefault()}
-                      onClick={() => onSelect(item)}
-                    >
-                      <span className="shrink-0 font-mono text-xs leading-4">{item.label}</span>
-                      {descriptionSnippet && (
-                        <span
-                          className={cn(
-                            "min-w-0 truncate text-[10px] leading-4",
-                            idx === selectedIndex
-                              ? "text-daintree-text/80"
-                              : "text-daintree-text/30"
-                          )}
-                        >
-                          {descriptionSnippet}
-                        </span>
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {item.description ? `${item.label} — ${item.description}` : item.label}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={idx === selectedIndex}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
+                      idx === selectedIndex
+                        ? "bg-daintree-accent/20 text-daintree-text"
+                        : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
+                    )}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => onSelect(item)}
+                  >
+                    <span className="shrink-0 font-mono text-xs leading-4">{item.label}</span>
+                    {descriptionSnippet && (
+                      <span
+                        className={cn(
+                          "min-w-0 truncate text-[10px] leading-4",
+                          idx === selectedIndex ? "text-daintree-text/80" : "text-daintree-text/30"
+                        )}
+                      >
+                        {descriptionSnippet}
+                      </span>
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {item.description ? `${item.label} — ${item.description}` : item.label}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </ScrollShadow>

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -59,7 +59,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
               : undefined;
 
             return (
-              <Tooltip>
+              <Tooltip key={item.key}>
                 <TooltipTrigger asChild>
                   <button
                     type="button"

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, type CSSProperties } from "react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type ButtonVariant = "primary" | "accent" | "dismiss" | "danger" | "dangerFilled";
 
@@ -188,12 +188,10 @@ function InlineStatusBannerComponent({
           );
 
           return action.title ? (
-            <TooltipProvider key={action.id}>
-              <Tooltip>
-                <TooltipTrigger asChild>{buttonEl}</TooltipTrigger>
-                <TooltipContent side="bottom">{action.title}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>{buttonEl}</TooltipTrigger>
+              <TooltipContent side="bottom">{action.title}</TooltipContent>
+            </Tooltip>
           ) : (
             <React.Fragment key={action.id}>{buttonEl}</React.Fragment>
           );

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -188,7 +188,7 @@ function InlineStatusBannerComponent({
           );
 
           return action.title ? (
-            <Tooltip>
+            <Tooltip key={action.id}>
               <TooltipTrigger asChild>{buttonEl}</TooltipTrigger>
               <TooltipContent side="bottom">{action.title}</TooltipContent>
             </Tooltip>

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { Pause, Lock } from "lucide-react";
 import type { AgentState, PanelKind, AgentStateChangeTrigger } from "@/types";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
@@ -165,82 +165,78 @@ function TerminalHeaderContentComponent({
     const stateLabel = getEffectiveStateLabel(agentState, waitingReason);
 
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="inline-flex items-center gap-1.5 shrink-0">
-              <div className="relative inline-flex items-center shrink-0">
-                <div
-                  className={cn(
-                    "inline-flex items-center justify-center w-5 h-5 rounded-full border shrink-0",
-                    chipStyle,
-                    effectiveColor
-                  )}
-                  role="status"
-                  aria-label={`Agent state: ${stateLabel}`}
-                >
-                  <StateIcon
-                    className={cn(
-                      "w-3 h-3",
-                      agentState === "working" && "animate-spin-slow",
-                      "motion-reduce:animate-none"
-                    )}
-                    aria-hidden="true"
-                  />
-                </div>
-                {errorCount > 0 && (
-                  <span
-                    className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-error"
-                    aria-label={`${errorCount} error${errorCount > 1 ? "s" : ""}`}
-                  />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="inline-flex items-center gap-1.5 shrink-0">
+            <div className="relative inline-flex items-center shrink-0">
+              <div
+                className={cn(
+                  "inline-flex items-center justify-center w-5 h-5 rounded-full border shrink-0",
+                  chipStyle,
+                  effectiveColor
                 )}
+                role="status"
+                aria-label={`Agent state: ${stateLabel}`}
+              >
+                <StateIcon
+                  className={cn(
+                    "w-3 h-3",
+                    agentState === "working" && "animate-spin-slow",
+                    "motion-reduce:animate-none"
+                  )}
+                  aria-hidden="true"
+                />
               </div>
-              {(agentState === "completed" || agentState === "exited") && sessionCost != null && (
-                <span
-                  className="text-[11px] text-daintree-text/50 font-mono shrink-0"
-                  style={{ fontVariantNumeric: "tabular-nums" }}
-                >
-                  ${sessionCost.toFixed(2)}
-                  {sessionTokens != null && ` · ${formatTokenCount(sessionTokens)}`}
-                </span>
-              )}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="max-w-xs">
-            <div className="flex flex-col gap-0.5">
-              <span className="font-medium">
-                {headline}
-                {startedAt != null && <ElapsedTime startedAt={startedAt} />}
-              </span>
-              {isExited && exitCode != null && (
-                <span className="text-status-error tabular-nums">Exit code: {exitCode}</span>
-              )}
-              <span>
-                State: {stateLabel}
-                {showStateDuration && <> · {formatElapsedDuration(tick - lastStateChange!)}</>}
-                {stateChangeTrigger && <> · {TRIGGER_LABELS[stateChangeTrigger]}</>}
-                {showConfidence && <> ({Math.round(stateChangeConfidence * 100)}%)</>}
-              </span>
-              {lastStateChange != null && lastStateChange > 0 && (
-                <span className="text-daintree-text/60">
-                  Since: {formatTimeAgo(lastStateChange)}
-                </span>
-              )}
-              {sessionCost != null && (
-                <span className="text-daintree-text/60 tabular-nums">
-                  Cost: ${sessionCost.toFixed(2)}
-                  {sessionTokens != null && ` · ${formatTokenCount(sessionTokens)} tokens`}
-                </span>
-              )}
               {errorCount > 0 && (
-                <span className="text-status-error">
-                  {errorCount} error{errorCount > 1 ? "s" : ""}
-                </span>
+                <span
+                  className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-status-error"
+                  aria-label={`${errorCount} error${errorCount > 1 ? "s" : ""}`}
+                />
               )}
             </div>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+            {(agentState === "completed" || agentState === "exited") && sessionCost != null && (
+              <span
+                className="text-[11px] text-daintree-text/50 font-mono shrink-0"
+                style={{ fontVariantNumeric: "tabular-nums" }}
+              >
+                ${sessionCost.toFixed(2)}
+                {sessionTokens != null && ` · ${formatTokenCount(sessionTokens)}`}
+              </span>
+            )}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-xs">
+          <div className="flex flex-col gap-0.5">
+            <span className="font-medium">
+              {headline}
+              {startedAt != null && <ElapsedTime startedAt={startedAt} />}
+            </span>
+            {isExited && exitCode != null && (
+              <span className="text-status-error tabular-nums">Exit code: {exitCode}</span>
+            )}
+            <span>
+              State: {stateLabel}
+              {showStateDuration && <> · {formatElapsedDuration(tick - lastStateChange!)}</>}
+              {stateChangeTrigger && <> · {TRIGGER_LABELS[stateChangeTrigger]}</>}
+              {showConfidence && <> ({Math.round(stateChangeConfidence * 100)}%)</>}
+            </span>
+            {lastStateChange != null && lastStateChange > 0 && (
+              <span className="text-daintree-text/60">Since: {formatTimeAgo(lastStateChange)}</span>
+            )}
+            {sessionCost != null && (
+              <span className="text-daintree-text/60 tabular-nums">
+                Cost: ${sessionCost.toFixed(2)}
+                {sessionTokens != null && ` · ${formatTokenCount(sessionTokens)} tokens`}
+              </span>
+            )}
+            {errorCount > 0 && (
+              <span className="text-status-error">
+                {errorCount} error{errorCount > 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
     );
   };
 
@@ -248,16 +244,14 @@ function TerminalHeaderContentComponent({
     <>
       {/* Command Pill - shows currently running command (inline with title) */}
       {showCommandPill && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="px-3 py-1 rounded-full text-[11px] font-mono bg-overlay-soft text-daintree-text/60 border border-divider truncate max-w-[20rem]">
-                {lastCommand}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{lastCommand}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="px-3 py-1 rounded-full text-[11px] font-mono bg-overlay-soft text-daintree-text/60 border border-divider truncate max-w-[20rem]">
+              {lastCommand}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{lastCommand}</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Exit code badge */}
@@ -269,142 +263,126 @@ function TerminalHeaderContentComponent({
 
       {/* Queue count badge */}
       {queueCount > 0 && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className="inline-flex items-center gap-1 text-xs font-sans bg-daintree-accent/15 text-daintree-text px-1.5 py-0.5 rounded ml-1"
-                role="status"
-                aria-live="polite"
-              >
-                <span className="font-mono tabular-nums">{queueCount}</span>
-                <span>queued</span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {`${queueCount} command${queueCount > 1 ? "s" : ""} queued`}
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="inline-flex items-center gap-1 text-xs font-sans bg-daintree-accent/15 text-daintree-text px-1.5 py-0.5 rounded ml-1"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="font-mono tabular-nums">{queueCount}</span>
+              <span>queued</span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {`${queueCount} command${queueCount > 1 ? "s" : ""} queued`}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Paused badge */}
       {flowStatus === "paused-backpressure" && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
-                role="status"
-                aria-live="polite"
-              >
-                <Pause className="w-3 h-3" aria-hidden="true" />
-                Paused
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              Terminal paused due to buffer overflow (right-click for Force Resume)
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
+              role="status"
+              aria-live="polite"
+            >
+              <Pause className="w-3 h-3" aria-hidden="true" />
+              Paused
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Terminal paused due to buffer overflow (right-click for Force Resume)
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Suspended badge */}
       {flowStatus === "suspended" && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
-                role="status"
-                aria-live="polite"
-              >
-                <Pause className="w-3 h-3" aria-hidden="true" />
-                Suspended
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              Terminal output streaming suspended due to a stall (auto-recovers on focus)
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
+              role="status"
+              aria-live="polite"
+            >
+              <Pause className="w-3 h-3" aria-hidden="true" />
+              Suspended
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            Terminal output streaming suspended due to a stall (auto-recovers on focus)
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Input locked indicator */}
       {isInputLocked && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center text-daintree-text/50 shrink-0" role="status">
-                <Lock className="w-3.5 h-3.5" aria-hidden="true" />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Input locked (read-only monitor mode)</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center text-daintree-text/50 shrink-0" role="status">
+              <Lock className="w-3.5 h-3.5" aria-hidden="true" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Input locked (read-only monitor mode)</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Resource monitoring badge */}
       {showResource && (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className={cn(
-                  "inline-flex items-center gap-1 text-[11px] font-mono shrink-0 ml-1",
-                  {
-                    "text-daintree-text/40":
-                      getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) ===
-                      "muted",
-                    "text-status-warning":
-                      getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) ===
-                      "amber",
-                    "text-status-error":
-                      getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) ===
-                      "red",
-                  }
-                )}
-                style={{ fontVariantNumeric: "tabular-nums" }}
-                role="status"
-              >
-                <TerminalResourceSparkline history={resourceState.cpuHistory} />
-                <span>
-                  {Math.round(resourceState.cpuPercent)}% · {formatMemory(resourceState.memoryKb)}
-                </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={cn("inline-flex items-center gap-1 text-[11px] font-mono shrink-0 ml-1", {
+                "text-daintree-text/40":
+                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "muted",
+                "text-status-warning":
+                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "amber",
+                "text-status-error":
+                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "red",
+              })}
+              style={{ fontVariantNumeric: "tabular-nums" }}
+              role="status"
+            >
+              <TerminalResourceSparkline history={resourceState.cpuHistory} />
+              <span>
+                {Math.round(resourceState.cpuPercent)}% · {formatMemory(resourceState.memoryKb)}
+              </span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-xs">
+            <div className="flex flex-col gap-1">
+              <div className="font-medium" style={{ fontVariantNumeric: "tabular-nums" }}>
+                CPU: {resourceState.cpuPercent.toFixed(1)}% · Memory:{" "}
+                {formatMemory(resourceState.memoryKb)}
               </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-xs">
-              <div className="flex flex-col gap-1">
-                <div className="font-medium" style={{ fontVariantNumeric: "tabular-nums" }}>
-                  CPU: {resourceState.cpuPercent.toFixed(1)}% · Memory:{" "}
-                  {formatMemory(resourceState.memoryKb)}
-                </div>
-                {resourceState.breakdown.length > 0 && (
-                  <table className="text-xs" style={{ fontVariantNumeric: "tabular-nums" }}>
-                    <thead>
-                      <tr className="text-daintree-text/60">
-                        <th className="text-left pr-2">PID</th>
-                        <th className="text-left pr-2">Name</th>
-                        <th className="text-right pr-2">CPU</th>
-                        <th className="text-right">Mem</th>
+              {resourceState.breakdown.length > 0 && (
+                <table className="text-xs" style={{ fontVariantNumeric: "tabular-nums" }}>
+                  <thead>
+                    <tr className="text-daintree-text/60">
+                      <th className="text-left pr-2">PID</th>
+                      <th className="text-left pr-2">Name</th>
+                      <th className="text-right pr-2">CPU</th>
+                      <th className="text-right">Mem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {resourceState.breakdown.map((p) => (
+                      <tr key={p.pid}>
+                        <td className="pr-2 text-daintree-text/60">{p.pid}</td>
+                        <td className="pr-2 truncate max-w-[8rem]">{p.comm}</td>
+                        <td className="text-right pr-2">{p.cpuPercent.toFixed(1)}%</td>
+                        <td className="text-right">{formatMemory(p.memoryKb)}</td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {resourceState.breakdown.map((p) => (
-                        <tr key={p.pid}>
-                          <td className="pr-2 text-daintree-text/60">{p.pid}</td>
-                          <td className="pr-2 truncate max-w-[8rem]">{p.comm}</td>
-                          <td className="text-right pr-2">{p.cpuPercent.toFixed(1)}%</td>
-                          <td className="text-right">{formatMemory(p.memoryKb)}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Agent state chip */}

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { Info } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -80,12 +80,10 @@ function InfoRow({ label, value, mono = false }: InfoRowProps) {
     <div className="flex justify-between items-start gap-4 text-sm">
       <span className="text-daintree-text/70 shrink-0 select-none">{label}:</span>
       {typeof displayValue === "string" ? (
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>{valueElement}</TooltipTrigger>
-            <TooltipContent side="bottom">{displayValue}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{valueElement}</TooltipTrigger>
+          <TooltipContent side="bottom">{displayValue}</TooltipContent>
+        </Tooltip>
       ) : (
         valueElement
       )}

--- a/src/components/Terminal/TerminalSearchBar.tsx
+++ b/src/components/Terminal/TerminalSearchBar.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { X, ChevronUp, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { SEARCH_HIGHLIGHT_LIMIT } from "@/services/terminal/TerminalAddonManager";
 import { validateRegexTerm, buildSearchOptions, type SearchStatus } from "./terminalSearchUtils";
@@ -216,47 +216,43 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
         )}
       />
 
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleCaseSensitiveToggle}
-              className={cn(
-                "px-1.5 py-1 text-xs rounded transition-colors",
-                caseSensitive
-                  ? "bg-status-info text-daintree-bg"
-                  : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
-              )}
-              aria-label="Toggle case sensitivity"
-              aria-pressed={caseSensitive}
-            >
-              Aa
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Case sensitive</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleCaseSensitiveToggle}
+            className={cn(
+              "px-1.5 py-1 text-xs rounded transition-colors",
+              caseSensitive
+                ? "bg-status-info text-daintree-bg"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+            )}
+            aria-label="Toggle case sensitivity"
+            aria-pressed={caseSensitive}
+          >
+            Aa
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Case sensitive</TooltipContent>
+      </Tooltip>
 
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleRegexToggle}
-              className={cn(
-                "px-1.5 py-1 text-xs font-mono rounded transition-colors",
-                regexEnabled
-                  ? "bg-status-info text-daintree-bg"
-                  : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
-              )}
-              aria-label="Toggle regex mode"
-              aria-pressed={regexEnabled}
-            >
-              .*
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Regex</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleRegexToggle}
+            className={cn(
+              "px-1.5 py-1 text-xs font-mono rounded transition-colors",
+              regexEnabled
+                ? "bg-status-info text-daintree-bg"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+            )}
+            aria-label="Toggle regex mode"
+            aria-pressed={regexEnabled}
+          >
+            .*
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Regex</TooltipContent>
+      </Tooltip>
 
       {statusText && (
         <span
@@ -274,67 +270,61 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
         {statusText}
       </span>
 
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <button
-                onClick={() => performSearch(searchTerm, "prev")}
-                disabled={!searchTerm}
-                className={cn(
-                  "p-1 rounded transition-colors",
-                  "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
-                  "disabled:opacity-30 disabled:cursor-not-allowed"
-                )}
-                aria-label="Previous match"
-              >
-                <ChevronUp className="w-4 h-4" />
-              </button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Previous match (Shift+Enter)</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">
-              <button
-                onClick={() => performSearch(searchTerm, "next")}
-                disabled={!searchTerm}
-                className={cn(
-                  "p-1 rounded transition-colors",
-                  "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
-                  "disabled:opacity-30 disabled:cursor-not-allowed"
-                )}
-                aria-label="Next match"
-              >
-                <ChevronDown className="w-4 h-4" />
-              </button>
-            </span>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Next match (Enter)</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
             <button
-              onClick={handleClose}
+              onClick={() => performSearch(searchTerm, "prev")}
+              disabled={!searchTerm}
               className={cn(
                 "p-1 rounded transition-colors",
-                "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+                "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
+                "disabled:opacity-30 disabled:cursor-not-allowed"
               )}
-              aria-label="Close search"
+              aria-label="Previous match"
             >
-              <X className="w-4 h-4" />
+              <ChevronUp className="w-4 h-4" />
             </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Close (Esc)</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Previous match (Shift+Enter)</TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <button
+              onClick={() => performSearch(searchTerm, "next")}
+              disabled={!searchTerm}
+              className={cn(
+                "p-1 rounded transition-colors",
+                "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
+                "disabled:opacity-30 disabled:cursor-not-allowed"
+              )}
+              aria-label="Next match"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Next match (Enter)</TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={handleClose}
+            className={cn(
+              "p-1 rounded transition-colors",
+              "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+            )}
+            aria-label="Close search"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Close (Esc)</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -25,6 +25,13 @@ vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -3,6 +3,13 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TerminalRestartStatusBanner } from "../TerminalRestartStatusBanner";
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,

--- a/src/components/Terminal/__tests__/TerminalSearchBar.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalSearchBar.test.tsx
@@ -8,6 +8,13 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   },
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 import { TerminalSearchBar } from "../TerminalSearchBar";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -17,7 +17,7 @@ import { TerminalRecipeIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
@@ -281,7 +281,7 @@ export function RecipeManager({
   };
 
   return (
-    <TooltipProvider delayDuration={400} skipDelayDuration={300}>
+    <>
       <AppDialog isOpen={isOpen} onClose={onClose} size="lg">
         <AppDialog.Header>
           <AppDialog.Title>
@@ -481,6 +481,6 @@ export function RecipeManager({
           </Button>
         </AppDialog.Footer>
       </AppDialog>
-    </TooltipProvider>
+    </>
   );
 }

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -182,7 +182,7 @@ export function FileChangeList({
     const displayDir = formatDirForDisplay(dir);
 
     return (
-      <Tooltip>
+      <Tooltip key={`${change.path}-${change.status}`}>
         <TooltipTrigger asChild>
           <div
             className="group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors"

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -3,7 +3,7 @@ import type { FileChangeDetail, GitStatus } from "../../types";
 import { cn } from "../../lib/utils";
 import { FileDiffModal } from "./FileDiffModal";
 import { Folder } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 function isAbsolutePath(filePath: string): boolean {
   return (
@@ -182,39 +182,37 @@ export function FileChangeList({
     const displayDir = formatDirForDisplay(dir);
 
     return (
-      <TooltipProvider key={`${change.path}-${change.status}`}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className="group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors"
-              onClick={() => handleFileClick(change)}
-            >
-              <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="group/filerow flex items-center text-xs font-mono hover:bg-tint/5 rounded px-1.5 py-0.5 -mx-1.5 cursor-pointer transition-colors"
+            onClick={() => handleFileClick(change)}
+          >
+            <span className={cn("w-4 font-bold shrink-0", config.color)}>{config.label}</span>
 
-              <div className="flex-1 min-w-0 flex items-center mr-2">
-                {showDir && displayDir && (
-                  <span className="truncate min-w-0 text-daintree-text/60 opacity-60 group-hover/filerow:opacity-80">
-                    {displayDir}/
-                  </span>
-                )}
-                <span className="text-daintree-text group-hover/filerow:text-daintree-text font-medium truncate min-w-0">
-                  {base}
+            <div className="flex-1 min-w-0 flex items-center mr-2">
+              {showDir && displayDir && (
+                <span className="truncate min-w-0 text-daintree-text/60 opacity-60 group-hover/filerow:opacity-80">
+                  {displayDir}/
                 </span>
-              </div>
-
-              <div className="flex items-center gap-2 shrink-0 text-[11px]">
-                {(change.insertions ?? 0) > 0 && (
-                  <span className="text-status-success/80">+{change.insertions}</span>
-                )}
-                {(change.deletions ?? 0) > 0 && (
-                  <span className="text-status-error/80">-{change.deletions}</span>
-                )}
-              </div>
+              )}
+              <span className="text-daintree-text group-hover/filerow:text-daintree-text font-medium truncate min-w-0">
+                {base}
+              </span>
             </div>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{change.relativePath}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+
+            <div className="flex items-center gap-2 shrink-0 text-[11px]">
+              {(change.insertions ?? 0) > 0 && (
+                <span className="text-status-success/80">+{change.insertions}</span>
+              )}
+              {(change.deletions ?? 0) > 0 && (
+                <span className="text-status-error/80">-{change.deletions}</span>
+              )}
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{change.relativePath}</TooltipContent>
+      </Tooltip>
     );
   };
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -27,7 +27,7 @@ import type { RecipeTerminal } from "@shared/types";
 import { IssueSelector } from "@/components/GitHub/IssueSelector";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { parseBranchInput } from "./branchPrefixUtils";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
@@ -866,933 +866,916 @@ export function NewWorktreeDialog({
             <span className="ml-2 text-sm text-daintree-text/60">Loading branches...</span>
           </div>
         ) : (
-          <TooltipProvider>
-            <div className="space-y-4">
-              {initialPR ? (
-                <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-daintree-accent/5 border border-daintree-accent/20 text-sm min-w-0">
-                  <WorktreeIcon
-                    className="w-4 h-4 text-daintree-accent shrink-0"
-                    aria-hidden="true"
-                  />
-                  <span className="text-daintree-text/80 min-w-0 truncate">
-                    PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
-                    {initialPR.title}
-                  </span>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <label className="block text-sm font-medium text-daintree-text">
-                      Link Issue (Optional)
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                          aria-label="Help for Link Issue field"
-                          disabled={isPending}
-                        >
-                          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                          <span className="sr-only">Help for Link Issue field</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        <p>Select an issue to auto-generate a branch name</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <IssueSelector
-                    projectPath={rootPath}
-                    selectedIssue={selectedIssue}
-                    onSelect={handleIssueSelect}
-                    disabled={isPending}
-                  />
-                </div>
-              )}
-
-              {!initialPR && canAssignIssue && (
-                <div className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border bg-daintree-bg/50 border-daintree-border transition-colors">
-                  {currentUserAvatar ? (
-                    <img
-                      src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=64`}
-                      alt={currentUser}
-                      className="w-8 h-8 rounded-full shrink-0"
-                    />
-                  ) : (
-                    <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-daintree-accent/10 text-daintree-accent">
-                      <UserPlus className="w-4 h-4" />
-                    </div>
-                  )}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-medium text-daintree-text">Assign to me</span>
-                      <span className="text-xs text-daintree-text/50 font-mono">
-                        @{currentUser}
-                      </span>
-                    </div>
-                  </div>
-                  <label className="relative inline-flex items-center cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={assignWorktreeToSelf}
-                      onChange={(e) => setAssignWorktreeToSelf(e.target.checked)}
-                      disabled={isPending}
-                      className="sr-only peer"
-                      aria-label="Assign issue to me when creating worktree"
-                    />
-                    <div
-                      className={cn(
-                        "w-9 h-5 rounded-full transition-colors",
-                        "peer-focus-visible:ring-2 peer-focus-visible:ring-daintree-accent",
-                        "after:content-[''] after:absolute after:top-0.5 after:left-0.5",
-                        "after:rounded-full after:h-4 after:w-4",
-                        "after:transition-transform after:duration-200",
-                        assignWorktreeToSelf
-                          ? "bg-daintree-accent after:translate-x-4 after:bg-text-inverse"
-                          : "bg-daintree-border after:translate-x-0 after:bg-daintree-text",
-                        isPending && "opacity-50 cursor-not-allowed"
-                      )}
-                    />
-                  </label>
-                </div>
-              )}
-
-              {!initialPR && (
-                <div
-                  className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-                  role="radiogroup"
-                  aria-label="Branch mode"
-                >
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={branchMode === "new"}
-                    onClick={() => handleBranchModeChange("new")}
-                    disabled={isPending}
-                    className={cn(
-                      "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                      branchMode === "new"
-                        ? "bg-daintree-bg text-daintree-text shadow-sm"
-                        : "text-daintree-text/60 hover:text-daintree-text"
-                    )}
-                  >
-                    New Branch
-                  </button>
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={branchMode === "existing"}
-                    onClick={() => handleBranchModeChange("existing")}
-                    disabled={isPending}
-                    className={cn(
-                      "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                      branchMode === "existing"
-                        ? "bg-daintree-bg text-daintree-text shadow-sm"
-                        : "text-daintree-text/60 hover:text-daintree-text"
-                    )}
-                  >
-                    Existing Branch
-                  </button>
-                </div>
-              )}
-
-              {!isExistingMode && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <label
-                      htmlFor="base-branch"
-                      className="block text-sm font-medium text-daintree-text"
-                    >
-                      Base Branch
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                          aria-label="Help for Base Branch field"
-                          disabled={isPending}
-                        >
-                          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                          <span className="sr-only">Help for Base Branch field</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        <p>The branch to create the new worktree from</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <Popover open={branchPickerOpen} onOpenChange={setBranchPickerOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="base-branch"
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={branchPickerOpen}
-                        aria-haspopup="listbox"
-                        aria-invalid={errorField === "base-branch" ? true : undefined}
-                        aria-describedby={
-                          errorField === "base-branch" ? "validation-error" : undefined
-                        }
-                        className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                        disabled={isPending}
-                      >
-                        <span className="truncate">
-                          {selectedBranchOption?.labelText || "Select base branch..."}
-                        </span>
-                        <ChevronsUpDown className="opacity-50 shrink-0" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-[400px] p-0"
-                      align="start"
-                      onEscapeKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center border-b border-daintree-border px-3">
-                        <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
-                        <input
-                          ref={branchInputRef}
-                          className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                          placeholder="Search branches..."
-                          value={branchQuery}
-                          onChange={(e) => setBranchQuery(e.target.value)}
-                          onKeyDown={handleBranchKeyDown}
-                          role="combobox"
-                          aria-label="Search base branches"
-                          aria-autocomplete="list"
-                          aria-controls="branch-list"
-                          aria-expanded={branchPickerOpen}
-                          aria-activedescendant={
-                            selectableRows.length > 0 && selectedIndex >= 0
-                              ? `branch-option-${selectedIndex}`
-                              : undefined
-                          }
-                        />
-                      </div>
-                      <ScrollShadow
-                        ref={branchListRef}
-                        id="branch-list"
-                        role="listbox"
-                        className="max-h-[300px]"
-                        scrollClassName="p-1"
-                      >
-                        {selectableRows.length === 0 ? (
-                          <div className="py-6 text-center text-sm text-muted-foreground">
-                            {branchQuery ? "No branches found" : "No branches available"}
-                          </div>
-                        ) : (
-                          (() => {
-                            let optionIndex = 0;
-                            return branchRows.map((row) => {
-                              if (row.kind === "section") {
-                                return (
-                                  <div
-                                    key={`section-${row.label}`}
-                                    role="presentation"
-                                    className="px-2 py-1 text-xs font-medium text-daintree-text/50 uppercase tracking-wider"
-                                  >
-                                    {row.label}
-                                  </div>
-                                );
-                              }
-                              const idx = optionIndex++;
-                              return (
-                                <div
-                                  key={row.name}
-                                  id={`branch-option-${idx}`}
-                                  data-option-index={idx}
-                                  role="option"
-                                  aria-selected={row.name === baseBranch}
-                                  onClick={() => {
-                                    if (row.inUseWorktree) {
-                                      actionService.dispatch("worktree.setActive", {
-                                        worktreeId: row.inUseWorktree.id,
-                                      });
-                                      setBranchPickerOpen(false);
-                                      onClose();
-                                      return;
-                                    }
-                                    handleBranchSelect(row);
-                                  }}
-                                  className={cn(
-                                    "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                                    row.name === baseBranch && "bg-daintree-border",
-                                    idx === selectedIndex && "bg-daintree-accent/10"
-                                  )}
-                                >
-                                  <span className="truncate">
-                                    <HighlightBranchText
-                                      text={row.labelText}
-                                      matchRanges={row.matchRanges}
-                                      nameLength={row.name.length}
-                                    />
-                                  </span>
-                                  <span className="flex items-center gap-1 shrink-0">
-                                    {row.inUseWorktree && (
-                                      <span
-                                        className="text-xs text-status-warning"
-                                        title={`In use by worktree: ${row.inUseWorktree.name}`}
-                                      >
-                                        in use
-                                      </span>
-                                    )}
-                                    {row.name === baseBranch && (
-                                      <Check className="h-4 w-4 text-daintree-accent" />
-                                    )}
-                                  </span>
-                                </div>
-                              );
-                            });
-                          })()
-                        )}
-                      </ScrollShadow>
-                      {!branchQuery && branchOptions.length > 500 && (
-                        <div className="border-t border-daintree-border px-3 py-2 text-xs text-daintree-text/60">
-                          Showing first 500 branches. Type to search.
-                        </div>
-                      )}
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              )}
-
-              {isExistingMode ? (
-                <div className="space-y-2">
-                  <label className="block text-sm font-medium text-daintree-text">
-                    Select Branch
-                  </label>
-                  <Popover
-                    open={existingBranchPickerOpen}
-                    onOpenChange={setExistingBranchPickerOpen}
-                  >
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={existingBranchPickerOpen}
-                        aria-haspopup="listbox"
-                        className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                        disabled={isPending}
-                        data-testid="existing-branch-picker"
-                      >
-                        <span className="flex items-center gap-2 truncate">
-                          <GitBranch className="w-4 h-4 shrink-0 text-daintree-accent" />
-                          {selectedExistingBranch ? (
-                            <span className="font-mono text-sm">{selectedExistingBranch}</span>
-                          ) : (
-                            <span className="text-daintree-text/60">Select a local branch...</span>
-                          )}
-                        </span>
-                        <ChevronsUpDown className="opacity-50 shrink-0" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-[400px] p-0"
-                      align="start"
-                      onEscapeKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <div className="flex items-center border-b border-daintree-border px-3">
-                        <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
-                        <input
-                          className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                          placeholder="Search local branches..."
-                          value={existingBranchQuery}
-                          onChange={(e) => setExistingBranchQuery(e.target.value)}
-                          autoFocus
-                          aria-label="Search existing branches"
-                          data-testid="existing-branch-search"
-                        />
-                      </div>
-                      <ScrollShadow role="listbox" className="max-h-[300px]" scrollClassName="p-1">
-                        {filteredExistingBranches.length === 0 ? (
-                          <div className="py-6 text-center text-sm text-muted-foreground">
-                            {existingBranchQuery
-                              ? "No matching branches"
-                              : "No available local branches"}
-                          </div>
-                        ) : (
-                          filteredExistingBranches.map((branch) => (
-                            <div
-                              key={branch.name}
-                              role="option"
-                              aria-selected={branch.name === selectedExistingBranch}
-                              onClick={() => {
-                                setSelectedExistingBranch(branch.name);
-                                setExistingBranchPickerOpen(false);
-                                setExistingBranchQuery("");
-                                setValidationError(null);
-                                setErrorField(null);
-                                setCreationError(null);
-                              }}
-                              className={cn(
-                                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border font-mono",
-                                branch.name === selectedExistingBranch && "bg-daintree-border"
-                              )}
-                            >
-                              <span className="truncate">{branch.name}</span>
-                              {branch.name === selectedExistingBranch && (
-                                <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                              )}
-                            </div>
-                          ))
-                        )}
-                      </ScrollShadow>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              ) : (
-                <div className="space-y-2">
-                  <label
-                    htmlFor="new-branch"
-                    className="block text-sm font-medium text-daintree-text"
-                  >
-                    New Branch Name
-                  </label>
-                  <Popover open={prefixPickerOpen} onOpenChange={setPrefixPickerOpen}>
-                    <PopoverTrigger asChild>
-                      <div className="relative">
-                        <input
-                          ref={newBranchInputRef}
-                          id="new-branch"
-                          type="text"
-                          data-testid="branch-name-input"
-                          value={branchInput}
-                          onChange={(e) => {
-                            setBranchInput(e.target.value);
-                            markBranchInputTouched();
-                            setValidationError(null);
-                            setErrorField(null);
-                            setCreationError(null);
-                          }}
-                          onKeyDown={handlePrefixKeyDown}
-                          placeholder="feature/add-user-auth"
-                          className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent font-mono text-sm"
-                          disabled={isPending}
-                          aria-invalid={errorField === "new-branch" ? true : undefined}
-                          aria-describedby={
-                            [
-                              errorField === "new-branch" ? "validation-error" : null,
-                              branchWasAutoResolved ? "branch-resolved-hint" : null,
-                            ]
-                              .filter(Boolean)
-                              .join(" ") || undefined
-                          }
-                          role="combobox"
-                          aria-autocomplete="list"
-                          aria-controls="prefix-list"
-                          aria-expanded={prefixPickerOpen}
-                        />
-                        {isCheckingBranch && (
-                          <Spinner
-                            size="md"
-                            className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
-                          />
-                        )}
-                      </div>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      align="start"
-                      className="w-[var(--radix-popover-trigger-width)] p-0 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]"
-                      onOpenAutoFocus={(e) => e.preventDefault()}
-                      onEscapeKeyDown={(e) => e.stopPropagation()}
-                    >
-                      <ScrollShadow
-                        ref={prefixListRef}
-                        id="prefix-list"
-                        role="listbox"
-                        className="max-h-[240px]"
-                        scrollClassName="p-1"
-                      >
-                        {prefixSuggestions.length === 0 ? (
-                          <div className="py-4 text-center text-sm text-daintree-text/60">
-                            No matching prefixes
-                          </div>
-                        ) : (
-                          prefixSuggestions.map((suggestion, index) => (
-                            <div
-                              key={suggestion.type.prefix}
-                              role="option"
-                              aria-selected={index === prefixSelectedIndex}
-                              onClick={() => handlePrefixSelect(suggestion.type.prefix)}
-                              className={cn(
-                                "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                                index === prefixSelectedIndex && "bg-daintree-accent/10"
-                              )}
-                            >
-                              <span className="font-mono text-daintree-accent">
-                                {suggestion.type.prefix}/
-                              </span>
-                              <span className="text-daintree-text/60">
-                                {suggestion.type.displayName}
-                              </span>
-                            </div>
-                          ))
-                        )}
-                      </ScrollShadow>
-                    </PopoverContent>
-                  </Popover>
-                  <p className="text-xs text-daintree-text/60 select-text">
-                    {parsedBranch.hasPrefix ? (
-                      <>
-                        <span className="font-mono text-daintree-accent">
-                          {parsedBranch.prefix}/
-                        </span>
-                        <span className="font-mono">{parsedBranch.slug || "..."}</span>
-                      </>
-                    ) : (
-                      <span className="font-mono">{parsedBranch.fullBranchName || "..."}</span>
-                    )}
-                  </p>
-                  {branchWasAutoResolved && (
-                    <p
-                      id="branch-resolved-hint"
-                      className="text-xs text-status-success flex items-center gap-1.5 mt-1"
-                      role="status"
-                      aria-live="polite"
-                    >
-                      <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                      Name auto-incremented to avoid conflict with existing branch
-                    </p>
-                  )}
-                </div>
-              )}
-
+          <div className="space-y-4">
+            {initialPR ? (
+              <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-daintree-accent/5 border border-daintree-accent/20 text-sm min-w-0">
+                <WorktreeIcon
+                  className="w-4 h-4 text-daintree-accent shrink-0"
+                  aria-hidden="true"
+                />
+                <span className="text-daintree-text/80 min-w-0 truncate">
+                  PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
+                  {initialPR.title}
+                </span>
+              </div>
+            ) : (
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
-                  <label
-                    htmlFor="worktree-path"
-                    className="block text-sm font-medium text-daintree-text"
-                  >
-                    Worktree Path
+                  <label className="block text-sm font-medium text-daintree-text">
+                    Link Issue (Optional)
                   </label>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
                         type="button"
                         className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                        aria-label="Help for Worktree Path field"
+                        aria-label="Help for Link Issue field"
                         disabled={isPending}
                       >
                         <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                        <span className="sr-only">Help for Worktree Path field</span>
+                        <span className="sr-only">Help for Link Issue field</span>
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="right">
-                      <p>Directory where the worktree will be created</p>
+                      <p>Select an issue to auto-generate a branch name</p>
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <div className="flex gap-2 items-center">
-                  <div className="relative flex-1">
-                    <input
-                      id="worktree-path"
-                      data-testid="worktree-path-input"
-                      type="text"
-                      value={worktreePath}
-                      onChange={(e) => {
-                        setWorktreePath(e.target.value);
-                        pathTouchedRef.current = true;
-                        setValidationError(null);
-                        setErrorField(null);
-                        setCreationError(null);
-                      }}
-                      placeholder="/path/to/worktree"
-                      className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent"
-                      disabled={isPending}
-                      aria-invalid={errorField === "worktree-path" ? true : undefined}
-                      aria-describedby={
-                        errorField === "worktree-path" ? "validation-error" : undefined
-                      }
-                    />
-                    {isGeneratingPath && (
-                      <Spinner
-                        size="md"
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
-                      />
-                    )}
+                <IssueSelector
+                  projectPath={rootPath}
+                  selectedIssue={selectedIssue}
+                  onSelect={handleIssueSelect}
+                  disabled={isPending}
+                />
+              </div>
+            )}
+
+            {!initialPR && canAssignIssue && (
+              <div className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border bg-daintree-bg/50 border-daintree-border transition-colors">
+                {currentUserAvatar ? (
+                  <img
+                    src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=64`}
+                    alt={currentUser}
+                    className="w-8 h-8 rounded-full shrink-0"
+                  />
+                ) : (
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-daintree-accent/10 text-daintree-accent">
+                    <UserPlus className="w-4 h-4" />
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={async () => {
-                      try {
-                        const result = await actionService.dispatch(
-                          "project.openDialog",
-                          undefined,
-                          {
-                            source: "user",
-                          }
-                        );
-                        if (result.ok && result.result) {
-                          setWorktreePath(result.result as string);
-                          pathTouchedRef.current = true;
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-daintree-text">Assign to me</span>
+                    <span className="text-xs text-daintree-text/50 font-mono">@{currentUser}</span>
+                  </div>
+                </div>
+                <label className="relative inline-flex items-center cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={assignWorktreeToSelf}
+                    onChange={(e) => setAssignWorktreeToSelf(e.target.checked)}
+                    disabled={isPending}
+                    className="sr-only peer"
+                    aria-label="Assign issue to me when creating worktree"
+                  />
+                  <div
+                    className={cn(
+                      "w-9 h-5 rounded-full transition-colors",
+                      "peer-focus-visible:ring-2 peer-focus-visible:ring-daintree-accent",
+                      "after:content-[''] after:absolute after:top-0.5 after:left-0.5",
+                      "after:rounded-full after:h-4 after:w-4",
+                      "after:transition-transform after:duration-200",
+                      assignWorktreeToSelf
+                        ? "bg-daintree-accent after:translate-x-4 after:bg-text-inverse"
+                        : "bg-daintree-border after:translate-x-0 after:bg-daintree-text",
+                      isPending && "opacity-50 cursor-not-allowed"
+                    )}
+                  />
+                </label>
+              </div>
+            )}
+
+            {!initialPR && (
+              <div
+                className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
+                role="radiogroup"
+                aria-label="Branch mode"
+              >
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={branchMode === "new"}
+                  onClick={() => handleBranchModeChange("new")}
+                  disabled={isPending}
+                  className={cn(
+                    "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+                    branchMode === "new"
+                      ? "bg-daintree-bg text-daintree-text shadow-sm"
+                      : "text-daintree-text/60 hover:text-daintree-text"
+                  )}
+                >
+                  New Branch
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={branchMode === "existing"}
+                  onClick={() => handleBranchModeChange("existing")}
+                  disabled={isPending}
+                  className={cn(
+                    "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+                    branchMode === "existing"
+                      ? "bg-daintree-bg text-daintree-text shadow-sm"
+                      : "text-daintree-text/60 hover:text-daintree-text"
+                  )}
+                >
+                  Existing Branch
+                </button>
+              </div>
+            )}
+
+            {!isExistingMode && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="base-branch"
+                    className="block text-sm font-medium text-daintree-text"
+                  >
+                    Base Branch
+                  </label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+                        aria-label="Help for Base Branch field"
+                        disabled={isPending}
+                      >
+                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span className="sr-only">Help for Base Branch field</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p>The branch to create the new worktree from</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Popover open={branchPickerOpen} onOpenChange={setBranchPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="base-branch"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={branchPickerOpen}
+                      aria-haspopup="listbox"
+                      aria-invalid={errorField === "base-branch" ? true : undefined}
+                      aria-describedby={
+                        errorField === "base-branch" ? "validation-error" : undefined
+                      }
+                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+                      disabled={isPending}
+                    >
+                      <span className="truncate">
+                        {selectedBranchOption?.labelText || "Select base branch..."}
+                      </span>
+                      <ChevronsUpDown className="opacity-50 shrink-0" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[400px] p-0"
+                    align="start"
+                    onEscapeKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex items-center border-b border-daintree-border px-3">
+                      <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
+                      <input
+                        ref={branchInputRef}
+                        className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                        placeholder="Search branches..."
+                        value={branchQuery}
+                        onChange={(e) => setBranchQuery(e.target.value)}
+                        onKeyDown={handleBranchKeyDown}
+                        role="combobox"
+                        aria-label="Search base branches"
+                        aria-autocomplete="list"
+                        aria-controls="branch-list"
+                        aria-expanded={branchPickerOpen}
+                        aria-activedescendant={
+                          selectableRows.length > 0 && selectedIndex >= 0
+                            ? `branch-option-${selectedIndex}`
+                            : undefined
+                        }
+                      />
+                    </div>
+                    <ScrollShadow
+                      ref={branchListRef}
+                      id="branch-list"
+                      role="listbox"
+                      className="max-h-[300px]"
+                      scrollClassName="p-1"
+                    >
+                      {selectableRows.length === 0 ? (
+                        <div className="py-6 text-center text-sm text-muted-foreground">
+                          {branchQuery ? "No branches found" : "No branches available"}
+                        </div>
+                      ) : (
+                        (() => {
+                          let optionIndex = 0;
+                          return branchRows.map((row) => {
+                            if (row.kind === "section") {
+                              return (
+                                <div
+                                  key={`section-${row.label}`}
+                                  role="presentation"
+                                  className="px-2 py-1 text-xs font-medium text-daintree-text/50 uppercase tracking-wider"
+                                >
+                                  {row.label}
+                                </div>
+                              );
+                            }
+                            const idx = optionIndex++;
+                            return (
+                              <div
+                                key={row.name}
+                                id={`branch-option-${idx}`}
+                                data-option-index={idx}
+                                role="option"
+                                aria-selected={row.name === baseBranch}
+                                onClick={() => {
+                                  if (row.inUseWorktree) {
+                                    actionService.dispatch("worktree.setActive", {
+                                      worktreeId: row.inUseWorktree.id,
+                                    });
+                                    setBranchPickerOpen(false);
+                                    onClose();
+                                    return;
+                                  }
+                                  handleBranchSelect(row);
+                                }}
+                                className={cn(
+                                  "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                                  row.name === baseBranch && "bg-daintree-border",
+                                  idx === selectedIndex && "bg-daintree-accent/10"
+                                )}
+                              >
+                                <span className="truncate">
+                                  <HighlightBranchText
+                                    text={row.labelText}
+                                    matchRanges={row.matchRanges}
+                                    nameLength={row.name.length}
+                                  />
+                                </span>
+                                <span className="flex items-center gap-1 shrink-0">
+                                  {row.inUseWorktree && (
+                                    <span
+                                      className="text-xs text-status-warning"
+                                      title={`In use by worktree: ${row.inUseWorktree.name}`}
+                                    >
+                                      in use
+                                    </span>
+                                  )}
+                                  {row.name === baseBranch && (
+                                    <Check className="h-4 w-4 text-daintree-accent" />
+                                  )}
+                                </span>
+                              </div>
+                            );
+                          });
+                        })()
+                      )}
+                    </ScrollShadow>
+                    {!branchQuery && branchOptions.length > 500 && (
+                      <div className="border-t border-daintree-border px-3 py-2 text-xs text-daintree-text/60">
+                        Showing first 500 branches. Type to search.
+                      </div>
+                    )}
+                  </PopoverContent>
+                </Popover>
+              </div>
+            )}
+
+            {isExistingMode ? (
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-daintree-text">
+                  Select Branch
+                </label>
+                <Popover open={existingBranchPickerOpen} onOpenChange={setExistingBranchPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={existingBranchPickerOpen}
+                      aria-haspopup="listbox"
+                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+                      disabled={isPending}
+                      data-testid="existing-branch-picker"
+                    >
+                      <span className="flex items-center gap-2 truncate">
+                        <GitBranch className="w-4 h-4 shrink-0 text-daintree-accent" />
+                        {selectedExistingBranch ? (
+                          <span className="font-mono text-sm">{selectedExistingBranch}</span>
+                        ) : (
+                          <span className="text-daintree-text/60">Select a local branch...</span>
+                        )}
+                      </span>
+                      <ChevronsUpDown className="opacity-50 shrink-0" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[400px] p-0"
+                    align="start"
+                    onEscapeKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex items-center border-b border-daintree-border px-3">
+                      <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
+                      <input
+                        className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                        placeholder="Search local branches..."
+                        value={existingBranchQuery}
+                        onChange={(e) => setExistingBranchQuery(e.target.value)}
+                        autoFocus
+                        aria-label="Search existing branches"
+                        data-testid="existing-branch-search"
+                      />
+                    </div>
+                    <ScrollShadow role="listbox" className="max-h-[300px]" scrollClassName="p-1">
+                      {filteredExistingBranches.length === 0 ? (
+                        <div className="py-6 text-center text-sm text-muted-foreground">
+                          {existingBranchQuery
+                            ? "No matching branches"
+                            : "No available local branches"}
+                        </div>
+                      ) : (
+                        filteredExistingBranches.map((branch) => (
+                          <div
+                            key={branch.name}
+                            role="option"
+                            aria-selected={branch.name === selectedExistingBranch}
+                            onClick={() => {
+                              setSelectedExistingBranch(branch.name);
+                              setExistingBranchPickerOpen(false);
+                              setExistingBranchQuery("");
+                              setValidationError(null);
+                              setErrorField(null);
+                              setCreationError(null);
+                            }}
+                            className={cn(
+                              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border font-mono",
+                              branch.name === selectedExistingBranch && "bg-daintree-border"
+                            )}
+                          >
+                            <span className="truncate">{branch.name}</span>
+                            {branch.name === selectedExistingBranch && (
+                              <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                            )}
+                          </div>
+                        ))
+                      )}
+                    </ScrollShadow>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <label
+                  htmlFor="new-branch"
+                  className="block text-sm font-medium text-daintree-text"
+                >
+                  New Branch Name
+                </label>
+                <Popover open={prefixPickerOpen} onOpenChange={setPrefixPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <div className="relative">
+                      <input
+                        ref={newBranchInputRef}
+                        id="new-branch"
+                        type="text"
+                        data-testid="branch-name-input"
+                        value={branchInput}
+                        onChange={(e) => {
+                          setBranchInput(e.target.value);
+                          markBranchInputTouched();
                           setValidationError(null);
                           setErrorField(null);
                           setCreationError(null);
+                        }}
+                        onKeyDown={handlePrefixKeyDown}
+                        placeholder="feature/add-user-auth"
+                        className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent font-mono text-sm"
+                        disabled={isPending}
+                        aria-invalid={errorField === "new-branch" ? true : undefined}
+                        aria-describedby={
+                          [
+                            errorField === "new-branch" ? "validation-error" : null,
+                            branchWasAutoResolved ? "branch-resolved-hint" : null,
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
                         }
-                      } catch (err: unknown) {
-                        console.error("Failed to open directory picker:", err);
-                        const message = formatErrorMessage(err, "Failed to open directory picker");
-                        setValidationError(`Failed to open directory picker: ${message}`);
-                        setErrorField(null);
-                      }
-                    }}
-                    disabled={isPending}
+                        role="combobox"
+                        aria-autocomplete="list"
+                        aria-controls="prefix-list"
+                        aria-expanded={prefixPickerOpen}
+                      />
+                      {isCheckingBranch && (
+                        <Spinner
+                          size="md"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
+                        />
+                      )}
+                    </div>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="start"
+                    className="w-[var(--radix-popover-trigger-width)] p-0 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]"
+                    onOpenAutoFocus={(e) => e.preventDefault()}
+                    onEscapeKeyDown={(e) => e.stopPropagation()}
                   >
-                    <FolderOpen />
-                  </Button>
-                </div>
-                {pathWasAutoResolved && (
+                    <ScrollShadow
+                      ref={prefixListRef}
+                      id="prefix-list"
+                      role="listbox"
+                      className="max-h-[240px]"
+                      scrollClassName="p-1"
+                    >
+                      {prefixSuggestions.length === 0 ? (
+                        <div className="py-4 text-center text-sm text-daintree-text/60">
+                          No matching prefixes
+                        </div>
+                      ) : (
+                        prefixSuggestions.map((suggestion, index) => (
+                          <div
+                            key={suggestion.type.prefix}
+                            role="option"
+                            aria-selected={index === prefixSelectedIndex}
+                            onClick={() => handlePrefixSelect(suggestion.type.prefix)}
+                            className={cn(
+                              "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                              index === prefixSelectedIndex && "bg-daintree-accent/10"
+                            )}
+                          >
+                            <span className="font-mono text-daintree-accent">
+                              {suggestion.type.prefix}/
+                            </span>
+                            <span className="text-daintree-text/60">
+                              {suggestion.type.displayName}
+                            </span>
+                          </div>
+                        ))
+                      )}
+                    </ScrollShadow>
+                  </PopoverContent>
+                </Popover>
+                <p className="text-xs text-daintree-text/60 select-text">
+                  {parsedBranch.hasPrefix ? (
+                    <>
+                      <span className="font-mono text-daintree-accent">{parsedBranch.prefix}/</span>
+                      <span className="font-mono">{parsedBranch.slug || "..."}</span>
+                    </>
+                  ) : (
+                    <span className="font-mono">{parsedBranch.fullBranchName || "..."}</span>
+                  )}
+                </p>
+                {branchWasAutoResolved && (
                   <p
+                    id="branch-resolved-hint"
                     className="text-xs text-status-success flex items-center gap-1.5 mt-1"
                     role="status"
                     aria-live="polite"
                   >
                     <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                    Path auto-incremented to avoid conflict with existing directory
+                    Name auto-incremented to avoid conflict with existing branch
                   </p>
                 )}
               </div>
+            )}
 
-              {!isExistingMode && (
-                <div className="flex items-center gap-2">
-                  <input
-                    id="from-remote"
-                    type="checkbox"
-                    checked={fromRemote}
-                    onChange={(e) => setFromRemote(e.target.checked)}
-                    className="rounded border-daintree-border text-daintree-accent focus:ring-daintree-accent"
-                    disabled={isPending}
-                  />
-                  <label htmlFor="from-remote" className="text-sm text-daintree-text select-none">
-                    Create from remote branch
-                  </label>
-                </div>
-              )}
-
-              {hasAnyEnvironments && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <label className="block text-sm font-medium text-daintree-text">
-                      Environment
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                          aria-label="Help for Environment field"
-                          disabled={isPending}
-                        >
-                          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        <p>
-                          Choose where this worktree runs. Non-local environments provision remote
-                          compute from project environment settings.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <div
-                    className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-                    role="radiogroup"
-                    aria-label="Worktree environment mode"
-                  >
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <label
+                  htmlFor="worktree-path"
+                  className="block text-sm font-medium text-daintree-text"
+                >
+                  Worktree Path
+                </label>
+                <Tooltip>
+                  <TooltipTrigger asChild>
                     <button
                       type="button"
+                      className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+                      aria-label="Help for Worktree Path field"
+                      disabled={isPending}
+                    >
+                      <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                      <span className="sr-only">Help for Worktree Path field</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    <p>Directory where the worktree will be created</p>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <div className="flex gap-2 items-center">
+                <div className="relative flex-1">
+                  <input
+                    id="worktree-path"
+                    data-testid="worktree-path-input"
+                    type="text"
+                    value={worktreePath}
+                    onChange={(e) => {
+                      setWorktreePath(e.target.value);
+                      pathTouchedRef.current = true;
+                      setValidationError(null);
+                      setErrorField(null);
+                      setCreationError(null);
+                    }}
+                    placeholder="/path/to/worktree"
+                    className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent"
+                    disabled={isPending}
+                    aria-invalid={errorField === "worktree-path" ? true : undefined}
+                    aria-describedby={
+                      errorField === "worktree-path" ? "validation-error" : undefined
+                    }
+                  />
+                  {isGeneratingPath && (
+                    <Spinner
+                      size="md"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
+                    />
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={async () => {
+                    try {
+                      const result = await actionService.dispatch("project.openDialog", undefined, {
+                        source: "user",
+                      });
+                      if (result.ok && result.result) {
+                        setWorktreePath(result.result as string);
+                        pathTouchedRef.current = true;
+                        setValidationError(null);
+                        setErrorField(null);
+                        setCreationError(null);
+                      }
+                    } catch (err: unknown) {
+                      console.error("Failed to open directory picker:", err);
+                      const message = formatErrorMessage(err, "Failed to open directory picker");
+                      setValidationError(`Failed to open directory picker: ${message}`);
+                      setErrorField(null);
+                    }
+                  }}
+                  disabled={isPending}
+                >
+                  <FolderOpen />
+                </Button>
+              </div>
+              {pathWasAutoResolved && (
+                <p
+                  className="text-xs text-status-success flex items-center gap-1.5 mt-1"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                  Path auto-incremented to avoid conflict with existing directory
+                </p>
+              )}
+            </div>
+
+            {!isExistingMode && (
+              <div className="flex items-center gap-2">
+                <input
+                  id="from-remote"
+                  type="checkbox"
+                  checked={fromRemote}
+                  onChange={(e) => setFromRemote(e.target.checked)}
+                  className="rounded border-daintree-border text-daintree-accent focus:ring-daintree-accent"
+                  disabled={isPending}
+                />
+                <label htmlFor="from-remote" className="text-sm text-daintree-text select-none">
+                  Create from remote branch
+                </label>
+              </div>
+            )}
+
+            {hasAnyEnvironments && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <label className="block text-sm font-medium text-daintree-text">
+                    Environment
+                  </label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+                        aria-label="Help for Environment field"
+                        disabled={isPending}
+                      >
+                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p>
+                        Choose where this worktree runs. Non-local environments provision remote
+                        compute from project environment settings.
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <div
+                  className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
+                  role="radiogroup"
+                  aria-label="Worktree environment mode"
+                >
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={worktreeMode === "local"}
+                    onClick={() => setWorktreeMode("local")}
+                    disabled={isPending}
+                    className={cn(
+                      "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+                      worktreeMode === "local"
+                        ? "bg-daintree-bg text-daintree-text shadow-sm"
+                        : "text-daintree-text/60 hover:text-daintree-text"
+                    )}
+                  >
+                    Local
+                  </button>
+                  {Object.entries(resourceEnvironments ?? {}).map(([key]) => (
+                    <button
+                      key={key}
+                      type="button"
                       role="radio"
-                      aria-checked={worktreeMode === "local"}
-                      onClick={() => setWorktreeMode("local")}
+                      aria-checked={worktreeMode === key}
+                      onClick={() => setWorktreeMode(key)}
                       disabled={isPending}
                       className={cn(
                         "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                        worktreeMode === "local"
+                        worktreeMode === key
                           ? "bg-daintree-bg text-daintree-text shadow-sm"
                           : "text-daintree-text/60 hover:text-daintree-text"
                       )}
                     >
-                      Local
+                      {key}
                     </button>
-                    {Object.entries(resourceEnvironments ?? {}).map(([key]) => (
-                      <button
-                        key={key}
-                        type="button"
-                        role="radio"
-                        aria-checked={worktreeMode === key}
-                        onClick={() => setWorktreeMode(key)}
-                        disabled={isPending}
-                        className={cn(
-                          "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                          worktreeMode === key
-                            ? "bg-daintree-bg text-daintree-text shadow-sm"
-                            : "text-daintree-text/60 hover:text-daintree-text"
-                        )}
-                      >
-                        {key}
-                      </button>
-                    ))}
-                  </div>
-                  {worktreeMode !== "local" && (
-                    <p className="text-xs text-daintree-text/50">
-                      Provisions {worktreeMode} environment after worktree setup
-                    </p>
-                  )}
+                  ))}
                 </div>
-              )}
+                {worktreeMode !== "local" && (
+                  <p className="text-xs text-daintree-text/50">
+                    Provisions {worktreeMode} environment after worktree setup
+                  </p>
+                )}
+              </div>
+            )}
 
-              {globalRecipes.length > 0 && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <label
-                      htmlFor="recipe-selector"
-                      className="block text-sm font-medium text-daintree-text"
-                    >
-                      Run Recipe (Optional)
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                          aria-label="Help for Run Recipe field"
-                          disabled={isPending}
-                        >
-                          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                          <span className="sr-only">Help for Run Recipe field</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        <p>Select a recipe to run after creating the worktree</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="recipe-selector"
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={recipePickerOpen}
-                        aria-haspopup="listbox"
-                        aria-controls="recipe-list"
-                        className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+            {globalRecipes.length > 0 && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="recipe-selector"
+                    className="block text-sm font-medium text-daintree-text"
+                  >
+                    Run Recipe (Optional)
+                  </label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+                        aria-label="Help for Run Recipe field"
                         disabled={isPending}
                       >
-                        <span className="flex items-center gap-2 truncate">
-                          {selectedRecipeId === CLONE_LAYOUT_ID ? (
-                            <>
-                              <Copy className="shrink-0 text-daintree-accent" />
-                              <span>Clone current layout</span>
-                            </>
-                          ) : selectedRecipe ? (
-                            <>
-                              <Play className="shrink-0 text-daintree-accent" />
-                              <span>{selectedRecipe.name}</span>
-                              <span className="text-xs text-daintree-text/50">
-                                ({selectedRecipe.terminals.length} terminal
-                                {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                              </span>
-                            </>
-                          ) : (
-                            <>
-                              <Play className="shrink-0 text-daintree-accent" />
-                              <span className="text-daintree-text/60">Empty</span>
-                            </>
-                          )}
-                        </span>
-                        <ChevronsUpDown className="opacity-50 shrink-0" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-[400px] p-0"
-                      align="start"
-                      onEscapeKeyDown={(e) => e.stopPropagation()}
+                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span className="sr-only">Help for Run Recipe field</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p>Select a recipe to run after creating the worktree</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="recipe-selector"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={recipePickerOpen}
+                      aria-haspopup="listbox"
+                      aria-controls="recipe-list"
+                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+                      disabled={isPending}
                     >
-                      <ScrollShadow
-                        id="recipe-list"
-                        role="listbox"
-                        className="max-h-[300px]"
-                        scrollClassName="p-1"
-                      >
-                        <div
-                          role="option"
-                          aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
-                          tabIndex={0}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              recipeSelectionTouchedRef.current = true;
-                              setSelectedRecipeId(CLONE_LAYOUT_ID);
-                              if (projectId)
-                                setLastSelectedWorktreeRecipeIdByProject(
-                                  projectId,
-                                  CLONE_LAYOUT_ID
-                                );
-                              setRecipePickerOpen(false);
-                            }
-                          }}
-                          onClick={() => {
+                      <span className="flex items-center gap-2 truncate">
+                        {selectedRecipeId === CLONE_LAYOUT_ID ? (
+                          <>
+                            <Copy className="shrink-0 text-daintree-accent" />
+                            <span>Clone current layout</span>
+                          </>
+                        ) : selectedRecipe ? (
+                          <>
+                            <Play className="shrink-0 text-daintree-accent" />
+                            <span>{selectedRecipe.name}</span>
+                            <span className="text-xs text-daintree-text/50">
+                              ({selectedRecipe.terminals.length} terminal
+                              {selectedRecipe.terminals.length !== 1 ? "s" : ""})
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            <Play className="shrink-0 text-daintree-accent" />
+                            <span className="text-daintree-text/60">Empty</span>
+                          </>
+                        )}
+                      </span>
+                      <ChevronsUpDown className="opacity-50 shrink-0" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[400px] p-0"
+                    align="start"
+                    onEscapeKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <ScrollShadow
+                      id="recipe-list"
+                      role="listbox"
+                      className="max-h-[300px]"
+                      scrollClassName="p-1"
+                    >
+                      <div
+                        role="option"
+                        aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
+                        tabIndex={0}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
                             recipeSelectionTouchedRef.current = true;
                             setSelectedRecipeId(CLONE_LAYOUT_ID);
                             if (projectId)
                               setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
                             setRecipePickerOpen(false);
-                          }}
-                          className={cn(
-                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                            selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
-                          )}
-                        >
-                          <div className="flex items-center gap-2">
-                            <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
-                            <span>Clone current layout</span>
-                          </div>
-                          {selectedRecipeId === CLONE_LAYOUT_ID && (
-                            <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                          )}
+                          }
+                        }}
+                        onClick={() => {
+                          recipeSelectionTouchedRef.current = true;
+                          setSelectedRecipeId(CLONE_LAYOUT_ID);
+                          if (projectId)
+                            setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
+                          setRecipePickerOpen(false);
+                        }}
+                        className={cn(
+                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                          selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
+                        )}
+                      >
+                        <div className="flex items-center gap-2">
+                          <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
+                          <span>Clone current layout</span>
                         </div>
-                        <div
-                          role="option"
-                          aria-selected={selectedRecipeId === null}
-                          tabIndex={0}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              recipeSelectionTouchedRef.current = true;
-                              setSelectedRecipeId(null);
-                              if (projectId)
-                                setLastSelectedWorktreeRecipeIdByProject(projectId, null);
-                              setRecipePickerOpen(false);
-                            }
-                          }}
-                          onClick={() => {
+                        {selectedRecipeId === CLONE_LAYOUT_ID && (
+                          <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                        )}
+                      </div>
+                      <div
+                        role="option"
+                        aria-selected={selectedRecipeId === null}
+                        tabIndex={0}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
                             recipeSelectionTouchedRef.current = true;
                             setSelectedRecipeId(null);
                             if (projectId)
                               setLastSelectedWorktreeRecipeIdByProject(projectId, null);
                             setRecipePickerOpen(false);
-                          }}
-                          className={cn(
-                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                            selectedRecipeId === null && "bg-daintree-border"
-                          )}
-                        >
-                          <span className="text-daintree-text/60">Empty</span>
-                          {selectedRecipeId === null && (
-                            <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                          )}
-                        </div>
-                        {globalRecipes.map((recipe) => (
-                          <div
-                            key={recipe.id}
-                            role="option"
-                            aria-selected={recipe.id === selectedRecipeId}
-                            tabIndex={0}
-                            onKeyDown={(event) => {
-                              if (event.key === "Enter" || event.key === " ") {
-                                event.preventDefault();
-                                recipeSelectionTouchedRef.current = true;
-                                setSelectedRecipeId(recipe.id);
-                                if (projectId)
-                                  setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
-                                setRecipePickerOpen(false);
-                              }
-                            }}
-                            onClick={() => {
+                          }
+                        }}
+                        onClick={() => {
+                          recipeSelectionTouchedRef.current = true;
+                          setSelectedRecipeId(null);
+                          if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, null);
+                          setRecipePickerOpen(false);
+                        }}
+                        className={cn(
+                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                          selectedRecipeId === null && "bg-daintree-border"
+                        )}
+                      >
+                        <span className="text-daintree-text/60">Empty</span>
+                        {selectedRecipeId === null && (
+                          <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                        )}
+                      </div>
+                      {globalRecipes.map((recipe) => (
+                        <div
+                          key={recipe.id}
+                          role="option"
+                          aria-selected={recipe.id === selectedRecipeId}
+                          tabIndex={0}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
                               recipeSelectionTouchedRef.current = true;
                               setSelectedRecipeId(recipe.id);
                               if (projectId)
                                 setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
                               setRecipePickerOpen(false);
-                            }}
-                            className={cn(
-                              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                              recipe.id === selectedRecipeId && "bg-daintree-border"
-                            )}
-                          >
-                            <div className="flex items-center gap-2 min-w-0">
-                              <span className="truncate">{recipe.name}</span>
-                              <span className="text-xs text-daintree-text/50 shrink-0">
-                                {recipe.terminals.length} terminal
-                                {recipe.terminals.length !== 1 ? "s" : ""}
+                            }
+                          }}
+                          onClick={() => {
+                            recipeSelectionTouchedRef.current = true;
+                            setSelectedRecipeId(recipe.id);
+                            if (projectId)
+                              setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
+                            setRecipePickerOpen(false);
+                          }}
+                          className={cn(
+                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                            recipe.id === selectedRecipeId && "bg-daintree-border"
+                          )}
+                        >
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="truncate">{recipe.name}</span>
+                            <span className="text-xs text-daintree-text/50 shrink-0">
+                              {recipe.terminals.length} terminal
+                              {recipe.terminals.length !== 1 ? "s" : ""}
+                            </span>
+                            {recipe.id === defaultRecipeId && (
+                              <span className="text-xs text-daintree-accent shrink-0">
+                                (default)
                               </span>
-                              {recipe.id === defaultRecipeId && (
-                                <span className="text-xs text-daintree-accent shrink-0">
-                                  (default)
-                                </span>
-                              )}
-                            </div>
-                            {recipe.id === selectedRecipeId && (
-                              <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
                             )}
                           </div>
-                        ))}
-                      </ScrollShadow>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              )}
+                          {recipe.id === selectedRecipeId && (
+                            <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                          )}
+                        </div>
+                      ))}
+                    </ScrollShadow>
+                  </PopoverContent>
+                </Popover>
+              </div>
+            )}
 
-              {initialPR && prBranchResolved === false && (
-                <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)]">
-                  <AlertCircle className="w-4 h-4 text-status-warning mt-0.5 flex-shrink-0" />
-                  <p className="text-sm text-status-warning">
-                    Could not fetch branch{" "}
-                    <span className="font-mono">{initialPR.headRefName ?? "unknown"}</span> from the
-                    remote. The worktree will be created from the fallback branch instead. You can
-                    try running <span className="font-mono">git fetch origin</span> manually and
-                    reopening this dialog.
-                  </p>
-                </div>
-              )}
+            {initialPR && prBranchResolved === false && (
+              <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)]">
+                <AlertCircle className="w-4 h-4 text-status-warning mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-status-warning">
+                  Could not fetch branch{" "}
+                  <span className="font-mono">{initialPR.headRefName ?? "unknown"}</span> from the
+                  remote. The worktree will be created from the fallback branch instead. You can try
+                  running <span className="font-mono">git fetch origin</span> manually and reopening
+                  this dialog.
+                </p>
+              </div>
+            )}
 
-              {validationError && (
-                <div
-                  id="validation-error"
-                  role="alert"
-                  className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)]"
-                >
+            {validationError && (
+              <div
+                id="validation-error"
+                role="alert"
+                className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)]"
+              >
+                <AlertCircle className="w-4 h-4 text-status-error mt-0.5 flex-shrink-0" />
+                <p className="text-sm text-status-error">{validationError}</p>
+              </div>
+            )}
+
+            {creationError && (
+              <div
+                role="alert"
+                className="p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)] space-y-2"
+              >
+                <div className="flex items-start gap-2">
                   <AlertCircle className="w-4 h-4 text-status-error mt-0.5 flex-shrink-0" />
-                  <p className="text-sm text-status-error">{validationError}</p>
+                  <p className="text-sm text-status-error">{creationError.friendly}</p>
                 </div>
-              )}
-
-              {creationError && (
-                <div
-                  role="alert"
-                  className="p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)] space-y-2"
-                >
-                  <div className="flex items-start gap-2">
-                    <AlertCircle className="w-4 h-4 text-status-error mt-0.5 flex-shrink-0" />
-                    <p className="text-sm text-status-error">{creationError.friendly}</p>
-                  </div>
-                  {creationError.recovery && (
-                    <button
-                      type="button"
-                      onClick={creationError.recovery.onAction}
-                      className="ml-6 text-xs font-medium text-status-error underline underline-offset-2 hover:text-status-error/80"
-                    >
-                      {creationError.recovery.label}
-                    </button>
-                  )}
-                  {creationError.raw !== creationError.friendly && (
-                    <details className="ml-6">
-                      <summary className="flex items-center gap-1 text-xs text-daintree-text/50 cursor-pointer select-none">
-                        <ChevronDown className="w-3 h-3" />
-                        Show details
-                      </summary>
-                      <pre className="mt-1.5 overflow-x-auto rounded bg-status-error/5 p-2 font-mono text-[11px] text-daintree-text/50 whitespace-pre-wrap break-all select-text">
-                        {creationError.raw}
-                      </pre>
-                    </details>
-                  )}
-                </div>
-              )}
-            </div>
-          </TooltipProvider>
+                {creationError.recovery && (
+                  <button
+                    type="button"
+                    onClick={creationError.recovery.onAction}
+                    className="ml-6 text-xs font-medium text-status-error underline underline-offset-2 hover:text-status-error/80"
+                  >
+                    {creationError.recovery.label}
+                  </button>
+                )}
+                {creationError.raw !== creationError.friendly && (
+                  <details className="ml-6">
+                    <summary className="flex items-center gap-1 text-xs text-daintree-text/50 cursor-pointer select-none">
+                      <ChevronDown className="w-3 h-3" />
+                      Show details
+                    </summary>
+                    <pre className="mt-1.5 overflow-x-auto rounded bg-status-error/5 p-2 font-mono text-[11px] text-daintree-text/50 whitespace-pre-wrap break-all select-text">
+                      {creationError.raw}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            )}
+          </div>
         )}
       </AppDialog.Body>
 

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -4,7 +4,7 @@ import type { StagingFileEntry } from "@shared/types";
 import type { GitStatus } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { Plus, Minus } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 const STATUS_CONFIG: Record<GitStatus, { label: string; bg: string; text: string }> = {
   modified: {
@@ -87,28 +87,26 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
         isStaged ? "bg-status-success/[0.06] hover:bg-status-success/[0.10]" : "hover:bg-tint/5"
       )}
     >
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={handleToggle}
-              className={cn(
-                "w-5 h-5 flex items-center justify-center rounded shrink-0 mr-2 transition-colors",
-                "hover:bg-tint/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-              )}
-              aria-label={isStaged ? `Unstage ${file.path}` : `Stage ${file.path}`}
-            >
-              {isStaged ? (
-                <Minus className="w-3 h-3 text-status-error" />
-              ) : (
-                <Plus className="w-3 h-3 text-status-success" />
-              )}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="right">{isStaged ? "Unstage" : "Stage"}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleToggle}
+            className={cn(
+              "w-5 h-5 flex items-center justify-center rounded shrink-0 mr-2 transition-colors",
+              "hover:bg-tint/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+            )}
+            aria-label={isStaged ? `Unstage ${file.path}` : `Stage ${file.path}`}
+          >
+            {isStaged ? (
+              <Minus className="w-3 h-3 text-status-error" />
+            ) : (
+              <Plus className="w-3 h-3 text-status-success" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right">{isStaged ? "Unstage" : "Stage"}</TooltipContent>
+      </Tooltip>
 
       <button
         type="button"

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -20,7 +20,7 @@ import {
   type GroupedSection,
 } from "@/lib/worktreeFilters";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { isAgentTerminal } from "@/utils/terminalType";
 
 interface OverviewWorktreeCardProps {
@@ -399,273 +399,271 @@ export function WorktreeOverviewModal({
       aria-modal="true"
       aria-labelledby="worktree-overview-title"
     >
-      <TooltipProvider delayDuration={400} skipDelayDuration={300}>
-        <div
-          className={cn(
-            "relative flex flex-col",
-            "w-[calc(100vw-80px)] h-[calc(100vh-80px)]",
-            "max-w-[1800px] max-h-[1200px]",
-            "bg-daintree-bg rounded-xl",
-            "border border-divider",
-            "shadow-[var(--theme-shadow-dialog)]",
-            "motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
-          )}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
-            <div className="flex items-center gap-3">
-              <WorktreeOverviewIcon className="w-5 h-5 text-daintree-text/60" />
-              <h2
-                id="worktree-overview-title"
-                className="text-daintree-text font-semibold text-base tracking-wide"
-              >
-                Worktrees Overview
-              </h2>
-              <span className="text-daintree-text/50 text-sm tabular-nums">
-                ({filteredWorktrees.length}
-                {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
-              </span>
-              {/* Aggregate activity statistics */}
-              {(aggregateStats.workingCount > 0 || aggregateStats.waitingCount > 0) && (
-                <div
-                  className="flex items-center gap-2 ml-2 pl-3 border-l border-divider"
-                  role="status"
-                  aria-label="Agent activity statistics"
-                >
-                  {aggregateStats.workingCount > 0 && (
-                    <span className="flex items-center gap-1 text-xs tabular-nums text-[var(--color-state-working)]">
-                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
-                      {aggregateStats.workingCount} working
-                    </span>
-                  )}
-                  {aggregateStats.waitingCount > 0 && (
-                    <span className="flex items-center gap-1 text-xs tabular-nums text-status-warning">
-                      <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
-                      {aggregateStats.waitingCount} waiting
-                    </span>
-                  )}
-                </div>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              {/* Hide main worktree toggle - show if there are non-main worktrees OR if filter is active (to allow recovery) */}
-              {(hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={!hideMainWorktree}
-                      aria-label={hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
-                      onClick={() => setHideMainWorktree(!hideMainWorktree)}
-                      className={cn(
-                        "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs transition-colors",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent",
-                        hideMainWorktree
-                          ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
-                          : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
-                      )}
-                    >
-                      <DaintreeAgentIcon
-                        className={cn(
-                          "w-3 h-3 transition-colors",
-                          hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
-                        )}
-                      />
-                      <span
-                        className={cn(
-                          "transition",
-                          hideMainWorktree && "line-through decoration-daintree-text/30"
-                        )}
-                      >
-                        main
-                      </span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    {hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {/* Filter Popover */}
-              <WorktreeFilterPopover />
-              {/* Clear Filters Button - only shown when filters are active */}
-              {hasActiveFilters() && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={clearAllFilters}
-                      className={cn(
-                        "flex items-center gap-1.5 px-2 py-1.5 rounded text-xs",
-                        "text-daintree-text/60 hover:text-daintree-text",
-                        "hover:bg-tint/[0.06]",
-                        "transition-colors",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
-                      )}
-                      aria-label="Clear all filters"
-                    >
-                      <FilterX className="w-3.5 h-3.5" />
-                      <span>Clear</span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Clear all filters</TooltipContent>
-                </Tooltip>
-              )}
-              {/* Close Button */}
-              <button
-                ref={closeButtonRef}
-                onClick={onClose}
-                className={cn(
-                  "p-2 rounded-lg transition-colors",
-                  "text-daintree-text/60 hover:text-daintree-text",
-                  "hover:bg-tint/[0.06]",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
-                )}
-                aria-label="Close overview"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </div>
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto p-6">
-            {worktrees.length === 0 ? (
-              <EmptyWorktreeState />
-            ) : filteredWorktrees.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-full gap-4 text-daintree-text/50">
-                <FilterX className="w-12 h-12 text-daintree-text/30" />
-                <div className="text-center">
-                  <p className="text-sm font-medium text-daintree-text/70">
-                    No worktrees match filters
-                  </p>
-                  <p className="text-xs mt-1">
-                    {worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""} hidden by active
-                    filters
-                  </p>
-                </div>
-                <Button variant="subtle" size="sm" onClick={clearAllFilters} className="mt-2">
-                  Clear all filters
-                </Button>
-              </div>
-            ) : groupedSections ? (
-              <div className="space-y-6">
-                {groupedSections.map((section: GroupedSection<WorktreeState>) => (
-                  <div key={section.type}>
-                    <div className="flex items-center gap-2 mb-3">
-                      <h3 className="text-xs font-medium text-daintree-text/60 uppercase tracking-wider">
-                        {section.displayName}
-                      </h3>
-                      <span className="text-xs text-daintree-text/40">
-                        ({section.worktrees.length})
-                      </span>
-                    </div>
-                    <div
-                      className={cn(
-                        "grid gap-3",
-                        "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                        "justify-center",
-                        "auto-rows-min"
-                      )}
-                    >
-                      {section.worktrees.map((worktree: WorktreeState) => (
-                        <div
-                          key={worktree.id}
-                          style={{
-                            contentVisibility: "auto",
-                            containIntrinsicSize: "auto 240px",
-                          }}
-                          className={cn(
-                            "rounded-lg overflow-hidden",
-                            "border border-divider",
-                            "bg-daintree-sidebar/50",
-                            "transition duration-200",
-                            "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
-                            worktree.id === activeWorktreeId &&
-                              "border-[var(--color-state-active)]/70 shadow-md"
-                          )}
-                        >
-                          <OverviewWorktreeCard
-                            worktreeId={worktree.id}
-                            activeWorktreeId={activeWorktreeId}
-                            focusedWorktreeId={focusedWorktreeId}
-                            totalWorktreeCount={worktrees.length}
-                            onSelectWorktree={onSelectWorktree}
-                            onCopyTree={onCopyTree}
-                            onOpenEditor={onOpenEditor}
-                            onSaveLayout={onSaveLayout}
-                            onLaunchAgent={onLaunchAgent}
-                            agentAvailability={agentAvailability}
-                            agentSettings={agentSettings}
-                            homeDir={homeDir}
-                            onClose={onClose}
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : (
+      <div
+        className={cn(
+          "relative flex flex-col",
+          "w-[calc(100vw-80px)] h-[calc(100vh-80px)]",
+          "max-w-[1800px] max-h-[1200px]",
+          "bg-daintree-bg rounded-xl",
+          "border border-divider",
+          "shadow-[var(--theme-shadow-dialog)]",
+          "motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
+          <div className="flex items-center gap-3">
+            <WorktreeOverviewIcon className="w-5 h-5 text-daintree-text/60" />
+            <h2
+              id="worktree-overview-title"
+              className="text-daintree-text font-semibold text-base tracking-wide"
+            >
+              Worktrees Overview
+            </h2>
+            <span className="text-daintree-text/50 text-sm tabular-nums">
+              ({filteredWorktrees.length}
+              {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
+            </span>
+            {/* Aggregate activity statistics */}
+            {(aggregateStats.workingCount > 0 || aggregateStats.waitingCount > 0) && (
               <div
-                className={cn(
-                  "grid gap-3",
-                  "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                  "justify-center",
-                  "items-start"
-                )}
+                className="flex items-center gap-2 ml-2 pl-3 border-l border-divider"
+                role="status"
+                aria-label="Agent activity statistics"
               >
-                {filteredWorktrees.map((worktree) => (
-                  <div
-                    key={worktree.id}
-                    style={{
-                      contentVisibility: "auto",
-                      containIntrinsicSize: "auto 240px",
-                    }}
-                    className={cn(
-                      "rounded-lg overflow-hidden",
-                      "border border-divider",
-                      "bg-daintree-sidebar/50",
-                      "transition duration-200",
-                      "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
-                      worktree.id === activeWorktreeId &&
-                        "border-[var(--color-state-active)]/70 shadow-md"
-                    )}
-                  >
-                    <OverviewWorktreeCard
-                      variant="grid"
-                      worktreeId={worktree.id}
-                      activeWorktreeId={activeWorktreeId}
-                      focusedWorktreeId={focusedWorktreeId}
-                      totalWorktreeCount={worktrees.length}
-                      onSelectWorktree={onSelectWorktree}
-                      onCopyTree={onCopyTree}
-                      onOpenEditor={onOpenEditor}
-                      onSaveLayout={onSaveLayout}
-                      onLaunchAgent={onLaunchAgent}
-                      agentAvailability={agentAvailability}
-                      agentSettings={agentSettings}
-                      homeDir={homeDir}
-                      onClose={onClose}
-                    />
-                  </div>
-                ))}
+                {aggregateStats.workingCount > 0 && (
+                  <span className="flex items-center gap-1 text-xs tabular-nums text-[var(--color-state-working)]">
+                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
+                    {aggregateStats.workingCount} working
+                  </span>
+                )}
+                {aggregateStats.waitingCount > 0 && (
+                  <span className="flex items-center gap-1 text-xs tabular-nums text-status-warning">
+                    <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
+                    {aggregateStats.waitingCount} waiting
+                  </span>
+                )}
               </div>
             )}
           </div>
-
-          {/* Footer hint */}
-          <div className="px-6 py-3 border-t border-divider shrink-0">
-            <div className="flex items-center justify-center gap-4 text-xs text-daintree-text/40">
-              <span>
-                <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd> to close
-              </span>
-              <span>Click a worktree to switch</span>
-            </div>
+          <div className="flex items-center gap-2">
+            {/* Hide main worktree toggle - show if there are non-main worktrees OR if filter is active (to allow recovery) */}
+            {(hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={!hideMainWorktree}
+                    aria-label={hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
+                    onClick={() => setHideMainWorktree(!hideMainWorktree)}
+                    className={cn(
+                      "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent",
+                      hideMainWorktree
+                        ? "bg-tint/[0.06] text-daintree-text/40 hover:text-daintree-text/60"
+                        : "bg-tint/[0.10] text-daintree-text/70 hover:text-daintree-text/90"
+                    )}
+                  >
+                    <DaintreeAgentIcon
+                      className={cn(
+                        "w-3 h-3 transition-colors",
+                        hideMainWorktree ? "text-daintree-text/30" : "text-daintree-text/50"
+                      )}
+                    />
+                    <span
+                      className={cn(
+                        "transition",
+                        hideMainWorktree && "line-through decoration-daintree-text/30"
+                      )}
+                    >
+                      main
+                    </span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  {hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {/* Filter Popover */}
+            <WorktreeFilterPopover />
+            {/* Clear Filters Button - only shown when filters are active */}
+            {hasActiveFilters() && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={clearAllFilters}
+                    className={cn(
+                      "flex items-center gap-1.5 px-2 py-1.5 rounded text-xs",
+                      "text-daintree-text/60 hover:text-daintree-text",
+                      "hover:bg-tint/[0.06]",
+                      "transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                    )}
+                    aria-label="Clear all filters"
+                  >
+                    <FilterX className="w-3.5 h-3.5" />
+                    <span>Clear</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Clear all filters</TooltipContent>
+              </Tooltip>
+            )}
+            {/* Close Button */}
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              className={cn(
+                "p-2 rounded-lg transition-colors",
+                "text-daintree-text/60 hover:text-daintree-text",
+                "hover:bg-tint/[0.06]",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
+              )}
+              aria-label="Close overview"
+            >
+              <X className="w-5 h-5" />
+            </button>
           </div>
         </div>
-      </TooltipProvider>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {worktrees.length === 0 ? (
+            <EmptyWorktreeState />
+          ) : filteredWorktrees.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full gap-4 text-daintree-text/50">
+              <FilterX className="w-12 h-12 text-daintree-text/30" />
+              <div className="text-center">
+                <p className="text-sm font-medium text-daintree-text/70">
+                  No worktrees match filters
+                </p>
+                <p className="text-xs mt-1">
+                  {worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""} hidden by active
+                  filters
+                </p>
+              </div>
+              <Button variant="subtle" size="sm" onClick={clearAllFilters} className="mt-2">
+                Clear all filters
+              </Button>
+            </div>
+          ) : groupedSections ? (
+            <div className="space-y-6">
+              {groupedSections.map((section: GroupedSection<WorktreeState>) => (
+                <div key={section.type}>
+                  <div className="flex items-center gap-2 mb-3">
+                    <h3 className="text-xs font-medium text-daintree-text/60 uppercase tracking-wider">
+                      {section.displayName}
+                    </h3>
+                    <span className="text-xs text-daintree-text/40">
+                      ({section.worktrees.length})
+                    </span>
+                  </div>
+                  <div
+                    className={cn(
+                      "grid gap-3",
+                      "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                      "justify-center",
+                      "auto-rows-min"
+                    )}
+                  >
+                    {section.worktrees.map((worktree: WorktreeState) => (
+                      <div
+                        key={worktree.id}
+                        style={{
+                          contentVisibility: "auto",
+                          containIntrinsicSize: "auto 240px",
+                        }}
+                        className={cn(
+                          "rounded-lg overflow-hidden",
+                          "border border-divider",
+                          "bg-daintree-sidebar/50",
+                          "transition duration-200",
+                          "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
+                          worktree.id === activeWorktreeId &&
+                            "border-[var(--color-state-active)]/70 shadow-md"
+                        )}
+                      >
+                        <OverviewWorktreeCard
+                          worktreeId={worktree.id}
+                          activeWorktreeId={activeWorktreeId}
+                          focusedWorktreeId={focusedWorktreeId}
+                          totalWorktreeCount={worktrees.length}
+                          onSelectWorktree={onSelectWorktree}
+                          onCopyTree={onCopyTree}
+                          onOpenEditor={onOpenEditor}
+                          onSaveLayout={onSaveLayout}
+                          onLaunchAgent={onLaunchAgent}
+                          agentAvailability={agentAvailability}
+                          agentSettings={agentSettings}
+                          homeDir={homeDir}
+                          onClose={onClose}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div
+              className={cn(
+                "grid gap-3",
+                "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                "justify-center",
+                "items-start"
+              )}
+            >
+              {filteredWorktrees.map((worktree) => (
+                <div
+                  key={worktree.id}
+                  style={{
+                    contentVisibility: "auto",
+                    containIntrinsicSize: "auto 240px",
+                  }}
+                  className={cn(
+                    "rounded-lg overflow-hidden",
+                    "border border-divider",
+                    "bg-daintree-sidebar/50",
+                    "transition duration-200",
+                    "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
+                    worktree.id === activeWorktreeId &&
+                      "border-[var(--color-state-active)]/70 shadow-md"
+                  )}
+                >
+                  <OverviewWorktreeCard
+                    variant="grid"
+                    worktreeId={worktree.id}
+                    activeWorktreeId={activeWorktreeId}
+                    focusedWorktreeId={focusedWorktreeId}
+                    totalWorktreeCount={worktrees.length}
+                    onSelectWorktree={onSelectWorktree}
+                    onCopyTree={onCopyTree}
+                    onOpenEditor={onOpenEditor}
+                    onSaveLayout={onSaveLayout}
+                    onLaunchAgent={onLaunchAgent}
+                    agentAvailability={agentAvailability}
+                    agentSettings={agentSettings}
+                    homeDir={homeDir}
+                    onClose={onClose}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="px-6 py-3 border-t border-divider shrink-0">
+          <div className="flex items-center justify-center gap-4 text-xs text-daintree-text/40">
+            <span>
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd> to close
+            </span>
+            <span>Click a worktree to switch</span>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { User } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface AvatarProps {
   src: string;
@@ -54,12 +54,10 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
 
   if (title) {
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>{avatarContent}</TooltipTrigger>
-          <TooltipContent side="bottom">{title}</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{avatarContent}</TooltipTrigger>
+        <TooltipContent side="bottom">{title}</TooltipContent>
+      </Tooltip>
     );
   }
 


### PR DESCRIPTION
## Summary

- Hoists a single `TooltipProvider` (`delayDuration=500`, `skipDelayDuration=150`) to the App root inside `ErrorBoundary`, outside `DndProvider`, replacing ~140 scattered per-component providers across 56 production files
- The shared delay group now spans the whole window, so the second tooltip you hover opens instantly regardless of which surface it's on
- Restores list `key` props on 5 `Tooltip` elements that lost them when their wrapping `TooltipProvider` was removed from `.map()` callbacks; adds tooltip module mocks to 7 test files

Resolves #5850

Supersedes the closed PR #5882.

## Changes

- `src/App.tsx`: single `TooltipProvider` added at root, inside `ErrorBoundary`, outside `DndProvider`
- 56 production component files: per-component `TooltipProvider` wrappers and their imports removed
- 5 components: `key` props restored on `Tooltip` roots inside `.map()` callbacks
- 7 test files: `@radix-ui/react-tooltip` mock added so tests don't break on the now-absent local provider

## Testing

Typecheck, lint, and format all pass clean. The tooltip delay group behaviour is a runtime UX concern that's straightforward to verify manually: hovering between any two icon buttons in the app should show the second tooltip without waiting the full 500ms delay once the first has been shown.