### PR TITLE
feat(ci): add integration tests to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -408,6 +408,32 @@ jobs:
       - name: Check renderer bundle size budget
         run: npm run renderer-bundle-budget:check
 
+  integration-test:
+    needs: [check, test]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run integration tests
+        run: npm run test:integration
+
   # E2E suites run in parallel with build (both gate on check + test)
   # Nightly runs the full suite (all 72 test files), not just the core subset
   e2e-full:
@@ -543,6 +569,7 @@ jobs:
         compiler-budget,
         eager-import-budget,
         renderer-bundle-budget,
+        integration-test,
         e2e-full,
         e2e-online,
         e2e-nightly,


### PR DESCRIPTION
## Summary
The integration test suite (12 `*.integration.test.ts` files with a working `vitest.integration.config.ts`) exists but nothing runs them in CI. They only execute when a developer remembers to run `npm run test:integration` locally.

This adds an `integration-test` job to the nightly workflow, Linux only. It's a signal channel rather than a gate: a failure auto-creates a tracking issue via the existing `nightly-failure` label, same as E2E failures already do.

Resolves #5911

## Changes
- New `integration-test` job in `.github/workflows/nightly.yml`, gated on `check` + `test`
- Runs `npm run test:integration` on ubuntu-22.04 with a 25-minute timeout
- Job added to the nightly final-gate `needs` list as a non-blocking signal channel

## Testing
The `test:integration` script already handles missing native deps by skipping cleanly (the `PtyManager.integration.test.ts` guard pattern). The job mirrors the existing `check`/`test` shape in the same workflow.