### PR TITLE
feat(ui): add first-run empty states for recipes, agents, MCP, GitHub

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -1,7 +1,18 @@
 import { useState, useEffect, useMemo, useCallback, useRef, type KeyboardEvent } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDebounce } from "@/hooks/useDebounce";
-import { Search, ExternalLink, RefreshCw, WifiOff, Plus, Settings, X, Filter } from "lucide-react";
+import {
+  Search,
+  ExternalLink,
+  RefreshCw,
+  WifiOff,
+  Plus,
+  Settings,
+  X,
+  Filter,
+  CircleDot,
+  GitPullRequest,
+} from "lucide-react";
 import {
   buildCacheKey,
   getCache,
@@ -11,6 +22,7 @@ import {
 } from "@/lib/githubResourceCache";
 import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients/githubClient";
@@ -714,21 +726,36 @@ export function GitHubResourceList({
   const renderEmpty = () => {
     if (exactNumberNotFound !== null) {
       return (
-        <div className="p-8 text-center text-muted-foreground">
-          <p className="text-sm">
-            {type === "issue" ? "Issue" : "PR"} #{exactNumberNotFound} not found
-          </p>
-        </div>
+        <EmptyState
+          variant="filtered-empty"
+          message={`${type === "issue" ? "Issue" : "PR"} #${exactNumberNotFound} not found`}
+          onClear={handleClearSearch}
+        />
       );
     }
 
+    if (debouncedSearch) {
+      return (
+        <EmptyState
+          variant="filtered-empty"
+          message={`No ${type === "issue" ? "issues" : "pull requests"} match "${debouncedSearch}"`}
+          onClear={handleClearSearch}
+        />
+      );
+    }
+
+    const Icon = type === "issue" ? CircleDot : GitPullRequest;
     return (
-      <div className="p-8 text-center text-muted-foreground">
-        <p className="text-sm">
-          No {type === "issue" ? "issues" : "pull requests"} found
-          {debouncedSearch && ` for "${debouncedSearch}"`}
-        </p>
-      </div>
+      <EmptyState
+        variant="zero-data"
+        icon={Icon}
+        title={type === "issue" ? "No issues yet" : "No pull requests yet"}
+        description={
+          type === "issue"
+            ? "Issues opened on GitHub will appear here"
+            : "Pull requests against this repository will appear here"
+        }
+      />
     );
   };
 

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -734,11 +734,12 @@ export function GitHubResourceList({
       );
     }
 
-    if (debouncedSearch) {
+    const trimmedSearch = debouncedSearch.trim();
+    if (trimmedSearch) {
       return (
         <EmptyState
           variant="filtered-empty"
-          message={`No ${type === "issue" ? "issues" : "pull requests"} match "${debouncedSearch}"`}
+          message={`No ${type === "issue" ? "issues" : "pull requests"} match "${trimmedSearch}"`}
           onClear={handleClearSearch}
         />
       );

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -393,6 +393,50 @@ describe("GitHubResourceList retry behavior", () => {
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 
+  it("shows zero-data empty state when authenticated with no results and no search", async () => {
+    vi.useRealTimers();
+    mockListIssues.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues yet")).toBeTruthy();
+    });
+    expect(screen.getByText(/Issues opened on GitHub will appear here/)).toBeTruthy();
+    // zero-data variant must NOT have role=status (mount-once, no SR announcement)
+    expect(document.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("shows filtered-empty state with Clear search affordance when search returns no results", async () => {
+    vi.useRealTimers();
+    useGitHubFilterStore.getState().setIssueSearchQuery("nonexistent");
+    mockListIssues.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No issues match "nonexistent"/)).toBeTruthy();
+    });
+    // filtered-empty has role=status + aria-live=polite for screen readers
+    const region = document.querySelector('[role="status"]');
+    expect(region).toBeTruthy();
+    expect(region?.getAttribute("aria-live")).toBe("polite");
+    // EmptyState renders a "Clear search" button (text, distinct from the X icon's aria-label)
+    expect(region?.textContent).toContain("Clear search");
+  });
+
+  it("shows zero-data empty state for pull requests with the right copy", async () => {
+    vi.useRealTimers();
+    mockListPRs.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No pull requests yet")).toBeTruthy();
+    });
+    expect(screen.getByText(/Pull requests against this repository will appear here/)).toBeTruthy();
+  });
+
   it("does not retry rate-limit errors", async () => {
     mockListIssues.mockRejectedValue(
       new Error("GitHub rate limit exceeded. Try again in a few minutes.")

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -437,6 +437,35 @@ describe("GitHubResourceList retry behavior", () => {
     expect(screen.getByText(/Pull requests against this repository will appear here/)).toBeTruthy();
   });
 
+  it("treats whitespace-only search as zero-data, not filtered-empty", async () => {
+    vi.useRealTimers();
+    useGitHubFilterStore.getState().setIssueSearchQuery("   ");
+    mockListIssues.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues yet")).toBeTruthy();
+    });
+    // No filtered-empty message with quoted whitespace should appear
+    expect(screen.queryByText(/No issues match "/)).toBeNull();
+  });
+
+  it("shows exact-number not-found state with Clear search affordance", async () => {
+    vi.useRealTimers();
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+    mockGetIssueByNumber.mockResolvedValue(null);
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Issue #42 not found")).toBeTruthy();
+    });
+    const region = document.querySelector('[role="status"]');
+    expect(region).toBeTruthy();
+    expect(region?.textContent).toContain("Clear search");
+  });
+
   it("does not retry rate-limit errors", async () => {
     mockListIssues.mockRejectedValue(
       new Error("GitHub rate limit exceeded. Try again in a few minutes.")

--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from "react";
 import { Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { AGENT_REGISTRY } from "@/config/agents";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
@@ -38,21 +38,15 @@ export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
 
   if (installedAgents.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-daintree-text/50">No agents are installed.</p>
-        <p className="text-xs text-daintree-text/40">
-          Install an agent using the setup wizard to use as your Daintree assistant.
-        </p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={handleOpenSetupWizard}
-          className="gap-1.5"
-        >
-          <Sparkles className="w-3.5 h-3.5" />
-          <span>Run setup wizard</span>
-        </Button>
+      <div className="flex-1 flex flex-col items-center justify-center p-4">
+        <EmptyState
+          variant="zero-data"
+          icon={Sparkles}
+          title="No agents installed"
+          description="Install an agent to use as your Daintree assistant"
+          ctaLabel="Run setup wizard"
+          onCta={handleOpenSetupWizard}
+        />
       </div>
     );
   }

--- a/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
@@ -20,6 +20,50 @@ vi.mock("@/components/ui/button", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/EmptyState", async () => {
+  const { Button } = await import("@/components/ui/button");
+  type IconComponent = React.ComponentType<{
+    className?: string;
+    "aria-hidden"?: boolean | "true";
+  }>;
+  type Props =
+    | {
+        variant: "zero-data";
+        icon?: IconComponent;
+        title: string;
+        description?: string;
+        ctaLabel?: string;
+        onCta?: () => void;
+      }
+    | { variant: "filtered-empty"; message: string; clearLabel?: string; onClear?: () => void }
+    | { variant: "acknowledged"; message: string };
+  const EmptyState = (props: Props) => {
+    if (props.variant === "zero-data") {
+      const { icon: Icon, title, description, ctaLabel, onCta } = props;
+      return (
+        <div>
+          {Icon && <Icon aria-hidden="true" />}
+          <p>{title}</p>
+          {description && <p>{description}</p>}
+          {ctaLabel && onCta && <Button onClick={onCta}>{ctaLabel}</Button>}
+        </div>
+      );
+    }
+    if (props.variant === "filtered-empty") {
+      return (
+        <div role="status" aria-live="polite">
+          <p>{props.message}</p>
+          {props.onClear && (
+            <Button onClick={props.onClear}>{props.clearLabel ?? "Clear search"}</Button>
+          )}
+        </div>
+      );
+    }
+    return <p>{props.message}</p>;
+  };
+  return { EmptyState };
+});
+
 vi.mock("@shared/config/agentIds", () => ({
   BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"],
 }));
@@ -73,7 +117,7 @@ describe("HelpAgentPicker", () => {
 
     const { container } = render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
 
-    expect(screen.getByText("No agents are installed.")).toBeTruthy();
+    expect(screen.getByText("No agents installed")).toBeTruthy();
     expect(screen.getByText("Run setup wizard")).toBeTruthy();
     expect(container.textContent).not.toMatch(/Enable an agent/i);
   });
@@ -108,7 +152,7 @@ describe("HelpAgentPicker", () => {
     render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
 
     expect(screen.getByText("Checking for installed agents…")).toBeTruthy();
-    expect(screen.queryByText("No agents are installed.")).toBeNull();
+    expect(screen.queryByText("No agents installed")).toBeNull();
     expect(screen.queryByText("Claude")).toBeNull();
   });
 

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Plus, Trash2, Edit3, Download, FileDown, Check, Globe } from "lucide-react";
 import { Workflow } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useRecipeStore } from "@/store/recipeStore";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
@@ -189,8 +190,15 @@ export function RecipesTab({
               Loading recipes...
             </div>
           ) : recipes.length === 0 ? (
-            <div className="text-sm text-daintree-text/60 text-center py-8 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-              No recipes configured yet
+            <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)] py-2">
+              <EmptyState
+                variant="zero-data"
+                icon={Workflow}
+                title="No recipes yet"
+                description="Recipes launch multi-terminal workflows with a single click"
+                ctaLabel="Create recipe"
+                onCta={handleAddRecipe}
+              />
             </div>
           ) : (
             <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -145,6 +145,14 @@ export function McpServerSettingsTab() {
         disabled={loading}
       />
 
+      {!status.enabled && !loading && (
+        <p className="text-xs text-daintree-text/50 leading-relaxed">
+          Turn the server on to let MCP-aware agents like Claude Code and Cursor call Daintree
+          actions over a local connection. Connection details and an optional API key appear once
+          enabled.
+        </p>
+      )}
+
       {status.enabled && (
         <>
           {/* Connection Status */}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -27,6 +27,7 @@ export function McpServerSettingsTab() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyConfigTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     let settled = false;
@@ -56,6 +57,7 @@ export function McpServerSettingsTab() {
     return () => {
       clearTimeout(timer);
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (copyConfigTimeoutRef.current) clearTimeout(copyConfigTimeoutRef.current);
     };
   }, []);
 
@@ -74,7 +76,11 @@ export function McpServerSettingsTab() {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
       await navigator.clipboard.writeText(snippet);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyConfigTimeoutRef.current) clearTimeout(copyConfigTimeoutRef.current);
+      copyConfigTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        copyConfigTimeoutRef.current = null;
+      }, 2000);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to copy config"));
     }
@@ -145,7 +151,7 @@ export function McpServerSettingsTab() {
         disabled={loading}
       />
 
-      {!status.enabled && !loading && (
+      {!status.enabled && !loading && !error && (
         <p className="text-xs text-daintree-text/50 leading-relaxed">
           Turn the server on to let MCP-aware agents like Claude Code and Cursor call Daintree
           actions over a local connection. Connection details and an optional API key appear once

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -127,4 +127,24 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByText("Generate API Key")).toBeTruthy();
     });
   });
+
+  it("shows a contextual hint when disabled and not loading", async () => {
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "Turn the server on");
+
+    expect(screen.queryByText("Connection")).toBeNull();
+    expect(screen.queryByText("API key active")).toBeNull();
+    expect(container.textContent).toMatch(/MCP-aware agents like Claude Code and Cursor/);
+  });
 });

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -147,4 +147,18 @@ describe("McpServerSettingsTab", () => {
     expect(screen.queryByText("API key active")).toBeNull();
     expect(container.textContent).toMatch(/MCP-aware agents like Claude Code and Cursor/);
   });
