### PR TITLE
feat(cli-availability): detect and surface duplicate agent CLI installs

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -1,6 +1,6 @@
 import { execFile, execFileSync } from "child_process";
 import { access, constants } from "fs/promises";
-import { delimiter, join } from "path";
+import { delimiter, dirname, join } from "path";
 import { homedir } from "os";
 import type {
   CliAvailability,
@@ -15,12 +15,21 @@ import {
   type AgentAuthCheck,
 } from "../../shared/config/agentRegistry.js";
 import { refreshPath, expandWindowsEnvVars } from "../setup/environment.js";
+import { store } from "../store.js";
+import { CHANNELS } from "../ipc/channels.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
 
 interface ProbeSuccess {
   status: "found";
   path: string;
   via: AgentCliProbeSource;
   wslDistro?: string;
+  /**
+   * All resolved paths from a shell probe (`which -a` on Unix, `where.exe`
+   * on Windows), deduplicated by directory. Populated only when the probe
+   * succeeded via `which`; first entry equals {@link ProbeSuccess.path}.
+   */
+  allPaths?: string[];
 }
 
 interface ProbeMissing {
@@ -45,6 +54,27 @@ interface AgentCheckOutcome {
 }
 
 const SECURITY_ERROR_CODES = new Set(["EACCES", "EPERM"]);
+
+/**
+ * Collapse PATH-resolved binary candidates that live in the same install
+ * directory. `where.exe` returns both `claude.cmd` and `claude.exe` for a
+ * single npm-global install — counting them as two installations would
+ * false-positive the duplicate-detection notification. Comparison is
+ * case-insensitive on Windows to mirror NTFS path semantics
+ * (matches `electron/setup/environment.ts:128`).
+ */
+function dedupePathsByDirectory(paths: string[], isWindows: boolean): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const p of paths) {
+    const dir = dirname(p);
+    const key = isWindows ? dir.toLowerCase() : dir;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p);
+  }
+  return out;
+}
 
 export class CliAvailabilityService {
   private static readonly CHECK_TIMEOUT_MS = 10_000;
@@ -144,6 +174,7 @@ export class CliAvailabilityService {
         if (this.checkId === currentCheckId) {
           this.availability = availability;
           this.details = details;
+          this.notifyDuplicateInstalls(outcomeEntries, entries);
         }
 
         return availability;
@@ -230,6 +261,12 @@ export class CliAvailabilityService {
         resolvedPath: probe.path,
         via: probe.via,
         authConfirmed,
+        // Only set when the shell probe surfaced multiple PATH matches —
+        // single-install probes leave this undefined so consumers can
+        // distinguish "not measured" from "exactly one install".
+        ...(probe.allPaths && probe.allPaths.length > 1
+          ? { allResolvedPaths: probe.allPaths }
+          : {}),
       },
     };
   }
