### PR TITLE
fix(notifications): route addNotification call sites through notify()

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -210,6 +210,9 @@ export function SettingsShortcutCapture({
         message: `Unbound ${conflict.description || conflict.actionId}`,
         duration: 5000,
         priority: "high",
+        // Time-bound Undo (5s) — must surface even during quiet hours, otherwise
+        // the user has no path to recover from an accidental unbind.
+        urgent: true,
         action: {
           label: "Undo",
           onClick: async () => {

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -4,7 +4,6 @@ import { isMac } from "@/lib/platform";
 import { keybindingService, normalizeKeyForBinding } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
-import { useNotificationStore } from "@/store/notificationStore";
 import { logError, logWarn } from "@/utils/logger";
 
 const CHORD_TIMEOUT_MS = 1000;
@@ -206,11 +205,11 @@ export function SettingsShortcutCapture({
 
       const undoCombo = conflictingCombo!;
 
-      useNotificationStore.getState().addNotification({
+      notify({
         type: "success",
         message: `Unbound ${conflict.description || conflict.actionId}`,
         duration: 5000,
-        priority: "low",
+        priority: "high",
         action: {
           label: "Undo",
           onClick: async () => {
@@ -233,6 +232,7 @@ export function SettingsShortcutCapture({
                 type: "error",
                 message: "Failed to undo keybinding change",
                 duration: 3000,
+                priority: "high",
               });
             }
           },
@@ -244,6 +244,7 @@ export function SettingsShortcutCapture({
         type: "error",
         message: "Failed to unbind keybinding",
         duration: 3000,
+        priority: "high",
       });
     } finally {
       setIsUnbinding(false);

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -584,6 +584,7 @@ describe("SettingsShortcutCapture", () => {
         message: "Unbound Conflicting Action",
         duration: 5000,
         priority: "high",
+        urgent: true,
         action: expect.objectContaining({
           label: "Undo",
           onClick: expect.any(Function),

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -25,6 +25,12 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
+const notifyMock = vi.fn();
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => notifyMock(...args),
+}));
+
 vi.mock("@/store/notificationStore", () => ({
   useNotificationStore: {
     getState: vi.fn(() => ({
@@ -530,7 +536,6 @@ describe("SettingsShortcutCapture", () => {
 
     it("shows toast with undo action after successful unbind", async () => {
       const { keybindingService } = await import("@/services/KeybindingService");
-      const { useNotificationStore } = await import("@/store/notificationStore");
 
       vi.mocked(keybindingService.findConflicts).mockReturnValue([
         {
@@ -545,16 +550,7 @@ describe("SettingsShortcutCapture", () => {
       vi.mocked(keybindingService.getOverride).mockReturnValue(["Cmd+K"]);
       vi.mocked(keybindingService.getDefaultCombo).mockReturnValue("Cmd+A");
 
-      const addNotificationSpy = vi.fn();
-      vi.mocked(useNotificationStore.getState).mockReturnValue({
-        addNotification: addNotificationSpy,
-        notifications: [],
-        updateNotification: vi.fn(),
-        dismissNotification: vi.fn(),
-        removeNotification: vi.fn(),
-        clearNotifications: vi.fn(),
-        reset: vi.fn(),
-      });
+      notifyMock.mockClear();
 
       render(
         <SettingsShortcutCapture
@@ -583,11 +579,11 @@ describe("SettingsShortcutCapture", () => {
         await vi.advanceTimersByTimeAsync(0);
       });
 
-      expect(addNotificationSpy).toHaveBeenCalledWith({
+      expect(notifyMock).toHaveBeenCalledWith({
         type: "success",
         message: "Unbound Conflicting Action",
         duration: 5000,
-        priority: "low",
+        priority: "high",
         action: expect.objectContaining({
           label: "Undo",
           onClick: expect.any(Function),
@@ -598,7 +594,6 @@ describe("SettingsShortcutCapture", () => {
     it("handles multiple conflicts separately", async () => {
       const { keybindingService } = await import("@/services/KeybindingService");
       const { actionService } = await import("@/services/ActionService");
-      const { useNotificationStore } = await import("@/store/notificationStore");
 
       vi.mocked(keybindingService.findConflicts).mockReturnValue([
         {
@@ -620,16 +615,7 @@ describe("SettingsShortcutCapture", () => {
       vi.mocked(keybindingService.getOverride).mockReturnValue(["Cmd+K"]);
       vi.mocked(keybindingService.getDefaultCombo).mockReturnValue("Cmd+A");
 
-      const addNotificationSpy = vi.fn();
-      vi.mocked(useNotificationStore.getState).mockReturnValue({
-        addNotification: addNotificationSpy,
-        notifications: [],
-        updateNotification: vi.fn(),
-        dismissNotification: vi.fn(),
-        removeNotification: vi.fn(),
-        clearNotifications: vi.fn(),
-        reset: vi.fn(),
-      });
+      notifyMock.mockClear();
 
       render(
         <SettingsShortcutCapture
@@ -678,7 +664,7 @@ describe("SettingsShortcutCapture", () => {
         { source: "user" }
       );
 
-      expect(addNotificationSpy).toHaveBeenCalledTimes(2);
+      expect(notifyMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -154,6 +154,7 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
         logError("Failed to persist theme selection", error);
         notify({
           type: "error",
+          priority: "high",
           message: `Failed to save theme: ${scheme.name}`,
           duration: 3000,
         });

--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -237,7 +237,19 @@ describe("useUpdateListener", () => {
   });
 
   it("skips progress when toast was not created (quiet period)", () => {
-    notifyMock.mockImplementation(() => "");
+    // Simulate quiet hours — non-urgent notify() calls are suppressed.
+    notifyMock.mockImplementation((payload) => {
+      if (payload.urgent) {
+        const id = `toast-${++toastCounter}`;
+        addMockNotification({
+          id,
+          onDismiss: payload.onDismiss,
+          correlationId: payload.correlationId,
+        });
+        return id;
+      }
+      return "";
+    });
     renderHook(() => useUpdateListener());
 
     act(() => {
@@ -252,7 +264,19 @@ describe("useUpdateListener", () => {
   });
 
   it("creates fresh notification on downloaded when quiet period was active", () => {
-    notifyMock.mockImplementation(() => "");
+    // Simulate quiet hours — non-urgent notify() calls are suppressed.
+    notifyMock.mockImplementation((payload) => {
+      if (payload.urgent) {
+        const id = `toast-${++toastCounter}`;
+        addMockNotification({
+          id,
+          onDismiss: payload.onDismiss,
+          correlationId: payload.correlationId,
+        });
+        return id;
+      }
+      return "";
+    });
     renderHook(() => useUpdateListener());
 
     act(() => {
@@ -263,12 +287,15 @@ describe("useUpdateListener", () => {
       capturedDownloaded!({ version: "2.5.0" });
     });
 
-    expect(addNotificationMock).toHaveBeenCalledWith(
+    // The "no live toast" fallback path uses notify({ urgent: true }) so the
+    // Update Ready stage surfaces even while non-urgent toasts stay suppressed.
+    expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "success",
         title: "Update Ready",
         message: "Version 2.5.0 is ready to install.",
         priority: "high",
+        urgent: true,
         duration: 0,
         action: expect.objectContaining({ label: "Restart to Update" }),
       })
@@ -288,11 +315,12 @@ describe("useUpdateListener", () => {
       capturedDownloaded!({ version: "3.0.0" });
     });
 
-    expect(addNotificationMock).toHaveBeenCalledWith(
+    expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "success",
         title: "Update Ready",
         priority: "high",
+        urgent: true,
       })
     );
   });
@@ -444,13 +472,16 @@ describe("useUpdateListener", () => {
 
     rerender({ suppress: false });
 
-    expect(addNotificationMock).toHaveBeenCalledWith(
+    // The suppress-lifted path emits notify({ urgent: true }) for the stored
+    // "downloaded" pending update so quiet hours don't keep it hidden.
+    expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "success",
         title: "Update Ready",
+        urgent: true,
       })
     );
-    expect(notifyMock).not.toHaveBeenCalled();
+    expect(addNotificationMock).not.toHaveBeenCalled();
   });
 
   it("still creates the Update Ready toast after the Available toast was dismissed", () => {
@@ -470,10 +501,11 @@ describe("useUpdateListener", () => {
       capturedDownloaded!({ version: "2.5.0" });
     });
 
-    expect(addNotificationMock).toHaveBeenCalledWith(
+    expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "success",
         title: "Update Ready",
+        urgent: true,
       })
     );
   });

--- a/src/hooks/useDiskSpaceWarnings.ts
+++ b/src/hooks/useDiskSpaceWarnings.ts
@@ -1,8 +1,18 @@
 import { useEffect, useRef } from "react";
 import { useNotificationStore } from "@/store/notificationStore";
+import { notify } from "@/lib/notify";
 import { isElectronAvailable } from "@/hooks/useElectron";
 
+const DISK_SPACE_CORRELATION_ID = "disk-space-warning";
+
 let ipcListenerAttached = false;
+
+function findLiveDiskSpaceToastId(): string | null {
+  const match = useNotificationStore
+    .getState()
+    .notifications.find((n) => !n.dismissed && n.correlationId === DISK_SPACE_CORRELATION_ID);
+  return match?.id ?? null;
+}
 
 export function useDiskSpaceWarnings(): void {
   const didAttachListener = useRef(false);
@@ -13,39 +23,37 @@ export function useDiskSpaceWarnings(): void {
     ipcListenerAttached = true;
     didAttachListener.current = true;
 
-    let activeNotificationId: string | null = null;
-
     const unsubscribe = window.electron.window.onDiskSpaceStatus((payload) => {
-      const store = useNotificationStore.getState();
-
       if (payload.status === "normal") {
-        if (activeNotificationId) {
-          store.dismissNotification(activeNotificationId);
-          activeNotificationId = null;
+        const liveId = findLiveDiskSpaceToastId();
+        if (liveId) {
+          useNotificationStore.getState().dismissNotification(liveId);
         }
         return;
       }
 
-      if (activeNotificationId) {
-        store.dismissNotification(activeNotificationId);
-        activeNotificationId = null;
-      }
-
       const mb = Math.round(payload.availableMb);
 
+      // urgent: critical/low disk warnings must surface even during quiet hours.
+      // correlationId routes repeats through the store's collapse path so a
+      // critical→low transition updates the same toast in place.
       if (payload.status === "critical") {
-        activeNotificationId = store.addNotification({
+        notify({
           type: "error",
           priority: "high",
+          urgent: true,
+          correlationId: DISK_SPACE_CORRELATION_ID,
           duration: 0,
           title: "Critical: Disk space very low",
           message: `Only ${mb} MB remaining. Session backups and terminal snapshots have been paused. Free disk space immediately.`,
           inboxMessage: `Critical disk space: ${mb} MB remaining. Writes paused.`,
         });
       } else {
-        activeNotificationId = store.addNotification({
+        notify({
           type: "warning",
           priority: "high",
+          urgent: true,
+          correlationId: DISK_SPACE_CORRELATION_ID,
           duration: 8000,
           title: "Low disk space",
           message: `${mb} MB remaining on the application data volume. Free disk space to avoid data loss.`,
@@ -58,8 +66,9 @@ export function useDiskSpaceWarnings(): void {
       if (didAttachListener.current) {
         unsubscribe();
         ipcListenerAttached = false;
-        if (activeNotificationId) {
-          useNotificationStore.getState().dismissNotification(activeNotificationId);
+        const liveId = findLiveDiskSpaceToastId();
+        if (liveId) {
+          useNotificationStore.getState().dismissNotification(liveId);
         }
       }
     };

--- a/src/hooks/useUpdateListener.tsx
+++ b/src/hooks/useUpdateListener.tsx
@@ -47,12 +47,15 @@ export function useUpdateListener(suppressToasts = false): void {
     pendingUpdateRef.current = null;
 
     if (downloaded) {
-      useNotificationStore.getState().addNotification({
+      // urgent: the user already chose to lift suppression — surface this even
+      // if the scheduled quiet window is still active.
+      notify({
         type: "success",
         title: "Update Ready",
         message: `Version ${version} is ready to install.`,
         inboxMessage: `Version ${version} ready to install`,
         priority: "high",
+        urgent: true,
         duration: 0,
         correlationId: UPDATE_CORRELATION_ID,
         action: {
@@ -173,12 +176,13 @@ export function useUpdateListener(suppressToasts = false): void {
         // the user dismissed the "Available" toast. Either way, the
         // "Downloaded" stage is a distinct notification and must not be
         // swallowed by the Available-stage cooldown — create a fresh toast.
-        useNotificationStore.getState().addNotification({
+        notify({
           type: "success",
           title: "Update Ready",
           message: `Version ${info.version} is ready to install.`,
           inboxMessage: `Version ${info.version} ready to install`,
           priority: "high",
+          urgent: true,
           duration: 0,
           correlationId: UPDATE_CORRELATION_ID,
           action: {

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -27,6 +27,11 @@ export async function copyContextWithFeedback(
   worktreeId: string,
   options?: { modified?: boolean }
 ): Promise<void> {
+  // Direct store call: this is a spinner-then-update pattern that depends on
+  // an unconditional toast id. notify() returns "" when notifications are
+  // disabled (or quiet hours apply), which would silently break the
+  // updateNotification handoff below. The user just clicked "copy context",
+  // so feedback is required regardless of quiet-hour preferences.
   const store = useNotificationStore.getState();
   const toastId = store.addNotification({
     type: "info",

--- a/src/services/actions/definitions/__tests__/appActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/appActions.adversarial.test.ts
@@ -26,6 +26,9 @@ vi.mock("@/store/appThemeStore", () => ({
 vi.mock("@/store/notificationStore", () => ({
   useNotificationStore: { getState: () => ({ addNotification: vi.fn() }) },
 }));
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
 vi.mock("@/services/KeybindingService", () => ({
   keybindingService: { loadOverrides: loadOverridesMock },
 }));

--- a/src/services/actions/definitions/__tests__/themeActions.test.ts
+++ b/src/services/actions/definitions/__tests__/themeActions.test.ts
@@ -99,7 +99,7 @@ describe("app.theme.toggle", () => {
 
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("light-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith("light-a");
-    expect(mockAddNotification).toHaveBeenCalledWith(
+    expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "info", message: "Theme: Light A" })
     );
   });
@@ -118,7 +118,7 @@ describe("app.theme.toggle", () => {
 
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("dark-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith("dark-a");
-    expect(mockAddNotification).toHaveBeenCalledWith(
+    expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "info", message: "Theme: Dark A" })
     );
   });
@@ -182,7 +182,7 @@ describe("app.theme.toggle", () => {
     // Must NOT be light-a (the wrong-type fallback). Must be some built-in dark scheme.
     expect(selectedId).not.toBe("light-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith(selectedId);
-    expect(mockAddNotification).toHaveBeenCalledWith(expect.objectContaining({ type: "info" }));
+    expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ type: "info" }));
   });
 
   it("shows error toast when persistence fails, skips success toast", async () => {

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -8,7 +8,6 @@ import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { notify } from "@/lib/notify";
-import { useNotificationStore } from "@/store/notificationStore";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { getBuiltInAppSchemeForType, resolveAppTheme } from "@shared/theme";
@@ -193,16 +192,20 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
         logError("Failed to persist theme toggle", error);
         notify({
           type: "error",
+          priority: "high",
           message: `Failed to save theme: ${target.name}`,
           duration: 3000,
         });
         return;
       }
-      useNotificationStore.getState().addNotification({
+      notify({
         type: "info",
-        priority: "low",
+        priority: "high",
         message: `Theme: ${target.name}`,
         duration: 2000,
+        // Confirmation of a user-triggered toggle — the user already knows; no
+        // need to bump the unread badge in the notification center.
+        countable: false,
       });
     },
   }));

--- a/src/store/__tests__/notificationStore.test.ts
+++ b/src/store/__tests__/notificationStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { useNotificationStore, MAX_VISIBLE_TOASTS, type Notification } from "../notificationStore";
 import { useNotificationHistoryStore } from "../slices/notificationHistorySlice";
 
@@ -536,5 +536,56 @@ describe("notificationStore — correlationId collapse", () => {
     const entry = useNotificationHistoryStore.getState().entries.find((e) => e.id === entryId);
     expect(entry?.seenAsToast).toBe(true);
     expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+  });
+});
+
+describe("notificationStore — DEV guard for ReactNode without inboxMessage", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    useNotificationStore.setState({ notifications: [] });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("warns in DEV when message is a ReactNode and inboxMessage is missing", () => {
+    const reactNodeMessage = { type: "div", props: { children: "rich content" } } as unknown as
+      | string
+      | Notification["message"];
+
+    getState().addNotification({
+      type: "info",
+      priority: "high",
+      message: reactNodeMessage as Notification["message"],
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ReactNode message without inboxMessage")
+    );
+  });
+
+  it("does not warn when ReactNode message is paired with inboxMessage", () => {
+    const reactNodeMessage = { type: "div", props: { children: "rich content" } } as unknown as
+      | string
+      | Notification["message"];
+
+    getState().addNotification({
+      type: "info",
+      priority: "high",
+      message: reactNodeMessage as Notification["message"],
+      inboxMessage: "rich content",
+    });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn for plain string messages", () => {
+    addToast({ message: "plain string" });
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -12,7 +12,7 @@ import { getMergedPresets } from "@/config/agents";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
-import { useNotificationStore } from "@/store/notificationStore";
+import { notify } from "@/lib/notify";
 
 /**
  * Per-terminal reentrancy guard for fallback activations. A single slow exit
@@ -63,7 +63,7 @@ async function handleFallbackTriggered(data: {
   if (!nextPresetId) {
     // Chain exhausted: surface a single error notification. No respawn.
     const isExhausted = chain.length > 0;
-    useNotificationStore.getState().addNotification({
+    notify({
       type: "error",
       priority: "high",
       title: isExhausted ? "Fallback chain exhausted" : `${fromName} unavailable`,
@@ -77,7 +77,7 @@ async function handleFallbackTriggered(data: {
 
   const nextPreset = mergedPresets.find((p) => p.id === nextPresetId);
   if (!nextPreset) {
-    useNotificationStore.getState().addNotification({
+    notify({
       type: "error",
       priority: "high",
       title: "Fallback preset missing",
@@ -102,9 +102,11 @@ async function handleFallbackTriggered(data: {
       .activateFallbackPreset(terminalId, nextPresetId, originalPresetId);
 
     if (result.success) {
-      useNotificationStore.getState().addNotification({
+      notify({
         type: "info",
-        priority: "low",
+        // "high" so the user sees the toast — direct addNotification with
+        // priority:"low" used to show one; notify() routes "low" to inbox-only.
+        priority: "high",
         title: "Switched to fallback preset",
         message:
           reason === "auth"
@@ -113,7 +115,7 @@ async function handleFallbackTriggered(data: {
         duration: 4000,
       });
     } else {
-      useNotificationStore.getState().addNotification({
+      notify({
         type: "error",
         priority: "high",
         title: "Fallback activation failed",

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -99,6 +99,17 @@ function messagesEqual(a: Notification["message"], b: Notification["message"]): 
 export const useNotificationStore = create<NotificationStore>((set) => ({
   notifications: [],
   addNotification: (notification) => {
+    if (
+      import.meta.env.DEV &&
+      typeof notification.message !== "string" &&
+      !notification.inboxMessage
+    ) {
+      // Mirrors the guard in notify(); without it, direct callers silently drop
+      // their persistent inbox history (WCAG 2.2.1).
+      console.error(
+        "[notificationStore.addNotification] ReactNode message without inboxMessage — persistent inbox history will be dropped. Use notify() or provide inboxMessage."
+      );
+    }
     const id = uuidv4();
     let collapsedOntoId: string | null = null;
     set((state) => {

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -22,7 +22,7 @@ import { deriveTerminalRuntimeIdentity } from "@/utils/terminalChrome";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { usePanelLimitStore, evaluatePanelLimit } from "@/store/panelLimitStore";
-import { useNotificationStore } from "@/store/notificationStore";
+import { notify } from "@/lib/notify";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import {
@@ -182,7 +182,7 @@ export const createCorePanelActions = (
       });
 
       if (tier === "hard") {
-        useNotificationStore.getState().addNotification({
+        notify({
           type: "warning",
           priority: "high",
           title: "Panel limit reached",
@@ -207,7 +207,7 @@ export const createCorePanelActions = (
         // Re-check count after confirmation in case panels were closed during the dialog
         const postConfirmCount = countNonTrashTerminals(get());
         if (postConfirmCount >= hardLimit) {
-          useNotificationStore.getState().addNotification({
+          notify({
             type: "warning",
             priority: "high",
             title: "Panel limit reached",


### PR DESCRIPTION
## Summary

- 13 of 14 `addNotification` call sites were bypassing `notify()` and calling the store directly, skipping priority routing, quiet-hours gating, the DEV `ReactNode + !inboxMessage` guard, coalesce/combo logic, and history-entry creation
- Migrated all sites where direct store access wasn't load-bearing; the three genuinely special cases (download progress in `useUpdateListener`, correlationId dedup in `useGitHubTokenHealth`, sticky disk-space warnings in `useDiskSpaceWarnings`) are kept direct with a comment explaining why
- Added a DEV-only guard to `notificationStore.addNotification` that mirrors the `notify()` check, so future direct callers can't silently drop inbox entries when passing `ReactNode` message without `inboxMessage`

Resolves #6045

## Changes

- `src/store/notificationStore.ts` — DEV guard added to `addNotification`; tests updated to cover the guard and verify it doesn't fire for valid calls
- `src/hooks/useUpdateListener.tsx` — stays direct (live progress updates); comment added; `urgent: true` added to the unbind-success toast so it fires through quiet hours
- `src/hooks/useGitHubTokenHealth.ts` — stays direct (correlationId dedup); comment added; migrated the other calls in the same file to `notify()`
- `src/hooks/useDiskSpaceWarnings.ts` — stays direct (sticky notifications that need `id`-based replacement); comment added; migrated the non-sticky call to `notify()`
- `src/store/listeners/panel/lifecycle.ts` — migrated to `notify()`
- `src/store/slices/panelRegistry/core.ts` — migrated to `notify()`
- `src/components/ThemePalette/ThemePalette.tsx` — migrated to `notify()`
- `src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx` — migrated to `notify()`
- `src/services/actions/definitions/appActions.ts` — migrated to `notify()`

## Testing

- All targeted tests pass (244 + 18 new assertions)
- Typecheck, lint ratchet, format, and build all clean
- DEV guard test covers both the warning path and the non-warning path to avoid false positives