### PR TITLE
fix(store): defer initialization to explicit bootstrap lifecycle point

### DIFF
--- a/electron/__tests__/store.proxy.test.ts
+++ b/electron/__tests__/store.proxy.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+vi.mock("electron-store", async () => {
+  const conf = await import("conf");
+  return { default: conf.default };
+});
+
+import { store, initializeStore, _resetStoreInstance, _peekStoreInstance } from "../store.js";
+
+describe("store Proxy", () => {
+  let tempDir: string;
+
+  function testOptions(cwd: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { defaults: { _schemaVersion: 0 } as Record<string, unknown>, cwd } as any;
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-store-proxy-"));
+    _resetStoreInstance();
+  });
+
+  afterEach(() => {
+    _resetStoreInstance();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not initialize at module-load time — only on explicit init or first access", () => {
+    expect(_peekStoreInstance()).toBeUndefined();
+  });
+
+  it("delegates get() and set() to the initialized instance", () => {
+    initializeStore(testOptions(tempDir));
+    store.set("_schemaVersion" as never, 7 as never);
+    expect(store.get("_schemaVersion" as never)).toBe(7);
+  });
+
+  it("supports `key in store` via the has trap", () => {
+    initializeStore(testOptions(tempDir));
+    expect("get" in store).toBe(true);
+    expect("set" in store).toBe(true);
+    expect("definitelyMissingMethod" in store).toBe(false);
+  });
+
+  it("binds methods so callers can detach them without losing `this`", () => {
+    initializeStore(testOptions(tempDir));
+    const get = store.get;
+    expect(() => get("_schemaVersion" as never)).not.toThrow();
+    expect(get("_schemaVersion" as never)).toBe(0);
+  });
+
+  it("lazy-initializes on first proxy access when init was skipped", () => {
+    expect(_peekStoreInstance()).toBeUndefined();
+    void store.get;
+    expect(_peekStoreInstance()).toBeDefined();
+  });
+
+  it("re-initializes after _resetStoreInstance()", () => {
+    initializeStore(testOptions(tempDir));
+    const first = _peekStoreInstance();
+    expect(first).toBeDefined();
+    _resetStoreInstance();
+    expect(_peekStoreInstance()).toBeUndefined();
+    initializeStore(testOptions(tempDir));
+    expect(_peekStoreInstance()).toBeDefined();
+  });
+});

--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -283,7 +283,6 @@ describe("initializeStore", () => {
     expect(consumePendingSettingsRecovery()).toBeNull();
   });
 