@@ -421,19 +458,38 @@ export class CliAvailabilityService {
   private probeViaShell(command: string): Promise<ProbeResult> {
     return new Promise((resolve) => {
       setImmediate(() => {
-        const checkCmd = process.platform === "win32" ? "where" : "which";
+        const isWindows = process.platform === "win32";
+        const checkCmd = isWindows ? "where" : "which";
+        // `where.exe` already prints every PATH match; `which` defaults to
+        // the first hit, so request all matches via `-a` to drive duplicate
+        // detection (#6054). BusyBox/minimal `which` builds without `-a`
+        // throw a non-zero exit, which the catch below treats as missing —
+        // duplicate detection silently degrades, the layered fallback
+        // probes still run, and single-install lookup is unaffected.
+        const args = isWindows ? [command] : ["-a", command];
         try {
-          // Capture stdout to expose the resolved absolute path in
-          // diagnostics. `where` may print multiple candidates on Windows
-          // (one per line) — the first line is the one `CreateProcess`
-          // resolves to, so take that.
-          const buffer = execFileSync(checkCmd, [command], {
+          const buffer = execFileSync(checkCmd, args, {
             stdio: ["ignore", "pipe", "ignore"],
             timeout: CliAvailabilityService.WHICH_TIMEOUT_MS,
           });
           const output = buffer.toString("utf8").trim();
-          const resolved = output.split(/\r?\n/)[0]?.trim() || command;
-          resolve({ status: "found", path: resolved, via: "which" });
+          const lines = output
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+          if (lines.length === 0) {
+            // `where.exe` can exit 0 with empty stdout in odd environments;
+            // fall back to the bare command so callers always have a path.
+            resolve({ status: "found", path: command, via: "which", allPaths: [command] });
+            return;
+          }
+          const allPaths = dedupePathsByDirectory(lines, isWindows);
+          resolve({
+            status: "found",
+            path: allPaths[0],
+            via: "which",
+            allPaths,
+          });
         } catch (err) {
           const code = (err as NodeJS.ErrnoException | undefined)?.code;
           // EACCES / EPERM from which/where itself is rare — most endpoint
@@ -652,5 +708,69 @@ export class CliAvailabilityService {
       return null;
     }
     return expanded;
+  }
+
+  /**
+   * Surface a one-time toast per agent when the shell probe found multiple
+   * PATH-resolved binaries (#6054). Multiple installs typically come from a
+   * mix of Homebrew, npm-global, and native installer paths and can leave
+   * the user confused about which copy is being launched.
+   *
+   * Persistence reuses `orchestrationMilestones` keyed by agent ID, so the
+   * notification fires exactly once per agent across app restarts. A user
+   * who consolidates their installs and triggers a re-check will not see
+   * the toast again.
+   */
+  private notifyDuplicateInstalls(
+    outcomeEntries: [string, AgentCheckOutcome][],
+    registryEntries: [string, AgentConfig][]
+  ): void {
+    const configById = new Map(registryEntries);
+    let milestones = store.get("orchestrationMilestones") ?? {};
+    let dirty = false;
+
+    for (const [agentId, outcome] of outcomeEntries) {
+      const paths = outcome.detail.allResolvedPaths;
+      if (!paths || paths.length <= 1) continue;
+
+      const milestoneKey = `duplicate-cli-warning:${agentId}`;
+      if (milestones[milestoneKey]) continue;
+
+      const config = configById.get(agentId);
+      const agentName = config?.name ?? agentId;
+      const [active, ...others] = paths;
+      const PREVIEW_LIMIT = 2;
+      const preview = others.slice(0, PREVIEW_LIMIT).join(", ");
+      const remainder = others.length - PREVIEW_LIMIT;
+      const alsoFound = remainder > 0 ? `${preview}, and ${remainder} more` : preview;
+
+      try {
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+          type: "warning",
+          title: `Multiple ${agentName} installations found`,
+          message: `Active: ${active}. Also found: ${alsoFound}. Use the native installer and remove legacy npm or Homebrew copies for the most reliable launches.`,
+        });
+      } catch (err) {
+        console.warn(
+          `[CliAvailabilityService] Failed to broadcast duplicate-install toast for ${agentId}:`,
+          err
+        );
+        continue;
+      }
+
+      milestones = { ...milestones, [milestoneKey]: true };
+      dirty = true;
+    }
+
+    if (dirty) {
+      try {
+        store.set("orchestrationMilestones", milestones);
+      } catch (err) {
+        console.warn(
+          "[CliAvailabilityService] Failed to persist duplicate-install milestone:",
+          err
+        );
+      }
+    }
   }
 }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -460,53 +460,84 @@ export class CliAvailabilityService {
       setImmediate(() => {
         const isWindows = process.platform === "win32";
         const checkCmd = isWindows ? "where" : "which";
-        // `where.exe` already prints every PATH match; `which` defaults to
-        // the first hit, so request all matches via `-a` to drive duplicate
-        // detection (#6054). BusyBox/minimal `which` builds without `-a`
-        // throw a non-zero exit, which the catch below treats as missing —
-        // duplicate detection silently degrades, the layered fallback
-        // probes still run, and single-install lookup is unaffected.
-        const args = isWindows ? [command] : ["-a", command];
-        try {
-          const buffer = execFileSync(checkCmd, args, {
-            stdio: ["ignore", "pipe", "ignore"],
-            timeout: CliAvailabilityService.WHICH_TIMEOUT_MS,
-          });
-          const output = buffer.toString("utf8").trim();
-          const lines = output
-            .split(/\r?\n/)
-            .map((line) => line.trim())
-            .filter(Boolean);
-          if (lines.length === 0) {
-            // `where.exe` can exit 0 with empty stdout in odd environments;
-            // fall back to the bare command so callers always have a path.
-            resolve({ status: "found", path: command, via: "which", allPaths: [command] });
-            return;
+        // `where.exe` already prints every PATH match. On Unix, request all
+        // matches via `which -a` to drive duplicate detection (#6054). When
+        // `-a` is rejected by a minimal `which` (e.g. older BusyBox), retry
+        // without the flag so duplicate detection degrades to a single-path
+        // lookup rather than reporting the agent as missing.
+        const runWhich = (
+          extraArgs: string[]
+        ): { ok: true; lines: string[] } | { ok: false; err: unknown } => {
+          try {
+            const buffer = execFileSync(checkCmd, [...extraArgs, command], {
+              stdio: ["ignore", "pipe", "ignore"],
+              timeout: CliAvailabilityService.WHICH_TIMEOUT_MS,
+            });
+            const output = buffer.toString("utf8").trim();
+            const lines = output
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter(Boolean);
+            return { ok: true, lines };
+          } catch (err) {
+            return { ok: false, err };
           }
-          const allPaths = dedupePathsByDirectory(lines, isWindows);
-          resolve({
-            status: "found",
-            path: allPaths[0],
-            via: "which",
-            allPaths,
-          });
-        } catch (err) {
+        };
+
+        const classifyError = (err: unknown): ProbeResult | null => {
           const code = (err as NodeJS.ErrnoException | undefined)?.code;
           // EACCES / EPERM from which/where itself is rare — most endpoint
           // security blocks surface on the spawn attempt. Still, when they
           // do, the binary clearly exists on disk (otherwise we'd have
           // ENOENT) so "blocked" is the correct classification.
           if (typeof code === "string" && SECURITY_ERROR_CODES.has(code)) {
-            resolve({
+            return {
               status: "blocked",
               reason: "security",
               via: "which",
               message: `${checkCmd} "${command}" failed with ${code} — likely blocked by security software or missing execute permission`,
-            });
+            };
+          }
+          return null;
+        };
+
+        const primary = runWhich(isWindows ? [] : ["-a"]);
+        if (primary.ok) {
+          if (primary.lines.length === 0) {
+            // Some shells exit 0 with empty stdout. Preserve the historical
+            // contract: fall back to the bare command so the binary is still
+            // launchable via PATH lookup at spawn time.
+            resolve({ status: "found", path: command, via: "which" });
             return;
           }
-          resolve({ status: "missing" });
+          const allPaths = dedupePathsByDirectory(primary.lines, isWindows);
+          resolve({ status: "found", path: allPaths[0], via: "which", allPaths });
+          return;
         }
+
+        // Non-zero exit. On Unix this can be BusyBox/minimal `which`
+        // rejecting `-a`; retry without the flag so a real install isn't
+        // misreported as missing. Skip for security errors so the blocked
+        // verdict surfaces directly.
+        const primaryBlocked = classifyError(primary.err);
+        if (primaryBlocked) {
+          resolve(primaryBlocked);
+          return;
+        }
+        if (!isWindows) {
+          const fallback = runWhich([]);
+          if (fallback.ok) {
+            const path = fallback.lines[0] ?? command;
+            resolve({ status: "found", path, via: "which" });
+            return;
+          }
+          const fallbackBlocked = classifyError(fallback.err);
+          if (fallbackBlocked) {
+            resolve(fallbackBlocked);
+            return;
+          }
+        }
+        resolve({ status: "missing" });
       });
     });
   }
@@ -748,7 +779,7 @@ export class CliAvailabilityService {
         broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
           type: "warning",
           title: `Multiple ${agentName} installations found`,
-          message: `Active: ${active}. Also found: ${alsoFound}. Use the native installer and remove legacy npm or Homebrew copies for the most reliable launches.`,
+          message: `Active: ${active}. Also found: ${alsoFound}. Pick one install method and remove the others so the most up-to-date version launches.`,
         });
       } catch (err) {
         console.warn(

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -8,6 +8,8 @@ import { join } from "path";
 import { CliAvailabilityService } from "../CliAvailabilityService.js";
 import { execFile, execFileSync } from "child_process";
 import { refreshPath } from "../../setup/environment.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
+import { CHANNELS } from "../../ipc/channels.js";
 
 // Mock child_process. Both `execFileSync` (sync shell probe) and `execFile`
 // (async npm-global / WSL probes) are used by the service — mock both or
@@ -46,6 +48,42 @@ vi.mock("fs/promises", () => ({
   constants: { R_OK: 4, X_OK: 1 },
 }));
 
+// Mock the electron-store singleton so duplicate-detection persistence
+// stays in-memory across the test run. Each test re-seeds via beforeEach.
+const { storeBackingMap } = vi.hoisted(() => ({
+  storeBackingMap: new Map<string, unknown>(),
+}));
+vi.mock("../../store.js", () => ({
+  store: {
+    get: vi.fn((key: string) => storeBackingMap.get(key)),
+    set: vi.fn((key: string, value: unknown) => {
+      storeBackingMap.set(key, value);
+    }),
+    delete: vi.fn((key: string) => {
+      storeBackingMap.delete(key);
+    }),
+    has: vi.fn((key: string) => storeBackingMap.has(key)),
+  },
+}));
+
+// Mock the IPC broadcast so duplicate-detection emits can be asserted
+// without spinning up real BrowserWindows. The CHANNELS module is real
+// (no mock) — the duplicate-emit code uses CHANNELS.NOTIFICATION_SHOW_TOAST.
+vi.mock("../../ipc/utils.js", () => ({
+  broadcastToRenderer: vi.fn(),
+}));
+
+/**
+ * Extract the command name from a `which`/`where` args array. On Unix the
+ * service now invokes `which -a <cmd>` (#6054), so the command is the last
+ * element; on Windows it remains `where <cmd>`. The command always sits at
+ * the tail of the args array, so this works on both platforms.
+ */
+const cmdOf = (args: unknown): string | undefined => {
+  if (!Array.isArray(args) || args.length === 0) return undefined;
+  return args[args.length - 1] as string;
+};
+
 describe("CliAvailabilityService", () => {
   let service: CliAvailabilityService;
   const mockedExecFileSync = vi.mocked(execFileSync);
@@ -74,6 +112,9 @@ describe("CliAvailabilityService", () => {
     }
 
     service = new CliAvailabilityService();
+    // Reset the in-memory store between tests so duplicate-cli milestone
+    // flags don't leak across cases.
+    storeBackingMap.clear();
     vi.clearAllMocks();
     // Re-establish default "file not found" behavior for fs access. A prior
     // test may have set mockResolvedValue on the same vi.fn(), and
@@ -185,7 +226,7 @@ describe("CliAvailabilityService", () => {
 
       // Only claude binary found
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           return Buffer.from("/usr/local/bin/claude");
         }
         throw new Error("Command not found");
@@ -219,7 +260,7 @@ describe("CliAvailabilityService", () => {
       process.env.DAINTREE_CLI_PATH_PREPEND = "/tmp/daintree-fake-bin";
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           return Buffer.from("/usr/local/bin/claude");
         }
         throw new Error("Command not found");
@@ -235,7 +276,11 @@ describe("CliAvailabilityService", () => {
 
       expect(result.claude).toBe("ready");
       expect(service.getDetails()?.claude?.resolvedPath).toBe("/tmp/daintree-fake-bin/claude");
-      expect(mockedExecFileSync).not.toHaveBeenCalledWith("which", ["claude"], expect.any(Object));
+      expect(mockedExecFileSync).not.toHaveBeenCalledWith(
+        "which",
+        ["-a", "claude"],
+        expect.any(Object)
+      );
     });
 
     it("uses which on Unix-like systems", async () => {
@@ -342,7 +387,7 @@ describe("CliAvailabilityService", () => {
       try {
         // Only codex binary found
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "codex") return Buffer.from("");
+          if (cmdOf(args) === "codex") return Buffer.from("");
           throw new Error("not found");
         });
 
@@ -365,7 +410,7 @@ describe("CliAvailabilityService", () => {
 
       // Only opencode binary found
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "opencode") return Buffer.from("");
+        if (cmdOf(args) === "opencode") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -387,7 +432,7 @@ describe("CliAvailabilityService", () => {
       try {
         // Only opencode binary found, no config file
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "opencode") return Buffer.from("");
+          if (cmdOf(args) === "opencode") return Buffer.from("");
           throw new Error("not found");
         });
 
@@ -409,7 +454,7 @@ describe("CliAvailabilityService", () => {
       try {
         // Only opencode binary found, no config file
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "opencode") return Buffer.from("");
+          if (cmdOf(args) === "opencode") return Buffer.from("");
           throw new Error("not found");
         });
 
@@ -431,7 +476,7 @@ describe("CliAvailabilityService", () => {
       try {
         // Only opencode binary found, no config file
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "opencode") return Buffer.from("");
+          if (cmdOf(args) === "opencode") return Buffer.from("");
           throw new Error("not found");
         });
 
@@ -449,7 +494,7 @@ describe("CliAvailabilityService", () => {
     it("returns ready with authConfirmed=false when OpenCode binary found but no auth", async () => {
       // Only opencode binary found, no config file, no env vars
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "opencode") return Buffer.from("");
+        if (cmdOf(args) === "opencode") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -470,7 +515,7 @@ describe("CliAvailabilityService", () => {
       try {
         // Only opencode binary found
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "opencode") return Buffer.from("");
+          if (cmdOf(args) === "opencode") return Buffer.from("");
           throw new Error("not found");
         });
 
@@ -529,7 +574,7 @@ describe("CliAvailabilityService", () => {
 
       // Only claude available now
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           return Buffer.from("/usr/local/bin/claude");
         }
         throw new Error("Command not found");
@@ -563,9 +608,8 @@ describe("CliAvailabilityService", () => {
       const executionOrder: string[] = [];
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0]) {
-          executionOrder.push(args[0]);
-        }
+        const cmd = cmdOf(args);
+        if (cmd) executionOrder.push(cmd);
         return Buffer.from("");
       });
 
@@ -624,7 +668,7 @@ describe("CliAvailabilityService", () => {
 
       // Only kiro-cli binary found; no auth files exist
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "kiro-cli") return Buffer.from("");
+        if (cmdOf(args) === "kiro-cli") return Buffer.from("");
         throw new Error("not found");
       });
       mockedAccess.mockRejectedValue(new Error("ENOENT"));
@@ -648,7 +692,7 @@ describe("CliAvailabilityService", () => {
       const mockedAccess = vi.mocked(access);
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "kiro-cli") return Buffer.from("");
+        if (cmdOf(args) === "kiro-cli") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -675,7 +719,7 @@ describe("CliAvailabilityService", () => {
 
       // Only copilot binary found
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "copilot") return Buffer.from("");
+        if (cmdOf(args) === "copilot") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -698,7 +742,7 @@ describe("CliAvailabilityService", () => {
       const mockedAccess = vi.mocked(access);
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "copilot") return Buffer.from("");
+        if (cmdOf(args) === "copilot") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -716,7 +760,7 @@ describe("CliAvailabilityService", () => {
   describe("diagnostic logging for auth discovery", () => {
     it("logs exactly once when auth discovery finds no credential", async () => {
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "copilot") return Buffer.from("");
+        if (cmdOf(args) === "copilot") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -743,7 +787,7 @@ describe("CliAvailabilityService", () => {
       const mockedAccess = vi.mocked(access);
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "kiro-cli") return Buffer.from("");
+        if (cmdOf(args) === "kiro-cli") return Buffer.from("");
         throw new Error("not found");
       });
       mockedAccess.mockRejectedValue(new Error("ENOENT"));
@@ -761,7 +805,7 @@ describe("CliAvailabilityService", () => {
     it("does NOT log when auth check is short-circuited by envVar (OPENAI_API_KEY)", async () => {
       process.env.OPENAI_API_KEY = "sk-test";
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "codex") return Buffer.from("");
+        if (cmdOf(args) === "codex") return Buffer.from("");
         throw new Error("not found");
       });
 
@@ -782,7 +826,7 @@ describe("CliAvailabilityService", () => {
       vi.useFakeTimers();
       try {
         mockedExecFileSync.mockImplementation((_file, args) => {
-          if (args?.[0] === "copilot") return Buffer.from("");
+          if (cmdOf(args) === "copilot") return Buffer.from("");
           throw new Error("not found");
         });
         // Make fs.access hang forever ONLY for copilot's auth config path so
@@ -824,7 +868,7 @@ describe("CliAvailabilityService", () => {
       const mockedAccess = vi.mocked(access);
 
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "copilot") return Buffer.from("");
+        if (cmdOf(args) === "copilot") return Buffer.from("");
         throw new Error("not found");
       });
       mockedAccess.mockResolvedValue(undefined);
@@ -846,7 +890,7 @@ describe("CliAvailabilityService", () => {
       const calls = mockedExecFileSync.mock.calls;
       calls.forEach((call) => {
         const args = call[1] as string[];
-        const command = args[0];
+        const command = cmdOf(args);
         expect(command).toMatch(/^[a-zA-Z0-9._-]+$/);
       });
     });
@@ -894,7 +938,7 @@ describe("CliAvailabilityService", () => {
 
       // Force the shell probe to miss Claude so the native path fallback runs.
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           throw Object.assign(new Error("not found"), { code: "ENOENT" });
         }
         return Buffer.from("");
@@ -927,7 +971,7 @@ describe("CliAvailabilityService", () => {
 
       // Shell probe fails for claude.
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           throw Object.assign(new Error("not found"), { code: "ENOENT" });
         }
         throw Object.assign(new Error("not found"), { code: "ENOENT" });
@@ -954,7 +998,7 @@ describe("CliAvailabilityService", () => {
 
     it("captures the resolved path from `which` stdout", async () => {
       mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
+        if (cmdOf(args) === "claude") {
           return Buffer.from("/opt/homebrew/bin/claude\n");
         }
         return Buffer.from("");
@@ -1388,6 +1432,212 @@ describe("CliAvailabilityService", () => {
           expect(argv[cmdIdx + 1]).toBe("codex");
         }
       }
+    });
+  });
+
+  describe("duplicate CLI detection (#6054)", () => {
+    const mockedBroadcast = vi.mocked(broadcastToRenderer);
+
+    it("requests all PATH matches via `which -a` on Unix", async () => {
+      mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+
+      await service.checkAvailability();
+
+      const claudeCall = mockedExecFileSync.mock.calls.find(
+        (call) => Array.isArray(call[1]) && (call[1] as string[])[1] === "claude"
+      );
+      expect(claudeCall).toBeDefined();
+      expect(claudeCall![0]).toBe("which");
+      expect(claudeCall![1]).toEqual(["-a", "claude"]);
+    });
+
+    it("captures every line of `which -a` stdout into allResolvedPaths", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[1] === "claude") {
+          return Buffer.from("/opt/homebrew/bin/claude\n/Users/x/.local/bin/claude\n");
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+
+      const detail = service.getDetails()!.claude!;
+      expect(detail.resolvedPath).toBe("/opt/homebrew/bin/claude");
+      expect(detail.allResolvedPaths).toEqual([
+        "/opt/homebrew/bin/claude",
+        "/Users/x/.local/bin/claude",
+      ]);
+    });
+
+    it("emits a one-time warning toast per agent when duplicates exist", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[1] === "claude") {
+          return Buffer.from("/opt/homebrew/bin/claude\n/Users/x/.local/bin/claude\n");
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(1);
+      const payload = toastCalls[0][1] as {
+        type: string;
+        title: string;
+        message: string;
+      };
+      expect(payload.type).toBe("warning");
+      expect(payload.title).toBe("Multiple Claude installations found");
+      expect(payload.message).toContain("/opt/homebrew/bin/claude");
+      expect(payload.message).toContain("/Users/x/.local/bin/claude");
+    });
+
+    it("does not re-fire the toast on subsequent refresh() calls (milestone guard)", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[1] === "claude") {
+          return Buffer.from("/opt/homebrew/bin/claude\n/Users/x/.local/bin/claude\n");
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+      mockedBroadcast.mockClear();
+
+      await service.refresh();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(0);
+    });
+
+    it("does not emit a toast when only one PATH match is found", async () => {
+      mockedExecFileSync.mockImplementation(() => Buffer.from("/opt/homebrew/bin/claude\n"));
+
+      await service.checkAvailability();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(0);
+
+      const detail = service.getDetails()!.claude!;
+      expect(detail.allResolvedPaths).toBeUndefined();
+    });
+
+    it("dedupes Windows where.exe results that share a directory (.cmd + .exe)", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", writable: true });
+      try {
+        mockedExecFileSync.mockImplementation((_file, args) => {
+          const argv = args as string[] | undefined;
+          if (argv?.[0] === "claude") {
+            // Same npm-global directory, two extensions — counts as one install.
+            return Buffer.from(
+              "C:\\Users\\x\\AppData\\Roaming\\npm\\claude.cmd\r\n" +
+                "C:\\Users\\x\\AppData\\Roaming\\npm\\claude.exe\r\n"
+            );
+          }
+          return Buffer.from("");
+        });
+
+        await service.checkAvailability();
+
+        const detail = service.getDetails()!.claude!;
+        // Only one unique install after dedup, so `allResolvedPaths` is
+        // intentionally omitted — the field signals duplicates only.
+        expect(detail.allResolvedPaths).toBeUndefined();
+        expect(detail.resolvedPath).toBe("C:\\Users\\x\\AppData\\Roaming\\npm\\claude.cmd");
+
+        const toastCalls = mockedBroadcast.mock.calls.filter(
+          (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+        );
+        expect(toastCalls).toHaveLength(0);
+      } finally {
+        Object.defineProperty(process, "platform", {
+          value: originalPlatform,
+          writable: true,
+        });
+      }
+    });
+
+    it("emits separate toasts per agent when multiple agents have duplicates", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        const cmd = argv?.[1];
+        if (cmd === "claude") {
+          return Buffer.from("/opt/homebrew/bin/claude\n/Users/x/.local/bin/claude\n");
+        }
+        if (cmd === "gemini") {
+          return Buffer.from("/opt/homebrew/bin/gemini\n/Users/x/.npm-global/bin/gemini\n");
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(2);
+      const titles = toastCalls.map((c) => (c[1] as { title: string }).title);
+      expect(titles).toContain("Multiple Claude installations found");
+      expect(titles).toContain("Multiple Gemini installations found");
+    });
+
+    it("truncates the 'Also found' list and notes how many additional copies remain", async () => {
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[1] === "claude") {
+          return Buffer.from(
+            "/a/bin/claude\n/b/bin/claude\n/c/bin/claude\n/d/bin/claude\n/e/bin/claude\n"
+          );
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(1);
+      const message = (toastCalls[0][1] as { message: string }).message;
+      expect(message).toContain("Active: /a/bin/claude");
+      expect(message).toContain("/b/bin/claude");
+      expect(message).toContain("/c/bin/claude");
+      // Tail entries should be summarized, not enumerated, to keep the toast short.
+      expect(message).not.toContain("/d/bin/claude");
+      expect(message).not.toContain("/e/bin/claude");
+      expect(message).toContain("and 2 more");
+    });
+
+    it("survives a milestone load with falsy/undefined value (legacy stores)", async () => {
+      // Simulate a store that has never persisted orchestrationMilestones.
+      storeBackingMap.delete("orchestrationMilestones");
+
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[1] === "claude") {
+          return Buffer.from("/opt/homebrew/bin/claude\n/Users/x/.local/bin/claude\n");
+        }
+        return Buffer.from("");
+      });
+
+      await service.checkAvailability();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(1);
+      // Milestone now persisted for follow-up checks.
+      const stored = storeBackingMap.get("orchestrationMilestones") as Record<string, boolean>;
+      expect(stored["duplicate-cli-warning:claude"]).toBe(true);
     });
   });
 });

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -587,7 +587,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
+      // 7 successful primary calls + 6 BusyBox-style bare-`which` retries
+      // (the 6 agents whose mock throws a generic `Error` with no errno
+      // code — which `probeViaShell` retries without `-a` to recover
+      // BusyBox/minimal `which` builds that reject the flag).
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
     });
 
     it("works on cold start before initial check", async () => {
@@ -1615,6 +1619,37 @@ describe("CliAvailabilityService", () => {
       expect(message).not.toContain("/d/bin/claude");
       expect(message).not.toContain("/e/bin/claude");
       expect(message).toContain("and 2 more");
+    });
+
+    it("falls back to bare `which` when BusyBox-style `which -a` exits non-zero", async () => {
+      // BusyBox/minimal `which` builds reject `-a` with a non-zero exit
+      // (no errno code). Without a fallback, every agent on Alpine would
+      // silently surface as "missing".
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        const argv = args as string[] | undefined;
+        if (argv?.[0] === "-a") {
+          const e = new Error("which: invalid option -- a");
+          throw Object.assign(e, { status: 1 });
+        }
+        // Plain `which kiro-cli` succeeds.
+        if (cmdOf(args) === "kiro-cli") {
+          return Buffer.from("/usr/local/bin/kiro-cli\n");
+        }
+        const enoent = new Error("not found");
+        throw Object.assign(enoent, { status: 1 });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result.kiro).toBe("ready");
+      const detail = service.getDetails()!.kiro!;
+      expect(detail.resolvedPath).toBe("/usr/local/bin/kiro-cli");
+      // Single-result fallback never surfaces duplicates.
+      expect(detail.allResolvedPaths).toBeUndefined();
+
+      const toastCalls = mockedBroadcast.mock.calls.filter(
+        (call) => call[0] === CHANNELS.NOTIFICATION_SHOW_TOAST
+      );
+      expect(toastCalls).toHaveLength(0);
     });
 
     it("survives a milestone load with falsy/undefined value (legacy stores)", async () => {

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -79,6 +79,13 @@ export interface AgentCliDetail {
   /** WSL distribution used when `via === "wsl"`. */
   wslDistro?: string;
   /**
+   * All paths emitted by the shell probe (`which -a` / `where.exe`), in PATH
+   * order. Populated only when the probe succeeded via `which`. The first
+   * entry equals {@link AgentCliDetail.resolvedPath}; additional entries are
+   * the duplicate installs that drove the duplicate-detection notification.
+   */
+  allResolvedPaths?: string[];
+  /**
    * Passive auth discovery result. Populated alongside the binary probe to
    * drive onboarding nudges ("Needs Setup" tray section, Settings auth
    * panel) without gating launch.


### PR DESCRIPTION
## Summary

- `CliAvailabilityService` previously took only the first PATH match. This PR uses `which -a` on Unix (and `where.exe` on Windows, which already returns all matches) to enumerate every resolved path for each agent CLI, then surfaces a one-time warning toast when more than one distinct install is found.
- Windows results are deduped by parent directory (case-insensitive) so `.cmd` and `.exe` shims in the same npm-global bin directory don't trigger a false positive.
- BusyBox builds of `which` reject the `-a` flag. Added a fallback retry without the flag so a real install isn't misreported as missing on Alpine or similar minimal environments.

Resolves #6054.

## Changes

- `electron/services/CliAvailabilityService.ts` -- `resolveAllPaths()` helper probes all PATH matches; new optional `allResolvedPaths` field on `AgentCliDetail` (populated only when duplicates exist); one-time toast via `NOTIFICATION_SHOW_TOAST` broadcast, guarded by an `orchestrationMilestones` entry so each agent warns exactly once across refreshes.
- `shared/types/ipc/system.ts` -- added `allResolvedPaths?: string[]` to `AgentCliDetail`.
- `electron/services/__tests__/CliAvailabilityService.test.ts` -- 9 new tests covering `which -a` invocation, all-paths capture, one-time toast emit, milestone guard on subsequent refreshes, no-toast on single install, Windows `.cmd`+`.exe` directory dedup, per-agent toasts when multiple agents have duplicates, "and N more" truncation, and BusyBox fallback recovery. 67 unit tests pass in total.

## Testing

Ran the full unit test suite (67 tests pass). Typecheck clean, lint warnings dropped from 361 to 359 (two warnings eliminated in the new code paths), format clean.