### PR TITLE
fix(renderer): standardize ID generation on crypto.randomUUID

### DIFF
--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -68,7 +68,9 @@ describe("ErrorBoundary", () => {
     const shortId = storeId.slice(-7);
     // In dev mode, incident ID is not displayed (only in prod)
     // but we can verify the error was added to the store
-    expect(storeId).toMatch(/^error-\d+-[a-z0-9]{7}$/);
+    expect(storeId).toMatch(
+      /^error-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
     expect(shortId).toHaveLength(7);
   });
 

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -243,7 +243,7 @@ export function AutomationTab({
               onRunCommandsChange([
                 ...runCommands,
                 {
-                  id: `cmd-${Date.now()}`,
+                  id: `cmd-${crypto.randomUUID()}`,
                   name: "",
                   command: "",
                 },

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -59,7 +59,7 @@ export function EnvironmentVariablesEditor({
   }, [globalEnvironmentVariables]);
 
   const addRow = () => {
-    setRows((prev) => [...prev, { id: `env-${Date.now()}-${Math.random()}`, key: "", value: "" }]);
+    setRows((prev) => [...prev, { id: `env-${crypto.randomUUID()}`, key: "", value: "" }]);
   };
 
   const deleteRow = (index: number, id: string) => {

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -379,7 +379,7 @@ export function ProjectOnboardingWizard({
                       onClick={() =>
                         setRunCommands((prev) => [
                           ...prev,
-                          { id: `cmd-${Date.now()}`, name: "", command: "" },
+                          { id: `cmd-${crypto.randomUUID()}`, name: "", command: "" },
                         ])
                       }
                       className="w-full"

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -144,7 +144,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
     e.preventDefault();
 
     const commandToSave: RunCommand = {
-      id: `cmd-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      id: `cmd-${crypto.randomUUID()}`,
       name: item.label,
       command: item.value,
       icon: "icon" in item ? item.icon || "terminal" : "terminal",

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -127,7 +127,7 @@ export function AgentSettings({
     try {
       await updateAgent(addDialogAgentId, { customPresets: updated, presetId: id });
       onSettingsChange?.();
-      lastAddTimeRef.current = now;
+      lastAddTimeRef.current = Date.now();
       setIsAddDialogOpen(false);
       setAddDialogAgentId(null);
     } catch (error) {

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -119,16 +119,10 @@ export function AgentSettings({
 
   const handleCreatePreset = async (presetData: Omit<AgentPreset, "id">) => {
     if (!addDialogAgentId) return;
-    const now = Date.now();
     const freshSettings = useAgentSettingsStore.getState().settings ?? DEFAULT_AGENT_SETTINGS;
     const entry = getAgentSettingsEntry(freshSettings, addDialogAgentId);
     const existing = entry.customPresets ?? [];
-    let id = `user-${now}`;
-    if (existing.some((f) => f.id === id)) {
-      let suffix = 1;
-      while (existing.some((f) => f.id === `user-${now}-${suffix}`)) suffix += 1;
-      id = `user-${now}-${suffix}`;
-    }
+    const id = `user-${crypto.randomUUID()}`;
     const updated = [...existing, { ...presetData, id }];
     try {
       await updateAgent(addDialogAgentId, { customPresets: updated, presetId: id });
@@ -461,7 +455,7 @@ export function AgentSettings({
               };
 
               const handleDuplicatePreset = (preset: AgentPreset) => {
-                const id = `user-${Date.now()}`;
+                const id = `user-${crypto.randomUUID()}`;
                 const updated = [
                   ...(activeEntry.customPresets ?? []),
                   { ...preset, id, name: `${preset.name} (copy)` },

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -19,7 +19,7 @@ function envVarsFromRecord(record: Record<string, string> | undefined): EnvVar[]
   return Object.entries(record)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => ({
-      id: `env-${Date.now()}-${Math.random()}`,
+      id: `env-${crypto.randomUUID()}`,
       key,
       value,
     }));
@@ -104,10 +104,7 @@ export function EnvironmentSettingsTab() {
   }, []);
 
   const addRow = useCallback(() => {
-    setEnvRows((prev) => [
-      ...prev,
-      { id: `env-${Date.now()}-${Math.random()}`, key: "", value: "" },
-    ]);
+    setEnvRows((prev) => [...prev, { id: `env-${crypto.randomUUID()}`, key: "", value: "" }]);
     setIsDirty(true);
   }, []);
 

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -228,7 +228,7 @@ export function RecipeEditor({
         const savedRecipe: TerminalRecipe = recipe
           ? { ...recipe, name: recipeName, terminals }
           : {
-              id: `recipe-${Date.now()}`,
+              id: `recipe-${crypto.randomUUID()}`,
               name: recipeName,
               projectId: scope === "global" ? undefined : currentProject!.id,
               worktreeId: scope === "global" ? undefined : worktreeId,

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -206,7 +206,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     const initialRunCommands = projectSettings.runCommands || [];
     const envVars = projectSettings.environmentVariables || {};
     const initialEnvVars = Object.entries(envVars).map(([key, value]) => ({
-      id: `env-${Date.now()}-${Math.random()}`,
+      id: `env-${crypto.randomUUID()}`,
       key,
       value,
     }));

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -526,7 +526,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
       const icon = agentInfo?.icon;
 
       if (background) {
-        const newTabId = `tab-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+        const newTabId = `tab-${crypto.randomUUID()}`;
         usePortalStore.setState((s) => ({
           tabs: [...s.tabs, { id: newTabId, url, title: finalTitle, icon }],
         }));

--- a/src/store/commandHistoryStore.ts
+++ b/src/store/commandHistoryStore.ts
@@ -52,7 +52,7 @@ export const useCommandHistoryStore = create<CommandHistoryState>()(
             return false;
           });
           const entry: PromptHistoryEntry = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            id: `cmdhist-${crypto.randomUUID()}`,
             prompt: trimmed,
             agentId: agentId ?? null,
             addedAt: Date.now(),

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -50,7 +50,7 @@ const MAX_ERRORS = 50;
 const ERROR_RATE_LIMIT_MS = 500;
 
 function generateErrorId(): string {
-  return `error-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  return `error-${crypto.randomUUID()}`;
 }
 
 const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -119,7 +119,7 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
     setActiveTab: (id) => set({ activeTabId: id }),
 
     createTab: (url, title) => {
-      const newTabId = `tab-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const newTabId = `tab-${crypto.randomUUID()}`;
       const newTab: PortalTab = { id: newTabId, url, title };
       set((s) => ({
         tabs: [...s.tabs, newTab],
@@ -137,7 +137,7 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
         return existingBlank.id;
       }
 
-      const newTabId = `tab-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const newTabId = `tab-${crypto.randomUUID()}`;
       const newTab: PortalTab = { id: newTabId, url: null, title: "New Tab" };
       set((s) => ({
         tabs: [...s.tabs, newTab],
@@ -215,7 +215,7 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
       const tab = state.tabs.find((t) => t.id === id);
       if (!tab?.url) return null;
 
-      const newTabId = `tab-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      const newTabId = `tab-${crypto.randomUUID()}`;
       const newTab: PortalTab = {
         id: newTabId,
         url: tab.url,
@@ -318,7 +318,7 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
             ...s.links,
             {
               ...link,
-              id: `user-${Date.now()}`,
+              id: `user-${crypto.randomUUID()}`,
               type: "user",
               enabled: true,
               order: maxOrder + 1,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -226,9 +226,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const isGlobal = projectId === undefined;
     const newRecipe: TerminalRecipe = {
-      id: isGlobal
-        ? `recipe-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-        : stableInRepoId(name),
+      id: isGlobal ? `recipe-${crypto.randomUUID()}` : stableInRepoId(name),
       name,
       projectId: isGlobal ? undefined : projectId,
       worktreeId: isGlobal ? undefined : worktreeId,
@@ -731,9 +729,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     const isGlobal = projectId === undefined;
     const recipeName = String(recipe.name);
     const importedRecipe: TerminalRecipe = {
-      id: isGlobal
-        ? `recipe-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-        : stableInRepoId(recipeName),
+      id: isGlobal ? `recipe-${crypto.randomUUID()}` : stableInRepoId(recipeName),
       name: recipeName,
       projectId: isGlobal ? undefined : projectId,
       worktreeId: isGlobal

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -32,7 +32,7 @@ export const createBackgroundActions = (
     let groupMetadata: import("./types").TrashedTerminalGroupMetadata | undefined;
 
     if (group) {
-      groupRestoreId = `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      groupRestoreId = `group-${crypto.randomUUID()}`;
       groupMetadata = {
         panelIds: [...group.panelIds],
         activeTabId: group.activeTabId ?? group.panelIds[0] ?? "",
@@ -99,7 +99,7 @@ export const createBackgroundActions = (
       return;
     }
 
-    const groupRestoreId = `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const groupRestoreId = `group-${crypto.randomUUID()}`;
     const panelIds = [...group.panelIds];
     const activeTabId = group.activeTabId ?? panelIds[0] ?? "";
     const state = get();

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -223,9 +223,7 @@ export const createCorePanelActions = (
 
     // Handle panels that use custom UI (browser, dev-preview, extensions) separately
     if (!panelKindUsesTerminalUi(requestedKind)) {
-      const id =
-        options.requestedId ||
-        `${requestedKind}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const id = options.requestedId || `${requestedKind}-${crypto.randomUUID()}`;
       const title = options.title || getDefaultTitle(requestedKind);
 
       const targetWorktreeId = options.worktreeId ?? null;
@@ -363,10 +361,7 @@ export const createCorePanelActions = (
     // Reserve the id up front so the panel can be committed to the store before
     // any async work (env fetch, spawn IPC). #5789: commit-then-spawn collapses
     // six rapid agent clicks from serialized spawns into six parallel placeholders.
-    const id =
-      options.existingId ??
-      options.requestedId ??
-      `${kind}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const id = options.existingId ?? options.requestedId ?? `${kind}-${crypto.randomUUID()}`;
 
     // For reconnects, use the backend's state directly - don't default to "working".
     // For new spawns, start with "working" in UI to show spinner immediately during boot.

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -62,7 +62,7 @@ export const createTabGroupActions = (
   },
 
   createTabGroup: (location, worktreeId, panelIds, activeTabId) => {
-    const groupId = `tabgroup-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const groupId = `tabgroup-${crypto.randomUUID()}`;
     const group: TabGroup = {
       id: groupId,
       location,

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -119,7 +119,7 @@ export const createTrashActions = (
     }
 
     const expiresAt = Date.now() + TRASH_TTL_MS;
-    const groupRestoreId = `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const groupRestoreId = `group-${crypto.randomUUID()}`;
     const panelIds = [...group.panelIds];
     const activeTabId = group.activeTabId ?? panelIds[0] ?? "";
     const state = get();


### PR DESCRIPTION
## Summary

- Replaced all remaining `Date.now()-Math.random()` and bare `Date.now()` ID generation sites across the renderer with `crypto.randomUUID()`
- The codebase had already standardised on `crypto.randomUUID()` in 8+ places — this catches the stragglers
- Human-readable prefixes (`env-`, `cmd-`, `tab-`) preserved for log grepping during incident triage

Resolves #5970

## Changes

- 18 files: 17 source across the renderer + 1 test update
- 25 call sites standardised: settings editors, portal store, command history, recipe store, panel registry slices, action definitions, and hooks
- `cmdhist-` prefix added to commandHistoryStore IDs
- ErrorBoundary test regex updated for the new UUID format
- Net -16 lines: `crypto.randomUUID()` is more concise than the old pattern

## Testing

- Typecheck, lint, format all pass with no new warnings
- Full test suite: 14,178 tests passing