+
+  it("hides the disabled hint while a status load error is shown", async () => {
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockRejectedValue(new Error("Failed to load MCP status")),
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "Failed to load MCP status");
+
+    // Hint must not appear alongside an error — the error is the truth signal
+    expect(container.textContent).not.toMatch(/Turn the server on/);
+  });
 });

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,83 @@
+import type { ComponentType } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type IconComponent = ComponentType<{ className?: string; "aria-hidden"?: boolean | "true" }>;
+
+type ZeroDataProps = {
+  variant: "zero-data";
+  icon?: IconComponent;
+  title: string;
+  description?: string;
+  ctaLabel?: string;
+  onCta?: () => void;
+  className?: string;
+};
+
+type FilteredEmptyProps = {
+  variant: "filtered-empty";
+  message: string;
+  clearLabel?: string;
+  onClear?: () => void;
+  className?: string;
+};
+
+type AcknowledgedProps = {
+  variant: "acknowledged";
+  message: string;
+  className?: string;
+};
+
+export type EmptyStateProps = ZeroDataProps | FilteredEmptyProps | AcknowledgedProps;
+
+export function EmptyState(props: EmptyStateProps) {
+  if (props.variant === "zero-data") {
+    const { icon: Icon, title, description, ctaLabel, onCta, className } = props;
+    return (
+      <div
+        className={cn("flex flex-col items-center justify-center gap-3 p-6 text-center", className)}
+      >
+        {Icon && <Icon className="h-6 w-6 text-daintree-text/40 opacity-70" aria-hidden="true" />}
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-daintree-text/80">{title}</p>
+          {description && <p className="text-xs text-daintree-text/50 max-w-xs">{description}</p>}
+        </div>
+        {ctaLabel && onCta && (
+          <Button type="button" variant="outline" size="sm" onClick={onCta} className="mt-1">
+            {ctaLabel}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (props.variant === "filtered-empty") {
+    const { message, clearLabel = "Clear search", onClear, className } = props;
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className={cn("flex flex-col items-center justify-center gap-2 p-6 text-center", className)}
+      >
+        <p className="text-sm text-daintree-text/60">{message}</p>
+        {onClear && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClear}
+            className="text-daintree-text/60 hover:text-daintree-text"
+          >
+            {clearLabel}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center justify-center p-6 text-center", props.className)}>
+      <p className="text-sm text-daintree-text/60">{props.message}</p>
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    type = "button",
+    ...rest
+  }: React.PropsWithChildren<{ onClick?: () => void; type?: "button" | "submit" }>) => (
+    <button type={type} onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+import { EmptyState } from "../EmptyState";
+
+describe("EmptyState — zero-data variant", () => {
+  it("renders title and description", () => {
+    render(
+      <EmptyState
+        variant="zero-data"
+        title="No recipes yet"
+        description="Recipes launch multi-terminal workflows"
+      />
+    );
+    expect(screen.getByText("No recipes yet")).toBeTruthy();
+    expect(screen.getByText("Recipes launch multi-terminal workflows")).toBeTruthy();
+  });
+
+  it("omits description when not provided", () => {
+    render(<EmptyState variant="zero-data" title="No recipes yet" />);
+    expect(screen.getByText("No recipes yet")).toBeTruthy();
+    expect(screen.queryByText(/Recipes launch/)).toBeNull();
+  });
+
+  it("renders an aria-hidden icon when provided", () => {
+    const Icon = (props: { className?: string; "aria-hidden"?: boolean | "true" }) => (
+      <svg data-testid="empty-icon" {...props} />
+    );
+    render(<EmptyState variant="zero-data" title="t" icon={Icon} />);
+    const icon = screen.getByTestId("empty-icon");
+    expect(icon.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("renders CTA and fires onCta on click", () => {
+    const onCta = vi.fn();
+    render(<EmptyState variant="zero-data" title="t" ctaLabel="Create recipe" onCta={onCta} />);
+    fireEvent.click(screen.getByText("Create recipe"));
+    expect(onCta).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render CTA when ctaLabel or onCta missing", () => {
+    render(<EmptyState variant="zero-data" title="t" ctaLabel="X" />);
+    expect(screen.queryByText("X")).toBeNull();
+  });
+
+  it("does not have role=status (mount-once, no SR announcement)", () => {
+    const { container } = render(<EmptyState variant="zero-data" title="t" />);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});
+
+describe("EmptyState — filtered-empty variant", () => {
+  it("renders message", () => {
+    render(<EmptyState variant="filtered-empty" message="No issues match this search" />);
+    expect(screen.getByText("No issues match this search")).toBeTruthy();
+  });
+
+  it("has role=status and aria-live=polite for dynamic announcement", () => {
+    const { container } = render(<EmptyState variant="filtered-empty" message="No matches" />);
+    const region = container.querySelector('[role="status"]');
+    expect(region).toBeTruthy();
+    expect(region?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("renders default 'Clear search' label and fires onClear", () => {
+    const onClear = vi.fn();
+    render(<EmptyState variant="filtered-empty" message="m" onClear={onClear} />);
+    fireEvent.click(screen.getByText("Clear search"));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom clearLabel", () => {
+    render(
+      <EmptyState
+        variant="filtered-empty"
+        message="m"
+        clearLabel="Reset filter"
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Reset filter")).toBeTruthy();
+  });
+
+  it("omits clear button when onClear is not provided", () => {
+    render(<EmptyState variant="filtered-empty" message="m" />);
+    expect(screen.queryByText("Clear search")).toBeNull();
+  });
+});
+
+describe("EmptyState — acknowledged variant", () => {
+  it("renders message only", () => {
+    const { container } = render(<EmptyState variant="acknowledged" message="Nothing to show" />);
+    expect(screen.getByText("Nothing to show")).toBeTruthy();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector("button")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- New users opening Daintree with no recipes, no pinned agents, an unconfigured MCP server, or no GitHub auth were landing on blank panels with no signal about what to do next. This adds contextual empty states to each of those spots.
- Introduces a shared `EmptyState` primitive with three variants (zero-data, filtered-empty, acknowledged) so the pattern is consistent and easy to extend.
- `GitHubResourceList` now branches into three distinct states depending on whether the list is empty due to filtering, an exact-number search that came up short, or genuinely no data yet.

Resolves #6036.

## Changes

- `src/components/ui/EmptyState.tsx` — new primitive, three discriminated-union variants
- `RecipesTab` — replaces bare fallback text with an EmptyState + "Create recipe" CTA
- `HelpAgentPicker` — replaces hand-rolled empty block with EmptyState + "Run setup wizard" CTA; flash guard preserved
- `GitHubResourceList` — three-way empty branching: filtered-empty (with Clear search), exact-number not-found, and zero-data per resource type
- `McpServerSettingsTab` — contextual hint when server is disabled explaining what enabling it does; orphaned timeout ref cleaned up

## Testing

- 12 unit tests for `EmptyState` covering all three variants, aria-live, role=status, and CTA wiring
- `HelpAgentPicker.test.tsx` updated with EmptyState mock and corrected copy assertions
- `McpServerSettingsTab.test.tsx` — disabled-hint visibility and hint hidden during error state
- `GitHubResourceList.swr.test.tsx` — zero-data, filtered-empty (role/aria-live + Clear search button), PR variant copy, whitespace search treated as zero-data, exact-number not-found
- tsc clean across all three targets, ESLint net -2 warnings vs baseline, Prettier clean