### PR TITLE
feat(github): keep cached data visible when background refresh fails

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -322,6 +322,12 @@ export function GitHubResourceList({
         }
 
         if (lastError != null) {
+          // Same generation guard as the success path: a stale background
+          // fetch finishing after the user switched filter/sort must not
+          // surface its error or wipe the freshly-loaded view.
+          if (options?.generation != null && options.cacheKey != null) {
+            if (getGeneration(options.cacheKey) !== options.generation) return;
+          }
           const message = formatErrorMessage(lastError, "Failed to fetch data");
           if (append) {
             setLoadMoreError(message);

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -33,6 +33,7 @@ import {
   RESOURCE_ITEM_HEIGHT_PX,
 } from "./GitHubDropdownSkeletons";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { formatTimeAgo } from "@/utils/timeAgo";
 
 type StateFilter = IssueStateFilter | PRStateFilter;
 
@@ -168,6 +169,10 @@ export function GitHubResourceList({
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(
+    () => cachedEntry?.timestamp ?? null
+  );
+  const [, setTick] = useState(0);
   const [exactNumberNotFound, setExactNumberNotFound] = useState<number | null>(null);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [sortPopoverOpen, setSortPopoverOpen] = useState(false);
@@ -286,12 +291,14 @@ export function GitHubResourceList({
 
             // Write first-page results to cache (skip search-filtered results)
             if (!append && options?.cacheKey && !debouncedSearch) {
+              const now = Date.now();
               setCache(options.cacheKey, {
                 items: result.items,
                 endCursor: result.pageInfo.endCursor,
                 hasNextPage: result.pageInfo.hasNextPage,
-                timestamp: Date.now(),
+                timestamp: now,
               });
+              setLastUpdatedAt(now);
             }
             lastError = null;
             return;
@@ -362,6 +369,7 @@ export function GitHubResourceList({
     setHasMore(false);
     setExactNumberNotFound(null);
     setData([]);
+    setLastUpdatedAt(null);
     fetchData(null, false, abortController.signal, {
       generation: gen,
       cacheKey,
@@ -590,6 +598,13 @@ export function GitHubResourceList({
   useEffect(() => {
     setActiveIndex(-1);
   }, [data]);
+
+  // Re-render the "Updated Xm ago" label every 60s while a stale-data banner is visible.
+  useEffect(() => {
+    if (lastUpdatedAt == null || error == null) return;
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [lastUpdatedAt, error]);
 
   useEffect(() => {
     if (activeIndex < 0) return;
@@ -941,6 +956,11 @@ export function GitHubResourceList({
               <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
                 <WifiOff className="h-3.5 w-3.5 shrink-0" />
                 <span className="text-xs truncate">{sanitizeIpcError(error)}</span>
+                {lastUpdatedAt != null && !debouncedSearch && (
+                  <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap">
+                    · Updated {formatTimeAgo(lastUpdatedAt)}
+                  </span>
+                )}
                 {isTokenError ? (
                   <Button
                     variant="ghost"

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -98,8 +98,12 @@ vi.mock("react-virtuoso", () => ({
   },
 }));
 
+const { formatTimeAgoMock } = vi.hoisted(() => ({
+  formatTimeAgoMock: vi.fn<(value: number | string) => string>(() => "1m ago"),
+}));
+
 vi.mock("@/utils/timeAgo", () => ({
-  formatTimeAgo: () => "1m ago",
+  formatTimeAgo: formatTimeAgoMock,
 }));
 
 import { GitHubResourceList } from "../GitHubResourceList";
@@ -126,6 +130,8 @@ beforeEach(() => {
   mockListPRs.mockReset();
   mockGetIssueByNumber.mockReset();
   mockGetPRByNumber.mockReset();
+  formatTimeAgoMock.mockClear();
+  formatTimeAgoMock.mockImplementation(() => "1m ago");
   const filterStore = useGitHubFilterStore.getState();
   filterStore.setIssueSearchQuery("");
   filterStore.setPrSearchQuery("");
@@ -197,11 +203,12 @@ describe("GitHubResourceList SWR behavior", () => {
 
   it("preserves cached data when background refresh fails", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    const seededTimestamp = Date.now() - 5 * 60 * 1000;
     setCache(cacheKey, {
       items: [makeIssue(20)],
       endCursor: null,
       hasNextPage: false,
-      timestamp: Date.now(),
+      timestamp: seededTimestamp,
     });
 
     mockListIssues.mockRejectedValue(new Error("Network error"));
@@ -217,6 +224,8 @@ describe("GitHubResourceList SWR behavior", () => {
     });
     expect(screen.getByTestId("item-20")).toBeTruthy();
     expect(screen.getByText(/Updated 1m ago/)).toBeTruthy();
+    // The label must reflect the cached timestamp, not Date.now() of the failure.
+    expect(formatTimeAgoMock).toHaveBeenCalledWith(seededTimestamp);
   });
 
   it("clears error banner and refreshes timestamp after successful retry", async () => {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -126,8 +126,13 @@ beforeEach(() => {
   mockListPRs.mockReset();
   mockGetIssueByNumber.mockReset();
   mockGetPRByNumber.mockReset();
-  useGitHubFilterStore.getState().setIssueSearchQuery("");
-  useGitHubFilterStore.getState().setPrSearchQuery("");
+  const filterStore = useGitHubFilterStore.getState();
+  filterStore.setIssueSearchQuery("");
+  filterStore.setPrSearchQuery("");
+  filterStore.setIssueFilter("open");
+  filterStore.setPrFilter("open");
+  filterStore.setIssueSortOrder("created");
+  filterStore.setPrSortOrder("created");
 });
 
 afterEach(() => {
@@ -206,11 +211,72 @@ describe("GitHubResourceList SWR behavior", () => {
     // Cached data shown immediately
     expect(screen.getByTestId("item-20")).toBeTruthy();
 
-    // After error, data persists and error banner appears
+    // After error, data persists and error banner appears with stale timestamp
     await waitFor(() => {
       expect(screen.getByText(/Network error/)).toBeTruthy();
     });
     expect(screen.getByTestId("item-20")).toBeTruthy();
+    expect(screen.getByText(/Updated 1m ago/)).toBeTruthy();
+  });
+
+  it("clears error banner and refreshes timestamp after successful retry", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(30)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now() - 60_000,
+    });
+
+    mockListIssues
+      .mockRejectedValueOnce(new Error("Network blip"))
+      .mockResolvedValue(makeResponse([makeIssue(30), makeIssue(31)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Banner appears after the failed background refresh
+    await waitFor(() => {
+      expect(screen.getByText(/Network blip/)).toBeTruthy();
+    });
+
+    // Click retry — second call succeeds
+    screen.getByRole("button", { name: /retry/i }).click();
+
+    // Error clears, new item appears, no banner
+    await waitFor(() => {
+      expect(screen.getByTestId("item-31")).toBeTruthy();
+    });
+    expect(screen.queryByText(/Network blip/)).toBeNull();
+    expect(screen.queryByText(/Updated/)).toBeNull();
+  });
+
+  it("does not bleed stale timestamp across filter changes", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(50)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Background revalidation for "open" fails — banner with timestamp appears
+    mockListIssues.mockRejectedValueOnce(new Error("Initial fail"));
+    // After filter switches to "closed", fetch never resolves so we can inspect transitional UI
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Initial fail/)).toBeTruthy();
+    });
+    expect(screen.getByText(/Updated 1m ago/)).toBeTruthy();
+
+    useGitHubFilterStore.getState().setIssueFilter("closed");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("item-50")).toBeNull();
+    });
+    expect(screen.queryByText(/Updated/)).toBeNull();
   });
 
   it("renders Load More footer when hasNextPage is true", async () => {


### PR DESCRIPTION
## Summary

- When a background refresh fails for a GitHub issue/PR list that has cached data, the list stays visible instead of being replaced with an error screen
- An inline "· Updated Xm ago" label is appended to the existing error banner so it's clear the data is stale, sourced from the cache entry's timestamp
- Full-panel error states are preserved for initial load failures where there's nothing to show

Resolves #6047

## Changes

- `GitHubResourceList.tsx`: added `lastUpdatedAt` state that captures the cache entry's timestamp on a successful load, updates inside the existing generation guard, and resets on filter/sort/project changes. A 60s ticker re-renders the relative-time string while a stale-data banner is showing. The error path now only activates when there's no cached data to fall back on.
- Hardened the generation guard: the error-set branch now applies the same key/generation check as the data branch, so a stale background fetch finishing after a filter/sort switch can't surface its error into the freshly-loaded view.
- Extended the existing SWR test to assert the timestamp label appears with the correct cached timestamp. Added two new tests: "clears error banner and refreshes timestamp after successful retry" and "does not bleed stale timestamp across filter changes". Tightened `beforeEach` to reset filter + sort state to prevent cross-test pollution.

## Testing

- Unit tests covering the stale-data banner with timestamp, successful retry clearing the banner, and filter changes not bleeding state across
- Manually verified the list stays visible with the inline banner when a refresh fails, and reverts to normal when the next refresh succeeds