### PR TITLE
test(ipc): add real-process IPC contract tests for PtyClient and WorkspaceHostProcess (#5912)

### DIFF
--- a/electron/services/__tests__/PtyClient.ipc.integration.test.ts
+++ b/electron/services/__tests__/PtyClient.ipc.integration.test.ts
@@ -1,0 +1,188 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const shared = vi.hoisted(() => {
+  const forkMock = vi.fn();
+  const appMock = {
+    getPath: vi.fn(() => "/tmp/userData"),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return { forkMock, appMock };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: { fork: shared.forkMock },
+  UtilityProcess: class {},
+  MessagePortMain: class {},
+  app: shared.appMock,
+  dialog: {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+  },
+}));
+
+vi.mock("../TrashedPidTracker.js", () => ({
+  getTrashedPidTracker: () => ({
+    removeTrashed: vi.fn(),
+    persistTrashed: vi.fn(),
+    clearAll: vi.fn(),
+  }),
+}));
+
+// Try to load the helpers — if worker_threads isn't available in this
+// runtime, skip the suite cleanly (matches PtyManager.integration precedent).
+let helpers: typeof import("./helpers/ipcContractTestUtils.js") | undefined;
+try {
+  helpers = await import("./helpers/ipcContractTestUtils.js");
+} catch (_err) {
+  console.warn("worker_threads helpers unavailable, skipping IPC contract tests");
+}
+
+const shouldSkip = !helpers;
+const stubWorkerPath = helpers ? helpers.helperPath("stubPtyHost.worker.mjs") : "";
+
+describe.skipIf(shouldSkip)("PtyClient IPC contract (real worker_threads boundary)", () => {
+  let handle: import("./helpers/ipcContractTestUtils.js").StubHostHandle;
+  let PtyClientCtor: typeof import("../PtyClient.js").PtyClient;
+
+  beforeEach(async () => {
+    handle = helpers!.spawnStubHost(stubWorkerPath);
+    shared.forkMock.mockReset();
+    shared.forkMock.mockReturnValue(handle.fakeChild);
+    shared.appMock.getPath.mockClear();
+    shared.appMock.on.mockClear();
+    shared.appMock.off.mockClear();
+
+    // Re-evaluate PtyClient against fresh mock state per test.
+    vi.resetModules();
+    const mod = await import("../PtyClient.js");
+    PtyClientCtor = mod.PtyClient;
+  });
+
+  afterEach(async () => {
+    await handle.dispose();
+    vi.clearAllMocks();
+  });
+
+  it("completes the ready handshake when the host posts `ready` over a real MessagePort", async () => {
+    const client = new PtyClientCtor({ healthCheckIntervalMs: 60_000 });
+    try {
+      await client.waitForReady();
+      // Child wired to our fakeChild — proves the mock substitution worked
+      // and the real handshake message traversed the worker port.
+      expect((client as any).child).toBe(handle.fakeChild);
+    } finally {
+      client.dispose();
+    }
+  });
+
+  it("roundtrips Map/Date/Buffer/Set payloads through real V8 structured-clone (both directions)", async () => {
+    const client = new PtyClientCtor({ healthCheckIntervalMs: 60_000 });
+    try {
+      await client.waitForReady();
+
+      const payload = {
+        map: new Map<string, number>([
+          ["a", 1],
+          ["b", 2],
+        ]),
+        date: new Date("2026-01-15T12:00:00.000Z"),
+        buf: Buffer.from("hello world", "utf8"),
+        nested: {
+          items: [
+            { id: "x", count: 42 },
+            { id: "y", count: -7 },
+          ],
+          tags: new Set(["alpha", "beta"]),
+        },
+      };
+
+      // Send through the fakeChild → real port → worker. The worker echoes
+      // it back unchanged. Asserting on the echoed value proves both
+      // serialization and deserialization preserve the types — a one-way
+      // assertion would only catch half the contract.
+      const resultPromise = helpers!.waitForChildMessage<{
+        type: string;
+        requestId: string;
+        payload: typeof payload;
+      }>(
+        handle.fakeChild,
+        (m: any) => m?.type === "ipc-test:roundtrip-result" && m?.requestId === "rt-1",
+        5000
+      );
+
+      handle.fakeChild.postMessage({
+        type: "ipc-test:roundtrip",
+        requestId: "rt-1",
+        payload,
+      });
+
+      const result = await resultPromise;
+
+      expect(result.payload.map).toBeInstanceOf(Map);
+      expect(result.payload.map.get("a")).toBe(1);
+      expect(result.payload.map.get("b")).toBe(2);
+
+      expect(result.payload.date).toBeInstanceOf(Date);
+      expect(result.payload.date.getTime()).toBe(payload.date.getTime());
+
+      // Buffers traverse worker_threads as Uint8Array; rewrap to Buffer
+      // for comparison.
+      const echoed = Buffer.from(result.payload.buf);
+      expect(echoed.toString("utf8")).toBe("hello world");
+
+      expect(result.payload.nested.items).toEqual(payload.nested.items);
+      expect(result.payload.nested.tags).toBeInstanceOf(Set);
+      expect(result.payload.nested.tags.has("alpha")).toBe(true);
+      expect(result.payload.nested.tags.has("beta")).toBe(true);
+    } finally {
+      client.dispose();
+    }
+  });
+
+  it("emits host-crash-details when the worker exits abruptly via real process.exit", async () => {
+    const client = new PtyClientCtor({ healthCheckIntervalMs: 60_000 });
+    try {
+      await client.waitForReady();
+
+      const crashPromise = new Promise<{
+        code: number | null;
+        crashType: string;
+        timestamp: number;
+      }>((resolve) => {
+        client.on("host-crash-details", (payload) => resolve(payload));
+      });
+
+      // Trigger a real process.exit(1) inside the worker — surfaces a real
+      // OS-level worker exit signal back to the parent test process.
+      handle.fakeChild.postMessage({ type: "ipc-test:die" });
+
+      const crash = await crashPromise;
+      expect(crash.crashType).toBeDefined();
+      expect(crash.crashType).not.toBe("CLEAN_EXIT");
+    } finally {
+      client.dispose();
+    }
+  });
+
+  it("responds to health-check pings with real pong messages over the worker port", async () => {
+    const client = new PtyClientCtor({ healthCheckIntervalMs: 60_000 });
+    try {
+      await client.waitForReady();
+
+      // Send a health-check directly through the fakeChild — the worker
+      // stub echoes pong via the real port, so this exercises the full
+      // health-check round-trip across the V8 boundary.
+      const pongPromise = helpers!.waitForChildMessage(
+        handle.fakeChild,
+        (m: any) => m?.type === "pong",
+        5000
+      );
+      handle.fakeChild.postMessage({ type: "health-check" });
+      const pong: any = await pongPromise;
+      expect(pong.type).toBe("pong");
+    } finally {
+      client.dispose();
+    }
+  });
+});

--- a/electron/services/__tests__/PtyClient.ipc.integration.test.ts
+++ b/electron/services/__tests__/PtyClient.ipc.integration.test.ts
@@ -149,8 +149,11 @@ describe.skipIf(shouldSkip)("PtyClient IPC contract (real worker_threads boundar
         code: number | null;
         crashType: string;
         timestamp: number;
-      }>((resolve) => {
+      }>((resolve, reject) => {
         client.on("host-crash-details", (payload) => resolve(payload));
+        // Local timeout — fail fast if `ipc-test:die` is dropped or the
+        // event wire-up regresses, instead of hanging until the 60s global.
+        setTimeout(() => reject(new Error("host-crash-details not emitted within 5s")), 5000);
       });
 
       // Trigger a real process.exit(1) inside the worker — surfaces a real
@@ -160,6 +163,45 @@ describe.skipIf(shouldSkip)("PtyClient IPC contract (real worker_threads boundar
       const crash = await crashPromise;
       expect(crash.crashType).toBeDefined();
       expect(crash.crashType).not.toBe("CLEAN_EXIT");
+    } finally {
+      client.dispose();
+    }
+  });
+
+  it("connectMessagePort sends `connect-port` with the port in the transferList second arg", async () => {
+    // Regression guard for the bug class motivating #5912: a refactor that
+    // moves the port into the message body or drops the transferList would
+    // silently break renderer ↔ pty-host port wiring. Asserting the call
+    // shape catches that even though worker_threads can't fully reproduce
+    // Electron's `event.ports` receipt semantics on the worker side.
+    const client = new PtyClientCtor({ healthCheckIntervalMs: 60_000 });
+    try {
+      await client.waitForReady();
+
+      // Spy after ready so startup chatter (set-log-level-overrides) doesn't
+      // pollute the captured calls. The spy still forwards to the original
+      // by default.
+      const postSpy = vi.spyOn(handle.fakeChild, "postMessage");
+
+      const { MessageChannel } = await import("node:worker_threads");
+      const channel = new MessageChannel();
+      try {
+        client.connectMessagePort(42, channel.port2 as any);
+
+        const connectCall = postSpy.mock.calls.find((c) => (c[0] as any)?.type === "connect-port");
+        expect(connectCall).toBeDefined();
+        expect(connectCall![0]).toEqual({ type: "connect-port", windowId: 42 });
+        expect(connectCall![1]).toBeDefined();
+        expect(Array.isArray(connectCall![1])).toBe(true);
+        expect((connectCall![1] as unknown[]).length).toBe(1);
+        expect((connectCall![1] as unknown[])[0]).toBe(channel.port2);
+      } finally {
+        try {
+          channel.port1.close();
+        } catch {
+          /* ignore */
+        }
+      }
     } finally {
       client.dispose();
     }

--- a/electron/services/__tests__/WorkspaceHostProcess.ipc.integration.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.ipc.integration.test.ts
@@ -1,0 +1,205 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const shared = vi.hoisted(() => {
+  const forkMock = vi.fn();
+  const appMock = {
+    getPath: vi.fn(() => "/tmp/userData"),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return { forkMock, appMock };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: { fork: shared.forkMock },
+  UtilityProcess: class {},
+  MessagePortMain: class {},
+  app: shared.appMock,
+}));
+
+vi.mock("../github/GitHubAuth.js", () => ({
+  GitHubAuth: {
+    getToken: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+let helpers: typeof import("./helpers/ipcContractTestUtils.js") | undefined;
+try {
+  helpers = await import("./helpers/ipcContractTestUtils.js");
+} catch (_err) {
+  console.warn("worker_threads helpers unavailable, skipping IPC contract tests");
+}
+
+const shouldSkip = !helpers;
+const stubWorkerPath = helpers ? helpers.helperPath("stubWorkspaceHost.worker.mjs") : "";
+
+describe.skipIf(shouldSkip)(
+  "WorkspaceHostProcess IPC contract (real worker_threads boundary)",
+  () => {
+    let handle: import("./helpers/ipcContractTestUtils.js").StubHostHandle;
+    let WorkspaceHostProcessCtor: typeof import("../WorkspaceHostProcess.js").WorkspaceHostProcess;
+
+    beforeEach(async () => {
+      handle = helpers!.spawnStubHost(stubWorkerPath);
+      shared.forkMock.mockReset();
+      shared.forkMock.mockReturnValue(handle.fakeChild);
+      shared.appMock.getPath.mockClear();
+      shared.appMock.on.mockClear();
+      shared.appMock.off.mockClear();
+
+      vi.resetModules();
+      const mod = await import("../WorkspaceHostProcess.js");
+      WorkspaceHostProcessCtor = mod.WorkspaceHostProcess;
+    });
+
+    afterEach(async () => {
+      await handle.dispose();
+      vi.clearAllMocks();
+    });
+
+    it("completes the ready handshake when the host posts `ready` over a real MessagePort", async () => {
+      const host = new WorkspaceHostProcessCtor("/tmp/project", {
+        maxRestartAttempts: 3,
+        healthCheckIntervalMs: 60_000,
+      } as any);
+      try {
+        await host.waitForReady();
+        expect(host.isReady()).toBe(true);
+        expect((host as any).child).toBe(handle.fakeChild);
+      } finally {
+        host.dispose();
+      }
+    });
+
+    it("roundtrips Map/Date/Buffer/RegExp through real V8 structured-clone (both directions)", async () => {
+      const host = new WorkspaceHostProcessCtor("/tmp/project", {
+        maxRestartAttempts: 3,
+        healthCheckIntervalMs: 60_000,
+      } as any);
+      try {
+        await host.waitForReady();
+
+        const payload = {
+          map: new Map<string, string>([
+            ["worktree-1", "main"],
+            ["worktree-2", "feature/x"],
+          ]),
+          createdAt: new Date("2026-02-01T08:30:00.000Z"),
+          rawDiff: Buffer.from("--- a/file\n+++ b/file\n@@ -1 +1 @@", "utf8"),
+          regex: /^[a-z0-9-]+$/i,
+        };
+
+        const resultPromise = helpers!.waitForChildMessage<{
+          type: string;
+          requestId: string;
+          payload: typeof payload;
+        }>(
+          handle.fakeChild,
+          (m: any) => m?.type === "ipc-test:roundtrip-result" && m?.requestId === "wkr-1",
+          5000
+        );
+
+        handle.fakeChild.postMessage({
+          type: "ipc-test:roundtrip",
+          requestId: "wkr-1",
+          payload,
+        });
+
+        const result = await resultPromise;
+
+        expect(result.payload.map).toBeInstanceOf(Map);
+        expect(result.payload.map.get("worktree-1")).toBe("main");
+        expect(result.payload.map.get("worktree-2")).toBe("feature/x");
+
+        expect(result.payload.createdAt).toBeInstanceOf(Date);
+        expect(result.payload.createdAt.getTime()).toBe(payload.createdAt.getTime());
+
+        const echoedDiff = Buffer.from(result.payload.rawDiff);
+        expect(echoedDiff.toString("utf8")).toBe("--- a/file\n+++ b/file\n@@ -1 +1 @@");
+
+        expect(result.payload.regex).toBeInstanceOf(RegExp);
+        expect(result.payload.regex.source).toBe("^[a-z0-9-]+$");
+        expect(result.payload.regex.flags).toBe("i");
+      } finally {
+        host.dispose();
+      }
+    });
+
+    it("emits host-recovering when the worker exits abruptly via real process.exit", async () => {
+      const host = new WorkspaceHostProcessCtor("/tmp/project", {
+        maxRestartAttempts: 0, // skip auto-restart so the test ends cleanly
+        healthCheckIntervalMs: 60_000,
+      } as any);
+      try {
+        await host.waitForReady();
+
+        const recoveringPromise = new Promise<number | null>((resolve) => {
+          host.on("host-recovering", (code: number | null) => resolve(code));
+        });
+
+        handle.fakeChild.postMessage({ type: "ipc-test:die" });
+
+        const code = await recoveringPromise;
+        expect(code).toBe(1);
+        expect(host.isReady()).toBe(false);
+      } finally {
+        host.dispose();
+      }
+    });
+
+    it("attachWorktreePort sends the port in the transferList second arg, not in the message body", async () => {
+      const host = new WorkspaceHostProcessCtor("/tmp/project", {
+        maxRestartAttempts: 3,
+        healthCheckIntervalMs: 60_000,
+      } as any);
+      try {
+        await host.waitForReady();
+
+        // Spy AFTER ready so we don't capture startup chatter
+        // (set-log-level-overrides etc.). The spy still forwards to the
+        // original by default — the worker actually receives the message.
+        const postSpy = vi.spyOn(handle.fakeChild, "postMessage");
+
+        const { MessageChannel } = await import("node:worker_threads");
+        const channel = new MessageChannel();
+        try {
+          const accepted = host.attachWorktreePort(channel.port2 as any);
+          expect(accepted).toBe(true);
+
+          const attachCall = postSpy.mock.calls.find(
+            (c) => (c[0] as any)?.type === "attach-worktree-port"
+          );
+          expect(attachCall).toBeDefined();
+          // Body holds only the type discriminator — no port reference.
+          expect(attachCall![0]).toEqual({ type: "attach-worktree-port" });
+          // Transfer list (second arg) carries the port itself. This matches
+          // the MessagePortMain transfer contract; mock-only tests can
+          // satisfy the call shape but only a real port survives the trip
+          // through the worker_threads structured-clone boundary.
+          expect(attachCall![1]).toBeDefined();
+          expect(Array.isArray(attachCall![1])).toBe(true);
+          expect((attachCall![1] as unknown[]).length).toBe(1);
+          expect((attachCall![1] as unknown[])[0]).toBe(channel.port2);
+        } finally {
+          try {
+            channel.port1.close();
+          } catch {
+            /* ignore */
+          }
+        }
+      } finally {
+        host.dispose();
+      }
+    });
+  }
+);

--- a/electron/services/__tests__/WorkspaceHostProcess.ipc.integration.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.ipc.integration.test.ts
@@ -143,8 +143,9 @@ describe.skipIf(shouldSkip)(
       try {
         await host.waitForReady();
 
-        const recoveringPromise = new Promise<number | null>((resolve) => {
+        const recoveringPromise = new Promise<number | null>((resolve, reject) => {
           host.on("host-recovering", (code: number | null) => resolve(code));
+          setTimeout(() => reject(new Error("host-recovering not emitted within 5s")), 5000);
         });
 
         handle.fakeChild.postMessage({ type: "ipc-test:die" });
@@ -186,6 +187,12 @@ describe.skipIf(shouldSkip)(
           // the MessagePortMain transfer contract; mock-only tests can
           // satisfy the call shape but only a real port survives the trip
           // through the worker_threads structured-clone boundary.
+          //
+          // Note: this assertion only locks the SOURCE-side call shape.
+          // worker_threads does not populate `event.ports` on the receiver,
+          // so the worker stub never sees the transferred port — that
+          // unwrap path is Electron-runtime-specific. See
+          // ipcContractTestUtils.ts header for the full gap rationale.
           expect(attachCall![1]).toBeDefined();
           expect(Array.isArray(attachCall![1])).toBe(true);
           expect((attachCall![1] as unknown[]).length).toBe(1);

--- a/electron/services/__tests__/helpers/ipcContractTestUtils.ts
+++ b/electron/services/__tests__/helpers/ipcContractTestUtils.ts
@@ -1,0 +1,193 @@
+import { MessageChannel, type MessagePort, Worker } from "node:worker_threads";
+import { EventEmitter } from "events";
+import { Readable } from "node:stream";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * A fake UtilityProcess-shaped object whose IPC is backed by a real
+ * worker_threads.MessageChannel. Forwarding postMessage/kill through a real
+ * Worker exercises the same V8 structured-clone path that
+ * `process.parentPort` uses inside an Electron utility process — the host
+ * code already casts `process.parentPort as unknown as MessagePort` from
+ * "node:worker_threads", so the serialization semantics match.
+ */
+export interface FakeUtilityChild extends EventEmitter {
+  postMessage: (msg: unknown, transferList?: ReadonlyArray<unknown>) => void;
+  kill: (signal?: string | number) => boolean;
+  stdout: Readable;
+  stderr: Readable;
+  pid?: number;
+}
+
+export interface StubHostHandle {
+  /** Fake UtilityProcess for injecting into utilityProcess.fork() mocks. */
+  fakeChild: FakeUtilityChild;
+  /** Underlying worker — terminate() to simulate abrupt host death. */
+  worker: Worker;
+  /**
+   * Test-side port for boundary tests that bypass clients. Touching this
+   * (attaching a listener) starts the port and drains any queued messages
+   * — do not use it when the fakeChild is also being consumed by a client,
+   * or messages will be split between the two listeners.
+   */
+  testPort: MessagePort;
+  /** Cleanup all resources (worker, ports, listeners). */
+  dispose: () => Promise<void>;
+}
+
+/**
+ * Resolve a worker script path relative to this helpers directory.
+ */
+export function helperPath(filename: string): string {
+  return path.resolve(__dirname, filename);
+}
+
+/**
+ * Spawn a stub host backed by a real worker_threads.Worker. The returned
+ * `fakeChild` delegates all postMessage/kill calls through a real
+ * MessageChannel, so the client under test exercises the actual V8
+ * serialization boundary, real port transfer/neutering, and real
+ * worker exit signaling.
+ */
+export function spawnStubHost(workerScriptPath: string): StubHostHandle {
+  const channel = new MessageChannel();
+  const worker = new Worker(workerScriptPath, {
+    workerData: { port: channel.port2 },
+    transferList: [channel.port2],
+  });
+  const fakeChild = createFakeChild(worker, channel.port1);
+
+  let disposed = false;
+  return {
+    fakeChild,
+    worker,
+    testPort: channel.port1,
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      try {
+        channel.port1.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await worker.terminate();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+function createFakeChild(worker: Worker, port: MessagePort): FakeUtilityChild {
+  const emitter = new EventEmitter() as FakeUtilityChild;
+  emitter.stdout = new Readable({ read() {} });
+  emitter.stderr = new Readable({ read() {} });
+  // Leave pid undefined so PtyClient/WorkspaceHostProcess watchdog paths
+  // skip process.kill() — workers don't have OS-level pids reachable from
+  // kill(2), and we don't want to send a real signal from a test.
+  emitter.pid = undefined;
+
+  emitter.postMessage = (msg, transferList) => {
+    try {
+      port.postMessage(msg, transferList as Parameters<typeof port.postMessage>[1] | undefined);
+    } catch (err) {
+      emitter.emit("error", err);
+    }
+  };
+
+  emitter.kill = () => {
+    void worker.terminate();
+    return true;
+  };
+
+  // Defer the port-side listener attachment until the consumer attaches its
+  // first "message" listener on the fake child. MessagePort buffers messages
+  // while paused; attaching the listener implicitly calls start() and drains
+  // the queue asynchronously — guaranteeing the consumer's handler is
+  // registered before queued messages are delivered. Without this, a worker
+  // that posts "ready" during startup would race the consumer's listener
+  // attachment and the message would be silently dropped.
+  let portStarted = false;
+  emitter.on("newListener", (event) => {
+    if (event === "message" && !portStarted) {
+      portStarted = true;
+      port.on("message", (msg) => emitter.emit("message", msg));
+    }
+  });
+
+  worker.on("exit", (code) => {
+    try {
+      emitter.stdout.push(null);
+    } catch {
+      /* already closed */
+    }
+    try {
+      emitter.stderr.push(null);
+    } catch {
+      /* already closed */
+    }
+    emitter.emit("exit", code);
+  });
+
+  worker.on("error", (err) => {
+    emitter.emit("error", err);
+  });
+
+  return emitter;
+}
+
+/**
+ * Wait for the first message on `child` matching `predicate`, or reject after
+ * `timeoutMs`. Used to assert real round-trips through the worker port.
+ */
+export function waitForChildMessage<T = unknown>(
+  child: EventEmitter,
+  predicate: (msg: unknown) => boolean,
+  timeoutMs: number = 5000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.off("message", onMessage);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for matching message`));
+    }, timeoutMs);
+    function onMessage(msg: unknown) {
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        child.off("message", onMessage);
+        resolve(msg as T);
+      }
+    }
+    child.on("message", onMessage);
+  });
+}
+
+/**
+ * Wait for the first message on a raw worker_threads MessagePort matching
+ * `predicate`, or reject after `timeoutMs`. Use for direct boundary tests
+ * that bypass the FakeUtilityChild abstraction.
+ */
+export function waitForPortMessage<T = unknown>(
+  port: MessagePort,
+  predicate: (msg: unknown) => boolean,
+  timeoutMs: number = 5000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      port.off("message", onMessage);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for matching port message`));
+    }, timeoutMs);
+    function onMessage(msg: unknown) {
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        port.off("message", onMessage);
+        resolve(msg as T);
+      }
+    }
+    port.on("message", onMessage);
+  });
+}

--- a/electron/services/__tests__/helpers/ipcContractTestUtils.ts
+++ b/electron/services/__tests__/helpers/ipcContractTestUtils.ts
@@ -14,6 +14,16 @@ const __dirname = path.dirname(__filename);
  * `process.parentPort` uses inside an Electron utility process — the host
  * code already casts `process.parentPort as unknown as MessagePort` from
  * "node:worker_threads", so the serialization semantics match.
+ *
+ * Known coverage gap: worker_threads does NOT populate `event.ports` on the
+ * receiver side when ports are passed via `transferList`. The production
+ * pty-host/workspace-host code reads `rawMsg?.ports || []` to extract
+ * transferred ports — that path only fires inside Electron's
+ * MessagePortMain, not in worker_threads. So tests using this harness can
+ * verify the SOURCE-side call shape (port lives in the transferList second
+ * arg, not the message body) but cannot verify the receiver actually unwraps
+ * the port. End-to-end port-receipt coverage requires a real Electron
+ * runtime and lives outside this contract test tier.
  */
 export interface FakeUtilityChild extends EventEmitter {
   postMessage: (msg: unknown, transferList?: ReadonlyArray<unknown>) => void;

--- a/electron/services/__tests__/helpers/stubPtyHost.worker.mjs
+++ b/electron/services/__tests__/helpers/stubPtyHost.worker.mjs
@@ -1,0 +1,63 @@
+// Minimal pty-host stub for IPC contract integration tests.
+// Mirrors the message-shape contract that PtyClient relies on:
+//   - Sends `{ type: "ready" }` on startup (matches pty-host.ts:1695).
+//   - Responds to `health-check` with `pong` (matches the heartbeat protocol).
+//   - Silently accepts other PtyClient-emitted messages so they don't error.
+//   - Echoes `ipc-test:roundtrip` payloads — the bidirectional roundtrip
+//     proves complex types (Map/Date/Buffer/nested) survive the V8
+//     structured-clone boundary in both directions.
+//   - Calls `process.exit(1)` on `ipc-test:die` to simulate a real host crash.
+
+import { workerData } from "node:worker_threads";
+import process from "node:process";
+
+const { port } = workerData;
+
+port.on("message", (raw) => {
+  // pty-host.ts:719 normalizes both possible wrapper shapes:
+  //   `const message = rawMsg?.data ?? rawMsg;`
+  // worker_threads delivers values directly, but match the same defensive
+  // shape to keep the stub a faithful contract surface.
+  const msg = raw && typeof raw === "object" && "data" in raw ? raw.data : raw;
+  const type = msg?.type;
+
+  switch (type) {
+    case "ipc-test:roundtrip":
+      port.postMessage({
+        type: "ipc-test:roundtrip-result",
+        requestId: msg.requestId,
+        payload: msg.payload,
+      });
+      return;
+
+    case "ipc-test:die":
+      // Hard-exit the worker to surface a real exit signal to the parent.
+      process.exit(1);
+      return;
+
+    case "health-check":
+      port.postMessage({ type: "pong" });
+      return;
+
+    case "set-log-level-overrides":
+    case "spawn":
+    case "kill":
+    case "set-ipc-data-mirror":
+    case "connect-port":
+    case "disconnect-port":
+    case "set-resource-monitoring":
+    case "set-session-persist-suppressed":
+    case "broadcast-write":
+      return;
+
+    default:
+      // Drop unknown messages silently — keeps the stub forward-compatible
+      // when PtyClient adds new request types.
+      return;
+  }
+});
+
+// Send the ready handshake. The Worker's `port.on("message", ...)` listener
+// is attached above before this postMessage, so any messages the client posts
+// during startup are buffered by the port until processing resumes.
+port.postMessage({ type: "ready" });

--- a/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
+++ b/electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs
@@ -1,0 +1,57 @@
+// Minimal workspace-host stub for IPC contract integration tests.
+// Mirrors the message-shape contract that WorkspaceHostProcess relies on:
+//   - Sends `{ type: "ready" }` on startup (matches workspace-host.ts:618).
+//   - Responds to `health-check` with `pong`.
+//   - Silently accepts WorkspaceHostProcess-emitted messages.
+//   - Echoes `ipc-test:roundtrip` payloads to verify complex types survive
+//     the V8 structured-clone boundary in both directions.
+//   - Calls `process.exit(1)` on `ipc-test:die` to simulate a host crash.
+
+import { workerData } from "node:worker_threads";
+import process from "node:process";
+
+const { port } = workerData;
+
+port.on("message", (raw) => {
+  // workspace-host.ts:270 normalizes both wrapper shapes via `rawMsg?.data ?? rawMsg`.
+  const msg = raw && typeof raw === "object" && "data" in raw ? raw.data : raw;
+  const type = msg?.type;
+
+  switch (type) {
+    case "ipc-test:roundtrip":
+      port.postMessage({
+        type: "ipc-test:roundtrip-result",
+        requestId: msg.requestId,
+        payload: msg.payload,
+      });
+      return;
+
+    case "ipc-test:die":
+      process.exit(1);
+      return;
+
+    case "health-check":
+      port.postMessage({ type: "pong" });
+      return;
+
+    case "set-log-level-overrides":
+    case "update-github-token":
+    case "attach-renderer-port":
+    case "attach-worktree-port":
+    case "dispose":
+    case "load-project":
+    case "sync":
+    case "project-switch":
+    case "set-active":
+    case "refresh":
+    case "set-polling-enabled":
+    case "background":
+    case "foreground":
+      return;
+
+    default:
+      return;
+  }
+});
+
+port.postMessage({ type: "ready" });


### PR DESCRIPTION
## Summary

- Existing `PtyClient` and `WorkspaceHostProcess` tests mock the utility process at the `EventEmitter` boundary via `vi.mock("electron")`, which means the real V8 structured-clone boundary, transferable ownership, and process lifecycle signals are never exercised.
- This PR adds 9 integration-tier tests using a real `worker_threads.Worker` stub host — `pty-host` already casts `process.parentPort` as a `worker_threads.MessagePort`, so the semantics match closely enough to be meaningful.
- Covers handshake, `Map`/`Date`/`Buffer`/`Set`/`RegExp` structured-clone roundtrip, host crash recovery, health-check pongs, and `attachWorktreePort`/`connectMessagePort` transferList shape.

Resolves #5912

## Changes

- `electron/services/__tests__/PtyClient.ipc.integration.test.ts` — 5 integration tests for `PtyClient`: handshake ready flow, structured-clone type roundtrip, crash detection and recovery, health-check pong, and `connectMessagePort` transferList shape
- `electron/services/__tests__/WorkspaceHostProcess.ipc.integration.test.ts` — 4 integration tests for `WorkspaceHostProcess`: handshake, structured-clone roundtrip, crash recovery, and `attachWorktreePort` transferList shape
- `electron/services/__tests__/helpers/ipcContractTestUtils.ts` — shared test utilities (deferred port-start helper to handle the worker startup race, worker lifecycle management)
- `electron/services/__tests__/helpers/stubPtyHost.worker.mjs` — minimal stub PTY host worker that responds to handshake and health-check messages
- `electron/services/__tests__/helpers/stubWorkspaceHost.worker.mjs` — minimal stub workspace host worker

## Testing

One documented coverage gap worth noting: `worker_threads` doesn't populate `event.ports` on the receiver side, so the harness verifies the source-side call shape (the transferList is passed correctly) but can't validate end-to-end port unwrapping. That part is Electron-runtime-specific and would need an E2E test to cover properly. This is called out in the test file comments.

All tests pass locally. The integration suite is gated separately from the unit run so this doesn't affect unit-test wall-clock time.