### PR TITLE
fix(fleet): exclude dock terminals from fleet eligibility (#5965)

### DIFF
--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -127,6 +127,7 @@ describe("FleetArmingDialog", () => {
       makeTerminal("trash-row", { title: "trashed", location: "trash" }),
       makeTerminal("nopty", { title: "no-pty", hasPty: false }),
       makeTerminal("exited", { title: "exited", runtimeStatus: "exited" }),
+      makeTerminal("docked", { title: "docked", location: "dock" }),
     ]);
     renderDialog([makeWorktreeSnap("wt-1", "Main")]);
     expect(screen.getByText("alpha")).toBeTruthy();
@@ -134,6 +135,7 @@ describe("FleetArmingDialog", () => {
     expect(screen.queryByText("trashed")).toBeNull();
     expect(screen.queryByText("no-pty")).toBeNull();
     expect(screen.queryByText("exited")).toBeNull();
+    expect(screen.queryByText("docked")).toBeNull();
   });
 
   it("shows empty state when there are no eligible terminals", () => {

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -203,14 +203,15 @@ describe("resolveFleetBroadcastTargetIds", () => {
     expect(resolveFleetBroadcastTargetIds()).toEqual([]);
   });
 
-  it("drops trashed/background/non-pty terminals silently", () => {
+  it("drops trashed/background/dock/non-pty terminals silently", () => {
     seedPanels([
       makeAgent("ok"),
       makeAgent("trashed", { location: "trash" }),
       makeAgent("bg", { location: "background" }),
       makeAgent("noPty", { hasPty: false }),
+      makeAgent("docked", { location: "dock" }),
     ]);
-    useFleetArmingStore.getState().armIds(["ok", "trashed", "bg", "noPty"]);
+    useFleetArmingStore.getState().armIds(["ok", "trashed", "bg", "noPty", "docked"]);
     expect(resolveFleetBroadcastTargetIds()).toEqual(["ok"]);
   });
 

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -100,6 +100,19 @@ describe("broadcastFleetLiteralPaste", () => {
     expect(result.total).toBe(0);
     expect(result.successCount).toBe(0);
   });
+
+  it("filters explicit targetIds through fleet eligibility (drops dock/trash)", async () => {
+    seedPanels([
+      makeAgent("ok"),
+      makeAgent("docked", { location: "dock" }),
+      makeAgent("trashed", { location: "trash" }),
+    ]);
+    const result = await broadcastFleetLiteralPaste("x", ["ok", "docked", "trashed"]);
+    expect(submitMock).toHaveBeenCalledTimes(1);
+    expect(submitMock).toHaveBeenCalledWith("ok", "x");
+    expect(result.successCount).toBe(1);
+    expect(result.failureCount).toBe(0);
+  });
 });
 
 describe("executeFleetBroadcast", () => {

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -93,8 +93,9 @@ describe("broadcastFleetRawInput", () => {
       makeTerminal("t1"),
       makeTerminal("trashed", { location: "trash" }),
       makeTerminal("no-pty", { hasPty: false }),
+      makeTerminal("docked", { location: "dock" }),
     ]);
-    useFleetArmingStore.getState().armIds(["t1", "trashed", "no-pty"]);
+    useFleetArmingStore.getState().armIds(["t1", "trashed", "no-pty", "docked"]);
 
     expect(broadcastFleetRawInput("t1", "still-local")).toBe(false);
 

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -102,6 +102,19 @@ describe("broadcastFleetRawInput", () => {
     expect(broadcastMock).not.toHaveBeenCalled();
   });
 
+  it("silently drops dock terminals while broadcasting to live grid targets", () => {
+    seedPanels([
+      makeTerminal("grid-a"),
+      makeTerminal("grid-b"),
+      makeTerminal("docked", { location: "dock" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["grid-a", "grid-b", "docked"]);
+
+    expect(broadcastFleetRawInput("grid-a", "ls\r")).toBe(true);
+
+    expect(broadcastMock).toHaveBeenCalledWith(["grid-a", "grid-b"], "ls\r");
+  });
+
   it("returns false for empty raw input", () => {
     seedPanels([makeTerminal("t1"), makeTerminal("t2")]);
     useFleetArmingStore.getState().armIds(["t1", "t2"]);

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -1,7 +1,9 @@
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { terminalClient } from "@/clients";
+import { isTerminalFleetEligible } from "@/store/fleetEligibility";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
+import type { TerminalInstance } from "@shared/types";
 import {
   buildFleetBroadcastRecipeContext,
   FLEET_LARGE_PASTE_BATCH_SIZE,
@@ -39,8 +41,22 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
 
   for (const id of armOrder) {
     if (!armedIds.has(id)) continue;
-    const panel = panelsById[id];
-    if (!panel || panel.location === "trash" || panel.location === "background") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const panel: any = panelsById[id];
+
+    if (isTerminalFleetEligible(panel)) {
+      const ctx = buildFleetBroadcastRecipeContext(id);
+      const resolved = ctx ? replaceRecipeVariables(draft, ctx) : draft;
+      const unresolvedVars = ctx ? detectUnresolved(draft, ctx) : [];
+
+      previews.push({
+        terminalId: id,
+        title: (panel as TerminalInstance).title ?? "Agent",
+        resolvedPayload: resolved,
+        unresolvedVars,
+        excluded: false,
+      });
+    } else {
       previews.push({
         terminalId: id,
         title: panel?.title ?? "Unknown",
@@ -49,20 +65,7 @@ export function buildFleetTargetPreviews(draft: string): FleetTargetPreview[] {
         excluded: true,
         exclusionReason: "Panel no longer eligible",
       });
-      continue;
     }
-
-    const ctx = buildFleetBroadcastRecipeContext(id);
-    const resolved = ctx ? replaceRecipeVariables(draft, ctx) : draft;
-    const unresolvedVars = ctx ? detectUnresolved(draft, ctx) : [];
-
-    previews.push({
-      terminalId: id,
-      title: panel.title ?? "Agent",
-      resolvedPayload: resolved,
-      unresolvedVars,
-      excluded: false,
-    });
   }
 
   return previews;
@@ -82,6 +85,11 @@ function detectUnresolved(text: string, ctx: RecipeContext): string[] {
     if (resolved === "") unresolved.push(name);
   }
   return unresolved;
+}
+
+function filterEligibleIds(ids: string[]): string[] {
+  const { panelsById } = usePanelStore.getState();
+  return ids.filter((id) => isTerminalFleetEligible(panelsById[id]));
 }
 
 function resolveVariable(name: string, ctx: RecipeContext): string {
@@ -209,7 +217,7 @@ export async function broadcastFleetLiteralPaste(
   text: string,
   targetIds?: string[]
 ): Promise<FleetExecutionResult> {
-  const ids = targetIds ?? resolveFleetBroadcastTargetIds();
+  const ids = targetIds ? filterEligibleIds(targetIds) : resolveFleetBroadcastTargetIds();
   const submissions: Promise<void>[] = [];
   const collected: string[] = [];
 

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -26,7 +26,6 @@ import {
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
-import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -90,9 +89,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const activePanel = useMemo(() => {
     return panels.find((p) => p.id === activeTabId) ?? panels[0];
   }, [panels, activeTabId]);
-  const isFleetHybridInputMember = useFleetArmingStore((s) =>
-    activePanel ? s.armedIds.has(activePanel.id) && s.armedIds.size >= 2 : false
-  );
 
   // Derive isOpen from store state - open if ANY panel in this group is active
   const isOpen = panels.some((p) => p.id === activeDockTerminalId);
@@ -513,7 +509,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           const focusTarget = getTerminalFocusTarget({
-            hasHybridInputSurface: activeChrome.isAgent || isFleetHybridInputMember,
+            hasHybridInputSurface: activeChrome.isAgent,
             isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
             hybridInputEnabled,
             hybridInputAutoFocus,

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -13,7 +13,6 @@ import {
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
-import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -43,9 +42,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
   const hybridInputAutoFocus = useTerminalInputStore((s) => s.hybridInputAutoFocus);
-  const isFleetHybridInputMember = useFleetArmingStore(
-    (s) => s.armedIds.has(terminal.id) && s.armedIds.size >= 2
-  );
 
   // Derive isOpen from store state
   const isOpen = activeDockTerminalId === terminal.id;
@@ -380,7 +376,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           const focusTarget = getTerminalFocusTarget({
-            hasHybridInputSurface: chrome.isAgent || isFleetHybridInputMember,
+            hasHybridInputSurface: chrome.isAgent,
             isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
             hybridInputEnabled,
             hybridInputAutoFocus,

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -192,12 +192,13 @@ describe("fleetArmingStore", () => {
       expect(useFleetArmingStore.getState().lastArmedId).toBe("t2");
     });
 
-    it("excludes trash/background/hasPty=false panels", () => {
+    it("excludes trash/background/dock/hasPty=false panels", () => {
       seedPanels([
         makeAgentTerminal("t1", { agentState: "working" }),
         makeAgentTerminal("t2", { agentState: "working", location: "trash" }),
         makeAgentTerminal("t3", { agentState: "working", location: "background" }),
         makeAgentTerminal("t4", { agentState: "working", hasPty: false }),
+        makeAgentTerminal("t5", { agentState: "working", location: "dock" }),
       ]);
       useFleetArmingStore.getState().armByState("working", "current", false);
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["t1"]);
@@ -229,6 +230,12 @@ describe("fleetArmingStore", () => {
       ]);
       useFleetArmingStore.getState().armAll("current");
       expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
+    });
+
+    it("skips dock-located terminals", () => {
+      seedPanels([makeAgentTerminal("a1"), makeAgentTerminal("a2", { location: "dock" })]);
+      useFleetArmingStore.getState().armAll("current");
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
     });
 
     it("scope 'all' arms across worktrees", () => {
@@ -299,6 +306,7 @@ describe("fleetArmingStore", () => {
           detectedAgentId: undefined,
           everDetectedAgent: false,
         }),
+        makeAgentTerminal("a6", { worktreeId: "wt-1", location: "dock" }),
       ]);
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1", "a5"]);
@@ -453,6 +461,10 @@ describe("fleetArmingStore", () => {
 
     it("rejects background terminals", () => {
       expect(isFleetArmEligible(makeAgentTerminal("a", { location: "background" }))).toBe(false);
+    });
+
+    it("rejects dock terminals", () => {
+      expect(isFleetArmEligible(makeAgentTerminal("a", { location: "dock" }))).toBe(false);
     });
 
     it("rejects hasPty=false terminals", () => {
@@ -668,6 +680,15 @@ describe("fleetArmingStore", () => {
       useFleetArmingStore.getState().armIds(["a", "b"]);
 
       seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b", { location: "trash" })]);
+
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
+    });
+
+    it("drops armed ids when a panel transitions to dock", () => {
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b")]);
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b", { location: "dock" })]);
 
       expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
     });

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -4,11 +4,13 @@ import { getBuiltInRuntimeAgentId } from "@/utils/terminalType";
 
 /**
  * Fleet membership/broadcast predicate: the terminal has a writable PTY and is
- * not in a lifecycle state where Fleet should address it.
+ * in a location where Fleet should address it. Dock terminals are excluded —
+ * the collapsed dock surface has no room to render the armed/follower visual
+ * state that warns a user their keystrokes are being broadcast.
  */
 export function isTerminalFleetEligible(t: TerminalInstance | undefined): t is TerminalInstance {
   if (!t) return false;
-  if (t.location === "trash" || t.location === "background") return false;
+  if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
   if (t.hasPty === false) return false;
   // `runtimeStatus` is the renderer's authoritative liveness signal. `hasPty`
   // can lag after backend snapshots/reconnect for panels preserved after exit.


### PR DESCRIPTION
## Summary

- Dock terminals were silently receiving fleet broadcasts with no visual feedback — the dock button shows no armed indicator, no follower stripe, and no preview tint when collapsed.
- Went with Option B (exclude dock terminals from eligibility) based on how mature tools handle this: tmux suspends `synchronize-panes` for hidden panes by default, and iTerm2 requires an explicit modal warning plus persistent visual state on every receiving surface. We have neither right now, so exclusion is the safer default.
- The dock becomes the place for terminals you're not broadcasting to. Move to grid first if you want them in the fleet.

Resolves #5965

## Changes

- `src/store/fleetEligibility.ts`: added `t.location === "dock"` to the `isTerminalFleetEligible` predicate (single-line change, single source of truth)
- `DockedTerminalItem.tsx` / `DockedTabGroup.tsx`: removed dead `isFleetHybridInputMember` subscriptions and unused `useFleetArmingStore` imports — these can never be true for dock-located panels after the predicate change
- `src/components/Fleet/fleetExecution.ts`: `buildFleetTargetPreviews` now delegates to `isTerminalFleetEligible` instead of a hand-rolled trash/background check; `broadcastFleetLiteralPaste` filters explicit `targetIds` through `isTerminalFleetEligible` to close the sub-millisecond race window in the `fleet.retryFailures` path
- Test coverage across 5 files: arming store multi-case ineligible tests, dialog renders-only-eligible, broadcast drops ineligible at send time, raw input degenerate count + mixed grid/dock happy path, explicit targetIds filtering in execution

## Testing

- 171 tests pass across affected files
- Typecheck clean, lint baseline improved by 2, format clean, build passes (18.25s renderer + 342ms main)