### PR TITLE
fix(toolbar): drop accent colour on routine agent button hover/focus

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -341,8 +341,6 @@ export function AgentButton({
                   onPointerEnter={clearFocusRestoreSuppression}
                   className={cn(
                     "toolbar-agent-button text-daintree-text transition-colors relative",
-                    isReady &&
-                      "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
                     needsSetup && "opacity-70"
                   )}
                   aria-label={ariaLabel}
@@ -435,8 +433,6 @@ export function AgentButton({
                 onPointerEnter={clearFocusRestoreSuppression}
                 className={cn(
                   "toolbar-agent-button text-daintree-text transition-colors rounded-r-none border-r border-transparent relative",
-                  isReady &&
-                    "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
                   needsSetup && "opacity-70"
                 )}
                 aria-label={ariaLabel}
@@ -466,7 +462,6 @@ export function AgentButton({
                     className={cn(
                       "toolbar-agent-button text-daintree-text transition-colors rounded-l-none",
                       "h-8 w-6 p-0 flex items-center justify-center",
-                      "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]",
                       !isReady && !isLoading && "opacity-60"
                     )}
                     aria-label={chevronTooltip}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -570,7 +570,7 @@ export function AgentTrayButton({
               variant="ghost"
               size="icon"
               data-toolbar-item={dataToolbarItem}
-              className="toolbar-agent-button text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] transition-colors"
+              className="toolbar-agent-button text-daintree-text transition-colors"
               aria-label={showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"}
               onPointerEnter={clearFocusRestoreSuppression}
             >

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -26,14 +26,17 @@
   box-shadow: var(--_hover-shadow);
 }
 
-.toolbar-agent-button:hover,
-.toolbar-agent-button:focus-visible {
+.toolbar-agent-button:hover {
   background: var(
     --toolbar-agent-hover-bg,
     var(--toolbar-control-hover-bg, var(--theme-overlay-elevated))
   );
-  color: var(--_hover-fg);
   box-shadow: var(--_hover-shadow);
+}
+
+.toolbar-agent-button:focus-visible {
+  outline: 2px solid var(--theme-accent-primary);
+  outline-offset: 2px;
 }
 
 .toolbar-icon-button:active,


### PR DESCRIPTION
## Summary

- Agent buttons were shifting their icon colour to the accent on every hover and focus-visible event. With eight buttons sitting side by side, accent became a generic \"this is interactive\" affordance rather than a load-bearing signal.
- Hover now gets a neutral background lift only (background + box-shadow). Focus-visible gets the canonical WCAG 2.4.13 outline ring instead of a colour change, consistent with the rest of the app.
- Removed the redundant inline `hover:text-[var(--toolbar-control-hover-fg,...)]` and `focus-visible:text-[...]` Tailwind classes from `AgentButton` and `AgentTrayButton` — the CSS layer handles it.

Resolves #5980

## Changes

- `src/styles/components/toolbar.css` — split the combined `:hover`/`:focus-visible` rule; hover keeps background + box-shadow, focus-visible becomes a 2px solid outline ring.
- `src/components/Layout/AgentButton.tsx` — removed redundant inline accent text classes from the primary button, split-primary half, and split-chevron half.
- `src/components/Layout/AgentTrayButton.tsx` — same inline cleanup on the tray trigger.

Active/armed agent states (status dot, accent colour) are unaffected. No theme files changed.

## Testing

84 unit tests pass, ESLint clean, typecheck clean, format clean. Lint ratchet maintained.