### PR TITLE
feat(worktree-port): type the RPC protocol with a discriminated union

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -56,6 +56,7 @@ import type { ColorVisionMode, AppColorScheme } from "../shared/types/appTheme.j
 import type {
   WorktreePortAction,
   WorktreePortPayload,
+  WorktreePortRequestArgs,
   WorktreePortResult,
 } from "../shared/types/worktree-port.js";
 import type {
@@ -271,8 +272,8 @@ class WorktreePortClient {
         clearTimeout(entry.timeout);
         this.pending.delete(data.id);
 
-        if (data.error) {
-          entry.reject(new Error(data.error));
+        if (data.error != null) {
+          entry.reject(new Error(String(data.error)));
         } else {
           entry.resolve(data.result);
         }
@@ -377,7 +378,7 @@ class WorktreePortClient {
       const id = crypto.randomUUID();
       const timeout = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(`Worktree port request timed out: ${action}`));
+        reject(new Error(`Worktree port request timed out: ${String(action)}`));
       }, timeoutMs);
 
       this.pending.set(id, {
@@ -630,8 +631,9 @@ const api: ElectronAPI = {
   worktreePort: {
     request: <K extends WorktreePortAction>(
       action: K,
-      payload?: WorktreePortPayload<K>
-    ): Promise<WorktreePortResult<K>> => worktreePortClient.request(action, payload),
+      ...args: WorktreePortRequestArgs<K>
+    ): Promise<WorktreePortResult<K>> =>
+      worktreePortClient.request<K>(action, args[0] as WorktreePortPayload<K> | undefined),
 
     onEvent: (type: string, callback: (data: unknown) => void): (() => void) =>
       worktreePortClient.onEvent(type, callback),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -54,6 +54,11 @@ import type {
 } from "../shared/types/index.js";
 import type { ColorVisionMode, AppColorScheme } from "../shared/types/appTheme.js";
 import type {
+  WorktreePortAction,
+  WorktreePortPayload,
+  WorktreePortResult,
+} from "../shared/types/worktree-port.js";
+import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
@@ -358,9 +363,12 @@ class WorktreePortClient {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  request(action: string, payload?: Record<string, unknown>, timeoutMs = 10000): Promise<any> {
-    return new Promise((resolve, reject) => {
+  request<K extends WorktreePortAction>(
+    action: K,
+    payload?: WorktreePortPayload<K>,
+    timeoutMs = 10000
+  ): Promise<WorktreePortResult<K>> {
+    return new Promise<WorktreePortResult<K>>((resolve, reject) => {
       if (!this.port) {
         reject(new Error("Worktree port not ready"));
         return;
@@ -372,10 +380,14 @@ class WorktreePortClient {
         reject(new Error(`Worktree port request timed out: ${action}`));
       }, timeoutMs);
 
-      this.pending.set(id, { resolve, reject, timeout });
+      this.pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        timeout,
+      });
 
       try {
-        this.port.postMessage({ id, action, payload: payload || {} });
+        this.port.postMessage({ id, action, payload: payload ?? {} });
       } catch (error) {
         clearTimeout(timeout);
         this.pending.delete(id);
@@ -616,9 +628,10 @@ const api: ElectronAPI = {
 
   // Worktree Port API (Phase 1 — dedicated MessagePort with request/response)
   worktreePort: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    request: (action: string, payload?: Record<string, unknown>): Promise<any> =>
-      worktreePortClient.request(action, payload),
+    request: <K extends WorktreePortAction>(
+      action: K,
+      payload?: WorktreePortPayload<K>
+    ): Promise<WorktreePortResult<K>> => worktreePortClient.request(action, payload),
 
     onEvent: (type: string, callback: (data: unknown) => void): (() => void) =>
       worktreePortClient.onEvent(type, callback),

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -20,6 +20,7 @@ import { fileTreeService } from "./services/FileTreeService.js";
 import { projectPulseService } from "./services/ProjectPulseService.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 import type { WorkspaceHostRequest, WorkspaceHostEvent } from "../shared/types/workspace-host.js";
+import type { WorktreePortRequest } from "../shared/types/worktree-port.js";
 import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
 import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
@@ -61,14 +62,13 @@ function sendToWorktreePorts(event: WorkspaceHostEvent): void {
 
 async function handleWorktreePortRequest(
   rPort: MessagePort,
-  id: string,
-  action: string,
-  payload: Record<string, unknown>
+  msg: WorktreePortRequest
 ): Promise<void> {
+  const { id } = msg;
   try {
     let result: unknown;
 
-    switch (action) {
+    switch (msg.action) {
       case "get-all-states": {
         const states = workspaceService.getSnapshotsSync();
         result = { states };
@@ -77,25 +77,21 @@ async function handleWorktreePortRequest(
 
       case "set-active": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        workspaceService.setActiveWorktree(requestId, payload.worktreeId as string);
+        workspaceService.setActiveWorktree(requestId, msg.payload.worktreeId);
         result = { ok: true };
         break;
       }
 
       case "refresh": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await workspaceService.refresh(requestId, payload.worktreeId as string | undefined);
+        await workspaceService.refresh(requestId, msg.payload.worktreeId);
         result = { ok: true };
         break;
       }
 
       case "create-worktree": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await workspaceService.createWorktree(
-          requestId,
-          payload.rootPath as string,
-          payload.options as any
-        );
+        await workspaceService.createWorktree(requestId, msg.payload.rootPath, msg.payload.options);
         result = { ok: true };
         break;
       }
@@ -104,9 +100,9 @@ async function handleWorktreePortRequest(
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         await workspaceService.deleteWorktree(
           requestId,
-          payload.worktreeId as string,
-          payload.force as boolean | undefined,
-          payload.deleteBranch as boolean | undefined
+          msg.payload.worktreeId,
+          msg.payload.force,
+          msg.payload.deleteBranch
         );
         result = { ok: true };
         break;
@@ -114,14 +110,14 @@ async function handleWorktreePortRequest(
 
       case "list-branches": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await workspaceService.listBranches(requestId, payload.rootPath as string);
+        await workspaceService.listBranches(requestId, msg.payload.rootPath);
         result = { ok: true };
         break;
       }
 
       case "get-recent-branches": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await workspaceService.getRecentBranches(requestId, payload.rootPath as string);
+        await workspaceService.getRecentBranches(requestId, msg.payload.rootPath);
         result = { ok: true };
         break;
       }
@@ -137,8 +133,8 @@ async function handleWorktreePortRequest(
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         const actionResult = await workspaceService.runResourceAction(
           requestId,
-          payload.worktreeId as string,
-          payload.action as "provision" | "teardown" | "resume" | "pause" | "status"
+          msg.payload.worktreeId,
+          msg.payload.action
         );
         if (!actionResult.success) {
           rPort.postMessage({ id, error: actionResult.error ?? "Resource action failed" });
@@ -152,21 +148,25 @@ async function handleWorktreePortRequest(
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         await workspaceService.switchWorktreeEnvironment(
           requestId,
-          payload.worktreeId as string,
-          payload.envKey as string
+          msg.payload.worktreeId,
+          msg.payload.envKey
         );
         result = { ok: true };
         break;
       }
 
       case "has-resource-config": {
-        const hasConfig = await workspaceService.hasResourceConfig(payload.rootPath as string);
+        const hasConfig = await workspaceService.hasResourceConfig(msg.payload.rootPath);
         result = { hasConfig };
         break;
       }
 
-      default:
-        throw new Error(`Unknown worktree port action: ${action}`);
+      default: {
+        const _exhaustive: never = msg;
+        throw new Error(
+          `Unknown worktree port action: ${(_exhaustive as { action: string }).action}`
+        );
+      }
     }
 
     rPort.postMessage({ id, result });
@@ -180,10 +180,19 @@ function attachWorktreePort(newPort: MessagePort): void {
   worktreePorts.push(newPort);
 
   newPort.on("message", (rawMsg: any) => {
-    const msg = rawMsg?.data ? rawMsg.data : rawMsg;
-    if (!msg?.id || !msg?.action) return;
+    const raw = rawMsg?.data ? rawMsg.data : rawMsg;
+    if (!raw?.id || !raw?.action) return;
 
-    handleWorktreePortRequest(newPort, msg.id, msg.action, msg.payload || {}).catch((err) => {
+    // Renderer is trusted; runtime validation happens at the input boundary in
+    // `WorktreePortClient.request<K>` via the typed protocol map. Cast here so
+    // the dispatcher body can stay free of per-field `as` casts.
+    const msg = {
+      id: raw.id,
+      action: raw.action,
+      payload: raw.payload ?? {},
+    } as WorktreePortRequest;
+
+    handleWorktreePortRequest(newPort, msg).catch((err) => {
       try {
         newPort.postMessage({ id: msg.id, error: (err as Error).message });
       } catch {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -368,6 +368,16 @@ export type {
   BranchInfo as WorkspaceBranchInfo,
 } from "./workspace-host.js";
 
+// Worktree Port RPC protocol - typed request/response for the dedicated MessagePort
+export type {
+  WorktreePortProtocol,
+  WorktreePortAction,
+  WorktreePortPayload,
+  WorktreePortResult,
+  WorktreePortRequest,
+  WorktreePortResourceAction,
+} from "./worktree-port.js";
+
 // Project Pulse types - activity heatmap and commit history
 export type {
   PulseRangeDays,

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -375,6 +375,7 @@ export type {
   WorktreePortPayload,
   WorktreePortResult,
   WorktreePortRequest,
+  WorktreePortRequestArgs,
   WorktreePortResourceAction,
 } from "./worktree-port.js";
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -27,7 +27,7 @@ import type {
 } from "./worktree.js";
 import type {
   WorktreePortAction,
-  WorktreePortPayload,
+  WorktreePortRequestArgs,
   WorktreePortResult,
 } from "../worktree-port.js";
 import type {
@@ -230,7 +230,7 @@ export interface ElectronAPI {
   worktreePort: {
     request<K extends WorktreePortAction>(
       action: K,
-      payload?: WorktreePortPayload<K>
+      ...args: WorktreePortRequestArgs<K>
     ): Promise<WorktreePortResult<K>>;
     onEvent(type: string, callback: (data: unknown) => void): () => void;
     isReady(): boolean;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -26,6 +26,11 @@ import type {
   IssueAssociation,
 } from "./worktree.js";
 import type {
+  WorktreePortAction,
+  WorktreePortPayload,
+  WorktreePortResult,
+} from "../worktree-port.js";
+import type {
   TerminalSpawnOptions,
   TerminalReconnectResult,
   BackendTerminalInfo,
@@ -223,8 +228,10 @@ export interface ElectronAPI {
     onActivated(callback: (data: { worktreeId: string }) => void): () => void;
   };
   worktreePort: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    request(action: string, payload?: Record<string, unknown>): Promise<any>;
+    request<K extends WorktreePortAction>(
+      action: K,
+      payload?: WorktreePortPayload<K>
+    ): Promise<WorktreePortResult<K>>;
     onEvent(type: string, callback: (data: unknown) => void): () => void;
     isReady(): boolean;
     onReady(callback: () => void): () => void;

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -1,0 +1,77 @@
+/**
+ * Typed RPC protocol for the dedicated worktree MessagePort transport.
+ *
+ * Each entry in `WorktreePortProtocol` defines the payload accepted and the
+ * result returned for a single action. `WorktreePortRequest` is the derived
+ * discriminated union consumed by the workspace-host dispatcher; the renderer
+ * client (`WorktreePortClient.request<K>`) indexes the protocol map directly
+ * to infer per-action payload and result types.
+ *
+ * The wire framing (`{ id, action, payload }` request, `{ id, result | error }`
+ * response) is unchanged — these types are compile-time only.
+ */
+
+import type { CreateWorktreeOptions, WorktreeSnapshot } from "./workspace-host.js";
+
+export type WorktreePortResourceAction = "provision" | "teardown" | "resume" | "pause" | "status";
+
+export interface WorktreePortProtocol {
+  "get-all-states": {
+    payload: Record<string, never>;
+    result: { states: WorktreeSnapshot[] };
+  };
+  "set-active": {
+    payload: { worktreeId: string };
+    result: { ok: true };
+  };
+  refresh: {
+    payload: { worktreeId?: string };
+    result: { ok: true };
+  };
+  "create-worktree": {
+    payload: { rootPath: string; options: CreateWorktreeOptions };
+    result: { ok: true };
+  };
+  "delete-worktree": {
+    payload: { worktreeId: string; force?: boolean; deleteBranch?: boolean };
+    result: { ok: true };
+  };
+  "list-branches": {
+    payload: { rootPath: string };
+    result: { ok: true };
+  };
+  "get-recent-branches": {
+    payload: { rootPath: string };
+    result: { ok: true };
+  };
+  "refresh-prs": {
+    payload: Record<string, never>;
+    result: { ok: true };
+  };
+  "resource-action": {
+    payload: { worktreeId: string; action: WorktreePortResourceAction };
+    result: { ok: true };
+  };
+  "switch-worktree-environment": {
+    payload: { worktreeId: string; envKey: string };
+    result: { ok: true };
+  };
+  "has-resource-config": {
+    payload: { rootPath: string };
+    result: { hasConfig: boolean };
+  };
+}
+
+export type WorktreePortAction = keyof WorktreePortProtocol;
+
+export type WorktreePortPayload<K extends WorktreePortAction> = WorktreePortProtocol[K]["payload"];
+
+export type WorktreePortResult<K extends WorktreePortAction> = WorktreePortProtocol[K]["result"];
+
+export type WorktreePortRequest = {
+  [K in WorktreePortAction]: {
+    id: string;
+    action: K;
+    payload: WorktreePortPayload<K>;
+  };
+}[WorktreePortAction];

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -75,3 +75,14 @@ export type WorktreePortRequest = {
     payload: WorktreePortPayload<K>;
   };
 }[WorktreePortAction];
+
+/**
+ * Rest-args tuple that makes `payload` optional only when an empty object is
+ * assignable to the action's payload (i.e. all fields optional, or
+ * `Record<string, never>`). Required-field payloads (e.g. `set-active`) become
+ * a compile error if omitted.
+ */
+export type WorktreePortRequestArgs<K extends WorktreePortAction> =
+  Record<string, never> extends WorktreePortPayload<K>
+    ? [payload?: WorktreePortPayload<K>]
+    : [payload: WorktreePortPayload<K>];

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -97,15 +97,15 @@ export const worktreeClient = {
     return window.electron.worktree.onActivated(callback);
   },
 
-  resourceAction: (
+  resourceAction: async (
     worktreeId: string,
     action: "provision" | "teardown" | "resume" | "pause" | "status"
   ): Promise<void> => {
-    return window.electron.worktreePort.request("resource-action", { worktreeId, action });
+    await window.electron.worktreePort.request("resource-action", { worktreeId, action });
   },
 
-  switchEnvironment: (worktreeId: string, envKey: string): Promise<void> => {
-    return window.electron.worktreePort.request("switch-worktree-environment", {
+  switchEnvironment: async (worktreeId: string, envKey: string): Promise<void> => {
+    await window.electron.worktreePort.request("switch-worktree-environment", {
       worktreeId,
       envKey,
     });


### PR DESCRIPTION
## Summary

- Introduces `WorktreePortProtocol` in `shared/types/worktree-port.ts`, a map of all 11 worktree port actions to their typed payload and result shapes. `WorktreePortRequest` and `WorktreePortAction` derive from it as a discriminated union, giving both sides of the transport a single source of truth.
- The host-side `handleWorktreePortRequest` is now exhaustive over the action union with a `never`-typed default branch. All the per-field `as` casts on `payload` are gone, replaced by the narrowed union member.
- The renderer-facing API gets a generic `request<K extends WorktreePortAction>` signature so call sites get the right `Promise<T>` back. `WorktreePortRequestArgs<K>` uses a conditional rest-args tuple to make `payload` required when the action needs fields, optional when it doesn't.

Resolves #5917

## Changes

- `shared/types/worktree-port.ts` (new): `WorktreePortProtocol` map (11 actions), `WorktreePortAction`, `WorktreePortPayload<K>`, `WorktreePortResult<K>`, `WorktreePortRequest`, `WorktreePortResourceAction`, `WorktreePortRequestArgs<K>`
- `shared/types/index.ts`: barrel export for the new types file
- `shared/types/ipc/api.ts`: `ElectronAPI.worktreePort.request<K>` generic signature
- `electron/preload.cts`: `WorktreePortClient.request<K>` generic; preload wrapper wired with generic
- `electron/workspace-host.ts`: `handleWorktreePortRequest(msg: WorktreePortRequest)`, exhaustiveness check on default branch, single boundary cast at `attachWorktreePort`, all field-level casts removed
- `src/clients/worktreeClient.ts`: `resourceAction`/`switchEnvironment` switched to `async` to match their declared `Promise<void>` return; error check tightened from `if (data.error)` to `if (data.error != null)`

## Testing

- `npm run check` passes clean (0 errors, warnings are pre-existing)
- The discriminated union enforces exhaustiveness at compile time; adding a new action without a handler branch is a compile error