### PR TITLE
refactor(pty): extract SessionSnapshotter from TerminalProcess (#5930)

### DIFF
--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -59,6 +59,9 @@ export class SessionSnapshotter {
       const state = this.host.hasBannerMarkers()
         ? this.host.serializeForPersistence()
         : await this.host.getSerializedStateAsync();
+      // Re-check lifecycle after the await — a kill or dispose during async
+      // serialize would otherwise stomp the sync snapshot written from kill().
+      if (this.disposed || this.host.wasKilled) return;
       if (!state) return;
       if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
         return;

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -1,0 +1,142 @@
+import {
+  TERMINAL_SESSION_PERSISTENCE_ENABLED,
+  SESSION_SNAPSHOT_MAX_BYTES,
+  SESSION_SNAPSHOT_DEBOUNCE_MS,
+  persistSessionSnapshotSync,
+  persistSessionSnapshotAsync,
+  isSessionPersistSuppressed,
+} from "./terminalSessionPersistence.js";
+
+const EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS = 2000;
+
+export interface SessionSnapshotterHost {
+  readonly id: string;
+  readonly wasKilled: boolean;
+  readonly launchAgentId: string | undefined;
+  hasBannerMarkers(): boolean;
+  getSerializedState(): string | null;
+  getSerializedStateAsync(): Promise<string | null>;
+  serializeForPersistence(): string | null;
+}
+
+export class SessionSnapshotter {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private dirty = false;
+  private inFlight = false;
+  private lastEventDrivenFlushAt = -Infinity;
+  private disposed = false;
+
+  constructor(private readonly host: SessionSnapshotterHost) {}
+
+  schedule(): void {
+    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+    if (isSessionPersistSuppressed()) return;
+    if (this.host.launchAgentId) return;
+    if (this.host.wasKilled) return;
+    if (this.disposed) return;
+
+    this.dirty = true;
+    if (this.timer) return;
+
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.persistAsync();
+    }, SESSION_SNAPSHOT_DEBOUNCE_MS);
+  }
+
+  private async persistAsync(): Promise<void> {
+    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+    if (isSessionPersistSuppressed()) return;
+    if (this.host.launchAgentId) return;
+    if (this.host.wasKilled) return;
+    if (this.disposed) return;
+    if (!this.dirty) return;
+    if (this.inFlight) return;
+
+    this.inFlight = true;
+    try {
+      this.dirty = false;
+      const state = this.host.hasBannerMarkers()
+        ? this.host.serializeForPersistence()
+        : await this.host.getSerializedStateAsync();
+      if (!state) return;
+      if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
+        return;
+      }
+      await persistSessionSnapshotAsync(this.host.id, state);
+    } catch (error) {
+      console.warn(`[TerminalProcess] Failed to persist session for ${this.host.id}:`, error);
+    } finally {
+      this.inFlight = false;
+      if (!this.disposed && this.dirty) {
+        this.schedule();
+      }
+    }
+  }
+
+  flushEventDriven(): void {
+    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+    if (isSessionPersistSuppressed()) return;
+    if (this.host.wasKilled) return;
+    if (this.disposed) return;
+
+    const now = performance.now();
+    if (now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS) return;
+    this.lastEventDrivenFlushAt = now;
+
+    const state = this.host.getSerializedState();
+    if (!state) return;
+    if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
+
+    persistSessionSnapshotAsync(this.host.id, state).catch((error) => {
+      console.warn(`[TerminalProcess] Event-driven snapshot failed for ${this.host.id}:`, error);
+    });
+  }
+
+  // Last-chance unconditional flush invoked by kill() before wasKilled is set.
+  // Mirrors the legacy inline block: plain sync serialize, no banner awareness,
+  // skipped only when persistence is disabled / suppressed / agent terminal.
+  flushSyncOnKill(): void {
+    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+    if (isSessionPersistSuppressed()) return;
+    if (this.host.launchAgentId) return;
+
+    try {
+      const state = this.host.getSerializedState();
+      if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
+        persistSessionSnapshotSync(this.host.id, state);
+      }
+    } catch {
+      // best-effort only
+    }
+  }
+
+  // Sync flush invoked from dispose() when the debounced timer never fired.
+  // Banner-aware (matches the debounced async path) and gated by `dirty` so
+  // an already-persisted session is not rewritten on teardown.
+  flushSyncOnDispose(): void {
+    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+    if (isSessionPersistSuppressed()) return;
+    if (!this.dirty) return;
+    if (this.host.wasKilled) return;
+
+    try {
+      const state = this.host.serializeForPersistence() ?? this.host.getSerializedState();
+      if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
+        persistSessionSnapshotSync(this.host.id, state);
+        this.dirty = false;
+      }
+    } catch {
+      // best-effort only
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.dirty = false;
+  }
+}

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -60,7 +60,7 @@ import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
   restoreSessionFromFile,
 } from "./terminalSessionPersistence.js";
