### PR TITLE
fix(worktree): use neutral tokens for drag handle during sort

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -770,7 +770,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
                 className={cn(
                   "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors",
                   isDraggingSort
-                    ? "bg-accent-primary/20 text-accent-primary"
+                    ? "bg-overlay-emphasis text-text-primary"
                     : isWorktreeSortDragging
                       ? "text-text-primary/30 hover:text-text-primary/50 hover:bg-overlay-soft"
                       : "text-transparent hover:text-text-primary/30 hover:bg-overlay-soft"


### PR DESCRIPTION
## Summary

- The grip handle on a worktree card was painting in accent (`bg-accent-primary/20 text-accent-primary`) while dragging to reorder. The cursor is already `cursor-grabbing` and the card is in motion, so the colour signal is redundant.
- Swapped to `bg-overlay-emphasis text-text-primary` (a neutral elevation tint), consistent with how VS Code, Linear, and Notion handle drag handles: keep the handle neutral, let motion and cursor carry the drag state.
- Aligns with the accent-restraint rule in CLAUDE.md — accent is a scarce signal, not a default highlight for interactive states.

Resolves #5984

## Changes

- `src/components/Worktree/WorktreeCard.tsx` line 773: swap accent classes on the `isDraggingSort` grip handle to neutral elevation tokens.

## Testing

- Vitest: 31/31 passing
- TypeScript: clean
- ESLint: 361 warnings (baseline, no new)
- Prettier: clean
- Build: clean