### PR TITLE
fix(logging): route renderer console.error to structured logger

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -29,6 +29,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { logError } from "@/utils/logger";
 
 export interface BrowserPaneProps extends BasePanelProps {
   initialUrl: string;
@@ -498,7 +499,7 @@ export function BrowserPane({
     try {
       await saveProjectSettings({ ...baseSettings, browserAllowedHosts: nextAllowed });
     } catch (err) {
-      console.error("[BrowserPane] Failed to save approved host", err);
+      logError("[BrowserPane] Failed to save approved host", err);
       return;
     }
     commitNavigation(url);
@@ -584,7 +585,7 @@ export function BrowserPane({
       const pngData = new Uint8Array(image.toPNG());
       await window.electron.clipboard.writeImage(pngData);
     } catch (err) {
-      console.error("[BrowserPane] Screenshot capture failed:", err);
+      logError("[BrowserPane] Screenshot capture failed", err);
     }
   }, [isWebviewReady]);
 

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -22,6 +22,7 @@ import { useUrlHistoryStore, getFrecencySuggestions } from "@/store/urlHistorySt
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ViewportPresetId } from "@shared/types/panel";
 import { VIEWPORT_PRESET_LIST, getViewportPreset } from "@/panels/dev-preview/viewportPresets";
+import { logError } from "@/utils/logger";
 
 const ZOOM_PRESETS = [
   { value: 0.25, label: "25%" },
@@ -221,7 +222,7 @@ export function BrowserToolbar({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error("Failed to copy URL:", err);
+      logError("Failed to copy URL", err);
     }
   }, [terminalId, url]);
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -33,6 +33,7 @@ import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import type { ViewportPresetId } from "@shared/types/panel";
+import { logError } from "@/utils/logger";
 
 import { looksLikeOAuthUrl } from "@shared/utils/urlUtils";
 
@@ -468,7 +469,7 @@ export function DevPreviewPane({
         devServerDismissed: false,
       });
     } catch (err) {
-      console.error("Failed to auto-detect dev server:", err);
+      logError("Failed to auto-detect dev server", err);
     } finally {
       if (isMountedRef.current) {
         setIsAutoDetecting(false);
@@ -841,6 +842,7 @@ export function DevPreviewPane({
 
   // Listen for blocked navigation events from main process
   useEffect(() => {
+    let disposed = false;
     const cleanup = window.electron.webview.onNavigationBlocked((data) => {
       if (data.panelId !== id) return;
       const sessionStorageSnapshotPromise = looksLikeOAuthUrl(data.url)
@@ -850,17 +852,23 @@ export function DevPreviewPane({
         clearTimeout(blockedNavTimerRef.current);
       }
       blockedNavTimerRef.current = setTimeout(() => {
-        void sessionStorageSnapshotPromise.then((sessionStorageSnapshot) => {
-          setBlockedNav({
-            url: data.url,
-            canOpenExternal: data.canOpenExternal,
-            sessionStorageSnapshot,
+        void sessionStorageSnapshotPromise
+          .then((sessionStorageSnapshot) => {
+            if (disposed) return;
+            setBlockedNav({
+              url: data.url,
+              canOpenExternal: data.canOpenExternal,
+              sessionStorageSnapshot,
+            });
+            blockedNavTimerRef.current = null;
+          })
+          .catch((err) => {
+            if (!disposed) logError("Failed to capture session storage snapshot", err);
           });
-          blockedNavTimerRef.current = null;
-        });
       }, 150);
     });
     return () => {
+      disposed = true;
       cleanup();
       if (blockedNavTimerRef.current) {
         clearTimeout(blockedNavTimerRef.current);

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -21,6 +21,7 @@ import {
 } from "./DiagnosticsActions";
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
+import { logError } from "@/utils/logger";
 
 interface TabButtonProps {
   tab: DiagnosticsTab;
@@ -143,7 +144,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
         try {
           await appClient.setState({ diagnosticsHeight: height });
         } catch (error) {
-          console.error("Failed to persist diagnostics height:", error);
+          logError("Failed to persist diagnostics height", error);
         }
       }, 300);
       return () => clearTimeout(timer);
@@ -159,7 +160,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
           setHeight(appState.diagnosticsHeight);
         }
       } catch (error) {
-        console.error("Failed to restore diagnostics height:", error);
+        logError("Failed to restore diagnostics height", error);
       }
     };
     restoreHeight();

--- a/src/components/Diagnostics/EventsContent.tsx
+++ b/src/components/Diagnostics/EventsContent.tsx
@@ -6,6 +6,7 @@ import { EventTimeline } from "../EventInspector/EventTimeline";
 import { EventDetail } from "../EventInspector/EventDetail";
 import { EventFilters } from "../EventInspector/EventFilters";
 import { eventInspectorClient } from "@/clients";
+import { logError } from "@/utils/logger";
 
 export interface EventsContentProps {
   className?: string;
@@ -53,7 +54,7 @@ export function EventsContent({ className }: EventsContentProps) {
         setEvents(existingEvents);
       })
       .catch((error) => {
-        console.error("Failed to load events:", error);
+        logError("Failed to load events", error);
       });
 
     const unsubscribe = eventInspectorClient.onEventBatch((events) => {

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -9,6 +9,7 @@ import { LogFilters } from "../Logs/LogFilters";
 import type { LogEntry as LogEntryType, LogLevel } from "@/types";
 
 import { logsClient, appClient } from "@/clients";
+import { logError } from "@/utils/logger";
 
 export interface LogsContentProps {
   className?: string;
@@ -111,11 +112,11 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
 
     Promise.all([
       logsClient.getAll().catch((error) => {
-        console.error("Failed to load logs:", error);
+        logError("Failed to load logs", error);
         return [];
       }),
       logsClient.getSources().catch((error) => {
-        console.error("Failed to load log sources:", error);
+        logError("Failed to load log sources", error);
         return [];
       }),
     ]).then(([existingLogs, existingSources]) => {

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { useErrorStore, type AppError, type RetryAction } from "@/store";
 import { Copy, Check, Lightbulb } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { logError } from "@/utils/logger";
 
 const ERROR_TYPE_LABELS: Record<string, string> = {
   git: "Git",
@@ -97,7 +98,7 @@ function ErrorRow({
         copyTimeoutRef.current = null;
       }, 2000);
     } catch (err) {
-      console.error("Failed to copy to clipboard:", err);
+      logError("Failed to copy to clipboard", err);
     }
   };
 

--- a/src/components/Diagnostics/TelemetryContent.tsx
+++ b/src/components/Diagnostics/TelemetryContent.tsx
@@ -7,6 +7,7 @@ import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 import { telemetryPreviewClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import type { SanitizedTelemetryEvent } from "@shared/types";
+import { logError } from "@/utils/logger";
 
 export interface TelemetryContentProps {
   className?: string;
@@ -103,7 +104,7 @@ function TelemetryDetail({ event }: DetailProps) {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
       copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error("Failed to copy telemetry payload:", err);
+      logError("Failed to copy telemetry payload", err);
     }
   }, [event, payloadJson]);
 
@@ -210,7 +211,7 @@ export function TelemetryContent({ className }: TelemetryContentProps) {
         if (!disposed) setActive(state.active);
       })
       .catch((err) => {
-        console.error("Failed to read telemetry preview state:", err);
+        logError("Failed to read telemetry preview state", err);
       });
 
     const unsubscribeBatch = telemetryPreviewClient.onEventBatch((incoming) => {

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -74,7 +74,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         correlationId,
       });
     } catch (storeError) {
-      console.error("Failed to add error to store:", storeError);
+      logError("Failed to add error to store", storeError);
     }
 
     this.setState({
@@ -86,7 +86,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       try {
         onError(error, errorInfo);
       } catch (handlerError) {
-        console.error("Error in onError handler:", handlerError);
+        logError("Error in onError handler", handlerError);
       }
     }
 
@@ -98,7 +98,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       incidentId,
     });
 
-    console.error("ErrorBoundary caught error:", error, errorInfo);
+    logError("ErrorBoundary caught error", error, { errorInfo });
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {

--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { useEventStore, type EventRecord, type EventFilterOptions } from "@/store/eventStore";
 import { Copy, Check, ChevronDown, ChevronRight, Filter, X } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { logError } from "@/utils/logger";
 
 interface EventDetailProps {
   event: EventRecord | null;
@@ -115,7 +116,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
         copyTimeoutRef.current = null;
       }, 2000);
     } catch (err) {
-      console.error("Failed to copy payload:", err);
+      logError("Failed to copy payload", err);
     }
   };
 

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -13,6 +13,7 @@ import { formatBytes } from "@/lib/formatBytes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
+import { logError } from "@/utils/logger";
 
 export interface FileViewerModalProps {
   isOpen: boolean;
@@ -180,7 +181,7 @@ export function FileViewerModal({
         { path: filePath, line: initialLine, col: initialCol },
         { source: "user" }
       )
-      .catch((err) => console.error("[FileViewerModal] openInEditor failed:", err));
+      .catch((err) => logError("[FileViewerModal] openInEditor failed", err));
   }, [filePath, initialLine, initialCol]);
 
   const handleImageError = useCallback(() => {
@@ -191,7 +192,7 @@ export function FileViewerModal({
   const handleOpenInImageViewer = useCallback(() => {
     actionService
       .dispatch("file.openImageViewer", { path: filePath }, { source: "user" })
-      .catch((err) => console.error("[FileViewerModal] openImageViewer failed:", err));
+      .catch((err) => logError("[FileViewerModal] openImageViewer failed", err));
   }, [filePath]);
 
   const handleCopyDiff = useCallback(async () => {

--- a/src/components/GitHub/CommitListItem.tsx
+++ b/src/components/GitHub/CommitListItem.tsx
@@ -6,6 +6,7 @@ import { formatTimeAgo } from "@/utils/timeAgo";
 import type { GitCommit } from "@shared/types/github";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { parseConventionalCommit } from "./commitListUtils";
+import { logError } from "@/utils/logger";
 
 interface CommitListItemProps {
   commit: GitCommit;
@@ -43,7 +44,7 @@ export function CommitListItem({ commit, optionId, isActive }: CommitListItemPro
       setCopied(true);
       timeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
     } catch (error) {
-      console.error("Failed to copy:", error);
+      logError("Failed to copy", error);
     }
   };
 

--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { GitHubResourceRowsSkeleton } from "./GitHubDropdownSkeletons";
+import { logError } from "@/utils/logger";
 
 interface IssueSelectorProps {
   projectPath: string;
@@ -46,7 +47,7 @@ export function IssueSelector({
       })
       .catch((err) => {
         if (!abortController.signal.aborted) {
-          console.error("Failed to fetch issues:", err);
+          logError("Failed to fetch issues", err);
           setIssues([]);
         }
       })

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -4,6 +4,7 @@ import { isMac } from "@/lib/platform";
 import { keybindingService, normalizeKeyForBinding } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { useNotificationStore } from "@/store/notificationStore";
+import { logError, logWarn } from "@/utils/logger";
 
 const CHORD_TIMEOUT_MS = 1000;
 
@@ -195,7 +196,7 @@ export function SettingsShortcutCapture({
           throw new Error(setResult.error?.message || "Failed to update keybinding");
         }
       } else {
-        console.error("Could not identify conflicting combo");
+        logWarn("Could not identify conflicting combo");
         setIsUnbinding(false);
         return;
       }
@@ -226,7 +227,7 @@ export function SettingsShortcutCapture({
               }
               setConflictRefreshKey((prev) => prev + 1);
             } catch (err) {
-              console.error("Failed to undo keybinding change:", err);
+              logError("Failed to undo keybinding change", err);
               useNotificationStore.getState().addNotification({
                 type: "error",
                 message: "Failed to undo keybinding change",
@@ -238,7 +239,7 @@ export function SettingsShortcutCapture({
         },
       });
     } catch (err) {
-      console.error("Failed to unbind keybinding:", err);
+      logError("Failed to unbind keybinding", err);
       useNotificationStore.getState().addNotification({
         type: "error",
         message: "Failed to unbind keybinding",

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -33,6 +33,7 @@ import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState } from "@/hooks";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
+import { logError } from "@/utils/logger";
 
 interface AppLayoutProps {
   children?: ReactNode;
@@ -122,7 +123,7 @@ export function AppLayout({
         });
         useFleetScopeFlagStore.getState().hydrate(appState.fleetScopeMode);
       } catch (error) {
-        console.error("Failed to restore app state:", error);
+        logError("Failed to restore app state", error);
       }
     };
     restoreState();
@@ -135,7 +136,7 @@ export function AppLayout({
       try {
         await appClient.setState({ sidebarWidth });
       } catch (error) {
-        console.error("Failed to persist sidebar width:", error);
+        logError("Failed to persist sidebar width", error);
       }
     };
 
@@ -157,7 +158,7 @@ export function AppLayout({
         try {
           await appClient.setState({ focusMode: layout.isFocusMode });
         } catch (error) {
-          console.error("Failed to persist focus mode to global state:", error);
+          logError("Failed to persist focus mode to global state", error);
         }
         return;
       }
@@ -169,7 +170,7 @@ export function AppLayout({
           layout.savedPanelState as PanelState | undefined
         );
       } catch (error) {
-        console.error("Failed to persist focus mode to project state:", error);
+        logError("Failed to persist focus mode to project state", error);
       }
     };
 
@@ -191,14 +192,14 @@ export function AppLayout({
         try {
           await window.electron.project.setFocusMode(currentProject.id, false, undefined);
         } catch (error) {
-          console.error("Failed to clear focus panel state:", error);
+          logError("Failed to clear focus panel state", error);
         }
       } else {
         // Fall back to global state if no project
         try {
           await appClient.setState({ focusPanelState: undefined });
         } catch (error) {
-          console.error("Failed to clear focus panel state:", error);
+          logError("Failed to clear focus panel state", error);
         }
       }
     } else {
@@ -212,14 +213,14 @@ export function AppLayout({
         try {
           await window.electron.project.setFocusMode(currentProject.id, true, currentPanelState);
         } catch (error) {
-          console.error("Failed to persist focus panel state:", error);
+          logError("Failed to persist focus panel state", error);
         }
       } else {
         // Fall back to global state if no project
         try {
           await appClient.setState({ focusPanelState: currentPanelState });
         } catch (error) {
-          console.error("Failed to persist focus panel state:", error);
+          logError("Failed to persist focus panel state", error);
         }
       }
     }

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -12,6 +12,7 @@ import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, useWorktreeSelectionStore, type TerminalInstance } from "@/store";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { logError } from "@/utils/logger";
 
 interface DockPanelContextValue {
   portalTarget: (terminalId: string, target: HTMLElement | null) => void;
@@ -108,7 +109,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         setActiveTab(groupId, newPanelId);
         openDockTerminal(newPanelId);
       } catch (error) {
-        console.error("Failed to add tab:", error);
+        logError("Failed to add tab", error);
         if (createdNewGroup && groupId!) {
           deleteTabGroup(groupId);
         }

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -15,6 +15,7 @@ import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modi
 import { Plus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 import {
   useTerminalInputStore,
   usePanelStore,
@@ -345,7 +346,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       setFocused(newPanelId);
       openDockTerminal(newPanelId);
     } catch (error) {
-      console.error("Failed to add tab:", error);
+      logError("Failed to add tab", error);
     }
   }, [
     activePanel,

--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -5,6 +5,7 @@ import { actionService } from "@/services/ActionService";
 import { dismissSetupBanner as dismissSetupBannerFromHook } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import type { OnboardingState } from "@shared/types";
 import type { CliAvailability } from "@shared/types";
+import { logError } from "@/utils/logger";
 
 const SKIP_FIRST_RUN_DIALOGS = isDaintreeEnvEnabled("DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS");
 
@@ -48,7 +49,7 @@ export function OnboardingFlow({
     (async () => {
       const onboardingState = await window.electron.onboarding.get();
       setState(onboardingState);
-    })().catch(console.error);
+    })().catch((err) => logError("Onboarding step failed", err));
   }, []);
 
   // Listen for manual wizard open events (from Settings / toolbar / panel palette / welcome banner).

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -10,6 +10,7 @@ import { getAIAgentInfo } from "@/lib/aiAgentDetection";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 import {
   ContextMenu,
   ContextMenuCheckboxItem,
@@ -108,10 +109,10 @@ export function PortalDock() {
           { source: "user" }
         );
         if (!result.ok) {
-          console.error("Failed to activate portal tab:", result.error);
+          logError("Failed to activate portal tab", undefined, { error: result.error });
         }
       } catch (error) {
-        console.error("Failed to activate portal tab:", error);
+        logError("Failed to activate portal tab", error);
       } finally {
         setIsSwitching(false);
       }
@@ -183,7 +184,7 @@ export function PortalDock() {
   const handleGoBack = useCallback(async () => {
     const result = await actionService.dispatch("portal.goBack", undefined, { source: "user" });
     if (!result.ok) {
-      console.error("Failed to go back:", result.error);
+      logError("Failed to go back", undefined, { error: result.error });
     }
   }, [activeTabId]);
 
@@ -192,14 +193,14 @@ export function PortalDock() {
       source: "user",
     });
     if (!result.ok) {
-      console.error("Failed to go forward:", result.error);
+      logError("Failed to go forward", undefined, { error: result.error });
     }
   }, [activeTabId]);
 
   const handleReload = useCallback(async () => {
     const result = await actionService.dispatch("portal.reload", undefined, { source: "user" });
     if (!result.ok) {
-      console.error("Failed to reload:", result.error);
+      logError("Failed to reload", undefined, { error: result.error });
     }
   }, [activeTabId]);
 
@@ -208,14 +209,14 @@ export function PortalDock() {
       source: "user",
     });
     if (!result.ok) {
-      console.error("Failed to open URL externally:", result.error);
+      logError("Failed to open URL externally", undefined, { error: result.error });
     }
   }, []);
 
   const handleCopyUrl = useCallback(async () => {
     const result = await actionService.dispatch("portal.copyUrl", undefined, { source: "user" });
     if (!result.ok) {
-      console.error("Failed to copy URL:", result.error);
+      logError("Failed to copy URL", undefined, { error: result.error });
     }
   }, []);
 
@@ -228,7 +229,7 @@ export function PortalDock() {
         { source: "context-menu" }
       );
       if (!result.ok) {
-        console.error("Failed to duplicate tab:", result.error);
+        logError("Failed to duplicate tab", undefined, { error: result.error });
       }
     },
     [isSwitching]
@@ -243,7 +244,7 @@ export function PortalDock() {
         { source: "context-menu" }
       );
       if (!result.ok) {
-        console.error("Failed to close other tabs:", result.error);
+        logError("Failed to close other tabs", undefined, { error: result.error });
       }
     },
     [isSwitching]
@@ -258,7 +259,7 @@ export function PortalDock() {
         { source: "context-menu" }
       );
       if (!result.ok) {
-        console.error("Failed to close tabs to the right:", result.error);
+        logError("Failed to close tabs to the right", undefined, { error: result.error });
       }
     },
     [isSwitching]
@@ -271,7 +272,7 @@ export function PortalDock() {
       { source: "context-menu" }
     );
     if (!result.ok) {
-      console.error("Failed to copy tab URL:", result.error);
+      logError("Failed to copy tab URL", undefined, { error: result.error });
     }
   }, []);
 
@@ -282,7 +283,7 @@ export function PortalDock() {
       { source: "context-menu" }
     );
     if (!result.ok) {
-      console.error("Failed to open tab externally:", result.error);
+      logError("Failed to open tab externally", undefined, { error: result.error });
     }
   }, []);
 
@@ -293,7 +294,7 @@ export function PortalDock() {
       { source: "context-menu" }
     );
     if (!result.ok) {
-      console.error("Failed to reload tab:", result.error);
+      logError("Failed to reload tab", undefined, { error: result.error });
     }
   }, []);
 

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { usePortalStore } from "@/store";
 import { useUIStore } from "@/store/uiStore";
 import { getPortalPlaceholderBounds } from "@/lib/portalBounds";
+import { logError } from "@/utils/logger";
 
 /**
  * Zero-UI controller component that manages portal visibility.
@@ -78,7 +79,7 @@ export function PortalVisibilityController(): null {
 
         await window.electron.portal.show({ tabId, bounds });
       } catch (error) {
-        console.error("Failed to restore tab:", error);
+        logError("Failed to restore tab", error);
       } finally {
         isRestoringRef.current = false;
         const pending = pendingRestoreRef.current as { tabId: string; tabUrl: string } | null;

--- a/src/components/Project/ContextTab.tsx
+++ b/src/components/Project/ContextTab.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { copyTreeClient } from "@/clients/copyTreeClient";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { CopyTreeSettings, CopyTreeTestConfigResult, Worktree } from "@/types";
+import { logError } from "@/utils/logger";
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";
@@ -110,7 +111,7 @@ export function ContextTab({
       const result = await copyTreeClient.testConfig(mainWorktree.id, testOptions);
       setTestConfigResult(result);
     } catch (error) {
-      console.error("Failed to test config:", error);
+      logError("Failed to test config", error);
       setTestConfigResult({
         includedFiles: 0,
         includedSize: 0,

--- a/src/components/Project/ProjectNotificationsTab.tsx
+++ b/src/components/Project/ProjectNotificationsTab.tsx
@@ -86,7 +86,7 @@ export function ProjectNotificationsTab({ overrides, onChange }: ProjectNotifica
               .getSettings()
               .then(setGlobalSettings)
               .catch((err) => {
-                console.error("[ProjectNotificationsTab] Retry failed:", err);
+                logError("[ProjectNotificationsTab] Retry failed", err);
                 setGlobalError("Failed to load global settings");
               });
           }}

--- a/src/components/Project/ProjectNotificationsTab.tsx
+++ b/src/components/Project/ProjectNotificationsTab.tsx
@@ -5,6 +5,7 @@ import { SettingsCheckbox } from "@/components/Settings/SettingsCheckbox";
 import { SettingsSelect } from "@/components/Settings/SettingsSelect";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import type { NotificationSettings } from "@shared/types/ipc/api";
+import { logError } from "@/utils/logger";
 
 const AVAILABLE_SOUNDS: { file: string; label: string }[] = [
   { file: "chime.wav", label: "Chime" },
@@ -40,7 +41,7 @@ export function ProjectNotificationsTab({ overrides, onChange }: ProjectNotifica
         if (mounted) setGlobalSettings(settings);
       })
       .catch((err) => {
-        console.error("[ProjectNotificationsTab] Failed to load global settings:", err);
+        logError("[ProjectNotificationsTab] Failed to load global settings", err);
         if (mounted) setGlobalError("Failed to load global settings");
       });
 

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -259,7 +259,7 @@ export function ProjectResourceBadge() {
         projects: projects.map((p: Project) => ({ id: p.id, name: p.name })),
       };
     } catch (error) {
-      console.error("[ProjectResourceBadge] Failed to fetch stats:", error);
+      logError("[ProjectResourceBadge] Failed to fetch stats", error);
       return null;
     }
   }, []);
@@ -308,7 +308,7 @@ export function ProjectResourceBadge() {
           setPopoverData({ processMetrics, heapStats, diagnosticsInfo, projectStats });
         }
       } catch (error) {
-        console.error("[ProjectResourceBadge] Failed to fetch popover data:", error);
+        logError("[ProjectResourceBadge] Failed to fetch popover data", error);
       }
     };
 

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { projectClient, systemClient } from "@/clients";
 import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { logError } from "@/utils/logger";
 import type { ProcessMetricEntry, HeapStats, DiagnosticsInfo } from "@shared/types/ipc/system";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
 import type { Project } from "@shared/types";

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -119,7 +119,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
           localStorage.removeItem(`${HISTORY_KEY_PREFIX}${projectId}`);
         }
       } catch (e) {
-        console.error("Failed to parse command history", e);
+        logError("Failed to parse command history", e);
         localStorage.removeItem(`${HISTORY_KEY_PREFIX}${projectId}`);
       }
     }
@@ -162,7 +162,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
     try {
       await promoteToSaved(commandToSave);
     } catch (err) {
-      console.error("Failed to pin command:", err);
+      logError("Failed to pin command", err);
     }
   };
 
@@ -173,7 +173,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
     try {
       await removeFromSaved(item.value);
     } catch (err) {
-      console.error("Failed to unpin command:", err);
+      logError("Failed to unpin command", err);
     }
   };
 
@@ -318,7 +318,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
         spawnedBy: "quickrun",
       });
     } catch (error) {
-      console.error("Failed to spawn terminal:", error);
+      logError("Failed to spawn terminal", error);
     } finally {
       isRunningRef.current = false;
     }

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -18,6 +18,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { RunCommand } from "@/types";
+import { logError } from "@/utils/logger";
 import { RunningTaskList } from "./RunningTaskList";
 
 interface QuickRunProps {

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -53,7 +53,7 @@ export function RecipesTab({
     if (isOpen && !hasLoadedRecipes.current && !recipesLoading && projectId) {
       hasLoadedRecipes.current = true;
       loadRecipes(projectId).catch((err) => {
-        console.error("Failed to load recipes:", err);
+        logError("Failed to load recipes", err);
       });
     }
   }, [isOpen, recipesLoading, loadRecipes, projectId]);
@@ -115,7 +115,7 @@ export function RecipesTab({
       }
       setRecipeToDelete(null);
     } catch (err) {
-      console.error("Failed to delete recipe:", err);
+      logError("Failed to delete recipe", err);
       setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
     }
   };
@@ -136,7 +136,7 @@ export function RecipesTab({
           exportTimeoutRef.current = null;
         }, 2000);
       } catch (err) {
-        console.error("Failed to copy to clipboard:", err);
+        logError("Failed to copy to clipboard", err);
         setExportError(formatErrorMessage(err, "Failed to copy to clipboard"));
       }
     }

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalRecipe, Worktree } from "@/types";
+import { logError } from "@/utils/logger";
 import { isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 

--- a/src/components/Project/RunningTaskList.tsx
+++ b/src/components/Project/RunningTaskList.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { terminalClient } from "@/clients";
 import { cn } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 
 const MAX_VISIBLE = 5;
 const AUTO_CLEAR_DELAY = 3000;
@@ -120,7 +121,7 @@ export function RunningTaskList({ worktreeId }: RunningTaskListProps) {
   }, [quickRunTerminals]);
 
   const handleStop = useCallback((id: string) => {
-    terminalClient.kill(id).catch(console.error);
+    terminalClient.kill(id).catch((err) => logError("Failed to kill terminal", err));
   }, []);
 
   const handleFocus = useCallback(

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Plug } from "@/components/icons";
 import { AppDialog } from "../ui/AppDialog";
 import { Button } from "../ui/button";
+import { logError } from "@/utils/logger";
 import type {
   PendingCrash,
   PanelSummary,
@@ -107,7 +108,9 @@ export function CrashRecoveryDialog({
   }, [allSelected, panels]);
 
   const handleOpenLogFile = useCallback(() => {
-    window.electron.system.openPath(crash.logPath).catch(console.error);
+    window.electron.system
+      .openPath(crash.logPath)
+      .catch((err) => logError("Failed to open crash log path", err));
   }, [crash.logPath]);
 
   const handleReport = useCallback(() => {
@@ -120,7 +123,9 @@ export function CrashRecoveryDialog({
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
-    window.electron.system.openExternal(ISSUES_URL).catch(console.error);
+    window.electron.system
+      .openExternal(ISSUES_URL)
+      .catch((err) => logError("Failed to open issues URL", err));
   }, [privacyWarningShown, crash]);
 
   const handleAutoRestore = useCallback(

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -8,6 +8,7 @@ import type { AgentHelpResult } from "@shared/types/ipc/agent";
 import type { AgentAvailabilityState } from "@shared/types";
 import { isAgentInstalled, isAgentMissing } from "../../../shared/utils/agentAvailability";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 interface AgentHelpOutputProps {
   agentId: string;
@@ -115,7 +116,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
         copyTimeoutRef.current = null;
       }, 2000);
     } catch (err) {
-      console.error("Failed to copy to clipboard:", err);
+      logError("Failed to copy to clipboard", err);
     }
   }, [helpResult]);
 

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -4,6 +4,7 @@ import { useAgentSettingsStore, useCliAvailabilityStore, useAgentPreferencesStor
 import { cliAvailabilityClient } from "@/clients";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
+import { logError } from "@/utils/logger";
 import { Button } from "@/components/ui/button";
 import {
   DEFAULT_AGENT_SETTINGS,
@@ -79,7 +80,7 @@ export function AgentSettings({
       const details = await cliAvailabilityClient.getDetails();
       setCliDetails(details);
     } catch (error) {
-      console.error("[AgentSettings] Failed to fetch CLI details:", error);
+      logError("[AgentSettings] Failed to fetch CLI details", error);
     }
   }, []);
 
@@ -97,7 +98,7 @@ export function AgentSettings({
       await refreshCliAvailability(true);
       await fetchCliDetails();
     } catch (error) {
-      console.error("[AgentSettings] Failed to refresh CLI availability:", error);
+      logError("[AgentSettings] Failed to refresh CLI availability", error);
     }
   }, [isRefreshingCli, refreshCliAvailability, fetchCliDetails]);
 
@@ -137,7 +138,7 @@ export function AgentSettings({
       setIsAddDialogOpen(false);
       setAddDialogAgentId(null);
     } catch (error) {
-      console.error("[AgentSettings] Failed to create preset:", error);
+      logError("[AgentSettings] Failed to create preset", error);
     }
   };
 
@@ -352,7 +353,7 @@ export function AgentSettings({
                         );
                         if (!result.ok) throw new Error(result.error.message);
                       } catch (error) {
-                        console.error("Failed to open usage URL:", error);
+                        logError("Failed to open usage URL", error);
                       }
                     }}
                   >
@@ -498,7 +499,7 @@ export function AgentSettings({
                     await updateAgent(activeAgent.id, { customPresets: updated });
                     onSettingsChange?.();
                   } catch (error) {
-                    console.error("Failed to update preset:", error);
+                    logError("Failed to update preset", error);
                   }
                 })();
               };

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -18,6 +18,7 @@ import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { APP_THEME_PREVIEW_KEYS } from "@shared/theme";
 import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { logError } from "@/utils/logger";
 
 function shuffleArray<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -124,7 +125,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     (e: ChangeEvent<HTMLInputElement>) => {
       setAccentColorOverride(e.target.value);
       appThemeClient.setAccentColorOverride(e.target.value).catch((error) => {
-        console.error("Failed to persist accent color override:", error);
+        logError("Failed to persist accent color override", error);
       });
     },
     [setAccentColorOverride]
@@ -133,7 +134,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
   const handleAccentReset = useCallback(() => {
     setAccentColorOverride(null);
     appThemeClient.setAccentColorOverride(null).catch((error) => {
-      console.error("Failed to clear accent color override:", error);
+      logError("Failed to clear accent color override", error);
     });
   }, [setAccentColorOverride]);
 
@@ -141,7 +142,9 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     async (id: string, origin?: { x: number; y: number }) => {
       if (followSystem) {
         setFollowSystem(false);
-        appThemeClient.setFollowSystem(false).catch(console.error);
+        appThemeClient
+          .setFollowSystem(false)
+          .catch((err) => logError("Failed to clear follow system", err));
       }
 
       commitSchemeSelection(id);
@@ -152,7 +155,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
         await appThemeClient.setColorScheme(id);
         await appThemeClient.setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds);
       } catch (error) {
-        console.error("Failed to persist app theme:", error);
+        logError("Failed to persist app theme", error);
       }
     },
     [commitSchemeSelection, followSystem, setFollowSystem]
@@ -164,7 +167,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
     try {
       await appThemeClient.setFollowSystem(newValue);
     } catch (error) {
-      console.error("Failed to persist follow system:", error);
+      logError("Failed to persist follow system", error);
     }
   }, [followSystem, setFollowSystem]);
 
@@ -174,7 +177,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       try {
         await appThemeClient.setPreferredDarkScheme(id);
       } catch (error) {
-        console.error("Failed to persist preferred dark scheme:", error);
+        logError("Failed to persist preferred dark scheme", error);
       }
     },
     [setPreferredDarkSchemeId]
@@ -186,7 +189,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       try {
         await appThemeClient.setPreferredLightScheme(id);
       } catch (error) {
-        console.error("Failed to persist preferred light scheme:", error);
+        logError("Failed to persist preferred light scheme", error);
       }
     },
     [setPreferredLightSchemeId]
@@ -218,7 +221,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
         setImportMessage(`Imported "${result.scheme.name}".`);
       }
     } catch (error) {
-      console.error("Failed to import app theme:", error);
+      logError("Failed to import app theme", error);
       setImportMessage("Failed to import app theme.");
     }
   }, [addCustomScheme, handleSelect]);
@@ -229,7 +232,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       const effectiveScheme = applyAccentOverrideToScheme(selectedScheme, accentColorOverride);
       await appThemeClient.exportTheme(effectiveScheme);
     } catch (error) {
-      console.error("Failed to export app theme:", error);
+      logError("Failed to export app theme", error);
       setImportMessage("Failed to export app theme.");
     }
   }, [selectedScheme, accentColorOverride]);

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -10,6 +10,7 @@ import {
 import { useTerminalColorSchemeStore } from "@/store/terminalColorSchemeStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { terminalConfigClient } from "@/clients/terminalConfigClient";
+import { logError } from "@/utils/logger";
 
 function SchemePreview({ scheme }: { scheme: TerminalColorScheme }) {
   const c = scheme.colors;
@@ -144,7 +145,7 @@ export function ColorSchemePicker() {
           useTerminalColorSchemeStore.getState().recentSchemeIds
         );
       } catch (error) {
-        console.error("Failed to persist color scheme:", error);
+        logError("Failed to persist color scheme", error);
       }
     },
     [setSelectedSchemeId, setPreviewSchemeId]
@@ -164,7 +165,7 @@ export function ColorSchemePicker() {
       await persistCustomSchemes();
       await handleSelect(scheme.id);
     } catch (error) {
-      console.error("Failed to import color scheme:", error);
+      logError("Failed to import color scheme", error);
     }
   }, [addCustomScheme, handleSelect]);
 

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -9,6 +9,7 @@ import {
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
 import type { ColorVisionMode } from "@shared/types";
+import { logError } from "@/utils/logger";
 
 const COLOR_VISION_OPTIONS: Array<{ id: ColorVisionMode; label: string; description: string }> = [
   { id: "default", label: "Default", description: "No color adjustments" },
@@ -73,7 +74,7 @@ export function ColorVisionPicker() {
       try {
         await appThemeClient.setColorVisionMode(mode);
       } catch (error) {
-        console.error("Failed to persist color vision mode:", error);
+        logError("Failed to persist color vision mode", error);
       }
     },
     [setColorVisionMode]

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -6,6 +6,7 @@ import type { CommandManifestEntry, CommandOverride } from "@shared/types/comman
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { extractTemplateVariables, validatePromptTemplate } from "@shared/utils/promptTemplate";
+import { logError } from "@/utils/logger";
 
 interface CommandOverridesTabProps {
   projectId: string;
@@ -35,7 +36,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
           setCommands(result);
         }
       } catch (error) {
-        console.error("Failed to load commands:", error);
+        logError("Failed to load commands", error);
       } finally {
         if (mounted) {
           setIsLoading(false);

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -6,6 +6,7 @@ import { editorClient } from "@/clients/editorClient";
 import type { EditorConfig, DiscoveredEditor, KnownEditorId } from "@shared/types/editor";
 import { useProjectStore } from "@/store";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 const EDITOR_LABELS: Record<KnownEditorId, string> = {
   vscode: "VS Code",
@@ -76,7 +77,7 @@ export function EditorIntegrationTab() {
       })
       .catch((err) => {
         if (cancelled || !isMountedRef.current) return;
-        console.error("[EditorIntegrationTab] Failed to load config:", err);
+        logError("[EditorIntegrationTab] Failed to load config", err);
       });
     return () => {
       cancelled = true;
@@ -90,7 +91,7 @@ export function EditorIntegrationTab() {
       if (!isMountedRef.current) return;
       setDiscoveredEditors(editors);
     } catch (err) {
-      console.error("[EditorIntegrationTab] Rescan failed:", err);
+      logError("[EditorIntegrationTab] Rescan failed", err);
     } finally {
       if (isMountedRef.current) setIsRescanning(false);
     }

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -36,6 +36,7 @@ import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 const GENERAL_SUBTABS: SettingsSubtabItem[] = [
   { id: "overview", label: "Overview" },
@@ -143,8 +144,9 @@ export function GeneralTab({
       .then((ch) => {
         if (!cancelled) setUpdateChannel(ch);
       })
-      .catch(() => {
+      .catch((error) => {
         if (!cancelled) setUpdateChannel("stable");
+        logError("Failed to get update channel", error);
       });
     return () => {
       cancelled = true;
@@ -158,7 +160,7 @@ export function GeneralTab({
       const result = await window.electron.update.setChannel(channel);
       if (isMountedRef.current) setUpdateChannel(result);
     } catch (error) {
-      console.error("Failed to set update channel:", error);
+      logError("Failed to set update channel", error);
     } finally {
       if (isMountedRef.current) setChannelSaving(false);
     }
@@ -186,7 +188,7 @@ export function GeneralTab({
       .catch((error) => {
         clearTimeout(timer);
         if (cancelled) return;
-        console.error("Failed to load hibernation config:", error);
+        logError("Failed to load hibernation config", error);
         setConfigError(formatErrorMessage(error, "Failed to load hibernation settings"));
       });
 
@@ -201,7 +203,7 @@ export function GeneralTab({
       })
       .catch((error) => {
         if (cancelled) return;
-        console.error("Failed to load idle terminal notify config:", error);
+        logError("Failed to load idle terminal notify config", error);
       });
 
     return () => {
@@ -243,7 +245,7 @@ export function GeneralTab({
       })
       .catch((error) => {
         if (cancelled) return;
-        console.error("[GeneralTab] Failed to load agent availability:", error);
+        logError("[GeneralTab] Failed to load agent availability", error);
         setCliCheckFailed(true);
       })
       .finally(() => clearTimeout(timeoutId));
@@ -316,7 +318,7 @@ export function GeneralTab({
       setHibernationConfig(result.result as HibernationConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
-      console.error("Failed to update hibernation config:", error);
+      logError("Failed to update hibernation config", error);
     } finally {
       if (isMountedRef.current) {
         setIsSaving(false);
@@ -340,7 +342,7 @@ export function GeneralTab({
       setIdleNotifyConfig(result.result as IdleTerminalNotifyConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
-      console.error("Failed to update idle terminal notify config:", error);
+      logError("Failed to update idle terminal notify config", error);
     } finally {
       if (isMountedRef.current) {
         setIsIdleNotifySaving(false);
@@ -364,7 +366,7 @@ export function GeneralTab({
       setIdleNotifyConfig(result.result as IdleTerminalNotifyConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
-      console.error("Failed to update idle terminal notify threshold:", error);
+      logError("Failed to update idle terminal notify threshold", error);
     } finally {
       if (isMountedRef.current) {
         setIsIdleNotifySaving(false);
@@ -388,7 +390,7 @@ export function GeneralTab({
       setHibernationConfig(result.result as HibernationConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
-      console.error("Failed to update hibernation threshold:", error);
+      logError("Failed to update hibernation threshold", error);
     } finally {
       if (isMountedRef.current) {
         setIsSaving(false);

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { useGitHubConfigStore } from "@/store";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
+import { logError } from "@/utils/logger";
 
 type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
 
@@ -75,7 +76,7 @@ export function GitHubSettingsTab() {
         setErrorMessage(validation.error || "Invalid token");
       }
     } catch (error) {
-      console.error("Failed to save GitHub token:", error);
+      logError("Failed to save GitHub token", error);
       setValidationResult("error");
       setErrorMessage("Failed to save token");
     } finally {
@@ -101,7 +102,7 @@ export function GitHubSettingsTab() {
       setValidationResult(null);
       setErrorMessage(null);
     } catch (error) {
-      console.error("Failed to clear GitHub token:", error);
+      logError("Failed to clear GitHub token", error);
       setValidationResult("error");
       setErrorMessage("Failed to clear token");
     }
@@ -129,7 +130,7 @@ export function GitHubSettingsTab() {
         setErrorMessage(validation.error || "Invalid token");
       }
     } catch (error) {
-      console.error("Failed to test GitHub token:", error);
+      logError("Failed to test GitHub token", error);
       setValidationResult("test-error");
       setErrorMessage("Failed to validate token");
     } finally {

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -3,6 +3,7 @@ import { Image } from "lucide-react";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { useProjectStore } from "@/store";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 type ImageViewerMode = "os" | "custom";
 
@@ -50,7 +51,7 @@ export function ImageViewerTab() {
       })
       .catch((err) => {
         if (cancelled || !isMountedRef.current) return;
-        console.error("[ImageViewerTab] Failed to load settings:", err);
+        logError("[ImageViewerTab] Failed to load settings", err);
       })
       .finally(() => {
         clearTimeout(timer);

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -3,6 +3,7 @@ import { Search, X, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { keybindingService, KeybindingConfig } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { KeybindingProfileActions } from "./KeybindingProfileActions";
@@ -149,7 +150,7 @@ export function KeyboardShortcutsTab() {
       { source: "user" }
     );
     if (!result.ok) {
-      console.error("Failed to save keybinding override:", result.error);
+      logError("Failed to save keybinding override", undefined, { error: result.error });
     }
     setEditingActionId(null);
     loadBindings();
@@ -162,7 +163,7 @@ export function KeyboardShortcutsTab() {
       { source: "user" }
     );
     if (!result.ok) {
-      console.error("Failed to reset keybinding override:", result.error);
+      logError("Failed to reset keybinding override", undefined, { error: result.error });
     }
     loadBindings();
   };
@@ -181,7 +182,7 @@ export function KeyboardShortcutsTab() {
         confirmed: true,
       });
       if (!result.ok) {
-        console.error("Failed to reset all keybinding overrides:", result.error);
+        logError("Failed to reset all keybinding overrides", undefined, { error: result.error });
         return;
       }
       await keybindingService.loadOverrides();

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -8,6 +8,7 @@ import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { ANALYTICS_EVENTS } from "@shared/config/telemetry";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 
 type TelemetryLevel = "off" | "errors" | "full";
 type LogRetention = 7 | 30 | 90 | 0;
@@ -114,7 +115,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           title: "Failed to load settings",
           message: "Privacy settings could not be loaded.",
         });
-        console.error("Failed to load privacy settings:", err);
+        logError("Failed to load privacy settings", err);
       });
   }, []);
 
@@ -138,7 +139,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           title: "Failed to save setting",
           message: "Telemetry level could not be saved. Please try again.",
         });
-        console.error("Failed to set telemetry level:", err);
+        logError("Failed to set telemetry level", err);
       }
     },
     [telemetryLevel]
@@ -157,7 +158,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           title: "Failed to save setting",
           message: "Log retention could not be saved. Please try again.",
         });
-        console.error("Failed to set log retention:", err);
+        logError("Failed to set log retention", err);
       }
     },
     [logRetentionDays]
@@ -175,7 +176,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
       setCacheCleared(true);
       setTimeout(() => setCacheCleared(false), 3000);
     } catch (err) {
-      console.error("Failed to clear cache:", err);
+      logError("Failed to clear cache", err);
     } finally {
       setCacheClearing(false);
     }

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -12,6 +12,7 @@ import {
   useContext,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
+import { logError } from "@/utils/logger";
 import {
   usePortalStore,
   usePerformanceModeStore,
@@ -322,7 +323,7 @@ function SettingsDialogInner({
         .getVersion()
         .then(setAppVersion)
         .catch((error) => {
-          console.error("Failed to fetch app version:", error);
+          logError("Failed to fetch app version", error);
           setAppVersion("Unavailable");
         });
     }

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -18,6 +18,7 @@ import { AppThemePicker } from "./AppThemePicker";
 import { ColorVisionPicker } from "./ColorVisionPicker";
 import { DockDensityPicker } from "./DockDensityPicker";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { logError } from "@/utils/logger";
 
 const MIN_FONT_SIZE = 8;
 const MAX_FONT_SIZE = 24;
@@ -111,7 +112,7 @@ export function TerminalAppearanceTab({
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist terminal font size:", error);
+      logError("Failed to persist terminal font size", error);
       setFontSizeInput(String(previous));
       setFontSizeError("Failed to save font size.");
     }
@@ -134,7 +135,7 @@ export function TerminalAppearanceTab({
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist terminal font family:", error);
+      logError("Failed to persist terminal font family", error);
     }
   };
 

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -26,6 +26,7 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { SettingsNumberInput } from "@/components/Settings/SettingsNumberInput";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
+import { logError } from "@/utils/logger";
 import {
   useLayoutConfigStore,
   usePerformanceModeStore,
@@ -194,7 +195,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist scrollback setting:", error);
+      logError("Failed to persist scrollback setting", error);
     }
   };
 
@@ -221,7 +222,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist performance mode setting:", error);
+      logError("Failed to persist performance mode setting", error);
     }
   };
 
@@ -237,7 +238,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist hybrid input setting:", error);
+      logError("Failed to persist hybrid input setting", error);
     }
   };
 
@@ -253,7 +254,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist hybrid input focus setting:", error);
+      logError("Failed to persist hybrid input focus setting", error);
     }
   };
 
@@ -268,7 +269,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist screen reader mode:", error);
+      logError("Failed to persist screen reader mode", error);
     }
   };
 
@@ -283,7 +284,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to persist cached project views setting:", error);
+      logError("Failed to persist cached project views setting", error);
     }
   };
 

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -19,6 +19,7 @@ import type { AppState, SystemHealthCheckResult } from "@shared/types";
 import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
 import type { ReplacementRule } from "@shared/utils/diagnosticsTransform";
 import { actionService } from "@/services/ActionService";
+import { logError, logWarn } from "@/utils/logger";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
@@ -236,7 +237,7 @@ export function TroubleshootingTab() {
       await logsClient.clearLevelOverrides();
       setLogOverrides({});
     } catch (error) {
-      console.error("Failed to clear log level overrides:", error);
+      logError("Failed to clear log level overrides", error);
     }
   }, []);
 
@@ -257,7 +258,7 @@ export function TroubleshootingTab() {
         }
       })
       .catch((error) => {
-        console.error("Failed to get verbose logging state:", error);
+        logError("Failed to get verbose logging state", error);
       });
   }, []);
 
@@ -277,7 +278,7 @@ export function TroubleshootingTab() {
           throw new Error(result.error.message);
         }
       } catch (error) {
-        console.error("Failed to save developer mode settings:", error);
+        logError("Failed to save developer mode settings", error);
       }
     },
     []
@@ -358,11 +359,11 @@ export function TroubleshootingTab() {
       );
       const payload = result.ok ? (result.result as { success: boolean }) : null;
       if (!result.ok || !payload?.success) {
-        console.error("Backend rejected verbose logging toggle");
+        logWarn("Backend rejected verbose logging toggle");
         setVerboseLogging(!newState);
       }
     } catch (error) {
-      console.error("Failed to set verbose logging:", error);
+      logError("Failed to set verbose logging", error);
       setVerboseLogging(!newState);
     } finally {
       setVerboseLoggingPending(false);
@@ -378,7 +379,7 @@ export function TroubleshootingTab() {
         throw new Error(result.error.message);
       }
     } catch (error) {
-      console.error("Failed to clear logs:", error);
+      logError("Failed to clear logs", error);
     }
   };
 

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -10,6 +10,7 @@ import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { useAgentSettingsStore } from "@/store";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
+import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
@@ -384,7 +385,7 @@ export function AgentSetupWizard({
             dispatch({ type: "SET_AVAILABILITY", payload: result });
           }
         })
-        .catch(console.error);
+        .catch((err) => logError("Failed to refresh CLI availability", err));
     };
 
     poll();
@@ -422,7 +423,9 @@ export function AgentSetupWizard({
       // Auto-select mirrors OS appearance — not a direct user pick, so use the
       // silent setter to avoid polluting the recently-used list.
       setSelectedSchemeIdSilent(targetId);
-      appThemeClient.setColorScheme(targetId).catch(console.error);
+      appThemeClient
+        .setColorScheme(targetId)
+        .catch((err) => logError("Failed to set color scheme", err));
     }
   }, [isFirstRun, isOpen, state.step.type, selectedSchemeId, setSelectedSchemeIdSilent]);
 
@@ -432,7 +435,7 @@ export function AgentSetupWizard({
       try {
         await appThemeClient.setColorScheme(id);
       } catch (error) {
-        console.error("Failed to persist app theme:", error);
+        logError("Failed to persist app theme", error);
       }
     },
     [setSelectedSchemeId]
@@ -445,7 +448,7 @@ export function AgentSetupWizard({
       await window.electron.telemetry.markPromptShown();
       telemetryCommittedRef.current = true;
     } catch (error) {
-      console.error("Failed to commit telemetry preference:", error);
+      logError("Failed to commit telemetry preference", error);
     }
   }, []);
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -63,6 +63,7 @@ import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
 import { isAgentTerminal } from "@/utils/terminalType";
+import { logError } from "@/utils/logger";
 
 export function preloadNewWorktreeDialog() {
   return import("@/components/Worktree/NewWorktreeDialog");
@@ -401,7 +402,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const [homeDir, setHomeDir] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    systemClient.getHomeDir().then(setHomeDir).catch(console.error);
+    systemClient
+      .getHomeDir()
+      .then(setHomeDir)
+      .catch((err) => logError("Failed to get home dir", err));
   }, []);
 
   const handleRefreshAll = useCallback(() => {

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { useDroppable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import {
   usePanelStore,
@@ -495,7 +496,7 @@ export function ContentGrid({
         setActiveTab(groupId, newPanelId);
         setFocused(newPanelId);
       } catch (error) {
-        console.error("Failed to add tab:", error);
+        logError("Failed to add tab", error);
         if (createdNewGroup && groupId!) {
           deleteTabGroup(groupId);
         }

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "react";
 import { usePanelStore, type TerminalInstance } from "@/store";
+import { logError } from "@/utils/logger";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
@@ -313,7 +314,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
       setActiveTab(group.id, newPanelId);
       setFocused(newPanelId);
     } catch (error) {
-      console.error("Failed to add tab:", error);
+      logError("Failed to add tab", error);
     }
   }, [activePanel, group.id, addPanel, addPanelToGroup, setActiveTab, setFocused]);
 

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -13,6 +13,7 @@ import { EditorView, drawSelection } from "@codemirror/view";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@/types";
+import { logError } from "@/utils/logger";
 import { getAgentConfig } from "@/config/agents";
 import { cn } from "@/lib/utils";
 import { useFileAutocomplete } from "@/hooks/useFileAutocomplete";
@@ -891,7 +892,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         if (result.success && result.prompt) {
           sendText(result.prompt);
         } else if (!result.success && result.error) {
-          console.error("[HybridInputBar] Command execution failed:", result.error);
+          logError("[HybridInputBar] Command execution failed", result.error);
         }
       },
       [sendText]

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { Info } from "lucide-react";
+import { logError } from "@/utils/logger";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
@@ -255,7 +256,7 @@ Performance & Diagnostics:
     try {
       await navigator.clipboard.writeText(diagnosticInfo);
     } catch (err) {
-      console.error("Failed to copy to clipboard:", err);
+      logError("Failed to copy to clipboard", err);
     }
   };
 

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { FolderOpen, AlertCircle } from "lucide-react";
+import { logError } from "@/utils/logger";
 import { systemClient } from "@/clients/systemClient";
 import { usePanelStore } from "@/store/panelStore";
 
@@ -55,7 +56,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
       onClose();
     } catch (error) {
       setValidationError("Could not restart terminal. Please try again.");
-      console.error("Failed to update CWD and restart:", error);
+      logError("Failed to update CWD and restart", error);
     } finally {
       setValidating(false);
     }

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -19,6 +19,7 @@ import { terminalFontReady } from "@/config/terminalFont";
 import { getSoftNewlineSequence } from "../../../shared/utils/terminalInputProtocol.js";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 import { useTerminalFileTransfer } from "./useTerminalFileTransfer";
 
 export interface XtermAdapterProps {
@@ -216,6 +217,8 @@ function XtermAdapterComponent({
     const container = containerRef.current;
     if (!container) return;
 
+    let disposed = false;
+
     const managed = terminalInstanceService.getOrCreate(
       terminalId,
       launchAgentId,
@@ -311,14 +314,15 @@ function XtermAdapterComponent({
                 )
                 .then((dispatchResult) => {
                   if (!dispatchResult.ok) {
-                    console.error(
-                      `[XtermKeybinding] Action "${result.match!.actionId}" failed:`,
-                      dispatchResult.error
+                    logError(
+                      `[XtermKeybinding] Action "${result.match!.actionId}" failed`,
+                      undefined,
+                      { error: dispatchResult.error }
                     );
                   }
                 })
                 .catch((error) => {
-                  console.error(`[XtermKeybinding] Unexpected error:`, error);
+                  logError("[XtermKeybinding] Unexpected error", error);
                 });
             }
             // Chord prefix consumed to prevent terminal leakage
@@ -399,16 +403,23 @@ function XtermAdapterComponent({
       !(wasDetachedForSwitch && hasSavedTargetDims) &&
       !hasVisibleBufferContent()
     ) {
-      void terminalInstanceService.fetchAndRestore(terminalId).then((restored) => {
-        if (restored) {
-          requestAnimationFrame(() => performFit());
-        }
-      });
+      void terminalInstanceService
+        .fetchAndRestore(terminalId)
+        .then((restored) => {
+          if (disposed) return;
+          if (restored) {
+            requestAnimationFrame(() => performFit());
+          }
+        })
+        .catch((err) => {
+          if (!disposed) logError("Failed to restore terminal buffer", err);
+        });
     }
 
     onReady?.();
 
     return () => {
+      disposed = true;
       // Pass the captured generation so stale dock→grid unmount cleanup
       // doesn't background a terminal that has already been re-attached elsewhere.
       terminalInstanceService.setVisible(terminalId, false, attachGen);

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -20,6 +20,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { logError } from "@/utils/logger";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import type { TerminalRecipe } from "@/types";
 import { useRef } from "react";
@@ -84,7 +85,7 @@ export function RecipeManager({
       await deleteRecipe(recipeId);
       setRecipeToDelete(null);
     } catch (err) {
-      console.error("Failed to delete recipe:", err);
+      logError("Failed to delete recipe", err);
       setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
     }
   };
@@ -102,7 +103,7 @@ export function RecipeManager({
             exportTimeoutRef.current = null;
           }, 2000);
         } catch (err) {
-          console.error("Failed to copy to clipboard:", err);
+          logError("Failed to copy to clipboard", err);
         }
       }
     },
@@ -130,7 +131,7 @@ export function RecipeManager({
     try {
       await deleteRecipe(recipeToDeleteAfterSave);
     } catch (err) {
-      console.error("Failed to delete original recipe:", err);
+      logError("Failed to delete original recipe", err);
     }
     setRecipeToDeleteAfterSave(null);
   };

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { injectSchemeToDOM, useAppThemeStore } from "@/store/appThemeStore";
 import { useThemeBrowserStore } from "@/store/themeBrowserStore";
+import { logError } from "@/utils/logger";
 import { appThemeClient } from "@/clients/appThemeClient";
 import { runThemeReveal } from "@/lib/appThemeViewTransition";
 import {
@@ -190,7 +191,9 @@ export function ThemeBrowser() {
 
     if (followSystem) {
       setFollowSystem(false);
-      appThemeClient.setFollowSystem(false).catch(console.error);
+      appThemeClient
+        .setFollowSystem(false)
+        .catch((err) => logError("Failed to clear follow system", err));
     }
 
     // Clear preview state BEFORE the View Transition fires. Otherwise the
@@ -212,7 +215,7 @@ export function ThemeBrowser() {
       await appThemeClient.setColorScheme(targetId);
       await appThemeClient.setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds);
     } catch (error) {
-      console.error("Failed to persist app theme:", error);
+      logError("Failed to persist app theme", error);
     }
   }, [
     close,

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
@@ -150,7 +151,7 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
       committedRef.current = true;
       setSelectedSchemeId(scheme.id);
       appThemeClient.setColorScheme(scheme.id).catch((error) => {
-        console.error("Failed to persist theme selection:", error);
+        logError("Failed to persist theme selection", error);
         useNotificationStore.getState().addNotification({
           type: "error",
           priority: "low",

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -35,6 +35,7 @@ import { notify } from "@/lib/notify";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
 import { mapCreationError, type WorktreeCreationError } from "./worktreeCreationErrors";
+import { logError } from "@/utils/logger";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
@@ -638,7 +639,7 @@ export function NewWorktreeDialog({
                       runRecipe(recipeId, recipePath, worktreeId, {
                         worktreePath: recipePath,
                         branchName: selectedExistingBranch,
-                      }).catch(console.error);
+                      }).catch((err) => logError("Failed to run recipe", err));
                     },
                   },
                 ],
@@ -820,8 +821,8 @@ export function NewWorktreeDialog({
                 {
                   label: "Retry Recipe",
                   onClick: () => {
-                    runRecipe(recipeId, recipePath, recipeWorktreeId, recipeContext).catch(
-                      console.error
+                    runRecipe(recipeId, recipePath, recipeWorktreeId, recipeContext).catch((err) =>
+                      logError("Failed to run recipe", err)
                     );
                   },
                 },
@@ -1417,7 +1418,7 @@ export function NewWorktreeDialog({
                         setCreationError(null);
                       }
                     } catch (err: unknown) {
-                      console.error("Failed to open directory picker:", err);
+                      logError("Failed to open directory picker", err);
                       const message = formatErrorMessage(err, "Failed to open directory picker");
                       setValidationError(`Failed to open directory picker: ${message}`);
                       setErrorField(null);

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useShallow } from "zustand/react/shallow";
 import type { WorktreeState } from "../../types";
 import type { GitHubIssue } from "@shared/types/github";
+import { logError } from "@/utils/logger";
 import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
 
 import { useDroppable } from "@dnd-kit/core";
@@ -355,7 +356,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         await errorsClient.retry(errorId, action, args);
         removeError(errorId);
       } catch (error) {
-        console.error("Error retry failed:", error);
+        logError("Error retry failed", error);
       }
     },
     [removeError]

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import type { WorktreeState } from "@/types";
+import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -77,7 +78,7 @@ export function useWorktreeActions({
           branchName: worktree.branch,
         });
       } catch (error) {
-        console.error("Failed to run recipe:", error);
+        logError("Failed to run recipe", error);
       } finally {
         setRunningRecipeId(null);
       }

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -8,6 +8,7 @@ import { LiveTimeAgo } from "./LiveTimeAgo";
 import { cn } from "../../lib/utils";
 import { GitCommit, Copy, Check, ExternalLink } from "lucide-react";
 import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
+import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -96,7 +97,7 @@ export function WorktreeDetails({
         }
       }, 2000);
     } catch (err) {
-      console.error("Failed to copy path:", err);
+      logError("Failed to copy path", err);
     }
   };
 

--- a/src/components/Worktree/hooks/useBranchValidation.ts
+++ b/src/components/Worktree/hooks/useBranchValidation.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { worktreeClient } from "@/clients";
+import { logError } from "@/utils/logger";
 import { parseBranchInput } from "../branchPrefixUtils";
 
 export interface UseBranchValidationResult {
@@ -116,7 +117,7 @@ export function useBranchValidation({
               onBranchAutoResolved(availableBranch);
             }
           } else {
-            console.error("Failed to get available branch:", branchResult.reason);
+            logError("Failed to get available branch", branchResult.reason);
             setBranchWasAutoResolved(false);
           }
 
@@ -128,7 +129,7 @@ export function useBranchValidation({
             setPathWasAutoResolved(pathResolved);
             setWorktreePath(suggestedPath);
           } else {
-            console.error("Failed to get default path:", pathResult.reason);
+            logError("Failed to get default path", pathResult.reason);
             setPathWasAutoResolved(false);
             const sanitizedBranch = fullName.replace(/[^a-zA-Z0-9-_]/g, "-");
             const separator = rootPath.includes("\\") ? "\\" : "/";
@@ -166,7 +167,7 @@ export function useBranchValidation({
         })
         .catch((err) => {
           if (abortController.signal.aborted) return;
-          console.error("Failed to get default path:", err);
+          logError("Failed to get default path", err);
           setIsGeneratingPath(false);
           setPathWasAutoResolved(false);
           const sanitizedBranch = trimmedInput.replace(/[^a-zA-Z0-9-_]/g, "-");

--- a/src/components/Worktree/hooks/useNewWorktreeProjectSettings.ts
+++ b/src/components/Worktree/hooks/useNewWorktreeProjectSettings.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { projectClient } from "@/clients";
+import { logError } from "@/utils/logger";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
 import type { ProjectSettings } from "@/types";
@@ -55,10 +56,10 @@ export function useNewWorktreeProjectSettings({
           }
         }
       })
-      .catch((err) => console.error("Failed to load project settings:", err));
+      .catch((err) => logError("Failed to load project settings", err));
 
     if (recipes.length === 0 && currentProject?.id) {
-      loadRecipes(currentProject.id).catch((err) => console.error("Failed to load recipes:", err));
+      loadRecipes(currentProject.id).catch((err) => logError("Failed to load recipes", err));
     }
   }, [isOpen, currentProject, recipes.length, loadRecipes]);
 

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useId, createContext, useContext } from
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import { usePortalStore } from "@/store";
@@ -133,7 +134,7 @@ export function AppDialog({
       const canClose = await onBeforeClose();
       if (canClose) onClose();
     } catch (error) {
-      console.error("AppDialog onBeforeClose failed", error);
+      logError("AppDialog onBeforeClose failed", error);
     } finally {
       closeInFlightRef.current = false;
     }

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -736,7 +736,8 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
       });
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[Toaster] non-string message without inboxMessage")
+        expect.stringContaining("[Toaster] non-string message without inboxMessage"),
+        expect.anything()
       );
       consoleSpy.mockRestore();
     });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -10,6 +10,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { logError } from "@/utils/logger";
 import { useNotificationStore, type Notification } from "@/store/notificationStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useShallow } from "zustand/react/shallow";
@@ -69,8 +70,8 @@ function Toast({ notification }: { notification: Notification }) {
       typeof notification.message !== "string" &&
       !notification.inboxMessage
     ) {
-      console.error(
-        "[Toaster] non-string message without inboxMessage — aria-live announcement will be empty."
+      logError(
+        "[Toaster] non-string message without inboxMessage — aria-live announcement will be empty"
       );
     }
     const text =
@@ -105,7 +106,7 @@ function Toast({ notification }: { notification: Notification }) {
     try {
       notification.onDismiss?.();
     } catch (err) {
-      console.error("[Toast] onDismiss handler threw:", err);
+      logError("[Toast] onDismiss handler threw", err);
     }
     dismissNotification(notification.id);
     setIsVisible(false);

--- a/src/hooks/__tests__/useNewTerminalPalette.test.tsx
+++ b/src/hooks/__tests__/useNewTerminalPalette.test.tsx
@@ -2,6 +2,12 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorktreeState } from "@/types";
+import { logError } from "@/utils/logger";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
 
 const {
   dispatchMock,
@@ -115,7 +121,7 @@ function makeWorktreeMap(): Map<string, WorktreeState> {
 }
 
 describe("useNewTerminalPalette", () => {
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  const logErrorMock = vi.mocked(logError);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -137,7 +143,7 @@ describe("useNewTerminalPalette", () => {
     ]);
 
     dispatchMock.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
-    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logErrorMock.mockClear();
   });
 
   function render() {
@@ -275,9 +281,12 @@ describe("useNewTerminalPalette", () => {
       await result.current.handleSelect(option!);
     });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Failed to launch claude terminal:",
-      expect.objectContaining({ message: "Action not found" })
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "Failed to launch claude terminal",
+      undefined,
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Action not found" }),
+      })
     );
   });
 });

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { hydrateAppState, type HydrationOptions } from "../../utils/stateHydration";
 import { isElectronAvailable } from "../useElectron";
 import { setStartupQuietPeriod } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import { usePanelStore } from "@/store";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
@@ -72,7 +73,7 @@ export function useAppHydration(enabled = true) {
           }
         }
       } catch (error) {
-        console.error("Failed to restore app state:", error);
+        logError("Failed to restore app state", error);
       } finally {
         setIsStateLoaded(true);
         setStartupQuietPeriod(5000);

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -3,6 +3,7 @@ import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "../useProjectSettings";
 import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
 import { detectCloudSyncService, type Platform } from "@/utils/cloudSyncDetection";
 import { isMac, isLinux } from "@/lib/platform";
@@ -64,7 +65,7 @@ export function useCloudSyncWarning(homeDir?: string) {
               });
               removeNotification(notificationId);
             } catch (err) {
-              console.error("Failed to save cloud sync warning preference:", err);
+              logError("Failed to save cloud sync warning preference", err);
               notify({
                 type: "error",
                 title: "Failed to save preference",

--- a/src/hooks/app/useContextFilesOffer.tsx
+++ b/src/hooks/app/useContextFilesOffer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
 import { projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -51,7 +52,7 @@ export function useContextFilesOffer() {
       try {
         foundFiles = await projectClient.detectContextFiles(targetProjectId);
       } catch (error) {
-        console.error("Failed to detect project context files:", error);
+        logError("Failed to detect project context files", error);
         if (inFlightProjectRef.current === targetProjectId) {
           inFlightProjectRef.current = null;
         }
@@ -107,7 +108,7 @@ export function useContextFilesOffer() {
                   notificationIdRef.current = null;
                 }
               } catch (err) {
-                console.error("Failed to enable in-repo settings from context offer:", err);
+                logError("Failed to enable in-repo settings from context offer", err);
                 notify({
                   type: "error",
                   title: "Failed to enable project context",
@@ -132,7 +133,7 @@ export function useContextFilesOffer() {
                   notificationIdRef.current = null;
                 }
               } catch (err) {
-                console.error("Failed to dismiss context files offer:", err);
+                logError("Failed to dismiss context files offer", err);
                 notify({
                   type: "error",
                   title: "Failed to save preference",

--- a/src/hooks/app/useErrorRetry.ts
+++ b/src/hooks/app/useErrorRetry.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useErrorStore, type RetryAction } from "@/store";
+import { logError } from "@/utils/logger";
 import { errorsClient } from "@/clients";
 
 export function useErrorRetry() {
@@ -12,7 +13,7 @@ export function useErrorRetry() {
         await errorsClient.retry(errorId, action, args);
         removeError(errorId);
       } catch (error) {
-        console.error("Error retry failed:", error);
+        logError("Error retry failed", error);
       } finally {
         clearRetryProgress(errorId);
       }

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -4,6 +4,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
 import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 import type { TerminalInstance } from "@shared/types/panel";
@@ -129,7 +130,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         setOnboardingCompleted(onboarding.completed);
         setChecklist(checklistState);
       })
-      .catch(console.error);
+      .catch((err) => logError("Failed to load checklist state", err));
   }, [isStateLoaded]);
 
   // Subscribe to main-process checklist pushes. Every active WebContentsView
@@ -218,7 +219,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
           .then((state) => {
             setChecklist({ ...state, dismissed: false });
           })
-          .catch(console.error);
+          .catch((err) => logError("Failed to show getting started checklist", err));
       }
     };
     window.addEventListener("daintree:show-getting-started", handleShow);
@@ -236,7 +237,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         // Reconcile after hydration in case stores already have data
         setTimeout(() => reconcileCurrentState(markItem, () => checklistRef.current), 0);
       })
-      .catch(console.error);
+      .catch((err) => logError("Failed to notify onboarding complete", err));
   }, [markItem]);
 
   // Auto-clear celebration after animation completes

--- a/src/hooks/app/useHomeDir.ts
+++ b/src/hooks/app/useHomeDir.ts
@@ -1,11 +1,23 @@
 import { useEffect, useState } from "react";
 import { systemClient } from "@/clients";
+import { logError } from "@/utils/logger";
 
 export function useHomeDir() {
   const [homeDir, setHomeDir] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    systemClient.getHomeDir().then(setHomeDir).catch(console.error);
+    let disposed = false;
+    systemClient
+      .getHomeDir()
+      .then((dir) => {
+        if (!disposed) setHomeDir(dir);
+      })
+      .catch((err) => {
+        if (!disposed) logError("Failed to fetch home directory", err);
+      });
+    return () => {
+      disposed = true;
+    };
   }, []);
 
   return { homeDir };

--- a/src/hooks/app/useOrchestrationMilestones.ts
+++ b/src/hooks/app/useOrchestrationMilestones.ts
@@ -4,6 +4,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useRecipeStore } from "@/store/recipeStore";
 import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
 
 interface MilestoneDefinition {
   id: string;
@@ -209,7 +210,7 @@ export function useOrchestrationMilestones(isStateLoaded: boolean): void {
           window.removeEventListener("daintree:context-injected", onContextInjected)
         );
       })
-      .catch(console.error);
+      .catch((err) => logError("Failed to load milestones", err));
 
     return () => {
       disposed = true;

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -8,6 +8,7 @@ import { isElectronAvailable } from "./useElectron";
 
 import { agentSettingsClient, systemClient } from "@/clients";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
+import { logError, logWarn } from "@/utils/logger";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -117,7 +118,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         }
       })
       .catch((error) => {
-        console.error("Failed to load agent settings:", error);
+        logError("Failed to load agent settings", error);
       });
 
     // Re-check availability when the window regains focus so that agents
@@ -168,7 +169,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           });
           return terminalId;
         } catch (error) {
-          console.error("Failed to launch browser pane:", error);
+          logError("Failed to launch browser pane", error);
           return null;
         }
       }
@@ -185,7 +186,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           });
           return terminalId;
         } catch (error) {
-          console.error("Failed to launch dev-preview pane:", error);
+          logError("Failed to launch dev-preview pane", error);
           return null;
         }
       }
@@ -322,7 +323,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           : (agentConfig?.name ?? "Terminal");
 
       if (isAgent && !command) {
-        console.error(`Cannot launch ${agentId} agent: command could not be generated`);
+        logWarn(`Cannot launch ${agentId} agent: command could not be generated`);
         return null;
       }
 
@@ -356,7 +357,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         const terminalId = await addPanel(options);
         return terminalId;
       } catch (error) {
-        console.error(`Failed to launch ${agentId} agent:`, error);
+        logError(`Failed to launch ${agentId} agent`, error);
         return null;
       }
     },

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
+import { logError } from "@/utils/logger";
 import { normalizeAccentHex, normalizeAppColorScheme } from "@shared/theme";
 import type { AppColorScheme } from "@shared/types/appTheme";
 import type { ColorVisionMode } from "@shared/types";
@@ -82,7 +83,7 @@ export function useAppThemeConfig() {
         }
       })
       .catch((error) => {
-        console.error("Failed to load app theme config:", error);
+        logError("Failed to load app theme config", error);
       });
 
     return () => {

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { keybindingService, normalizeKeyForBinding } from "../services/KeybindingService";
 import { actionService } from "../services/ActionService";
+import { logError } from "@/utils/logger";
 import { openPanelContextMenu } from "../lib/panelContextMenu";
 import { usePanelStore } from "../store";
 
@@ -96,9 +97,10 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
             )
             .then((dispatchResult) => {
               if (!dispatchResult.ok) {
-                console.error(
-                  `[GlobalKeybinding] Action "${result.match!.actionId}" failed:`,
-                  dispatchResult.error
+                logError(
+                  `[GlobalKeybinding] Action "${result.match!.actionId}" failed`,
+                  undefined,
+                  { error: dispatchResult.error }
                 );
               }
             });

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 import type { ActionId } from "@shared/types/actions";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
@@ -18,7 +19,7 @@ export function useMcpBridge(): void {
         const manifest = actionService.list();
         window.electron.mcpBridge.sendGetManifestResponse(requestId, manifest);
       } catch (err) {
-        console.error("[MCP Bridge] Failed to build manifest:", err);
+        logError("[MCP Bridge] Failed to build manifest", err);
         window.electron.mcpBridge.sendGetManifestResponse(requestId, []);
       }
     });

--- a/src/hooks/useMenuActions.ts
+++ b/src/hooks/useMenuActions.ts
@@ -3,6 +3,7 @@ import { isElectronAvailable } from "./useElectron";
 import { actionService } from "@/services/ActionService";
 import type { ActionId } from "@shared/types/actions";
 import type { SettingsNavTarget } from "@/components/Settings";
+import { logError } from "@/utils/logger";
 
 export interface UseMenuActionsOptions {
   onOpenSettings: () => void;
@@ -44,7 +45,9 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
             { source: "menu" }
           );
           if (!result.ok) {
-            console.error(`[Menu] Failed to launch agent "${agentId}":`, result.error);
+            logError(`[Menu] Failed to launch agent "${agentId}"`, undefined, {
+              error: result.error,
+            });
           }
           return;
         }
@@ -56,7 +59,7 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
               source: "menu",
             });
             if (!result.ok) {
-              console.error("[Menu] Failed to open settings:", result.error);
+              logError("[Menu] Failed to open settings", undefined, { error: result.error });
             }
             return;
           }
@@ -67,7 +70,9 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
               { source: "menu" }
             );
             if (!result.ok) {
-              console.error(`[Menu] Failed to open settings tab "${tab}":`, result.error);
+              logError(`[Menu] Failed to open settings tab "${tab}"`, undefined, {
+                error: result.error,
+              });
             }
           }
           return;
@@ -97,13 +102,13 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
         if (actionId) {
           const result = await actionService.dispatch(actionId, undefined, { source: "menu" });
           if (!result.ok) {
-            console.error(`[Menu] Action "${actionId}" failed:`, result.error);
+            logError(`[Menu] Action "${actionId}" failed`, undefined, { error: result.error });
           }
         } else {
           console.warn("[Menu] Unhandled action:", action);
         }
       } catch (error) {
-        console.error("[Menu] Failed to process action:", action, error);
+        logError("[Menu] Failed to process action", error, { action });
       }
     });
 

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -7,6 +7,7 @@ import {
 import { useWorktreeSelectionStore, usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { logError } from "@/utils/logger";
 import type { WorktreeState } from "@/types";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { actionService } from "@/services/ActionService";
@@ -105,11 +106,13 @@ export function useNewTerminalPalette({
           { source: "user" }
         );
         if (!result.ok) {
-          console.error(`Failed to launch ${option.launchAgentId} terminal:`, result.error);
+          logError(`Failed to launch ${option.launchAgentId} terminal`, undefined, {
+            error: result.error,
+          });
         }
         close();
       } catch (error) {
-        console.error(`Failed to launch ${option.launchAgentId} terminal:`, error);
+        logError(`Failed to launch ${option.launchAgentId} terminal`, error);
       }
     },
     [activeWorktreeId, worktreeMap, currentProject, addPanel, close]

--- a/src/hooks/usePanelHandlers.ts
+++ b/src/hooks/usePanelHandlers.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { usePanelStore } from "@/store";
+import { logError } from "@/utils/logger";
 import { getTerminalAnimationDuration } from "@/lib/animationUtils";
 import type { PanelLifecycle } from "./usePanelLifecycle";
 
@@ -41,7 +42,7 @@ export function usePanelHandlers({
           try {
             trashPanelGroup(terminalId);
           } catch (error) {
-            console.error("Failed to trash terminal:", error);
+            logError("Failed to trash terminal", error);
           } finally {
             if (lifecycle.mountedRef.current) {
               lifecycle.setIsTrashing(false);

--- a/src/hooks/useProjectSettings.ts
+++ b/src/hooks/useProjectSettings.ts
@@ -3,6 +3,7 @@ import type { ProjectSettings, RunCommand } from "../types";
 import { useProjectStore } from "../store/projectStore";
 import { useProjectSettingsStore } from "../store/projectSettingsStore";
 import { projectClient } from "@/clients";
+import { logError } from "@/utils/logger";
 import { updateBrandingCache } from "./useProjectBranding";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
@@ -75,7 +76,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
         setLocalDetectedRunners(newDetected);
       }
     } catch (err) {
-      console.error("Failed to load project settings:", err);
+      logError("Failed to load project settings", err);
       if (requestedProjectId === latestTargetIdRef.current) {
         setLocalError(formatErrorMessage(err, "Failed to load project settings"));
         setLocalSettings({ runCommands: [] });
@@ -146,7 +147,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
 
         setLocalError(null);
       } catch (err) {
-        console.error("Failed to save project settings:", err);
+        logError("Failed to save project settings", err);
         const errorMsg = formatErrorMessage(err, "Failed to save project settings");
         setLocalError(errorMsg);
         throw err;
@@ -201,7 +202,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
 
         setLocalError(null);
       } catch (err) {
-        console.error("Failed to promote command:", err);
+        logError("Failed to promote command", err);
         setLocalError(formatErrorMessage(err, "Failed to promote command"));
         throw err;
       }
@@ -263,7 +264,7 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
 
         setLocalError(null);
       } catch (err) {
-        console.error("Failed to remove command:", err);
+        logError("Failed to remove command", err);
         setLocalError(formatErrorMessage(err, "Failed to remove command"));
         throw err;
       }

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -3,6 +3,7 @@ import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useRecipeStore } from "@/store/recipeStore";
+import { logError } from "@/utils/logger";
 import { debounce } from "@/utils/debounce";
 import {
   createProjectSettingsSnapshot,
@@ -404,7 +405,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
         lastSavedSnapshotRef.current = currentProjectSnapshot;
       }
     } catch (err) {
-      console.error("Failed to auto-save project settings:", err);
+      logError("Failed to auto-save project settings", err);
       setProjectAutoSaveError(formatErrorMessage(err, "Failed to save settings"));
     }
   };

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { logError } from "@/utils/logger";
 import { useTerminalFontStore, useScreenReaderStore } from "@/store";
 import { useTerminalColorSchemeStore } from "@/store/terminalColorSchemeStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
@@ -59,7 +60,7 @@ export function useTerminalConfig() {
         }
       })
       .catch((error) => {
-        console.error("Failed to load terminal config:", error);
+        logError("Failed to load terminal config", error);
       });
 
     return () => {

--- a/src/hooks/useTerminalLogic.ts
+++ b/src/hooks/useTerminalLogic.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import type { RetryAction } from "@/store/errorStore";
 import { useErrorStore } from "@/store/errorStore";
+import { logError } from "@/utils/logger";
 import { errorsClient } from "@/clients";
 
 interface UseTerminalLogicOptions {
@@ -50,7 +51,7 @@ export function useTerminalLogic({
         await errorsClient.retry(errorId, action, args);
         removeError(errorId);
       } catch (error) {
-        console.error("Error retry failed:", error);
+        logError("Error retry failed", error);
       } finally {
         clearRetryProgress(errorId);
       }

--- a/src/hooks/useUpdateListener.tsx
+++ b/src/hooks/useUpdateListener.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useNotificationStore } from "@/store/notificationStore";
+import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 
 const AVAILABLE_HINT = 'Use "Check for Updates..." to check again.';
@@ -75,7 +76,7 @@ export function useUpdateListener(suppressToasts = false): void {
         onDismiss: () => {
           void window.electron?.update
             ?.notifyDismiss?.(version)
-            ?.catch((err) => console.error("[useUpdateListener] notifyDismiss failed:", err));
+            ?.catch((err) => logError("[useUpdateListener] notifyDismiss failed", err));
         },
       });
     }
@@ -116,7 +117,7 @@ export function useUpdateListener(suppressToasts = false): void {
         onDismiss: () => {
           void window.electron?.update
             ?.notifyDismiss?.(version)
-            ?.catch((err) => console.error("[useUpdateListener] notifyDismiss failed:", err));
+            ?.catch((err) => logError("[useUpdateListener] notifyDismiss failed", err));
         },
       });
     });

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 import type { WorktreeSnapshot, RecipeTerminal } from "@/types";
 import { useErrorStore, type AppError } from "@/store";
 import { useRecipeStore } from "@/store/recipeStore";
+import { logError } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
 import { formatBytes } from "@/lib/formatBytes";
 import { actionService } from "@/services/ActionService";
@@ -166,7 +167,7 @@ export function useWorktreeActions({
           correlationId: crypto.randomUUID(),
         });
 
-        console.error("Failed to copy context:", message);
+        logError("Failed to copy context", undefined, { message });
         return undefined;
       }
     },

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -11,6 +11,7 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { getBuiltInAppSchemeForType, resolveAppTheme } from "@shared/theme";
+import { logError } from "@/utils/logger";
 
 async function refreshRendererConfig(): Promise<void> {
   await Promise.all([
@@ -114,7 +115,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     try {
       await refreshRendererConfig();
     } catch (e) {
-      console.error("[app.reloadConfig] Failed to refresh renderer config:", e);
+      logError("[app.reloadConfig] Failed to refresh renderer config", e);
     }
   };
   if (
@@ -188,7 +189,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
       try {
         await appThemeClient.setColorScheme(target.id);
       } catch (error) {
-        console.error("Failed to persist theme toggle:", error);
+        logError("Failed to persist theme toggle", error);
         useNotificationStore.getState().addNotification({
           type: "error",
           priority: "low",

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -8,6 +8,7 @@ import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { usePortalStore } from "@/store/portalStore";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { useUIStore } from "@/store/uiStore";
+import { logError } from "@/utils/logger";
 
 export function registerPanelActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   // Query action: list all panels with metadata
@@ -149,7 +150,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
       }
       await window.electron.portal.show({ tabId, bounds });
     } catch (error) {
-      console.error("Failed to activate portal tab:", error);
+      logError("Failed to activate portal tab", error);
     }
   };
 
@@ -535,7 +536,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
           await window.electron.portal.create({ tabId: newTabId, url });
           state.markTabCreated(newTabId);
         } catch (error) {
-          console.error("Failed to create background portal tab:", error);
+          logError("Failed to create background portal tab", error);
           usePortalStore.setState((s) => ({
             tabs: s.tabs.filter((t) => t.id !== newTabId),
           }));
@@ -697,7 +698,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
         state.markTabCreated(newTabId);
         await window.electron.portal.show({ tabId: newTabId, bounds });
       } catch (error) {
-        console.error("Failed to duplicate portal tab:", error);
+        logError("Failed to duplicate portal tab", error);
         state.closeTab(newTabId);
       }
     },

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -9,6 +9,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 import { notify } from "@/lib/notify";
 import { getVisibleWorktreesForCycling } from "@/lib/worktreeCyclingOrder";
+import { logError, logWarn } from "@/utils/logger";
 
 export function registerWorktreeActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   // Query action: list all worktrees with metadata
@@ -806,11 +807,11 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           const url = new URL(worktree.prUrl);
           if (!["https:", "http:"].includes(url.protocol)) {
-            console.error(`Invalid PR URL protocol: ${url.protocol}`);
+            logWarn(`Invalid PR URL protocol: ${url.protocol}`);
             return;
           }
         } catch (error) {
-          console.error(`Invalid PR URL: ${worktree.prUrl}`, error);
+          logError(`Invalid PR URL: ${worktree.prUrl}`, error);
           return;
         }
 

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -2,6 +2,7 @@ import type { Terminal, ILinkProvider, ILink, IBufferRange } from "@xterm/xterm"
 import { systemClient } from "@/clients";
 import * as path from "path-browserify";
 import { actionService } from "@/services/ActionService";
+import { logError } from "@/utils/logger";
 
 interface ResolvedFilePath {
   absolutePath: string;
@@ -153,7 +154,9 @@ class FileLink implements ILink {
           });
         })
         .catch((error) => {
-          console.error("[FileLinksAddon] Failed to open in editor:", this._absolutePath, error);
+          logError("[FileLinksAddon] Failed to open in editor", error, {
+            absolutePath: this._absolutePath,
+          });
         });
     } else {
       actionService
@@ -167,7 +170,9 @@ class FileLink implements ILink {
           return systemClient.openPath(this._absolutePath);
         })
         .catch((error) => {
-          console.error("[FileLinksAddon] Failed to view file:", this._absolutePath, error);
+          logError("[FileLinksAddon] Failed to view file", error, {
+            absolutePath: this._absolutePath,
+          });
         });
     }
   }

--- a/src/services/terminal/TerminalLinkHandler.ts
+++ b/src/services/terminal/TerminalLinkHandler.ts
@@ -3,6 +3,7 @@ import { actionService } from "@/services/ActionService";
 import { isLocalhostUrl, normalizeBrowserUrl } from "@/components/Browser/browserUtils";
 import { usePanelStore } from "@/store/panelStore";
 import { isMac } from "@/lib/platform";
+import { logError } from "@/utils/logger";
 
 export class TerminalLinkHandler {
   openLink(url: string, terminalId: string, event?: MouseEvent): void {
@@ -51,7 +52,7 @@ export class TerminalLinkHandler {
         return systemClient.openExternal(normalizedUrl);
       })
       .catch((error) => {
-        console.error("[TerminalLinkHandler] Failed to open URL:", error);
+        logError("[TerminalLinkHandler] Failed to open URL", error);
       });
   }
 }

--- a/src/store/commandStore.ts
+++ b/src/store/commandStore.ts
@@ -7,6 +7,7 @@ import type {
 } from "@shared/types/commands";
 import { commandsClient } from "@/clients/commandsClient";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 interface CommandStore {
   // Picker state
@@ -80,7 +81,7 @@ export const useCommandStore = create<CommandStore>()((set, get) => ({
         }
       } catch (error) {
         const message = formatErrorMessage(error, "Failed to load builder");
-        console.error("Failed to fetch builder steps:", error);
+        logError("Failed to fetch builder steps", error);
         const currentCommandId = get().activeCommandId;
         if (currentCommandId === commandId) {
           set({ builderLoadError: message, isLoadingBuilder: false });
@@ -147,7 +148,7 @@ export const useCommandStore = create<CommandStore>()((set, get) => ({
       const commands = await commandsClient.list(context);
       set({ commands });
     } catch (error) {
-      console.error("Failed to load commands:", error);
+      logError("Failed to load commands", error);
     } finally {
       set({ isLoadingCommands: false });
     }

--- a/src/store/dockStore.ts
+++ b/src/store/dockStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { appClient } from "@/clients";
+import { logError } from "@/utils/logger";
 
 interface DockState {
   peek: boolean;
@@ -40,7 +41,7 @@ async function persistPopoverHeight(height: number): Promise<void> {
   try {
     await appClient.setState({ dockedPopoverHeight: height });
   } catch (error) {
-    console.error("Failed to persist docked popover height:", error);
+    logError("Failed to persist docked popover height", error);
   }
 }
 

--- a/src/store/fleetScopeFlagStore.ts
+++ b/src/store/fleetScopeFlagStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { logError } from "@/utils/logger";
 
 export type FleetScopeMode = "legacy" | "scoped";
 
@@ -31,6 +32,6 @@ async function persistMode(mode: FleetScopeMode): Promise<void> {
     const { appClient } = await import("@/clients");
     await appClient.setState({ fleetScopeMode: mode });
   } catch (error) {
-    console.error("Failed to persist fleet scope mode:", error);
+    logError("Failed to persist fleet scope mode", error);
   }
 }

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -4,6 +4,7 @@ import { debounce } from "@/utils/debounce";
 import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
+import { logError } from "@/utils/logger";
 
 type ProjectClientType = typeof projectClient;
 
@@ -179,7 +180,7 @@ export class PanelPersistence {
       const payloadBytes = collectPerf ? estimatePayloadBytes(transformed) : null;
 
       this.pendingPersist = this.client.setTerminals(projectId, transformed).catch((error) => {
-        console.error("Failed to persist terminals:", error);
+        logError("Failed to persist terminals", error);
         if (collectPerf) {
           const now = typeof performance !== "undefined" ? performance.now() : Date.now();
           markRendererPerformance("persistence_terminals_save", {
@@ -234,7 +235,7 @@ export class PanelPersistence {
       this.pendingTabGroupPersist = this.client
         .setTabGroups(projectId, tabGroups)
         .catch((error) => {
-          console.error("Failed to persist tab groups:", error);
+          logError("Failed to persist tab groups", error);
           if (collectPerf) {
             const now = typeof performance !== "undefined" ? performance.now() : Date.now();
             markRendererPerformance("persistence_tab_groups_save", {

--- a/src/store/projectSettingsStore.ts
+++ b/src/store/projectSettingsStore.ts
@@ -2,6 +2,7 @@ import { create, type StateCreator } from "zustand";
 import type { ProjectSettings, RunCommand } from "@shared/types";
 import { projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError } from "@/utils/logger";
 
 interface ProjectSettingsState {
   /** Cached settings for the current project */
@@ -107,7 +108,7 @@ const createProjectSettingsStore: StateCreator<ProjectSettingsState & ProjectSet
       });
       evictOldestSettings();
     } catch (err) {
-      console.error("Failed to load project settings:", err);
+      logError("Failed to load project settings", err);
 
       // Verify we're still loading for this project
       if (get().projectId !== projectId) {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -8,6 +8,7 @@ import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariab
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { logError, logWarn } from "@/utils/logger";
 
 export interface RecipeSpawnResult {
   index: number;
@@ -198,7 +199,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       if (requestId !== loadRecipesRequestId || get().currentProjectId !== projectId) {
         return;
       }
-      console.error("Failed to load recipes:", error);
+      logError("Failed to load recipes", error);
       set({
         recipes: [],
         globalRecipes: [],
@@ -257,7 +258,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         await projectClient.updateInRepoRecipe(projectId, newRecipe);
       }
     } catch (error) {
-      console.error("Failed to persist recipe:", error);
+      logError("Failed to persist recipe", error);
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,
@@ -342,7 +343,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         await projectClient.updateRecipe(recipe.projectId!, id, sanitizedUpdates);
       }
     } catch (error) {
-      console.error("Failed to persist recipe update:", error);
+      logError("Failed to persist recipe update", error);
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,
@@ -390,7 +391,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         await projectClient.deleteRecipe(recipe.projectId!, id);
       }
     } catch (error) {
-      console.error("Failed to persist recipe deletion:", error);
+      logError("Failed to persist recipe deletion", error);
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,
@@ -433,7 +434,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     try {
       await projectClient.updateInRepoRecipe(currentProjectId, promoted);
     } catch (error) {
-      console.error("Failed to save recipe to repo:", error);
+      logError("Failed to save recipe to repo", error);
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,
@@ -452,7 +453,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         }
       } catch (error) {
         // In-repo write succeeded; roll back only the delete portion
-        console.error("Failed to delete original recipe:", error);
+        logError("Failed to delete original recipe", error);
         set({
           globalRecipes: prevGlobal,
           projectRecipes: prevProject,
@@ -491,7 +492,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     get()
       .updateRecipe(recipeId, { lastUsedAt: now, usageHistory })
       .catch((error) => {
-        console.warn("Failed to update lastUsedAt for recipe:", error);
+        logWarn("Failed to update lastUsedAt for recipe", { error });
       });
 
     const terminalStore = usePanelStore.getState();
@@ -514,7 +515,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         agentSettings = settings;
         clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
       } catch (error) {
-        console.warn("Failed to fetch agent settings for recipe:", error);
+        logWarn("Failed to fetch agent settings for recipe", { error });
       }
     }
 
@@ -595,7 +596,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         }
       } catch (error) {
         const message = formatErrorMessage(error, "Failed to spawn terminal");
-        console.error(`Failed to spawn terminal for recipe ${recipeId}:`, error);
+        logError(`Failed to spawn terminal for recipe ${recipeId}`, error);
         results.failed.push({ index, error: message });
       }
     }
