### PR TITLE
fix(errors): humanize routeError toast titles and bodies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -158,6 +158,18 @@ export default tseslint.config(
           message:
             "Don't use `void window.electron.X()` for fire-and-forget IPC — wrap the promise in safeFireAndForget(promise, { context }) from @/utils/safeFireAndForget so rejections reach reportRendererGlobalError with call-site context.",
         },
+        {
+          // Block raw `error.message` / `err.message` / `e.message` inside
+          // notify({...}) and addNotification({...}) message properties.
+          // These calls go to user-facing toasts; raw library messages leak
+          // jargon (paths, errno strings, internal source IDs). Use
+          // humanizeAppError() from @shared/utils/errorMessage instead.
+          // See issue #6050.
+          selector:
+            "CallExpression[callee.name=/^(notify|addNotification)$/] ObjectExpression > Property[key.name='message'] MemberExpression[object.name=/^(error|err|e)$/][property.name='message']",
+          message:
+            "Don't pipe raw error.message into user-facing notifications. Use humanizeAppError(error) from @shared/utils/errorMessage to produce a friendly title and body, and stash the raw message in a 'Copy details' action. See #6050.",
+        },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -159,14 +159,22 @@ export default tseslint.config(
             "Don't use `void window.electron.X()` for fire-and-forget IPC — wrap the promise in safeFireAndForget(promise, { context }) from @/utils/safeFireAndForget so rejections reach reportRendererGlobalError with call-site context.",
         },
         {
-          // Block raw `error.message` / `err.message` / `e.message` inside
-          // notify({...}) and addNotification({...}) message properties.
-          // These calls go to user-facing toasts; raw library messages leak
-          // jargon (paths, errno strings, internal source IDs). Use
-          // humanizeAppError() from @shared/utils/errorMessage instead.
+          // Block raw `error.message` / `err.message` / `e.message` /
+          // `result.error.message` inside notify({...}) /
+          // addNotification({...}) message properties. These calls go to
+          // user-facing toasts; raw library messages leak jargon (paths,
+          // errno strings, internal source IDs). Use humanizeAppError()
+          // from @shared/utils/errorMessage instead.
+          //
+          // The selector must match both bare-identifier calls
+          // (`notify({...})`) and member-call patterns
+          // (`useNotificationStore.getState().addNotification({...})`),
+          // hence the `:matches()` over `callee.name` and
+          // `callee.property.name`. The inner MemberExpression matches both
+          // single-hop (`error.message`) and tail-of-chain (`x.error.message`).
           // See issue #6050.
           selector:
-            "CallExpression[callee.name=/^(notify|addNotification)$/] ObjectExpression > Property[key.name='message'] MemberExpression[object.name=/^(error|err|e)$/][property.name='message']",
+            "CallExpression:matches([callee.name=/^(notify|addNotification)$/], [callee.property.name=/^(notify|addNotification)$/]) ObjectExpression > Property[key.name='message'] MemberExpression[property.name='message']:matches([object.name=/^(error|err|e)$/], [object.property.name=/^(error|err|e)$/])",
           message:
             "Don't pipe raw error.message into user-facing notifications. Use humanizeAppError(error) from @shared/utils/errorMessage to produce a friendly title and body, and stash the raw message in a 'Copy details' action. See #6050.",
         },

