### PR TITLE
fix(settings): type GitHub action dispatch results explicitly

### DIFF
--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -4,6 +4,7 @@ import { Key, Check, AlertCircle, FlaskConical, ExternalLink, Github } from "luc
 import { Spinner } from "@/components/ui/Spinner";
 import { useGitHubConfigStore } from "@/store";
 import { actionService } from "@/services/ActionService";
+import type { GitHubTokenConfig, GitHubTokenValidation } from "@/types";
 import { SettingsSection } from "./SettingsSection";
 
 type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
@@ -47,7 +48,7 @@ export function GitHubSettingsTab() {
     setErrorMessage(null);
 
     try {
-      const result = await actionService.dispatch(
+      const result = await actionService.dispatch<GitHubTokenValidation>(
         "github.setToken",
         { token: githubToken.trim() },
         { source: "user" }
@@ -55,18 +56,19 @@ export function GitHubSettingsTab() {
       if (!result.ok) {
         throw new Error(result.error.message);
       }
-      const validation = result.result as { valid: boolean; error?: string };
+      const validation = result.result;
       if (validation.valid) {
         setGithubToken("");
         setValidationResult("success");
-        const configResult = await actionService.dispatch("github.getConfig", undefined, {
-          source: "user",
-        });
+        const configResult = await actionService.dispatch<GitHubTokenConfig>(
+          "github.getConfig",
+          undefined,
+          { source: "user" }
+        );
         if (!configResult.ok) {
           throw new Error(configResult.error.message);
         }
-        const config = configResult.result as any;
-        updateConfig(config);
+        updateConfig(configResult.result);
         void actionService.dispatch("worktree.refresh", undefined, {
           source: "user",
         });
@@ -91,13 +93,15 @@ export function GitHubSettingsTab() {
       if (!clearResult.ok) {
         throw new Error(clearResult.error.message);
       }
-      const configResult = await actionService.dispatch("github.getConfig", undefined, {
-        source: "user",
-      });
+      const configResult = await actionService.dispatch<GitHubTokenConfig>(
+        "github.getConfig",
+        undefined,
+        { source: "user" }
+      );
       if (!configResult.ok) {
         throw new Error(configResult.error.message);
       }
-      updateConfig(configResult.result as any);
+      updateConfig(configResult.result);
       setValidationResult(null);
       setErrorMessage(null);
     } catch (error) {
@@ -115,7 +119,7 @@ export function GitHubSettingsTab() {
     setErrorMessage(null);
 
     try {
-      const result = await actionService.dispatch(
+      const result = await actionService.dispatch<GitHubTokenValidation>(
         "github.validateToken",
         { token: githubToken.trim() },
         { source: "user" }
@@ -123,7 +127,7 @@ export function GitHubSettingsTab() {
       if (!result.ok) {
         throw new Error(result.error.message);
       }
-      const validation = result.result as { valid: boolean; error?: string };
+      const validation = result.result;
       setValidationResult(validation.valid ? "test-success" : "test-error");
       if (!validation.valid) {
         setErrorMessage(validation.error || "Invalid token");

--- a/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
@@ -39,7 +39,7 @@ describe("GitHubSettingsTab handleSaveToken", () => {
   it("dispatches worktree.refresh after a successful token save so the sidebar re-fetches", async () => {
     mockedDispatch.mockImplementation(async (actionId: string) => {
       if (actionId === "github.setToken") {
-        return { ok: true, result: { valid: true } } as never;
+        return { ok: true, result: { valid: true, scopes: [] } } as never;
       }
       if (actionId === "github.getConfig") {
         return {
@@ -80,7 +80,7 @@ describe("GitHubSettingsTab handleSaveToken", () => {
       if (actionId === "github.setToken") {
         return {
           ok: true,
-          result: { valid: false, error: "Invalid token" },
+          result: { valid: false, scopes: [], error: "Invalid token" },
         } as never;
       }
       return { ok: true, result: undefined } as never;


### PR DESCRIPTION
## Summary

- Removed 4 unsafe casts (`as any` and inline `{ valid: boolean; error?: string }` shapes) from `GitHubSettingsTab.tsx` by passing typed generics to `actionService.dispatch<GitHubTokenValidation>` and `actionService.dispatch<GitHubTokenConfig>`
- Types imported from `@/types` rather than redefined inline, so the compiler enforces the contract end-to-end
- No behavioural change, purely type-level hygiene

Resolves #5972

## Changes

- `src/components/Settings/GitHubSettingsTab.tsx`: added `GitHubTokenValidation` and `GitHubTokenConfig` imports, replaced 4 unsafe casts with typed dispatch generics
- `src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx`: aligned mock fixtures to include `scopes: []` as required by the `GitHubTokenValidation` interface

## Testing

- `npm run check` passes clean (typecheck + lint + format)
- All 9 tests in the Settings suite pass
- `lint:ratchet` shows 2 fewer warnings than baseline (the two removed `as any` casts)