### PR TITLE
feat(worktree): add conditional tooltips for truncated paths and branch names

### DIFF
--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -9,6 +9,8 @@ import { DiffViewer } from "./DiffViewer";
 import { WorktreeSelector } from "./WorktreeSelector";
 import { sortWorktreesForComparison } from "./crossWorktreeDiffUtils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
 interface CrossWorktreeDiffProps {
   isOpen: boolean;
@@ -31,6 +33,38 @@ function statusLabel(status: string): { label: string; className: string } {
     default:
       return { label: status, className: "text-text-muted" };
   }
+}
+
+interface CrossWorktreeFileRowProps {
+  file: CrossWorktreeFile;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+function CrossWorktreeFileRow({ file, isSelected, onClick }: CrossWorktreeFileRowProps) {
+  const { ref, isTruncated } = useTruncationDetection();
+  const { label, className: statusClass } = statusLabel(file.status);
+
+  return (
+    <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-surface-panel-elevated transition-colors",
+          isSelected && "bg-surface-panel-elevated"
+        )}
+      >
+        <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
+          {label}
+        </span>
+        <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
+        <span ref={ref} className="text-text-secondary truncate min-w-0">
+          {file.path.split(/[/\\]/).filter(Boolean).pop()}
+        </span>
+      </button>
+    </TruncatedTooltip>
+  );
 }
 
 export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossWorktreeDiffProps) {
@@ -218,28 +252,14 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                 No differences between these branches
               </div>
             )}