--- a/shared/utils/__tests__/errorMessage.test.ts
+++ b/shared/utils/__tests__/errorMessage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatErrorMessage } from "../errorMessage.js";
+import { formatErrorMessage, humanizeAppError } from "../errorMessage.js";
+import type { ErrorRecord, ErrorType, GitOperationReason } from "../../types/ipc/errors.js";
 
 describe("formatErrorMessage", () => {
   const FALLBACK = "Couldn't load thing";
@@ -105,6 +106,133 @@ describe("formatErrorMessage", () => {
         }
       );
       expect(formatErrorMessage(hostile, FALLBACK)).toBe(FALLBACK);
+    });
+  });
+});
+
+describe("humanizeAppError", () => {
+  type HumanizeInput = Pick<
+    ErrorRecord,
+    "type" | "source" | "message" | "gitReason" | "recoveryHint"
+  >;
+
+  const baseError = (overrides: Partial<HumanizeInput> = {}): HumanizeInput => ({
+    type: "unknown",
+    message: "raw library output",
+    ...overrides,
+  });
+
+  describe("ErrorType fallbacks", () => {
+    const cases: Array<[ErrorType, string]> = [
+      ["git", "Git operation failed"],
+      ["process", "Background process failed"],
+      ["filesystem", "File operation failed"],
+      ["network", "Network problem"],
+      ["config", "Configuration problem"],
+      ["unknown", "Something went wrong"],
+    ];
+
+    it.each(cases)("returns the %s fallback title and body", (type, expectedTitle) => {
+      const result = humanizeAppError(baseError({ type }));
+      expect(result.title).toBe(expectedTitle);
+      expect(result.body.length).toBeGreaterThan(0);
+    });
+
+    it("falls through to 'unknown' for a runtime-unknown type value", () => {
+      // Force-cast: structured-clone could in theory deliver a string outside
+      // the union (older main + newer renderer, or vice versa).
+      const result = humanizeAppError(
+        baseError({ type: "totally-new-category" as unknown as ErrorType })
+      );
+      expect(result.title).toBe("Something went wrong");
+    });
+
+    it("never leaks raw error.message into the body", () => {
+      const result = humanizeAppError(
+        baseError({
+          type: "filesystem",
+          message: "EBUSY: resource busy or locked /Users/me/secret/path",
+        })
+      );
+      expect(result.body).not.toContain("EBUSY");
+      expect(result.body).not.toContain("/Users/me/secret/path");
+    });
+
+    it("never uses error.source as the title", () => {
+      const result = humanizeAppError(baseError({ type: "process", source: "WorktreeMonitor" }));
+      expect(result.title).not.toContain("WorktreeMonitor");
+    });
+  });
+
+  describe("gitReason mapping", () => {
+    const reasons: GitOperationReason[] = [
+      "auth-failed",
+      "network-unavailable",
+      "repository-not-found",
+      "not-a-repository",
+      "dubious-ownership",
+      "config-missing",
+      "worktree-dirty",
+      "conflict-unresolved",
+      "push-rejected-outdated",
+      "push-rejected-policy",
+      "pathspec-invalid",
+      "lfs-missing",
+      "lfs-quota-exceeded",
+      "hook-rejected",
+      "system-io-error",
+    ];
+
+    it.each(reasons)("returns a friendly title and instruction body for %s", (reason) => {
+      const result = humanizeAppError(baseError({ type: "git", gitReason: reason }));
+      expect(result.title.length).toBeGreaterThan(0);
+      expect(result.title).not.toBe("Git operation failed");
+      expect(result.body.length).toBeGreaterThan(0);
+    });
+
+    it("uses generic git fallback when gitReason is 'unknown'", () => {
+      const result = humanizeAppError(baseError({ type: "git", gitReason: "unknown" }));
+      expect(result.title).toBe("Git operation failed");
+    });
+
+    it("uses generic git fallback when gitReason is undefined", () => {
+      const result = humanizeAppError(baseError({ type: "git" }));
+      expect(result.title).toBe("Git operation failed");
+    });
+
+    it("specific git body matches the recovery hint copy", () => {
+      const result = humanizeAppError(baseError({ type: "git", gitReason: "auth-failed" }));
+      expect(result.title).toBe("Git authentication failed");
+      expect(result.body).toBe("Check your Git credentials or SSH key configuration.");
+    });
+  });
+
+  describe("recoveryHint integration", () => {
+    it("uses recoveryHint as the body when no gitReason mapping wins", () => {
+      const result = humanizeAppError(
+        baseError({
+          type: "filesystem",
+          recoveryHint: "Free up disk space and retry the operation.",
+        })
+      );
+      expect(result.title).toBe("File operation failed");
+      expect(result.body).toBe("Free up disk space and retry the operation.");
+    });
+
+    it("ignores empty recoveryHint and keeps the type fallback body", () => {
+      const result = humanizeAppError(baseError({ type: "config", recoveryHint: "" }));
+      expect(result.body).toBe("Daintree found a problem with the current configuration.");
+    });
+
+    it("gitReason wins over recoveryHint when both are present", () => {
+      const result = humanizeAppError(
+        baseError({
+          type: "git",
+          gitReason: "auth-failed",
+          recoveryHint: "Should be ignored.",
+        })
+      );
+      expect(result.body).toBe("Check your Git credentials or SSH key configuration.");
     });
   });
 });

