### PR TITLE
feat(diagnostics): add dev-mode lifecycle leak diagnostics

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import "./setup/environment.js";
 import nodeV8 from "node:v8";
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
+import { startDevDiagnostics } from "./setup/devDiagnostics.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
@@ -153,6 +154,10 @@ if (!gotTheLock) {
   crashReporter.start({ uploadToServer: false });
   initializeCrashLoopGuard();
   registerGlobalErrorHandlers();
+
+  if (!app.isPackaged) {
+    startDevDiagnostics();
+  }
 
   const distPath = path.join(__dirname, "../../dist");
 

--- a/electron/setup/__tests__/devDiagnostics.test.ts
+++ b/electron/setup/__tests__/devDiagnostics.test.ts
@@ -216,7 +216,7 @@ describe("devDiagnostics", () => {
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
 
       // Both sweeps fired
-      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+      const leakWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("Listener leak suspected")
       );
       expect(leakWarnings.length).toBeGreaterThanOrEqual(2);
@@ -261,7 +261,7 @@ describe("devDiagnostics", () => {
       startDevDiagnostics();
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
 
-      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+      const leakWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("Listener leak suspected")
       );
       expect(leakWarnings).toHaveLength(1);
@@ -291,7 +291,7 @@ describe("devDiagnostics", () => {
       fsMock.readdirSync.mockReturnValueOnce(Array.from({ length: 15 }, (_, i) => String(i)));
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
 
-      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+      const fdWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("fd leak suspected")
       );
       expect(fdWarnings).toHaveLength(0);
@@ -305,7 +305,7 @@ describe("devDiagnostics", () => {
         throw new Error("EACCES");
       });
       expect(() => vi.advanceTimersByTime(SWEEP_INTERVAL_MS)).not.toThrow();
-      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+      const fdWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("fd leak suspected")
       );
       expect(fdWarnings).toHaveLength(0);
@@ -322,7 +322,7 @@ describe("devDiagnostics", () => {
       fsMock.readdirSync.mockReturnValue(Array.from({ length: 50 }, (_, i) => String(i)));
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS * 3);
 
-      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+      const fdWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("fd leak suspected")
       );
       expect(fdWarnings).toHaveLength(0);
@@ -346,7 +346,7 @@ describe("devDiagnostics", () => {
       stopDevDiagnostics();
 
       vi.advanceTimersByTime(SWEEP_INTERVAL_MS * 3);
-      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+      const leakWarnings = warnSpy.mock.calls.filter((c: unknown[]) =>
         String(c[0]).includes("Listener leak suspected")
       );
       expect(leakWarnings).toHaveLength(0);

--- a/electron/setup/__tests__/devDiagnostics.test.ts
+++ b/electron/setup/__tests__/devDiagnostics.test.ts
@@ -230,9 +230,43 @@ describe("devDiagnostics", () => {
       startDevDiagnostics();
       expect(() => vi.advanceTimersByTime(SWEEP_INTERVAL_MS)).not.toThrow();
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Listener sweep failed"),
+        expect.stringContaining("Listener sweep failed for ipcMain"),
         expect.any(Error)
       );
+    });
+
+    it("still checks ipcMain when app introspection throws", () => {
+      appMock.eventNames.mockImplementation(() => {
+        throw new Error("app failed");
+      });
+      ipcMainMock.eventNames.mockReturnValue(["leaky"]);
+      ipcMainMock.listenerCount.mockReturnValue(6);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Listener sweep failed for app"),
+        expect.any(Error)
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Listener leak suspected on ipcMain")
+      );
+    });
+
+    it("only reports the leaky channel when multiple are present", () => {
+      appMock.eventNames.mockReturnValue(["safe", "leaky"]);
+      appMock.listenerCount.mockImplementation((name) => (name === "leaky" ? 6 : 2));
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Listener leak suspected")
+      );
+      expect(leakWarnings).toHaveLength(1);
+      expect(String(leakWarnings[0][0])).toContain("leaky");
+      expect(String(leakWarnings[0][0])).not.toContain("'safe'");
     });
   });
 
