### PR TITLE
feat(fleet): add fleet-arming dialog to worktree sidebar Zap button

### DIFF
--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -1,0 +1,540 @@
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactElement,
+} from "react";
+import * as Checkbox from "@radix-ui/react-checkbox";
+import { CheckIcon, MinusIcon, Search, Zap } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { useEscapeStack } from "@/hooks";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { cn } from "@/lib/utils";
+import type { TerminalInstance } from "@shared/types";
+
+export type FleetArmingDialogChip = "all" | "waiting" | "working";
+
+interface FleetArmingDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface DialogTerminal {
+  id: string;
+  title: string;
+  worktreeId: string;
+  agentState: TerminalInstance["agentState"];
+}
+
+interface WorktreeGroup {
+  worktreeId: string;
+  worktreeName: string;
+  terminals: DialogTerminal[];
+}
+
+const FALLBACK_GROUP_ID = "__no_worktree__";
+const FALLBACK_GROUP_NAME = "Unassigned";
+
+function isWaiting(t: DialogTerminal): boolean {
+  return t.agentState === "waiting";
+}
+
+function isWorking(t: DialogTerminal): boolean {
+  return t.agentState === "working";
+}
+
+function deriveGroupCheckedState(
+  groupIds: string[],
+  selectedIds: ReadonlySet<string>
+): boolean | "indeterminate" {
+  if (groupIds.length === 0) return false;
+  let selected = 0;
+  for (const id of groupIds) {
+    if (selectedIds.has(id)) selected++;
+  }
+  if (selected === 0) return false;
+  if (selected === groupIds.length) return true;
+  return "indeterminate";
+}
+
+export function FleetArmingDialog({
+  isOpen,
+  onClose,
+}: FleetArmingDialogProps): ReactElement | null {
+  const armIds = useFleetArmingStore((s) => s.armIds);
+
+  const { panelIds, panelsById } = usePanelStore(
+    useShallow((s) => ({ panelIds: s.panelIds, panelsById: s.panelsById }))
+  );
+  const worktreeNames = useWorktreeStore(
+    useShallow((s) => {
+      const out: Record<string, string> = {};
+      s.worktrees.forEach((wt, id) => {
+        out[id] = wt.name;
+      });
+      return out;
+    })
+  );
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [searchTerm, setSearchTerm] = useState("");
+  const [activeChip, setActiveChip] = useState<FleetArmingDialogChip>("all");
+  const deferredSearchTerm = useDeferredValue(searchTerm);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const listContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset all dialog-local state on each open/close transition. Single
+  // useEffect keyed on [isOpen] per lesson #4958.
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedIds(new Set());
+      setSearchTerm("");
+      setActiveChip("all");
+    }
+  }, [isOpen]);
+
+  const eligibleTerminals = useMemo<DialogTerminal[]>(() => {
+    const out: DialogTerminal[] = [];
+    for (const id of panelIds) {
+      const t = panelsById[id];
+      if (!isFleetArmEligible(t)) continue;
+      out.push({
+        id: t.id,
+        title: t.title,
+        worktreeId: t.worktreeId ?? FALLBACK_GROUP_ID,
+        agentState: t.agentState,
+      });
+    }
+    return out;
+  }, [panelIds, panelsById]);
+
+  const eligibleIdSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const t of eligibleTerminals) s.add(t.id);
+    return s;
+  }, [eligibleTerminals]);
+
+  const visibleTerminals = useMemo<DialogTerminal[]>(() => {
+    const needle = deferredSearchTerm.trim().toLowerCase();
+    return eligibleTerminals.filter((t) => {
+      if (activeChip === "waiting" && !isWaiting(t)) return false;
+      if (activeChip === "working" && !isWorking(t)) return false;
+      if (needle === "") return true;
+      const haystack = `${t.title.toLowerCase()} ${(worktreeNames[t.worktreeId] ?? "").toLowerCase()}`;
+      return haystack.includes(needle);
+    });
+  }, [eligibleTerminals, activeChip, deferredSearchTerm, worktreeNames]);
+
+  const visibleIds = useMemo(() => visibleTerminals.map((t) => t.id), [visibleTerminals]);
+
+  const groupedVisible = useMemo<WorktreeGroup[]>(() => {
+    const order: string[] = [];
+    const buckets = new Map<string, DialogTerminal[]>();
+    for (const t of visibleTerminals) {
+      const bucket = buckets.get(t.worktreeId);
+      if (bucket) {
+        bucket.push(t);
+      } else {
+        buckets.set(t.worktreeId, [t]);
+        order.push(t.worktreeId);
+      }
+    }
+    return order.map((wid) => ({
+      worktreeId: wid,
+      worktreeName: wid === FALLBACK_GROUP_ID ? FALLBACK_GROUP_NAME : (worktreeNames[wid] ?? wid),
+      terminals: buckets.get(wid)!,
+    }));
+  }, [visibleTerminals, worktreeNames]);
+
+  // Counts derived from full eligible set, not visibleTerminals — chip
+  // labels show project-wide totals so the user can see what's available
+  // even after filtering.
+  const eligibleCounts = useMemo(() => {
+    let waiting = 0;
+    let working = 0;
+    for (const t of eligibleTerminals) {
+      if (isWaiting(t)) waiting++;
+      if (isWorking(t)) working++;
+    }
+    return { all: eligibleTerminals.length, waiting, working };
+  }, [eligibleTerminals]);
+
+  // Confirm payload: filter ids that may have become ineligible while the
+  // dialog was open. No pruning effect — kept inline per plan decision.
+  const confirmedIds = useMemo(() => {
+    const out: string[] = [];
+    for (const id of selectedIds) {
+      if (eligibleIdSet.has(id)) out.push(id);
+    }
+    return out;
+  }, [selectedIds, eligibleIdSet]);
+
+  const isSingleWorktree = groupedVisible.length === 1;
+
+  const clearSearch = useCallback(() => setSearchTerm(""), []);
+  // First Esc clears search; second Esc closes the dialog (handled by
+  // AppDialog itself). LIFO means the search-clear handler runs first
+  // because it's registered later in the call tree only when the search
+  // is non-empty.
+  useEscapeStack(isOpen && searchTerm !== "", clearSearch);
+
+  const toggleId = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleGroupHeaderToggle = useCallback((group: WorktreeGroup) => {
+    setSelectedIds((prev) => {
+      const groupIds = group.terminals.map((t) => t.id);
+      const state = deriveGroupCheckedState(groupIds, prev);
+      const next = new Set(prev);
+      if (state === true) {
+        // All selected → deselect all in group
+        for (const id of groupIds) next.delete(id);
+      } else if (state === "indeterminate") {
+        // Safe-reset: deselect rather than complete
+        for (const id of groupIds) next.delete(id);
+      } else {
+        // None selected → select all in group
+        for (const id of groupIds) next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleListKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a") {
+        e.preventDefault();
+        setSelectedIds(new Set(visibleIds));
+      }
+    },
+    [visibleIds]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (confirmedIds.length === 0) return;
+    armIds(confirmedIds);
+    onClose();
+  }, [armIds, confirmedIds, onClose]);
+
+  const confirmLabel =
+    confirmedIds.length === 0 ? "Arm selected" : `Arm ${confirmedIds.length} selected`;
+
+  return (
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      maxHeight="max-h-[75vh]"
+      data-testid="fleet-arming-dialog"
+    >
+      <AppDialog.Header>
+        <AppDialog.Title icon={<Zap className="h-4 w-4 text-daintree-text/70" />}>
+          Select terminals to arm
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <div className="flex flex-1 flex-col min-h-0">
+        <div className="px-6 py-3 border-b border-daintree-border shrink-0 flex flex-col gap-3">
+          <div className="relative">
+            <Search
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-daintree-text/40 pointer-events-none"
+              aria-hidden="true"
+            />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder="Search terminals or worktrees"
+              aria-label="Search terminals"
+              className={cn(
+                "w-full rounded border border-daintree-border bg-daintree-bg pl-8 pr-2 py-1.5 text-[13px] text-daintree-text",
+                "placeholder:text-daintree-text/40",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+              )}
+              data-testid="fleet-arming-dialog-search"
+            />
+          </div>
+          <div className="flex items-center gap-1.5" role="tablist" aria-label="Filter by state">
+            <ChipButton
+              active={activeChip === "all"}
+              count={eligibleCounts.all}
+              onClick={() => setActiveChip("all")}
+              testId="fleet-arming-dialog-chip-all"
+            >
+              All
+            </ChipButton>
+            <ChipButton
+              active={activeChip === "waiting"}
+              count={eligibleCounts.waiting}
+              onClick={() => setActiveChip("waiting")}
+              testId="fleet-arming-dialog-chip-waiting"
+            >
+              Waiting
+            </ChipButton>
+            <ChipButton
+              active={activeChip === "working"}
+              count={eligibleCounts.working}
+              onClick={() => setActiveChip("working")}
+              testId="fleet-arming-dialog-chip-working"
+            >
+              Working
+            </ChipButton>
+          </div>
+        </div>
+
+        <div
+          ref={listContainerRef}
+          onKeyDown={handleListKeyDown}
+          tabIndex={-1}
+          className="flex-1 min-h-0 overflow-y-auto px-2 py-2 outline-none"
+          data-testid="fleet-arming-dialog-list"
+        >
+          {eligibleTerminals.length === 0 ? (
+            <EmptyState
+              title="No terminals available"
+              hint="Open or focus a terminal to add it to the fleet."
+            />
+          ) : visibleTerminals.length === 0 ? (
+            <EmptyState
+              title="No terminals match"
+              hint="Adjust the search or filter to see more terminals."
+            />
+          ) : (
+            groupedVisible.map((group) => (
+              <WorktreeGroupSection
+                key={group.worktreeId}
+                group={group}
+                selectedIds={selectedIds}
+                hideHeader={isSingleWorktree}
+                onToggleId={toggleId}
+                onToggleGroup={handleGroupHeaderToggle}
+              />
+            ))
+          )}
+        </div>
+      </div>
+
+      <AppDialog.Footer
+        primaryAction={{
+          label: confirmLabel,
+          onClick: handleConfirm,
+          disabled: confirmedIds.length === 0,
+        }}
+        secondaryAction={{
+          label: "Cancel",
+          onClick: onClose,
+        }}
+      />
+    </AppDialog>
+  );
+}
+
+interface ChipButtonProps {
+  active: boolean;
+  count: number;
+  onClick: () => void;
+  testId?: string;
+  children: React.ReactNode;
+}
+
+function ChipButton({ active, count, onClick, testId, children }: ChipButtonProps): ReactElement {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      data-testid={testId}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[12px] transition-colors",
+        active
+          ? "bg-overlay-subtle text-daintree-text"
+          : "bg-tint/[0.06] text-daintree-text/70 hover:bg-tint/[0.1] hover:text-daintree-text",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+      )}
+    >
+      <span>{children}</span>
+      <span className="tabular-nums text-daintree-text/55">{count}</span>
+    </button>
+  );
+}
+
+interface EmptyStateProps {
+  title: string;
+  hint: string;
+}
+
+function EmptyState({ title, hint }: EmptyStateProps): ReactElement {
+  return (
+    <div
+      className="flex h-full min-h-[120px] flex-col items-center justify-center gap-1 px-6 text-center"
+      data-testid="fleet-arming-dialog-empty"
+    >
+      <div className="text-[13px] font-medium text-daintree-text">{title}</div>
+      <div className="text-[12px] text-daintree-text/60">{hint}</div>
+    </div>
+  );
+}
+
+interface WorktreeGroupSectionProps {
+  group: WorktreeGroup;
+  selectedIds: ReadonlySet<string>;
+  hideHeader: boolean;
+  onToggleId: (id: string) => void;
+  onToggleGroup: (group: WorktreeGroup) => void;
+}
+
+function WorktreeGroupSection({
+  group,
+  selectedIds,
+  hideHeader,
+  onToggleId,
+  onToggleGroup,
+}: WorktreeGroupSectionProps): ReactElement {
+  const groupIds = useMemo(() => group.terminals.map((t) => t.id), [group.terminals]);
+  const groupState = useMemo(
+    () => deriveGroupCheckedState(groupIds, selectedIds),
+    [groupIds, selectedIds]
+  );
+  const selectedInGroup = useMemo(() => {
+    let n = 0;
+    for (const id of groupIds) if (selectedIds.has(id)) n++;
+    return n;
+  }, [groupIds, selectedIds]);
+
+  return (
+    <section className="mb-1">
+      {!hideHeader && (
+        <header
+          className="flex items-center gap-2 px-2 py-1.5 sticky top-0 bg-surface-panel z-[1]"
+          data-testid={`fleet-arming-dialog-group-${group.worktreeId}`}
+        >
+          <DialogCheckbox
+            checked={groupState}
+            onCheckedChange={() => onToggleGroup(group)}
+            ariaLabel={`Select all ${group.terminals.length} terminals in ${group.worktreeName}`}
+          />
+          <button
+            type="button"
+            onClick={() => onToggleGroup(group)}
+            className="flex flex-1 items-center justify-between gap-2 text-left text-[12px] font-medium text-daintree-text/80 hover:text-daintree-text"
+          >
+            <span className="truncate">{group.worktreeName}</span>
+            <span className="shrink-0 tabular-nums text-[11px] text-daintree-text/55">
+              {selectedInGroup} / {group.terminals.length}
+            </span>
+          </button>
+        </header>
+      )}
+      <ul className="flex flex-col">
+        {group.terminals.map((t) => (
+          <TerminalRow
+            key={t.id}
+            terminal={t}
+            checked={selectedIds.has(t.id)}
+            onToggle={() => onToggleId(t.id)}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface TerminalRowProps {
+  terminal: DialogTerminal;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+function TerminalRow({ terminal, checked, onToggle }: TerminalRowProps): ReactElement {
+  const stateBadge = renderStateBadge(terminal.agentState);
+  return (
+    <li className="flex items-center">
+      <label
+        className={cn(
+          "flex flex-1 items-center gap-2 px-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer",
+          "hover:bg-tint/[0.06]"
+        )}
+      >
+        <DialogCheckbox
+          checked={checked}
+          onCheckedChange={onToggle}
+          ariaLabel={`Select ${terminal.title}`}
+        />
+        <span className="truncate flex-1">{terminal.title}</span>
+        {stateBadge}
+      </label>
+    </li>
+  );
+}
+
+function renderStateBadge(agentState: TerminalInstance["agentState"]): ReactElement | null {
+  if (agentState !== "waiting" && agentState !== "working") return null;
+  const label = agentState === "waiting" ? "Waiting" : "Working";
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium tabular-nums",
+        "bg-tint/[0.08] text-daintree-text/70"
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+interface DialogCheckboxProps {
+  checked: boolean | "indeterminate";
+  onCheckedChange: () => void;
+  ariaLabel: string;
+}
+
+function DialogCheckbox({
+  checked,
+  onCheckedChange,
+  ariaLabel,
+}: DialogCheckboxProps): ReactElement {
+  return (
+    <Checkbox.Root
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      aria-label={ariaLabel}
+      onClick={(e) => e.stopPropagation()}
+      className={cn(
+        "relative flex shrink-0 w-4 h-4 rounded border transition-colors duration-150",
+        "bg-daintree-bg border-border-strong",
+        "data-[state=checked]:bg-daintree-accent data-[state=checked]:border-daintree-accent",
+        // Neutral indeterminate fill — accent is reserved for the primary
+        // signal (the confirm CTA). Per CLAUDE.md accent restraint rule.
+        "data-[state=indeterminate]:bg-border-strong data-[state=indeterminate]:border-border-strong",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
+      )}
+    >
+      <Checkbox.Indicator className="flex items-center justify-center w-full h-full text-text-inverse">
+        {checked === "indeterminate" ? (
+          <MinusIcon className="w-3 h-3" />
+        ) : (
+          <CheckIcon className="w-3 h-3" />
+        )}
+      </Checkbox.Indicator>
+    </Checkbox.Root>
+  );
+}

--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -127,7 +127,11 @@ export function FleetArmingDialog({
       if (activeChip === "waiting" && !isWaiting(t)) return false;
       if (activeChip === "working" && !isWorking(t)) return false;
       if (needle === "") return true;
-      const haystack = `${t.title.toLowerCase()} ${(worktreeNames[t.worktreeId] ?? "").toLowerCase()}`;
+      const groupName =
+        t.worktreeId === FALLBACK_GROUP_ID
+          ? FALLBACK_GROUP_NAME
+          : (worktreeNames[t.worktreeId] ?? "");
+      const haystack = `${t.title.toLowerCase()} ${groupName.toLowerCase()}`;
       return haystack.includes(needle);
     });
   }, [eligibleTerminals, activeChip, deferredSearchTerm, worktreeNames]);
@@ -176,7 +180,15 @@ export function FleetArmingDialog({
     return out;
   }, [selectedIds, eligibleIdSet]);
 
-  const isSingleWorktree = groupedVisible.length === 1;
+  // Hide the group header when the project itself only has one eligible
+  // worktree — not when filtering happens to narrow the visible list to a
+  // single group. Otherwise the user loses the only label telling them
+  // which worktree the visible terminals belong to.
+  const isSingleWorktree = useMemo(() => {
+    const ids = new Set<string>();
+    for (const t of eligibleTerminals) ids.add(t.worktreeId);
+    return ids.size <= 1;
+  }, [eligibleTerminals]);
 
   const clearSearch = useCallback(() => setSearchTerm(""), []);
   // First Esc clears search; second Esc closes the dialog (handled by

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen, act } from "@testing-library/react";
+
+vi.mock("@/components/ui/ScrollShadow", () => ({
+  ScrollShadow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/lib/animationUtils", () => ({
+  UI_ENTER_DURATION: 0,
+  UI_EXIT_DURATION: 0,
+  UI_ENTER_EASING: "linear",
+  UI_EXIT_EASING: "linear",
+  getUiTransitionDuration: () => 0,
+}));
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+import { FleetArmingDialog } from "../FleetArmingDialog";
+import { usePanelStore } from "@/store/panelStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
+import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+
+function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    kind: "terminal",
+    worktreeId: "wt-1",
+    location: "grid",
+    hasPty: true,
+    agentState: "idle",
+    runtimeStatus: "running",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedTerminals(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+function makeWorktreeSnap(id: string, name: string): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/repo/${id}`,
+    name,
+    isCurrent: false,
+  } as WorktreeSnapshot;
+}
+
+function renderDialog(
+  worktrees: WorktreeSnapshot[],
+  isOpen = true,
+  onClose: () => void = () => {}
+) {
+  const store = createWorktreeStore();
+  store.getState().applySnapshot(worktrees, 1);
+  return render(
+    <WorktreeStoreContext.Provider value={store}>
+      <FleetArmingDialog isOpen={isOpen} onClose={onClose} />
+    </WorktreeStoreContext.Provider>
+  );
+}
+
+function resetStores(): void {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+    previewArmedIds: new Set<string>(),
+    broadcastSignal: 0,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [], focusedId: null });
+  resetEscapeStack();
+}
+
+describe("FleetArmingDialog", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("does not render when closed", () => {
+    seedTerminals([makeTerminal("a"), makeTerminal("b")]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], false);
+    expect(screen.queryByTestId("fleet-arming-dialog")).toBeNull();
+  });
+
+  it("renders only fleet-eligible terminals", () => {
+    seedTerminals([
+      makeTerminal("alpha", { title: "alpha" }),
+      makeTerminal("beta", { title: "beta" }),
+      makeTerminal("trash-row", { title: "trashed", location: "trash" }),
+      makeTerminal("nopty", { title: "no-pty", hasPty: false }),
+      makeTerminal("exited", { title: "exited", runtimeStatus: "exited" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+    expect(screen.queryByText("trashed")).toBeNull();
+    expect(screen.queryByText("no-pty")).toBeNull();
+    expect(screen.queryByText("exited")).toBeNull();
+  });
+
+  it("shows empty state when there are no eligible terminals", () => {
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.getByText("No terminals available")).toBeTruthy();
+  });
+
+  it("shows different empty state when search/chip yields no matches", () => {
+    seedTerminals([makeTerminal("alpha", { title: "alpha" })]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    const search = screen.getByTestId("fleet-arming-dialog-search") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "zzzzz" } });
+    expect(screen.getByText("No terminals match")).toBeTruthy();
+  });
+
+  it("toggling a terminal checkbox updates the confirm button label", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.getByText("Arm selected")).toBeTruthy();
+    const alphaCheckbox = screen.getByLabelText("Select alpha");
+    fireEvent.click(alphaCheckbox);
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+  });
+
+  it("confirm button is disabled when nothing is selected", () => {
+    seedTerminals([makeTerminal("a")]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    const confirm = screen.getByText("Arm selected").closest("button") as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+  });
+
+  it("confirm calls armIds with selected ids and invokes onClose", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha" }),
+      makeTerminal("b", { title: "beta" }),
+      makeTerminal("c", { title: "gamma" }),
+    ]);
+    const onClose = vi.fn();
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], true, onClose);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select gamma"));
+    fireEvent.click(screen.getByText("Arm 2 selected"));
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["a", "c"]);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel does not call armIds", () => {
+    seedTerminals([makeTerminal("a"), makeTerminal("b")]);
+    const onClose = vi.fn();
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], true, onClose);
+    fireEvent.click(screen.getByLabelText("Select a"));
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("waiting chip filters the visible list to waiting agents only", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", agentState: "waiting" }),
+      makeTerminal("b", { title: "beta", agentState: "working" }),
+      makeTerminal("c", { title: "gamma", agentState: "idle" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-waiting"));
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.queryByText("beta")).toBeNull();
+    expect(screen.queryByText("gamma")).toBeNull();
+  });
+
+  it("chip does not mutate selection — only filters the visible list", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", agentState: "waiting" }),
+      makeTerminal("b", { title: "beta", agentState: "working" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-working"));
+    // alpha is still selected even though it's not visible
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+    expect(screen.getByText("beta")).toBeTruthy();
+  });
+
+  it("search filters by title and worktree name", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "build-server", worktreeId: "wt-1" }),
+      makeTerminal("b", { title: "test-runner", worktreeId: "wt-2" }),
+    ]);
+    renderDialog([
+      makeWorktreeSnap("wt-1", "feature-foo"),
+      makeWorktreeSnap("wt-2", "feature-bar"),
+    ]);
+    const search = screen.getByTestId("fleet-arming-dialog-search") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "build" } });
+    expect(screen.getByText("build-server")).toBeTruthy();
+    expect(screen.queryByText("test-runner")).toBeNull();
+    // search by worktree name
+    fireEvent.change(search, { target: { value: "feature-bar" } });
+    expect(screen.queryByText("build-server")).toBeNull();
+    expect(screen.getByText("test-runner")).toBeTruthy();
+  });
+
+  it("Cmd+A on the list selects only currently visible terminals", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", agentState: "waiting" }),
+      makeTerminal("b", { title: "beta", agentState: "working" }),
+      makeTerminal("c", { title: "gamma", agentState: "waiting" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-waiting"));
+    const list = screen.getByTestId("fleet-arming-dialog-list");
+    fireEvent.keyDown(list, { key: "a", metaKey: true });
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+  });
+
+  it("worktree group header click selects all visible terminals in that group", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+      makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+      makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+    fireEvent.click(screen.getByLabelText("Select all 2 terminals in Main"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+  });
+
+  it("worktree group header click when partially selected deselects all in group (safe reset)", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+      makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+      makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    // Group "Main" is now indeterminate (1/2 selected). Header click should deselect both.
+    fireEvent.click(screen.getByLabelText("Select all 2 terminals in Main"));
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    expect(screen.queryByText(/Arm \d/)).toBeNull();
+    expect(screen.getByText("Arm selected")).toBeTruthy();
+  });
+
+  it("worktree group header is hidden when there is only one group", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+      makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.queryByTestId("fleet-arming-dialog-group-wt-1")).toBeNull();
+  });
+
+  it("first Esc clears search; second Esc closes dialog", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" })]);
+    const onClose = vi.fn();
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], true, onClose);
+    const search = screen.getByTestId("fleet-arming-dialog-search") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "zzz" } });
+    expect(search.value).toBe("zzz");
+    act(() => {
+      dispatchEscape();
+    });
+    expect((screen.getByTestId("fleet-arming-dialog-search") as HTMLInputElement).value).toBe("");
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => {
+      dispatchEscape();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ineligible selected ids are filtered out at confirm time", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    const onClose = vi.fn();
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], true, onClose);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    // Drop beta from the panel store before confirming.
+    act(() => {
+      const state = usePanelStore.getState();
+      const next = { ...state.panelsById };
+      delete next.b;
+      usePanelStore.setState({ panelsById: next, panelIds: ["a"] });
+    });
+    fireEvent.click(screen.getByText("Arm 1 selected"));
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["a"]);
+  });
+});

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -301,4 +301,67 @@ describe("FleetArmingDialog", () => {
     fireEvent.click(screen.getByText("Arm 1 selected"));
     expect(useFleetArmingStore.getState().armOrder).toEqual(["a"]);
   });
+
+  it("confirm replaces (not extends) the existing armed set", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    useFleetArmingStore.getState().armIds(["old"]);
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["old"]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    fireEvent.click(screen.getByText("Arm 1 selected"));
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["b"]);
+    expect(useFleetArmingStore.getState().armedIds.has("old")).toBe(false);
+  });
+
+  it("group header stays visible when a chip filters all but one group", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1", agentState: "waiting" }),
+      makeTerminal("b", { title: "beta", worktreeId: "wt-2", agentState: "working" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+    fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-waiting"));
+    // Only Main has waiting terminals; its header must remain visible so the
+    // user knows which worktree the row belongs to.
+    expect(screen.getByTestId("fleet-arming-dialog-group-wt-1")).toBeTruthy();
+  });
+
+  it("excludes background and error-status terminals", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha" }),
+      makeTerminal("bg", { title: "background", location: "background" }),
+      makeTerminal("err", { title: "errored", runtimeStatus: "error" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.queryByText("background")).toBeNull();
+    expect(screen.queryByText("errored")).toBeNull();
+  });
+
+  it("terminals without a worktreeId fall under 'Unassigned' and search hits the fallback name", () => {
+    seedTerminals([
+      makeTerminal("orphan", { title: "homeless", worktreeId: undefined }),
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    expect(screen.getByText("Unassigned")).toBeTruthy();
+    const search = screen.getByTestId("fleet-arming-dialog-search") as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "unassigned" } });
+    expect(screen.getByText("homeless")).toBeTruthy();
+    expect(screen.queryByText("alpha")).toBeNull();
+  });
+
+  it("group safe-reset clears only that group, not other groups", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+      makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+      makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select gamma"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    // Click Main's header (indeterminate: 1/2 selected) — should deselect Main only.
+    fireEvent.click(screen.getByLabelText("Select all 2 terminals in Main"));
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+  });
 });

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,4 +1,5 @@
 export { FleetArmingRibbon } from "./FleetArmingRibbon";
+export { FleetArmingDialog } from "./FleetArmingDialog";
 export {
   buildFleetTargetPreviews,
   executeFleetBroadcast,

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -28,6 +28,7 @@ import {
   QuickStateFilterBar,
 } from "@/components/Worktree";
 import { BulkCreateWorktreeDialog } from "@/components/GitHub/BulkCreateWorktreeDialog";
+import { FleetArmingDialog } from "@/components/Fleet/FleetArmingDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { WorktreeCardErrorFallback } from "@/components/Worktree/WorktreeCardErrorFallback";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -327,6 +328,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   useEffect(() => {
     if (createDialog.isOpen) setHasOpenedNewWorktree(true);
   }, [createDialog.isOpen]);
+
+  const [isFleetArmingDialogOpen, setIsFleetArmingDialogOpen] = useState(false);
+  const openFleetArmingDialog = useCallback(() => setIsFleetArmingDialogOpen(true), []);
+  const closeFleetArmingDialog = useCallback(() => setIsFleetArmingDialogOpen(false), []);
 
   // Filter/sort state - destructured for stable memoization
   const {
@@ -931,16 +936,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
-                  onClick={() =>
-                    actionService.dispatch("terminal.armAll", { scope: "all" }, { source: "user" })
-                  }
+                  onClick={openFleetArmingDialog}
                   className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
-                  aria-label="Arm all terminals"
+                  aria-label="Select terminals to arm"
                 >
                   <Zap className="w-3.5 h-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Arm all terminals</TooltipContent>
+              <TooltipContent side="bottom">Select terminals to arm</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -1149,6 +1152,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         selectedPRs={bulkCreateDialog.selectedPRs}
         onComplete={closeBulkCreateDialog}
       />
+
+      <FleetArmingDialog isOpen={isFleetArmingDialogOpen} onClose={closeFleetArmingDialog} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the Zap button's direct `terminal.armAll` dispatch with a selection dialog so users can see and choose what gets armed before committing
- The dialog lists every fleet-eligible terminal grouped by worktree, with search, state filter chips (All / Waiting / Working), per-row and per-group checkboxes, and a live-updating "Arm N selected" confirm button
- 22 vitest tests cover eligibility filtering, search, chip filtering, group safe-reset semantics, stale-id handling, two-step Escape, and edge cases

Resolves #5960

## Changes

- `src/components/Fleet/FleetArmingDialog.tsx` (new, ~470 lines): the dialog component with search input, filter chips, worktree-grouped terminal list, indeterminate group checkboxes, Cmd/Ctrl+A select-visible, and two-step Escape
- `src/components/Fleet/__tests__/FleetArmingDialog.test.tsx` (new, ~340 lines): full unit test suite
- `src/components/Fleet/index.ts`: barrel export for the new component
- `src/components/Sidebar/SidebarContent.tsx`: ~10 lines wiring up dialog open state and render in place of the direct armAll dispatch

The `terminal.armAll` action is untouched, so keyboard shortcut and command-palette users still get direct arming. The "Arm X matching" sidebar button is also unchanged.

## Testing

- All 22 unit tests pass
- Lint and formatting clean (no errors, pre-existing warnings only)
- Manually verified: Zap button opens dialog, filter chips narrow the list without auto-selecting, Cmd+A selects visible set, first Escape clears search, second Escape closes, "Arm N selected" calls `armIds` and closes, Cancel leaves existing selection untouched