### PR TITLE
feat(pty): replace implicit lifecycle flags with explicit PtyState machine

### DIFF
--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -741,6 +741,15 @@ export type DaintreeEventMap = {
    */
   "terminal:exited": {
     terminalId: string;
+    /**
+     * Session-scoped token (the spawning timestamp) that distinguishes
+     * different `TerminalProcess` instances which happen to share an `id`
+     * — e.g. when `PtyManager.spawn(id)` kills the prior terminal and
+     * respawns under the same id. Subscribers must filter on both
+     * `terminalId` AND `spawnedAt` to avoid firing the new instance's
+     * handlers on the old PTY's exit.
+     */
+    spawnedAt: number;
     code: number | null;
     signal?: number;
     reason: ExitReason;

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -3,6 +3,7 @@ import type { NotificationPayload, AgentState, TaskState, EventCategory } from "
 import type { EventContext } from "../../shared/types/events.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import type { TerminalReliabilityMetricPayload } from "../../shared/types/pty-host.js";
+import type { ExitReason } from "./pty/types.js";
 
 export type { EventCategory };
 
@@ -288,6 +289,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresContext: true,
     requiresTimestamp: true,
     description: "Terminal agent state changed (idle, working, completed, etc.)",
+  },
+  "terminal:exited": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Terminal PTY exited (natural, kill, graceful-shutdown, or dispose)",
   },
 
   // Task events
@@ -721,6 +728,31 @@ export type DaintreeEventMap = {
     confidence: number;
   }>;
 
