### PR TITLE
fix(notify): enforce inboxMessage invariant at compile and dev time

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -722,5 +723,56 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
       vi.advanceTimersByTime(60_000);
     });
     expect(screen.getByText("Stuck")).toBeTruthy();
+  });
+
+  describe("dev guard — inboxMessage invariant", () => {
+    it("logs dev guard when non-string message has no inboxMessage", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      render(<Toaster />);
+      const jsxElement = React.createElement("span", null, "rich");
+      await act(async () => {
+        addToast({ message: jsxElement as unknown as React.ReactNode });
+        vi.advanceTimersByTime(16);
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[Toaster] non-string message without inboxMessage")
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT log toaster guard when non-string message has inboxMessage", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      render(<Toaster />);
+      const jsxElement = React.createElement("span", null, "rich");
+      await act(async () => {
+        addToast({
+          message: jsxElement as unknown as React.ReactNode,
+          inboxMessage: "Fallback text",
+        });
+        vi.advanceTimersByTime(16);
+      });
+
+      const toasterGuardCall = consoleSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("[Toaster]")
+      );
+      expect(toasterGuardCall).toBeUndefined();
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT log toaster guard for string message without inboxMessage", async () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      render(<Toaster />);
+      await act(async () => {
+        addToast({ message: "Plain string" });
+        vi.advanceTimersByTime(16);
+      });
+
+      const toasterGuardCall = consoleSpy.mock.calls.find(
+        (call) => typeof call[0] === "string" && call[0].includes("[Toaster]")
+      );
+      expect(toasterGuardCall).toBeUndefined();
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -64,6 +64,15 @@ function Toast({ notification }: { notification: Notification }) {
   }, []);
 
   useEffect(() => {
+    if (
+      import.meta.env.DEV &&
+      typeof notification.message !== "string" &&
+      !notification.inboxMessage
+    ) {
+      console.error(
+        "[Toaster] non-string message without inboxMessage — aria-live announcement will be empty."
+      );
+    }
     const text =
       typeof notification.message === "string"
         ? notification.message

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -103,12 +103,11 @@ describe("notify()", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       const jsxElement = React.createElement("span", null, "test");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       notify({
         type: "info",
         message: jsxElement,
         priority: "low",
-      } as any);
+      } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
       expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("[notify] ReactNode message without inboxMessage")

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import {
   notify,
@@ -98,14 +99,61 @@ describe("notify()", () => {
       expect(useNotificationHistoryStore.getState().entries[0]!.message).toBe("inbox message");
     });
 
-    it("skips history entry if no string message and no inboxMessage", () => {
+    it("skips history entry if ReactNode message and no inboxMessage", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const jsxElement = React.createElement("span", null, "test");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       notify({
         type: "info",
-        message: null as unknown as string,
+        message: jsxElement,
+        priority: "low",
+      } as any);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[notify] ReactNode message without inboxMessage")
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("creates history entry when ReactNode message provides inboxMessage", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const jsxElement = React.createElement("span", null, "rich");
+      notify({
+        type: "info",
+        message: jsxElement,
+        inboxMessage: "Plain text fallback",
         priority: "low",
       });
-      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+      expect(useNotificationHistoryStore.getState().entries[0]!.message).toBe(
+        "Plain text fallback"
+      );
+    });
+
+    it("does NOT log dev guard for string message without inboxMessage", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      notify({ type: "info", message: "Just a string", priority: "low" });
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+      consoleSpy.mockRestore();
+    });
+
+    it("logs dev guard when ReactNode message has empty-string inboxMessage", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const jsxElement = React.createElement("span", null, "test");
+      notify({
+        type: "info",
+        message: jsxElement,
+        inboxMessage: "",
+        priority: "low",
+      });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[notify] ReactNode message without inboxMessage")
+      );
+      consoleSpy.mockRestore();
     });
 
     it("stores correlationId in history entry", () => {

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -181,10 +181,32 @@ export function isScheduledQuietHours(now: Date = new Date()): boolean {
  * | any     | watch    | yes   | yes       | yes     |
  *
  * The `grid-bar` placement bypasses priority routing and always renders inline.
+ *
+ * When `message` is a non-string ReactNode, `inboxMessage` is required —
+ * otherwise the persistent inbox history entry is silently dropped (WCAG 2.2.1).
+ * String messages auto-derive the history text from the message itself.
  */
+export function notify(
+  payload: Omit<NotifyPayload, "message" | "inboxMessage"> & {
+    message: string;
+    inboxMessage?: string;
+  }
+): string;
+export function notify(
+  payload: Omit<NotifyPayload, "message" | "inboxMessage"> & {
+    message: Exclude<ReactNode, string>;
+    inboxMessage: string;
+  }
+): string;
 export function notify(payload: NotifyPayload): string {
   const priority = payload.priority ?? "high";
   const { placement, correlationId, type, title, message, inboxMessage, context } = payload;
+
+  if (import.meta.env.DEV && typeof message !== "string" && !inboxMessage) {
+    console.error(
+      "[notify] ReactNode message without inboxMessage — persistent inbox history will be dropped. Provide inboxMessage for WCAG 2.2.1 compliance."
+    );
+  }
 
   const historyMessage = inboxMessage ?? (typeof message === "string" ? message : undefined);
 


### PR DESCRIPTION
## Summary
- Added TypeScript function overloads so callers passing a ReactNode message are forced to provide inboxMessage at compile time
- Added dev-mode console.error guards in both notify() and the toaster aria-live path for store-bypass callers
- No runtime behaviour changes for compliant callsites -- every current caller already passes inboxMessage

Resolves #5915

## Changes
- `src/lib/notify.ts` -- two overloads: string message (inboxMessage optional) and non-string ReactNode message (inboxMessage required). Dev guard logs to console.error when the invariant is violated.
- `src/components/ui/toaster.tsx` -- parallel dev guard for the aria-live path where notifications arrive via store bypass
- Tests for both guards, including empty-string edge case, string-without-inboxMessage confirming no false positive, and ReactNode-with-inboxMessage confirming no false positive

## Testing
- Unit tests for the overload contract and dev guards in both notify.test.ts and toaster.test.tsx
- Typecheck, lint, and format all pass