### PR TITLE
fix(project): timestamp quarantines to prevent overwrite

### DIFF
--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -38,7 +38,7 @@ export class GlobalFileStore {
     } catch (error) {
       console.error("[GlobalFileStore] Failed to load recipes:", error);
       try {
-        const quarantinePath = `${this.recipesPath}.corrupted`;
+        const quarantinePath = `${this.recipesPath}.corrupted.${Date.now()}`;
         await resilientRename(this.recipesPath, quarantinePath);
         console.warn(`[GlobalFileStore] Corrupted recipes file moved to ${quarantinePath}`);
       } catch {

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -35,7 +35,7 @@ export class ProjectFileStore {
     } catch (error) {
       console.error(`[ProjectFileStore] Failed to load recipes for ${projectId}:`, error);
       try {
-        const quarantinePath = `${filePath}.corrupted`;
+        const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
         await resilientRename(filePath, quarantinePath);
         console.warn(`[ProjectFileStore] Corrupted recipes file moved to ${quarantinePath}`);
       } catch {

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -231,7 +231,7 @@ export class ProjectSettingsManager {
       console.error(`[ProjectSettingsManager] Failed to load settings for ${projectId}:`, error);
       this.notificationOverridesCache.delete(projectId);
       try {
-        const quarantinePath = `${filePath}.corrupted`;
+        const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
         await resilientRename(filePath, quarantinePath);
         console.warn(`[ProjectSettingsManager] Corrupted settings file moved to ${quarantinePath}`);
       } catch {

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -216,7 +216,7 @@ export class ProjectStateManager {
     } catch (error) {
       console.error(`[ProjectStateManager] Failed to load state for project ${projectId}:`, error);
       try {
-        const quarantinePath = `${filePath}.corrupted`;
+        const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
         markPerformance(PERF_MARKS.PROJECT_STATE_QUARANTINE, { projectId });
         await resilientRename(filePath, quarantinePath);
         this.pendingQuarantines.set(projectId, quarantinePath);

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -46,7 +46,7 @@ describe("GlobalFileStore adversarial", () => {
     expect(result).toEqual([]);
     expect(utilsMock.resilientRename).toHaveBeenCalledWith(
       RECIPES_FILE,
-      `${RECIPES_FILE}.corrupted`
+      expect.stringMatching(/^\/tmp\/daintree-global\/recipes\.json\.corrupted\.\d+$/)
     );
   });
 

--- a/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
@@ -65,7 +65,7 @@ describe("ProjectFileStore adversarial", () => {
     expect(result).toEqual([]);
     expect(utilsMock.resilientRename).toHaveBeenCalledWith(
       EXPECTED_RECIPES_FILE,
-      `${EXPECTED_RECIPES_FILE}.corrupted`
+      expect.stringMatching(/^\/tmp\/daintree-projects\/a{64}\/recipes\.json\.corrupted\.\d+$/)
     );
   });
 

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -206,8 +206,8 @@ describe("ProjectStateManager quarantine recovery", () => {
     const result = await manager.getProjectStateWithRecovery(projectId);
 
     expect(result.state).toBeNull();
-    expect(result.quarantinedPath).toBe(`${filePath}.corrupted`);
-    await expect(fs.access(`${filePath}.corrupted`)).resolves.toBeUndefined();
+    expect(result.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
+    await expect(fs.access(result.quarantinedPath!)).resolves.toBeUndefined();
   });
 
   it("drains the quarantine signal after one read — subsequent reads return no path", async () => {
@@ -215,7 +215,7 @@ describe("ProjectStateManager quarantine recovery", () => {
     await fs.writeFile(filePath, "{ not valid json", "utf-8");
 
     const first = await manager.getProjectStateWithRecovery(projectId);
-    expect(first.quarantinedPath).toBe(`${filePath}.corrupted`);
+    expect(first.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
 
     const second = await manager.getProjectStateWithRecovery(projectId);
     expect(second.state).toBeNull();
@@ -244,7 +244,7 @@ describe("ProjectStateManager quarantine recovery", () => {
     // still receive the quarantined path.
     const result = await manager.getProjectStateWithRecovery(projectId);
     expect(result.state).toBeNull();
-    expect(result.quarantinedPath).toBe(`${filePath}.corrupted`);
+    expect(result.quarantinedPath).toMatch(/\.corrupted\.\d+$/);
   });
 });
 

--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -11,10 +11,10 @@ const VALID_PROJECT_ID = "a".repeat(64);
 const VALID_PROJECT_ID_2 = "b".repeat(64);
 
 const QUARANTINE_FILES = [
-  "state.json.corrupted",
-  "settings.json.corrupted",
-  "recipes.json.corrupted",
-  "workflows.json.corrupted",
+  "state.json.corrupted.1234567890",
+  "settings.json.corrupted.1234567890",
+  "recipes.json.corrupted.1234567890",
+  "workflows.json.corrupted.1234567890",
 ];
 
 let tmpDir: string;
@@ -54,7 +54,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
     const filePath = await createCorruptedFile(
       projectDir,
-      "state.json.corrupted",
+      "state.json.corrupted.1234567890",
       THIRTY_ONE_DAYS_MS,
       NOW
     );
@@ -69,7 +69,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
     const filePath = await createCorruptedFile(
       projectDir,
-      "state.json.corrupted",
+      "state.json.corrupted.1234567890",
       TWENTY_NINE_DAYS_MS,
       NOW
     );
@@ -110,7 +110,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
   it("skips directories with invalid project IDs", async () => {
     const invalidDir = path.join(tmpDir, "not-a-valid-hex-id");
     await fs.mkdir(invalidDir);
-    const filePath = path.join(invalidDir, "state.json.corrupted");
+    const filePath = path.join(invalidDir, "state.json.corrupted.1234567890");
     await fs.writeFile(filePath, "data");
     const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
     await fs.utimes(filePath, oldTime, oldTime);
@@ -152,19 +152,19 @@ describe("cleanupQuarantinedProjectFiles", () => {
 
     const oldFile1 = await createCorruptedFile(
       dir1,
-      "state.json.corrupted",
+      "state.json.corrupted.1234567890",
       THIRTY_ONE_DAYS_MS,
       NOW
     );
     const oldFile2 = await createCorruptedFile(
       dir2,
-      "settings.json.corrupted",
+      "settings.json.corrupted.1234567890",
       THIRTY_ONE_DAYS_MS,
       NOW
     );
     const freshFile = await createCorruptedFile(
       dir2,
-      "recipes.json.corrupted",
+      "recipes.json.corrupted.1234567890",
       TWENTY_NINE_DAYS_MS,
       NOW
     );
@@ -179,7 +179,12 @@ describe("cleanupQuarantinedProjectFiles", () => {
 
   it("is idempotent — calling twice is safe", async () => {
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
-    await createCorruptedFile(projectDir, "state.json.corrupted", THIRTY_ONE_DAYS_MS, NOW);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
 
     const deleted1 = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
     expect(deleted1).toBe(1);
@@ -193,7 +198,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const exactlyThirtyDays = 30 * 24 * 60 * 60 * 1000;
     const filePath = await createCorruptedFile(
       projectDir,
-      "state.json.corrupted",
+      "state.json.corrupted.1234567890",
       exactlyThirtyDays,
       NOW
     );
@@ -208,7 +213,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
     // File is only 1 day old relative to wall clock
     const filePath = await createCorruptedFile(
       projectDir,
-      "state.json.corrupted",
+      "state.json.corrupted.1234567890",
       1 * 24 * 60 * 60 * 1000,
       Date.now()
     );

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -6,11 +6,11 @@ import { logInfo, logError } from "../utils/logger.js";
 
 const QUARANTINE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
-const QUARANTINE_FILENAMES = [
-  "state.json.corrupted",
-  "settings.json.corrupted",
-  "recipes.json.corrupted",
-  "workflows.json.corrupted",
+const QUARANTINE_PREFIXES = [
+  "state.json.corrupted.",
+  "settings.json.corrupted.",
+  "recipes.json.corrupted.",
+  "workflows.json.corrupted.",
 ];
 
 export async function cleanupQuarantinedProjectFiles(
@@ -33,9 +33,19 @@ export async function cleanupQuarantinedProjectFiles(
 
     const projectDir = path.join(projectsConfigDir, entry.name);
 
-    for (const filename of QUARANTINE_FILENAMES) {
-      const filePath = path.join(projectDir, filename);
+    let dirEntries: import("fs").Dirent[];
+    try {
+      dirEntries = await fs.readdir(projectDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
 
+    for (const dirent of dirEntries) {
+      if (!dirent.isFile()) continue;
+      const matches = QUARANTINE_PREFIXES.some((prefix) => dirent.name.startsWith(prefix));
+      if (!matches) continue;
+
+      const filePath = path.join(projectDir, dirent.name);
       try {
         const stats = await fs.stat(filePath);
         if (stats.mtimeMs < threshold) {

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -8,9 +8,13 @@ const QUARANTINE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 const QUARANTINE_PREFIXES = [
   "state.json.corrupted.",
+  "state.json.corrupted",
   "settings.json.corrupted.",
+  "settings.json.corrupted",
   "recipes.json.corrupted.",
+  "recipes.json.corrupted",
   "workflows.json.corrupted.",
+  "workflows.json.corrupted",
 ];
 
 export async function cleanupQuarantinedProjectFiles(


### PR DESCRIPTION
## Summary
- Corruption quarantine filenames were fixed (`state.json.corrupted`), so a second corruption of the same file would overwrite the first quarantine. That destroyed the only forensic trace of the original failure.
- Added a `Date.now()` timestamp to the quarantine suffix (e.g. `state.json.corrupted.1714774000000`), matching the pattern the main electron-store already uses.
- Updated the quarantine cleanup service to handle both legacy untimestamped files and the new timestamped ones via prefix matching.

Resolves #6037

## Changes
- **ProjectStateManager, ProjectSettingsManager, ProjectFileStore, GlobalFileStore** -- appended `.${Date.now()}` to quarantine paths
- **projectQuarantineCleanup** -- switched from exact filename matching to prefix matching so both old and new quarantine files are found and cleaned up
- Updated all related tests to use timestamp-aware assertions

## Testing
- Unit tests pass for all four stores and the quarantine cleanup service
- Verified that legacy quarantine files (without timestamps) are still cleaned up correctly