### PR TITLE
feat(ui): add reusable EmptyState component for zero-data, filtered, and cleared lists

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/store/slices/notificationHistorySlice";
 import { NotificationCenterEntry } from "./NotificationCenterEntry";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -338,14 +339,21 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       </div>
       <div className="flex-1 overflow-y-auto">
         {groups.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-10 text-daintree-text/30">
-            <Bell className="h-6 w-6 mb-2" />
-            <span className="text-xs">
-              {filter === "unread" && entries.length > 0
-                ? "You're all caught up"
-                : "No notifications yet"}
-            </span>
-          </div>
+          filter === "unread" && entries.length > 0 ? (
+            <EmptyState
+              variant="user-cleared"
+              title="You're all caught up"
+              icon={<Bell />}
+              className="py-10"
+            />
+          ) : (
+            <EmptyState
+              variant="zero-data"
+              title="No notifications yet"
+              icon={<Bell />}
+              className="py-10"
+            />
+          )
         ) : (
           <div className="divide-y divide-tint/[0.04]">
             {groups.map((group) =>

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Plus, Trash2, Edit3, Download, FileDown, Check, Globe } from "lucide-react";
 import { Workflow } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useRecipeStore } from "@/store/recipeStore";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
@@ -189,8 +190,19 @@ export function RecipesTab({
               Loading recipes...
             </div>
           ) : recipes.length === 0 ? (
-            <div className="text-sm text-daintree-text/60 text-center py-8 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-              No recipes configured yet
+            <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
+              <EmptyState
+                variant="zero-data"
+                icon={<Workflow />}
+                title="No recipes configured yet"
+                description="Create a recipe to spawn multiple terminals with predefined commands and settings."
+                action={
+                  <Button variant="outline" size="sm" onClick={handleAddRecipe}>
+                    <Plus />
+                    Add recipe
+                  </Button>
+                }
+              />
             </div>
           ) : (
             <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { CircleHelp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
@@ -314,10 +315,17 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   noMatchMessage,
   children,
 }: AppPaletteEmptyProps) {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery) {
+    return (
+      <EmptyState
+        variant="filtered-empty"
+        title={noMatchMessage || `No items match "${query}"`}
+        className="px-3 py-8"
+      />
+    );
+  }
   return (
-    <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">
-      {query.trim() ? <>{noMatchMessage || `No items match "${query}"`}</> : <>{emptyMessage}</>}
-      {!query.trim() && children}
-    </div>
+    <EmptyState variant="zero-data" title={emptyMessage} action={children} className="px-3 py-8" />
   );
 };

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -320,7 +320,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
     return (
       <EmptyState
         variant="filtered-empty"
-        title={noMatchMessage || `No items match "${query}"`}
+        title={noMatchMessage || `No items match "${trimmedQuery}"`}
         className="px-3 py-8"
       />
     );

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -25,7 +25,11 @@ export type EmptyStateProps =
 export function EmptyState(props: EmptyStateProps) {
   const { variant, title, description, className } = props;
   const descriptionId = useId();
-  const hasDescription = description !== undefined && description !== null && description !== "";
+  const hasDescription =
+    description !== undefined &&
+    description !== null &&
+    description !== false &&
+    description !== "";
 
   const icon = variant === "filtered-empty" ? null : props.icon;
   const action = variant === "user-cleared" ? null : props.action;
@@ -34,6 +38,7 @@ export function EmptyState(props: EmptyStateProps) {
     <div
       role="status"
       aria-live="polite"
+      aria-describedby={hasDescription ? descriptionId : undefined}
       className={cn("flex flex-col items-center justify-center text-center px-4 py-8", className)}
     >
       <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 flex flex-col items-center gap-2">

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,0 +1,55 @@
+import { useId, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type EmptyStateBaseProps = {
+  title: string;
+  description?: ReactNode;
+  className?: string;
+};
+
+export type EmptyStateProps =
+  | (EmptyStateBaseProps & {
+      variant: "zero-data";
+      icon?: ReactNode;
+      action?: ReactNode;
+    })
+  | (EmptyStateBaseProps & {
+      variant: "filtered-empty";
+      action?: ReactNode;
+    })
+  | (EmptyStateBaseProps & {
+      variant: "user-cleared";
+      icon?: ReactNode;
+    });
+
+export function EmptyState(props: EmptyStateProps) {
+  const { variant, title, description, className } = props;
+  const descriptionId = useId();
+  const hasDescription = description !== undefined && description !== null && description !== "";
+
+  const icon = variant === "filtered-empty" ? null : props.icon;
+  const action = variant === "user-cleared" ? null : props.action;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn("flex flex-col items-center justify-center text-center px-4 py-8", className)}
+    >
+      <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 flex flex-col items-center gap-2">
+        {icon ? (
+          <div className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6" aria-hidden="true">
+            {icon}
+          </div>
+        ) : null}
+        <p className="text-sm font-medium text-daintree-text/70">{title}</p>
+        {hasDescription ? (
+          <p id={descriptionId} className="text-xs text-daintree-text/50 max-w-xs">
+            {description}
+          </p>
+        ) : null}
+        {action ? <div className="mt-2">{action}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -168,7 +168,7 @@ describe("EmptyState", () => {
   describe("falsy description handling", () => {
     it("does not render an empty paragraph when description is false", () => {
       const { container } = render(
-        <EmptyState variant="zero-data" title="No items" description={false && "hidden"} />
+        <EmptyState variant="zero-data" title="No items" description={false as unknown as string} />
       );
       const paragraphs = container.querySelectorAll("p");
       // Only the title paragraph should render; no empty description paragraph.

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { EmptyState } from "../EmptyState";
+
+describe("EmptyState", () => {
+  describe("zero-data variant", () => {
+    it("renders title", () => {
+      render(<EmptyState variant="zero-data" title="No recipes yet" />);
+      expect(screen.getByText("No recipes yet")).toBeTruthy();
+    });
+
+    it("renders description when provided", () => {
+      render(
+        <EmptyState
+          variant="zero-data"
+          title="No recipes yet"
+          description="Add a recipe to get started"
+        />
+      );
+      expect(screen.getByText("Add a recipe to get started")).toBeTruthy();
+    });
+
+    it("renders icon when provided", () => {
+      render(
+        <EmptyState variant="zero-data" title="No recipes yet" icon={<svg data-testid="icon" />} />
+      );
+      expect(screen.getByTestId("icon")).toBeTruthy();
+    });
+
+    it("renders action when provided", () => {
+      render(
+        <EmptyState
+          variant="zero-data"
+          title="No recipes yet"
+          action={<button data-testid="cta">Add</button>}
+        />
+      );
+      expect(screen.getByTestId("cta")).toBeTruthy();
+    });
+  });
+
+  describe("filtered-empty variant", () => {
+    it("renders title", () => {
+      render(<EmptyState variant="filtered-empty" title='No matches for "foo"' />);
+      expect(screen.getByText('No matches for "foo"')).toBeTruthy();
+    });
+
+    it("renders action when provided", () => {
+      render(
+        <EmptyState
+          variant="filtered-empty"
+          title="No matches"
+          action={<button data-testid="clear">Clear filters</button>}
+        />
+      );
+      expect(screen.getByTestId("clear")).toBeTruthy();
+    });
+  });
+
+  describe("user-cleared variant", () => {
+    it("renders title", () => {
+      render(<EmptyState variant="user-cleared" title="You're all caught up" />);
+      expect(screen.getByText("You're all caught up")).toBeTruthy();
+    });
+
+    it("renders icon when provided", () => {
+      render(
+        <EmptyState
+          variant="user-cleared"
+          title="You're all caught up"
+          icon={<svg data-testid="icon" />}
+        />
+      );
+      expect(screen.getByTestId("icon")).toBeTruthy();
+    });
+  });
+
+  describe("accessibility", () => {
+    it('uses role="status" on the container', () => {
+      render(<EmptyState variant="zero-data" title="No items" />);
+      expect(screen.getByRole("status")).toBeTruthy();
+    });
+
+    it('sets aria-live="polite"', () => {
+      render(<EmptyState variant="zero-data" title="No items" />);
+      const status = screen.getByRole("status");
+      expect(status.getAttribute("aria-live")).toBe("polite");
+    });
+
+    it("hides icon decoration from assistive tech", () => {
+      const { container } = render(
+        <EmptyState variant="zero-data" title="No items" icon={<svg data-testid="icon" />} />
+      );
+      const wrapper = container.querySelector('[aria-hidden="true"]');
+      expect(wrapper).toBeTruthy();
+      expect(wrapper?.querySelector('[data-testid="icon"]')).toBeTruthy();
+    });
+  });
+
+  describe("animation", () => {
+    it("applies motion-safe entry animation classes on inner content", () => {
+      const { container } = render(<EmptyState variant="zero-data" title="No items" />);
+      const inner = container.querySelector(".motion-safe\\:animate-in");
+      expect(inner).toBeTruthy();
+      expect(inner?.className).toContain("motion-safe:fade-in");
+      expect(inner?.className).toContain("motion-safe:duration-150");
+    });
+
+    it("does not use transition-all", () => {
+      const { container } = render(<EmptyState variant="zero-data" title="No items" />);
+      expect(container.innerHTML).not.toContain("transition-all");
+    });
+  });
+
+  describe("className passthrough", () => {
+    it("merges custom className on the container", () => {
+      render(<EmptyState variant="zero-data" title="No items" className="my-custom-class" />);
+      const status = screen.getByRole("status");
+      expect(status.className).toContain("my-custom-class");
+    });
+  });
+});

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -61,6 +61,18 @@ describe("EmptyState", () => {
       );
       expect(screen.getByTestId("clear")).toBeTruthy();
     });
+
+    it("does not render an icon even if one is passed via type cast", () => {
+      // The discriminated union forbids `icon` on filtered-empty at compile time;
+      // this guards against a runtime regression if the gate is removed.
+      const props = {
+        variant: "filtered-empty",
+        title: "No matches",
+        icon: <svg data-testid="icon" />,
+      } as unknown as React.ComponentProps<typeof EmptyState>;
+      render(<EmptyState {...props} />);
+      expect(screen.queryByTestId("icon")).toBeNull();
+    });
   });
 
   describe("user-cleared variant", () => {
@@ -78,6 +90,16 @@ describe("EmptyState", () => {
         />
       );
       expect(screen.getByTestId("icon")).toBeTruthy();
+    });
+
+    it("does not render an action even if one is passed via type cast", () => {
+      const props = {
+        variant: "user-cleared",
+        title: "You're all caught up",
+        action: <button data-testid="cta">Should not appear</button>,
+      } as unknown as React.ComponentProps<typeof EmptyState>;
+      render(<EmptyState {...props} />);
+      expect(screen.queryByTestId("cta")).toBeNull();
     });
   });
 
@@ -101,6 +123,23 @@ describe("EmptyState", () => {
       expect(wrapper).toBeTruthy();
       expect(wrapper?.querySelector('[data-testid="icon"]')).toBeTruthy();
     });
+
+    it("wires aria-describedby to the description when one is present", () => {
+      render(
+        <EmptyState variant="zero-data" title="No items" description="Add one to get started" />
+      );
+      const status = screen.getByRole("status");
+      const describedById = status.getAttribute("aria-describedby");
+      expect(describedById).toBeTruthy();
+      const description = document.getElementById(describedById!);
+      expect(description?.textContent).toBe("Add one to get started");
+    });
+
+    it("does not set aria-describedby when no description is present", () => {
+      render(<EmptyState variant="zero-data" title="No items" />);
+      const status = screen.getByRole("status");
+      expect(status.getAttribute("aria-describedby")).toBeNull();
+    });
   });
 
   describe("animation", () => {
@@ -123,6 +162,25 @@ describe("EmptyState", () => {
       render(<EmptyState variant="zero-data" title="No items" className="my-custom-class" />);
       const status = screen.getByRole("status");
       expect(status.className).toContain("my-custom-class");
+    });
+  });
+
+  describe("falsy description handling", () => {
+    it("does not render an empty paragraph when description is false", () => {
+      const { container } = render(
+        <EmptyState variant="zero-data" title="No items" description={false && "hidden"} />
+      );
+      const paragraphs = container.querySelectorAll("p");
+      // Only the title paragraph should render; no empty description paragraph.
+      expect(paragraphs.length).toBe(1);
+      expect(paragraphs[0]?.textContent).toBe("No items");
+    });
+
+    it("does not render an empty paragraph when description is null", () => {
+      const { container } = render(
+        <EmptyState variant="zero-data" title="No items" description={null} />
+      );
+      expect(container.querySelectorAll("p").length).toBe(1);
     });
   });
 });

--- a/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
+++ b/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
@@ -67,10 +67,12 @@ describe("AppPaletteDialog.Empty", () => {
 
   it('exposes role="status" so screen readers announce the empty state', () => {
     render(<AppPaletteDialog.Empty query="" emptyMessage="No items available" />);
-    expect(screen.getByRole("status")).toBeTruthy();
+    const status = screen.getByRole("status");
+    expect(status).toBeTruthy();
+    expect(status.getAttribute("aria-live")).toBe("polite");
   });
 
-  it('also exposes role="status" in the no-match case', () => {
+  it('also exposes role="status" with aria-live polite in the no-match case', () => {
     render(
       <AppPaletteDialog.Empty
         query="zzz"
@@ -78,6 +80,13 @@ describe("AppPaletteDialog.Empty", () => {
         noMatchMessage="Nothing found"
       />
     );
-    expect(screen.getByRole("status")).toBeTruthy();
+    const status = screen.getByRole("status");
+    expect(status).toBeTruthy();
+    expect(status.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("trims whitespace from query when rendering the default no-match copy", () => {
+    render(<AppPaletteDialog.Empty query="  foo  " emptyMessage="No items available" />);
+    expect(screen.getByText('No items match "foo"')).toBeTruthy();
   });
 });

--- a/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
+++ b/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
@@ -64,4 +64,20 @@ describe("AppPaletteDialog.Empty", () => {
     expect(screen.getByText("Nothing found")).toBeTruthy();
     expect(screen.queryByTestId("cta")).toBeNull();
   });
+
+  it('exposes role="status" so screen readers announce the empty state', () => {
+    render(<AppPaletteDialog.Empty query="" emptyMessage="No items available" />);
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it('also exposes role="status" in the no-match case', () => {
+    render(
+      <AppPaletteDialog.Empty
+        query="zzz"
+        emptyMessage="No items available"
+        noMatchMessage="Nothing found"
+      />
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

- Introduces a new `EmptyState` component (`src/components/ui/EmptyState.tsx`) with discriminated-union variants (`zero-data` | `filtered-empty` | `user-cleared`) so the three distinct empty conditions are handled correctly rather than conflated
- Migrates `NotificationCenter`, `RecipesTab`, and `AppPaletteDialog.Empty` to use the new primitive, replacing bespoke inline implementations with a consistent shared one
- Accessibility handled once: `role="status"`, `aria-live="polite"`, and `aria-describedby` wiring are built in, with `prefers-reduced-motion` respected for the scale animation

Resolves #6034

## Changes

- `src/components/ui/EmptyState.tsx` — new component, 3 variants, optional icon + description + action slot
- `src/components/ui/__tests__/EmptyState.test.tsx` — 22-test suite covering all variants, aria attributes, animation, className passthrough, and falsy description handling
- `src/components/ui/__tests__/PaletteEmptyStates.test.tsx` — extended with `role=status`, `aria-live`, and trimmed-query assertions
- `AppPaletteDialog` — `Empty` sub-component now delegates to `EmptyState` internally; existing prop signature (`emptyMessage`, `noMatchMessage`, `children`) is unchanged
- `NotificationCenter` — zero-data and user-cleared cases driven by filter state rather than ad-hoc inline markup
- `RecipesTab` — zero-data case uses `EmptyState` with an outline-button CTA

## Testing

All targeted unit tests pass. `npm run check` (typecheck + lint + format) passes clean. ESLint warning count decreased by 2 compared to the base branch.