### PR TITLE
fix(theme): reduce accent saturation across selection states

### DIFF
--- a/e2e/full/core-settings-tabs.spec.ts
+++ b/e2e/full/core-settings-tabs.spec.ts
@@ -184,7 +184,7 @@ test.describe.serial("Core: Settings Tabs Coverage", () => {
 
     // Click "Errors Only" and verify it gets the selected border
     await errorsButton.click();
-    await expect(errorsButton).toHaveClass(/border-daintree-accent/, { timeout: T_SHORT });
+    await expect(errorsButton).toHaveClass(/border-border-strong/, { timeout: T_SHORT });
 
     await window.keyboard.press("Escape");
     await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });

--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -190,8 +190,8 @@ export function AgentSelectorDropdown({
                 onMouseEnter={() => setActiveIndex(index)}
                 className={cn(
                   "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] cursor-pointer text-sm",
-                  isActive && "bg-daintree-accent/10",
-                  isSelected && "text-daintree-accent",
+                  isActive && "bg-overlay-selected",
+                  isSelected && "text-daintree-text font-medium",
                   !isActive && !isSelected && "text-daintree-text"
                 )}
               >

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -248,7 +248,7 @@ export function ColorSchemePicker() {
                       "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
                       "[&>*]:pointer-events-none",
                       isSelected
-                        ? "border-daintree-accent bg-daintree-accent/10"
+                        ? "border-border-strong bg-overlay-selected"
                         : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
                     )}
                   >
@@ -257,9 +257,7 @@ export function ColorSchemePicker() {
                       <span className="text-xs text-daintree-text truncate flex-1">
                         {scheme.name}
                       </span>
-                      {isSelected && (
-                        <Check className="w-3.5 h-3.5 text-daintree-accent shrink-0" />
-                      )}
+                      {isSelected && <Check className="w-3.5 h-3.5 text-daintree-text shrink-0" />}
                     </div>
                   </button>
                 );

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -198,7 +198,7 @@ export function ColorSchemePicker() {
               className={cn(
                 "px-2.5 py-0.5 text-[11px] font-medium transition-colors",
                 typeFilter === "dark"
-                  ? "bg-daintree-accent/15 text-daintree-text"
+                  ? "bg-overlay-selected text-daintree-text"
                   : "text-daintree-text/50 hover:text-daintree-text/70"
               )}
             >
@@ -210,7 +210,7 @@ export function ColorSchemePicker() {
               className={cn(
                 "px-2.5 py-0.5 text-[11px] font-medium transition-colors border-l border-daintree-border",
                 typeFilter === "light"
-                  ? "bg-daintree-accent/15 text-daintree-text"
+                  ? "bg-overlay-selected text-daintree-text"
                   : "text-daintree-text/50 hover:text-daintree-text/70"
               )}
             >

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -554,7 +554,7 @@ export function GeneralTab({
                   className={cn(
                     "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
                     updateChannel === ch
-                      ? "bg-daintree-accent/10 border border-daintree-accent text-daintree-accent"
+                      ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
                       : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                   )}
                 >
@@ -661,7 +661,7 @@ export function GeneralTab({
                         className={cn(
                           "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
                           idleNotifyConfig.thresholdMinutes === value
-                            ? "bg-daintree-accent/10 border border-daintree-accent text-daintree-accent"
+                            ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
                             : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                         )}
                       >
@@ -718,7 +718,7 @@ export function GeneralTab({
                         className={cn(
                           "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
                           hibernationConfig.inactiveThresholdHours === value
-                            ? "bg-daintree-accent/10 border border-daintree-accent text-daintree-accent"
+                            ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
                             : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                         )}
                       >

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -252,8 +252,8 @@ function PresetOption({
       tabIndex={0}
       className={cn(
         "flex items-center gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] cursor-pointer text-sm",
-        "hover:bg-daintree-accent/10 focus:bg-daintree-accent/10 focus:outline-none",
-        isSelected && "text-daintree-accent"
+        "hover:bg-overlay-soft focus:bg-overlay-soft focus:outline-none",
+        isSelected && "text-daintree-text font-medium bg-overlay-selected"
       )}
     >
       <span

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -213,7 +213,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                   "w-full text-left p-4 rounded-[var(--radius-lg)] border transition-colors",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                   telemetryLevel === option.level
-                    ? "border-daintree-accent/40 bg-daintree-accent/5"
+                    ? "border-border-strong bg-overlay-selected"
                     : "border-daintree-border hover:bg-tint/5"
                 )}
               >
@@ -222,12 +222,12 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                     className={cn(
                       "w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0",
                       telemetryLevel === option.level
-                        ? "border-daintree-accent"
+                        ? "border-border-strong"
                         : "border-daintree-text/30"
                     )}
                   >
                     {telemetryLevel === option.level && (
-                      <div className="w-2 h-2 rounded-full bg-daintree-accent" />
+                      <div className="w-2 h-2 rounded-full bg-daintree-text" />
                     )}
                   </div>
                   <div>
@@ -346,7 +346,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                     "px-3 py-2 rounded-[var(--radius-md)] text-sm font-medium transition-colors",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                     logRetentionDays === option.value
-                      ? "bg-daintree-accent/10 text-daintree-accent border border-daintree-accent/30"
+                      ? "bg-overlay-selected text-daintree-text font-medium border border-border-strong"
                       : "text-daintree-text/60 border border-daintree-border hover:bg-tint/5 hover:text-daintree-text"
                   )}
                 >

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -547,7 +547,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 className={cn(
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   cachedProjectViews === value
-                    ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                    ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                     : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                 )}
               >
@@ -721,7 +721,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   className={cn(
                     "flex flex-col items-center justify-center p-4 rounded-[var(--radius-md)] border transition-colors",
                     layoutConfig.strategy === id
-                      ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                      ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                       : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                   )}
                 >
@@ -782,7 +782,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   performanceMode && "opacity-50 cursor-not-allowed",
                   scrollbackLines === value
-                    ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                    ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                     : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                 )}
               >
@@ -873,7 +873,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 className={cn(
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   screenReaderMode === value
-                    ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                    ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                     : "border-daintree-border hover:bg-tint/5 text-daintree-text/70"
                 )}
               >

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -126,7 +126,7 @@ export function ThemeSelector<T extends { id: string }>({
         "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
         "[&>*]:pointer-events-none",
         item.id === selectedId
-          ? "border-daintree-accent bg-daintree-accent/10"
+          ? "border-border-strong bg-overlay-selected"
           : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
       )}
     >

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -244,7 +244,7 @@ export function WorktreeSettingsTab() {
                       className={cn(
                         "px-3 py-1.5 text-xs rounded-[var(--radius-md)] border transition-colors",
                         pattern === preset.pattern
-                          ? "bg-daintree-accent/10 border-daintree-accent text-daintree-accent"
+                          ? "bg-overlay-selected border-border-strong text-daintree-text font-medium"
                           : "border-daintree-border text-daintree-text/70 hover:bg-daintree-border/50"
                       )}
                     >

--- a/src/components/Settings/__tests__/PrivacyDataTab.test.tsx
+++ b/src/components/Settings/__tests__/PrivacyDataTab.test.tsx
@@ -60,7 +60,7 @@ describe("PrivacyDataTab", () => {
 
     await waitFor(() => {
       const errorsButton = screen.getByText("Errors Only").closest("button")!;
-      expect(errorsButton.className).toContain("border-daintree-accent/40");
+      expect(errorsButton.className).toContain("border-border-strong");
     });
   });
 
@@ -80,7 +80,7 @@ describe("PrivacyDataTab", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Off").closest("button")!.className).toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
     });
 
@@ -89,10 +89,10 @@ describe("PrivacyDataTab", () => {
     await waitFor(() => {
       // Should revert back to "Off" being selected
       expect(screen.getByText("Off").closest("button")!.className).toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
       expect(screen.getByText("Errors Only").closest("button")!.className).not.toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
     });
 
@@ -123,7 +123,7 @@ describe("PrivacyDataTab", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Off").closest("button")!.className).toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
     });
 
@@ -131,7 +131,7 @@ describe("PrivacyDataTab", () => {
     fireEvent.click(screen.getByText("Errors Only").closest("button")!);
     await waitFor(() => {
       expect(screen.getByText("Errors Only").closest("button")!.className).toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
     });
 
@@ -140,10 +140,10 @@ describe("PrivacyDataTab", () => {
     await waitFor(() => {
       // Should revert to "errors" (the last successful value), NOT "off"
       expect(screen.getByText("Errors Only").closest("button")!.className).toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
       expect(screen.getByText("Full Usage").closest("button")!.className).not.toContain(
-        "border-daintree-accent/40"
+        "border-border-strong"
       );
     });
   });
@@ -185,7 +185,7 @@ describe("PrivacyDataTab", () => {
 
     await waitFor(() => {
       expect(screen.getByText("30 days").closest("button")!.className).toContain(
-        "bg-daintree-accent/10"
+        "bg-overlay-selected"
       );
     });
 
@@ -194,10 +194,10 @@ describe("PrivacyDataTab", () => {
     await waitFor(() => {
       // Should revert back to 30 days
       expect(screen.getByText("30 days").closest("button")!.className).toContain(
-        "bg-daintree-accent/10"
+        "bg-overlay-selected"
       );
       expect(screen.getByText("90 days").closest("button")!.className).not.toContain(
-        "bg-daintree-accent/10"
+        "bg-overlay-selected"
       );
     });
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1115,7 +1115,7 @@ export function NewWorktreeDialog({
                                 className={cn(
                                   "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
                                   row.name === baseBranch && "bg-daintree-border",
-                                  idx === selectedIndex && "bg-daintree-accent/10"
+                                  idx === selectedIndex && "bg-overlay-selected"
                                 )}
                               >
                                 <span className="truncate">
@@ -1135,7 +1135,7 @@ export function NewWorktreeDialog({
                                     </span>
                                   )}
                                   {row.name === baseBranch && (
-                                    <Check className="h-4 w-4 text-daintree-accent" />
+                                    <Check className="h-4 w-4 text-daintree-text" />
                                   )}
                                 </span>
                               </div>
@@ -1226,7 +1226,7 @@ export function NewWorktreeDialog({
                           >
                             <span className="truncate">{branch.name}</span>
                             {branch.name === selectedExistingBranch && (
-                              <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                              <Check className="h-4 w-4 shrink-0 text-daintree-text" />
                             )}
                           </div>
                         ))
@@ -1311,10 +1311,10 @@ export function NewWorktreeDialog({
                             onClick={() => handlePrefixSelect(suggestion.type.prefix)}
                             className={cn(
                               "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                              index === prefixSelectedIndex && "bg-daintree-accent/10"
+                              index === prefixSelectedIndex && "bg-overlay-selected"
                             )}
                           >
-                            <span className="font-mono text-daintree-accent">
+                            <span className="font-mono text-daintree-text">
                               {suggestion.type.prefix}/
                             </span>
                             <span className="text-daintree-text/60">
@@ -1329,7 +1329,7 @@ export function NewWorktreeDialog({
                 <p className="text-xs text-daintree-text/60 select-text">
                   {parsedBranch.hasPrefix ? (
                     <>
-                      <span className="font-mono text-daintree-accent">{parsedBranch.prefix}/</span>
+                      <span className="font-mono text-daintree-text">{parsedBranch.prefix}/</span>
                       <span className="font-mono">{parsedBranch.slug || "..."}</span>
                     </>
                   ) : (
@@ -1636,7 +1636,7 @@ export function NewWorktreeDialog({
                           <span>Clone current layout</span>
                         </div>
                         {selectedRecipeId === CLONE_LAYOUT_ID && (
-                          <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                          <Check className="h-4 w-4 shrink-0 text-daintree-text" />
                         )}
                       </div>
                       <div
@@ -1666,7 +1666,7 @@ export function NewWorktreeDialog({
                       >
                         <span className="text-daintree-text/60">Empty</span>
                         {selectedRecipeId === null && (
-                          <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                          <Check className="h-4 w-4 shrink-0 text-daintree-text" />
                         )}
                       </div>
                       {globalRecipes.map((recipe) => (
@@ -1704,13 +1704,11 @@ export function NewWorktreeDialog({
                               {recipe.terminals.length !== 1 ? "s" : ""}
                             </span>
                             {recipe.id === defaultRecipeId && (
-                              <span className="text-xs text-daintree-accent shrink-0">
-                                (default)
-                              </span>
+                              <span className="text-xs text-daintree-text shrink-0">(default)</span>
                             )}
                           </div>
                           {recipe.id === selectedRecipeId && (
-                            <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
+                            <Check className="h-4 w-4 shrink-0 text-daintree-text" />
                           )}
                         </div>
                       ))}

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1704,7 +1704,9 @@ export function NewWorktreeDialog({
                               {recipe.terminals.length !== 1 ? "s" : ""}
                             </span>
                             {recipe.id === defaultRecipeId && (
-                              <span className="text-xs text-daintree-text shrink-0">(default)</span>
+                              <span className="text-xs text-daintree-text/50 shrink-0">
+                                (default)
+                              </span>
                             )}
                           </div>
                           {recipe.id === selectedRecipeId && (


### PR DESCRIPTION
## Summary

Selection states across Settings, the New Worktree dialog, and agent/preset dropdowns had drifted toward accent colour as a default highlight. A single Settings tab could stack three or four accent-tinted radio-pill groups vertically, and the New Worktree dialog could show three or more accent checkmarks at once. Nothing genuinely stood out.

This pulls accent back to its intended role — focus rings, the macro-focus state, and singular signals like the current-worktree left bar. Persistent selection states now use the neutral surface tokens the theme already exposes for exactly this purpose (`overlay-selected`, `border-border-strong`, `font-medium`).

Resolves #5921

## Changes

- Settings radio pills (General, Terminal, Worktree, PrivacyData tabs) use `overlay-selected` + `border-border-strong` instead of `bg-daintree-accent/10 border-daintree-accent text-daintree-accent`
- AgentSelectorDropdown and PresetSelector membership checkmarks use `text-foreground` instead of `text-daintree-accent`
- ColorSchemePicker toggle selected state uses neutral fill instead of accent background
- ThemeSelector and WorktreeSettingsTab selected items use neutral surface tokens
- Recipe badge in NewWorktreeDialog uses `overlay-subtle` fill instead of accent tint
- NewWorktreeDialog selected branch, recipe, and tracking options use neutral selection tokens
- E2E and unit test assertions updated to match the new token choices

## Testing

- All unit and integration tests pass
- E2E core-settings-tabs test assertion updated
- Verified across built-in light and dark themes