--- a/shared/utils/__tests__/errorMessage.test.ts
+++ b/shared/utils/__tests__/errorMessage.test.ts
@@ -200,6 +200,20 @@ describe("humanizeAppError", () => {
       expect(result.title).toBe("Git operation failed");
     });
 
+    it("falls back to generic git title when gitReason is an out-of-union string (version skew)", () => {
+      // Older renderer + newer main process can deliver a future reason code
+      // not yet known to the renderer. The `satisfies` check is compile-time
+      // only; the runtime lookup must still produce a real title.
+      const result = humanizeAppError(
+        baseError({
+          type: "git",
+          gitReason: "future-reason-2027" as unknown as GitOperationReason,
+        })
+      );
+      expect(result.title).toBe("Git operation failed");
+      expect(result.body.length).toBeGreaterThan(0);
+    });
+
     it("specific git body matches the recovery hint copy", () => {
       const result = humanizeAppError(baseError({ type: "git", gitReason: "auth-failed" }));
       expect(result.title).toBe("Git authentication failed");

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -1,3 +1,6 @@
+import type { ErrorRecord, ErrorType, GitOperationReason } from "../types/ipc/errors.js";
+import { getGitRecoveryHint } from "./gitOperationErrors.js";
+
 /**
  * Extract a human-readable message from an unknown caught error, falling back
  * to a caller-supplied domain string for opaque or non-Error values.
@@ -23,5 +26,105 @@ export function formatErrorMessage(error: unknown, fallback: string): string {
       // Proxies with throwing `has` traps or accessor errors fall back.
     }
   }
+  return fallback;
+}
+
+/**
+ * Friendly user-facing copy keyed by `ErrorType`. Used as the fallback when
+ * no more-specific mapping (e.g. by `gitReason`) applies. The `satisfies`
+ * clause forces compile-time exhaustiveness across the `ErrorType` union.
+ */
+const ERROR_TYPE_FALLBACKS = {
+  git: {
+    title: "Git operation failed",
+    body: "A git operation didn't complete. Open the panel for details, or try again.",
+  },
+  process: {
+    title: "Background process failed",
+    body: "A background process couldn't complete the requested operation.",
+  },
+  filesystem: {
+    title: "File operation failed",
+    body: "Daintree couldn't read or update the requested files.",
+  },
+  network: {
+    title: "Network problem",
+    body: "Daintree couldn't reach the remote service. Check your connection and try again.",
+  },
+  config: {
+    title: "Configuration problem",
+    body: "Daintree found a problem with the current configuration.",
+  },
+  validation: {
+    title: "Invalid input",
+    body: "Daintree received invalid input for this operation.",
+  },
+  unknown: {
+    title: "Something went wrong",
+    body: "Daintree hit an unexpected problem. Open the panel for details.",
+  },
+} as const satisfies Record<ErrorType, { title: string; body: string }>;
+
+/**
+ * Short user-facing titles keyed by `GitOperationReason`. Bodies for known
+ * reasons come from `getGitRecoveryHint()` which already returns
+ * instruction-grade copy. The `satisfies` clause enforces full coverage.
+ */
+const GIT_REASON_TITLES = {
+  "auth-failed": "Git authentication failed",
+  "network-unavailable": "Couldn't reach the remote",
+  "repository-not-found": "Repository not found",
+  "not-a-repository": "Not a git repository",
+  "dubious-ownership": "Repository ownership not trusted",
+  "config-missing": "Git configuration incomplete",
+  "worktree-dirty": "Local changes would be overwritten",
+  "conflict-unresolved": "Merge conflicts unresolved",
+  "push-rejected-outdated": "Push rejected — branch out of date",
+  "push-rejected-policy": "Push blocked by repository policy",
+  "pathspec-invalid": "Branch or path not found",
+  "lfs-missing": "Git LFS object missing",
+  "lfs-quota-exceeded": "Git LFS quota exceeded",
+  "hook-rejected": "Push rejected by server hook",
+  "system-io-error": "Git filesystem error",
+  unknown: ERROR_TYPE_FALLBACKS.git.title,
+} as const satisfies Record<GitOperationReason, string>;
+
+/**
+ * Translate an `ErrorRecord` into user-facing toast copy.
+ *
+ * The renderer should never pipe `error.source` (an internal service
+ * identifier such as `"WorktreeMonitor"` or `"main-process"`) or raw library
+ * messages (`"EBUSY: resource busy or locked /Users/.../foo"`) into a toast.
+ * This function is the single translation point that maps the structured
+ * `ErrorRecord` into a friendly `{ title, body }` pair.
+ *
+ * Resolution order:
+ *   1. `gitReason` (when present and not `"unknown"`) → `GIT_REASON_TITLES`
+ *      title + `getGitRecoveryHint()` body, falling back to the `git`
+ *      fallback body when the hint is undefined.
+ *   2. `recoveryHint` (when present) → `ErrorType` fallback title + the
+ *      hint as the body.
+ *   3. `ErrorType` fallback table.
+ *
+ * Raw `error.message` is never used as the toast body — it's reserved for
+ * the structured Copy details payload assembled at the call site.
+ */
+export function humanizeAppError(
+  error: Pick<ErrorRecord, "type" | "source" | "message" | "gitReason" | "recoveryHint">
+): { title: string; body: string } {
+  if (error.gitReason && error.gitReason !== "unknown") {
+    const hint = getGitRecoveryHint(error.gitReason);
+    return {
+      title: GIT_REASON_TITLES[error.gitReason],
+      body: hint ?? ERROR_TYPE_FALLBACKS.git.body,
+    };
+  }
+
+  const fallback = ERROR_TYPE_FALLBACKS[error.type] ?? ERROR_TYPE_FALLBACKS.unknown;
+
+  if (error.recoveryHint && error.recoveryHint.length > 0) {
+    return { title: fallback.title, body: error.recoveryHint };
+  }
+
   return fallback;
 }

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -113,9 +113,14 @@ export function humanizeAppError(
   error: Pick<ErrorRecord, "type" | "source" | "message" | "gitReason" | "recoveryHint">
 ): { title: string; body: string } {
   if (error.gitReason && error.gitReason !== "unknown") {
+    // The `satisfies` constraint is compile-time only; an out-of-union string
+    // can still arrive via IPC during version skew (newer main, older
+    // renderer). Fall back to the generic git title so the toast never
+    // renders with `title: undefined`.
+    const reasonTitle = GIT_REASON_TITLES[error.gitReason];
     const hint = getGitRecoveryHint(error.gitReason);
     return {
-      title: GIT_REASON_TITLES[error.gitReason],
+      title: reasonTitle ?? ERROR_TYPE_FALLBACKS.git.title,
       body: hint ?? ERROR_TYPE_FALLBACKS.git.body,
     };
   }

--- a/src/hooks/__tests__/useErrors.test.ts
+++ b/src/hooks/__tests__/useErrors.test.ts
@@ -287,3 +287,140 @@ describe("useErrors — escalation of persistent transient errors", () => {
     unmount();
   });
 });
+
+describe("useErrors — humanized toast payload", () => {
+  let capturedOnError: (error: ErrorRecord) => void;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "electron", {
+      value: { errors: {} },
+      writable: true,
+      configurable: true,
+    });
+
+    onErrorMock.mockImplementation((cb: (error: ErrorRecord) => void) => {
+      capturedOnError = cb;
+      return vi.fn();
+    });
+    getPendingMock.mockResolvedValue([]);
+    notifyMock.mockClear();
+    notifyMock.mockReturnValue("toast-id");
+    shouldEscalateMock.mockReset();
+    shouldEscalateMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not pass raw error.source as the toast title", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "filesystem",
+      source: "WorktreeMonitor",
+      message: "EBUSY: resource busy or locked",
+      isTransient: false,
+    });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.title).not.toContain("WorktreeMonitor");
+    expect(payload.title).toBe("File operation failed");
+    unmount();
+  });
+
+  it("does not pass raw error.message as the toast body", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "filesystem",
+      source: "WorktreeMonitor",
+      message: "EBUSY: resource busy or locked /Users/me/proj",
+      isTransient: false,
+    });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.message).not.toContain("EBUSY");
+    expect(payload.message).not.toContain("/Users/me/proj");
+    unmount();
+  });
+
+  it("uses gitReason-specific copy when present", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "git",
+      gitReason: "auth-failed",
+      message: "fatal: Authentication failed for 'https://...'",
+      isTransient: false,
+    });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.title).toBe("Git authentication failed");
+    expect(payload.message).toBe("Check your Git credentials or SSH key configuration.");
+    unmount();
+  });
+
+  it("attaches a 'Copy details' action for high-priority errors", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({ type: "process", isTransient: false });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.action).toBeDefined();
+    expect(payload.action.label).toBe("Copy details");
+    unmount();
+  });
+
+  it("omits the 'Copy details' action for low-priority errors", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({ type: "network", isTransient: true });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.action).toBeUndefined();
+    unmount();
+  });
+
+  it("Copy details action writes the raw payload to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "filesystem",
+      source: "WorktreeMonitor",
+      message: "EBUSY: resource busy",
+      details: "stack trace goes here",
+      correlationId: "corr-1",
+      isTransient: false,
+    });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    payload.action.onClick();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const written = writeText.mock.calls[0]?.[0] ?? "";
+    expect(written).toContain("WorktreeMonitor");
+    expect(written).toContain("EBUSY: resource busy");
+    expect(written).toContain("corr-1");
+    unmount();
+  });
+});