@@ -766,7 +767,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         await projectClient.updateInRepoRecipe(projectId, importedRecipe);
       }
     } catch (_error) {
-      console.error("Failed to persist imported recipe:", _error);
+      logError("Failed to persist imported recipe", _error);
       set({
         globalRecipes: prevGlobal,
         projectRecipes: prevProject,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -8,7 +8,7 @@ import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariab
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { stableInRepoId, isInRepoRecipeId } from "@shared/utils/recipeFilename";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { logError, logWarn } from "@/utils/logger";
+import { logError } from "@/utils/logger";
 
 export interface RecipeSpawnResult {
   index: number;
@@ -492,7 +492,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     get()
       .updateRecipe(recipeId, { lastUsedAt: now, usageHistory })
       .catch((error) => {
-        logWarn("Failed to update lastUsedAt for recipe", { error });
+        logError("Failed to update lastUsedAt for recipe", error);
       });
 
     const terminalStore = usePanelStore.getState();
@@ -515,7 +515,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         agentSettings = settings;
         clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
       } catch (error) {
-        logWarn("Failed to fetch agent settings for recipe", { error });
+        logError("Failed to fetch agent settings for recipe", error);
       }
     }
 

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -6,6 +6,7 @@ import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { ABSOLUTE_MAX_GRID_TERMINALS } from "@/lib/terminalLayout";
 import { deriveTerminalChrome, type TerminalChromeInput } from "@/utils/terminalChrome";
+import { logError } from "@/utils/logger";
 
 // Re-export for backward compatibility
 export const MAX_GRID_TERMINALS = ABSOLUTE_MAX_GRID_TERMINALS;
@@ -106,9 +107,6 @@ export function stopDevPreviewByPanelId(panelId: string): void {
   if (!stopByPanel) return;
 
   void stopByPanel({ panelId }).catch((error) => {
-    console.error(
-      `[TerminalStore] Failed to stop dev preview session for panel ${panelId}:`,
-      error
-    );
+    logError(`[TerminalStore] Failed to stop dev preview session for panel ${panelId}`, error);
   });
 }

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -8,6 +8,7 @@ import { TRASH_TTL_MS } from "@shared/config/trash";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { stopDevPreviewByPanelId } from "./helpers";
+import { logError } from "@/utils/logger";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -47,7 +48,7 @@ export const createTrashActions = (
     // Only call PTY operations for PTY-backed terminals
     if (panelKindHasPty(terminal.kind ?? "terminal")) {
       terminalClient.trash(id).catch((error) => {
-        console.error("Failed to trash terminal:", error);
+        logError("Failed to trash terminal", error);
       });
     }
 
@@ -154,7 +155,7 @@ export const createTrashActions = (
       }
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
         terminalClient.trash(id).catch((error) => {
-          console.error("Failed to trash terminal:", error);
+          logError("Failed to trash terminal", error);
         });
       }
     }
@@ -216,7 +217,7 @@ export const createTrashActions = (
 
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
       terminalClient.restore(id).catch((error) => {
-        console.error("Failed to restore terminal:", error);
+        logError("Failed to restore terminal", error);
       });
     }
 
@@ -273,7 +274,7 @@ export const createTrashActions = (
       const terminal = get().panelsById[id];
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
         terminalClient.restore(id).catch((error) => {
-          console.error("Failed to restore terminal:", error);
+          logError("Failed to restore terminal", error);
         });
       }
     }

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -5,6 +5,7 @@ import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import type { AgentState } from "@/types";
 import { isRuntimeAgentTerminal } from "../../utils/terminalType";
 import { validateTerminals, type ValidationResult } from "@/utils/terminalValidation";