-
   describe("consumePendingSettingsRecovery", () => {
     it("returns null on normal startup", () => {
       initializeStore(testOptions(tempDir));

--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -17,6 +17,7 @@ import {
   initializeStore,
   consumePendingSettingsRecovery,
   _resetPendingSettingsRecovery,
+  _resetStoreInstance,
 } from "../store.js";
 
 describe("Store backup/restore helpers", () => {
@@ -152,11 +153,13 @@ describe("initializeStore", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-06-15T12:00:00.000Z"));
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-store-init-"));
+    _resetStoreInstance();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     _resetPendingSettingsRecovery();
+    _resetStoreInstance();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -268,6 +271,18 @@ describe("initializeStore", () => {
     expect(recovery?.kind).toBe("restored-from-backup");
     expect(recovery?.quarantinedPath).toBeDefined();
   });
+
+  it("is idempotent — second call returns the same instance and skips re-init", () => {
+    const first = initializeStore(testOptions(tempDir));
+    const configPath = path.join(tempDir, "config.json");
+    fs.writeFileSync(configPath, "{corrupt!", "utf8");
+    const second = initializeStore(testOptions(tempDir));
+    expect(second).toBe(first);
+    // Existing config left untouched — no quarantine triggered on second call
+    expect(fs.readFileSync(configPath, "utf8")).toBe("{corrupt!");
+    expect(consumePendingSettingsRecovery()).toBeNull();
+  });
+
 
   describe("consumePendingSettingsRecovery", () => {
     it("returns null on normal startup", () => {

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -1,9 +1,11 @@
 import { enableCompileCache } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
-import { app } from "electron";
+import { app, dialog } from "electron";
 import { runBootMigrations } from "./boot/migrations/index.js";
 import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
+import { initializeStore } from "./store.js";
+import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
 try {
@@ -21,6 +23,23 @@ try {
   await runBootMigrations({ isSafeMode: isSafeModeActive() });
 } catch (err) {
   console.error("[Bootstrap] Boot migrations failed — continuing with existing state:", err);
+}
+
+// Initialize the persistent store at an explicit lifecycle point. A failure
+// here (e.g. quarantine fails on disk full / EPERM) would otherwise crash
+// silently before the renderer exists. Surface it via a native dialog and
+// exit cleanly. dialog.showErrorBox is safe pre-app.whenReady() on macOS and
+// Windows; on Linux it falls back to stderr, which is still better than a
+// silent crash.
+try {
+  initializeStore();
+} catch (err) {
+  const message = formatErrorMessage(err, "Unknown store initialization error");
+  dialog.showErrorBox(
+    "Couldn't start Daintree",
+    `Failed to initialize settings.\n\nPath: ${app.getPath("userData")}\n\n${message}`
+  );
+  app.exit(1);
 }
 
 await import("./main.js");

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -1,10 +1,17 @@
+// Environment setup must run before anything that reads `app.getPath("userData")`
+// — in dev mode it calls `app.setPath("userData", "daintree-dev")` so the dev
+// instance doesn't collide with the production app. Importing it here ensures
+// runBootMigrations, the compile-cache dir, and initializeStore all resolve to
+// the correct directory before main.ts re-imports it (idempotent via ESM cache).
+import "./setup/environment.js";
+
 import { enableCompileCache } from "node:module";
 import fs from "node:fs";
 import path from "node:path";
 import { app, dialog } from "electron";
 import { runBootMigrations } from "./boot/migrations/index.js";
 import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
-import { initializeStore } from "./store.js";
+import { initializeStore, _peekStoreInstance } from "./store.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
@@ -25,21 +32,33 @@ try {
   console.error("[Bootstrap] Boot migrations failed — continuing with existing state:", err);
 }
 
-// Initialize the persistent store at an explicit lifecycle point. A failure
-// here (e.g. quarantine fails on disk full / EPERM) would otherwise crash
-// silently before the renderer exists. Surface it via a native dialog and
-// exit cleanly. dialog.showErrorBox is safe pre-app.whenReady() on macOS and
-// Windows; on Linux it falls back to stderr, which is still better than a
-// silent crash.
-try {
-  initializeStore();
-} catch (err) {
-  const message = formatErrorMessage(err, "Unknown store initialization error");
+// Initialize the persistent store at an explicit lifecycle point. Two failure
+// modes are surfaced via a native error dialog before the renderer ever loads:
+//   1. An unexpected throw escapes initializeStore() (defensive — the function
+//      catches its own constructor failures internally).
+//   2. initializeStore() falls back to the in-memory store (path === "") — this
+//      means the on-disk store is unrecoverable (e.g. EPERM, ENOSPC, or both
+//      config and backup are corrupt). Letting the app continue would lose any
+//      user changes on the next restart, silently.
+// dialog.showErrorBox is safe pre-app.whenReady() on macOS and Windows; on Linux
+// it falls back to stderr, which is still better than a silent failure.
+function showFatalStoreError(reason: string): void {
   dialog.showErrorBox(
     "Couldn't start Daintree",
-    `Failed to initialize settings.\n\nPath: ${app.getPath("userData")}\n\n${message}`
+    `Failed to initialize settings.\n\nPath: ${app.getPath("userData")}\n\n${reason}`
   );
   app.exit(1);
+}
+
+try {
+  initializeStore();
+  if (_peekStoreInstance()?.path === "") {
+    showFatalStoreError(
+      "Settings file is unreadable and the on-disk fallback couldn't be created. The app would lose any changes on restart. Check disk space and folder permissions for the path above, then relaunch."
+    );
+  }
+} catch (err) {
+  showFatalStoreError(formatErrorMessage(err, "Unknown store initialization error"));
 }
 
 await import("./main.js");

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -491,7 +491,11 @@ export function _resetPendingSettingsRecovery(): void {
   pendingSettingsRecovery = null;
 }
 
+let storeInstance: Store<StoreSchema> | undefined;
+
 export function initializeStore(options: typeof storeOptions = storeOptions): Store<StoreSchema> {
+  if (storeInstance) return storeInstance;
+
   const configPath = resolveConfigPath(options.cwd);
 
   if (configPath) {
@@ -508,7 +512,7 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
 
   try {
     const preSnapshot = configPath ? readRawSnapshot(configPath) : null;
-    const instance = new Store<StoreSchema>({
+    const created = new Store<StoreSchema>({
       ...options,
       clearInvalidConfig: true,
     });
@@ -524,17 +528,53 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
         pendingSettingsRecovery = { kind: "reset-to-defaults" };
       }
     } else {
-      refreshBackup(instance.path);
+      refreshBackup(created.path);
     }
-    return instance;
+    storeInstance = created;
+    return created;
   } catch (error) {
     console.warn("[Store] Failed to initialize electron-store, using in-memory fallback:", error);
     pendingSettingsRecovery = { kind: "reset-to-defaults" };
-    return createInMemoryFallback();
+    const fallback = createInMemoryFallback();
+    storeInstance = fallback;
+    return fallback;
   }
 }
 
-export const store = initializeStore();
+export function _resetStoreInstance(): void {
+  storeInstance = undefined;
+}
+
+export function _peekStoreInstance(): Store<StoreSchema> | undefined {
+  return storeInstance;
+}
+
+function getOrLazyInitInstance(): Store<StoreSchema> {
+  // In production, bootstrap.ts calls initializeStore() explicitly before
+  // any module reads the store, so this branch is unreachable. The lazy
+  // fallback exists for tests that import services using `store` without
+  // mocking it: they get the in-memory fallback that the previous
+  // module-load `export const store = initializeStore()` provided implicitly.
+  return storeInstance ?? initializeStore();
+}
+
+export const store = new Proxy({} as Store<StoreSchema>, {
+  get(_target, prop) {
+    const instance = getOrLazyInitInstance();
+    const value = Reflect.get(instance as object, prop, instance);
+    return typeof value === "function"
+      ? (value as (...args: unknown[]) => unknown).bind(instance)
+      : value;
+  },
+  set(_target, prop, value) {
+    const instance = getOrLazyInitInstance();
+    return Reflect.set(instance as object, prop, value, instance);
+  },
+  has(_target, prop) {
+    const instance = getOrLazyInitInstance();
+    return Reflect.has(instance as object, prop);
+  },
+});
 
 export {
   resolveConfigPath,


### PR DESCRIPTION
## Summary

- `electron/store.ts` was initializing at module-load time, which meant anything that imported the store (preflight, quarantine, test helpers) triggered `new Store()` before `app.whenReady()` and before `app.setPath('userData', ...)` had run in dev
- Moved init to an explicit `initializeStore()` call in `bootstrap.ts`, called after migrations, with the environment setup importing first so the dev userData path is set correctly
- Added a Proxy export so all existing call-sites continue to work without changes; the proxy delegates via Reflect and has a lazy fallback for tests that import services transitively without explicitly bootstrapping

## Changes

- `electron/store.ts` — `export const store` is now a Proxy. `initializeStore()` is idempotent (module-scoped `storeInstance`). Added `_resetStoreInstance` and `_peekStoreInstance` for test isolation.
- `electron/bootstrap.ts` — imports `./setup/environment.js` first so `app.setPath('userData', 'daintree-dev')` runs before any path reads. Calls `initializeStore()` after migrations. Detects a catastrophic failure via `_peekStoreInstance()?.path === ""` and surfaces a native dialog with disk-space/permissions guidance before `app.exit(1)`.
- `electron/__tests__/storeBackupRestore.test.ts` — resets store instance in `before/afterEach`; added idempotency test.
- `electron/__tests__/store.proxy.test.ts` — new test file covering proxy delegation, `has` trap, method binding, lazy-init, and re-init after reset.

Resolves #6059

## Testing

Typecheck, lint, and format all pass. 14,288 tests pass across 876 files (lint:ratchet shows warnings decreased by 2). The proxy behaviour and bootstrap ordering are covered by the new `store.proxy.test.ts` suite.