### PR TITLE
fix(ui): tighten dialog primaries and remove redundant Dismiss CTAs

### DIFF
--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -145,7 +145,7 @@ export function AddPresetDialog({
 
       <AppDialog.Footer
         secondaryAction={{ label: "Cancel", onClick: onClose }}
-        primaryAction={{ label: "Create", onClick: handleCreate, disabled: !canCreate }}
+        primaryAction={{ label: "Create preset", onClick: handleCreate, disabled: !canCreate }}
       />
     </AppDialog>
   );

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, type CSSProperties } from "react";
+import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -26,6 +27,7 @@ export interface InlineStatusBannerProps {
   actions: BannerAction[];
   role?: "alert" | "status";
   ariaLive?: "polite" | "assertive";
+  onClose?: () => void;
 }
 
 const SEVERITY_VAR: Record<"error" | "warning", string> = {
@@ -76,6 +78,7 @@ function InlineStatusBannerComponent({
   actions,
   role = "alert",
   ariaLive = "polite",
+  onClose,
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
     typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -156,6 +159,16 @@ function InlineStatusBannerComponent({
       </div>
 
       <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Dismiss"
+            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 focus-visible:outline-2 focus-visible:outline-daintree-accent"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        )}
         {actions.map((action) => {
           const variant = action.variant ?? "primary";
           const variantClasses = getButtonClasses(variant);

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -162,7 +162,10 @@ function InlineStatusBannerComponent({
         {onClose && (
           <button
             type="button"
-            onClick={onClose}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
             aria-label="Dismiss"
             className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 focus-visible:outline-2 focus-visible:outline-daintree-accent"
           >

--- a/src/components/Terminal/ReconnectErrorBanner.tsx
+++ b/src/components/Terminal/ReconnectErrorBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clock, RotateCcw, X, AlertTriangle } from "lucide-react";
+import { Clock, RotateCcw, AlertTriangle } from "lucide-react";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { TerminalReconnectError } from "@/types";
 
@@ -66,16 +66,8 @@ function ReconnectErrorBannerComponent({
           title: "Restart Terminal",
           ariaLabel: "Restart terminal",
         },
-        {
-          id: "dismiss",
-          label: "Dismiss",
-          icon: X,
-          variant: "dismiss",
-          onClick: () => onDismiss(terminalId),
-          title: "Dismiss",
-          ariaLabel: "Dismiss notification",
-        },
       ]}
+      onClose={() => onDismiss(terminalId)}
       className={className}
     />
   );

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AlertTriangle, RotateCcw, X } from "lucide-react";
+import { AlertTriangle, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { RestartBannerVariant } from "./restartStatus";
@@ -44,17 +44,8 @@ function TerminalRestartStatusBannerComponent({
               title: "Restart Session",
               ariaLabel: "Restart session",
             },
-            {
-              id: "dismiss",
-              label: "Dismiss",
-              icon: X,
-              variant: "danger",
-              iconOnly: true,
-              onClick: onDismiss,
-              title: "Dismiss",
-              ariaLabel: "Dismiss restart prompt",
-            },
           ]}
+          onClose={onDismiss}
         />
       );
   }

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -86,7 +86,7 @@ describe("TerminalRestartStatusBanner", () => {
         onDismiss={onDismiss}
       />
     );
-    const button = screen.getByRole("button", { name: /dismiss restart prompt/i });
+    const button = screen.getByRole("button", { name: "Dismiss" });
     fireEvent.click(button);
     expect(onDismiss).toHaveBeenCalledOnce();
   });


### PR DESCRIPTION
## Summary
- Tightened the primary action label on the Add Preset dialog from "Create" to "Create preset", following the verb-noun convention for creation primaries.
- Removed redundant Dismiss buttons from the ReconnectErrorBanner and TerminalRestartStatusBanner. The X close affordance already covers dismissal, so keeping a separate Dismiss CTA next to the recovery action adds unnecessary cognitive load.
- Added a proper `onClose` prop to InlineStatusBanner so child banners can wire the X consistently, with stopPropagation on the button click.

Resolves #5923.

## Changes
- **AddPresetDialog**: primary action label changed from "Create" to "Create preset"
- **InlineStatusBanner**: added optional `onClose` prop and stopPropagation on the close button click
- **ReconnectErrorBanner**: removed Dismiss action, wired the banner's `onClose` for dismissal
- **TerminalRestartStatusBanner**: removed Dismiss action, wired the banner's `onClose` for dismissal
- **TerminalRestartStatusBanner test**: updated query to use the X close button instead of the removed Dismiss button

## Testing
- Verified the X close button still works on all three banners
- Confirmed keyboard users can still dismiss banners without the Dismiss button
- Existing test suite passes