### PR TITLE
refactor(pty): extract WriteQueue from TerminalProcess (#5927)

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -26,11 +26,11 @@ import {
   type TerminalSnapshot,
   OUTPUT_BUFFER_SIZE,
   DEFAULT_SCROLLBACK,
-  WRITE_INTERVAL_MS,
   GRACEFUL_SHUTDOWN_TIMEOUT_MS,
   GRACEFUL_SHUTDOWN_BUFFER_SIZE,
   GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS,
 } from "./types.js";
+import { WriteQueue } from "./WriteQueue.js";
 import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 import { events } from "../events.js";
 import { AgentSpawnedSchema } from "../../schemas/agent.js";
@@ -47,7 +47,6 @@ import {
   getSoftNewlineSequence,
   getSubmitEnterDelay,
   isBracketedPaste,
-  chunkInput,
   delay,
   BRACKETED_PASTE_START,
   BRACKETED_PASTE_END,
@@ -143,8 +142,6 @@ export interface TerminalProcessDependencies {
 export class TerminalProcess {
   private activityMonitor: ActivityMonitor | null = null;
   private processDetector: ProcessDetector | null = null;
-  private submitQueue: string[] = [];
-  private submitInFlight = false;
   private headlineGenerator = new ActivityHeadlineGenerator();
   private lastDetectedProcessIconId: string | undefined;
 
@@ -153,8 +150,7 @@ export class TerminalProcess {
 
   private semanticBufferManager!: SemanticBufferManager;
 
-  private inputWriteQueue: string[] = [];
-  private inputWriteTimeout: NodeJS.Timeout | null = null;
+  private writeQueue!: WriteQueue;
   private readonly processTreeKiller: ProcessTreeKiller;
   private shellIdentityFallbackTimer: NodeJS.Timeout | null = null;
   private shellIdentityFallbackSubmittedAt: number | null = null;
@@ -387,8 +383,6 @@ export class TerminalProcess {
       lastOutputTime: spawnedAt,
       lastCheckTime: spawnedAt,
       semanticBuffer: [],
-      inputWriteQueue: [],
-      inputWriteTimeout: null,
       headlessTerminal,
       serializeAddon,
       rawOutputBuffer: undefined,
@@ -417,6 +411,15 @@ export class TerminalProcess {
 
     this.semanticBufferManager = new SemanticBufferManager(this.terminalInfo);
     this.processTreeKiller = new ProcessTreeKiller(ptyProcess, deps.processTreeCache);
+    this.writeQueue = new WriteQueue({
+      writeToPty: (data) => {
+        this.terminalInfo.ptyProcess.write(data);
+      },
+      isExited: () => this.terminalInfo.isExited === true,
+      lastOutputTime: () => this.terminalInfo.lastOutputTime,
+      performSubmit: (text) => this.performSubmit(text),
+      onWriteError: (error, context) => this.logWriteError(error, context),
+    });
     this.setupPtyHandlers(ptyProcess);
 
     const ptyPid = ptyProcess.pid;
@@ -728,9 +731,7 @@ export class TerminalProcess {
       return;
     }
 
-    const chunks = chunkInput(data);
-    this.inputWriteQueue.push(...chunks);
-    this.startWrite();
+    this.writeQueue.enqueueChunked(data);
   }
 
   submit(text: string): void {
@@ -746,26 +747,7 @@ export class TerminalProcess {
       this.activityMonitor.notifySubmission();
     }
 
-    this.submitQueue.push(text);
-    if (this.submitInFlight) {
-      return;
-    }
-    this.submitInFlight = true;
-    void this.drainSubmitQueue();
-  }
-
-  private async drainSubmitQueue(): Promise<void> {
-    try {
-      while (this.submitQueue.length > 0) {
-        const next = this.submitQueue.shift();
-        if (next === undefined) {
-          continue;
-        }
-        await this.performSubmit(next);
-      }
-    } finally {
-      this.submitInFlight = false;
-    }
+    this.writeQueue.submit(text);
   }
 
   private async performSubmit(text: string): Promise<void> {
@@ -813,10 +795,14 @@ export class TerminalProcess {
       }
     }
 
-    await this.waitForInputWriteDrain();
+    await this.writeQueue.waitForInputWriteDrain();
 
     if (useOutputSettle) {
-      await this.waitForOutputSettle();
+      await this.writeQueue.waitForOutputSettle({
+        debounceMs: OUTPUT_SETTLE_DEBOUNCE_MS,
+        maxWaitMs: OUTPUT_SETTLE_MAX_WAIT_MS,
+        pollMs: OUTPUT_SETTLE_POLL_INTERVAL_MS,
+      });
     } else {
       await delay(getSubmitEnterDelay(terminal));
     }
@@ -828,51 +814,6 @@ export class TerminalProcess {
     this.suppressNextShellSubmitSignal = true;
     this.markShellCommandSubmitted(body);
     this.write(enterSuffix);
-  }
-
-  private async waitForInputWriteDrain(): Promise<void> {
-    if (this.inputWriteQueue.length === 0 && this.inputWriteTimeout === null) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      const check = () => {
-        if (this.terminalInfo.isExited || !this.terminalInfo.ptyProcess) {
-          resolve();
-          return;
-        }
-        if (this.inputWriteQueue.length === 0 && this.inputWriteTimeout === null) {
-          resolve();
-          return;
-        }
-        setTimeout(check, 0);
-      };
-      check();
-    });
-  }
-
-  private async waitForOutputSettle(): Promise<void> {
-    const startWait = Date.now();
-    const terminal = this.terminalInfo;
-
-    while (true) {
-      if (terminal.isExited || !terminal.ptyProcess || terminal.wasKilled) {
-        return;
-      }
-
-      const settleFrom = Math.max(startWait, terminal.lastOutputTime);
-      const timeSinceOutput = Date.now() - settleFrom;
-
-      if (timeSinceOutput >= OUTPUT_SETTLE_DEBOUNCE_MS) {
-        return;
-      }
-
-      if (Date.now() - startWait > OUTPUT_SETTLE_MAX_WAIT_MS) {
-        return;
-      }
-
-      await delay(OUTPUT_SETTLE_POLL_INTERVAL_MS);
-    }
   }
 
   resize(cols: number, rows: number): void {
@@ -1028,11 +969,7 @@ export class TerminalProcess {
 
     this.semanticBufferManager.flush();
 
-    if (this.inputWriteTimeout) {
-      clearTimeout(this.inputWriteTimeout);
-      this.inputWriteTimeout = null;
-    }
-    this.inputWriteQueue = [];
+    this.writeQueue.dispose();
 
     // Flush session snapshot synchronously before marking as killed.
     // Once wasKilled is set, all persistence paths are blocked, and
@@ -1718,10 +1655,7 @@ export class TerminalProcess {
 
     this.clearSessionPersistTimer();
 
-    if (this.inputWriteTimeout) {
-      clearTimeout(this.inputWriteTimeout);
-      this.inputWriteTimeout = null;
-    }
+    this.writeQueue.dispose();
 
     this.disposeHeadless();
 
@@ -1801,11 +1735,7 @@ export class TerminalProcess {
       this.stopShellIdentityFallbackWatcher();
       this.semanticBufferManager.flush();
 
-      if (this.inputWriteTimeout) {
-        clearTimeout(this.inputWriteTimeout);
-        this.inputWriteTimeout = null;
-      }
-      this.inputWriteQueue = [];
+      this.writeQueue.dispose();
 
       this.clearSessionPersistTimer();
       this.sessionPersistDirty = false;
@@ -2073,41 +2003,6 @@ export class TerminalProcess {
         timestamp: Date.now(),
         lastCommand,
       });
-    }
-  }
-
-  private startWrite(): void {
-    if (this.inputWriteTimeout !== null || this.inputWriteQueue.length === 0) {
-      return;
-    }
-
-    this.doWrite();
-
-    if (this.inputWriteQueue.length > 0) {
-      this.inputWriteTimeout = setTimeout(() => {
-        this.inputWriteTimeout = null;
-        this.startWrite();
-      }, WRITE_INTERVAL_MS);
-    }
-  }
-
-  private doWrite(): void {
-    if (this.inputWriteQueue.length === 0) {
-      return;
-    }
-
-    const chunk = this.inputWriteQueue.shift()!;
-    const terminal = this.terminalInfo;
-    if (terminal.isExited) {
-      return;
-    }
-    if (!terminal.ptyProcess) {
-      return;
-    }
-    try {
-      terminal.ptyProcess.write(chunk);
-    } catch (error) {
-      this.logWriteError(error, { operation: "write(chunk)" });
     }
   }
 }

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -171,7 +171,13 @@ export class WriteQueue {
       while (!this.disposed && this.submitQueue.length > 0) {
         const next = this.submitQueue.shift();
         if (next === undefined) continue;
-        await this.options.performSubmit(next);
+        try {
+          await this.options.performSubmit(next);
+        } catch (error) {
+          // Don't let a single submit failure abandon the rest of the queue
+          // or escape as an unhandled rejection from the void caller above.
+          this.options.onWriteError?.(error, { operation: "performSubmit" });
+        }
       }
     } finally {
       this.submitInFlight = false;

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -1,0 +1,180 @@
+import { WRITE_INTERVAL_MS } from "./types.js";
+import { chunkInput } from "./terminalInput.js";
+
+export interface WriteQueueOptions {
+  /** Raw byte sink for paced chunks. May throw on PTY errors. */
+  writeToPty: (data: string) => void;
+  /** True once the underlying PTY has exited; aborts pacing and drain waits. */
+  isExited: () => boolean;
+  /** Current `lastOutputTime` accessor used by `waitForOutputSettle`. */
+  lastOutputTime: () => number;
+  /** Per-text submit handler — owns all shell-side-effect bookkeeping. */
+  performSubmit: (text: string) => Promise<void>;
+  /** Optional sink for synchronous PTY write errors. */
+  onWriteError?: (error: unknown, context: { operation: string }) => void;
+}
+
+export interface OutputSettleOptions {
+  debounceMs: number;
+  maxWaitMs: number;
+  pollMs: number;
+}
+
+/**
+ * Owns the two write-pacing state machines that used to live inline on
+ * `TerminalProcess`:
+ *
+ * 1. The chunked input queue + interval timer (paces large payloads through
+ *    the PTY at `WRITE_INTERVAL_MS` to avoid overwhelming TUI parsers).
+ * 2. The submit queue + in-flight guard (serialises async submit jobs so a
+ *    second submission cannot interleave its body/Enter writes with an
+ *    earlier one's output-settle wait).
+ *
+ * Shell-capture side effects (`suppressNextShellSubmitSignal`,
+ * `markShellCommandSubmitted`, activity-monitor notification) stay in
+ * `TerminalProcess`; the queue's job is purely serialisation and pacing.
+ */
+export class WriteQueue {
+  private inputWriteQueue: string[] = [];
+  private inputWriteTimeout: NodeJS.Timeout | null = null;
+  private submitQueue: string[] = [];
+  private submitInFlight = false;
+  private disposed = false;
+
+  constructor(private readonly options: WriteQueueOptions) {}
+
+  /**
+   * Split `data` into PTY-sized chunks and enqueue for paced delivery. Does
+   * nothing after `dispose()`; an empty payload is a no-op.
+   */
+  enqueueChunked(data: string): void {
+    if (this.disposed) return;
+    const chunks = chunkInput(data);
+    if (chunks.length === 0) return;
+    this.inputWriteQueue.push(...chunks);
+    this.startWrite();
+  }
+
+  /** True while pacing is in flight (queued chunks or pending timer). */
+  hasPendingWrites(): boolean {
+    return this.inputWriteQueue.length > 0 || this.inputWriteTimeout !== null;
+  }
+
+  /**
+   * Serialise an async submit. The first caller wins the in-flight slot and
+   * runs `options.performSubmit(text)`; subsequent calls queue behind it and
+   * drain in FIFO order. The in-flight flag is set synchronously before the
+   * first await so two callers cannot both pass the guard.
+   */
+  submit(text: string): void {
+    if (this.disposed) return;
+    this.submitQueue.push(text);
+    if (this.submitInFlight) return;
+    this.submitInFlight = true;
+    void this.drainSubmitQueue();
+  }
+
+  /**
+   * Resolves once the chunked input queue is fully drained, the PTY has
+   * exited, or the queue has been disposed. Polling preserves the existing
+   * semantics; the `disposed` check is the teardown termination condition
+   * that prevents `performSubmit` from deadlocking when `dispose()` fires
+   * mid-drain.
+   */
+  async waitForInputWriteDrain(): Promise<void> {
+    if (!this.hasPendingWrites()) return;
+    await new Promise<void>((resolve) => {
+      const check = (): void => {
+        if (this.disposed || this.options.isExited()) {
+          resolve();
+          return;
+        }
+        if (!this.hasPendingWrites()) {
+          resolve();
+          return;
+        }
+        setTimeout(check, 0);
+      };
+      check();
+    });
+  }
+
+  /**
+   * Wait for PTY output to fall idle for `debounceMs` (used by the submit
+   * path on terminals without bracketed-paste support so the pre-Enter
+   * payload has time to render before Enter fires). Bounded by `maxWaitMs`.
+   */
+  async waitForOutputSettle(opts: OutputSettleOptions): Promise<void> {
+    const startWait = Date.now();
+    while (true) {
+      if (this.disposed || this.options.isExited()) return;
+      const settleFrom = Math.max(startWait, this.options.lastOutputTime());
+      const timeSinceOutput = Date.now() - settleFrom;
+      if (timeSinceOutput >= opts.debounceMs) return;
+      if (Date.now() - startWait > opts.maxWaitMs) return;
+      await new Promise((r) => setTimeout(r, opts.pollMs));
+    }
+  }
+
+  /**
+   * Cancel the pacing timer, drop pending chunks and submits, and mark the
+   * queue disposed. Idempotent. Any in-flight `waitForInputWriteDrain` /
+   * `waitForOutputSettle` resolves immediately on the next poll because the
+   * `disposed` flag short-circuits both loops — without this, an in-flight
+   * `performSubmit` mid-`await waitForInputWriteDrain()` would deadlock and
+   * leak `submitInFlight`.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.inputWriteTimeout) {
+      clearTimeout(this.inputWriteTimeout);
+      this.inputWriteTimeout = null;
+    }
+    this.inputWriteQueue = [];
+    this.submitQueue = [];
+  }
+
+  private startWrite(): void {
+    if (this.disposed) return;
+    if (this.inputWriteTimeout !== null || this.inputWriteQueue.length === 0) {
+      return;
+    }
+
+    this.doWrite();
+
+    if (this.inputWriteQueue.length > 0) {
+      this.inputWriteTimeout = setTimeout(() => {
+        if (this.disposed) return;
+        this.inputWriteTimeout = null;
+        this.startWrite();
+      }, WRITE_INTERVAL_MS);
+    }
+  }
+
+  private doWrite(): void {
+    if (this.disposed) return;
+    if (this.inputWriteQueue.length === 0) return;
+
+    const chunk = this.inputWriteQueue.shift()!;
+    if (this.options.isExited()) return;
+
+    try {
+      this.options.writeToPty(chunk);
+    } catch (error) {
+      this.options.onWriteError?.(error, { operation: "write(chunk)" });
+    }
+  }
+
+  private async drainSubmitQueue(): Promise<void> {
+    try {
+      while (!this.disposed && this.submitQueue.length > 0) {
+        const next = this.submitQueue.shift();
+        if (next === undefined) continue;
+        await this.options.performSubmit(next);
+      }
+    } finally {
+      this.submitInFlight = false;
+    }
+  }
+}

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -17,8 +17,6 @@ function createTerminal(overrides: Partial<TerminalInfo> = {}): TerminalInfo {
     launchAgentId: "claude",
     agentState: "idle",
     ptyProcess: {} as never,
-    inputWriteQueue: [],
-    inputWriteTimeout: null,
     outputBuffer: "",
     semanticBuffer: [],
     ...overrides,

--- a/electron/services/pty/__tests__/SemanticBufferManager.test.ts
+++ b/electron/services/pty/__tests__/SemanticBufferManager.test.ts
@@ -14,8 +14,6 @@ function createTerminalInfo(overrides: Partial<TerminalInfo> = {}): TerminalInfo
     lastCheckTime: 0,
     restartCount: 0,
     ptyProcess: {} as never,
-    inputWriteQueue: [],
-    inputWriteTimeout: null,
     outputBuffer: "",
     semanticBuffer: [],
     ...overrides,

--- a/electron/services/pty/__tests__/TerminalRegistry.projectIdInference.test.ts
+++ b/electron/services/pty/__tests__/TerminalRegistry.projectIdInference.test.ts
@@ -33,8 +33,6 @@ function createMockTerminalProcess(options: {
     worktreeId: options.worktreeId,
     outputBuffer: "",
     semanticBuffer: [],
-    inputWriteQueue: [],
-    inputWriteTimeout: null,
     ptyProcess: { pid: 12345 },
   };
 

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -74,6 +74,24 @@ describe("WriteQueue.enqueueChunked", () => {
     expect(written).toBe(big);
   });
 
+  it("preserves order when a second enqueueChunked arrives while the first is still pacing", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    const first = "a".repeat(WRITE_MAX_CHUNK_SIZE * 3);
+    const second = "b".repeat(WRITE_MAX_CHUNK_SIZE * 2);
+
+    wq.enqueueChunked(first);
+    // After one interval, the second chunk of `first` has fired but the
+    // queue is still draining. Append `second` mid-flight.
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
+    wq.enqueueChunked(second);
+
+    await vi.runAllTimersAsync();
+
+    const written = m.writeToPty.mock.calls.map((c) => c[0]).join("");
+    expect(written).toBe(first + second);
+  });
+
   it("ignores empty payloads", () => {
     const m = makeOptions();
     const wq = new WriteQueue(m.options);
@@ -134,6 +152,25 @@ describe("WriteQueue.submit", () => {
 
     await vi.runAllTimersAsync();
     expect(order).toEqual(["first", "second", "third"]);
+  });
+
+  it("absorbs a performSubmit rejection without abandoning the queue", async () => {
+    const m = makeOptions();
+    const seen: string[] = [];
+    m.performSubmit.mockImplementation(async (text) => {
+      seen.push(text);
+      if (text === "boom") throw new Error("submit failed");
+    });
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("boom");
+    wq.submit("after");
+
+    await vi.runAllTimersAsync();
+
+    expect(seen).toEqual(["boom", "after"]);
+    expect(m.onWriteError).toHaveBeenCalledOnce();
+    expect(m.onWriteError.mock.calls[0]?.[1]).toEqual({ operation: "performSubmit" });
   });
 
   it("serialises overlapping submits — second performSubmit waits for the first to resolve", async () => {

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WriteQueue, type WriteQueueOptions } from "../WriteQueue.js";
+import { WRITE_INTERVAL_MS, WRITE_MAX_CHUNK_SIZE } from "../types.js";
+
+type MutableOptions = {
+  writeToPty: ReturnType<typeof vi.fn<(data: string) => void>>;
+  isExited: { value: boolean };
+  lastOutputTime: { value: number };
+  performSubmit: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+  onWriteError: ReturnType<typeof vi.fn>;
+  options: WriteQueueOptions;
+};
+
+function makeOptions(): MutableOptions {
+  const isExited = { value: false };
+  const lastOutputTime = { value: Date.now() };
+  const writeToPty = vi.fn<(data: string) => void>();
+  const performSubmit = vi.fn<(text: string) => Promise<void>>(async () => {});
+  const onWriteError = vi.fn();
+  return {
+    writeToPty,
+    isExited,
+    lastOutputTime,
+    performSubmit,
+    onWriteError,
+    options: {
+      writeToPty: (data) => writeToPty(data),
+      isExited: () => isExited.value,
+      lastOutputTime: () => lastOutputTime.value,
+      performSubmit: (text) => performSubmit(text),
+      onWriteError: (e, ctx) => onWriteError(e, ctx),
+    },
+  };
+}
+
+describe("WriteQueue.enqueueChunked", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes a single small payload synchronously", () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    wq.enqueueChunked("hello");
+
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+    expect(m.writeToPty).toHaveBeenCalledWith("hello");
+  });
+
+  it("paces large payloads at WRITE_INTERVAL_MS between chunks", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    // Force at least three chunks.
+    const big = "x".repeat(WRITE_MAX_CHUNK_SIZE * 3);
+
+    wq.enqueueChunked(big);
+
+    // First chunk fires synchronously.
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
+    expect(m.writeToPty).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS);
+    expect(m.writeToPty).toHaveBeenCalledTimes(3);
+
+    // Reassembled order matches input.
+    const written = m.writeToPty.mock.calls.map((c) => c[0]).join("");
+    expect(written).toBe(big);
+  });
+
+  it("ignores empty payloads", () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    wq.enqueueChunked("");
+
+    expect(m.writeToPty).not.toHaveBeenCalled();
+  });
+
+  it("stops writing once isExited turns true mid-drain", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    const big = "x".repeat(WRITE_MAX_CHUNK_SIZE * 3);
+
+    wq.enqueueChunked(big);
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+
+    m.isExited.value = true;
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 5);
+
+    // No further writes after exit.
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes writeToPty exceptions to onWriteError without throwing", () => {
+    const m = makeOptions();
+    m.writeToPty.mockImplementation(() => {
+      throw new Error("EBADF");
+    });
+    const wq = new WriteQueue(m.options);
+
+    expect(() => wq.enqueueChunked("oops")).not.toThrow();
+    expect(m.onWriteError).toHaveBeenCalledOnce();
+    expect(m.onWriteError.mock.calls[0]?.[1]).toEqual({ operation: "write(chunk)" });
+  });
+});
+
+describe("WriteQueue.submit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes performSubmit for each queued text in FIFO order", async () => {
+    const m = makeOptions();
+    const order: string[] = [];
+    m.performSubmit.mockImplementation(async (text) => {
+      order.push(text);
+    });
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("first");
+    wq.submit("second");
+    wq.submit("third");
+
+    await vi.runAllTimersAsync();
+    expect(order).toEqual(["first", "second", "third"]);
+  });
+
+  it("serialises overlapping submits — second performSubmit waits for the first to resolve", async () => {
+    const m = makeOptions();
+    let firstResolve!: () => void;
+    let firstStarted = false;
+    let secondStarted = false;
+    m.performSubmit.mockImplementation((text) => {
+      if (text === "a") {
+        firstStarted = true;
+        return new Promise<void>((r) => {
+          firstResolve = r;
+        });
+      }
+      secondStarted = true;
+      return Promise.resolve();
+    });
+
+    const wq = new WriteQueue(m.options);
+    wq.submit("a");
+    wq.submit("b");
+
+    // Allow the scheduler to call into the first performer.
+    await Promise.resolve();
+    expect(firstStarted).toBe(true);
+    expect(secondStarted).toBe(false);
+
+    firstResolve();
+    await vi.runAllTimersAsync();
+    expect(secondStarted).toBe(true);
+  });
+});
+
+describe("WriteQueue.waitForInputWriteDrain", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when nothing is queued", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
+  });
+
+  it("resolves after the chunked queue empties", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 2));
+
+    let resolved = false;
+    void wq.waitForInputWriteDrain().then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 5);
+    expect(resolved).toBe(true);
+  });
+
+  it("resolves promptly when dispose() fires mid-drain", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 5));
+
+    let resolved = false;
+    void wq.waitForInputWriteDrain().then(() => {
+      resolved = true;
+    });
+
+    wq.dispose();
+    // The polling loop uses setTimeout(check, 0). Flush microtasks + the
+    // 0-ms timer so the resolver runs.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toBe(true);
+  });
+});
+
+describe("WriteQueue.dispose", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is idempotent", () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    expect(() => {
+      wq.dispose();
+      wq.dispose();
+    }).not.toThrow();
+  });
+
+  it("drops further enqueueChunked and submit calls", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.dispose();
+
+    wq.enqueueChunked("nope");
+    wq.submit("nope");
+
+    await vi.runAllTimersAsync();
+    expect(m.writeToPty).not.toHaveBeenCalled();
+    expect(m.performSubmit).not.toHaveBeenCalled();
+  });
+
+  it("cancels the pacing timer so no further writes fire after dispose", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 4));
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+
+    wq.dispose();
+    await vi.advanceTimersByTimeAsync(WRITE_INTERVAL_MS * 10);
+    expect(m.writeToPty).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a write timer in the constructor (no enqueue, no work)", () => {
+    const m = makeOptions();
+    new WriteQueue(m.options);
+    // No timers should have been scheduled yet.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
+
+describe("WriteQueue.waitForOutputSettle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns once enough quiet time has elapsed", async () => {
+    const m = makeOptions();
+    const start = Date.now();
+    m.lastOutputTime.value = start;
+    const wq = new WriteQueue(m.options);
+
+    let resolved = false;
+    void wq.waitForOutputSettle({ debounceMs: 100, maxWaitMs: 1000, pollMs: 25 }).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(resolved).toBe(true);
+  });
+
+  it("returns when maxWaitMs elapses even if output keeps arriving", async () => {
+    const m = makeOptions();
+    m.lastOutputTime.value = Date.now();
+    const wq = new WriteQueue(m.options);
+
+    let resolved = false;
+    void wq.waitForOutputSettle({ debounceMs: 500, maxWaitMs: 200, pollMs: 25 }).then(() => {
+      resolved = true;
+    });
+
+    // Advance in increments while bumping lastOutputTime so debounce never trips.
+    for (let i = 0; i < 10; i++) {
+      m.lastOutputTime.value = Date.now();
+      await vi.advanceTimersByTimeAsync(30);
+    }
+    expect(resolved).toBe(true);
+  });
+});

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -100,8 +100,6 @@ export interface TerminalRuntime {
   headlessTerminal?: HeadlessTerminal;
   serializeAddon?: SerializeAddon;
   processDetector?: ProcessDetector;
-  inputWriteQueue: string[];
-  inputWriteTimeout: NodeJS.Timeout | null;
   outputBuffer: string;
   semanticBuffer: string[];
   rawOutputBuffer?: string;
@@ -124,10 +122,6 @@ export interface TerminalInfo extends TerminalPublicState {
   serializeAddon?: SerializeAddon;
   /** @deprecated Internal to TerminalProcess */
   processDetector?: ProcessDetector;
-  /** @deprecated Internal queue - use TerminalProcess.write() */
-  inputWriteQueue: string[];
-  /** @deprecated Internal timer */
-  inputWriteTimeout: NodeJS.Timeout | null;
   /** @deprecated Use TerminalProcess.getOutputBuffer() */
   outputBuffer: string;
   /** @deprecated Use TerminalProcess.getSemanticBuffer() */


### PR DESCRIPTION
## Summary

- Extracts the two write-pacing state machines that `TerminalProcess` hosted inline (chunked input queue + interval timer, and submit queue + in-flight serialisation) into a dedicated `WriteQueue` collaborator with a clean DI surface (`writeToPty`, `isExited`, `lastOutputTime`, `performSubmit`, `onWriteError`).
- Three teardown sites now converge on `writeQueue.dispose()`, which also fixes a pre-existing leak where `TerminalProcess.dispose()` (graceful exit path) cleared the timer but not the queue. Disposed-flag guards prevent `waitForInputWriteDrain` from deadlocking `performSubmit` during teardown.
- Drops dead `inputWriteQueue` / `inputWriteTimeout` fields from `TerminalRuntime` and `TerminalInfo`.

Resolves #5927

## Changes

- `electron/services/pty/WriteQueue.ts` — new ~180-line collaborator covering chunked-enqueue FIFO ordering, submit serialisation, output-settle quiet/maxWait paths, and idempotent dispose.
- `electron/services/pty/TerminalProcess.ts` — ~120 lines removed; side-effect wrappers (suppressNextShellSubmitSignal, markShellCommandSubmitted, captureShellInput, activityMonitor.notifySubmission) stay in TerminalProcess as call-site delegates.
- `electron/services/pty/__tests__/WriteQueue.test.ts` — ~330-line unit suite covering pacing, FIFO ordering, drain semantics, dispose mid-flight, performSubmit rejection containment, idempotent dispose, and no-constructor-timers.
- `electron/services/pty/types.ts` — removes 6 lines of now-dead fields.
- Three test fixtures updated for the removed fields.

## Testing

Typecheck clean, lint warning count decreased by 5, format clean, 70 unit tests across 6 files all pass. WriteQueue.test.ts covers the full public surface including edge cases (dispose mid-drain, rejection containment, output-settle maxWait expiry).