### PR TITLE
fix(onboarding): replace accent checkmark with neutral selection state in theme picker

### DIFF
--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -727,9 +727,9 @@ function SelectionStep({
                   key={scheme.id}
                   onClick={() => onThemeSelect(scheme.id)}
                   className={cn(
-                    "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border-2 transition-colors text-left",
+                    "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border transition-colors text-left",
                     isSelected
-                      ? "border-daintree-accent bg-daintree-accent/10"
+                      ? "border-border-strong bg-overlay-selected"
                       : "border-daintree-border bg-daintree-bg hover:border-daintree-text/30"
                   )}
                 >
@@ -746,11 +746,7 @@ function SelectionStep({
                         {isDark ? "Dark" : "Light"}
                       </span>
                     </div>
-                    {isSelected && (
-                      <div className="w-4 h-4 rounded-full bg-daintree-accent flex items-center justify-center">
-                        <Check className="w-2.5 h-2.5 text-accent-primary-foreground" />
-                      </div>
-                    )}
+                    {isSelected && <Check className="w-3.5 h-3.5 text-daintree-text shrink-0" />}
                   </div>
                 </button>
               );

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -718,13 +718,16 @@ function SelectionStep({
           <p className="text-sm text-daintree-text/60 mb-4">
             Choose your preferred theme. More options available in Settings.
           </p>
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-4" role="listbox" aria-label="Theme">
             {schemes.map((scheme) => {
               const isSelected = selectedSchemeId === scheme.id;
               const isDark = scheme.type === "dark";
               return (
                 <button
                   key={scheme.id}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
                   onClick={() => onThemeSelect(scheme.id)}
                   className={cn(
                     "flex flex-col gap-2 p-3 rounded-[var(--radius-md)] border transition-colors text-left",


### PR DESCRIPTION
## Summary

- The theme card checkmark in the agent setup wizard was using `bg-daintree-accent` + `text-accent-primary-foreground`, which drifted back to the deprecated accent-badge treatment that #5955 cleaned up in `ColorSchemePicker` and `ThemeSelector`.
- Replaced with the canonical neutral pattern: `border-border-strong` + `bg-overlay-selected` + an inline `Check` icon in `text-foreground`, consistent with post-#5955 conventions.
- Added `role="listbox"`/`role="option"` + `aria-selected` + `type="button"` while here for a11y compliance.

Resolves #5986

## Changes

- `src/components/Setup/AgentSetupWizard.tsx`: swap accent-coloured checkmark badge for neutral border/fill selection state; add listbox/option ARIA semantics to the theme card grid.
- `ThemeMockup` data preview left untouched. The accent colours inside the mockup are intentional, they're previewing the theme's own accent, not chrome selection state.

## Testing

- 27/27 wizard unit tests pass.
- Typecheck, lint, format, and build all clean.
- Manually verified the theme picker renders correct neutral selection state and the mockup accent previews are unaffected.