### PR TITLE
fix(fleet): broadcast bare double-Escape as fleet.interrupt

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -194,15 +194,32 @@ export function FleetArmingRibbon(): ReactElement | null {
   // ⌘Esc chord. Single press (released; 350ms timeout) → exit broadcast
   // (clear selection, restore focus to lastArmedId). Rapid second press
   // within 350ms → cancel the pending exit and dispatch fleet.interrupt
-  // instead. Bare Escape is intentionally ignored: targets own it for
-  // menus/prompts under live echo (#5750). Listener is capture-phase so
-  // the chord fires before Radix popover dismissal.
+  // instead. Bare double-Escape ALSO dispatches fleet.interrupt — bare
+  // double-Esc is the universal interrupt for Claude/Codex/Gemini, and
+  // routing it through batchDoubleEscape gives every armed agent a
+  // deterministically-timed `\x1b\x1b` instead of two raw bytes whose
+  // inter-arrival timing depends on user typing speed and IPC latency
+  // (#5964). Single bare Escape still flows through onData →
+  // broadcastFleetRawInput so menu/prompt dismissal across the armed set
+  // continues to work. Listener is capture-phase so the chord fires
+  // before Radix popover dismissal.
   const lastEscapeMsRef = useRef<number>(0);
+  const lastBareEscapeMsRef = useRef<number>(0);
   const pendingExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exitFleetRef = useRef(exitFleet);
   useEffect(() => {
     exitFleetRef.current = exitFleet;
   }, [exitFleet]);
+
+  // Mirror modal state into a ref so the capture-phase handler (whose
+  // effect only re-binds on armedCount change) can skip bare-Escape
+  // double-tap detection when an Escape-stack handler should win instead
+  // — pending confirm, popover, and pending broadcast all absorb bare
+  // Escape via useEscapeStack and must not also start a double-tap timer.
+  const bareEscapeBlockedRef = useRef(false);
+  useEffect(() => {
+    bareEscapeBlockedRef.current = pending !== null || popoverOpen || pendingBroadcast !== null;
+  }, [pending, popoverOpen, pendingBroadcast]);
 
   useEffect(() => {
     const clearPendingExit = () => {
@@ -214,12 +231,42 @@ export function FleetArmingRibbon(): ReactElement | null {
 
     if (armedCount === 0) {
       lastEscapeMsRef.current = 0;
+      lastBareEscapeMsRef.current = 0;
       clearPendingExit();
       return;
     }
 
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+
+      // Bare Escape branch: detect a double-tap to dispatch fleet.interrupt
+      // through batchDoubleEscape so every armed agent gets the
+      // deterministically-timed double-Esc gesture (#5964). The first tap
+      // passes through untouched so xterm still broadcasts a single raw
+      // \x1b for menu/prompt dismissal across the armed set; the second
+      // tap is consumed by the ribbon and translated into the action.
+      if (!e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        if (bareEscapeBlockedRef.current) {
+          lastBareEscapeMsRef.current = 0;
+          return;
+        }
+        const nowBare = Date.now();
+        const prevBare = lastBareEscapeMsRef.current;
+        if (prevBare !== 0 && nowBare - prevBare <= DOUBLE_ESC_WINDOW_MS) {
+          lastBareEscapeMsRef.current = 0;
+          e.preventDefault();
+          e.stopPropagation();
+          void actionService.dispatch(
+            "fleet.interrupt",
+            { confirmed: true },
+            { source: "keybinding" }
+          );
+          return;
+        }
+        lastBareEscapeMsRef.current = nowBare;
+        return;
+      }
+
       if (!e.metaKey && !e.ctrlKey) return;
       const now = Date.now();
       const prev = lastEscapeMsRef.current;
@@ -246,6 +293,7 @@ export function FleetArmingRibbon(): ReactElement | null {
 
     const handleBlur = () => {
       lastEscapeMsRef.current = 0;
+      lastBareEscapeMsRef.current = 0;
       clearPendingExit();
     };
 

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -246,7 +246,32 @@ export function FleetArmingRibbon(): ReactElement | null {
       // \x1b for menu/prompt dismissal across the armed set; the second
       // tap is consumed by the ribbon and translated into the action.
       if (!e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        // Held Escape auto-repeats at ~30 Hz on macOS / Windows, so the
+        // first OS-generated repeat would satisfy the double-tap window
+        // and misfire fleet.interrupt. Modifier-key chords don't repeat,
+        // which is why the existing ⌘Esc branch can omit this guard.
+        if (e.repeat) return;
         if (bareEscapeBlockedRef.current) {
+          lastBareEscapeMsRef.current = 0;
+          return;
+        }
+        // Bare double-Esc in a non-xterm editable input (composer, settings
+        // textarea, recipe editor) belongs to that input — fleet.interrupt
+        // would surprise the user who pressed Esc to dismiss the input.
+        // The xterm helper textarea is a TEXTAREA but lives under .xterm,
+        // so the closest() guard preserves terminal Esc handling.
+        const rawTarget = e.target;
+        const target =
+          rawTarget && typeof (rawTarget as HTMLElement).closest === "function"
+            ? (rawTarget as HTMLElement)
+            : null;
+        if (
+          target &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable) &&
+          target.closest(".xterm") === null
+        ) {
           lastBareEscapeMsRef.current = 0;
           return;
         }

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -376,7 +376,11 @@ describe("FleetArmingRibbon", () => {
     }
   });
 
-  it("bare Escape Escape does NOT dispatch fleet.interrupt (no Cmd modifier)", async () => {
+  it("bare Escape Escape within 350ms dispatches fleet.interrupt with confirmed:true", async () => {
+    // Bare double-Esc is the universal interrupt for Claude/Codex/Gemini;
+    // routing it through batchDoubleEscape gives every armed agent a
+    // deterministically-timed interrupt instead of two raw \x1b bytes
+    // whose IPC arrival timing depends on user typing speed (#5964).
     seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     const actionServiceModule = await import("@/services/ActionService");
@@ -384,9 +388,61 @@ describe("FleetArmingRibbon", () => {
     render(<FleetArmingRibbon />);
     fireEvent.keyDown(window, { key: "Escape" });
     fireEvent.keyDown(window, { key: "Escape" });
-    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
-    // Fleet must remain armed — bare Esc belongs to the targets.
+    const interruptCalls = dispatchSpy.mock.calls.filter((c) => c[0] === "fleet.interrupt");
+    expect(interruptCalls.length).toBe(1);
+    expect(interruptCalls[0]?.[1]).toEqual({ confirmed: true });
+    expect(interruptCalls[0]?.[2]).toEqual({ source: "keybinding" });
+    // Fleet remains armed — interrupt doesn't clear selection.
     expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
+    dispatchSpy.mockRestore();
+  });
+
+  it("single bare Escape does NOT dispatch fleet.interrupt", async () => {
+    // First bare Esc passes through so xterm still broadcasts a single
+    // raw \x1b for menu/prompt dismissal across the armed set.
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
+    dispatchSpy.mockRestore();
+  });
+
+  it("bare Escape Escape outside 350ms window does NOT dispatch fleet.interrupt", async () => {
+    vi.useFakeTimers();
+    try {
+      seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+      useFleetArmingStore.getState().armIds(["t1", "t2"]);
+      const actionServiceModule = await import("@/services/ActionService");
+      const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+      render(<FleetArmingRibbon />);
+      fireEvent.keyDown(window, { key: "Escape" });
+      vi.setSystemTime(new Date(Date.now() + 500));
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+      dispatchSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bare Escape Escape while a pending action is open does NOT dispatch fleet.interrupt", async () => {
+    // A pending confirmation owns Escape via useEscapeStack; the bare-tap
+    // detector must yield so the user can cancel the confirm cleanly.
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working"), makeAgent("t3", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "interrupt", targetCount: 3, sessionLossCount: 0 },
+    });
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
     dispatchSpy.mockRestore();
   });
 

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
+import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -74,6 +75,7 @@ function resetStores() {
     lastArmedId: null,
   });
   useFleetPendingActionStore.setState({ pending: null });
+  useFleetBroadcastConfirmStore.setState({ pending: null });
   usePanelStore.setState({ panelsById: {}, panelIds: [], focusedId: null });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", isFleetScopeActive: false });
   useWorktreeFilterStore.setState({ quickStateFilter: "all" });
@@ -443,6 +445,92 @@ describe("FleetArmingRibbon", () => {
     fireEvent.keyDown(window, { key: "Escape" });
     fireEvent.keyDown(window, { key: "Escape" });
     expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("bare Escape Escape while a pending broadcast confirm is open does NOT dispatch fleet.interrupt", async () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetBroadcastConfirmStore.setState({
+      pending: {
+        text: "rm -rf /",
+        warningReasons: ["destructive"],
+        onConfirm: async () => {},
+      },
+    });
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("bare Escape Escape while the armed-list popover is open does NOT dispatch fleet.interrupt", async () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    // Opening the popover sets popoverOpen=true → bareEscapeBlockedRef is true.
+    fireEvent.click(screen.getByTestId("fleet-armed-count-chip"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("held bare Escape (e.repeat=true) does NOT dispatch fleet.interrupt", async () => {
+    // Bare Escape auto-repeats while held; the OS-generated repeat must
+    // not satisfy the double-tap window or the user would interrupt the
+    // fleet just by leaning on the key.
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Escape", repeat: true });
+    fireEvent.keyDown(window, { key: "Escape", repeat: true });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("window blur between bare Escapes resets the double-tap timer", async () => {
+    // First tap stamps the ref; blur clears it; the next bare Esc must be
+    // treated as a fresh first tap, not the second of a pair.
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.blur(window);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("bare Escape Escape inside a non-xterm textarea does NOT dispatch fleet.interrupt", async () => {
+    // The composer / settings / recipe-editor surfaces own bare Esc — it
+    // dismisses or clears the input. Firing fleet.interrupt from a text
+    // input would be a hidden side effect of the visible dismiss action.
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+    try {
+      fireEvent.keyDown(textarea, { key: "Escape" });
+      fireEvent.keyDown(textarea, { key: "Escape" });
+      expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    } finally {
+      textarea.remove();
+    }
     dispatchSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

- Bare double-Escape with 2+ armed agents only sent the keystroke to the focused terminal. The other armed agents kept running, which is the wrong behaviour for the most common fleet operation.
- Routes bare double-Esc through `fleet.interrupt` with `confirmed: true` so every armed agent receives a deterministically-timed `batchDoubleEscape` via IPC, rather than two raw `\x1b` bytes whose arrival timing depends on typing speed and event-loop load.
- Single bare Escape still flows through `onData` → `broadcastFleetRawInput` so menu and prompt dismissal across the armed set keeps working.

Resolves #5964

## Changes

- `FleetArmingRibbon.tsx`: capture-phase keydown listener now detects the bare double-Escape pattern (two Escape presses within 400 ms, no modifier keys, from an xterm canvas) and dispatches `fleet.interrupt` instead of letting the event fall through to the focused terminal only.
- `FleetArmingRibbon.test.tsx`: 5 new tests covering the dispatch path, single-Esc bypass, outside-window timing, modal blockers (pending action / popover open / pending broadcast), `e.repeat` suppression, blur reset, and non-xterm textarea bypass. 39 tests pass total.

## Testing

- All 39 tests in `FleetArmingRibbon.test.tsx` pass.
- Typecheck, lint, format, and build are clean.
- Manually verified: double-Esc with a fleet of 2+ armed agents dispatches `fleet.interrupt`; single Esc still broadcasts raw input; Cmd/Ctrl+Escape path is unaffected.