### PR TITLE
feat(hooks): add useLoadingState for deferred spinner and slow-call signals

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -29,6 +29,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useLoadingState } from "@/hooks/useLoadingState";
 import { logError } from "@/utils/logger";
 
 export interface BrowserPaneProps extends BasePanelProps {
@@ -131,6 +132,7 @@ export function BrowserPane({
   });
 
   const [isLoading, setIsLoading] = useState(true);
+  const { showSpinner } = useLoadingState(isLoading);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [blockedNav, setBlockedNav] = useState<{
     url: string;
@@ -1001,7 +1003,7 @@ export function BrowserPane({
             )}
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-              {isLoading && (
+              {showSpinner && (
                 <div className="absolute inset-0 flex items-center justify-center bg-daintree-bg z-10">
                   <Spinner size="2xl" className="text-status-info" />
                 </div>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -31,6 +31,7 @@ import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useLoadingState } from "@/hooks/useLoadingState";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 import type { ViewportPresetId } from "@shared/types/panel";
 import { logError } from "@/utils/logger";
@@ -227,6 +228,8 @@ export function DevPreviewPane({
   });
 
   const [isLoading, setIsLoading] = useState(false);
+  const devServerPending = isRestarting || status === "starting" || status === "installing";
+  const { showSpinner: showDevServerSpinner } = useLoadingState(devServerPending);
   const [blockedNav, setBlockedNav] = useState<{
     url: string;
     canOpenExternal: boolean;
@@ -945,7 +948,7 @@ export function DevPreviewPane({
               {getViewportPreset(viewportPreset).height}
             </div>
           )}
-          {isRestarting || status === "starting" || status === "installing" ? (
+          {devServerPending && showDevServerSpinner ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg">
               <Spinner size="2xl" className="text-status-info mb-4" />
               <p className="text-sm text-daintree-text/60">

--- a/src/hooks/__tests__/useLoadingState.test.tsx
+++ b/src/hooks/__tests__/useLoadingState.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useLoadingState } from "../useLoadingState";
+
+describe("useLoadingState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns all flags false when not pending", () => {
+    const { result } = renderHook(() => useLoadingState(false));
+    expect(result.current).toEqual({
+      showSpinner: false,
+      isSlow: false,
+      isOverdue: false,
+    });
+  });
+
+  it("returns all flags false at the moment isPending flips true", () => {
+    const { result } = renderHook(() => useLoadingState(true));
+    expect(result.current).toEqual({
+      showSpinner: false,
+      isSlow: false,
+      isOverdue: false,
+    });
+  });
+
+  it("does not show the spinner before the defer delay elapses", () => {
+    const { result } = renderHook(() => useLoadingState(true));
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current.showSpinner).toBe(false);
+  });
+
+  it("shows the spinner once the defer delay has elapsed", () => {
+    const { result } = renderHook(() => useLoadingState(true));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.showSpinner).toBe(true);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isOverdue).toBe(false);
+  });
+
+  it("flips isSlow true after the slow threshold", () => {
+    const { result } = renderHook(() => useLoadingState(true));
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.showSpinner).toBe(true);
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isOverdue).toBe(false);
+  });
+
+  it("flips isOverdue true after the overdue threshold", () => {
+    const { result } = renderHook(() => useLoadingState(true));
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toEqual({
+      showSpinner: true,
+      isSlow: true,
+      isOverdue: true,
+    });
+  });
+
+  it("never shows the spinner if isPending resolves before defer delay", () => {
+    const { result, rerender } = renderHook(
+      ({ pending }: { pending: boolean }) => useLoadingState(pending),
+      { initialProps: { pending: true } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ pending: false });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toEqual({
+      showSpinner: false,
+      isSlow: false,
+      isOverdue: false,
+    });
+  });
+
+  it("resets all flags immediately when isPending flips false", () => {
+    const { result, rerender } = renderHook(
+      ({ pending }: { pending: boolean }) => useLoadingState(pending),
+      { initialProps: { pending: true } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current.isOverdue).toBe(true);
+
+    rerender({ pending: false });
+    expect(result.current).toEqual({
+      showSpinner: false,
+      isSlow: false,
+      isOverdue: false,
+    });
+  });
+
+  it("respects custom thresholds", () => {
+    const { result } = renderHook(() => useLoadingState(true, 100, 500, 2000));
+
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+    expect(result.current.showSpinner).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.showSpinner).toBe(true);
+    expect(result.current.isSlow).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isOverdue).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(result.current.isOverdue).toBe(true);
+  });
+
+  it("clears all timers on unmount", () => {
+    const { unmount } = renderHook(() => useLoadingState(true));
+    expect(vi.getTimerCount()).toBe(3);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not leak timers when isPending toggles rapidly", () => {
+    const { rerender } = renderHook(
+      ({ pending }: { pending: boolean }) => useLoadingState(pending),
+      { initialProps: { pending: false } }
+    );
+
+    rerender({ pending: true });
+    expect(vi.getTimerCount()).toBe(3);
+
+    rerender({ pending: false });
+    expect(vi.getTimerCount()).toBe(0);
+
+    rerender({ pending: true });
+    expect(vi.getTimerCount()).toBe(3);
+
+    rerender({ pending: false });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("re-runs timers when thresholds change mid-cycle", () => {
+    const { result, rerender } = renderHook(
+      ({ defer }: { defer: number }) => useLoadingState(true, defer),
+      { initialProps: { defer: 200 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.showSpinner).toBe(false);
+
+    rerender({ defer: 500 });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.showSpinner).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.showSpinner).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useLoadingState.test.tsx
+++ b/src/hooks/__tests__/useLoadingState.test.tsx
@@ -54,7 +54,12 @@ describe("useLoadingState", () => {
     const { result } = renderHook(() => useLoadingState(true));
 
     act(() => {
-      vi.advanceTimersByTime(3000);
+      vi.advanceTimersByTime(2999);
+    });
+    expect(result.current.isSlow).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
     });
     expect(result.current.showSpinner).toBe(true);
     expect(result.current.isSlow).toBe(true);
@@ -65,7 +70,12 @@ describe("useLoadingState", () => {
     const { result } = renderHook(() => useLoadingState(true));
 
     act(() => {
-      vi.advanceTimersByTime(10000);
+      vi.advanceTimersByTime(9999);
+    });
+    expect(result.current.isOverdue).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
     });
     expect(result.current).toEqual({
       showSpinner: true,
@@ -189,5 +199,79 @@ describe("useLoadingState", () => {
       vi.advanceTimersByTime(300);
     });
     expect(result.current.showSpinner).toBe(true);
+  });
+
+  it("clears already-set isSlow flag when slowThreshold extends mid-cycle", () => {
+    const { result, rerender } = renderHook(
+      ({ slow }: { slow: number }) => useLoadingState(true, 200, slow, 10000),
+      { initialProps: { slow: 500 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isSlow).toBe(true);
+
+    rerender({ slow: 2000 });
+    expect(result.current.isSlow).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isSlow).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isSlow).toBe(true);
+  });
+
+  it("clears already-set isOverdue flag when overdueThreshold extends mid-cycle", () => {
+    const { result, rerender } = renderHook(
+      ({ overdue }: { overdue: number }) => useLoadingState(true, 200, 3000, overdue),
+      { initialProps: { overdue: 1000 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isOverdue).toBe(true);
+
+    rerender({ overdue: 5000 });
+    expect(result.current.isOverdue).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.isOverdue).toBe(false);
+  });
+
+  it("clears flags from a prior pending cycle when isPending toggles back on", () => {
+    const { result, rerender } = renderHook(
+      ({ pending }: { pending: boolean }) => useLoadingState(pending),
+      { initialProps: { pending: true } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current).toEqual({
+      showSpinner: true,
+      isSlow: true,
+      isOverdue: true,
+    });
+
+    rerender({ pending: false });
+    rerender({ pending: true });
+    expect(result.current).toEqual({
+      showSpinner: false,
+      isSlow: false,
+      isOverdue: false,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current.showSpinner).toBe(false);
   });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -102,6 +102,9 @@ export type { UseUnsavedChangesOptions } from "./useUnsavedChanges";
 
 export { useDebounce } from "./useDebounce";
 
+export { useLoadingState } from "./useLoadingState";
+export type { UseLoadingStateResult } from "./useLoadingState";
+
 export { useShortcutHintHover } from "./useShortcutHintHover";
 
 export { useTruncationDetection, isElementTruncated } from "./useTruncationDetection";

--- a/src/hooks/useLoadingState.ts
+++ b/src/hooks/useLoadingState.ts
@@ -17,10 +17,10 @@ export function useLoadingState(
   const [isOverdue, setIsOverdue] = useState(false);
 
   useEffect(() => {
+    setShowSpinner(false);
+    setIsSlow(false);
+    setIsOverdue(false);
     if (!isPending) {
-      setShowSpinner(false);
-      setIsSlow(false);
-      setIsOverdue(false);
       return;
     }
     const deferTimer = setTimeout(() => setShowSpinner(true), deferDelay);

--- a/src/hooks/useLoadingState.ts
+++ b/src/hooks/useLoadingState.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "react";
+
+export interface UseLoadingStateResult {
+  showSpinner: boolean;
+  isSlow: boolean;
+  isOverdue: boolean;
+}
+
+export function useLoadingState(
+  isPending: boolean,
+  deferDelay: number = 200,
+  slowThreshold: number = 3000,
+  overdueThreshold: number = 10000
+): UseLoadingStateResult {
+  const [showSpinner, setShowSpinner] = useState(false);
+  const [isSlow, setIsSlow] = useState(false);
+  const [isOverdue, setIsOverdue] = useState(false);
+
+  useEffect(() => {
+    if (!isPending) {
+      setShowSpinner(false);
+      setIsSlow(false);
+      setIsOverdue(false);
+      return;
+    }
+    const deferTimer = setTimeout(() => setShowSpinner(true), deferDelay);
+    const slowTimer = setTimeout(() => setIsSlow(true), slowThreshold);
+    const overdueTimer = setTimeout(() => setIsOverdue(true), overdueThreshold);
+    return () => {
+      clearTimeout(deferTimer);
+      clearTimeout(slowTimer);
+      clearTimeout(overdueTimer);
+    };
+  }, [isPending, deferDelay, slowThreshold, overdueThreshold]);
+
+  return { showSpinner, isSlow, isOverdue };
+}


### PR DESCRIPTION
## Summary

- Adds `useLoadingState(isPending, deferDelay?, slowThreshold?, overdueThreshold?)` — a flat-params hook that returns `{ showSpinner, isSlow, isOverdue }`. The spinner is gated behind a defer window (default 200ms) so fast loads don't flash a spinner at all.
- Wires it into `BrowserPane` and `DevPreviewPane`, replacing the ad-hoc spinner logic in both with a consistent primitive. DevPreviewPane also suppresses the "Starting / Installing / Restarting" label for the same 200ms window — sub-200ms transitions don't need a label.
- `isSlow` and `isOverdue` are exposed on the return value for future consumers; the "Taking longer than usual" copy and cancel UI are out of scope here since they need per-component cancellation chains that don't exist yet.

Resolves #6030

## Changes

- `src/hooks/useLoadingState.ts` — three independent `setTimeout` calls in one `useEffect`; flags reset at the top of the effect so threshold changes mid-cycle don't leave stale state
- `src/hooks/__tests__/useLoadingState.test.tsx` — 15 tests covering deferred onset, threshold boundaries, mid-cycle threshold changes, prior-cycle flag leakage, and unmount cleanup
- `src/hooks/index.ts` — barrel export added
- `src/components/Browser/BrowserPane.tsx` — spinner overlay gated on `showSpinner`
- `src/components/DevPreview/DevPreviewPane.tsx` — dev-server spinner and status label gated on `showDevServerSpinner`

**Naming note:** `isOverdue` was chosen over the issue's `isError` to avoid collision with the existing `isError` / `status === "error"` semantics already in both components.

## Testing

- 15/15 unit tests pass with fake timers covering all boundary conditions
- `npm run check` passes: typecheck clean, lint ratchet at -2 warnings, format unchanged