-import { SessionSnapshotter } from "./SessionSnapshotter.js";
+import { SessionSnapshotter, type SessionSnapshotterHost } from "./SessionSnapshotter.js";
 import {
   createProcessStateValidator,
   buildActivityMonitorOptions,
@@ -209,22 +209,39 @@ export class TerminalProcess {
   }
 
   private createSessionSnapshotter(): SessionSnapshotter {
-    const self = this;
-    return new SessionSnapshotter({
-      get id() {
-        return self.id;
-      },
-      get wasKilled() {
-        return self.terminalInfo.wasKilled === true;
-      },
-      get launchAgentId() {
-        return self.terminalInfo.launchAgentId;
-      },
-      hasBannerMarkers: () => !!(self._restoreBannerStart || self._restoreBannerEnd),
-      getSerializedState: () => self.getSerializedState(),
-      getSerializedStateAsync: () => self.getSerializedStateAsync(),
-      serializeForPersistence: () => self._serializeForPersistence(),
-    });
+    class Host implements SessionSnapshotterHost {
+      constructor(private parent: TerminalProcess) {}
+
+      get id(): string {
+        return this.parent.id;
+      }
+
+      get wasKilled(): boolean {
+        return this.parent.terminalInfo.wasKilled === true;
+      }
+
+      get launchAgentId(): string | undefined {
+        return this.parent.terminalInfo.launchAgentId;
+      }
+
+      hasBannerMarkers(): boolean {
+        return !!(this.parent._restoreBannerStart || this.parent._restoreBannerEnd);
+      }
+
+      getSerializedState(): string | null {
+        return this.parent.getSerializedState();
+      }
+
+      getSerializedStateAsync(): Promise<string | null> {
+        return this.parent.getSerializedStateAsync();
+      }
+
+      serializeForPersistence(): string | null {
+        return this.parent._serializeForPersistence();
+      }
+    }
+
+    return new SessionSnapshotter(new Host(this));
   }
 
   private logWriteError(error: unknown, context: { operation: string; traceId?: string }): void {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -58,13 +58,9 @@ import {
 import type { IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
-  SESSION_SNAPSHOT_MAX_BYTES,
-  SESSION_SNAPSHOT_DEBOUNCE_MS,
   restoreSessionFromFile,
-  persistSessionSnapshotSync,
-  persistSessionSnapshotAsync,
-  isSessionPersistSuppressed,
 } from "./terminalSessionPersistence.js";
+import { SessionSnapshotter } from "./SessionSnapshotter.js";
 import {
   createProcessStateValidator,
   buildActivityMonitorOptions,
@@ -92,7 +88,6 @@ type CursorBuffer = {
   getLine: (index: number) => { translateToString: (trimRight?: boolean) => string } | undefined;
 };
 
-const EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS = 2000;
 const SHELL_IDENTITY_FALLBACK_COMMIT_MS = 1200;
 const SHELL_IDENTITY_FALLBACK_POLL_MS = 200;
 const SHELL_IDENTITY_FALLBACK_PROMPT_POLLS = 2;
@@ -165,10 +160,7 @@ export class TerminalProcess {
 
   private _scrollback: number;
   private headlessResponderDisposable: { dispose: () => void } | null = null;
-  private sessionPersistTimer: NodeJS.Timeout | null = null;
-  private sessionPersistDirty = false;
-  private sessionPersistInFlight = false;
-  private lastEventDrivenFlushAt = -Infinity;
+  private sessionSnapshotter!: SessionSnapshotter;
 
   private readonly terminalInfo: TerminalInfo;
 
@@ -212,73 +204,26 @@ export class TerminalProcess {
     }
   }
 
-  private scheduleSessionPersist(): void {
-    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
-    if (isSessionPersistSuppressed()) return;
-    if (this.terminalInfo.launchAgentId) return;
-    if (this.terminalInfo.wasKilled) return;
-
-    this.sessionPersistDirty = true;
-    if (this.sessionPersistTimer) return;
-
-    this.sessionPersistTimer = setTimeout(() => {
-      this.sessionPersistTimer = null;
-      void this.persistSessionSnapshot();
-    }, SESSION_SNAPSHOT_DEBOUNCE_MS);
-  }
-
-  private async persistSessionSnapshot(): Promise<void> {
-    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
-    if (isSessionPersistSuppressed()) return;
-    if (this.terminalInfo.launchAgentId) return;
-    if (this.terminalInfo.wasKilled) return;
-    if (!this.sessionPersistDirty) return;
-    if (this.sessionPersistInFlight) return;
-
-    this.sessionPersistInFlight = true;
-    try {
-      this.sessionPersistDirty = false;
-      const state =
-        this._restoreBannerStart || this._restoreBannerEnd
-          ? this._serializeForPersistence()
-          : await this.getSerializedStateAsync();
-      if (!state) return;
-      if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
-        return;
-      }
-      await persistSessionSnapshotAsync(this.id, state);
-    } catch (error) {
-      console.warn(`[TerminalProcess] Failed to persist session for ${this.id}:`, error);
-    } finally {
-      this.sessionPersistInFlight = false;
-      if (this.sessionPersistDirty) {
-        this.scheduleSessionPersist();
-      }
-    }
-  }
-
-  private clearSessionPersistTimer(): void {
-    if (this.sessionPersistTimer) {
-      clearTimeout(this.sessionPersistTimer);
-      this.sessionPersistTimer = null;
-    }
-  }
-
   flushEventDrivenSnapshot(): void {
-    if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
-    if (isSessionPersistSuppressed()) return;
-    if (this.terminalInfo.wasKilled) return;
+    this.sessionSnapshotter.flushEventDriven();
+  }
 
-    const now = performance.now();
-    if (now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS) return;
-    this.lastEventDrivenFlushAt = now;
-
-    const state = this.getSerializedState();
-    if (!state) return;
-    if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
-
-    persistSessionSnapshotAsync(this.id, state).catch((error) => {
-      console.warn(`[TerminalProcess] Event-driven snapshot failed for ${this.id}:`, error);
+  private createSessionSnapshotter(): SessionSnapshotter {
+    const self = this;
+    return new SessionSnapshotter({
+      get id() {
+        return self.id;
+      },
+      get wasKilled() {
+        return self.terminalInfo.wasKilled === true;
+      },
+      get launchAgentId() {
+        return self.terminalInfo.launchAgentId;
+      },
+      hasBannerMarkers: () => !!(self._restoreBannerStart || self._restoreBannerEnd),
+      getSerializedState: () => self.getSerializedState(),
+      getSerializedStateAsync: () => self.getSerializedStateAsync(),
+      serializeForPersistence: () => self._serializeForPersistence(),
     });
   }
 
@@ -420,6 +365,7 @@ export class TerminalProcess {
       performSubmit: (text) => this.performSubmit(text),
       onWriteError: (error, context) => this.logWriteError(error, context),
     });
+    this.sessionSnapshotter = this.createSessionSnapshotter();
     this.setupPtyHandlers(ptyProcess);
 
     const ptyPid = ptyProcess.pid;
@@ -974,23 +920,10 @@ export class TerminalProcess {
     // Flush session snapshot synchronously before marking as killed.
     // Once wasKilled is set, all persistence paths are blocked, and
     // disposeHeadless() destroys the buffer — so this is the last chance.
-    if (
-      TERMINAL_SESSION_PERSISTENCE_ENABLED &&
-      !this.terminalInfo.launchAgentId &&
-      !isSessionPersistSuppressed()
-    ) {
-      try {
-        const state = this.getSerializedState();
-        if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
-          persistSessionSnapshotSync(this.id, state);
-        }
-      } catch {
-        // best-effort only
-      }
-    }
+    this.sessionSnapshotter.flushSyncOnKill();
 
     terminal.wasKilled = true;
-    this.clearSessionPersistTimer();
+    this.sessionSnapshotter.dispose();
 
     if (getLiveAgentId(terminal)) {
       this.deps.agentStateService.updateAgentState(terminal, {
@@ -1636,24 +1569,8 @@ export class TerminalProcess {
 
     this.semanticBufferManager.dispose();
 
-    if (
-      TERMINAL_SESSION_PERSISTENCE_ENABLED &&
-      this.sessionPersistDirty &&
-      !this.terminalInfo.wasKilled &&
-      !isSessionPersistSuppressed()
-    ) {
-      try {
-        const state = this._serializeForPersistence() ?? this.getSerializedState();
-        if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
-          persistSessionSnapshotSync(this.id, state);
-          this.sessionPersistDirty = false;
-        }
-      } catch {
-        // best-effort only
-      }
-    }
-
-    this.clearSessionPersistTimer();
+    this.sessionSnapshotter.flushSyncOnDispose();
+    this.sessionSnapshotter.dispose();
 
     this.writeQueue.dispose();
 
@@ -1697,7 +1614,7 @@ export class TerminalProcess {
       }
 
       terminal.headlessTerminal?.write(data);
-      this.scheduleSessionPersist();
+      this.sessionSnapshotter.schedule();
 
       this.emitData(rendererData);
       this.forensicsBuffer.capture(data);
@@ -1737,8 +1654,7 @@ export class TerminalProcess {
 
       this.writeQueue.dispose();
 
-      this.clearSessionPersistTimer();
-      this.sessionPersistDirty = false;
+      this.sessionSnapshotter.dispose();
 
       this.processTreeKiller.abort();
 

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -3,7 +3,7 @@ import { SessionSnapshotter, type SessionSnapshotterHost } from "../SessionSnaps
 
 const persistAsyncMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const persistSyncMock = vi.hoisted(() => vi.fn());
-const setSuppressedMock = vi.hoisted(() => vi.fn());
+const isSuppressedMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
   const orig = (await importOriginal()) as Record<string, unknown>;
@@ -12,7 +12,7 @@ vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
     TERMINAL_SESSION_PERSISTENCE_ENABLED: true,
     persistSessionSnapshotSync: persistSyncMock,
     persistSessionSnapshotAsync: persistAsyncMock,
-    setSessionPersistSuppressed: setSuppressedMock,
+    isSessionPersistSuppressed: isSuppressedMock,
   };
 });
 
@@ -78,6 +78,8 @@ describe("SessionSnapshotter", () => {
     persistAsyncMock.mockReset();
     persistAsyncMock.mockResolvedValue(undefined);
     persistSyncMock.mockReset();
+    isSuppressedMock.mockReset();
+    isSuppressedMock.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -108,6 +110,7 @@ describe("SessionSnapshotter", () => {
       snap.schedule();
       await vi.advanceTimersByTimeAsync(5000);
 
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
       expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
     });
 
@@ -180,7 +183,7 @@ describe("SessionSnapshotter", () => {
       }).not.toThrow();
     });
 
-    it("blocks reschedule from in-flight finally block when disposed mid-flight", async () => {
+    it("blocks reschedule and post-await persist when disposed mid-flight", async () => {
       const host = createHost();
       host.asyncResolved = false;
       const snap = new SessionSnapshotter(host);
@@ -196,16 +199,37 @@ describe("SessionSnapshotter", () => {
       // Dispose while the async serialize is still pending.
       snap.dispose();
 
-      // Resolve the in-flight promise — the finally block must not reschedule.
+      // Resolve the in-flight promise — neither persist nor reschedule should
+      // fire: the post-await disposed check bails before persistSessionSnapshotAsync.
       host.asyncResolve();
       await Promise.resolve();
       await Promise.resolve();
       await vi.advanceTimersByTimeAsync(10_000);
 
-      // persistAsyncMock may have been called once before the deferred resolve
-      // (since the async serializer awaits before calling persist), but no
-      // reschedule should fire after dispose.
       expect(vi.getTimerCount()).toBe(0);
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks post-await persist when wasKilled is set mid-flight", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Simulate kill: flushSyncOnKill writes a sync snapshot, then wasKilled
+      // is set. The post-await guard must prevent the in-flight async from
+      // overwriting the sync snapshot.
+      snap.flushSyncOnKill();
+      host.wasKilled = true;
+
+      host.asyncResolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).not.toHaveBeenCalled();
     });
 
     it("schedule after dispose is a no-op", async () => {
@@ -228,6 +252,7 @@ describe("SessionSnapshotter", () => {
 
       snap.flushEventDriven();
 
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
       expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "sync-state");
     });
 
@@ -308,6 +333,7 @@ describe("SessionSnapshotter", () => {
 
       snap.flushSyncOnKill();
 
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
       expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
     });
 
@@ -337,6 +363,7 @@ describe("SessionSnapshotter", () => {
 
       snap.flushSyncOnKill();
 
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
       expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
     });
   });
@@ -358,6 +385,7 @@ describe("SessionSnapshotter", () => {
       snap.schedule(); // sets dirty=true
       snap.flushSyncOnDispose();
 
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
       expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
     });
 
@@ -379,6 +407,7 @@ describe("SessionSnapshotter", () => {
       snap.schedule();
       snap.flushSyncOnDispose();
 
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
       expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
     });
 
@@ -391,6 +420,27 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnDispose();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isSessionPersistSuppressed gate", () => {
+    it("blocks all persistence paths when suppression is active", async () => {
+      isSuppressedMock.mockReturnValue(true);
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+      snap.flushEventDriven();
+      snap.flushSyncOnKill();
+      // schedule was no-op so dirty is false; force dirty for the dispose path.
+      isSuppressedMock.mockReturnValue(false);
+      snap.schedule();
+      isSuppressedMock.mockReturnValue(true);
+      snap.flushSyncOnDispose();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+      expect(persistSyncMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionSnapshotter, type SessionSnapshotterHost } from "../SessionSnapshotter.js";
+
+const persistAsyncMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const persistSyncMock = vi.hoisted(() => vi.fn());
+const setSuppressedMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    TERMINAL_SESSION_PERSISTENCE_ENABLED: true,
+    persistSessionSnapshotSync: persistSyncMock,
+    persistSessionSnapshotAsync: persistAsyncMock,
+    setSessionPersistSuppressed: setSuppressedMock,
+  };
+});
+
+interface MutableHost extends SessionSnapshotterHost {
+  wasKilled: boolean;
+  launchAgentId: string | undefined;
+  bannerMarkers: boolean;
+  serializedState: string | null;
+  serializedStateAsync: string | null;
+  serializedForPersistence: string | null;
+  asyncResolve: () => void;
+  asyncResolved: boolean;
+}
+
+function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
+  // Allow tests to install a deferred async serializer when they need to
+  // observe in-flight behavior.
+  let asyncResolve: () => void = () => {};
+  let asyncResolved = true;
+
+  const host: MutableHost = {
+    id: "t-test",
+    wasKilled: false,
+    launchAgentId: undefined,
+    bannerMarkers: false,
+    serializedState: "sync-state",
+    serializedStateAsync: "async-state",
+    serializedForPersistence: "banner-state",
+    hasBannerMarkers() {
+      return this.bannerMarkers;
+    },
+    getSerializedState() {
+      return this.serializedState;
+    },
+    async getSerializedStateAsync() {
+      if (asyncResolved) return this.serializedStateAsync;
+      await new Promise<void>((resolve) => {
+        asyncResolve = () => {
+          asyncResolved = true;
+          resolve();
+        };
+      });
+      return this.serializedStateAsync;
+    },
+    serializeForPersistence() {
+      return this.serializedForPersistence;
+    },
+    asyncResolve: () => asyncResolve(),
+    get asyncResolved() {
+      return asyncResolved;
+    },
+    set asyncResolved(v: boolean) {
+      asyncResolved = v;
+    },
+    ...overrides,
+  };
+  return host;
+}
+
+describe("SessionSnapshotter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    persistAsyncMock.mockReset();
+    persistAsyncMock.mockResolvedValue(undefined);
+    persistSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("schedule + debounced async persist", () => {
+    it("debounces and persists once after 5s", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.schedule();
+      snap.schedule();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "async-state");
+    });
+
+    it("uses banner-aware sync serialize when banner markers are present", async () => {
+      const host = createHost({ bannerMarkers: true });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+    });
+
+    it("skips scheduling when launchAgentId is set (agent terminal)", async () => {
+      const host = createHost({ launchAgentId: "claude" });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("skips scheduling when wasKilled is true", async () => {
+      const host = createHost({ wasKilled: true });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("does not persist when serialized state is null", async () => {
+      const host = createHost({ serializedStateAsync: null });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("does not persist when serialized state exceeds max bytes", async () => {
+      const oversized = "x".repeat(6 * 1024 * 1024);
+      const host = createHost({ serializedStateAsync: oversized });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dispose", () => {
+    it("clears pending timer and prevents persist callback from firing", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+      snap.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("is safe to call multiple times", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      expect(() => {
+        snap.dispose();
+        snap.dispose();
+        snap.dispose();
+      }).not.toThrow();
+    });
+
+    it("blocks reschedule from in-flight finally block when disposed mid-flight", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      // Schedule and let the timer fire — the persistAsync starts and stalls
+      // on the deferred getSerializedStateAsync().
+      snap.schedule();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      // Mark dirty mid-flight so the finally block would normally reschedule.
+      snap.schedule();
+
+      // Dispose while the async serialize is still pending.
+      snap.dispose();
+
+      // Resolve the in-flight promise — the finally block must not reschedule.
+      host.asyncResolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // persistAsyncMock may have been called once before the deferred resolve
+      // (since the async serializer awaits before calling persist), but no
+      // reschedule should fire after dispose.
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("schedule after dispose is a no-op", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.dispose();
+      snap.schedule();
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe("flushEventDriven", () => {
+    it("persists with sync serialized state", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+    });
+
+    it("throttles repeated calls within 2s", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      snap.flushEventDriven();
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows another flush after throttle window elapses", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      vi.advanceTimersByTime(2001);
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT skip for agent terminals (snapshots agents on event)", () => {
+      const host = createHost({ launchAgentId: "claude" });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips when wasKilled is true", () => {
+      const host = createHost({ wasKilled: true });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("skips when disposed", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.dispose();
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("skips when serialized state is null", () => {
+      const host = createHost({ serializedState: null });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("skips when serialized state exceeds max bytes", () => {
+      const oversized = "x".repeat(6 * 1024 * 1024);
+      const host = createHost({ serializedState: oversized });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flushSyncOnKill", () => {
+    it("persists synchronously regardless of dirty flag", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushSyncOnKill();
+
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+    });
+
+    it("skips for agent terminals", () => {
+      const host = createHost({ launchAgentId: "claude" });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushSyncOnKill();
+
+      expect(persistSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("ignores serialize errors silently", () => {
+      const host = createHost();
+      host.getSerializedState = () => {
+        throw new Error("serialize boom");
+      };
+      const snap = new SessionSnapshotter(host);
+
+      expect(() => snap.flushSyncOnKill()).not.toThrow();
+      expect(persistSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("uses plain sync serialize (not banner-aware)", () => {
+      const host = createHost({ bannerMarkers: true });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushSyncOnKill();
+
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+    });
+  });
+
+  describe("flushSyncOnDispose", () => {
+    it("skips when not dirty", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushSyncOnDispose();
+
+      expect(persistSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("persists when dirty (after schedule)", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule(); // sets dirty=true
+      snap.flushSyncOnDispose();
+
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+    });
+
+    it("skips when wasKilled is true", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      host.wasKilled = true;
+      snap.flushSyncOnDispose();
+
+      expect(persistSyncMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to plain sync serialize when banner-aware returns null", () => {
+      const host = createHost({ serializedForPersistence: null });
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushSyncOnDispose();
+
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+    });
+
+    it("clears dirty flag after persist so a second call is a no-op", () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.schedule();
+      snap.flushSyncOnDispose();
+      snap.flushSyncOnDispose();
+
+      expect(persistSyncMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Lifts the session-snapshot scheduling layer out of `TerminalProcess` into a new `SessionSnapshotter` collaborator. Four instance fields (`sessionPersistTimer`, `sessionPersistDirty`, `sessionPersistInFlight`, `lastEventDrivenFlushAt`) and their four scheduling methods now live in a focused, independently-testable file.
- Splits the two distinct sync flush sites into named methods: `flushSyncOnKill` (unconditional, plain serialise) and `flushSyncOnDispose` (banner-aware, dirty-gated). Adds a disposed guard in the in-flight `finally` block and a post-await re-check in `persistAsync` so a concurrent async serialise can't overwrite the sync snapshot written from `kill()`.
- Adds 37 dedicated unit tests in `SessionSnapshotter.test.ts`; existing `TerminalProcess.exit-cleanup.test.ts` and `TerminalProcess.snapshot.test.ts` pass unchanged.

Resolves #5930.

## Changes

- `electron/services/pty/SessionSnapshotter.ts` — new collaborator class (145 lines)
- `electron/services/pty/TerminalProcess.ts` — removes scheduling state and delegates to `SessionSnapshotter`
- `electron/services/pty/__tests__/SessionSnapshotter.test.ts` — 37 unit tests covering schedule, debounce, flush, dispose, and concurrency guards

## Testing

Unit tests: 37 `SessionSnapshotter` tests pass alongside the 8 existing `TerminalProcess` snapshot and exit-cleanup tests. Lint, format, and typecheck all clean.