### PR TITLE
fix(boot): gate boot migrations behind crash-loop safe mode

### DIFF
--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { app } from "electron";
 import { runBootMigrations } from "./boot/migrations/index.js";
+import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
 try {
@@ -16,12 +17,8 @@ try {
 // Failures are logged but non-fatal — forward-only idempotency means the
 // failing migration retries on the next boot, and the app should still be
 // usable as long as existing state is intact.
-//
-// TODO: wire `isSafeMode` from CrashLoopGuardService once it initializes
-// here rather than inside main.ts — today the guard boots after bootstrap,
-// so safe-mode detection isn't available at this point.
 try {
-  await runBootMigrations();
+  await runBootMigrations({ isSafeMode: isSafeModeActive() });
 } catch (err) {
   console.error("[Bootstrap] Boot migrations failed — continuing with existing state:", err);
 }

--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -32,6 +32,7 @@ export class CrashLoopGuardService {
   private safeMode = false;
   private relaunchAllowed = true;
   private stabilityTimer: ReturnType<typeof setTimeout> | null = null;
+  private initialized = false;
 
   constructor() {
     this.userData = app.getPath("userData");
@@ -39,6 +40,9 @@ export class CrashLoopGuardService {
   }
 
   initialize(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+
     const state = this.readState();
     const now = Date.now();
 
@@ -168,6 +172,32 @@ export class CrashLoopGuardService {
       // Fallback: direct write (non-atomic but functional)
       fs.writeFileSync(this.statePath, data, "utf8");
     }
+  }
+}
+
+export function isSafeModeActive(userDataPath?: string): boolean {
+  const dir = userDataPath ?? app.getPath("userData");
+  const statePath = path.join(dir, STATE_FILENAME);
+
+  try {
+    if (!fs.existsSync(statePath)) return false;
+    const raw = fs.readFileSync(statePath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<CrashLoopState>;
+    if (
+      parsed.version === 1 &&
+      typeof parsed.crashes === "number" &&
+      Array.isArray(parsed.launches) &&
+      typeof parsed.cleanExit === "boolean" &&
+      typeof parsed.lastReset === "number"
+    ) {
+      if (parsed.cleanExit) return false;
+      const now = Date.now();
+      const recentLaunches = parsed.launches.filter((ts) => now - ts < RAPID_CRASH_WINDOW_MS);
+      return recentLaunches.length >= CRASH_THRESHOLD;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -11,7 +11,111 @@ vi.mock("electron", () => ({
   app: appMock,
 }));
 
-import { CrashLoopGuardService } from "../CrashLoopGuardService.js";
+import { CrashLoopGuardService, isSafeModeActive } from "../CrashLoopGuardService.js";
+
+describe("isSafeModeActive", () => {
+  let tmpDir: string;
+  let statePath: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "isSafeModeActive-"));
+    appMock.getPath.mockReturnValue(tmpDir);
+    statePath = path.join(tmpDir, "crash-loop-state.json");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false when no state file exists", () => {
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(false);
+  });
+
+  it("returns false on clean-exit state", () => {
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 0,
+        launches: [],
+        cleanExit: true,
+        lastReset: Date.now(),
+      }),
+      "utf8"
+    );
+
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("returns true with 3 recent unclean launches", () => {
+    const now = Date.now();
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 3,
+        launches: [now - 10000, now - 20000, now - 30000],
+        cleanExit: false,
+        lastReset: now - 60000,
+      }),
+      "utf8"
+    );
+
+    expect(isSafeModeActive(tmpDir)).toBe(true);
+  });
+
+  it("returns false when crashes are below threshold", () => {
+    const now = Date.now();
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 2,
+        launches: [now - 10000, now - 20000],
+        cleanExit: false,
+        lastReset: now - 60000,
+      }),
+      "utf8"
+    );
+
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("returns false when launches are outside the rapid crash window", () => {
+    const now = Date.now();
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: 1,
+        crashes: 3,
+        launches: [now - 120000, now - 90000, now - 70000],
+        cleanExit: false,
+        lastReset: now - 300000,
+      }),
+      "utf8"
+    );
+
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("returns false on corrupted state file", () => {
+    fs.writeFileSync(statePath, "not valid json!!!", "utf8");
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("returns false on invalid state structure", () => {
+    fs.writeFileSync(statePath, JSON.stringify({ version: 2, foo: "bar" }), "utf8");
+    expect(isSafeModeActive(tmpDir)).toBe(false);
+  });
+
+  it("defaults to app.getPath('userData') when called without args", () => {
+    appMock.getPath.mockReturnValue(tmpDir);
+    expect(isSafeModeActive()).toBe(false);
+  });
+});
 
 describe("CrashLoopGuardService", () => {
   let tmpDir: string;
@@ -206,6 +310,15 @@ describe("CrashLoopGuardService", () => {
     expect(guard.shouldRelaunch()).toBe(true);
 
     guard.dispose();
+  });
+
+  it("initialize is idempotent — second call is a no-op", () => {
+    const guard = new CrashLoopGuardService();
+    guard.initialize();
+    guard.initialize();
+
+    const state = readState();
+    expect(state.launches).toHaveLength(1);
   });
 
   it("startStabilityTimer is idempotent", () => {


### PR DESCRIPTION
## Summary
- Added a standalone `isSafeModeActive()` that reads the crash-loop state file synchronously, available before `app.whenReady()`.
- Wired it into `runBootMigrations()` in `bootstrap.ts`, so a crashing migration retries instead of bricking the app.
- Made `CrashLoopGuardService.initialize()` idempotent as a guard against double-init.

Resolves #5914

## Changes
- `electron/bootstrap.ts` — passes `isSafeModeActive()` to `runBootMigrations()`, removes the TODO
- `electron/services/CrashLoopGuardService.ts` — adds standalone `isSafeModeActive()` function + idempotent initializer
- `electron/services/__tests__/CrashLoopGuardService.test.ts` — 8 new tests covering all safe-mode edges (no file, clean exit, threshold, window, corruption) plus idempotency

## Testing
- Unit tests pass for all safe-mode detection paths
- Existing crash-loop guard tests pass unchanged