@@ -271,6 +305,23 @@ describe("devDiagnostics", () => {
         throw new Error("EACCES");
       });
       expect(() => vi.advanceTimersByTime(SWEEP_INTERVAL_MS)).not.toThrow();
+      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("fd leak suspected")
+      );
+      expect(fdWarnings).toHaveLength(0);
+    });
+
+    it("does not produce false positives when baseline read failed", () => {
+      // Baseline read throws — fd sweep must be disabled, not start with baseline=0
+      fsMock.readdirSync.mockImplementationOnce(() => {
+        throw new Error("EACCES");
+      });
+      startDevDiagnostics();
+
+      // Subsequent successful reads should not trigger spurious warnings
+      fsMock.readdirSync.mockReturnValue(Array.from({ length: 50 }, (_, i) => String(i)));
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS * 3);
+
       const fdWarnings = warnSpy.mock.calls.filter((c) =>
         String(c[0]).includes("fd leak suspected")
       );
@@ -322,6 +373,38 @@ describe("devDiagnostics", () => {
       stopDevDiagnostics();
       startDevDiagnostics();
       expect(process.listeners("warning")).toHaveLength(1);
+    });
+
+    it("does not call app.exit when warning fires after stop", () => {
+      startDevDiagnostics();
+      stopDevDiagnostics();
+
+      const warning = new Error("too many listeners");
+      warning.name = "MaxListenersExceededWarning";
+      process.emit("warning", warning);
+
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("_resetDevDiagnosticsForTesting", () => {
+    it("removes the warning handler", () => {
+      startDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(1);
+
+      _resetDevDiagnosticsForTesting();
+      expect(process.listeners("warning")).toHaveLength(0);
+    });
+
+    it("prevents app.exit on warnings emitted after reset", () => {
+      startDevDiagnostics();
+      _resetDevDiagnosticsForTesting();
+
+      const warning = new Error("too many listeners");
+      warning.name = "MaxListenersExceededWarning";
+      process.emit("warning", warning);
+
+      expect(appMock.exit).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/setup/__tests__/devDiagnostics.test.ts
+++ b/electron/setup/__tests__/devDiagnostics.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const appMock = vi.hoisted(() => ({
+  exit: vi.fn(),
+  eventNames: vi.fn<() => Array<string | symbol>>(() => []),
+  listenerCount: vi.fn<(name: string | symbol) => number>(() => 0),
+}));
+
+const ipcMainMock = vi.hoisted(() => ({
+  eventNames: vi.fn<() => Array<string | symbol>>(() => []),
+  listenerCount: vi.fn<(name: string | symbol) => number>(() => 0),
+}));
+
+const fsMock = vi.hoisted(() => ({
+  readdirSync: vi.fn<(path: string) => string[]>(() => []),
+}));
+
+vi.mock("electron", () => ({
+  app: appMock,
+  ipcMain: ipcMainMock,
+}));
+
+vi.mock("node:fs", () => ({
+  default: fsMock,
+}));
+
+import {
+  _resetDevDiagnosticsForTesting,
+  startDevDiagnostics,
+  stopDevDiagnostics,
+} from "../devDiagnostics.js";
+
+const SWEEP_INTERVAL_MS = 10_000;
+
+describe("devDiagnostics", () => {
+  let originalPlatform: NodeJS.Platform;
+  let originalTraceProcessWarnings: boolean;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let originalWarningListeners: NodeJS.WarningListener[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
+    originalTraceProcessWarnings = process.traceProcessWarnings;
+    process.traceProcessWarnings = false;
+
+    originalWarningListeners = process.listeners("warning") as NodeJS.WarningListener[];
+    process.removeAllListeners("warning");
+
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    fsMock.readdirSync.mockReturnValue([]);
+    appMock.eventNames.mockReturnValue([]);
+    appMock.listenerCount.mockReturnValue(0);
+    ipcMainMock.eventNames.mockReturnValue([]);
+    ipcMainMock.listenerCount.mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    stopDevDiagnostics();
+    _resetDevDiagnosticsForTesting();
+
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+      configurable: true,
+    });
+    process.traceProcessWarnings = originalTraceProcessWarnings;
+
+    process.removeAllListeners("warning");
+    for (const listener of originalWarningListeners) {
+      process.on("warning", listener);
+    }
+
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  describe("startDevDiagnostics", () => {
+    it("enables process.traceProcessWarnings", () => {
+      startDevDiagnostics();
+      expect(process.traceProcessWarnings).toBe(true);
+    });
+
+    it("registers a single warning handler", () => {
+      startDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(1);
+    });
+
+    it("is idempotent — second call does not re-register", () => {
+      startDevDiagnostics();
+      startDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(1);
+    });
+
+    it("captures fd baseline at start", () => {
+      fsMock.readdirSync.mockReturnValueOnce(["0", "1", "2", "3", "4"]);
+      startDevDiagnostics();
+      expect(fsMock.readdirSync).toHaveBeenCalledWith("/proc/self/fd");
+    });
+
+    it("uses /dev/fd on macOS", () => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      fsMock.readdirSync.mockReturnValueOnce(["0", "1", "2"]);
+      startDevDiagnostics();
+      expect(fsMock.readdirSync).toHaveBeenCalledWith("/dev/fd");
+    });
+
+    it("skips fd sweep on unsupported platforms", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      startDevDiagnostics();
+      // Only listener sweep is scheduled; fd sweep is not.
+      // Advance and verify readdirSync is never called for fd sweep.
+      fsMock.readdirSync.mockClear();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+      expect(fsMock.readdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("warning handler", () => {
+    it("calls app.exit(1) on MaxListenersExceededWarning", () => {
+      startDevDiagnostics();
+      const warning = new Error("too many listeners");
+      warning.name = "MaxListenersExceededWarning";
+
+      process.emit("warning", warning);
+
+      expect(appMock.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("logs warning stack on MaxListenersExceededWarning", () => {
+      startDevDiagnostics();
+      const warning = new Error("too many listeners");
+      warning.name = "MaxListenersExceededWarning";
+      warning.stack = "stack-trace-here";
+
+      process.emit("warning", warning);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("MaxListenersExceededWarning"),
+        "stack-trace-here"
+      );
+    });
+
+    it("ignores non-MaxListeners warnings", () => {
+      startDevDiagnostics();
+      const warning = new Error("experimental feature");
+      warning.name = "ExperimentalWarning";
+
+      process.emit("warning", warning);
+
+      expect(appMock.exit).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listener sweep", () => {
+    it("warns when an ipcMain channel exceeds the threshold", () => {
+      ipcMainMock.eventNames.mockReturnValue(["leaky:channel"]);
+      ipcMainMock.listenerCount.mockReturnValue(6);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Listener leak suspected on ipcMain")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("leaky:channel"));
+    });
+
+    it("warns when an app event exceeds the threshold", () => {
+      appMock.eventNames.mockReturnValue(["window-all-closed"]);
+      appMock.listenerCount.mockReturnValue(7);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Listener leak suspected on app")
+      );
+    });
+
+    it("does not warn at the threshold boundary (count === 5)", () => {
+      ipcMainMock.eventNames.mockReturnValue(["normal:channel"]);
+      ipcMainMock.listenerCount.mockReturnValue(5);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles symbol event names", () => {
+      const symbolName = Symbol("internal-event");
+      appMock.eventNames.mockReturnValue([symbolName]);
+      appMock.listenerCount.mockReturnValue(10);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(String(symbolName)));
+    });
+
+    it("reschedules itself after a sweep", () => {
+      ipcMainMock.eventNames.mockReturnValue(["c"]);
+      ipcMainMock.listenerCount.mockReturnValue(6);
+
+      startDevDiagnostics();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      // Both sweeps fired
+      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Listener leak suspected")
+      );
+      expect(leakWarnings.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does not throw when emitter introspection fails", () => {
+      ipcMainMock.eventNames.mockImplementation(() => {
+        throw new Error("introspection failed");
+      });
+
+      startDevDiagnostics();
+      expect(() => vi.advanceTimersByTime(SWEEP_INTERVAL_MS)).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Listener sweep failed"),
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe("fd sweep", () => {
+    it("warns when fd count grows beyond the threshold", () => {
+      // Baseline = 5 fds
+      fsMock.readdirSync.mockReturnValueOnce(["0", "1", "2", "3", "4"]);
+      startDevDiagnostics();
+
+      // Sweep returns 16 fds — growth of 11, > threshold 10
+      fsMock.readdirSync.mockReturnValueOnce(Array.from({ length: 16 }, (_, i) => String(i)));
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("fd leak suspected"));
+    });
+
+    it("does not warn for growth at or below the threshold", () => {
+      fsMock.readdirSync.mockReturnValueOnce(["0", "1", "2", "3", "4"]);
+      startDevDiagnostics();
+
+      // Growth of exactly 10 — at threshold, not >
+      fsMock.readdirSync.mockReturnValueOnce(Array.from({ length: 15 }, (_, i) => String(i)));
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS);
+
+      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("fd leak suspected")
+      );
+      expect(fdWarnings).toHaveLength(0);
+    });
+
+    it("does not throw or warn when readdirSync fails mid-sweep", () => {
+      fsMock.readdirSync.mockReturnValueOnce(["0", "1", "2"]);
+      startDevDiagnostics();
+
+      fsMock.readdirSync.mockImplementationOnce(() => {
+        throw new Error("EACCES");
+      });
+      expect(() => vi.advanceTimersByTime(SWEEP_INTERVAL_MS)).not.toThrow();
+      const fdWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("fd leak suspected")
+      );
+      expect(fdWarnings).toHaveLength(0);
+    });
+  });
+
+  describe("stopDevDiagnostics", () => {
+    it("removes the warning handler", () => {
+      startDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(1);
+
+      stopDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(0);
+    });
+
+    it("stops the listener sweep timer", () => {
+      ipcMainMock.eventNames.mockReturnValue(["c"]);
+      ipcMainMock.listenerCount.mockReturnValue(6);
+
+      startDevDiagnostics();
+      stopDevDiagnostics();
+
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS * 3);
+      const leakWarnings = warnSpy.mock.calls.filter((c) =>
+        String(c[0]).includes("Listener leak suspected")
+      );
+      expect(leakWarnings).toHaveLength(0);
+    });
+
+    it("stops the fd sweep timer", () => {
+      fsMock.readdirSync.mockReturnValue(["0", "1"]);
+      startDevDiagnostics();
+      stopDevDiagnostics();
+
+      fsMock.readdirSync.mockClear();
+      vi.advanceTimersByTime(SWEEP_INTERVAL_MS * 3);
+      expect(fsMock.readdirSync).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when called twice", () => {
+      startDevDiagnostics();
+      stopDevDiagnostics();
+      expect(() => stopDevDiagnostics()).not.toThrow();
+    });
+
+    it("allows clean restart after stop", () => {
+      startDevDiagnostics();
+      stopDevDiagnostics();
+      startDevDiagnostics();
+      expect(process.listeners("warning")).toHaveLength(1);
+    });
+  });
+});

--- a/electron/setup/devDiagnostics.ts
+++ b/electron/setup/devDiagnostics.ts
@@ -8,7 +8,7 @@ const FD_GROWTH_THRESHOLD = 10;
 let started = false;
 let listenerSweepTimer: NodeJS.Timeout | null = null;
 let fdSweepTimer: NodeJS.Timeout | null = null;
-let fdBaseline = 0;
+let fdBaseline: number | null = null;
 let fdPath: string | null = null;
 
 function handleProcessWarning(warning: Error): void {
@@ -29,20 +29,26 @@ function resolveFdPath(): string | null {
   return null;
 }
 
-function readFdCount(path: string): number {
+function readFdCount(path: string): number | null {
   try {
     return fs.readdirSync(path).length;
   } catch {
-    return 0;
+    return null;
   }
 }
 
 function sweepListeners(): void {
+  // Each emitter wrapped independently so a failure introspecting `app` does
+  // not skip the `ipcMain` check (where listener leaks are most common).
   try {
     checkEmitter("app", app.eventNames(), (name) => app.listenerCount(name));
+  } catch (error) {
+    console.warn("[DEV] Listener sweep failed for app:", error);
+  }
+  try {
     checkEmitter("ipcMain", ipcMain.eventNames(), (name) => ipcMain.listenerCount(name));
   } catch (error) {
-    console.warn("[DEV] Listener sweep failed:", error);
+    console.warn("[DEV] Listener sweep failed for ipcMain:", error);
   }
 }
 
@@ -62,9 +68,9 @@ function checkEmitter(
 }
 
 function sweepFds(): void {
-  if (!fdPath) return;
+  if (!fdPath || fdBaseline === null) return;
   const current = readFdCount(fdPath);
-  if (current === 0) return;
+  if (current === null) return;
   if (current - fdBaseline > FD_GROWTH_THRESHOLD) {
     console.warn(
       `[DEV] fd leak suspected: ${current} open fds vs baseline ${fdBaseline} (growth ${current - fdBaseline}, threshold ${FD_GROWTH_THRESHOLD})`
@@ -96,10 +102,12 @@ export function startDevDiagnostics(): void {
   process.on("warning", handleProcessWarning);
 
   fdPath = resolveFdPath();
-  fdBaseline = fdPath ? readFdCount(fdPath) : 0;
+  fdBaseline = fdPath ? readFdCount(fdPath) : null;
 
   scheduleListenerSweep();
-  if (fdPath) scheduleFdSweep();
+  // Skip fd sweep if the baseline read failed — a sentinel baseline would
+  // produce false positives on the first successful read.
+  if (fdPath && fdBaseline !== null) scheduleFdSweep();
 }
 
 export function stopDevDiagnostics(): void {
@@ -121,6 +129,7 @@ export function stopDevDiagnostics(): void {
 /** @internal Reset module state for testing only. */
 export function _resetDevDiagnosticsForTesting(): void {
   started = false;
+  process.off("warning", handleProcessWarning);
   if (listenerSweepTimer) {
     clearTimeout(listenerSweepTimer);
     listenerSweepTimer = null;
@@ -129,6 +138,6 @@ export function _resetDevDiagnosticsForTesting(): void {
     clearTimeout(fdSweepTimer);
     fdSweepTimer = null;
   }
-  fdBaseline = 0;
+  fdBaseline = null;
   fdPath = null;
 }

--- a/electron/setup/devDiagnostics.ts
+++ b/electron/setup/devDiagnostics.ts
@@ -1,0 +1,134 @@
+import { app, ipcMain } from "electron";
+import fs from "node:fs";
+
+const SWEEP_INTERVAL_MS = 10_000;
+const LISTENER_THRESHOLD = 5;
+const FD_GROWTH_THRESHOLD = 10;
+
+let started = false;
+let listenerSweepTimer: NodeJS.Timeout | null = null;
+let fdSweepTimer: NodeJS.Timeout | null = null;
+let fdBaseline = 0;
+let fdPath: string | null = null;
+
+function handleProcessWarning(warning: Error): void {
+  if (warning.name !== "MaxListenersExceededWarning") {
+    return;
+  }
+  console.warn("[DEV] MaxListenersExceededWarning:", warning.stack ?? warning.message);
+  // app.exit(1) skips before-quit/will-quit/quit so the CrashLoopGuard does not
+  // count this as a crash, and Chromium subprocesses are torn down cleanly.
+  // throw would route through globalErrorHandlers' relaunch path; process.exit
+  // would orphan child processes.
+  app.exit(1);
+}
+
+function resolveFdPath(): string | null {
+  if (process.platform === "darwin") return "/dev/fd";
+  if (process.platform === "linux") return "/proc/self/fd";
+  return null;
+}
+
+function readFdCount(path: string): number {
+  try {
+    return fs.readdirSync(path).length;
+  } catch {
+    return 0;
+  }
+}
+
+function sweepListeners(): void {
+  try {
+    checkEmitter("app", app.eventNames(), (name) => app.listenerCount(name));
+    checkEmitter("ipcMain", ipcMain.eventNames(), (name) => ipcMain.listenerCount(name));
+  } catch (error) {
+    console.warn("[DEV] Listener sweep failed:", error);
+  }
+}
+
+function checkEmitter(
+  label: string,
+  names: ReadonlyArray<string | symbol>,
+  countFor: (name: string | symbol) => number
+): void {
+  for (const name of names) {
+    const count = countFor(name);
+    if (count > LISTENER_THRESHOLD) {
+      console.warn(
+        `[DEV] Listener leak suspected on ${label}: '${String(name)}' has ${count} listeners (threshold ${LISTENER_THRESHOLD})`
+      );
+    }
+  }
+}
+
+function sweepFds(): void {
+  if (!fdPath) return;
+  const current = readFdCount(fdPath);
+  if (current === 0) return;
+  if (current - fdBaseline > FD_GROWTH_THRESHOLD) {
+    console.warn(
+      `[DEV] fd leak suspected: ${current} open fds vs baseline ${fdBaseline} (growth ${current - fdBaseline}, threshold ${FD_GROWTH_THRESHOLD})`
+    );
+  }
+}
+
+function scheduleListenerSweep(): void {
+  listenerSweepTimer = setTimeout(() => {
+    sweepListeners();
+    if (started) scheduleListenerSweep();
+  }, SWEEP_INTERVAL_MS);
+  listenerSweepTimer.unref();
+}
+
+function scheduleFdSweep(): void {
+  fdSweepTimer = setTimeout(() => {
+    sweepFds();
+    if (started) scheduleFdSweep();
+  }, SWEEP_INTERVAL_MS);
+  fdSweepTimer.unref();
+}
+
+export function startDevDiagnostics(): void {
+  if (started) return;
+  started = true;
+
+  process.traceProcessWarnings = true;
+  process.on("warning", handleProcessWarning);
+
+  fdPath = resolveFdPath();
+  fdBaseline = fdPath ? readFdCount(fdPath) : 0;
+
+  scheduleListenerSweep();
+  if (fdPath) scheduleFdSweep();
+}
+
+export function stopDevDiagnostics(): void {
+  if (!started) return;
+  started = false;
+
+  process.off("warning", handleProcessWarning);
+
+  if (listenerSweepTimer) {
+    clearTimeout(listenerSweepTimer);
+    listenerSweepTimer = null;
+  }
+  if (fdSweepTimer) {
+    clearTimeout(fdSweepTimer);
+    fdSweepTimer = null;
+  }
+}
+
+/** @internal Reset module state for testing only. */
+export function _resetDevDiagnosticsForTesting(): void {
+  started = false;
+  if (listenerSweepTimer) {
+    clearTimeout(listenerSweepTimer);
+    listenerSweepTimer = null;
+  }
+  if (fdSweepTimer) {
+    clearTimeout(fdSweepTimer);
+    fdSweepTimer = null;
+  }
+  fdBaseline = 0;
+  fdPath = null;
+}


### PR DESCRIPTION
## Summary

- Adds `electron/setup/devDiagnostics.ts`, gated behind `!app.isPackaged`, so it only runs in development and never ships to users
- Catches three classes of problems proactively: `MaxListenersExceededWarning` (hard-fails dev with `app.exit(1)`), listener accumulation on `app` and `ipcMain` (periodic 10s sweep, threshold of 5), and fd count growth on macOS and Linux (threshold of 10, matching `FdMonitor`'s `SAFETY_MARGIN`)
- All timers are `.unref()`-ed so they don't hold the event loop; an idempotency guard prevents double-registration

Resolves #6023

## Changes

- `electron/setup/devDiagnostics.ts` (new) — `startDevDiagnostics()` / `stopDevDiagnostics()` with module-level named handler for clean `process.off` in stop; `_resetDevDiagnosticsForTesting()` for test isolation
- `electron/setup/__tests__/devDiagnostics.test.ts` (new) — 29 unit tests covering happy paths, error tolerance, threshold boundaries, idempotency, post-stop safety, baseline-failure suppression, and partial emitter failure isolation
- `electron/main.ts` — 5-line call to `startDevDiagnostics()` guarded by `!app.isPackaged`

## Testing

Unit test suite covers the diagnostic module end-to-end. Each emitter sweep is wrapped in its own try/catch so an introspection failure on one doesn't skip the others. The fd reader uses a null sentinel to distinguish a real count from a failed read, which means a baseline failure suppresses subsequent growth alerts rather than false-positiving.