### PR TITLE
fix(pty): silence IdentityDebug console output in production

### DIFF
--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -97,6 +97,15 @@ const PROCESS_ICON_MAP: Record<string, string> = {
 
 const PACKAGE_MANAGER_ICON_IDS = new Set(["npm", "yarn", "pnpm", "bun", "composer"]);
 
+const IDENTITY_DEBUG_ENABLED =
+  process.env.NODE_ENV === "development" || Boolean(process.env.DAINTREE_DEBUG);
+
+function logIdentityDebug(message: string): void {
+  if (IDENTITY_DEBUG_ENABLED) {
+    console.log(message);
+  }
+}
+
 /**
  * Extract non-flag command name candidates from a full `command` line in
  * argv order. Used when `comm` basename doesn't match a known CLI — most
@@ -409,7 +418,7 @@ export class ProcessDetector {
     this.shellCommandStickyUntil = observedAt + ProcessDetector.SHELL_COMMAND_STICKY_MS;
     this.shellCommandExpiresAt = observedAt + ProcessDetector.SHELL_COMMAND_EXPIRY_MS;
 
-    console.log(
+    logIdentityDebug(
       `[IdentityDebug] shell-evidence term=${this.terminalId.slice(-8)} ` +
         `agent=${identity.agentType ?? "<none>"} icon=${identity.processIconId ?? "<none>"} ` +
         `name=${JSON.stringify(identity.processName)}`
@@ -443,7 +452,7 @@ export class ProcessDetector {
       this.lastDetected === null && this.lastProcessIconId !== null && shellWasSoleSupport;
 
     if (this.shellCommandIdentity !== null) {
-      console.log(
+      logIdentityDebug(
         `[IdentityDebug] shell-evidence-clear term=${this.terminalId.slice(-8)} ` +
           `reason=${reason} agent=${this.shellCommandIdentity.agentType ?? "<none>"} ` +
           `icon=${this.shellCommandIdentity.processIconId ?? "<none>"} ` +
@@ -485,14 +494,14 @@ export class ProcessDetector {
 
   start(): void {
     if (this.isStarted) {
-      console.log(
+      logIdentityDebug(
         `[IdentityDebug] detector START-SKIPPED term=${this.terminalId.slice(-8)} pid=${this.ptyPid} reason=already-started`
       );
       logWarn(`ProcessDetector for terminal ${this.terminalId} already started`);
       return;
     }
 
-    console.log(
+    logIdentityDebug(
       `[IdentityDebug] detector START term=${this.terminalId.slice(-8)} pid=${this.ptyPid}`
     );
 
@@ -503,7 +512,7 @@ export class ProcessDetector {
     this.unsubscribe = this.cache.onRefresh(() => {
       if (firstRefresh) {
         firstRefresh = false;
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] detector FIRST-TICK term=${this.terminalId.slice(-8)} pid=${this.ptyPid} children=${this.cache.getChildren(this.ptyPid).length}`
         );
       }
@@ -566,7 +575,7 @@ export class ProcessDetector {
           const signature = `${this.shellCommandIdentity.agentType}|${childCount}`;
           if (signature !== this.lastShellEvidenceRetentionSignature) {
             this.lastShellEvidenceRetentionSignature = signature;
-            console.log(
+            logIdentityDebug(
               `[IdentityDebug] shell-evidence-retain term=${this.terminalId.slice(-8)} ` +
                 `reason=agent-requires-explicit-exit agent=${this.shellCommandIdentity.agentType} ` +
                 `children=${childCount}`
@@ -591,7 +600,7 @@ export class ProcessDetector {
           const passSignature = `${result.detectionState}|${result.agentType ?? ""}|${result.evidenceSource ?? ""}|${procs}`;
           if (passSignature !== this.lastPassSignature) {
             this.lastPassSignature = passSignature;
-            console.log(
+            logIdentityDebug(
               `[IdentityDebug] pass term=${this.terminalId.slice(-8)} pid=${this.ptyPid} ` +
                 `state=${result.detectionState} agent=${result.agentType ?? "<none>"} ` +
                 `src=${result.evidenceSource ?? "<none>"} procs=[${procs}]`
@@ -689,7 +698,7 @@ export class ProcessDetector {
           // elements while still running. Prompt-return clears via
           // clearShellCommandEvidence("prompt-return").
           if (this.offStreak === 0) {
-            console.log(
+            logIdentityDebug(
               `[IdentityDebug] demote-hold term=${this.terminalId.slice(-8)} ` +
                 `reason=agent-requires-explicit-exit agent=${committedAgent} ` +
                 `rawIcon=${rawIcon ?? "<none>"}`
@@ -755,7 +764,7 @@ export class ProcessDetector {
         // only runs when we actually emit (gatedCommitted or a busy/command
         // side-channel change).
         if (gatedCommitted) {
-          console.log(
+          logIdentityDebug(
             `[IdentityDebug] commit term=${this.terminalId.slice(-8)} pid=${this.ptyPid} state=${result.detectionState} agent=${result.agentType ?? "null"} icon=${result.processIconId ?? "null"} src=${result.evidenceSource ?? "process_tree"}`
           );
         }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -78,6 +78,15 @@ import { detectPrompt } from "./PromptDetector.js";
 import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
 import type { SpawnContext } from "./terminalSpawn.js";
 
+const IDENTITY_DEBUG_ENABLED =
+  process.env.NODE_ENV === "development" || Boolean(process.env.DAINTREE_DEBUG);
+
+function logIdentityDebug(message: string): void {
+  if (IDENTITY_DEBUG_ENABLED) {
+    console.log(message);
+  }
+}
+
 type CursorBuffer = {
   cursorY?: number;
   baseY: number;
@@ -688,7 +697,7 @@ export class TerminalProcess {
       if (this.suppressNextShellSubmitSignal) {
         this.suppressNextShellSubmitSignal = false;
       } else if (isAgentUiPromptResponse) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] shell-submit-skip term=${this.id.slice(-8)} reason=agent-ui-prompt`
         );
       } else {
@@ -1203,7 +1212,7 @@ export class TerminalProcess {
     const identity = detectCommandIdentity(normalized);
     if (!identity) return;
     this.seededLaunchCommandText = normalized;
-    console.log(
+    logIdentityDebug(
       `[IdentityDebug] shell-submit term=${this.id.slice(-8)} src=spawn ` +
         `agent=${identity.agentType ?? "<none>"} icon=${identity.processIconId ?? "<none>"} ` +
         `argv0=${redactArgv(normalized)}`
@@ -1366,7 +1375,7 @@ export class TerminalProcess {
 
     if (!this.shellIdentityFallbackIdentity) {
       if (promptVisible && Date.now() - submittedAt >= SHELL_IDENTITY_FALLBACK_COMMIT_MS) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] shell-fallback-stop term=${this.id.slice(-8)} reason=no-identity-prompt`
         );
         this.stopShellIdentityFallbackWatcher();
@@ -1381,7 +1390,7 @@ export class TerminalProcess {
       }
 
       if (promptVisible && !this.shellIdentityFallbackIdentity.agentType) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] shell-fallback-stop term=${this.id.slice(-8)} ` +
             `reason=prompt-before-commit icon=${this.shellIdentityFallbackIdentity.processIconId ?? "<none>"}`
         );
@@ -1434,7 +1443,7 @@ export class TerminalProcess {
       !this.isForegroundShellIdleForAgentDemotion()
     ) {
       if (this.shellIdentityFallbackPromptStreak > 0) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] shell-fallback-hold term=${this.id.slice(-8)} ` +
             `reason=foreground-child-active`
         );
@@ -1449,7 +1458,7 @@ export class TerminalProcess {
       this.hasAgentUiPromptFalsePositive()
     ) {
       if (this.shellIdentityFallbackPromptStreak > 0) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] shell-fallback-hold term=${this.id.slice(-8)} ` +
             `reason=agent-ui-prompt count=${ptyDescendantCount ?? "unknown"} ` +
             `sawDescendant=${this.shellIdentityFallbackSawPtyDescendant}`
@@ -1979,7 +1988,7 @@ export class TerminalProcess {
     } else if (isDetected && !result.agentType && result.processIconId) {
       // Non-agent process detected (npm, python, docker, etc.)
       if (terminal.detectedAgentId) {
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] terminal-demote-hold term=${this.id.slice(-8)} ` +
             `reason=agent-requires-explicit-exit agent=${terminal.detectedAgentId} ` +
             `processIcon=${result.processIconId}`
@@ -2000,13 +2009,13 @@ export class TerminalProcess {
       const previousAgent = terminal.detectedAgentId;
       if (previousAgent) {
         if (result.evidenceSource !== "shell_command") {
-          console.log(
+          logIdentityDebug(
             `[IdentityDebug] terminal-demote-hold term=${this.id.slice(-8)} ` +
               `reason=agent-requires-explicit-exit agent=${previousAgent}`
           );
           return;
         }
-        console.log(
+        logIdentityDebug(
           `[IdentityDebug] terminal-demote-apply term=${this.id.slice(-8)} ` +
             `reason=prompt-return agent=${previousAgent}`
         );


### PR DESCRIPTION
## Summary
- Wrapped all ~24 `console.log("[IdentityDebug] ...")` calls in `TerminalProcess.ts` and `ProcessDetector.ts` behind a `logIdentityDebug()` helper that only fires in development or when `DAINTREE_DEBUG` is set.
- These log messages are useful for identity-tangle debugging but pollute the main-process log in production with no value to end users.

Resolves #5924

## Changes
- Added `IDENTITY_DEBUG_ENABLED` flag and `logIdentityDebug()` helper to both `electron/services/pty/TerminalProcess.ts` and `electron/services/ProcessDetector.ts`.
- Replaced all direct `console.log("[IdentityDebug] ...")` calls with `logIdentityDebug(...)`.
- Enabled only when `NODE_ENV === "development"` or `process.env.DAINTREE_DEBUG` is set.

## Testing
- Confirmed the helpers compile cleanly with `tsc --noEmit`.
- Verified no IdentityDebug output in the production path by tracing the guard condition.