+  /**
+   * Emitted exactly once per `TerminalProcess` lifetime when the PTY
+   * transitions out of `alive`. Subscribers handle forensics logging,
+   * agent completion emission, and fallback classification — work that
+   * previously lived inline inside the PTY exit handler.
+   *
+   * `code` is `null` only when `dispose()` is called without a prior
+   * natural exit (e.g. LRU eviction). `recentOutput` is captured before
+   * the headless buffer is torn down so subscribers can scan exit-time
+   * output without racing teardown.
+   */
+  "terminal:exited": {
+    terminalId: string;
+    code: number | null;
+    signal?: number;
+    reason: ExitReason;
+    recentOutput: string;
+    hadAgent: boolean;
+    liveAgentAtExit?: string;
+    launchAgentId?: string;
+    agentPresetId?: string;
+    originalAgentPresetId?: string;
+    timestamp: number;
+  };
+
   // Task Lifecycle Events (Future-proof for task management)
 
   /**
@@ -835,6 +867,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "terminal:foregrounded",
   "terminal:reliability-metric",
   "terminal:state-changed",
+  "terminal:exited",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -587,6 +587,7 @@ export class TerminalProcess {
 
     events.emit("terminal:exited", {
       terminalId: this.id,
+      spawnedAt: terminal.spawnedAt,
       code: args.code,
       signal: args.signal,
       reason: args.reason,
@@ -611,8 +612,13 @@ export class TerminalProcess {
    */
   private _exitObserverDisposable: { dispose: () => void } | null = null;
   private _subscribeExitObservers(): void {
+    const sessionToken = this.terminalInfo.spawnedAt;
     const off = events.on("terminal:exited", (payload) => {
-      if (payload.terminalId !== this.id) return;
+      // Filter on terminalId AND the session token. Without spawnedAt, an
+      // old PTY's exit (after `PtyManager.spawn(id)` killed it and
+      // respawned under the same id) would consume the new instance's
+      // listener and silence its real exit later.
+      if (payload.terminalId !== this.id || payload.spawnedAt !== sessionToken) return;
 
       // Forensics: log abnormal exits with the tail captured at exit time.
       // `wasKilled` is encoded in the reason — kill / graceful-shutdown
@@ -684,8 +690,21 @@ export class TerminalProcess {
 
   getPublicState(): TerminalPublicState {
     const t = this.terminalInfo;
-    // Terminal has a PTY when it hasn't been killed and hasn't exited
-    const hasPty = !t.wasKilled && !t.isExited;
+    // Derive lifecycle flags from the state machine so disposed terminals
+    // reflect `hasPty: false` even when `dispose()` ran without setting
+    // the legacy `wasKilled`/`isExited` flags. The legacy flags remain
+    // populated where the existing code paths set them (kill, preserve)
+    // and we OR them in to keep behaviour identical for those paths.
+    const state = this._ptyState;
+    const exitedState = state.kind === "exited" || state.kind === "disposed";
+    const killReason =
+      (state.kind === "shutting-down" || state.kind === "exited" || state.kind === "disposed") &&
+      (state.reason === "kill" ||
+        state.reason === "graceful-shutdown" ||
+        state.reason === "dispose");
+    const wasKilled = t.wasKilled || killReason;
+    const isExited = t.isExited || exitedState;
+    const hasPty = !wasKilled && !isExited;
     return {
       id: t.id,
       projectId: t.projectId,
@@ -696,8 +715,8 @@ export class TerminalProcess {
       title: t.title,
       titleMode: t.titleMode,
       spawnedAt: t.spawnedAt,
-      wasKilled: t.wasKilled,
-      isExited: t.isExited,
+      wasKilled,
+      isExited,
       agentState: t.agentState,
       waitingReason: t.waitingReason,
       lastStateChange: t.lastStateChange,
@@ -1880,6 +1899,14 @@ export class TerminalProcess {
 
     ptyProcess.onExit(({ exitCode, signal }) => {
       if (terminal.ptyProcess !== ptyProcess) {
+        return;
+      }
+
+      // dispose() may have already emitted terminal:exited and notified
+      // the registry via callbacks.onExit. A late OS-delivered exit must
+      // not double-fire either path — both downstream subscribers and
+      // PtyManager are not idempotent.
+      if (this._exitEventEmitted) {
         return;
       }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -20,7 +20,9 @@ import { ActivityMonitor } from "../ActivityMonitor.js";
 import { AgentStateService } from "./AgentStateService.js";
 import { ActivityHeadlineGenerator } from "../ActivityHeadlineGenerator.js";
 import {
+  type ExitReason,
   type PtySpawnOptions,
+  type PtyState,
   type TerminalInfo,
   type TerminalPublicState,
   type TerminalSnapshot,
@@ -147,6 +149,8 @@ export class TerminalProcess {
 
   private writeQueue!: WriteQueue;
   private readonly processTreeKiller: ProcessTreeKiller;
+  private _ptyState: PtyState = { kind: "alive" };
+  private _exitEventEmitted = false;
   private shellIdentityFallbackTimer: NodeJS.Timeout | null = null;
   private shellIdentityFallbackSubmittedAt: number | null = null;
   private shellIdentityFallbackCommandText: string | undefined;
@@ -377,12 +381,13 @@ export class TerminalProcess {
       writeToPty: (data) => {
         this.terminalInfo.ptyProcess.write(data);
       },
-      isExited: () => this.terminalInfo.isExited === true,
+      isExited: () => this._ptyState.kind !== "alive",
       lastOutputTime: () => this.terminalInfo.lastOutputTime,
       performSubmit: (text) => this.performSubmit(text),
       onWriteError: (error, context) => this.logWriteError(error, context),
     });
     this.sessionSnapshotter = this.createSessionSnapshotter();
+    this._subscribeExitObservers();
     this.setupPtyHandlers(ptyProcess);
 
     const ptyPid = ptyProcess.pid;
@@ -484,6 +489,192 @@ export class TerminalProcess {
     }
     terminal.headlessTerminal = undefined;
     terminal.serializeAddon = undefined;
+  }
+
+  /**
+   * Replace the lifecycle state. Returns `false` (no-op) when the requested
+   * transition is illegal — most importantly when something tries to enter
+   * `shutting-down` while we are already past `alive`. This is what makes
+   * `teardown()`, `kill()`, and `dispose()` idempotent: the second caller
+   * sees `false` and returns immediately.
+   */
+  private transition(next: PtyState): boolean {
+    const current = this._ptyState;
+    if (current.kind === next.kind) {
+      return false;
+    }
+
+    let valid = false;
+    switch (current.kind) {
+      case "alive":
+        valid = next.kind === "shutting-down";
+        break;
+      case "shutting-down":
+        valid = next.kind === "exited" || next.kind === "disposed";
+        break;
+      case "exited":
+        valid = next.kind === "disposed";
+        break;
+      case "disposed":
+        valid = false;
+        break;
+    }
+
+    if (!valid) {
+      return false;
+    }
+
+    this._ptyState = next;
+    return true;
+  }
+
+  /**
+   * Mechanical resource cleanup shared by `kill()`, `dispose()`, and the
+   * natural PTY `onExit` handler. Idempotent — the first caller transitions
+   * `alive → shutting-down` and clears collaborators/timers; later callers
+   * see the state mismatch and return `false`.
+   *
+   * Critical orderings (lessons #3177 and #3728):
+   *
+   * 1. The session snapshot flush in `kill()` runs *before* this method, so
+   *    that path is preserved by the existing `kill()` ordering — `teardown`
+   *    only blocks debounced persistence by clearing the timer here.
+   * 2. Activity / process-tree monitors are stopped here so they don't poll
+   *    a dying PTY (the recursive timer in ActivityMonitor already guards
+   *    its own `disposed` flag, but stopping it here makes the contract
+   *    explicit).
+   * 3. The headless buffer is *not* torn down here. Callers that need to
+   *    preserve it on exit (agent terminal, exit code 0) skip the
+   *    `disposeHeadless()` call after teardown returns.
+   */
+  private teardown(reason: ExitReason): boolean {
+    if (!this.transition({ kind: "shutting-down", reason })) {
+      return false;
+    }
+
+    this.stopProcessDetector();
+    this.stopActivityMonitor();
+    this.stopShellIdentityFallbackWatcher();
+    this.semanticBufferManager.flush();
+
+    this.writeQueue.dispose();
+    this.processTreeKiller.abort();
+
+    return true;
+  }
+
+  /**
+   * Emit `terminal:exited` exactly once per terminal lifetime. Forensics,
+   * `agent:completed`, and fallback classification subscribe to this event
+   * (see `_subscribeExitObservers`) instead of running inline inside the
+   * PTY `onExit` callback. `recentOutput` must be captured before the
+   * headless buffer is torn down — `disposeHeadless()` clears the
+   * forensics buffer, and a fallback subscriber that scans exit-time
+   * output cannot recover it once cleared.
+   */
+  private emitTerminalExited(args: {
+    code: number | null;
+    signal?: number;
+    reason: ExitReason;
+    recentOutput: string;
+  }): void {
+    if (this._exitEventEmitted) return;
+    this._exitEventEmitted = true;
+
+    const terminal = this.terminalInfo;
+    const liveAgentAtExit = getLiveAgentId(terminal);
+    const hadAgent = !!terminal.launchAgentId || !!terminal.everDetectedAgent;
+
+    events.emit("terminal:exited", {
+      terminalId: this.id,
+      code: args.code,
+      signal: args.signal,
+      reason: args.reason,
+      recentOutput: args.recentOutput,
+      hadAgent,
+      liveAgentAtExit,
+      launchAgentId: terminal.launchAgentId,
+      agentPresetId: terminal.agentPresetId,
+      originalAgentPresetId: terminal.originalAgentPresetId,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Subscribe forensics logging, agent-completion emission, and fallback
+   * classification to the `terminal:exited` event. Registered once during
+   * construction and torn down when the event fires (or in `dispose()` if
+   * the terminal is destroyed without ever emitting).
+   *
+   * Filters by `terminalId` so the singleton event bus can fan out to many
+   * terminals without each subscriber re-checking.
+   */
+  private _exitObserverDisposable: { dispose: () => void } | null = null;
+  private _subscribeExitObservers(): void {
+    const off = events.on("terminal:exited", (payload) => {
+      if (payload.terminalId !== this.id) return;
+
+      // Forensics: log abnormal exits with the tail captured at exit time.
+      // `wasKilled` is encoded in the reason — kill / graceful-shutdown
+      // paths suppress the abnormal-exit log even if the exit code was
+      // non-zero, matching the prior inline behaviour.
+      this.forensicsBuffer.logForensics(
+        this.id,
+        payload.code ?? 0,
+        this.terminalInfo,
+        payload.hadAgent,
+        payload.signal
+      );
+
+      // Agent state machine: only natural exits update agent state and
+      // emit agent:completed. kill / graceful-shutdown route through the
+      // kill path which has already emitted agent:killed before teardown.
+      if (payload.reason === "natural" && payload.hadAgent) {
+        this.deps.agentStateService.updateAgentState(this.terminalInfo, {
+          type: "exit",
+          code: payload.code ?? 0,
+          signal: payload.signal,
+        });
+      }
+
+      if (payload.reason === "natural" && payload.hadAgent && payload.liveAgentAtExit) {
+        this.deps.agentStateService.emitAgentCompleted(this.terminalInfo, payload.code ?? 0);
+      }
+
+      // Fallback classification: only fires for natural exits of agent
+      // terminals with a launched preset. Killed agents never trigger
+      // fallback (the user explicitly stopped them).
+      if (
+        payload.reason === "natural" &&
+        payload.launchAgentId &&
+        payload.agentPresetId &&
+        payload.code !== null
+      ) {
+        const cls = classifyExitOutput({
+          recentOutput: payload.recentOutput,
+          // Pass through as-is so a null/undefined code (crash, signal) does
+          // NOT short-circuit the scan. Only an explicit exit 0 skips the tail.
+          exitCode: payload.code,
+          wasKilled: false,
+        });
+        if (shouldTriggerFallback(cls)) {
+          events.emit("agent:fallback-triggered", {
+            terminalId: this.id,
+            agentId: payload.launchAgentId,
+            fromPresetId: payload.agentPresetId,
+            originalPresetId: payload.originalAgentPresetId ?? payload.agentPresetId,
+            reason: cls as "connection" | "auth",
+            exitCode: payload.code,
+            timestamp: Date.now(),
+          });
+        }
+      }
+
+      this._exitObserverDisposable?.dispose();
+      this._exitObserverDisposable = null;
+    });
+
+    this._exitObserverDisposable = { dispose: off };
   }
 
   /** @deprecated Use getPublicState() for IPC-safe data */
@@ -918,26 +1109,17 @@ export class TerminalProcess {
 
   kill(reason?: string): void {
     const terminal = this.terminalInfo;
+    const exitReason: ExitReason = reason === "graceful-shutdown" ? "graceful-shutdown" : "kill";
 
-    if (this.processDetector) {
-      this.processDetector.stop();
-      this.processDetector = null;
-      terminal.processDetector = undefined;
-    }
-
-    if (this.activityMonitor) {
-      this.activityMonitor.dispose();
-      this.activityMonitor = null;
-    }
-
-    this.semanticBufferManager.flush();
-
-    this.writeQueue.dispose();
-
-    // Flush session snapshot synchronously before marking as killed.
-    // Once wasKilled is set, all persistence paths are blocked, and
-    // disposeHeadless() destroys the buffer — so this is the last chance.
+    // Flush session snapshot synchronously BEFORE teardown.
+    // Once teardown disposes the writeQueue and processTreeKiller.abort() fires,
+    // debounced writes are lost — so this is the last chance.
+    // See lesson #3177.
     this.sessionSnapshotter.flushSyncOnKill();
+
+    if (!this.teardown(exitReason)) {
+      return;
+    }
 
     terminal.wasKilled = true;
     this.sessionSnapshotter.dispose();
@@ -949,6 +1131,12 @@ export class TerminalProcess {
       this.deps.agentStateService.emitAgentKilled(terminal, reason);
     }
 
+    // Capture forensic tail before disposeHeadless() clears the buffer so
+    // any subscriber that runs synchronously after the natural-exit
+    // emit-path can still read it. The kill path emits no `terminal:exited`
+    // here — natural onExit will fire (or `dispose()` will emit if it
+    // doesn't), carrying `reason: "kill"` through the exit-reason carried
+    // by the state machine.
     this.disposeHeadless();
 
     this.processTreeKiller.execute(false);
@@ -1580,20 +1768,51 @@ export class TerminalProcess {
   }
 
   dispose(): void {
-    this.stopProcessDetector();
-    this.stopActivityMonitor();
-    this.stopShellIdentityFallbackWatcher();
+    const recentOutput = this.forensicsBuffer.getRecentOutput();
 
-    this.semanticBufferManager.dispose();
-
+    // Best-effort flush before teardown disposes the writeQueue and tears down
+    // the buffer. Only attempted on the alive→dispose path — if we already
+    // passed through kill / natural exit, persistence has already been handled.
     this.sessionSnapshotter.flushSyncOnDispose();
     this.sessionSnapshotter.dispose();
 
-    this.writeQueue.dispose();
-
+    this.teardown("dispose");
+    this.semanticBufferManager.dispose();
     this.disposeHeadless();
-
     this.processTreeKiller.execute(true);
+
+    // If the PTY never fired onExit (LRU eviction, app shutdown, or kill()
+    // followed by dispose() before the kernel reaped the child), this is
+    // the last chance to notify subscribers. `_exitEventEmitted` makes a
+    // late natural-exit emit a no-op if onExit fires after dispose.
+    if (!this._exitEventEmitted) {
+      this.emitTerminalExited({
+        code: null,
+        reason: this.getExitReason() ?? "dispose",
+        recentOutput,
+      });
+    }
+
+    if (this._ptyState.kind !== "disposed") {
+      this._ptyState = { kind: "disposed", reason: this.getExitReason() ?? "dispose" };
+    }
+
+    this._exitObserverDisposable?.dispose();
+    this._exitObserverDisposable = null;
+  }
+
+  /**
+   * Read the exit reason captured by `teardown()` if available. Returns
+   * `null` for terminals that are still `alive` — primarily useful when
+   * `dispose()` runs after a prior `kill()` or natural exit and needs to
+   * preserve the original reason in the final `disposed` state.
+   */
+  private getExitReason(): ExitReason | null {
+    const s = this._ptyState;
+    if (s.kind === "shutting-down" || s.kind === "exited" || s.kind === "disposed") {
+      return s.reason;
+    }
+    return null;
   }
 
   private setupPtyHandlers(ptyProcess: pty.IPty): void {
@@ -1664,32 +1883,20 @@ export class TerminalProcess {
         return;
       }
 
-      this.stopProcessDetector();
-      this.stopActivityMonitor();
-      this.stopShellIdentityFallbackWatcher();
-      this.semanticBufferManager.flush();
+      // Capture forensic tail before disposeHeadless() clears the buffer.
+      // The terminal:exited subscriber reads this via the payload — once
+      // `disposeHeadless` runs, `forensicsBuffer.getRecentOutput()` is gone.
+      const recentOutput = this.forensicsBuffer.getRecentOutput();
 
-      this.writeQueue.dispose();
-
+      // teardown() returns false when kill() / dispose() got here first,
+      // in which case the prior reason is preserved in `_ptyState`. The
+      // event payload still carries the actual exit code from the PTY,
+      // so subscribers see e.g. `reason: "kill"` with `code: 0`.
+      const teardownReason = this.getExitReason() ?? "natural";
+      this.teardown("natural");
       this.sessionSnapshotter.dispose();
 
-      this.processTreeKiller.abort();
-
-      const hadAgent = !!terminal.launchAgentId || !!terminal.everDetectedAgent;
-      const liveAgentAtExit = getLiveAgentId(terminal);
-      this.forensicsBuffer.logForensics(this.id, exitCode ?? 0, terminal, hadAgent, signal);
-
-      if (hadAgent && !terminal.wasKilled) {
-        this.deps.agentStateService.updateAgentState(terminal, {
-          type: "exit",
-          code: exitCode ?? 0,
-          signal: signal ?? undefined,
-        });
-      }
-
-      if (hadAgent && liveAgentAtExit && !terminal.wasKilled) {
-        this.deps.agentStateService.emitAgentCompleted(terminal, exitCode ?? 0);
-      }
+      const reasonForEvent = this.getExitReason() ?? teardownReason;
 
       const previousAgent = terminal.detectedAgentId;
       const hadDetectedIdentity =
@@ -1718,38 +1925,28 @@ export class TerminalProcess {
 
       this.callbacks.onExit(this.id, exitCode ?? 0);
 
-      // Fallback detection: inspect the forensic buffer BEFORE teardown clears
-      // anything and emit a fallback-triggered event so the renderer can walk
-      // the preset's fallbacks[] chain. Passive observation only — we do not
-      // modify the terminal, spawn anything, or touch user config here.
-      if (terminal.launchAgentId && terminal.agentPresetId && !terminal.wasKilled) {
-        const cls = classifyExitOutput({
-          recentOutput: this.forensicsBuffer.getRecentOutput(),
-          // Pass through as-is so a null/undefined code (crash, signal) does
-          // NOT short-circuit the scan. Only an explicit exit 0 skips the tail.
-          exitCode: exitCode,
-          wasKilled: terminal.wasKilled,
-        });
-        if (shouldTriggerFallback(cls)) {
-          events.emit("agent:fallback-triggered", {
-            terminalId: this.id,
-            agentId: terminal.launchAgentId,
-            fromPresetId: terminal.agentPresetId,
-            originalPresetId: terminal.originalAgentPresetId ?? terminal.agentPresetId,
-            reason: cls as "connection" | "auth",
-            exitCode: exitCode ?? 0,
-            timestamp: Date.now(),
-          });
-        }
-      }
+      this.emitTerminalExited({
+        code: exitCode ?? 0,
+        signal,
+        reason: reasonForEvent,
+        recentOutput,
+      });
 
-      if (this.shouldPreserveOnExit(exitCode ?? 0)) {
+      const preserve = this.shouldPreserveOnExit(exitCode ?? 0);
+      if (preserve) {
         terminal.exitCode = exitCode ?? 0;
         terminal.isExited = true;
+        this._ptyState = {
+          kind: "exited",
+          code: exitCode ?? 0,
+          signal,
+          reason: reasonForEvent,
+        };
         return;
       }
 
       this.disposeHeadless();
+      this._ptyState = { kind: "disposed", reason: reasonForEvent };
     });
   }
 

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -124,6 +124,32 @@ describe("TerminalProcess.kill — agent state event", () => {
     );
     expect(emitAgentKilledSpy).toHaveBeenCalled();
   });
+
+  // The state machine collapses kill / dispose / onExit into a single
+  // idempotent teardown. Calling kill() twice must not double-fire
+  // agent:killed or attempt to flush persistence twice.
+  it("is idempotent — second kill() is a no-op", () => {
+    const updateAgentStateSpy = vi.fn();
+    const emitAgentKilledSpy = vi.fn();
+
+    const terminal = createTerminal(
+      { kind: "terminal", launchAgentId: "claude" },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: updateAgentStateSpy,
+          emitAgentKilled: emitAgentKilledSpy,
+        } as never,
+      }
+    );
+
+    terminal.kill("first");
+    terminal.kill("second");
+
+    // Each agent-state hook fires exactly once even though kill() was called twice.
+    expect(updateAgentStateSpy).toHaveBeenCalledTimes(1);
+    expect(emitAgentKilledSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("TerminalProcess.kill — session persistence", () => {

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -102,12 +102,14 @@ function createTerminal(
   );
 }
 
+type TerminalExitedPayload = Parameters<Parameters<typeof events.on<"terminal:exited">>[1]>[0];
+
 describe("TerminalProcess — terminal:exited event", () => {
-  let exitedListener: ReturnType<typeof vi.fn>;
+  let exitedListener: ReturnType<typeof vi.fn<(p: TerminalExitedPayload) => void>>;
   let unsubscribe: () => void;
 
   beforeEach(() => {
-    exitedListener = vi.fn();
+    exitedListener = vi.fn<(p: TerminalExitedPayload) => void>();
     unsubscribe = events.on("terminal:exited", exitedListener);
   });
 

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -288,4 +288,119 @@ describe("TerminalProcess — observer-driven exit handlers", () => {
 
     expect(emitAgentCompletedSpy).not.toHaveBeenCalled();
   });
+
+  // PtyManager.spawn(id) kills the existing terminal and respawns under
+  // the same id. The new instance's `terminal:exited` listener must NOT
+  // be consumed by the old PTY's eventual exit — that would silence its
+  // own real exit later.
+  it("filters terminal:exited by spawnedAt to survive id reuse during respawn", () => {
+    const pty1 = createControllablePty();
+    const emitAgentCompletedSpy1 = vi.fn();
+    const t1 = createTerminal(
+      pty1,
+      { kind: "terminal", launchAgentId: "claude" },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: emitAgentCompletedSpy1,
+        } as never,
+      },
+      "t-shared-id"
+    );
+    t1.kill("respawn");
+
+    // Wait one millisecond so the second terminal's spawnedAt token
+    // differs from the first.
+    const start = Date.now();
+    while (Date.now() === start) {
+      /* spin briefly */
+    }
+
+    const pty2 = createControllablePty();
+    const emitAgentCompletedSpy2 = vi.fn();
+    createTerminal(
+      pty2,
+      { kind: "terminal", launchAgentId: "claude" },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: emitAgentCompletedSpy2,
+        } as never,
+      },
+      "t-shared-id"
+    );
+
+    // Old PTY fires its long-delayed exit. Subscriber for t1 may run; the
+    // subscriber for t2 must NOT (it was killed, so reason !== natural,
+    // but the critical case is that t2's listener is also still wired
+    // and would otherwise match terminalId).
+    pty1.emitExit(0);
+
+    // Now t2 exits naturally — its own subscriber must still be wired.
+    pty2.emitExit(0);
+
+    // t1 was killed, no agent:completed expected for it.
+    expect(emitAgentCompletedSpy1).not.toHaveBeenCalled();
+    // t2 exited naturally; its subscriber must have fired.
+    expect(emitAgentCompletedSpy2).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-fire callbacks.onExit when natural exit follows dispose()", () => {
+    const pty = createControllablePty();
+    const onExitSpy = vi.fn();
+
+    const terminal = new TerminalProcess(
+      "t-late-exit",
+      { cwd: process.cwd(), cols: 80, rows: 24, kind: "terminal" },
+      { emitData: () => {}, onExit: onExitSpy },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      defaultSpawnContext(),
+      pty
+    );
+
+    terminal.dispose();
+    pty.emitExit(0);
+
+    expect(onExitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalProcess — getPublicState lifecycle derivation", () => {
+  it("reflects hasPty=false after dispose() even without prior kill", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty);
+
+    expect(terminal.getPublicState().hasPty).toBe(true);
+
+    terminal.dispose();
+
+    const state = terminal.getPublicState();
+    expect(state.hasPty).toBe(false);
+    expect(state.wasKilled).toBe(true);
+  });
+
+  it("reflects hasPty=false after natural exit (preserved agent terminal)", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty, { kind: "terminal", launchAgentId: "claude" });
+
+    pty.emitExit(0);
+
+    const state = terminal.getPublicState();
+    expect(state.hasPty).toBe(false);
+    expect(state.isExited).toBe(true);
+    expect(state.exitCode).toBe(0);
+  });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+import { events } from "../../events.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
+  const orig = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...orig,
+    TERMINAL_SESSION_PERSISTENCE_ENABLED: false,
+    persistSessionSnapshotSync: vi.fn(),
+    persistSessionSnapshotAsync: vi.fn(),
+  };
+});
+
+type DataCb = (data: string) => void;
+type ExitCb = (e: { exitCode: number; signal?: number }) => void;
+
+function createControllablePty(): IPty & {
+  emitData: (d: string) => void;
+  emitExit: (code: number, signal?: number) => void;
+} {
+  let dataCb: DataCb | null = null;
+  let exitCb: ExitCb | null = null;
+
+  const pty: Partial<IPty> & {
+    emitData: (d: string) => void;
+    emitExit: (code: number, signal?: number) => void;
+  } = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      dataCb = cb;
+      return { dispose: () => {} };
+    },
+    onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
+      exitCb = cb;
+      return { dispose: () => {} };
+    },
+    emitData: (d: string) => {
+      dataCb?.(d);
+    },
+    emitExit: (code: number, signal?: number) => {
+      exitCb?.({ exitCode: code, signal });
+    },
+  };
+  return pty as IPty & { emitData: (d: string) => void; emitExit: (c: number, s?: number) => void };
+}
+
+function defaultSpawnContext(): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
+
+function createTerminal(
+  pty: IPty,
+  options?: Partial<TerminalProcessOptions>,
+  deps?: Partial<TerminalProcessDeps>,
+  id = "t-lifecycle"
+): TerminalProcess {
+  const merged = {
+    cwd: process.cwd(),
+    cols: 80,
+    rows: 24,
+    kind: "terminal" as const,
+    ...options,
+  };
+  return new TerminalProcess(
+    id,
+    merged,
+    { emitData: () => {}, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+        emitAgentCompleted: () => {},
+      } as unknown as TerminalProcessDeps["agentStateService"],
+      ptyPool: null,
+      processTreeCache: null,
+      ...deps,
+    },
+    defaultSpawnContext(),
+    pty
+  );
+}
+
+describe("TerminalProcess — terminal:exited event", () => {
+  let exitedListener: ReturnType<typeof vi.fn>;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    exitedListener = vi.fn();
+    unsubscribe = events.on("terminal:exited", exitedListener);
+  });
+
+  afterEach(() => {
+    unsubscribe();
+  });
+
+  it("emits exactly once on natural exit with reason 'natural'", () => {
+    const pty = createControllablePty();
+    createTerminal(pty);
+
+    pty.emitExit(0);
+
+    const calls = exitedListener.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-lifecycle"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]).toMatchObject({
+      terminalId: "t-lifecycle",
+      code: 0,
+      reason: "natural",
+    });
+  });
+
+  it("captures recentOutput before headless dispose", () => {
+    const pty = createControllablePty();
+    createTerminal(pty);
+
+    pty.emitData("connection refused\n");
+    pty.emitExit(1);
+
+    const call = exitedListener.mock.calls.find(
+      (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-lifecycle"
+    );
+    expect(call).toBeDefined();
+    const payload = call![0] as { recentOutput: string };
+    expect(payload.recentOutput).toContain("connection refused");
+  });
+
+  it("uses reason='kill' when kill() runs before the natural PTY exit", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty, {
+      kind: "terminal",
+      launchAgentId: "claude",
+    });
+
+    terminal.kill("user requested");
+    pty.emitExit(0);
+
+    const calls = exitedListener.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-lifecycle"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]).toMatchObject({
+      terminalId: "t-lifecycle",
+      reason: "kill",
+    });
+  });
+
+  it("emits with reason='dispose' and code=null when dispose() fires before any exit", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty);
+
+    terminal.dispose();
+
+    const calls = exitedListener.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-lifecycle"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![0]).toMatchObject({
+      terminalId: "t-lifecycle",
+      code: null,
+      reason: "dispose",
+    });
+  });
+
+  it("does not double-emit when natural exit fires after dispose()", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty);
+
+    terminal.dispose();
+    pty.emitExit(0);
+
+    const calls = exitedListener.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-lifecycle"
+    );
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("TerminalProcess — observer-driven exit handlers", () => {
+  it("fires fallback classifier on natural agent exit with connection error tail", () => {
+    const pty = createControllablePty();
+    const fallbackListener = vi.fn();
+    const off = events.on("agent:fallback-triggered", fallbackListener);
+
+    try {
+      createTerminal(
+        pty,
+        {
+          kind: "terminal",
+          launchAgentId: "claude",
+          agentPresetId: "claude-default",
+          originalAgentPresetId: "claude-default",
+        },
+        undefined,
+        "t-fallback"
+      );
+
+      pty.emitData("API Error: 503 Service Unavailable\n");
+      pty.emitExit(1);
+
+      const calls = fallbackListener.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-fallback"
+      );
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![0]).toMatchObject({
+        terminalId: "t-fallback",
+        agentId: "claude",
+        fromPresetId: "claude-default",
+        reason: "connection",
+      });
+    } finally {
+      off();
+    }
+  });
+
+  it("does NOT fire fallback when terminal was killed before exit", () => {
+    const pty = createControllablePty();
+    const fallbackListener = vi.fn();
+    const off = events.on("agent:fallback-triggered", fallbackListener);
+
+    try {
+      const terminal = createTerminal(
+        pty,
+        {
+          kind: "terminal",
+          launchAgentId: "claude",
+          agentPresetId: "claude-default",
+        },
+        undefined,
+        "t-killed"
+      );
+
+      pty.emitData("API Error: 503 Service Unavailable\n");
+      terminal.kill("user");
+      pty.emitExit(1);
+
+      const calls = fallbackListener.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { terminalId: string }).terminalId === "t-killed"
+      );
+      expect(calls).toHaveLength(0);
+    } finally {
+      off();
+    }
+  });
+
+  it("emits agent:completed only on natural exit, not on kill→onExit", () => {
+    const pty = createControllablePty();
+    const emitAgentCompletedSpy = vi.fn();
+
+    const terminal = createTerminal(
+      pty,
+      { kind: "terminal", launchAgentId: "claude" },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: emitAgentCompletedSpy,
+        } as never,
+      },
+      "t-completed"
+    );
+
+    terminal.kill("user");
+    pty.emitExit(0);
+
+    expect(emitAgentCompletedSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -136,6 +136,57 @@ export interface PtyManagerEvents {
   error: (id: string, error: string) => void;
 }
 
+/**
+ * Why a TerminalProcess transitioned out of `alive`. Used by `teardown()` to
+ * route observers (forensics, fallback classifier, agent state machine) and
+ * to derive the IPC-visible `wasKilled` flag.
+ *
+ * - `kill`: explicit `kill()` call (user action, registry cleanup).
+ * - `graceful-shutdown`: `gracefulShutdown()` finished and routed through
+ *   `kill()` to capture the agent session ID before tearing down.
+ * - `dispose`: `dispose()` called without a prior PTY exit — typically LRU
+ *   eviction or app shutdown. SIGKILL is sent immediately.
+ * - `natural`: the underlying PTY emitted `onExit` on its own (clean exit,
+ *   crash, or external signal).
+ */
+export type ExitReason = "kill" | "graceful-shutdown" | "dispose" | "natural";
+
+/**
+ * Explicit lifecycle for a `TerminalProcess`. Replaces the previous trio of
+ * implicit booleans (`wasKilled`, `isExited`, `exitCode`) with a single
+ * discriminated union so every code path that gates on lifecycle state can
+ * narrow on a single field.
+ *
+ * Transition graph:
+ * ```
+ *   alive ──► shutting-down ──► exited
+ *     │           │               │
+ *     │           ▼               ▼
+ *     └───────► disposed ◄────────┘
+ * ```
+ *
+ * `alive` is the initial state — the PTY is passed live to the constructor.
+ * `shutting-down` is set the moment `teardown(reason)` begins (kill, dispose,
+ * or natural exit). `exited` is the preserve-on-exit terminal state for
+ * agents that exited cleanly; the headless buffer is retained so the user
+ * can inspect output. `disposed` is the final state — headless buffer torn
+ * down, PTY descendants killed.
+ *
+ * The `wasKilled` and `isExited` fields on `TerminalPublicState` remain in
+ * the IPC contract for backward compatibility and are derived from this
+ * state in `getPublicState()`.
+ */
+export type PtyState =
+  | { readonly kind: "alive" }
+  | { readonly kind: "shutting-down"; readonly reason: ExitReason }
+  | {
+      readonly kind: "exited";
+      readonly code: number;
+      readonly signal?: number;
+      readonly reason: ExitReason;
+    }
+  | { readonly kind: "disposed"; readonly reason: ExitReason };
+
 export interface TerminalSnapshot {
   id: string;
   lines: string[];


### PR DESCRIPTION
## Summary

- Replaces four implicit boolean/optional fields (`wasKilled`, `isExited`, `exitCode`, `killTreeTimer`) with a discriminated `PtyState` union (`alive | shutting-down | exited | disposed`) and a typed `ExitReason` union, giving the PTY a single source-of-truth lifecycle.
- Collapses four separate teardown paths (`kill`, `dispose`, `gracefulShutdown`, `onExit`) into one idempotent `teardown(reason)` routine. Crash vs normal exit differs only in the `ExitReason` payload.
- Moves forensics logging, `agent:completed` emission, and fallback classification out of the inline `onExit` handler and into subscribers of a new `terminal:exited` event, scoped by `terminalId + spawnedAt` to survive id reuse during respawn.

Resolves #5932

## Changes

- `electron/services/pty/types.ts` — new `PtyState`, `ExitReason`, and `TerminalExitedEvent` types
- `electron/services/events.ts` — new `terminal:exited` event definition
- `electron/services/pty/TerminalProcess.ts` — full state-machine rewrite; `TerminalPublicState.wasKilled`/`isExited` kept as derived outputs for IPC backward compat
- `electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts` — 12 new lifecycle tests covering state transitions, idempotent teardown, and event scoping
- `electron/services/pty/__tests__/TerminalProcess.kill.test.ts` — extended kill-idempotency test

## Testing

12 new lifecycle tests added; full electron service suite (3,464 tests) passes. Tests cover: state transitions through the full lifecycle, idempotent `teardown()` calls from multiple paths, `terminal:exited` event scoping by `spawnedAt` token to guard against id reuse, and late `onExit` callbacks arriving after `dispose`.