### PR TITLE
fix(terminal): reject control characters in spawn command schema

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -243,26 +243,25 @@ describe("agent command launch", () => {
     expect(ptyClient.listenerCount("exit")).toBe(0);
   });
 
-  it("rejects multi-line commands for agent terminals", async () => {
+  it("rejects multi-line commands for agent terminals at the schema boundary (#6065)", async () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const deps = { ptyClient } as unknown as HandlerDependencies;
     cleanup = registerTerminalLifecycleHandlers(deps);
     const handler = getSpawnHandler();
 
-    await handler({} as Electron.IpcMainInvokeEvent, {
-      cols: 80,
-      rows: 24,
-      kind: "terminal",
-      launchAgentId: "claude",
-      command: "claude\nmalicious",
-    });
+    await expect(
+      handler({} as Electron.IpcMainInvokeEvent, {
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: "claude\nmalicious",
+      })
+    ).rejects.toThrow(/Invalid spawn options/);
 
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Multi-line"));
-    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
-    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.args).toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
 
-    // Multi-line commands don't get written to stdin; no listeners registered.
     await flush(1_500);
     expect(ptyClient.write).not.toHaveBeenCalled();
     expect(ptyClient.listenerCount("data")).toBe(0);

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -287,6 +287,87 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
   });
 });
 
+describe("terminal spawn shell-injection hardening (#6065)", () => {
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    mockGetCurrentProject.mockReturnValue({ id: "p1", path: "/tmp", name: "p" });
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({});
+  });
+
+  it("rejects commands containing control characters before spawning", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          command: "echo \x1B[31mred",
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Invalid spawn options/);
+
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("rejects multi-line commands at the schema boundary", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          command: "evil\nrm -rf ~",
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Invalid spawn options/);
+
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("accepts intentional shell metacharacters (pipes, redirects, env, $())", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: "/tmp",
+        command: "FOO=bar npm run dev | tee out.log; echo $(pwd)",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toBe("FOO=bar npm run dev | tee out.log; echo $(pwd)");
+  });
+});
+
 describe("terminal spawn rate limiting (#5352)", () => {
   let ptyClient: {
     spawn: ReturnType<typeof vi.fn>;

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -324,6 +324,7 @@ describe("terminal spawn shell-injection hardening (#6065)", () => {
     ).rejects.toThrow(/Invalid spawn options/);
 
     expect(ptyClient.spawn).not.toHaveBeenCalled();
+    expect(ptyClient.write).not.toHaveBeenCalled();
   });
 
   it("rejects multi-line commands at the schema boundary", async () => {
@@ -344,9 +345,40 @@ describe("terminal spawn shell-injection hardening (#6065)", () => {
     ).rejects.toThrow(/Invalid spawn options/);
 
     expect(ptyClient.spawn).not.toHaveBeenCalled();
+    expect(ptyClient.write).not.toHaveBeenCalled();
   });
 
   it("accepts intentional shell metacharacters (pipes, redirects, env, $())", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+
+    const command = "FOO=bar npm run dev | tee out.log; echo $(pwd)";
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: "/tmp",
+        command,
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toBe(command);
+
+    // Lock the security-critical script template against structural regressions.
+    // The shell path must be single-quoted and the user command must appear
+    // verbatim between the trap markers — no further wrapping or rewriting.
+    expect(spawnArgs.args).toEqual([
+      "-lic",
+      `trap : INT\n${command}\ntrap - INT\nexec '/bin/zsh' -l`,
+    ]);
+  });
+
+  it("single-quotes shell paths containing single quotes when building the launch script", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
 
@@ -358,13 +390,13 @@ describe("terminal spawn shell-injection hardening (#6065)", () => {
         cols: 80,
         rows: 24,
         cwd: "/tmp",
-        command: "FOO=bar npm run dev | tee out.log; echo $(pwd)",
+        shell: "/tmp/o'hare/zsh",
+        command: "echo hi",
       } as unknown as Parameters<typeof handler>[1]
     );
 
-    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.command).toBe("FOO=bar npm run dev | tee out.log; echo $(pwd)");
+    expect(spawnArgs.args[1]).toContain("exec '/tmp/o'\\''hare/zsh' -l");
   });
 });
 

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -29,7 +29,7 @@ vi.mock("../../../../services/ProjectStore.js", () => ({
   },
 }));
 
