### PR TITLE
fix(ui): suppress hover styles on disabled hand-rolled buttons

### DIFF
--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -282,7 +282,7 @@ export function BrowserToolbar({
               type="button"
               onClick={onBack}
               disabled={!canGoBack}
-              className={buttonClass}
+              className={cn(buttonClass, "disabled:pointer-events-none")}
               aria-label="Go back"
               data-testid="browser-back"
             >
@@ -299,7 +299,7 @@ export function BrowserToolbar({
               type="button"
               onClick={onForward}
               disabled={!canGoForward}
-              className={buttonClass}
+              className={cn(buttonClass, "disabled:pointer-events-none")}
               aria-label="Go forward"
               data-testid="browser-forward"
             >
@@ -342,7 +342,7 @@ export function BrowserToolbar({
                   type="button"
                   onClick={() => handleZoomStep("out")}
                   disabled={!canZoomOut}
-                  className={buttonClass}
+                  className={cn(buttonClass, "disabled:pointer-events-none")}
                   aria-label="Zoom out"
                 >
                   <ZoomOut className="w-3.5 h-3.5" />
@@ -360,7 +360,7 @@ export function BrowserToolbar({
                   disabled={!isNonDefaultZoom}
                   className={cn(
                     "px-1.5 py-1 rounded text-xs font-medium transition-colors",
-                    "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed",
+                    "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none",
                     isNonDefaultZoom ? "text-status-info" : "text-daintree-text/60"
                   )}
                   aria-label="Reset zoom"
@@ -378,7 +378,7 @@ export function BrowserToolbar({
                   type="button"
                   onClick={() => handleZoomStep("in")}
                   disabled={!canZoomIn}
-                  className={buttonClass}
+                  className={cn(buttonClass, "disabled:pointer-events-none")}
                   aria-label="Zoom in"
                 >
                   <ZoomIn className="w-3.5 h-3.5" />
@@ -593,7 +593,7 @@ export function BrowserToolbar({
               type="button"
               onClick={onCaptureScreenshot}
               disabled={!isWebviewReady}
-              className={buttonClass}
+              className={cn(buttonClass, "disabled:hover:bg-transparent")}
               aria-label="Capture screenshot"
             >
               <Camera className="w-4 h-4" />
@@ -629,7 +629,7 @@ export function BrowserToolbar({
               type="button"
               onClick={onToggleDevTools}
               disabled={!isWebviewReady}
-              className={buttonClass}
+              className={cn(buttonClass, "disabled:hover:bg-transparent")}
               aria-label="Toggle DevTools"
             >
               <Code className="w-4 h-4" />

--- a/src/components/Browser/FindBar.tsx
+++ b/src/components/Browser/FindBar.tsx
@@ -68,7 +68,7 @@ export function FindBar({ find }: FindBarProps) {
         type="button"
         onClick={goPrev}
         disabled={matchCount === 0}
-        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 text-daintree-text/70"
+        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 disabled:pointer-events-none text-daintree-text/70"
         aria-label="Previous match"
       >
         <ChevronUp className="w-3.5 h-3.5" />
@@ -77,7 +77,7 @@ export function FindBar({ find }: FindBarProps) {
         type="button"
         onClick={goNext}
         disabled={matchCount === 0}
-        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 text-daintree-text/70"
+        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 disabled:pointer-events-none text-daintree-text/70"
         aria-label="Next match"
       >
         <ChevronDown className="w-3.5 h-3.5" />

--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -124,7 +124,7 @@ export function ConsoleDrawer({
                   onClick={onHardRestart}
                   disabled={hardRestartDisabled}
                   className={cn(
-                    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed transition-colors",
+                    "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors",
                     isRestarting && "animate-spin"
                   )}
                   aria-label={restartTooltip}

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -290,7 +290,7 @@ export function FileViewerModal({
                   "px-2.5 py-1 text-xs font-medium rounded transition-colors",
                   mode === "view"
                     ? "bg-daintree-border text-daintree-text"
-                    : "text-muted-foreground hover:text-daintree-text disabled:opacity-40 disabled:cursor-not-allowed"
+                    : "text-muted-foreground hover:text-daintree-text disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                 )}
               >
                 View

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -702,7 +702,7 @@ export function FleetArmingRibbon(): ReactElement | null {
                 disabled={isSendingBroadcast}
                 onClick={() => void confirmPendingBroadcast()}
                 data-testid="fleet-paste-confirm-send"
-                className="rounded bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
               >
                 Send anyway
               </button>

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -301,7 +301,7 @@ export function SettingsShortcutCapture({
                 <button
                   onClick={() => handleUnbindConflict(conflict)}
                   disabled={isUnbinding}
-                  className="flex items-center gap-1 px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex items-center gap-1 px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                 >
                   <X className="w-3 h-3" />
                   <span>Unbind</span>

--- a/src/components/Portal/PortalToolbar.tsx
+++ b/src/components/Portal/PortalToolbar.tsx
@@ -241,7 +241,7 @@ export function PortalToolbar({
                 onClick={onGoBack}
                 disabled={!activeTabId}
                 aria-label="Go back"
-                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ArrowLeft className="w-3.5 h-3.5" />
               </button>
@@ -254,7 +254,7 @@ export function PortalToolbar({
                 onClick={onGoForward}
                 disabled={!activeTabId}
                 aria-label="Go forward"
-                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ArrowRight className="w-3.5 h-3.5" />
               </button>
@@ -267,7 +267,7 @@ export function PortalToolbar({
                 onClick={onReload}
                 disabled={!activeTabId}
                 aria-label="Reload"
-                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <RotateCw className="w-3.5 h-3.5" />
               </button>
@@ -280,7 +280,7 @@ export function PortalToolbar({
                 onClick={onCopyUrl}
                 disabled={!activeTabId || !hasActiveUrl}
                 aria-label="Copy URL"
-                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <Link2 className="w-3.5 h-3.5" />
               </button>
@@ -293,7 +293,7 @@ export function PortalToolbar({
                 onClick={onOpenExternal}
                 disabled={!activeTabId || !hasActiveUrl}
                 aria-label="Open in external browser"
-                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="p-1 rounded hover:bg-tint/[0.06] text-muted-foreground hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ExternalLink className="w-3.5 h-3.5" />
               </button>

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -199,7 +199,7 @@ export function AutomationTab({
                         }
                       }}
                       disabled={index === 0}
-                      className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                       aria-label="Move run command up"
                     >
                       <ChevronUp className="h-4 w-4" />
@@ -217,7 +217,7 @@ export function AutomationTab({
                         }
                       }}
                       disabled={index === runCommands.length - 1}
-                      className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                       aria-label="Move run command down"
                     >
                       <ChevronDown className="h-4 w-4" />

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -335,7 +335,7 @@ export function ProjectOnboardingWizard({
                                 }
                               }}
                               disabled={index === 0}
-                              className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                              className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                               aria-label="Move up"
                             >
                               <ChevronUp className="h-3.5 w-3.5" />
@@ -355,7 +355,7 @@ export function ProjectOnboardingWizard({
                                 }
                               }}
                               disabled={index === runCommands.length - 1}
-                              className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                              className="p-1 rounded hover:bg-daintree-border/50 disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                               aria-label="Move down"
                             >
                               <ChevronDown className="h-3.5 w-3.5" />

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -465,7 +465,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
           <button
             onClick={handleRefresh}
             disabled={isLoading}
-            className="pulse-control rounded-md p-1.5 text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50"
+            className="pulse-control rounded-md p-1.5 text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50 disabled:pointer-events-none"
             aria-label="Refresh"
           >
             <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} />

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -176,7 +176,7 @@ export function EditorIntegrationTab() {
                 onClick={handleRescan}
                 disabled={isRescanning}
                 title="Re-scan for installed editors"
-                className="p-2 rounded-[var(--radius-md)] border border-daintree-border hover:bg-tint/5 text-daintree-text/60 hover:text-daintree-text transition-colors disabled:opacity-40"
+                className="p-2 rounded-[var(--radius-md)] border border-daintree-border hover:bg-tint/5 text-daintree-text/60 hover:text-daintree-text transition-colors disabled:opacity-40 disabled:pointer-events-none"
               >
                 <RefreshCw className={cn("w-4 h-4", isRescanning && "animate-spin")} />
               </button>
@@ -244,7 +244,7 @@ export function EditorIntegrationTab() {
             <button
               onClick={handleSave}
               disabled={isSaving || !activeProjectId}
-              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 transition-colors"
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
             </button>
@@ -252,7 +252,7 @@ export function EditorIntegrationTab() {
             <button
               onClick={handleTest}
               disabled={isTesting}
-              className="px-4 py-2 rounded-[var(--radius-md)] border border-daintree-border text-sm text-daintree-text/70 hover:text-daintree-text hover:bg-tint/5 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+              className="px-4 py-2 rounded-[var(--radius-md)] border border-daintree-border text-sm text-daintree-text/70 hover:text-daintree-text hover:bg-tint/5 disabled:opacity-50 disabled:pointer-events-none transition-colors flex items-center gap-1.5"
             >
               <ExternalLink className="w-3.5 h-3.5" />
               {isTesting ? "Testing…" : "Test"}

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -170,7 +170,7 @@ export function ImageViewerTab() {
                 <button
                   onClick={handleSave}
                   disabled={isSaving || isLoading}
-                  className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
                 >
                   {isSaving ? "Saving…" : "Save"}
                 </button>

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -434,7 +434,7 @@ export function PortalSettingsTab() {
             <button
               onClick={handleAddLink}
               disabled={!newLinkName.trim() || !newLinkUrl.trim()}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-daintree-accent/90 transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:bg-daintree-accent/90 transition-colors"
             >
               <Plus className="w-4 h-4" />
               Add

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -296,10 +296,7 @@ export function PortalSettingsTab() {
                 )
               }
               disabled={link.alwaysEnabled}
-              className={cn(
-                "p-1.5 rounded hover:bg-daintree-border/50 text-daintree-text/50 hover:text-status-error",
-                link.alwaysEnabled && "opacity-50 cursor-not-allowed"
-              )}
+              className="p-1.5 rounded hover:bg-daintree-border/50 text-daintree-text/50 hover:text-status-error disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
             >
               <Trash2 className="w-4 h-4" />
             </button>

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -113,7 +113,7 @@ function CommandList({
                 type="button"
                 onClick={() => moveCommand(index, -1)}
                 disabled={index === 0}
-                className="p-0.5 rounded hover:bg-surface-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                className="p-0.5 rounded hover:bg-surface-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                 aria-label={`Move command ${index + 1} up`}
               >
                 <ChevronUp className="h-3 w-3 text-daintree-text" />
@@ -122,7 +122,7 @@ function CommandList({
                 type="button"
                 onClick={() => moveCommand(index, 1)}
                 disabled={index === commands.length - 1}
-                className="p-0.5 rounded hover:bg-surface-hover disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                className="p-0.5 rounded hover:bg-surface-hover disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
                 aria-label={`Move command ${index + 1} down`}
               >
                 <ChevronDown className="h-3 w-3 text-daintree-text" />

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -305,7 +305,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                       disabled={isInstalling || isBatchRunning}
                       onClick={() => handleMethodChange(agentId, idx)}
                       data-selected={idx === currentMethodIdx || undefined}
-                      className="px-1.5 py-0.5 rounded text-[10px] text-daintree-text/50 transition-colors hover:text-daintree-text/80 data-[selected]:bg-tint/[0.12] data-[selected]:text-daintree-text disabled:opacity-50"
+                      className="px-1.5 py-0.5 rounded text-[10px] text-daintree-text/50 transition-colors hover:text-daintree-text/80 data-[selected]:bg-tint/[0.12] data-[selected]:text-daintree-text disabled:opacity-50 disabled:pointer-events-none"
                     >
                       {block.label ?? `Method ${idx + 1}`}
                     </button>
@@ -365,7 +365,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
           type="button"
           disabled={isBatchRunning}
           onClick={handleInstallAll}
-          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 transition-colors disabled:opacity-50"
+          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {isBatchRunning ? (
             <>

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -143,7 +143,7 @@ export function SystemRequirementsSection({
             type="button"
             onClick={() => void runCheck()}
             disabled={isChecking}
-            className="inline-flex items-center gap-1.5 text-xs text-daintree-text/50 hover:text-daintree-text disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            className="inline-flex items-center gap-1.5 text-xs text-daintree-text/50 hover:text-daintree-text disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors"
           >
             <RotateCw className={`w-3 h-3 ${isChecking ? "animate-spin" : ""}`} />
             {isChecking ? "Checking..." : "Re-check"}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -950,7 +950,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <button
                   onClick={handleRefreshAll}
                   disabled={isRefreshing}
-                  className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/40"
                   aria-label="Refresh sidebar"
                 >
                   <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -143,7 +143,7 @@ function ArtifactItem({
               className={cn(
                 "px-3 py-1 text-xs rounded transition-colors",
                 "border border-status-info/30 text-status-info hover:bg-status-info/10",
-                "disabled:opacity-50 disabled:cursor-not-allowed"
+                "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
               )}
             >
               Copy Code
@@ -154,7 +154,7 @@ function ArtifactItem({
               className={cn(
                 "px-3 py-1 text-xs rounded transition-colors",
                 "bg-daintree-border hover:bg-[color-mix(in_oklab,var(--color-daintree-border)_100%,white_20%)] text-daintree-text",
-                "disabled:opacity-50 disabled:cursor-not-allowed"
+                "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
               )}
             >
               Save to File
@@ -354,7 +354,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   type="button"
                   onClick={clearArtifacts}
                   disabled={isBulkActionRunning}
-                  className="text-xs text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="text-xs text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Clear all artifacts"
                 >
                   Clear
@@ -363,7 +363,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                   type="button"
                   onClick={() => setIsExpanded(false)}
                   disabled={isBulkActionRunning}
-                  className="text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="text-daintree-text/40 hover:text-daintree-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Close artifact overlay"
                 >
                   ×
@@ -400,7 +400,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                                 ? "bg-daintree-border text-daintree-text"
                                 : "bg-daintree-sidebar text-daintree-text/60",
                               "hover:brightness-110",
-                              "disabled:opacity-50 disabled:cursor-not-allowed"
+                              "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                             )}
                           >
                             {includeAllTypes ? "All" : "Code"}
@@ -421,7 +421,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                     className={cn(
                       "px-3 py-1 text-xs rounded transition-colors",
                       "bg-daintree-border hover:bg-[color-mix(in_oklab,var(--color-daintree-border)_100%,white_20%)] text-daintree-text",
-                      "disabled:opacity-50 disabled:cursor-not-allowed"
+                      "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                     )}
                   >
                     Save All
@@ -438,7 +438,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
                           className={cn(
                             "px-3 py-1 text-xs rounded transition-colors",
                             "bg-status-success hover:brightness-110 text-daintree-bg",
-                            "disabled:opacity-50 disabled:cursor-not-allowed"
+                            "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                           )}
                         >
                           Apply All Patches

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -169,7 +169,7 @@ function ArtifactItem({
                       className={cn(
                         "px-3 py-1 text-xs rounded transition-colors",
                         "bg-status-success hover:brightness-110 text-daintree-bg",
-                        "disabled:opacity-50 disabled:cursor-not-allowed"
+                        "disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                       )}
                     >
                       Apply Patch

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -50,7 +50,7 @@ export function RecipeRunnerItem({
             type="button"
             onClick={() => onRun(recipe.id)}
             disabled={disabled}
-            className="group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
+            className="group flex flex-col items-start gap-1.5 p-3 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
           >
             <div className="flex items-center gap-2 w-full">
               <Play
@@ -93,7 +93,7 @@ export function RecipeRunnerItem({
           type="button"
           onClick={() => onRun(recipe.id)}
           disabled={disabled}
-          className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
+          className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-subtle hover:bg-overlay-soft hover:border-border-default transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-overlay-subtle disabled:hover:border-border-subtle aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
         >
           <Play
             className="h-3.5 w-3.5 text-status-success/50 group-hover:text-status-success transition-colors shrink-0"

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import { cn } from "@/lib/utils";
 import { getRecipeTerminalSummary } from "../utils/recipeUtils";
 import type { TerminalRecipe } from "@/types";
 
@@ -54,7 +55,10 @@ export function RecipeRunnerItem({
           >
             <div className="flex items-center gap-2 w-full">
               <Play
-                className="h-3.5 w-3.5 text-status-success/50 group-hover:text-status-success transition-colors shrink-0"
+                className={cn(
+                  "h-3.5 w-3.5 text-status-success/50 transition-colors shrink-0",
+                  !disabled && "group-hover:text-status-success"
+                )}
                 aria-hidden
               />
               <span className="flex-1 text-sm font-medium text-daintree-text truncate">

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1001,7 +1001,7 @@ function TerminalPaneComponent({
                         });
                       }}
                       disabled={isRestartingService}
-                      className="px-4 py-2 border border-daintree-border text-daintree-text/80 hover:bg-overlay-soft hover:text-daintree-text rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                      className="px-4 py-2 border border-daintree-border text-daintree-text/80 hover:bg-overlay-soft hover:text-daintree-text rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none flex items-center justify-center gap-2"
                     >
                       {isRestartingService ? (
                         <Spinner size="md" />


### PR DESCRIPTION
## Summary

- Hand-rolled `<button>` elements throughout the codebase were dimming on `disabled` but still showing hover backgrounds and pointer cursors — the control read as "active but grayed out" rather than "unavailable".
- The design-system `<Button>` already handled this correctly via `disabled:pointer-events-none` in its CVA config. This brings the 20 affected hand-rolled sites into line with the same convention.
- For tooltip-wrapped buttons where `pointer-events-none` would kill the tooltip, the fix uses `disabled:hover:bg-transparent` + matching text-color overrides instead.

Resolves #5971

## Changes

- Added `disabled:pointer-events-none` (or `disabled:hover:*` overrides where tooltip wrapping required it) across 20 component files in Browser, DevPreview, FileViewer, Fleet, Portal, Project, Pulse, Settings, Setup, Sidebar, and Terminal.
- No logic changes, no new abstractions — purely additive Tailwind classes.

## Testing

Verified locally that affected buttons (e.g. sidebar refresh, rescan, recipe runner controls) no longer show hover background or change cursor when disabled. Tooltip behaviour confirmed intact on the Radix-wrapped cases. Typecheck, lint, and format all clean.