### PR TITLE
fix(store): preserve recovery backup when electron-store wipes schema-invalid config

### DIFF
--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -212,6 +212,24 @@ describe("initializeStore", () => {
     expect(instance.path).toBe("");
   });
 
+  it("does NOT overwrite backup when store silently clears a schema-invalid config", () => {
+    const configPath = path.join(tempDir, "config.json");
+    const lastGood = JSON.stringify({ _schemaVersion: 7 });
+    const violating = JSON.stringify({ _schemaVersion: "not-a-number" });
+    fs.writeFileSync(configPath, violating, "utf8");
+    fs.writeFileSync(`${configPath}.bak`, lastGood, "utf8");
+
+    const opts = testOptions(tempDir);
+    opts.schema = { _schemaVersion: { type: "number" } };
+
+    const instance = initializeStore(opts);
+    expect(instance).toBeDefined();
+    // Store has been silently reset to defaults by electron-store
+    expect(instance.get("_schemaVersion")).toBe(0);
+    // Backup must remain untouched — recovery is still possible
+    expect(fs.readFileSync(`${configPath}.bak`, "utf8")).toBe(lastGood);
+  });
+
   describe("consumePendingSettingsRecovery", () => {
     it("returns null on normal startup", () => {
       initializeStore(testOptions(tempDir));
@@ -245,6 +263,18 @@ describe("initializeStore", () => {
       initializeStore(testOptions("/nonexistent/\0/path"));
       const recovery = consumePendingSettingsRecovery();
       expect(recovery).toEqual({ kind: "reset-to-defaults" });
+    });
+
+    it("returns reset-to-defaults when store silently clears schema-invalid config", () => {
+      const configPath = path.join(tempDir, "config.json");
+      fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: "bad" }), "utf8");
+      fs.writeFileSync(`${configPath}.bak`, JSON.stringify({ _schemaVersion: 7 }), "utf8");
+      const opts = testOptions(tempDir);
+      opts.schema = { _schemaVersion: { type: "number" } };
+      initializeStore(opts);
+      const recovery = consumePendingSettingsRecovery();
+      expect(recovery).toEqual({ kind: "reset-to-defaults" });
+      expect(consumePendingSettingsRecovery()).toBeNull();
     });
 
     it("consume-once: second call returns null", () => {

--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -228,6 +228,45 @@ describe("initializeStore", () => {
     expect(instance.get("_schemaVersion")).toBe(0);
     // Backup must remain untouched — recovery is still possible
     expect(fs.readFileSync(`${configPath}.bak`, "utf8")).toBe(lastGood);
+    // …and recovery state should reflect the silent reset
+    expect(consumePendingSettingsRecovery()).toEqual({ kind: "reset-to-defaults" });
+  });
+
+  it("refreshes backup when conf merges new defaults into a valid config (app upgrade scenario)", () => {
+    const configPath = path.join(tempDir, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: 5 }), "utf8");
+
+    const opts = testOptions(tempDir);
+    // Simulate app upgrade adding a new default key the existing config lacks
+    opts.defaults = { _schemaVersion: 0, newDefault: "added" };
+
+    const instance = initializeStore(opts);
+    expect(instance.get("_schemaVersion")).toBe(5);
+    expect(instance.get("newDefault")).toBe("added");
+    // Backup must reflect the merged-on-disk content, not stay frozen
+    const backup = JSON.parse(fs.readFileSync(`${configPath}.bak`, "utf8"));
+    expect(backup._schemaVersion).toBe(5);
+    expect(backup.newDefault).toBe("added");
+    // No phantom recovery notification on a benign merge
+    expect(consumePendingSettingsRecovery()).toBeNull();
+  });
+
+  it("preserves restored-from-backup recovery when conf merges defaults into restored backup", () => {
+    const configPath = path.join(tempDir, "config.json");
+    // Main config is corrupt (preflight will quarantine it and restore .bak)
+    fs.writeFileSync(configPath, "{corrupt!", "utf8");
+    // Backup is valid but missing a current default key (typical post-upgrade state)
+    fs.writeFileSync(`${configPath}.bak`, JSON.stringify({ _schemaVersion: 7 }), "utf8");
+
+    const opts = testOptions(tempDir);
+    opts.defaults = { _schemaVersion: 0, newDefault: "added" };
+
+    const instance = initializeStore(opts);
+    expect(instance.get("_schemaVersion")).toBe(7);
+
+    const recovery = consumePendingSettingsRecovery();
+    expect(recovery?.kind).toBe("restored-from-backup");
+    expect(recovery?.quarantinedPath).toBeDefined();
   });
 
   describe("consumePendingSettingsRecovery", () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -412,6 +412,15 @@ function refreshBackup(configPath: string): void {
   }
 }
 
+function readRawSnapshot(filePath: string): Buffer | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return fs.readFileSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
 function createInMemoryFallback(): Store<StoreSchema> {
   const memoryStore = new Map();
   return {
@@ -453,11 +462,23 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
   }
 
   try {
+    const preSnapshot = configPath ? readRawSnapshot(configPath) : null;
     const instance = new Store<StoreSchema>({
       ...options,
       clearInvalidConfig: true,
     });
-    refreshBackup(instance.path);
+    const postSnapshot = configPath ? readRawSnapshot(configPath) : null;
+    const wipedDuringConstruction =
+      preSnapshot !== null &&
+      (postSnapshot === null || !preSnapshot.equals(postSnapshot));
+    if (wipedDuringConstruction) {
+      console.warn(
+        "[Store] electron-store silently replaced config.json during construction; preserving .bak"
+      );
+      pendingSettingsRecovery = { kind: "reset-to-defaults" };
+    } else {
+      refreshBackup(instance.path);
+    }
     return instance;
   } catch (error) {
     console.warn("[Store] Failed to initialize electron-store, using in-memory fallback:", error);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -421,6 +421,44 @@ function readRawSnapshot(filePath: string): Buffer | null {
   }
 }
 
+// A "wipe" is an electron-store rewrite that loses user data (clearInvalidConfig
+// path). A "merge" is an electron-store rewrite that adds missing default keys
+// while preserving every user value. Byte-equality cannot tell them apart, so
+// we parse pre/post and check whether every key from pre survives in post with
+// an identical value. Any dropped or changed user value means the file was
+// wiped.
+function detectStoreWipe(pre: Buffer, post: Buffer | null): boolean {
+  if (post === null) return true;
+  if (pre.equals(post)) return false;
+  let preObj: unknown;
+  let postObj: unknown;
+  try {
+    preObj = JSON.parse(pre.toString("utf8"));
+  } catch {
+    // Pre-content was not parseable JSON; preflight should have caught this,
+    // but if we got here the safest move is to treat the rewrite as a wipe.
+    return true;
+  }
+  try {
+    postObj = JSON.parse(post.toString("utf8"));
+  } catch {
+    return true;
+  }
+  if (typeof preObj !== "object" || preObj === null || Array.isArray(preObj)) {
+    return false;
+  }
+  if (typeof postObj !== "object" || postObj === null || Array.isArray(postObj)) {
+    return true;
+  }
+  const preRecord = preObj as Record<string, unknown>;
+  const postRecord = postObj as Record<string, unknown>;
+  for (const key of Object.keys(preRecord)) {
+    if (!Object.prototype.hasOwnProperty.call(postRecord, key)) return true;
+    if (JSON.stringify(preRecord[key]) !== JSON.stringify(postRecord[key])) return true;
+  }
+  return false;
+}
+
 function createInMemoryFallback(): Store<StoreSchema> {
   const memoryStore = new Map();
   return {
@@ -469,13 +507,15 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
     });
     const postSnapshot = configPath ? readRawSnapshot(configPath) : null;
     const wipedDuringConstruction =
-      preSnapshot !== null &&
-      (postSnapshot === null || !preSnapshot.equals(postSnapshot));
+      preSnapshot !== null && detectStoreWipe(preSnapshot, postSnapshot);
     if (wipedDuringConstruction) {
       console.warn(
         "[Store] electron-store silently replaced config.json during construction; preserving .bak"
       );
-      pendingSettingsRecovery = { kind: "reset-to-defaults" };
+      // Don't clobber a more specific recovery state already set by preflight.
+      if (pendingSettingsRecovery === null) {
+        pendingSettingsRecovery = { kind: "reset-to-defaults" };
+      }
     } else {
       refreshBackup(instance.path);
     }


### PR DESCRIPTION
## Summary

- When `electron-store` silently replaces a schema-invalid config with defaults, `refreshBackup` was immediately copying the now-defaulted file over `.bak`, destroying the user's last recoverable state
- Added `readRawSnapshot` and `detectStoreWipe` helpers to compare the on-disk file before and after store construction, and gated `refreshBackup` behind the wipe check so it only runs when the file is genuinely the user's own
- Also fixed a secondary path where `pendingSettingsRecovery` could be overwritten if the store write-then-default cycle happened to hit the preflight-set state

Resolves #6035

## Changes

- `electron/store.ts`: added `readRawSnapshot` (reads raw bytes pre-construction), `detectStoreWipe` (compares snapshot to post-construction store values), gated `refreshBackup` and `pendingSettingsRecovery` assignment accordingly
- `electron/__tests__/storeBackupRestore.test.ts`: 4 new tests covering schema-wipe protection, app-upgrade default merge (no false positive), restored-from-backup preservation across default merge, and the consume-once notification path

## Testing

31/31 tests pass in `storeBackupRestore.test.ts`. `npm run check` clean (typecheck, lint, format, channel drift all pass; lint warnings down 2 from baseline).