### PR TITLE
fix(watcher): handle macOS EMFILE in recursive worktree watcher

### DIFF
--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -353,6 +353,23 @@ export class WorkspaceClient extends EventEmitter {
         });
         break;
       }
+
+      case "emfile-limit-reached": {
+        // System-wide macOS condition — same broadcasting rationale as the
+        // inotify case above. Fires once per host-process lifetime.
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+          type: "warning",
+          title: "File watching degraded",
+          message:
+            "macOS file descriptor ceiling reached. Some files may not auto-refresh until you raise it.",
+          action: {
+            label: "Copy fix command",
+            ipcChannel: CHANNELS.CLIPBOARD_WRITE_TEXT,
+            data: "sudo sysctl -w kern.maxfilesperproc=64000",
+          },
+        });
+        break;
+      }
     }
   }
 

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -788,6 +788,186 @@ describe("GitFileWatcher", () => {
     Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
   });
 
+  it("onEmfileLimitReached fires alongside onWatcherFailed on macOS EMFILE at runtime", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onEmfileLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onEmfileLimitReached,
+    });
+
+    gitWatcher.start();
+    const emfileError = new Error("EMFILE") as NodeJS.ErrnoException;
+    emfileError.code = "EMFILE";
+    errorHandler?.(emfileError);
+
+    expect(onEmfileLimitReached).toHaveBeenCalledTimes(1);
+    expect(onWatcherFailed).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("does not call onEmfileLimitReached for non-EMFILE runtime errors on macOS", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onEmfileLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onEmfileLimitReached,
+    });
+
+    gitWatcher.start();
+    const otherError = new Error("permission denied") as NodeJS.ErrnoException;
+    otherError.code = "EACCES";
+    errorHandler?.(otherError);
+
+    expect(onEmfileLimitReached).not.toHaveBeenCalled();
+    expect(onWatcherFailed).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("startup EMFILE on macOS calls both onEmfileLimitReached and onWatcherFailed", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onEmfileLimitReached = vi.fn();
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    // Only the recursive watcher throws on construction; the non-recursive
+    // git-internal watchers constructed earlier in start() succeed.
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      if (opts?.recursive) {
+        const err = new Error("EMFILE") as NodeJS.ErrnoException;
+        err.code = "EMFILE";
+        throw err;
+      }
+      return createMockWatcher();
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onEmfileLimitReached,
+    });
+
+    expect(gitWatcher.start()).toBe(false);
+    expect(onEmfileLimitReached).toHaveBeenCalledTimes(1);
+    expect(onWatcherFailed).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("does not signal emfile-limit on non-Darwin platforms for EMFILE", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onEmfileLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onEmfileLimitReached,
+    });
+
+    gitWatcher.start();
+    const emfileError = new Error("EMFILE") as NodeJS.ErrnoException;
+    emfileError.code = "EMFILE";
+    errorHandler?.(emfileError);
+
+    expect(onEmfileLimitReached).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
   it("does not signal inotify-limit on non-Linux platforms for ENOSPC", () => {
     const onChange = vi.fn();
     const onWatcherFailed = vi.fn();

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -793,6 +793,7 @@ describe("GitFileWatcher", () => {
     const onWatcherFailed = vi.fn();
     const onEmfileLimitReached = vi.fn();
     let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+    let recursiveWatcher: FSWatcher | undefined;
 
     const origPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
@@ -804,6 +805,7 @@ describe("GitFileWatcher", () => {
     ) => {
       const w = createMockWatcher();
       if (opts?.recursive) {
+        recursiveWatcher = w;
         vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
           if (event === "error") {
             errorHandler = handler as (error: NodeJS.ErrnoException) => void;
@@ -831,6 +833,13 @@ describe("GitFileWatcher", () => {
 
     expect(onEmfileLimitReached).toHaveBeenCalledTimes(1);
     expect(onWatcherFailed).toHaveBeenCalledTimes(1);
+    // The broken watcher must be closed and removed from internal state so a
+    // subsequent dispose() doesn't double-close (and so it stops receiving
+    // OS events that could fire duplicate EMFILE callbacks).
+    expect(recursiveWatcher).toBeDefined();
+    expect(recursiveWatcher?.close).toHaveBeenCalledTimes(1);
+    gitWatcher.dispose();
+    expect(recursiveWatcher?.close).toHaveBeenCalledTimes(1);
 
     Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
   });

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -28,6 +28,10 @@ export interface GitFileWatcherOptions {
   /** Called when the recursive worktree watcher fails specifically because of
    *  the Linux inotify watch limit (ENOSPC). Fires in addition to `onWatcherFailed`. */
   onInotifyLimitReached?: () => void;
+  /** Called when the recursive worktree watcher fails specifically because of
+   *  the macOS FSEvents file descriptor ceiling (EMFILE). Fires in addition to
+   *  `onWatcherFailed`. */
+  onEmfileLimitReached?: () => void;
 }
 
 export class GitFileWatcher {
@@ -48,6 +52,7 @@ export class GitFileWatcher {
   private readonly onChange: () => void;
   private readonly onWatcherFailed: (() => void) | undefined;
   private readonly onInotifyLimitReached: (() => void) | undefined;
+  private readonly onEmfileLimitReached: (() => void) | undefined;
   private readonly watchWorktree: boolean;
   private currentBranch?: string;
 
@@ -60,6 +65,7 @@ export class GitFileWatcher {
     this.onChange = options.onChange;
     this.onWatcherFailed = options.onWatcherFailed;
     this.onInotifyLimitReached = options.onInotifyLimitReached;
+    this.onEmfileLimitReached = options.onEmfileLimitReached;
     this.currentBranch = options.branch;
     this.watchWorktree = options.watchWorktree ?? false;
   }
@@ -216,6 +222,24 @@ export class GitFileWatcher {
           }
           this.onInotifyLimitReached?.();
           this.onWatcherFailed?.();
+        } else if (process.platform === "darwin" && errno.code === "EMFILE") {
+          logWarn(
+            "FSEvents file descriptor ceiling reached — recursive file watching may be incomplete. " +
+              "Temporary fix: sudo sysctl -w kern.maxfilesperproc=64000. " +
+              "Permanent fix: add kern.maxfilesperproc=64000 to /etc/sysctl.conf",
+            { path: this.worktreePath }
+          );
+          const idx = this.watchers.indexOf(watcher);
+          if (idx !== -1) {
+            this.watchers.splice(idx, 1);
+          }
+          try {
+            watcher.close();
+          } catch {
+            // Ignore close errors on already-broken watcher
+          }
+          this.onEmfileLimitReached?.();
+          this.onWatcherFailed?.();
         } else {
           logWarn("Worktree recursive watcher error", {
             path: this.worktreePath,
@@ -236,6 +260,15 @@ export class GitFileWatcher {
           { path: this.worktreePath }
         );
         this.onInotifyLimitReached?.();
+        this.onWatcherFailed?.();
+      } else if (process.platform === "darwin" && errno.code === "EMFILE") {
+        logWarn(
+          "FSEvents file descriptor ceiling reached — recursive file watching may be incomplete. " +
+            "Temporary fix: sudo sysctl -w kern.maxfilesperproc=64000. " +
+            "Permanent fix: add kern.maxfilesperproc=64000 to /etc/sysctl.conf",
+          { path: this.worktreePath }
+        );
+        this.onEmfileLimitReached?.();
         this.onWatcherFailed?.();
       } else {
         logWarn("Failed to start recursive worktree watcher", {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -138,6 +138,9 @@ export class WorkspaceService {
   /** Session-scoped guard so we notify the user about Linux inotify limits
    *  only once, even if many worktrees hit ENOSPC concurrently. */
   private inotifyLimitNotified = false;
+  /** Session-scoped guard so we notify the user about the macOS FSEvents file
+   *  descriptor ceiling only once, even if many worktrees hit EMFILE concurrently. */
+  private emfileLimitNotified = false;
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.prService = new PRIntegrationService(pullRequestService, events, {
@@ -443,6 +446,7 @@ export class WorkspaceService {
           );
         },
         onInotifyLimitReached: () => this.handleInotifyLimitReached(),
+        onEmfileLimitReached: () => this.handleEmfileLimitReached(),
       },
       this.mainBranch,
       this.pollQueue
@@ -589,6 +593,13 @@ export class WorkspaceService {
     if (this.inotifyLimitNotified) return;
     this.inotifyLimitNotified = true;
     this.sendEvent({ type: "inotify-limit-reached" });
+  }
+
+  private handleEmfileLimitReached(): void {
+    if (process.platform !== "darwin") return;
+    if (this.emfileLimitNotified) return;
+    this.emfileLimitNotified = true;
+    this.sendEvent({ type: "emfile-limit-reached" });
   }
 
   private handleExternalWorktreeRemoval(worktreeId: string): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -47,6 +47,7 @@ export interface WorktreeMonitorCallbacks {
   onExternalRemoval?: (worktreeId: string) => void;
   onResourceStatusPoll?: (worktreeId: string) => Promise<unknown> | void;
   onInotifyLimitReached?: (worktreeId: string) => void;
+  onEmfileLimitReached?: (worktreeId: string) => void;
 }
 
 export class WorktreeMonitor {
@@ -670,6 +671,7 @@ export class WorktreeMonitor {
       worktreeMaxWaitMs: WATCHER_WORKTREE_MAX_WAIT_MS,
       onWatcherFailed: () => this.handleWatcherFailed(),
       onInotifyLimitReached: () => this.callbacks.onInotifyLimitReached?.(this.id),
+      onEmfileLimitReached: () => this.callbacks.onEmfileLimitReached?.(this.id),
     });
 
     const started = watcher.start();

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -337,4 +337,40 @@ describe("WorkspaceService adversarial", () => {
       }
     });
   });
+
+  describe("handleEmfileLimitReached", () => {
+    const setPlatform = (value: NodeJS.Platform) => {
+      Object.defineProperty(process, "platform", { value, configurable: true });
+    };
+
+    it("sends a single emfile-limit-reached event on macOS even when called many times", () => {
+      const origPlatform = process.platform;
+      setPlatform("darwin");
+      try {
+        const privateService = service as unknown as { handleEmfileLimitReached: () => void };
+        privateService.handleEmfileLimitReached();
+        privateService.handleEmfileLimitReached();
+        privateService.handleEmfileLimitReached();
+
+        const emfileEvents = sentEvents.filter((e) => e.type === "emfile-limit-reached");
+        expect(emfileEvents).toHaveLength(1);
+      } finally {
+        setPlatform(origPlatform);
+      }
+    });
+
+    it("does not emit on non-Darwin platforms", () => {
+      const origPlatform = process.platform;
+      setPlatform("linux");
+      try {
+        const privateService = service as unknown as { handleEmfileLimitReached: () => void };
+        privateService.handleEmfileLimitReached();
+
+        const emfileEvents = sentEvents.filter((e) => e.type === "emfile-limit-reached");
+        expect(emfileEvents).toHaveLength(0);
+      } finally {
+        setPlatform(origPlatform);
+      }
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -43,6 +43,7 @@ let mockWatcherStartResult = false;
 let mockWatcherStartFiresFailure = false;
 let capturedOnWatcherFailed: (() => void) | undefined;
 let capturedOnInotifyLimitReached: (() => void) | undefined;
+let capturedOnEmfileLimitReached: (() => void) | undefined;
 let capturedWatcherOptions: Record<string, unknown> | undefined;
 let watcherStartCallCount = 0;
 
@@ -54,11 +55,13 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
         opts: {
           onWatcherFailed?: () => void;
           onInotifyLimitReached?: () => void;
+          onEmfileLimitReached?: () => void;
         } & Record<string, unknown>
       ) {
         this.onWatcherFailed = opts.onWatcherFailed;
         capturedOnWatcherFailed = opts.onWatcherFailed;
         capturedOnInotifyLimitReached = opts.onInotifyLimitReached;
+        capturedOnEmfileLimitReached = opts.onEmfileLimitReached;
         capturedWatcherOptions = opts;
       }
       start() {
@@ -131,6 +134,7 @@ describe("WorktreeMonitor", () => {
     watcherStartCallCount = 0;
     capturedOnWatcherFailed = undefined;
     capturedOnInotifyLimitReached = undefined;
+    capturedOnEmfileLimitReached = undefined;
     capturedWatcherOptions = undefined;
   });
 
@@ -519,6 +523,29 @@ describe("WorktreeMonitor", () => {
       capturedOnInotifyLimitReached?.();
       expect(onInotifyLimitReached).toHaveBeenCalledWith(TEST_WORKTREE.id);
       expect(onInotifyLimitReached).toHaveBeenCalledTimes(1);
+
+      monitor.stop();
+    });
+
+    it("forwards emfile-limit signal to callbacks with the worktree id", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const onEmfileLimitReached = vi.fn();
+      const callbacks = makeCallbacks({ onEmfileLimitReached });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(capturedOnEmfileLimitReached).toBeDefined();
+      capturedOnEmfileLimitReached?.();
+      expect(onEmfileLimitReached).toHaveBeenCalledWith(TEST_WORKTREE.id);
+      expect(onEmfileLimitReached).toHaveBeenCalledTimes(1);
 
       monitor.stop();
     });

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -347,6 +347,9 @@ export type WorkspaceHostEvent =
   // Linux-only: fired once per host-process lifetime when the recursive file
   // watcher hits the inotify watch limit (ENOSPC).
   | { type: "inotify-limit-reached" }
+  // macOS-only: fired once per host-process lifetime when the recursive file
+  // watcher hits the FSEvents file descriptor ceiling (EMFILE).
+  | { type: "emfile-limit-reached" }
   // PR events
   | {
       type: "pr-detected";


### PR DESCRIPTION
## Summary

- macOS `fs.watch({ recursive: true })` hits a practical ~4096-path ceiling backed by FSEvents file-descriptor handles, throwing `EMFILE` when exceeded. Without handling this, worktree status goes stale silently with no user-visible explanation.
- This adds symmetric recovery to what already exists for Linux `ENOSPC`: log a diagnostic, fire an `onEmfileLimitReached` callback, fall back to polling.
- Verified the Windows `ReadDirectoryChangesW` path (VS Code #287800 CPU loop on deleted files) is already mitigated by `persistent: false`.

Resolves #6022

## Changes

- `electron/utils/gitFileWatcher.ts` — EMFILE catch block on macOS: logs fix steps, fires callback, falls back to poll
- `electron/workspace-host/WorktreeMonitor.ts` — wires `onEmfileLimitReached` callback
- `electron/workspace-host/WorkspaceService.ts` — propagates `emfileLimitReached` event upstream; exposed as `onEmfileLimitReached` on `WorkspaceClient`
- `electron/services/WorkspaceClient.ts` — exposes `onEmfileLimitReached` IPC event
- `shared/types/workspace-host.ts` — adds `EmfileLimitReachedPayload` event type
- Tests: `gitFileWatcher.test.ts` (EMFILE branch coverage), `WorktreeMonitor.test.ts` and `WorkspaceService.adversarial.test.ts` (wiring + callback propagation)

## Testing

- Unit tests cover the EMFILE error path end-to-end from `gitFileWatcher` through `WorkspaceService`
- Symmetric with the existing `ENOSPC` path on Linux — same structural pattern, same fallback behaviour