### PR TITLE
fix(fleet): indent terminal rows under worktree group headers

### DIFF
--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -588,7 +588,7 @@ function TerminalRow({ terminal, checked, snippet, onToggle }: TerminalRowProps)
     <li className="flex items-stretch">
       <label
         className={cn(
-          "flex flex-1 items-start gap-2 px-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer",
+          "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer",
           "hover:bg-tint/[0.06]"
         )}
       >


### PR DESCRIPTION
## Summary
In the fleet arming dialog, terminal rows sat flush-left under their worktree group headers. With several worktrees and a few terminals each, it was hard to scan which terminal belonged to which worktree -- the list read as a wall of text.

This adds a left indent on terminal rows. Group headers stay flush-left, which keeps the worktree name and tri-state checkbox at the same anchor and gives the eye a clean column to scan.

Resolves #6021

## Changes
- `FleetArmingDialog.tsx`: Changed `TerminalRow` label padding from `px-2` to `pl-5 pr-2`

## Testing
- Confirmed the change is a single-class swap with no structural impact
- Verified the dialog still renders with terminals visually grouped under their worktree headers