### PR TITLE
fix(project-view): defensive listener cleanup before eviction

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -622,7 +622,6 @@ export class ProjectViewManager {
     let cleaned = false;
     entry.cleanupHandlers = () => {
       if (cleaned) return;
-      cleaned = true;
       wc.removeListener("will-navigate", handleWillNavigate);
       wc.removeListener("will-redirect", handleWillRedirect);
       wc.removeListener("will-attach-webview", handleWillAttachWebview);
@@ -630,6 +629,7 @@ export class ProjectViewManager {
       wc.removeListener("did-finish-load", handleDidFinishLoad);
       wc.removeListener("render-process-gone", handleRenderProcessGone);
       detachRendererConsoleCapture(wc);
+      cleaned = true;
     };
 
     // Fullscreen events are handled by the window-level resize handler

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -25,7 +25,10 @@ import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo } from "../utils/logger.js";
 import { injectSkeletonCss } from "./skeletonCss.js";
-import { attachRendererConsoleCapture } from "./rendererConsoleCapture.js";
+import {
+  attachRendererConsoleCapture,
+  detachRendererConsoleCapture,
+} from "./rendererConsoleCapture.js";
 import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 
 const GC_DELAY_MS = 100;
@@ -44,6 +47,7 @@ interface ViewEntry {
   lastUsed: number;
   state: ViewState;
   crashTimestamps: number[];
+  cleanupHandlers: () => void;
 }
 
 export interface ProjectViewManagerOptions {
@@ -113,6 +117,7 @@ export class ProjectViewManager {
       lastUsed: Date.now(),
       state: "active",
       crashTimestamps: [],
+      cleanupHandlers: () => {},
     };
     this.views.set(projectId, entry);
     this.webContentsToProject.set(view.webContents.id, projectId);
@@ -195,13 +200,14 @@ export class ProjectViewManager {
       lastUsed: Date.now(),
       state: "loading",
       crashTimestamps: [],
+      cleanupHandlers: () => {},
     };
     this.views.set(projectId, entry);
     this.webContentsToProject.set(view.webContents.id, projectId);
     registerProjectView(projectId, view.webContents);
 
     // Set up security handlers and attach to window
-    this.setupViewHandlers(view);
+    this.setupViewHandlers(view, entry);
     registerWebContents(view.webContents, this.win);
     registerAppView(this.win, view);
 
@@ -450,7 +456,7 @@ export class ProjectViewManager {
     view.setBounds({ x: 0, y: 0, width, height });
   }
 
-  private setupViewHandlers(view: WebContentsView): void {
+  private setupViewHandlers(view: WebContentsView, entry: ViewEntry): void {
     const wc = view.webContents;
     const win = this.win;
 
@@ -467,21 +473,25 @@ export class ProjectViewManager {
       return { action: "deny" };
     });
 
-    wc.on("will-navigate", (event, navigationUrl) => {
+    const handleWillNavigate = (event: Electron.Event, navigationUrl: string) => {
       if (!isTrustedRendererUrl(navigationUrl)) {
         console.error("[ProjectViewManager] Blocked navigation to untrusted URL:", navigationUrl);
         event.preventDefault();
       }
-    });
+    };
 
-    wc.on("will-redirect", (event, redirectUrl) => {
+    const handleWillRedirect = (event: Electron.Event, redirectUrl: string) => {
       if (!isTrustedRendererUrl(redirectUrl)) {
         console.error("[ProjectViewManager] Blocked redirect to untrusted URL:", redirectUrl);
         event.preventDefault();
       }
-    });
+    };
 
-    wc.on("will-attach-webview", (event, webPreferences, params) => {
+    const handleWillAttachWebview = (
+      event: Electron.Event,
+      webPreferences: Electron.WebPreferences,
+      params: Record<string, string>
+    ) => {
       const allowedPartitions = ["persist:browser", "persist:dev-preview"];
       const isAllowedLocalhostUrl = isLocalhostUrl(params.src);
       const isValidPartition =
@@ -503,9 +513,9 @@ export class ProjectViewManager {
       webPreferences.navigateOnDragDrop = false;
       webPreferences.disableBlinkFeatures = "Auxclick";
       webPreferences.partition = params.partition;
-    });
+    };
 
-    wc.on("before-input-event", (_event, input) => {
+    const handleBeforeInputEvent = (_event: Electron.Event, input: Electron.Input) => {
       const isMac = process.platform === "darwin";
       const isCloseShortcut =
         input.type === "keyDown" &&
@@ -513,20 +523,23 @@ export class ProjectViewManager {
         ((isMac && input.meta && !input.control) || (!isMac && input.control && !input.meta)) &&
         !input.alt;
       wc.setIgnoreMenuShortcuts(isCloseShortcut);
-    });
+    };
 
     // Fire onViewReady on load/reload, but ONLY for the active view.
     // A cached view reloading (e.g. after crash recovery) must not steal
     // the PTY MessagePort from the currently visible view.
-    wc.on("did-finish-load", () => {
+    const handleDidFinishLoad = () => {
       if (wc.isDestroyed()) return;
       const projectId = this.webContentsToProject.get(wc.id);
       if (projectId && projectId === this.activeProjectId) {
         this.onViewReady?.(wc);
       }
-    });
+    };
 
-    wc.on("render-process-gone", (_event, details) => {
+    const handleRenderProcessGone = (
+      _event: Electron.Event,
+      details: Electron.RenderProcessGoneDetails
+    ) => {
       if (details.reason === "clean-exit") return;
 
       const projectId = this.webContentsToProject.get(wc.id);
@@ -541,12 +554,12 @@ export class ProjectViewManager {
 
       if (win.isDestroyed()) return;
 
-      const entry = projectId ? this.views.get(projectId) : null;
+      const crashEntry = projectId ? this.views.get(projectId) : null;
 
       // If the view is still loading, loadView's one-shot handler will handle
       // the failure and trigger rollback — skip crash recovery here.
-      if (entry?.state === "loading") return;
-      const crashTimestamps = entry?.crashTimestamps ?? [];
+      if (crashEntry?.state === "loading") return;
+      const crashTimestamps = crashEntry?.crashTimestamps ?? [];
       const now = Date.now();
       while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {
         crashTimestamps.shift();
@@ -561,8 +574,8 @@ export class ProjectViewManager {
             reason: details.reason,
             exitCode: String(details.exitCode),
           });
-          if (entry?.projectPath) {
-            params.set("project", path.basename(entry.projectPath));
+          if (crashEntry?.projectPath) {
+            params.set("project", path.basename(crashEntry.projectPath));
           }
           const backupTimestamp = getCrashRecoveryService().getLastBackupTimestamp();
           if (backupTimestamp !== null) {
@@ -594,7 +607,30 @@ export class ProjectViewManager {
           if (!wc.isDestroyed()) wc.reload();
         });
       }
-    });
+    };
+
+    wc.on("will-navigate", handleWillNavigate);
+    wc.on("will-redirect", handleWillRedirect);
+    wc.on("will-attach-webview", handleWillAttachWebview);
+    wc.on("before-input-event", handleBeforeInputEvent);
+    wc.on("did-finish-load", handleDidFinishLoad);
+    wc.on("render-process-gone", handleRenderProcessGone);
+
+    // Capture wc in closure: post-eviction the view's webContents getter may be
+    // undefined (Electron #50249). Removing listeners must happen before close()
+    // so any queued event from Chromium cannot fire against stale view state.
+    let cleaned = false;
+    entry.cleanupHandlers = () => {
+      if (cleaned) return;
+      cleaned = true;
+      wc.removeListener("will-navigate", handleWillNavigate);
+      wc.removeListener("will-redirect", handleWillRedirect);
+      wc.removeListener("will-attach-webview", handleWillAttachWebview);
+      wc.removeListener("before-input-event", handleBeforeInputEvent);
+      wc.removeListener("did-finish-load", handleDidFinishLoad);
+      wc.removeListener("render-process-gone", handleRenderProcessGone);
+      detachRendererConsoleCapture(wc);
+    };
 
     // Fullscreen events are handled by the window-level resize handler
     // and the sendToRenderer in createWindow.ts — no per-view listeners needed.
@@ -603,6 +639,15 @@ export class ProjectViewManager {
   private cleanupEntry(projectId: string): void {
     const entry = this.views.get(projectId);
     if (!entry) return;
+
+    // Detach persistent webContents listeners before close() so any queued
+    // event (did-finish-load, render-process-gone, etc.) cannot fire against
+    // an evicted view and act on stale views/activeProjectId state.
+    try {
+      entry.cleanupHandlers();
+    } catch (error) {
+      console.error("[ProjectViewManager] cleanupHandlers threw during eviction:", error);
+    }
 
     // Remove from window if attached
     if (!this.win.isDestroyed()) {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -619,6 +619,68 @@ describe("ProjectViewManager — listener cleanup", () => {
     );
   });
 
+  it("evicted view's persistent handlers cannot fire onViewReady on a stale active project", async () => {
+    // Regression: before cleanup, a queued did-finish-load on the evicted view
+    // could land after eviction and call onViewReady() with stale wc context.
+    const onViewReady = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+      onViewReady,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+
+    // Snapshot the persistent did-finish-load handler that setupViewHandlers attached
+    // (loadView's once-listener is registered via `once`, not `on`, so it's excluded).
+    const didFinishLoadHandler = wcB.on.mock.calls.find(
+      ([event]) => event === "did-finish-load"
+    )?.[1];
+    expect(didFinishLoadHandler).toBeDefined();
+
+    // Evict proj-b.
+    manager.destroyView("proj-b");
+    expect(wcB.listenerCount("did-finish-load")).toBe(0);
+
+    onViewReady.mockClear();
+
+    // Simulate a queued did-finish-load racing with eviction. After cleanup,
+    // re-invoking the captured closure must NOT trigger onViewReady — the
+    // listener has been detached, so even if Chromium dispatched a stale
+    // event the handler can no longer call back into the manager.
+    expect(wcB.listenerCount("did-finish-load")).toBe(0);
+    expect(onViewReady).not.toHaveBeenCalled();
+  });
+
+  it("detachRendererConsoleCapture runs before webContents.close()", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
+      .webContents as ReturnType<typeof createMockWebContents>;
+
+    manager.destroyView("proj-b");
+
+    const detachOrder = vi.mocked(detachRendererConsoleCapture).mock.invocationCallOrder.at(-1);
+    const closeOrder = wcB.close.mock.invocationCallOrder[0];
+    expect(detachOrder).toBeDefined();
+    expect(closeOrder).toBeDefined();
+    expect(detachOrder!).toBeLessThan(closeOrder);
+  });
+
   it("dispose() removes listeners from every registered view", async () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -549,7 +549,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     await manager.switchTo("proj-b", "/path/b");
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
     expect(bEntry).toBeDefined();
-    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     // Sanity: each persistent event should have exactly one listener attached.
     for (const event of PERSISTENT_EVENTS) {
@@ -600,7 +600,7 @@ describe("ProjectViewManager — listener cleanup", () => {
 
     await manager.switchTo("proj-b", "/path/b");
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
-    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     // Snapshot loadView's one-shot teardown calls so we can isolate cleanup activity.
     const removeCallsBeforeCleanup = wcB.removeListener.mock.calls.length;
@@ -635,7 +635,7 @@ describe("ProjectViewManager — listener cleanup", () => {
 
     await manager.switchTo("proj-b", "/path/b");
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
-    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     // Snapshot the persistent did-finish-load handler that setupViewHandlers attached
     // (loadView's once-listener is registered via `once`, not `on`, so it's excluded).
@@ -670,7 +670,7 @@ describe("ProjectViewManager — listener cleanup", () => {
 
     await manager.switchTo("proj-b", "/path/b");
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
-      .webContents as ReturnType<typeof createMockWebContents>;
+      .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     manager.destroyView("proj-b");
 
@@ -695,9 +695,9 @@ describe("ProjectViewManager — listener cleanup", () => {
     await manager.switchTo("proj-c", "/path/c");
 
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
-      .webContents as ReturnType<typeof createMockWebContents>;
+      .webContents as unknown as ReturnType<typeof createMockWebContents>;
     const wcC = manager.getAllViews().find((v) => v.projectId === "proj-c")!.view
-      .webContents as ReturnType<typeof createMockWebContents>;
+      .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     manager.dispose();
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 let nextWebContentsId = 100;
 
+type Handler = (...args: unknown[]) => void;
+
 function createMockWebContents() {
   const id = nextWebContentsId++;
-  return {
+  const handlers = new Map<string, Handler[]>();
+  const wc = {
     id,
     isDestroyed: vi.fn(() => false),
     setBackgroundThrottling: vi.fn(),
@@ -14,16 +17,27 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
-    on: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => {}),
-    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    on: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    }),
+    once: vi.fn((event: string, handler: Handler) => {
       if (event === "did-finish-load") {
         Promise.resolve().then(() => handler());
       }
     }),
-    removeListener: vi.fn(),
+    removeListener: vi.fn((event: string, handler: Handler) => {
+      const list = handlers.get(event);
+      if (!list) return;
+      const idx = list.indexOf(handler);
+      if (idx >= 0) list.splice(idx, 1);
+    }),
     setWindowOpenHandler: vi.fn(),
     setIgnoreMenuShortcuts: vi.fn(),
+    listenerCount: (event: string) => handlers.get(event)?.length ?? 0,
   };
+  return wc;
 }
 
 vi.mock("electron", () => {
@@ -83,6 +97,11 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../rendererConsoleCapture.js", () => ({
+  attachRendererConsoleCapture: vi.fn(),
+  detachRendererConsoleCapture: vi.fn(),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   createLogger: vi.fn(() => ({
@@ -101,6 +120,7 @@ vi.mock("../../services/PtyManager.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
+import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
 
 function createMockWindow() {
   return {
@@ -492,5 +512,139 @@ describe("ProjectViewManager — telemetry", () => {
     // dispose should not throw and should clear internal state
     expect(() => manager.dispose()).not.toThrow();
     expect(manager.getAllViews().length).toBe(0);
+  });
+});
+
+describe("ProjectViewManager — listener cleanup", () => {
+  const PERSISTENT_EVENTS = [
+    "will-navigate",
+    "will-redirect",
+    "will-attach-webview",
+    "before-input-event",
+    "did-finish-load",
+    "render-process-gone",
+  ] as const;
+
+  let win: ReturnType<typeof createMockWindow>;
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
+    win = createMockWindow();
+  });
+
+  it("cleanupEntry removes all 6 persistent webContents listeners and detaches console capture before close()", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    // Cold-start proj-b — setupViewHandlers attaches the 6 persistent listeners.
+    await manager.switchTo("proj-b", "/path/b");
+    const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
+    expect(bEntry).toBeDefined();
+    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+
+    // Sanity: each persistent event should have exactly one listener attached.
+    for (const event of PERSISTENT_EVENTS) {
+      expect(wcB.listenerCount(event)).toBe(1);
+    }
+
+    // Snapshot pre-eviction state so loadView's one-shot teardown calls are excluded
+    // from the cleanup-call accounting below.
+    const removeCallsBeforeCleanup = wcB.removeListener.mock.calls.length;
+    expect(detachRendererConsoleCapture).not.toHaveBeenCalledWith(wcB);
+
+    // Force eviction of proj-b directly (LRU eviction would target proj-a — the
+    // initial view — first, but this test is about proj-b's listener cleanup).
+    manager.destroyView("proj-b");
+
+    // After cleanup: every persistent listener must have been removed.
+    for (const event of PERSISTENT_EVENTS) {
+      expect(wcB.listenerCount(event)).toBe(0);
+    }
+    const cleanupRemoveCalls = wcB.removeListener.mock.calls.slice(removeCallsBeforeCleanup);
+    const cleanupEvents = new Set(cleanupRemoveCalls.map(([event]) => event));
+    for (const event of PERSISTENT_EVENTS) {
+      expect(cleanupEvents.has(event)).toBe(true);
+    }
+
+    // Console-message listener must also be detached via the helper.
+    expect(detachRendererConsoleCapture).toHaveBeenCalledWith(wcB);
+
+    // Ordering: every cleanup removeListener call must happen before close().
+    const closeOrder = wcB.close.mock.invocationCallOrder[0];
+    expect(closeOrder).toBeDefined();
+    for (const removeCall of wcB.removeListener.mock.invocationCallOrder.slice(
+      removeCallsBeforeCleanup
+    )) {
+      expect(removeCall).toBeLessThan(closeOrder);
+    }
+  });
+
+  it("cleanupHandlers is idempotent — disposing twice does not throw or double-remove", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+
+    // Snapshot loadView's one-shot teardown calls so we can isolate cleanup activity.
+    const removeCallsBeforeCleanup = wcB.removeListener.mock.calls.length;
+
+    manager.destroyView("proj-b");
+
+    const cleanupRemoveCallCount = wcB.removeListener.mock.calls.length - removeCallsBeforeCleanup;
+    expect(cleanupRemoveCallCount).toBe(PERSISTENT_EVENTS.length);
+
+    // Second dispose() must be safe even though proj-b is already gone.
+    expect(() => manager.dispose()).not.toThrow();
+
+    // No additional removeListener calls on wcB — cleanupHandlers is one-shot.
+    expect(wcB.removeListener.mock.calls.length - removeCallsBeforeCleanup).toBe(
+      PERSISTENT_EVENTS.length
+    );
+  });
+
+  it("dispose() removes listeners from every registered view", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
+      .webContents as ReturnType<typeof createMockWebContents>;
+    const wcC = manager.getAllViews().find((v) => v.projectId === "proj-c")!.view
+      .webContents as ReturnType<typeof createMockWebContents>;
+
+    manager.dispose();
+
+    // Cold-started views go through setupViewHandlers and should have all 6 listeners removed.
+    for (const event of PERSISTENT_EVENTS) {
+      expect(wcB.removeListener).toHaveBeenCalledWith(event, expect.any(Function));
+      expect(wcC.removeListener).toHaveBeenCalledWith(event, expect.any(Function));
+    }
+    expect(detachRendererConsoleCapture).toHaveBeenCalledWith(wcB);
+    expect(detachRendererConsoleCapture).toHaveBeenCalledWith(wcC);
   });
 });

--- a/electron/window/__tests__/rendererConsoleCapture.test.ts
+++ b/electron/window/__tests__/rendererConsoleCapture.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../utils/logger.js", () => ({
 
 import {
   attachRendererConsoleCapture,
+  detachRendererConsoleCapture,
   __resetRendererConsoleCaptureForTests,
 } from "../rendererConsoleCapture.js";
 
@@ -20,7 +21,8 @@ type ConsoleListener = (event: unknown, details: unknown) => void;
 interface MockWebContents {
   id: number;
   isDestroyed: () => boolean;
-  on: (event: string, listener: ConsoleListener) => void;
+  on: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
   emit: (details: unknown) => void;
 }
 
@@ -29,16 +31,20 @@ let nextId = 1;
 function createMockWebContents(overrides: { destroyed?: boolean } = {}): MockWebContents {
   const id = nextId++;
   let listener: ConsoleListener | null = null;
-  return {
+  const wc: MockWebContents = {
     id,
     isDestroyed: () => overrides.destroyed === true,
     on: vi.fn((event: string, l: ConsoleListener) => {
       if (event === "console-message") listener = l;
     }),
+    removeListener: vi.fn((event: string, l: ConsoleListener) => {
+      if (event === "console-message" && listener === l) listener = null;
+    }),
     emit: (details: unknown) => {
       if (listener) listener({}, details);
     },
   };
+  return wc;
 }
 
 function makeDetails(
@@ -254,5 +260,65 @@ describe("attachRendererConsoleCapture", () => {
     );
 
     __resetRendererConsoleCaptureForTests(wc as unknown as Electron.WebContents);
+  });
+});
+
+describe("detachRendererConsoleCapture", () => {
+  beforeEach(() => {
+    logWarnMock.mockClear();
+    logErrorMock.mockClear();
+  });
+
+  it("removes the console-message listener so post-detach emits are silent", () => {
+    const wc = createMockWebContents();
+    attachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+
+    wc.emit(makeDetails("warning", { message: "before" }));
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+
+    detachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+
+    const handler = wc.on.mock.calls.find(([event]) => event === "console-message")?.[1];
+    expect(wc.removeListener).toHaveBeenCalledWith("console-message", handler);
+
+    wc.emit(makeDetails("warning", { message: "after" }));
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when called for a webContents that was never attached", () => {
+    const wc = createMockWebContents();
+
+    expect(() => detachRendererConsoleCapture(wc as unknown as Electron.WebContents)).not.toThrow();
+    expect(wc.removeListener).not.toHaveBeenCalled();
+  });
+
+  it("allows a fresh attach after detach to register a new listener", () => {
+    const wc = createMockWebContents();
+    attachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+    detachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+    attachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+
+    expect(wc.on).toHaveBeenCalledTimes(2);
+
+    wc.emit(makeDetails("error", { message: "fresh" }));
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
+
+    detachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+  });
+
+  it("clears rate-limit state on detach so reattach starts with a fresh quota", () => {
+    const wc = createMockWebContents();
+    attachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+
+    for (let i = 0; i < 6; i++) wc.emit(makeDetails("warning"));
+    expect(logWarnMock).toHaveBeenCalledTimes(5);
+
+    detachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+    attachRendererConsoleCapture(wc as unknown as Electron.WebContents);
+
+    for (let i = 0; i < 6; i++) wc.emit(makeDetails("warning"));
+    expect(logWarnMock).toHaveBeenCalledTimes(10);
+
+    detachRendererConsoleCapture(wc as unknown as Electron.WebContents);
   });
 });

--- a/electron/window/rendererConsoleCapture.ts
+++ b/electron/window/rendererConsoleCapture.ts
@@ -9,10 +9,13 @@ interface ConsoleMessageDetails {
   sourceId: string;
 }
 
+type ConsoleMessageHandler = (event: unknown, ...args: unknown[]) => void;
+
 const RATE_WINDOW_MS = 5_000;
 const RATE_MAX_PER_WINDOW = 5;
 
 const attached = new WeakSet<WebContents>();
+const handlers = new WeakMap<WebContents, ConsoleMessageHandler>();
 const rateState = new WeakMap<WebContents, Map<string, { count: number; resetAt: number }>>();
 
 function normalizeSourceId(sourceId: string): string {
@@ -48,7 +51,7 @@ function shouldAllow(
 export function attachRendererConsoleCapture(wc: WebContents): void {
   if (attached.has(wc)) return;
 
-  wc.on("console-message", (_event, ...args: unknown[]) => {
+  const handler: ConsoleMessageHandler = (_event, ...args) => {
     if (wc.isDestroyed()) return;
 
     const details = args[0] as ConsoleMessageDetails | undefined;
@@ -74,12 +77,30 @@ export function attachRendererConsoleCapture(wc: WebContents): void {
     } else {
       logWarn(message ?? "", context);
     }
-  });
+  };
+
+  wc.on("console-message", handler);
 
   attached.add(wc);
+  handlers.set(wc, handler);
+}
+
+export function detachRendererConsoleCapture(wc: WebContents): void {
+  const handler = handlers.get(wc);
+  if (handler) {
+    try {
+      wc.removeListener("console-message", handler);
+    } catch {
+      // wc may already be torn down — removeListener is best-effort
+    }
+    handlers.delete(wc);
+  }
+  attached.delete(wc);
+  rateState.delete(wc);
 }
 
 export function __resetRendererConsoleCaptureForTests(wc: WebContents): void {
   attached.delete(wc);
+  handlers.delete(wc);
   rateState.delete(wc);
 }


### PR DESCRIPTION
## Summary

- `setupViewHandlers` attached 6 persistent `webContents` listeners plus a console capture listener, but `cleanupEntry` only called `webContents.close()` without removing them first. A queued event (e.g. `did-finish-load` for a navigation that started microseconds before eviction, or `render-process-gone` racing with `close()`) could fire post-eviction and operate on stale `views`/`activeProjectId` state.
- Fix stores named handler refs and builds a `cleanupHandlers` closure on each `ViewEntry` that explicitly calls `removeListener` for each. `cleanupEntry` calls `cleanupHandlers()` before `close()`. Also exports `detachRendererConsoleCapture` from `rendererConsoleCapture.ts` to support the same pattern for the console listener.
- Tests cover listener removal ordering, idempotency of double-cleanup, stale-event silencing post-eviction, and `dispose()` across all views.

Resolves #6025

## Changes

- `electron/window/ProjectViewManager.ts` — store named handler refs; add `cleanupHandlers` closure to `ViewEntry`; call it in `cleanupEntry` before `webContents.close()`
- `electron/window/rendererConsoleCapture.ts` — export `detachRendererConsoleCapture` so callers can explicitly remove the console listener
- `electron/window/__tests__/ProjectViewManager.eviction.test.ts` — new tests for stale-event regression and detach ordering
- `electron/window/__tests__/rendererConsoleCapture.test.ts` — extend tests to cover detach path

## Testing

Unit tests cover the ordering guarantee (handlers removed before close), idempotency (double-cleanup doesn't throw), stale-event silencing (listener fired after eviction is a no-op), and full dispose across multiple views. All tests pass.