+import { logError } from "@/utils/logger";
 
 export interface BulkRestartValidation {
   valid: TerminalInstance[];
@@ -56,7 +57,7 @@ export const createTerminalBulkActionsSlice = (
         try {
           await restartTerminal(id);
         } catch (error) {
-          console.error(`Failed to restart terminal ${id}:`, error);
+          logError(`Failed to restart terminal ${id}`, error);
         }
       })
     );
@@ -122,7 +123,7 @@ export const createTerminalBulkActionsSlice = (
         const valid = activeTerminals.filter((t) => !validationResults.get(t.id));
         await restartTerminals(valid);
       } catch (error) {
-        console.error("Failed to validate terminals for restart:", error);
+        logError("Failed to validate terminals for restart", error);
         await restartTerminals(activeTerminals);
       }
     },
@@ -253,7 +254,7 @@ export const createTerminalBulkActionsSlice = (
         const valid = activeTerminals.filter((t) => !validationResults.get(t.id));
         await restartTerminals(valid);
       } catch (error) {
-        console.error("Failed to validate terminals for restart:", error);
+        logError("Failed to validate terminals for restart", error);
         await restartTerminals(activeTerminals);
       }
     },

--- a/src/utils/__tests__/debounce.test.ts
+++ b/src/utils/__tests__/debounce.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { debounce } from "../debounce";
+import { logError } from "@/utils/logger";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
 
 describe("debounce", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
   });
 
   afterEach(() => {
@@ -79,8 +84,8 @@ describe("debounce", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(console.error).toHaveBeenCalledWith(
-      "Debounce execution failed:",
+    expect(logError).toHaveBeenCalledWith(
+      "Debounce execution failed",
       expect.objectContaining({ message: "boom" })
     );
   });

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,3 +1,5 @@
+import { logError } from "@/utils/logger";
+
 /**
  * Debounce utility with cancel and flush methods for persistence batching.
  * Collects rapid calls and executes only the final state after delay.
@@ -22,7 +24,7 @@ export function debounce<Args extends unknown[]>(
         lastArgs = null;
         const p = Promise.resolve()
           .then(() => func(...args))
-          .catch((err) => console.error("Debounce execution failed:", err))
+          .catch((err) => logError("Debounce execution failed", err))
           .finally(() => {
             if (runningPromise === p) {
               runningPromise = null;
@@ -49,7 +51,7 @@ export function debounce<Args extends unknown[]>(
       lastArgs = null;
       const p = Promise.resolve()
         .then(() => func(...args))
-        .catch((err) => console.error("Debounce flush failed:", err))
+        .catch((err) => logError("Debounce flush failed", err))
         .finally(() => {
           if (runningPromise === p) {
             runningPromise = null;


### PR DESCRIPTION
## Summary

- Migrated ~158 `console.error` call sites across 67 renderer files to `logError`/`logWarn` from `@/utils/logger`, so failures flow through IPC to the main process and surface in Sentry/diagnostics instead of vanishing silently.
- Added `.catch(err => logError(..., err))` handlers to two fire-and-forget promises that had none (`XtermAdapter.fetchAndRestore`, `DevPreviewPane.sessionStorageSnapshotPromise`), with disposed-flag guards to avoid stale state updates.
- Added a disposed guard to `useHomeDir`'s `useEffect` to prevent setting state after unmount.

Resolves #5967

## Changes

- `ActionError` objects use `logError(msg, undefined, { error: result.error })` so the renderer logger sees them before IPC serialisation drops non-enumerable Error properties.
- Soft refusals and expected branch points use `logWarn` rather than `logError` to keep Sentry signal clean.
- Two `recipeStore` lines switched from `logWarn({error})` to `logError(msg, error)` so `safeStringify` can extract Error props before the IPC hop (plain `JSON.stringify` drops non-enumerable properties).
- `debounce.ts` and its unit test updated to match the new logger call shape.
- Last-resort `console.error` fallbacks preserved in bootstrap paths (`main.tsx`, `rendererGlobalErrorHandlers`, `reactRootErrorCallbacks`, `rendererSentry`, `escapeStack`) and in the `notify` DEV-only guard, where replacing them with `logError` would create circular dependencies or swallow truly fatal startup failures.

## Testing

- `npm run check` passes cleanly (0 errors, warnings are pre-existing).
- Manually verified logger import paths and call signatures across representative files from each changed directory.
- `debounce.test.ts` updated and passing.