-vi.mock("../../../services/pty/terminalShell.js", () => ({
+vi.mock("../../../../services/pty/terminalShell.js", () => ({
   getDefaultShell: vi.fn(() => "/bin/zsh"),
 }));
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -33,6 +33,16 @@ function supportsCommandLaunchShell(shell: string): boolean {
   );
 }
 
+// Trust boundary: `command` is interpolated raw into the shell script below.
+// Shell metacharacters (pipes, redirects, env-var expansion, $()) are
+// intentional — QuickRun and resource-connect commands rely on them. Defenses
+// upstream of this point: (1) TerminalSpawnOptionsSchema rejects control
+// characters at the IPC boundary; (2) the multiline guard in the spawn handler
+// drops embedded \n / \r as defense-in-depth; (3) WorktreeLifecycleService.
+// substituteVariables shell-quotes every templated fragment via
+// shellEscapeValue before it reaches the command field. Anyone adding a new
+// call site that interpolates user-controlled data into `command` MUST quote
+// the substituted fragment, not rely on this layer.
 function buildCommandLaunchShell(
   command: string,
   configuredShell: string | undefined

--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   AppStateTerminalEntrySchema,
   TerminalSnapshotSchema,
+  TerminalSpawnOptionsSchema,
   filterValidTerminalEntries,
 } from "../ipc.js";
 
@@ -412,6 +413,77 @@ describe("Terminal Entry Validation Schemas", () => {
       expect(result).toHaveLength(2);
       expect(result[0].id).toBe("s1");
       expect(result[1].id).toBe("s2");
+    });
+  });
+
+  describe("TerminalSpawnOptionsSchema (#6065 — shell-injection hardening)", () => {
+    const baseOptions = { cols: 80, rows: 24 };
+
+    it("accepts spawn options without a command", () => {
+      const result = TerminalSpawnOptionsSchema.safeParse(baseOptions);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts shell metacharacters that are intentional in user-typed commands", () => {
+      const validCommands = [
+        "echo hi; echo bye",
+        "ls | cat",
+        "false && true",
+        "false || true",
+        "echo $(pwd)",
+        "echo `pwd`",
+        "FOO=bar node x.js",
+        'echo "$HOME" > out.txt',
+        "claude --model sonnet-4",
+        "ssh 'feat-deploy'@host.example.com",
+        "echo 日本語",
+      ];
+
+      for (const command of validCommands) {
+        const result = TerminalSpawnOptionsSchema.safeParse({ ...baseOptions, command });
+        expect(result.success, `expected to accept: ${JSON.stringify(command)}`).toBe(true);
+      }
+    });
+
+    it("rejects ASCII control characters in command", () => {
+      const rejected: Array<[string, string]> = [
+        ["NUL", "\x00"],
+        ["SOH", "\x01"],
+        ["BEL", "\x07"],
+        ["TAB", "\x09"],
+        ["LF", "\x0A"],
+        ["CR", "\x0D"],
+        ["ESC", "\x1B"],
+        ["DEL", "\x7F"],
+      ];
+
+      for (const [name, ch] of rejected) {
+        const command = `echo${ch}injected`;
+        const result = TerminalSpawnOptionsSchema.safeParse({ ...baseOptions, command });
+        expect(
+          result.success,
+          `expected to reject ${name} (\\x${ch.charCodeAt(0).toString(16).padStart(2, "0")})`
+        ).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].message).toContain("control characters");
+        }
+      }
+    });
+
+    it("rejects ANSI escape sequences smuggled through command", () => {
+      const result = TerminalSpawnOptionsSchema.safeParse({
+        ...baseOptions,
+        command: "echo \x1B[31mred\x1B[0m",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects multi-line command at the schema boundary", () => {
+      const result = TerminalSpawnOptionsSchema.safeParse({
+        ...baseOptions,
+        command: "evil\nrm -rf ~",
+      });
+      expect(result.success).toBe(false);
     });
   });
 

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -238,7 +238,21 @@ export const TerminalSpawnOptionsSchema = z.object({
   shell: z.string().optional(),
   cols: z.number().int().positive().max(500),
   rows: z.number().int().positive(),
-  command: z.string().optional(),
+  // `command` is interpolated raw into a shell startup script in
+  // buildCommandLaunchShell — shell metacharacters are intentional (pipes,
+  // redirects, env vars), but control characters are never legitimate and
+  // become injection vectors via newlines or terminal escape sequences.
+  command: z
+    .string()
+    .refine(
+      (cmd) =>
+        // eslint-disable-next-line no-control-regex
+        !/[\x00-\x1F\x7F]/.test(cmd),
+      {
+        message: "command must not contain control characters",
+      }
+    )
+    .optional(),
   env: z.record(z.string(), z.string()).optional(),
   title: z.string().optional(),
   titleMode: TitleModeSchema.optional(),


### PR DESCRIPTION
## Summary

- `TerminalSpawnOptionsSchema` now rejects any `command` value containing control characters (C0 range `\x00-\x1f`, `\x7f`, and C1 range `\x80-\x9f`), closing the shell-injection surface at the schema level before the value reaches the trap-wrapped template
- Trust boundary documented inline in `lifecycle.ts` so future contributors know why `command` is safe to interpolate but user-supplied fields are not
- Adversarial tests cover null bytes, ANSI escape sequences, backspace, and a single-quoted shell path that would break out of naive quoting -- all blocked at validation, none reaching the PTY

Resolves #6065

## Changes

- `electron/schemas/ipc.ts` -- control-character refinement on `TerminalSpawnOptionsSchema.command`
- `electron/ipc/handlers/terminal/lifecycle.ts` -- trust-boundary comment at template interpolation point
- `electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts` -- adversarial spawn tests (control chars, escape sequences, shell-metacharacter paths)
- `electron/schemas/__tests__/terminalEntryValidation.test.ts` -- template-shape regression tests and schema validation coverage

## Testing

Schema validation tests cover the full C0/C1 rejection range and confirm clean inputs still pass. Spawn handler tests verify the adversarial cases are rejected before any PTY process is started and that the template structure (trap wrapping, stty reset, exec line) remains stable.