### PR TITLE
fix(ui): distinguish read-only credential fields from editable inputs

### DIFF
--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -191,7 +191,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               value={parentPath}
               readOnly
               placeholder="Select a directory..."
-              className="flex-1 rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 disabled:opacity-50"
+              className="flex-1 rounded-md border border-daintree-border bg-muted/50 px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 disabled:opacity-50 select-all"
             />
             <Button
               variant="outline"

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Copy, Check, AlertCircle, Key, Hash, Shield, Eye, EyeOff, RefreshCw } from "lucide-react";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -25,6 +25,8 @@ export function McpServerSettingsTab() {
   const [error, setError] = useState<string | null>(null);
   const [portInput, setPortInput] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
+  const [copiedKey, setCopiedKey] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     let settled = false;
@@ -112,6 +114,17 @@ export function McpServerSettingsTab() {
       setError(formatErrorMessage(err, "Failed to clear API key"));
     }
   }, []);
+
+  const handleCopyApiKey = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(status.apiKey);
+      setCopiedKey(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopiedKey(false), 2000);
+    } catch {
+      // clipboard write failed — silently ignore
+    }
+  }, [status.apiKey]);
 
   const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
 
@@ -229,17 +242,14 @@ export function McpServerSettingsTab() {
                 </div>
 
                 <div className="flex items-center gap-2">
-                  <div className="flex-1 relative">
-                    <input
-                      type={showApiKey ? "text" : "password"}
-                      value={status.apiKey}
-                      readOnly
-                      className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 pr-10 font-mono text-xs text-daintree-text/80 focus:outline-none select-all"
-                    />
+                  <div className="flex-1 flex items-center gap-2 rounded-[var(--radius-md)] bg-surface-disabled border border-daintree-border px-3 py-2 font-mono text-xs text-daintree-text/80 select-all">
+                    <span className="flex-1 truncate">
+                      {showApiKey ? status.apiKey : "•".repeat(status.apiKey.length)}
+                    </span>
                     <button
                       type="button"
                       onClick={() => setShowApiKey((v) => !v)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-daintree-text/40 hover:text-daintree-text/70"
+                      className="shrink-0 text-daintree-text/40 hover:text-daintree-text/70"
                       aria-label={showApiKey ? "Hide API key" : "Show API key"}
                     >
                       {showApiKey ? (
@@ -249,6 +259,25 @@ export function McpServerSettingsTab() {
                       )}
                     </button>
                   </div>
+                  <button
+                    type="button"
+                    onClick={handleCopyApiKey}
+                    className={cn(
+                      "flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] transition-colors",
+                      "border border-daintree-border hover:bg-overlay-soft",
+                      copiedKey
+                        ? "text-status-success border-status-success/30"
+                        : "text-daintree-text/70 hover:text-daintree-text"
+                    )}
+                    aria-label="Copy API key"
+                  >
+                    {copiedKey ? (
+                      <Check className="w-3.5 h-3.5" />
+                    ) : (
+                      <Copy className="w-3.5 h-3.5" />
+                    )}
+                    {copiedKey ? "Copied!" : "Copy"}
+                  </button>
                   <button
                     onClick={handleGenerateApiKey}
                     className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -53,7 +53,10 @@ export function McpServerSettingsTab() {
         setLoading(false);
       });
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
   }, []);
 
   const handleToggle = useCallback(async () => {
@@ -100,6 +103,7 @@ export function McpServerSettingsTab() {
       const key = await window.electron.mcpServer.generateApiKey();
       setStatus((prev) => ({ ...prev, apiKey: key }));
       setShowApiKey(true);
+      setCopiedKey(false);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to generate API key"));
     }
@@ -110,6 +114,7 @@ export function McpServerSettingsTab() {
       setError(null);
       const newStatus = await window.electron.mcpServer.setApiKey("");
       setStatus(newStatus);
+      setCopiedKey(false);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to clear API key"));
     }

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { McpServerSettingsTab } from "../McpServerSettingsTab";
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+vi.mock("@/components/icons", () => ({
+  McpServerIcon: () => null,
+}));
+
+function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {}) {
+  return {
+    getStatus: vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 9020,
+      configuredPort: 9020,
+      apiKey: "dnt-key-abc123",
+    }),
+    setEnabled: vi.fn(),
+    setPort: vi.fn(),
+    getConfigSnippet: vi.fn().mockResolvedValue("http://127.0.0.1:9020/sse"),
+    generateApiKey: vi.fn().mockResolvedValue("dnt-key-new456"),
+    setApiKey: vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 9020,
+      configuredPort: 9020,
+      apiKey: "",
+    }),
+    ...overrides,
+  };
+}
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+describe("McpServerSettingsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+    window.electron = {
+      mcpServer: createMcpApi(),
+    } as unknown as typeof window.electron;
+  });
+
+  const waitForContent = (container: HTMLElement, text: string) =>
+    waitFor(
+      () => {
+        expect(container.textContent).toContain(text);
+      },
+      { timeout: 5000 }
+    );
+
+  it("renders API key in a non-input display element", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    const displayArea = container.querySelector(".bg-surface-disabled");
+    expect(displayArea).toBeTruthy();
+    expect(displayArea?.tagName).toBe("DIV");
+
+    const inputs = container.querySelectorAll("input[readonly]");
+    expect(inputs.length).toBe(0);
+  });
+
+  it("shows masked bullets by default, reveals key on toggle", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    const displayArea = container.querySelector(".bg-surface-disabled")!;
+    expect(displayArea.textContent).not.toContain("dnt-key-abc123");
+    expect(displayArea.textContent).toContain("•");
+
+    fireEvent.click(screen.getByLabelText("Show API key"));
+    await waitFor(() => {
+      expect(displayArea.textContent).toContain("dnt-key-abc123");
+    });
+
+    fireEvent.click(screen.getByLabelText("Hide API key"));
+    await waitFor(() => {
+      expect(displayArea.textContent).not.toContain("dnt-key-abc123");
+    });
+  });
+
+  it("copy button writes unmasked key to clipboard", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByLabelText("Copy API key"));
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("dnt-key-abc123");
+    });
+  });
+
+  it("copy button shows Copied! feedback", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByLabelText("Copy API key"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeTruthy();
+    });
+    expect(writeText).toHaveBeenCalledWith("dnt-key-abc123");
+  });
+
+  it("Regenerate calls generateApiKey", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByTitle("Regenerate API key"));
+    await waitFor(() => {
+      expect(window.electron.mcpServer.generateApiKey).toHaveBeenCalled();
+    });
+  });
+
+  it("Remove clears the key and shows Generate API Key button", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByText("Remove"));
+    await waitFor(() => {
+      expect(window.electron.mcpServer.setApiKey).toHaveBeenCalledWith("");
+      expect(screen.getByText("Generate API Key")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- The MCP server API key field rendered as `<input readOnly>` with the same visual treatment as editable inputs, making users think they could type in it. Changed it to a non-input display element with a muted background and a persistent copy button.
- Added a copy button with "Copied!" feedback that writes the unmasked key to clipboard even when the key is hidden behind bullets.
- Applied the same read-only styling pattern to the CloneRepoDialog path field for consistency.

Resolves #5974

## Changes
- **McpServerSettingsTab.tsx**: Replaced `<input readOnly>` with a `<div>`/`<span>` display pattern using `bg-surface-disabled`. Added copy button with timeout-managed feedback state. Cleaned up `copyTimeoutRef` on unmount.
- **CloneRepoDialog.tsx**: Updated read-only path input to use `bg-muted/50` and `select-all` for visual distinction.
- **McpServerSettingsTab.test.tsx**: 6 new tests covering display element rendering, show/hide toggle, clipboard copy, copy feedback, regenerate, and remove.

## Testing
- All 6 new tests pass (display element rendering, show/hide toggle, clipboard copy, copy feedback, regenerate, remove).
- Verified the API key field no longer shows a caret on click.
- Copy button copies the full unmasked key even when masked behind bullets.