--- a/src/hooks/__tests__/useErrors.test.ts
+++ b/src/hooks/__tests__/useErrors.test.ts
@@ -409,6 +409,7 @@ describe("useErrors — humanized toast payload", () => {
       message: "EBUSY: resource busy",
       details: "stack trace goes here",
       correlationId: "corr-1",
+      context: { worktreeId: "wt-42", filePath: "/tmp/proj/src/foo.ts" },
       isTransient: false,
     });
     act(() => capturedOnError(error));
@@ -421,6 +422,50 @@ describe("useErrors — humanized toast payload", () => {
     expect(written).toContain("WorktreeMonitor");
     expect(written).toContain("EBUSY: resource busy");
     expect(written).toContain("corr-1");
+    expect(written).toContain("wt-42");
+    expect(written).toContain("/tmp/proj/src/foo.ts");
+    unmount();
+  });
+
+  it("does not leak token-bearing or path-bearing raw messages into title or body", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "git",
+      gitReason: "auth-failed",
+      source: "GitHubService",
+      message: "fatal: Authentication failed for 'https://ghp_secrettoken@github.com/org/repo'",
+      isTransient: false,
+    });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(payload.title).not.toContain("ghp_secrettoken");
+    expect(payload.title).not.toContain("github.com");
+    expect(payload.title).not.toContain("fatal:");
+    expect(payload.message).not.toContain("ghp_secrettoken");
+    expect(payload.message).not.toContain("github.com");
+    expect(payload.message).not.toContain("fatal:");
+    unmount();
+  });
+
+  it("clipboard rejection does not throw out of the action handler", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard blocked"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({ type: "process", isTransient: false });
+    act(() => capturedOnError(error));
+
+    const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
+    expect(() => payload.action.onClick()).not.toThrow();
     unmount();
   });
 });

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -7,6 +7,7 @@ import type { ActionManifestEntry } from "@shared/types/actions";
 import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { extractAcronym, rankActionMatches } from "@/lib/actionPaletteSearch";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useSearchablePalette } from "./useSearchablePalette";
 
 export interface ActionPaletteItem {
@@ -152,7 +153,7 @@ export function useActionPalette(): UseActionPaletteReturn {
             notify({
               type: "error",
               title: "Action Failed",
-              message: result.error.message,
+              message: formatErrorMessage(result.error, "Action failed."),
             });
           }
         })

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -27,6 +27,7 @@ function buildCopyDetailsAction(error: ErrorRecord): NotificationAction {
           gitReason: error.gitReason,
           recoveryHint: error.recoveryHint,
           correlationId: error.correlationId,
+          context: error.context,
           details: error.details,
         },
         null,

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -4,13 +4,48 @@ import { isElectronAvailable } from "./useElectron";
 import { errorsClient } from "@/clients";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { notify, shouldEscalateTransientError, consumeEscalation } from "@/lib/notify";
