### PR TITLE
fix(window): stop singleton intervals on last-window-close

### DIFF
--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -61,6 +61,7 @@ import {
   getSystemSleepService,
 } from "../services/SystemSleepService.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
 import {
   markPerformance,
   startEventLoopLagMonitor,
@@ -1241,6 +1242,9 @@ export async function setupWindowServices(
     globalServicesInitialized = false;
     resetDeferredQueue();
 
+    getHibernationService().stop();
+    getIdleTerminalNotificationService().stop();
+    getCrashRecoveryService().stopBackupTimer();
     getSystemSleepService().dispose();
     gitHubTokenHealthService.dispose();
     notificationService.dispose();


### PR DESCRIPTION
## Summary
- Three singleton services (HibernationService, IdleTerminalNotificationService, CrashRecoveryService) had interval-based timers that kept running after the last window closed on macOS, preventing garbage collection of store, projectStore, and PTY/workspace references.
- Added stop() calls for all three to the existing last-window-close handler in windowServices.ts — these were the only remaining singleton intervals without cleanup.

Resolves #6017

## Changes
- Imported `getIdleTerminalNotificationService` into windowServices.ts
- Added `getHibernationService().stop()`, `getIdleTerminalNotificationService().stop()`, and `getCrashRecoveryService().stopBackupTimer()` to the last-window-close handler, alongside the ~10 other services already being disposed there.

## Testing
- Verified the handler block is only reached when the last window closes and no new window is opened within the grace period.
- Confirmed all three services already had idempotent stop() implementations.