### PR TITLE
fix(panels): drop accent border from inline title-edit inputs

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -731,7 +731,7 @@ function PanelHeaderComponent({
               onChange={(e) => onEditingValueChange(e.target.value)}
               onKeyDown={onTitleInputKeyDown}
               onBlur={onTitleSave}
-              className="text-sm font-medium bg-daintree-bg/60 border border-daintree-accent/50 px-1 h-5 min-w-32 text-daintree-text select-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+              className="text-sm font-medium bg-daintree-bg/60 border border-border-strong px-1 h-5 min-w-32 text-daintree-text select-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
               aria-label={getAriaLabel()}
             />
           ) : (

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -272,7 +272,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               onClick={handleInputClick}
               onDoubleClick={handleInputDoubleClick}
               onPointerDown={handleInputPointerDown}
-              className="text-xs bg-daintree-bg/80 border border-daintree-accent/50 px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent"
+              className="text-xs bg-daintree-bg/80 border border-border-strong px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent"
               aria-label={`Rename tab ${title}`}
             />
           ) : (


### PR DESCRIPTION
## Summary

- Both `PanelHeader` and `TabButton` rename inputs had a persistent `border-daintree-accent/50` that duplicated the accent focus outline already on the widget.
- Swapped to `border-border-strong` (neutral) so accent only appears via `focus-visible` outline, not the resting state.
- One canonical pattern across both rename inputs, consistent with the 2025/2026 convention VS Code and Notion use for inline edits.

Resolves #5983

## Changes

- `src/components/Panel/PanelHeader.tsx` line 734: `border-daintree-accent/50` → `border-border-strong`
- `src/components/Panel/TabButton.tsx` line 275: `border-daintree-accent/50` → `border-border-strong`

## Testing

Manually verified panel title rename and tab rename inputs: resting border is neutral, accent outline appears on focus, no double-accent on the widget.