### PR TITLE
fix(layout): replace accent ring on popover-open dock buttons with neutral lift

### DIFF
--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -149,7 +149,7 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
           size="sm"
           className={cn(
             compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
+            isOpen && "bg-overlay-emphasis border-border-default"
           )}
           aria-haspopup="dialog"
           aria-expanded={isOpen}

--- a/src/components/Layout/HelpAgentDockButton.tsx
+++ b/src/components/Layout/HelpAgentDockButton.tsx
@@ -20,10 +20,7 @@ export function HelpAgentDockButton() {
           type="button"
           variant="pill"
           size="sm"
-          className={cn(
-            "px-2",
-            isOpen && "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
-          )}
+          className={cn("px-2", isOpen && "bg-overlay-emphasis border-border-default")}
           onClick={handleClick}
           aria-label="Help Agent"
           aria-expanded={isOpen}

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -66,7 +66,7 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
           size="sm"
           className={cn(
             compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
+            isOpen && "bg-overlay-emphasis border-border-default"
           )}
           aria-haspopup="dialog"
           aria-expanded={isOpen}

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -149,7 +149,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
           data-testid="trash-container"
           className={cn(
             compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30"
+            isOpen && "bg-overlay-emphasis border-border-default"
           )}
           aria-haspopup="dialog"
           aria-expanded={isOpen}

--- a/src/components/Layout/__tests__/dockPopoverShadow.test.tsx
+++ b/src/components/Layout/__tests__/dockPopoverShadow.test.tsx
@@ -106,6 +106,38 @@ describe("Dock Popover Visual Layer - Issue #2316", () => {
     });
   });
 
+  describe("Neutral Lift on Popover-Open Dock Buttons - Issue #5928", () => {
+    const dockButtonFiles = [
+      "../StatusContainer.tsx",
+      "../BackgroundContainer.tsx",
+      "../TrashContainer.tsx",
+      "../HelpAgentDockButton.tsx",
+    ];
+
+    for (const relativePath of dockButtonFiles) {
+      it(`should not use accent ring on isOpen state in ${relativePath}`, async () => {
+        const fs = await import("fs/promises");
+        const path = await import("path");
+
+        const filePath = path.resolve(__dirname, relativePath);
+        const content = await fs.readFile(filePath, "utf-8");
+
+        expect(content).not.toContain("ring-daintree-accent");
+        expect(content).not.toContain("border-daintree-accent/40");
+      });
+
+      it(`should use neutral lift tokens on isOpen state in ${relativePath}`, async () => {
+        const fs = await import("fs/promises");
+        const path = await import("path");
+
+        const filePath = path.resolve(__dirname, relativePath);
+        const content = await fs.readFile(filePath, "utf-8");
+
+        expect(content).toContain("bg-overlay-emphasis border-border-default");
+      });
+    }
+  });
+
   describe("Conditional Escape Key Guard - Issue #4572", () => {
     it("should export handleDockEscapeKeyDown from dockPopoverGuard", async () => {
       const fs = await import("fs/promises");


### PR DESCRIPTION
## Summary

- Swapped `bg-daintree-border border-daintree-accent/40 ring-1 ring-daintree-accent/30` for `bg-overlay-emphasis border-border-default` on all four `isOpen` dock-button conditionals (Status, Background, Trash, HelpAgent). The open state stays visibly distinct from idle hover without pulling accent colour into a routine affordance.
- Frees the accent colour for the macro-focus ring that shares this layout layer, per the accent-restraint guidance in CLAUDE.md.
- Added 8 source-pattern regression tests in `dockPopoverShadow.test.tsx` to guard against the accent classes creeping back in.

Resolves #5928

## Changes

- `StatusContainer.tsx` — neutral `isOpen` lift
- `BackgroundContainer.tsx` — neutral `isOpen` lift
- `TrashContainer.tsx` — neutral `isOpen` lift
- `HelpAgentDockButton.tsx` — neutral `isOpen` lift (also tidied the `cn()` call while touching the file)
- `__tests__/dockPopoverShadow.test.tsx` — regression guards confirming absence of accent classes and presence of neutral-lift classes in open state

Out of scope (intentionally untouched): DockedTerminalItem, DockedTabGroup, ContentDock, TerminalDockRegion, Sidebar — different semantics and contexts not covered by the issue.

## Testing

- 28+ vitest tests pass across the touched test files
- Typecheck, lint, and format clean
- Manually verified on dark and light built-in themes — `overlay-emphasis` reads clearly against the dock backdrop on both