### PR TITLE
fix(dev-preview): persist scroll position across renderer death

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -126,6 +126,8 @@ export interface DevPreviewPanelOptions extends AddPanelOptionsBase {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
+  /** Last captured scroll position, paired with URL for stale-scroll prevention */
+  devPreviewScrollPosition?: { url: string; scrollY: number };
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -369,6 +369,8 @@ export interface DevPreviewPanelData extends BasePanelData {
   exitBehavior?: PanelExitBehavior;
   /** Active viewport preset (undefined = fill/full-width) */
   viewportPreset?: ViewportPresetId;
+  /** Last captured scroll position, paired with URL for stale-scroll prevention */
+  devPreviewScrollPosition?: { url: string; scrollY: number };
 }
 
 export type PanelInstance = PtyPanelData | BrowserPanelData | DevPreviewPanelData;
@@ -465,6 +467,8 @@ export interface TerminalInstance {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for dev-preview responsive emulation (undefined = fill) */
   viewportPreset?: ViewportPresetId;
+  /** Last captured dev-preview scroll position, paired with URL for stale-scroll prevention */
+  devPreviewScrollPosition?: { url: string; scrollY: number };
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
   /** Legacy persisted creation timestamp (milliseconds since epoch) */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -93,6 +93,8 @@ export interface PanelSnapshot {
   devPreviewConsoleOpen?: boolean;
   /** Active viewport preset for dev-preview responsive emulation */
   viewportPreset?: ViewportPresetId;
+  /** Last captured dev-preview scroll position, paired with URL for stale-scroll prevention */
+  devPreviewScrollPosition?: { url: string; scrollY: number };
   /** Behavior when terminal exits */
   exitBehavior?: PanelExitBehavior;
   /** Captured agent session ID from graceful shutdown (used for session resume) */

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -34,12 +34,6 @@ import { useFindInPage } from "@/hooks/useFindInPage";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import type { ViewportPresetId } from "@shared/types/panel";
 
-const scrollCache = new Map<string, { url: string; scrollY: number }>();
-
-export function _resetScrollCacheForTests(): void {
-  scrollCache.clear();
-}
-
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
 
 type SessionStorageEntry = [string, string];
@@ -194,6 +188,7 @@ export function DevPreviewPane({
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const setDevPreviewConsoleOpen = usePanelStore((state) => state.setDevPreviewConsoleOpen);
   const setViewportPreset = usePanelStore((state) => state.setViewportPreset);
+  const setDevPreviewScrollPosition = usePanelStore((state) => state.setDevPreviewScrollPosition);
   const currentProjectId = useProjectStore((state) => state.currentProject?.id);
   const projectSettings = useProjectSettingsStore((state) => state.settings);
   const projectEnv = projectSettings?.environmentVariables;
@@ -288,7 +283,7 @@ export function DevPreviewPane({
               .executeJavaScript("window.scrollY")
               .then((scrollY: number) => {
                 if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
-                  scrollCache.set(id, { url: currentWebviewUrl, scrollY });
+                  setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
                 }
               })
               .catch(() => {});
@@ -308,7 +303,7 @@ export function DevPreviewPane({
       }
       setWebviewElement(node);
     },
-    [id]
+    [id, setDevPreviewScrollPosition]
   );
 
   useEffect(() => {
@@ -330,7 +325,7 @@ export function DevPreviewPane({
             .executeJavaScript("window.scrollY")
             .then((scrollY: number) => {
               if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
-                scrollCache.set(id, { url: currentWebviewUrl, scrollY });
+                setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
               }
             })
             .catch(() => {});
@@ -339,7 +334,7 @@ export function DevPreviewPane({
         // Webview already detached
       }
     }
-  }, [status, id, webviewElement]);
+  }, [status, id, webviewElement, setDevPreviewScrollPosition]);
 
   useEffect(() => {
     setConsoleTerminalId(terminalId);
@@ -421,7 +416,7 @@ export function DevPreviewPane({
   }, [start]);
 
   const handleHardRestart = useCallback(() => {
-    scrollCache.delete(id);
+    setDevPreviewScrollPosition(id, undefined);
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);
       loadTimeoutRef.current = null;
@@ -433,7 +428,7 @@ export function DevPreviewPane({
     setIsWebviewReady(false);
     setWebviewLoadError(null);
     void restart();
-  }, [id, restart, setBrowserUrl]);
+  }, [id, restart, setBrowserUrl, setDevPreviewScrollPosition]);
 
   const handleAutoDetect = useCallback(async () => {
     if (!currentProjectId || isAutoDetecting) return;
@@ -659,12 +654,16 @@ export function DevPreviewPane({
         loadTimeoutRef.current = null;
       }
 
-      const saved = scrollCache.get(id);
-      if (saved) {
+      const saved = usePanelStore.getState().getTerminal(id)?.devPreviewScrollPosition;
+      if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
         try {
           const loadedUrl = webview.getURL();
-          if (loadedUrl === saved.url && saved.scrollY > 0) {
-            webview.executeJavaScript(`window.scrollTo(0, ${saved.scrollY})`).catch(() => {});
+          if (loadedUrl === saved.url) {
+            webview
+              .executeJavaScript(
+                `requestAnimationFrame(() => window.scrollTo(0, ${saved.scrollY}))`
+              )
+              .catch(() => {});
           }
         } catch {
           // Webview not ready
@@ -743,7 +742,7 @@ export function DevPreviewPane({
           wv.executeJavaScript("window.scrollY")
             .then((scrollY: number) => {
               if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
-                scrollCache.set(id, { url: currentWebviewUrl, scrollY });
+                setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
               }
             })
             .catch(() => {});
@@ -761,7 +760,7 @@ export function DevPreviewPane({
         failLoadRetryRef.current = null;
       }
     }
-  }, [isEvicted, id]);
+  }, [isEvicted, id, setDevPreviewScrollPosition]);
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -238,6 +238,10 @@ export function DevPreviewPane({
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryCountRef = useRef<number>(0);
+  // Generation token to invalidate in-flight async scroll captures when the
+  // user clears scroll state via hard restart. A pending executeJavaScript
+  // promise that resolves after the clear must NOT write the stale position back.
+  const scrollCaptureGenerationRef = useRef<number>(0);
   const isConsoleOpen = terminal?.devPreviewConsoleOpen ?? false;
   const [webviewLoadError, setWebviewLoadError] = useState<string | null>(null);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
@@ -279,9 +283,11 @@ export function DevPreviewPane({
           const prevWebview = webviewRef.current;
           const currentWebviewUrl = prevWebview.getURL();
           if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
+            const captureGeneration = scrollCaptureGenerationRef.current;
             prevWebview
               .executeJavaScript("window.scrollY")
               .then((scrollY: number) => {
+                if (scrollCaptureGenerationRef.current !== captureGeneration) return;
                 if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
                   setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
                 }
@@ -321,9 +327,11 @@ export function DevPreviewPane({
       try {
         const currentWebviewUrl = webviewElement.getURL();
         if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
+          const captureGeneration = scrollCaptureGenerationRef.current;
           webviewElement
             .executeJavaScript("window.scrollY")
             .then((scrollY: number) => {
+              if (scrollCaptureGenerationRef.current !== captureGeneration) return;
               if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
                 setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
               }
@@ -416,6 +424,9 @@ export function DevPreviewPane({
   }, [start]);
 
   const handleHardRestart = useCallback(() => {
+    // Invalidate any in-flight async scroll captures so they can't write
+    // stale data back over the cleared position.
+    scrollCaptureGenerationRef.current += 1;
     setDevPreviewScrollPosition(id, undefined);
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);
@@ -691,6 +702,19 @@ export function DevPreviewPane({
         } catch {
           // WebContents not available
         }
+        // dom-ready already fired before this listener attached. Run scroll
+        // restore here so the position survives tab switches and other
+        // re-renders that don't trigger another dom-ready.
+        const saved = usePanelStore.getState().getTerminal(id)?.devPreviewScrollPosition;
+        if (saved && Number.isFinite(saved.scrollY) && saved.scrollY > 0 && saved.url) {
+          if (existingUrl === saved.url) {
+            webview
+              .executeJavaScript(
+                `requestAnimationFrame(() => window.scrollTo(0, ${saved.scrollY}))`
+              )
+              .catch(() => {});
+          }
+        }
       }
     } catch {
       // Webview not yet attached to DOM - dom-ready handler will take over
@@ -739,8 +763,10 @@ export function DevPreviewPane({
         const wv = webviewRef.current;
         const currentWebviewUrl = wv.getURL();
         if (currentWebviewUrl && currentWebviewUrl !== "about:blank") {
+          const captureGeneration = scrollCaptureGenerationRef.current;
           wv.executeJavaScript("window.scrollY")
             .then((scrollY: number) => {
+              if (scrollCaptureGenerationRef.current !== captureGeneration) return;
               if (typeof scrollY === "number" && Number.isFinite(scrollY)) {
                 setDevPreviewScrollPosition(id, { url: currentWebviewUrl, scrollY });
               }

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -2,7 +2,7 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DevPreviewPaneProps } from "../DevPreviewPane";
-import { DevPreviewPane, _resetScrollCacheForTests } from "../DevPreviewPane";
+import { DevPreviewPane } from "../DevPreviewPane";
 
 type MockWebviewElement = HTMLElement & {
   reload: ReturnType<typeof vi.fn>;
@@ -57,6 +57,7 @@ type DevServerState = {
 
 const {
   terminalStoreState,
+  scrollPositionRef,
   usePanelStoreMock,
   useProjectStoreMock,
   useProjectSettingsStoreMock,
@@ -64,15 +65,27 @@ const {
   useDevServerMock,
   useIsDraggingMock,
 } = vi.hoisted(() => {
+  const scrollPositionRef: { current: { url: string; scrollY: number } | undefined } = {
+    current: undefined,
+  };
   const terminalStoreState = {
     getTerminal: vi.fn(),
     setBrowserUrl: vi.fn(),
     setBrowserHistory: vi.fn(),
     setBrowserZoom: vi.fn(),
     setDevPreviewConsoleOpen: vi.fn(),
+    setViewportPreset: vi.fn(),
+    setDevPreviewScrollPosition: vi.fn(
+      (_id: string, position: { url: string; scrollY: number } | undefined) => {
+        scrollPositionRef.current = position;
+      }
+    ),
   };
-  const usePanelStoreMock = vi.fn((selector: (state: typeof terminalStoreState) => unknown) =>
-    selector(terminalStoreState)
+  const usePanelStoreMock = Object.assign(
+    vi.fn((selector: (state: typeof terminalStoreState) => unknown) =>
+      selector(terminalStoreState)
+    ),
+    { getState: () => terminalStoreState }
   );
 
   const projectStoreState = {
@@ -118,6 +131,7 @@ const {
 
   return {
     terminalStoreState,
+    scrollPositionRef,
     usePanelStoreMock,
     useProjectStoreMock,
     useProjectSettingsStoreMock,
@@ -223,7 +237,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
-    _resetScrollCacheForTests();
+    scrollPositionRef.current = undefined;
     originalCreateElement = document.createElement.bind(document);
     document.createElement = ((tagName: string, options?: ElementCreationOptions) => {
       const element = originalCreateElement(tagName, options);
@@ -242,6 +256,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       browserZoom: 1.4,
       devPreviewConsoleOpen: false,
       devCommand: "npm run dev",
+      devPreviewScrollPosition: scrollPositionRef.current,
     }));
     devServerStateRef.current = {
       status: "running",
@@ -588,6 +603,10 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     expect(webview.executeJavaScript).toHaveBeenCalledWith("window.scrollY");
+    expect(terminalStoreState.setDevPreviewScrollPosition).toHaveBeenCalledWith(
+      "dev-preview-panel-1",
+      { url: "http://localhost:5173/", scrollY: 250 }
+    );
   });
 
   it("restores scroll position on dom-ready after remount", async () => {
@@ -625,7 +644,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       emitWebviewEvent(newWebview, "dom-ready");
     });
 
-    expect(newWebview.executeJavaScript).toHaveBeenCalledWith("window.scrollTo(0, 250)");
+    expect(newWebview.executeJavaScript).toHaveBeenCalledWith(
+      "requestAnimationFrame(() => window.scrollTo(0, 250))"
+    );
   });
 
   it("clears scroll cache on hard restart", async () => {
@@ -659,6 +680,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     // Hard restart clears cache
     fireEvent.click(screen.getByTestId("hard-restart"));
+
+    expect(terminalStoreState.setDevPreviewScrollPosition).toHaveBeenCalledWith(
+      "dev-preview-panel-1",
+      undefined
+    );
 
     // Remount
     devServerStateRef.current = {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -712,6 +712,85 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     expect(scrollToCalls).toHaveLength(0);
   });
 
+  it("ignores in-flight scroll captures that resolve after hard restart", async () => {
+    const { container, rerender } = render(<DevPreviewPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+
+    // Build a manually-resolvable promise so we can interleave the hard restart
+    // before the capture promise resolves.
+    let resolveScrollY: (v: number) => void = () => {};
+    const pending = new Promise<number>((resolve) => {
+      resolveScrollY = resolve;
+    });
+    webview.executeJavaScript.mockImplementationOnce(() => pending);
+
+    // Trigger a capture by transitioning away from running. The capture promise
+    // is now in-flight and parked on `pending`.
+    devServerStateRef.current = {
+      ...devServerStateRef.current,
+      status: "stopped",
+      url: null,
+    };
+    rerender(<DevPreviewPane {...baseProps} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Hard restart fires before the in-flight capture resolves.
+    fireEvent.click(screen.getByTestId("hard-restart"));
+
+    // The clear must have happened.
+    expect(terminalStoreState.setDevPreviewScrollPosition).toHaveBeenCalledWith(
+      "dev-preview-panel-1",
+      undefined
+    );
+
+    terminalStoreState.setDevPreviewScrollPosition.mockClear();
+
+    // Now resolve the previously parked capture.
+    await act(async () => {
+      resolveScrollY(987);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The stale capture must not have written anything back over the cleared state.
+    expect(terminalStoreState.setDevPreviewScrollPosition).not.toHaveBeenCalled();
+  });
+
+  it("does not restore scroll when saved URL differs from loaded URL", async () => {
+    scrollPositionRef.current = { url: "http://localhost:5173/old", scrollY: 250 };
+    const { container } = render(<DevPreviewPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+    webview.executeJavaScript.mockClear();
+
+    act(() => {
+      emitWebviewEvent(webview, "dom-ready");
+    });
+
+    const scrollToCalls = webview.executeJavaScript.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("scrollTo")
+    );
+    expect(scrollToCalls).toHaveLength(0);
+  });
+
+  it("does not restore scroll when saved scrollY is 0", async () => {
+    scrollPositionRef.current = { url: "http://localhost:5173/", scrollY: 0 };
+    const { container } = render(<DevPreviewPane {...baseProps} />);
+    const webview = getWebviewElement(container);
+    webview.executeJavaScript.mockClear();
+
+    act(() => {
+      emitWebviewEvent(webview, "dom-ready");
+    });
+
+    const scrollToCalls = webview.executeJavaScript.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].includes("scrollTo")
+    );
+    expect(scrollToCalls).toHaveLength(0);
+  });
+
   it("clears stale browserUrl when panel becomes unconfigured after settings load", async () => {
     // Start with settings loading (isUnconfigured = false during load)
     useProjectSettingsStoreMock.mockImplementation(

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -21,6 +21,7 @@ const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
       browserZoom: saved.browserZoom,
       devPreviewConsoleOpen: saved.devPreviewConsoleOpen,
       viewportPreset: saved.viewportPreset as ViewportPresetId | undefined,
+      devPreviewScrollPosition: saved.devPreviewScrollPosition,
       createdAt: saved.createdAt,
     };
   },

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -35,7 +35,6 @@ const MAX_AUTO_RECOVERY_ATTEMPTS = 1;
 /**
  * Module-level cache that persists the last successful ensure configKey across
  * React unmount/remount cycles (e.g. dock ↔ grid transitions). Keyed by panelId.
- * Mirrors the scrollCache pattern in DevPreviewPane.tsx.
  */
 const persistedEnsureCache = new Map<string, string>();
 

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -63,6 +63,7 @@ const PERSISTED_DEV_PREVIEW_FIELDS = [
   "browserHistory",
   "browserZoom",
   "devPreviewConsoleOpen",
+  "devPreviewScrollPosition",
   "exitBehavior",
 ] as const satisfies readonly (keyof DevPreviewData)[];
 
@@ -132,6 +133,7 @@ const devPreviewFixture: TerminalInstance = {
   browserHistory: browserHistoryFixture,
   browserZoom: 1,
   devPreviewConsoleOpen: false,
+  devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 250 },
   exitBehavior: "keep",
 };
 
@@ -152,6 +154,7 @@ const savedDevPreview: SavedTerminalData = {
   browserHistory: browserHistoryFixture,
   browserZoom: 1,
   devPreviewConsoleOpen: false,
+  devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 250 },
   exitBehavior: "keep",
   createdAt: 1_700_000_000_000,
 };

--- a/src/panels/__tests__/registry.roundtrip.test.ts
+++ b/src/panels/__tests__/registry.roundtrip.test.ts
@@ -49,6 +49,7 @@ type PersistedDevPreviewFields =
   | "browserHistory"
   | "browserZoom"
   | "devPreviewConsoleOpen"
+  | "devPreviewScrollPosition"
   | "exitBehavior";
 
 const browserHistoryArb = fc.record({
@@ -94,6 +95,11 @@ const browserArbSpec = {
   browserConsoleOpen: fc.option(fc.boolean(), { nil: undefined }),
 } satisfies { [K in PersistedBrowserFields]-?: fc.Arbitrary<BrowserData[K]> };
 
+const scrollPositionArb = fc.record({
+  url: fc.string(),
+  scrollY: fc.double({ min: 0, max: 1_000_000, noNaN: true, noDefaultInfinity: true }),
+});
+
 const devPreviewArbSpec = {
   cwd: fc.string(),
   devCommand: fc.option(fc.string(), { nil: undefined }),
@@ -101,6 +107,7 @@ const devPreviewArbSpec = {
   browserHistory: fc.option(browserHistoryArb, { nil: undefined }),
   browserZoom: fc.option(zoomArb, { nil: undefined }),
   devPreviewConsoleOpen: fc.option(fc.boolean(), { nil: undefined }),
+  devPreviewScrollPosition: fc.option(scrollPositionArb, { nil: undefined }),
   exitBehavior: fc.option(exitBehaviorArb, { nil: undefined }),
 } satisfies { [K in PersistedDevPreviewFields]-?: fc.Arbitrary<DevPreviewData[K]> };
 
@@ -203,6 +210,7 @@ describe("panel serializer round-trip (property tests)", () => {
         expect(restored.browserHistory).toEqual(fields.browserHistory);
         expect(restored.browserZoom).toBe(fields.browserZoom);
         expect(restored.devPreviewConsoleOpen).toBe(fields.devPreviewConsoleOpen);
+        expect(restored.devPreviewScrollPosition).toEqual(fields.devPreviewScrollPosition);
 
         // exitBehavior is NOT returned by getDeserializer("dev-preview"); the real
         // restore path adds it via buildArgsForNonPtyRecreation's base args before

--- a/src/panels/dev-preview/defaults.ts
+++ b/src/panels/dev-preview/defaults.ts
@@ -17,5 +17,6 @@ export function createDevPreviewDefaults(
     devPreviewConsoleOpen: options.devPreviewConsoleOpen,
     exitBehavior: options.exitBehavior,
     viewportPreset: options.viewportPreset,
+    devPreviewScrollPosition: options.devPreviewScrollPosition,
   };
 }

--- a/src/panels/dev-preview/serializer.ts
+++ b/src/panels/dev-preview/serializer.ts
@@ -20,6 +20,9 @@ export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelS
       devPreviewConsoleOpen: t.devPreviewConsoleOpen,
     }),
     ...(t.viewportPreset !== undefined && { viewportPreset: t.viewportPreset }),
+    ...(t.devPreviewScrollPosition !== undefined && {
+      devPreviewScrollPosition: t.devPreviewScrollPosition,
+    }),
     ...(t.createdAt !== undefined && { createdAt: t.createdAt }),
     ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
   };

--- a/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
@@ -152,6 +152,27 @@ describe("setDevPreviewScrollPosition", () => {
     expect(saveMock).not.toHaveBeenCalled();
   });
 
+  it("skips persistence when clearing an already-cleared position", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dev-1": {
+          id: "dev-1",
+          kind: "dev-preview",
+          title: "Dev",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["dev-1"],
+    });
+
+    usePanelStore.getState().setDevPreviewScrollPosition("dev-1", undefined);
+
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
   it("skips persistence when value is identical", () => {
     usePanelStore.setState({
       panelsById: {

--- a/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/setDevPreviewScrollPosition.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+const saveMock = vi.fn();
+
+vi.mock("../../../persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: saveMock,
+    saveTabGroups: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+const { usePanelStore } = await import("../../../panelStore");
+
+describe("setDevPreviewScrollPosition", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      electron: {},
+    });
+
+    const { reset } = usePanelStore.getState();
+    await reset();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("stores the scroll position on a dev-preview panel and triggers persistence", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dev-1": {
+          id: "dev-1",
+          kind: "dev-preview",
+          title: "Dev",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["dev-1"],
+    });
+
+    usePanelStore
+      .getState()
+      .setDevPreviewScrollPosition("dev-1", { url: "http://localhost:3000", scrollY: 420 });
+
+    const stored = usePanelStore.getState().panelsById["dev-1"];
+    expect(stored?.kind).toBe("dev-preview");
+    expect(stored?.devPreviewScrollPosition).toEqual({
+      url: "http://localhost:3000",
+      scrollY: 420,
+    });
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it("clears the scroll position when called with undefined", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dev-1": {
+          id: "dev-1",
+          kind: "dev-preview",
+          title: "Dev",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 100 },
+        },
+      },
+      panelIds: ["dev-1"],
+    });
+
+    usePanelStore.getState().setDevPreviewScrollPosition("dev-1", undefined);
+
+    const stored = usePanelStore.getState().panelsById["dev-1"];
+    expect(stored?.devPreviewScrollPosition).toBeUndefined();
+  });
+
+  it("is a no-op for non-dev-preview kinds", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "browser-1": {
+          id: "browser-1",
+          kind: "browser",
+          title: "Browser",
+          location: "grid",
+        },
+      },
+      panelIds: ["browser-1"],
+    });
+
+    usePanelStore
+      .getState()
+      .setDevPreviewScrollPosition("browser-1", { url: "https://example.com", scrollY: 200 });
+
+    const stored = usePanelStore.getState().panelsById["browser-1"] as
+      | Record<string, unknown>
+      | undefined;
+    expect(stored?.devPreviewScrollPosition).toBeUndefined();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("skips persistence when value is identical", () => {
+    usePanelStore.setState({
+      panelsById: {
+        "dev-1": {
+          id: "dev-1",
+          kind: "dev-preview",
+          title: "Dev",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          devPreviewScrollPosition: { url: "http://localhost:3000", scrollY: 420 },
+        },
+      },
+      panelIds: ["dev-1"],
+    });
+
+    usePanelStore
+      .getState()
+      .setDevPreviewScrollPosition("dev-1", { url: "http://localhost:3000", scrollY: 420 });
+
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -14,6 +14,7 @@ export const createBrowserActions = (
   | "setBrowserConsoleOpen"
   | "setDevPreviewConsoleOpen"
   | "setViewportPreset"
+  | "setDevPreviewScrollPosition"
   | "setDevServerState"
   | "setSpawnError"
   | "clearSpawnError"
@@ -101,6 +102,27 @@ export const createBrowserActions = (
       const newById = {
         ...state.panelsById,
         [id]: { ...terminal, viewportPreset: preset },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setDevPreviewScrollPosition: (id, position) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+
+      const existing = terminal.devPreviewScrollPosition;
+      if (existing === position) return state;
+      if (existing?.url === position?.url && existing?.scrollY === position?.scrollY) {
+        return state;
+      }
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, devPreviewScrollPosition: position },
       };
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -160,6 +160,10 @@ export interface PanelRegistrySlice {
     id: string,
     preset: import("@shared/types/panel.js").ViewportPresetId | undefined
   ) => void;
+  setDevPreviewScrollPosition: (
+    id: string,
+    position: { url: string; scrollY: number } | undefined
+  ) => void;
   setDevServerState: (
     id: string,
     status: "stopped" | "starting" | "installing" | "running" | "error",

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -37,6 +37,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   devServerTerminalId?: string | null;
   devPreviewConsoleOpen?: boolean;
   viewportPreset?: string;
+  devPreviewScrollPosition?: { url: string; scrollY: number };
 }
 
 export interface SavedTerminalData {
@@ -61,6 +62,7 @@ export interface SavedTerminalData {
   devCommand?: string;
   devPreviewConsoleOpen?: boolean;
   viewportPreset?: string;
+  devPreviewScrollPosition?: { url: string; scrollY: number };
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];
@@ -215,6 +217,7 @@ export function buildArgsForBackendTerminal(
     browserHistory: isDevPreview ? saved.browserHistory : undefined,
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+    devPreviewScrollPosition: isDevPreview ? saved.devPreviewScrollPosition : undefined,
     exitBehavior: saved.exitBehavior,
     agentSessionId: backendTerminal.agentSessionId ?? saved.agentSessionId,
     agentLaunchFlags: backendTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,
@@ -275,6 +278,7 @@ export function buildArgsForReconnectedFallback(
     browserHistory: isDevPreview ? saved.browserHistory : undefined,
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+    devPreviewScrollPosition: isDevPreview ? saved.devPreviewScrollPosition : undefined,
     exitBehavior: saved.exitBehavior,
     agentSessionId: reconnectedTerminal.agentSessionId ?? saved.agentSessionId,
     agentLaunchFlags: reconnectedTerminal.agentLaunchFlags ?? saved.agentLaunchFlags,


### PR DESCRIPTION
## Summary

- Dev-preview scroll position was stored in a module-scope `Map` that died with the renderer. Moved it onto `DevPreviewPanelData` so it flows through `panelStore` and `panelPersistence` the same way `browserUrl`, `browserHistory`, and `browserZoom` already do.
- Added a generation counter that invalidates any in-flight async scroll capture when a hard-restart fires, closing the race where a stale position could overwrite fresh state after restart.
- The tab-switch restore gap is also closed: scroll restore now runs in the already-loaded fast path, so re-renders that attach `dom-ready` after it already fired still recover the saved position.

Resolves #5916

## Changes

- `shared/types/panel.ts` / `project.ts` / `addPanelOptions.ts` — added `devPreviewScrollPosition: { url, scrollY }` field to type plumbing
- `src/panels/dev-preview/serializer.ts` + `defaults.ts` — kind-module persistence wired up
- `src/config/panelKindSerialisers.ts` — deserializer updated
- `src/store/slices/panelRegistry/browser.ts` + `types.ts` — `setDevPreviewScrollPosition` store action
- `src/components/DevPreview/DevPreviewPane.tsx` — capture sites, restore logic, hard-restart generation counter, RAF wrap
- `src/utils/stateHydration/statePatcher.ts` — `SavedTerminalData` / `AddTerminalArgs` builders updated

## Testing

- 46 unit tests pass covering the new store action (`setDevPreviewScrollPosition.test.ts`), serialiser round-trips (`registry.roundtrip.test.ts`), field coverage ratchet (`registry.fieldcoverage.test.ts`), and webview integration scenarios (`DevPreviewPane.webview.test.tsx`)
- Typecheck, lint ratchet, and format checks all clean