-import type { NotificationPriority } from "@/store/notificationStore";
+import type { NotificationAction, NotificationPriority } from "@/store/notificationStore";
+import { humanizeAppError } from "@shared/utils/errorMessage";
 
 export function getErrorPriority(
   error: Pick<ErrorRecord, "type" | "isTransient">
 ): NotificationPriority {
   if (error.isTransient) return "low";
   return "high";
+}
+
+function buildCopyDetailsAction(error: ErrorRecord): NotificationAction {
+  return {
+    label: "Copy details",
+    variant: "secondary",
+    onClick: () => {
+      const payload = JSON.stringify(
+        {
+          type: error.type,
+          source: error.source,
+          message: error.message,
+          gitReason: error.gitReason,
+          recoveryHint: error.recoveryHint,
+          correlationId: error.correlationId,
+          details: error.details,
+        },
+        null,
+        2
+      );
+      try {
+        const result = navigator.clipboard?.writeText(payload);
+        if (result && typeof result.catch === "function") {
+          result.catch(() => {
+            // Clipboard writes can reject in non-HTTPS or unfocused contexts.
+            // Failure is non-fatal — the toast already showed the user the
+            // friendly summary; the raw payload is recoverable from logs.
+          });
+        }
+      } catch {
+        // navigator.clipboard may be undefined in restricted contexts.
+      }
+    },
+  };
 }
 
 function routeError(error: ErrorRecord): void {
@@ -29,14 +64,23 @@ function routeError(error: ErrorRecord): void {
     fromPreviousSession: error.fromPreviousSession,
     correlationId: error.correlationId,
     recoveryHint: error.recoveryHint,
+    gitReason: error.gitReason,
   });