-            {result?.files.map((file) => {
-              const { label, className: statusClass } = statusLabel(file.status);
-              const isSelected = selectedFile?.path === file.path;
-              return (
-                <button
-                  key={`${file.status}:${file.path}`}
-                  onClick={() => void fetchFileDiff(file)}
-                  className={cn(
-                    "w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-surface-panel-elevated transition-colors",
-                    isSelected && "bg-surface-panel-elevated"
-                  )}
-                >
-                  <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
-                    {label}
-                  </span>
-                  <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
-                  <span className="text-text-secondary truncate min-w-0" title={file.path}>
-                    {file.path.split(/[/\\]/).filter(Boolean).pop()}
-                  </span>
-                </button>
-              );
-            })}
+            {result?.files.map((file) => (
+              <CrossWorktreeFileRow
+                key={`${file.status}:${file.path}`}
+                file={file}
+                isSelected={selectedFile?.path === file.path}
+                onClick={() => void fetchFileDiff(file)}
+              />
+            ))}
           </div>
         </div>
 

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -7,6 +7,7 @@ import { ExternalLink } from "lucide-react";
 import path from "path-browserify";
 import { getLanguageForFile } from "@/components/FileViewer/languageUtils";
 import { actionService } from "@/services/ActionService";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
 export interface DiffViewerProps {
   diff: string;
@@ -149,7 +150,9 @@ function FileDiff({ file, viewType, language, rootPath }: FileDiffProps) {
     <div className="mb-2">
       {relPath && (
         <div className="flex items-center justify-between px-3 py-1.5 bg-daintree-sidebar border-b border-daintree-border text-xs text-daintree-text/60 font-mono">
-          <span className="truncate">{relPath}</span>
+          <TruncatedTooltip content={relPath}>
+            <span className="truncate">{relPath}</span>
+          </TruncatedTooltip>
           <div className="flex items-center gap-2 shrink-0">
             {(additions > 0 || deletions > 0) && (
               <span className="flex items-center gap-1">

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -8,6 +8,8 @@ import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
 import type { WorktreeState } from "@/types";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
 interface IssuePickerDialogProps {
   isOpen: boolean;
@@ -19,6 +21,54 @@ interface IssuePickerDialogProps {
 }
 
 type StateFilter = "open" | "closed" | "all";
+
+interface IssueOptionRowProps {
+  issue: GitHubIssue;
+  isSelected: boolean;
+  isCurrentlyAttached: boolean;
+  onClick: () => void;
+}
+
+function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: IssueOptionRowProps) {
+  const { ref, isTruncated } = useTruncationDetection();
+
+  return (
+    <TruncatedTooltip content={issue.title} isTruncated={isTruncated}>
+      <button
+        type="button"
+        role="option"
+        aria-selected={isSelected}
+        onClick={onClick}
+        className={cn(
+          "w-full text-left px-3 py-2.5 rounded-[var(--radius-md)] transition-colors flex items-start gap-3",
+          isSelected
+            ? "bg-daintree-accent/10 border border-daintree-accent/30"
+            : "hover:bg-tint/5 border border-transparent",
+          isCurrentlyAttached && "ring-1 ring-status-success/30"
+        )}
+      >
+        {issue.state === "OPEN" ? (
+          <CircleDot className="w-4 h-4 text-github-open shrink-0 mt-0.5" />
+        ) : (
+          <CircleCheck className="w-4 h-4 text-github-merged shrink-0 mt-0.5" />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span ref={ref} className="text-sm text-daintree-text truncate">
+              {issue.title}
+            </span>
+            {isCurrentlyAttached && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-success/10 text-status-success shrink-0">
+                attached
+              </span>
+            )}
+          </div>
+          <span className="text-xs text-daintree-text/50 font-mono">#{issue.number}</span>
+        </div>
+      </button>
+    </TruncatedTooltip>
+  );
+}
 
 export function IssuePickerDialog({
   isOpen,
@@ -179,41 +229,15 @@ export function IssuePickerDialog({
           </div>
         ) : (
           <div ref={listRef} className="space-y-1" role="listbox">
-            {issues.map((issue, index) => {
-              const isCurrentlyAttached = issue.number === currentIssueNumber;
-              return (
-                <button
-                  key={issue.number}
-                  role="option"
-                  aria-selected={index === selectedIndex}
-                  onClick={() => handleSelectIssue(issue)}
-                  className={cn(
-                    "w-full text-left px-3 py-2.5 rounded-[var(--radius-md)] transition-colors flex items-start gap-3",
-                    index === selectedIndex
-                      ? "bg-daintree-accent/10 border border-daintree-accent/30"
-                      : "hover:bg-tint/5 border border-transparent",
-                    isCurrentlyAttached && "ring-1 ring-status-success/30"
-                  )}
-                >
-                  {issue.state === "OPEN" ? (
-                    <CircleDot className="w-4 h-4 text-github-open shrink-0 mt-0.5" />
-                  ) : (
-                    <CircleCheck className="w-4 h-4 text-github-merged shrink-0 mt-0.5" />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm text-daintree-text truncate">{issue.title}</span>
-                      {isCurrentlyAttached && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-status-success/10 text-status-success shrink-0">
-                          attached
-                        </span>
-                      )}
-                    </div>
-                    <span className="text-xs text-daintree-text/50 font-mono">#{issue.number}</span>
-                  </div>
-                </button>
-              );
-            })}
+            {issues.map((issue, index) => (
+              <IssueOptionRow
+                key={issue.number}
+                issue={issue}
+                isSelected={index === selectedIndex}
+                isCurrentlyAttached={issue.number === currentIssueNumber}
+                onClick={() => handleSelectIssue(issue)}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -28,6 +28,7 @@ import { IssueSelector } from "@/components/GitHub/IssueSelector";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { parseBranchInput } from "./branchPrefixUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
@@ -871,10 +872,12 @@ export function NewWorktreeDialog({
             {initialPR ? (
               <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-daintree-accent/5 border border-daintree-accent/20 text-sm min-w-0">
                 <FolderGit2 className="w-4 h-4 text-daintree-accent shrink-0" aria-hidden="true" />
-                <span className="text-daintree-text/80 min-w-0 truncate">
-                  PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
-                  {initialPR.title}
-                </span>
+                <TruncatedTooltip content={`PR #${initialPR.number} — ${initialPR.title}`}>
+                  <span className="text-daintree-text/80 min-w-0 truncate">
+                    PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
+                    {initialPR.title}
+                  </span>
+                </TruncatedTooltip>
               </div>
             ) : (
               <div className="space-y-2">

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Spinner } from "@/components/ui/Spinner";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
 const OPERATION_LABEL: Record<Exclude<RepoState, "CLEAN" | "DIRTY">, string> = {
   MERGING: "Merge",
@@ -162,22 +163,21 @@ export function ConflictPanel({
                 >
                   <AlertTriangle className="w-3 h-3 shrink-0 text-status-error" />
                   <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
-                  <div
-                    className="flex-1 min-w-0 flex items-baseline"
-                    title={`${file.path} (${file.label})`}
-                  >
-                    {dir && (
-                      <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
-                        {dir}/
+                  <TruncatedTooltip content={`${file.path} (${file.label})`}>
+                    <div className="flex-1 min-w-0 flex items-baseline">
+                      {dir && (
+                        <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
+                          {dir}/
+                        </span>
+                      )}
+                      <span className="shrink truncate text-daintree-text font-medium font-mono text-[11px]">
+                        {base}
                       </span>
-                    )}
-                    <span className="shrink truncate text-daintree-text font-medium font-mono text-[11px]">
-                      {base}
-                    </span>
-                    <span className="ml-2 text-[10px] uppercase tracking-wider text-daintree-text/50 font-mono">
-                      {file.label}
-                    </span>
-                  </div>
+                      <span className="ml-2 text-[10px] uppercase tracking-wider text-daintree-text/50 font-mono">
+                        {file.label}
+                      </span>
+                    </div>
+                  </TruncatedTooltip>
                   <div className="flex items-center gap-1 shrink-0">
                     <Button
                       variant="ghost"
@@ -235,16 +235,18 @@ export function ConflictPanel({
                   className="flex items-center gap-2 px-2 py-1 text-xs"
                 >
                   <Check className="w-3 h-3 shrink-0 text-status-success" />
-                  <div className="flex-1 min-w-0 flex items-baseline" title={file.path}>
-                    {dir && (
-                      <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
-                        {dir}/
+                  <TruncatedTooltip content={file.path}>
+                    <div className="flex-1 min-w-0 flex items-baseline">
+                      {dir && (
+                        <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
+                          {dir}/
+                        </span>
+                      )}
+                      <span className="shrink truncate text-daintree-text/80 font-mono text-[11px]">
+                        {base}
                       </span>
-                    )}
-                    <span className="shrink truncate text-daintree-text/80 font-mono text-[11px]">
-                      {base}
-                    </span>
-                  </div>
+                    </div>
+                  </TruncatedTooltip>
                 </li>
               );
             })}

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -6,7 +6,6 @@ import { cn } from "@/lib/utils";
 import { Plus, Minus } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
-import { useTruncationDetection } from "@/hooks/useTruncationDetection";
 
 const STATUS_CONFIG: Record<GitStatus, { label: string; bg: string; text: string }> = {
   modified: {
@@ -68,7 +67,6 @@ function splitPath(filePath: string): { dir: string; base: string } {
 export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStageRowProps) {
   const config = STATUS_CONFIG[file.status] || STATUS_CONFIG.untracked;
   const { dir, base } = splitPath(file.path);
-  const { ref, isTruncated } = useTruncationDetection();
 
   const handleToggle = useCallback(
     (e: React.MouseEvent) => {
@@ -111,7 +109,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
         <TooltipContent side="right">{isStaged ? "Unstage" : "Stage"}</TooltipContent>
       </Tooltip>
 
-      <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
+      <TruncatedTooltip content={file.path}>
         <button
           type="button"
           aria-label={`View diff: ${file.path}`}
@@ -136,10 +134,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
               {dir}/
             </span>
           )}
-          <span
-            ref={ref}
-            className="shrink truncate text-daintree-text group-hover/stagerow:text-daintree-text font-medium font-mono text-[11px] transition-colors"
-          >
+          <span className="shrink truncate text-daintree-text group-hover/stagerow:text-daintree-text font-medium font-mono text-[11px] transition-colors">
             {base}
           </span>
         </button>

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -5,6 +5,8 @@ import type { GitStatus } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { Plus, Minus } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
 
 const STATUS_CONFIG: Record<GitStatus, { label: string; bg: string; text: string }> = {
   modified: {
@@ -66,6 +68,7 @@ function splitPath(filePath: string): { dir: string; base: string } {
 export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStageRowProps) {
   const config = STATUS_CONFIG[file.status] || STATUS_CONFIG.untracked;
   const { dir, base } = splitPath(file.path);
+  const { ref, isTruncated } = useTruncationDetection();
 
   const handleToggle = useCallback(
     (e: React.MouseEvent) => {
@@ -108,35 +111,39 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
         <TooltipContent side="right">{isStaged ? "Unstage" : "Stage"}</TooltipContent>
       </Tooltip>
 
-      <button
-        type="button"
-        title={file.path}
-        aria-label={`View diff: ${file.path}`}
-        className={cn(
-          "flex min-w-0 flex-1 items-baseline rounded text-left",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
-        )}
-      >
-        <span
-          aria-hidden="true"
+      <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
+        <button
+          type="button"
+          aria-label={`View diff: ${file.path}`}
           className={cn(
-            "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
-            "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
-            config.bg,
-            config.text
+            "flex min-w-0 flex-1 items-baseline rounded text-left",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
           )}
         >
-          {config.label}
-        </span>
-        {dir && (
-          <span className="shrink truncate text-daintree-text/50 group-hover/stagerow:text-daintree-text/70 font-mono text-[11px] transition-colors">
-            {dir}/
+          <span
+            aria-hidden="true"
+            className={cn(
+              "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
+              "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
+              config.bg,
+              config.text
+            )}
+          >
+            {config.label}
           </span>
-        )}
-        <span className="shrink truncate text-daintree-text group-hover/stagerow:text-daintree-text font-medium font-mono text-[11px] transition-colors">
-          {base}
-        </span>
-      </button>
+          {dir && (
+            <span className="shrink truncate text-daintree-text/50 group-hover/stagerow:text-daintree-text/70 font-mono text-[11px] transition-colors">
+              {dir}/
+            </span>
+          )}
+          <span
+            ref={ref}
+            className="shrink truncate text-daintree-text group-hover/stagerow:text-daintree-text font-medium font-mono text-[11px] transition-colors"
+          >
+            {base}
+          </span>
+        </button>
+      </TruncatedTooltip>
     </div>
   );
 }

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -4,7 +4,7 @@ import type { StagingStatus, GitStatus } from "@shared/types";
 import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { cn } from "@/lib/utils";
-import { useOverlayState, useTruncationDetection } from "@/hooks";
+import { useOverlayState } from "@/hooks";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import {
   X,
@@ -108,7 +108,6 @@ interface BaseBranchFileRowProps {
 }
 
 function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
-  const { ref, isTruncated } = useTruncationDetection();
   const { label, className: statusClass } = statusLabel(file.status);
   const filename = file.path.split(/[/\\]/).filter(Boolean).pop() || file.path;
   const dirPath = /[/\\]/.test(file.path)
@@ -116,7 +115,7 @@ function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
     : "";
 
   return (
-    <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
+    <TruncatedTooltip content={file.path}>
       <button
         type="button"
         onClick={onClick}
@@ -130,9 +129,7 @@ function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
           {label}
         </span>
         <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
-        <span ref={ref} className="text-daintree-text/80 truncate min-w-0">
-          {filename}
-        </span>
+        <span className="text-daintree-text/80 truncate min-w-0">{filename}</span>
         <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
           {dirPath}
         </span>

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -4,7 +4,8 @@ import type { StagingStatus, GitStatus } from "@shared/types";
 import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { cn } from "@/lib/utils";
-import { useOverlayState } from "@/hooks";
+import { useOverlayState, useTruncationDetection } from "@/hooks";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import {
   X,
   RefreshCw,
@@ -99,6 +100,45 @@ function statusLabel(status: string): { label: string; className: string } {
     default:
       return { label: status, className: "text-text-muted" };
   }
+}
+
+interface BaseBranchFileRowProps {
+  file: CrossWorktreeFile;
+  onClick: () => void;
+}
+
+function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
+  const { ref, isTruncated } = useTruncationDetection();
+  const { label, className: statusClass } = statusLabel(file.status);
+  const filename = file.path.split(/[/\\]/).filter(Boolean).pop() || file.path;
+  const dirPath = /[/\\]/.test(file.path)
+    ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
+    : "";
+
+  return (
+    <TruncatedTooltip content={file.path} isTruncated={isTruncated}>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs",
+          "hover:bg-tint/[0.05] transition-colors",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent"
+        )}
+      >
+        <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
+          {label}
+        </span>
+        <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
+        <span ref={ref} className="text-daintree-text/80 truncate min-w-0">
+          {filename}
+        </span>
+        <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
+          {dirPath}
+        </span>
+      </button>
+    </TruncatedTooltip>
+  );
 }
 
 export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
@@ -524,13 +564,12 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                 Review & Commit
               </h2>
               {status?.currentBranch && (
-                <span
-                  title={status.currentBranch}
-                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] text-daintree-text/60 font-mono truncate max-w-[200px]"
-                >
-                  <GitBranch className="w-3 h-3 shrink-0" />
-                  <span className="truncate">{status.currentBranch}</span>
-                </span>
+                <TruncatedTooltip content={status.currentBranch}>
+                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-tint/[0.07] border border-tint/[0.08] text-[11px] text-daintree-text/60 font-mono truncate max-w-[200px]">
+                    <GitBranch className="w-3 h-3 shrink-0" />
+                    <span className="truncate">{status.currentBranch}</span>
+                  </span>
+                </TruncatedTooltip>
               )}
               {status?.hasRemote && worktreePR && worktreePR.prUrl && (
                 <button
@@ -756,44 +795,13 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                     </span>
                   </div>
                   <div className="px-2 py-1 flex flex-col gap-0.5">
-                    {baseBranchFiles.map((file) => {
-                      const { label, className: statusClass } = statusLabel(file.status);
-                      return (
-                        <button
-                          key={`${file.status}:${file.path}`}
-                          onClick={() => setSelectedBaseBranchFile(file)}
-                          className={cn(
-                            "w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs",
-                            "hover:bg-tint/[0.05] transition-colors",
-                            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent"
-                          )}
-                        >
-                          <span
-                            className={cn(
-                              "font-mono font-bold shrink-0 w-3 text-center",
-                              statusClass
-                            )}
-                          >
-                            {label}
-                          </span>
-                          <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
-                          <span
-                            className="text-daintree-text/80 truncate min-w-0"
-                            title={file.path}
-                          >
-                            {file.path.split(/[/\\]/).filter(Boolean).pop()}
-                          </span>
-                          <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
-                            {/[/\\]/.test(file.path)
-                              ? file.path.substring(
-                                  0,
-                                  Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\"))
-                                )
-                              : ""}
-                          </span>
-                        </button>
-                      );
-                    })}
+                    {baseBranchFiles.map((file) => (
+                      <BaseBranchFileRow
+                        key={`${file.status}:${file.path}`}
+                        file={file}
+                        onClick={() => setSelectedBaseBranchFile(file)}
+                      />
+                    ))}
                   </div>
                 </div>
               ) : null

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -68,7 +68,10 @@ vi.mock("react-dom", async () => {
   return { ...actual, createPortal: (children: ReactNode) => children };
 });
 
-vi.mock("@/hooks", () => ({ useOverlayState: vi.fn() }));
+vi.mock("@/hooks", () => ({
+  useOverlayState: vi.fn(),
+  useTruncationDetection: vi.fn(() => ({ ref: vi.fn(), isTruncated: false })),
+}));
 
 vi.mock("../../FileDiffModal", () => ({ FileDiffModal: () => null }));
 vi.mock("../BaseBranchDiffModal", () => ({ BaseBranchDiffModal: () => null }));
@@ -680,7 +683,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByText("index.ts"));
 
       // Click the file row button to open its diff (sets selectedFile)
-      const fileRow = screen.getByTitle("src/index.ts");
+      const fileRow = screen.getByText("index.ts").closest("button")!;
       fireEvent.click(fileRow);
 
       // First Escape should clear selectedFile, not close modal

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "../../ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
 import {
   ChevronRight,
@@ -569,19 +570,21 @@ export function WorktreeHeader({
               underlineOnHover={underlineOnHover}
             />
           ) : isMainStandardLayout ? (
-            <span
-              className={cn(
-                "truncate text-[13px] font-medium transition-colors duration-150",
-                isActive
-                  ? "text-text-primary/90"
-                  : isMuted
-                    ? "text-text-muted"
-                    : "text-text-secondary"
-              )}
-              data-testid="primary-worktree-project-name"
-            >
-              {worktree.name}
-            </span>
+            <TruncatedTooltip content={worktree.name}>
+              <span
+                className={cn(
+                  "truncate text-[13px] font-medium transition-colors duration-150",
+                  isActive
+                    ? "text-text-primary/90"
+                    : isMuted
+                      ? "text-text-muted"
+                      : "text-text-secondary"
+                )}
+                data-testid="primary-worktree-project-name"
+              >
+                {worktree.name}
+              </span>
+            </TruncatedTooltip>
           ) : (
             <BranchLabel
               label={branchLabel}

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -15,6 +15,8 @@ import {
   getEffectiveStateColor,
 } from "../terminalStateConfig";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
 import {
   ChevronRight,
   GripVertical,
@@ -77,6 +79,7 @@ interface TerminalRowProps {
 }
 
 function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
+  const { ref, isTruncated } = useTruncationDetection();
   const isArmed = useFleetArmingStore((s) => s.armedIds.has(term.id));
   const armBadge = useFleetArmingStore((s) => s.armOrderById[term.id]);
   const chrome = deriveTerminalChrome(term);
@@ -102,34 +105,39 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
       )}
     >
       <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 px-3 py-2 transition-colors">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClick(term);
-          }}
-          aria-selected={isArmed}
-          className="flex items-center gap-2 min-w-0 flex-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
-        >
-          <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
-            <TerminalIcon kind={term.kind} chrome={chrome} className="w-3 h-3" />
-          </div>
-          <div className="flex flex-col min-w-0">
-            <span className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text">
-              {term.title}
-            </span>
-            {!chrome.isAgent && term.activityStatus === "working" && term.lastCommand && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="truncate text-[11px] font-mono text-text-muted">
-                    {term.lastCommand}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-        </button>
+        <TruncatedTooltip content={term.title} isTruncated={isTruncated}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick(term);
+            }}
+            aria-selected={isArmed}
+            className="flex items-center gap-2 min-w-0 flex-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
+          >
+            <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
+              <TerminalIcon kind={term.kind} chrome={chrome} className="w-3 h-3" />
+            </div>
+            <div className="flex flex-col min-w-0">
+              <span
+                ref={ref}
+                className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text"
+              >
+                {term.title}
+              </span>
+              {!chrome.isAgent && term.activityStatus === "working" && term.lastCommand && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate text-[11px] font-mono text-text-muted">
+                      {term.lastCommand}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </button>
+        </TruncatedTooltip>
 
         <div className="flex items-center gap-2.5 shrink-0">
           {isArmed && armBadge !== undefined && (

--- a/src/components/Worktree/WorktreeCardErrorFallback.tsx
+++ b/src/components/Worktree/WorktreeCardErrorFallback.tsx
@@ -1,13 +1,15 @@
 import { TriangleAlert } from "lucide-react";
 import type { ErrorFallbackProps } from "@/components/ErrorBoundary/ErrorFallback";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
 export function WorktreeCardErrorFallback({ error, resetError }: ErrorFallbackProps) {
+  const message = import.meta.env.DEV ? error.message : "Card failed to render";
   return (
     <div className="flex items-center gap-2 px-4 py-3 border-b border-divider bg-[color-mix(in_oklab,var(--color-status-error)_6%,transparent)]">
       <TriangleAlert className="size-4 shrink-0 text-status-error" />
-      <span className="text-xs text-daintree-text/70 truncate flex-1">
-        {import.meta.env.DEV ? error.message : "Card failed to render"}
-      </span>
+      <TruncatedTooltip content={message}>
+        <span className="text-xs text-daintree-text/70 truncate flex-1">{message}</span>
+      </TruncatedTooltip>
       <button
         type="button"
         onClick={resetError}

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import type { WorktreeState } from "@/types";
 
 interface WorktreeListItemProps {
@@ -11,37 +13,43 @@ interface WorktreeListItemProps {
 }
 
 function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeListItemProps) {
+  const { ref, isTruncated } = useTruncationDetection();
+
   return (
-    <button
-      type="button"
-      tabIndex={-1}
-      onPointerDown={(e) => e.preventDefault()}
-      id={`worktree-option-${worktree.id}`}
-      onClick={onClick}
-      className={cn(
-        "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
-        "border-daintree-border/40 hover:border-daintree-border/60",
-        "bg-daintree-bg hover:bg-surface transition-colors",
-        isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
-      )}
-      aria-selected={isSelected}
-      role="option"
-    >
-      <div className="flex items-center justify-between text-sm">
-        <span className="font-medium text-daintree-text">{worktree.name}</span>
-        <div className="flex items-center gap-2 text-xs text-daintree-text/60">
-          {worktree.branch && (
-            <span className="font-mono text-daintree-text/70">{worktree.branch}</span>
-          )}
-          {isActive && (
-            <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-[11px] font-semibold">
-              Active
-            </span>
-          )}
+    <TruncatedTooltip content={worktree.path} isTruncated={isTruncated}>
+      <button
+        type="button"
+        tabIndex={-1}
+        onPointerDown={(e) => e.preventDefault()}
+        id={`worktree-option-${worktree.id}`}
+        onClick={onClick}
+        className={cn(
+          "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
+          "border-daintree-border/40 hover:border-daintree-border/60",
+          "bg-daintree-bg hover:bg-surface transition-colors",
+          isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
+        )}
+        aria-selected={isSelected}
+        role="option"
+      >
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-daintree-text">{worktree.name}</span>
+          <div className="flex items-center gap-2 text-xs text-daintree-text/60">
+            {worktree.branch && (
+              <span className="font-mono text-daintree-text/70">{worktree.branch}</span>
+            )}
+            {isActive && (
+              <span className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-[var(--color-state-active)]/15 text-[var(--color-state-active)] text-[11px] font-semibold">
+                Active
+              </span>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="text-[11px] text-daintree-text/50 truncate">{worktree.path}</div>
-    </button>
+        <div ref={ref} className="text-[11px] text-daintree-text/50 truncate">
+          {worktree.path}
+        </div>
+      </button>
+    </TruncatedTooltip>
   );
 }
 

--- a/src/components/Worktree/__tests__/WorktreeCardErrorFallback.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeCardErrorFallback.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { WorktreeCardErrorFallback } from "../WorktreeCardErrorFallback";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+function wrap(ui: React.ReactElement) {
+  return <TooltipProvider>{ui}</TooltipProvider>;
+}
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
@@ -29,21 +34,27 @@ describe("WorktreeCardErrorFallback", () => {
 
   it("renders error message in dev mode", () => {
     const resetError = vi.fn();
-    render(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />);
+    render(
+      wrap(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />)
+    );
     expect(screen.getByText("Card broke")).toBeTruthy();
   });
 
   it("renders generic message in production mode", () => {
     vi.stubEnv("DEV", false);
     const resetError = vi.fn();
-    render(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />);
+    render(
+      wrap(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />)
+    );
     expect(screen.getByText("Card failed to render")).toBeTruthy();
     expect(screen.queryByText("Card broke")).toBeNull();
   });
 
   it("calls resetError when retry is clicked", () => {
     const resetError = vi.fn();
-    render(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />);
+    render(
+      wrap(<WorktreeCardErrorFallback error={new Error("Card broke")} resetError={resetError} />)
+    );
     fireEvent.click(screen.getByText("Retry"));
     expect(resetError).toHaveBeenCalledOnce();
   });
@@ -57,15 +68,17 @@ describe("WorktreeCardErrorFallback", () => {
     }
 
     render(
-      <ErrorBoundary
-        variant="component"
-        componentName="WorktreeCard"
-        fallback={WorktreeCardErrorFallback}
-        resetKeys={["wt-1"]}
-        context={{ worktreeId: "wt-1" }}
-      >
-        <ThrowingCard />
-      </ErrorBoundary>
+      <TooltipProvider>
+        <ErrorBoundary
+          variant="component"
+          componentName="WorktreeCard"
+          fallback={WorktreeCardErrorFallback}
+          resetKeys={["wt-1"]}
+          context={{ worktreeId: "wt-1" }}
+        >
+          <ThrowingCard />
+        </ErrorBoundary>
+      </TooltipProvider>
     );
 
     expect(screen.getByText("Card render failed")).toBeTruthy();

--- a/src/components/ui/TruncatedTooltip.tsx
+++ b/src/components/ui/TruncatedTooltip.tsx
@@ -1,0 +1,64 @@
+import type { Ref } from "react";
+import React from "react";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { useTruncationDetection } from "@/hooks/useTruncationDetection";
+
+const FOCUSABLE_TAGS = new Set(["BUTTON", "A", "INPUT", "SELECT", "TEXTAREA", "AUDIO", "VIDEO"]);
+
+function mergeRefs<T>(...refs: (Ref<T> | undefined)[]) {
+  return (el: T | null) => {
+    for (const ref of refs) {
+      if (typeof ref === "function") {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<T | null>).current = el;
+      }
+    }
+  };
+}
+
+export interface TruncatedTooltipProps {
+  children: React.ReactElement;
+  content: React.ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+  contentClassName?: string;
+  disabled?: boolean;
+  isTruncated?: boolean;
+}
+
+export function TruncatedTooltip({
+  children,
+  content,
+  side,
+  align,
+  contentClassName,
+  disabled,
+  isTruncated: isTruncatedProp,
+}: TruncatedTooltipProps) {
+  const ownDetection = useTruncationDetection();
+  const isTruncated = isTruncatedProp ?? ownDetection.isTruncated;
+  const showTooltip = isTruncated && !disabled;
+
+  const childType = typeof children.type === "string" ? (children.type as string) : "";
+  const isFocusable = FOCUSABLE_TAGS.has(childType.toUpperCase());
+
+  const mergedRef = mergeRefs(
+    isTruncatedProp ? undefined : ownDetection.ref,
+    (children as any).ref
+  );
+
+  const extraProps: any = { ref: mergedRef };
+  if (!isFocusable && showTooltip) {
+    extraProps.tabIndex = 0;
+  }
+
+  return (
+    <Tooltip open={showTooltip ? undefined : false}>
+      <TooltipTrigger asChild>{React.cloneElement(children, extraProps)}</TooltipTrigger>
+      <TooltipContent side={side} align={align} className={contentClassName}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/ui/TruncatedTooltip.tsx
+++ b/src/components/ui/TruncatedTooltip.tsx
@@ -45,10 +45,10 @@ export function TruncatedTooltip({
 
   const mergedRef = mergeRefs(
     isTruncatedProp ? undefined : ownDetection.ref,
-    (children as any).ref
+    (children as React.ReactElement & { ref?: React.Ref<unknown> }).ref
   );
 
-  const extraProps: any = { ref: mergedRef };
+  const extraProps: Record<string, unknown> = { ref: mergedRef };
   if (!isFocusable && showTooltip) {
     extraProps.tabIndex = 0;
   }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -103,3 +103,5 @@ export type { UseUnsavedChangesOptions } from "./useUnsavedChanges";
 export { useDebounce } from "./useDebounce";
 
 export { useShortcutHintHover } from "./useShortcutHintHover";
+
+export { useTruncationDetection, isElementTruncated } from "./useTruncationDetection";

--- a/src/hooks/useTruncationDetection.ts
+++ b/src/hooks/useTruncationDetection.ts
@@ -1,0 +1,89 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+
+const TOLERANCE = 1;
+
+type Subscriber = {
+  setTruncated: (v: boolean) => void;
+  element: HTMLElement;
+};
+
+let singleton: {
+  observer: ResizeObserver | null;
+  subscribers: Map<HTMLElement, Subscriber>;
+  rafId: number | null;
+} | null = null;
+
+function getSingleton() {
+  if (!singleton) {
+    singleton = { observer: null, subscribers: new Map(), rafId: null };
+  }
+  return singleton;
+}
+
+function scheduleCheck() {
+  const s = getSingleton();
+  if (s.rafId !== null) return;
+  s.rafId = requestAnimationFrame(() => {
+    s.rafId = null;
+    for (const [el, sub] of s.subscribers) {
+      if (!el.isConnected) {
+        s.subscribers.delete(el);
+        continue;
+      }
+      const truncated = el.scrollWidth > el.clientWidth + TOLERANCE;
+      sub.setTruncated(truncated);
+    }
+  });
+}
+
+export function isElementTruncated(el: HTMLElement, tolerance = TOLERANCE): boolean {
+  return el.scrollWidth > el.clientWidth + tolerance;
+}
+
+export function useTruncationDetection() {
+  const [isTruncated, setIsTruncated] = useState(false);
+  const elementRef = useRef<HTMLElement | null>(null);
+  const stableSetter = useRef(setIsTruncated);
+  stableSetter.current = setIsTruncated;
+
+  const ref = useCallback((el: HTMLElement | null) => {
+    const s = getSingleton();
+    // Unregister previous element
+    const prev = elementRef.current;
+    if (prev && s.subscribers.has(prev)) {
+      s.subscribers.delete(prev);
+    }
+
+    elementRef.current = el;
+
+    if (!el) {
+      if (s.subscribers.size === 0 && s.observer) {
+        s.observer.disconnect();
+        s.observer = null;
+      }
+      return;
+    }
+
+    s.subscribers.set(el, { setTruncated: (v) => stableSetter.current(v), element: el });
+
+    if (!s.observer && typeof ResizeObserver !== "undefined") {
+      s.observer = new ResizeObserver(() => scheduleCheck());
+    }
+    if (s.observer) {
+      s.observer.observe(el);
+    }
+    // Initial check (layout-dependent; useLayoutEffect ensures after render)
+    const truncated = el.scrollWidth > el.clientWidth + TOLERANCE;
+    stableSetter.current(truncated);
+  }, []);
+
+  // Measure on mount if ResizeObserver isn't available (jsdom / SSR)
+  useLayoutEffect(() => {
+    const el = elementRef.current;
+    if (!el || typeof ResizeObserver !== "undefined") return;
+    const truncated = el.scrollWidth > el.clientWidth + TOLERANCE;
+    setIsTruncated(truncated);
+  });
+
+  return { ref, isTruncated };
+}

--- a/src/hooks/useTruncationDetection.ts
+++ b/src/hooks/useTruncationDetection.ts
@@ -51,6 +51,7 @@ export function useTruncationDetection() {
     // Unregister previous element
     const prev = elementRef.current;
     if (prev && s.subscribers.has(prev)) {
+      s.observer?.unobserve(prev);
       s.subscribers.delete(prev);
     }
 

--- a/src/hooks/useTruncationDetection.ts
+++ b/src/hooks/useTruncationDetection.ts
@@ -84,7 +84,7 @@ export function useTruncationDetection() {
     if (!el || typeof ResizeObserver !== "undefined") return;
     const truncated = el.scrollWidth > el.clientWidth + TOLERANCE;
     setIsTruncated(truncated);
-  });
+  }, []);
 
   return { ref, isTruncated };
 }


### PR DESCRIPTION
## Summary
- Adds a `useTruncationDetection` hook (singleton ResizeObserver) and `TruncatedTooltip` component (Radix-based, conditional) for overflow-aware tooltips
- Applies to 13 sites across the worktree UI: palette rows, diff headers, error fallbacks, header names, terminal titles, review hub badges, file stage rows, conflict panels, cross-worktree diffs, issue picker rows, and PR title banners
- Replaces all native `title=` attributes in the worktree component family with keyboard-accessible Radix tooltips
- Tooltips only appear when text is actually truncated (scrollWidth > clientWidth + 1px tolerance)

## Key changes
- `useTruncationDetection`: singleton `ResizeObserver` with rAF-throttled overflow checks, jsdom-safe (no `ResizeObserver` → measure-on-mount fallback)
- `TruncatedTooltip`: wraps a single child in `TooltipTrigger asChild`, gates `open={isTruncated ? undefined : false}`, auto-adds `tabIndex={0}` on non-focusable elements only when truncated
- No `aria-label` hacks — CSS truncation doesn't strip text from the a11y tree, screen readers already announce the full string

## Follow-up
- 4 NewWorktreeDialog picker rows deferred (nested PopoverTrigger complicates tooltip wrapping)
- `WorktreeDetailsSection` lifecycle label deferred (absolute-positioned button overlay + pointer-events-none span)
- `BranchLabel` and `FileChangeList` always-on tooltips are natural follow-ups per the issue description

Closes #5973

🤖 Generated with [Claude Code](https://claude.com/claude-code)