### PR TITLE
fix(panels): neutralize Exit Focus button to ghost-button pattern

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -1075,7 +1075,7 @@ function PanelHeaderComponent({
                   onToggleMaximize();
                 }}
                 onPointerDown={(e) => e.stopPropagation()}
-                className="flex items-center gap-1.5 px-2 py-1 bg-daintree-accent/10 text-daintree-accent hover:bg-daintree-accent/20 rounded transition-colors mr-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                className="flex items-center gap-1.5 px-2 py-1 hover:bg-daintree-text/10 focus-visible:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors"
                 aria-label="Exit Focus mode and restore grid view"
               >
                 <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- The Exit Focus button in maximised panel headers was styled as an accent badge (`bg-daintree-accent/10 text-daintree-accent`), competing directly with the accent macro-focus ring the panel itself wears.
- Swapped to the canonical ghost-button pattern used by all other sibling header controls: neutral text, hover/focus states without accent colouring, and the accent outline kept only for keyboard navigation.
- The text label is preserved so the escape affordance stays discoverable on first encounter — neutral doesn't mean invisible.

Resolves #5985

## Changes

- `src/components/Panel/PanelHeader.tsx` line 1078: removed `bg-daintree-accent/10`, `text-daintree-accent`, `hover:bg-daintree-accent/20`, `rounded`, `mr-1`; added `hover:bg-daintree-text/10`, `focus-visible:bg-daintree-text/10`, `text-daintree-text/60`, `hover:text-daintree-text`.

## Testing

- Verified typecheck, lint ratchet, format check, and channel drift all pass clean.
- Visually: Exit Focus button renders as a quiet sibling control; the macro-focus ring on the maximised panel is now the sole accent signal in that view.