+
+  const { title, body } = humanizeAppError(error);
+
+  // "Copy details" is omitted for low-priority errors: those route to the
+  // history inbox without a toast, so the action would never be reachable —
+  // and notify() auto-promotes action-bearing toasts to sticky.
+  const action = priority === "low" ? undefined : buildCopyDetailsAction(error);
 
   const toastId = notify({
     type: "error",
-    title: error.source,
-    message: error.message,
+    title,
+    message: body,
     correlationId: error.correlationId,
     priority,
+    action,
   });
 
   if (escalated && toastId) {

--- a/src/hooks/useQuickCreatePalette.ts
+++ b/src/hooks/useQuickCreatePalette.ts
@@ -186,7 +186,7 @@ export function useQuickCreatePalette(): UseQuickCreatePaletteReturn {
             notify({
               type: "error",
               title: "Creation Failed",
-              message: result.error.message,
+              message: formatErrorMessage(result.error, "Failed to create worktree"),
             });
           }
         } catch (error) {

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -1,4 +1,5 @@
 import { create, type StateCreator } from "zustand";
+import type { GitOperationReason } from "@shared/types/ipc/errors";
 
 export type ErrorType =
   | "git"
@@ -32,6 +33,8 @@ export interface ErrorRecord {
   correlationId?: string;
   recoveryHint?: string;
   retryProgress?: { attempt: number; maxAttempts: number };
+  /** Classified reason when this error originated from a git operation */
+  gitReason?: GitOperationReason;
 }
 
 interface ErrorStore {


### PR DESCRIPTION
## Summary

- `routeError()` was piping `error.source` (an internal service ID like `"WorktreeMonitor"`) as the toast title and the raw library message as the body. Users were seeing errno strings, internal paths, and opaque identifiers instead of readable copy.
- Adds `humanizeAppError()` to `@shared/utils/errorMessage` — a translation function keyed on `ErrorType`, `GitOperationReason`, and `recoveryHint` that produces a friendly `{ title, body }` pair. Resolves by structured data, never by raw message string.
- Adds a "Copy details" action to error toasts (skipped for `priority: "low"` since those route to the inbox and would auto-promote to sticky). Structured payload includes `source`, `message`, `gitReason`, and `correlationId` so the raw detail is still accessible for support without leaking into the primary copy.
- ESLint rule added to `eslint.config.js` that flags raw `.message` access on error objects inside `notify()` / `addNotification()` calls — prevents regression without manual review.

Resolves #6050

## Changes

- `shared/utils/errorMessage.ts` — `humanizeAppError()`, `ERROR_TYPE_FALLBACKS` table (exhaustive across `ErrorType`), `GIT_REASON_TITLES` table (exhaustive across `GitOperationReason`)
- `src/hooks/useErrors.ts` — `routeError()` now calls `humanizeAppError()` and attaches `buildCopyDetailsAction()` for non-low-priority errors
- `eslint.config.js` — no-restricted-syntax rule blocking raw `error.message` in notification calls
- Tests: `shared/utils/__tests__/errorMessage.test.ts`, `src/hooks/__tests__/useErrors.test.ts`

## Testing

- Unit tests cover all `ErrorType` fallbacks, all `GitOperationReason` mappings, `recoveryHint` override path, version-skew safety (unknown reason string falls back cleanly), and the `routeError` integration — title/body come from `humanizeAppError()`, "Copy details" present on high-priority errors, absent on low-priority.
- ESLint rule verified with a targeted test case in a throwaway branch.