### PR TITLE
feat(lifecycle): adopt DisposableStore pattern for window and view cleanup

### DIFF
--- a/electron/ipc/handlers/__tests__/project.getCurrent.test.ts
+++ b/electron/ipc/handlers/__tests__/project.getCurrent.test.ts
@@ -68,6 +68,7 @@ import type {
   WindowContext,
   WindowServices,
 } from "../../../window/WindowRegistry.js";
+import { DisposableStore } from "../../../utils/lifecycle.js";
 
 function makeWindowContext(
   windowId: number,
@@ -81,7 +82,7 @@ function makeWindowContext(
     projectPath: null,
     abortController: new AbortController(),
     services: services as WindowServices,
-    cleanup: [],
+    cleanup: new DisposableStore(),
   };
 }
 

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -68,6 +68,7 @@ import type {
   WindowContext,
   WindowServices,
 } from "../../../window/WindowRegistry.js";
+import { DisposableStore } from "../../../utils/lifecycle.js";
 
 function makeWindowContext(
   windowId: number,
@@ -81,7 +82,7 @@ function makeWindowContext(
     projectPath: null,
     abortController: new AbortController(),
     services: services as WindowServices,
-    cleanup: [],
+    cleanup: new DisposableStore(),
   };
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -30,6 +30,7 @@ import { ProjectViewManager } from "./window/ProjectViewManager.js";
 import { effectiveCachedProjectViews } from "./utils/cachedProjectViews.js";
 import { setupBrowserWindow } from "./window/createWindow.js";
 import { distributePortsToView } from "./window/portDistribution.js";
+import { toDisposable } from "./utils/lifecycle.js";
 import {
   setupWindowServices,
   getPtyClient,
@@ -248,11 +249,15 @@ if (!gotTheLock) {
         nodeV8.writeHeapSnapshot(filePath);
     }
 
-    // Clean up ProjectViewManager when window closes
-    win.once("closed", () => {
-      pvm.dispose();
-      setProjectViewManager(null);
-    });
+    // Clean up ProjectViewManager when the window's cleanup runs.
+    // Registered before setupWindowServices so pvm.dispose() runs first —
+    // views must close before per-window ports/event-buffer disconnect.
+    ctx.cleanup.add(
+      toDisposable(() => {
+        pvm.dispose();
+        setProjectViewManager(null);
+      })
+    );
 
     await setupWindowServices(win, {
       loadRenderer,

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -4,12 +4,13 @@ import { events } from "./events.js";
 import { projectStore } from "./ProjectStore.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { ProjectStatusMap } from "../../shared/types/ipc/project.js";
+import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const DEBOUNCE_MS = 200;
 
 export class ProjectStatsService {
-  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private intervalSlot = new MutableDisposable<IDisposable>();
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private unsubscribeAgentState: (() => void) | null = null;
   private started = false;
@@ -23,10 +24,7 @@ export class ProjectStatsService {
     this.started = true;
 
     void this.computeAndBroadcast();
-
-    this.intervalId = setInterval(() => {
-      void this.computeAndBroadcast();
-    }, this.pollIntervalMs);
+    this.armPollInterval();
 
     this.unsubscribeAgentState = events.on("agent:state-changed", () => {
       this.debouncedCompute();
@@ -36,11 +34,8 @@ export class ProjectStatsService {
   updatePollInterval(ms: number): void {
     if (this.pollIntervalMs === ms) return;
     this.pollIntervalMs = ms;
-    if (this.started && this.intervalId !== null) {
-      clearInterval(this.intervalId);
-      this.intervalId = setInterval(() => {
-        void this.computeAndBroadcast();
-      }, this.pollIntervalMs);
+    if (this.started) {
+      this.armPollInterval();
     }
   }
 
@@ -52,10 +47,7 @@ export class ProjectStatsService {
     if (!this.started) return;
     this.started = false;
 
-    if (this.intervalId !== null) {
-      clearInterval(this.intervalId);
-      this.intervalId = null;
-    }
+    this.intervalSlot.clear();
 
     if (this.debounceTimer !== null) {
       clearTimeout(this.debounceTimer);
@@ -66,6 +58,13 @@ export class ProjectStatsService {
       this.unsubscribeAgentState();
       this.unsubscribeAgentState = null;
     }
+  }
+
+  private armPollInterval(): void {
+    const id = setInterval(() => {
+      void this.computeAndBroadcast();
+    }, this.pollIntervalMs);
+    this.intervalSlot.value = toDisposable(() => clearInterval(id));
   }
 
   private debouncedCompute(): void {

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -158,7 +158,7 @@ export class IdentityWatcher {
   }
 
   onShellSubmit(commandText?: string, options: { allowWhenAgentDetected?: boolean } = {}): void {
-    if (this.delegate.isExited || this.delegate.wasKilled) {
+    if (this.stopped || this.delegate.isExited || this.delegate.wasKilled) {
       return;
     }
 

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -6,6 +6,7 @@ import {
   type ProcessDetector,
 } from "../ProcessDetector.js";
 import { detectPrompt } from "./PromptDetector.js";
+import { MutableDisposable, toDisposable, type IDisposable } from "../../utils/lifecycle.js";
 
 export const SHELL_IDENTITY_FALLBACK_COMMIT_MS = 1200;
 export const SHELL_IDENTITY_FALLBACK_POLL_MS = 200;
@@ -85,7 +86,7 @@ export function normalizeShellCommandText(commandText?: string): string | undefi
  * for a single concern.
  */
 export class IdentityWatcher {
-  private timer: NodeJS.Timeout | null = null;
+  private timer = new MutableDisposable<IDisposable>();
   private submittedAt: number | null = null;
   private commandText: string | undefined;
   private identity: CommandIdentity | null = null;
@@ -233,10 +234,7 @@ export class IdentityWatcher {
   }
 
   stop(): void {
-    if (this.timer) {
-      clearInterval(this.timer);
-      this.timer = null;
-    }
+    this.timer.clear();
     this.submittedAt = null;
     this.commandText = undefined;
     this.identity = null;
@@ -251,12 +249,13 @@ export class IdentityWatcher {
   }
 
   private start(): void {
-    if (this.timer || this.stopped) {
+    if (this.timer.value || this.stopped) {
       return;
     }
-    this.timer = setInterval(() => {
+    const id = setInterval(() => {
       this.poll();
     }, SHELL_IDENTITY_FALLBACK_POLL_MS);
+    this.timer.value = toDisposable(() => clearInterval(id));
   }
 
   private hasRecentCommandFailureOutput(): boolean {

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -224,6 +224,23 @@ describe("IdentityWatcher", () => {
       watcher.stop();
       expect(watcher.pendingFallbackIdentity).toBeNull();
     });
+
+    it("onShellSubmit after dispose is inert", () => {
+      // After dispose, a late onShellSubmit must not arm a new poll interval
+      // or mutate any state — the watcher is dead.
+      const { delegate, state } = createFakeDelegate({
+        cursorLine: "user@host:~$ ",
+        visibleLines: ["user@host:~$ "],
+      });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.dispose();
+      watcher.onShellSubmit("claude");
+
+      expect(watcher.pendingFallbackIdentity).toBeNull();
+      vi.advanceTimersByTime(5_000);
+      expect(state.detectionCalls).toHaveLength(0);
+    });
   });
 
   describe("seed", () => {

--- a/electron/utils/__tests__/lifecycle.test.ts
+++ b/electron/utils/__tests__/lifecycle.test.ts
@@ -87,6 +87,24 @@ describe("DisposableStore", () => {
     }
   });
 
+  it("re-entrant dispose() during a child's dispose() is safe", () => {
+    // Snapshot-before-iterate also makes it safe for a child to call
+    // store.dispose() during its own teardown — _isDisposed is set first,
+    // so the re-entrant call is a no-op and does not double-invoke siblings.
+    const store = new DisposableStore();
+    const sibling = vi.fn();
+    store.add(
+      toDisposable(() => {
+        store.dispose();
+      })
+    );
+    store.add(toDisposable(sibling));
+
+    store.dispose();
+    expect(sibling).toHaveBeenCalledOnce();
+    expect(store.isDisposed).toBe(true);
+  });
+
   it("clear() disposes all children but keeps the store usable", () => {
     const store = new DisposableStore();
     const a = vi.fn();

--- a/electron/utils/__tests__/lifecycle.test.ts
+++ b/electron/utils/__tests__/lifecycle.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  Disposable,
+  DisposableStore,
+  MutableDisposable,
+  toDisposable,
+  type IDisposable,
+} from "../lifecycle.js";
+
+describe("toDisposable", () => {
+  it("wraps a function as an IDisposable that calls it on dispose()", () => {
+    const fn = vi.fn();
+    const d = toDisposable(fn);
+    d.dispose();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("DisposableStore", () => {
+  it("disposes all registered children on dispose()", () => {
+    const store = new DisposableStore();
+    const a = vi.fn();
+    const b = vi.fn();
+    store.add(toDisposable(a));
+    store.add(toDisposable(b));
+    store.dispose();
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it("dispose() is idempotent", () => {
+    const store = new DisposableStore();
+    const a = vi.fn();
+    store.add(toDisposable(a));
+    store.dispose();
+    store.dispose();
+    expect(a).toHaveBeenCalledOnce();
+  });
+
+  it("a child throwing does not skip later children", () => {
+    const store = new DisposableStore();
+    const middle = vi.fn();
+    const last = vi.fn();
+    store.add(
+      toDisposable(() => {
+        throw new Error("boom");
+      })
+    );
+    store.add(toDisposable(middle));
+    store.add(toDisposable(last));
+    expect(() => store.dispose()).not.toThrow();
+    expect(middle).toHaveBeenCalledOnce();
+    expect(last).toHaveBeenCalledOnce();
+  });
+
+  it("returns the registered disposable from add() for inline use", () => {
+    const store = new DisposableStore();
+    const child = toDisposable(() => {});
+    expect(store.add(child)).toBe(child);
+  });
+
+  it("supports nested stores — disposing the parent disposes the child store", () => {
+    const parent = new DisposableStore();
+    const child = parent.add(new DisposableStore());
+    const fn = vi.fn();
+    child.add(toDisposable(fn));
+    parent.dispose();
+    expect(fn).toHaveBeenCalledOnce();
+    expect(child.isDisposed).toBe(true);
+  });
+
+  it("add-after-dispose immediately disposes the new item and logs an error", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const store = new DisposableStore();
+      store.dispose();
+      const late = vi.fn();
+      const handle = store.add(toDisposable(late));
+      expect(late).toHaveBeenCalledOnce();
+      expect(errSpy).toHaveBeenCalled();
+      // The store does not retain the late item.
+      expect(store.size).toBe(0);
+      // add() still returns the same handle so callers can chain.
+      expect(handle.dispose).toBeDefined();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("clear() disposes all children but keeps the store usable", () => {
+    const store = new DisposableStore();
+    const a = vi.fn();
+    store.add(toDisposable(a));
+    store.clear();
+    expect(a).toHaveBeenCalledOnce();
+    expect(store.isDisposed).toBe(false);
+
+    const b = vi.fn();
+    store.add(toDisposable(b));
+    store.dispose();
+    expect(b).toHaveBeenCalledOnce();
+  });
+});
+
+describe("MutableDisposable", () => {
+  it("auto-disposes the previous value when reassigned", () => {
+    const slot = new MutableDisposable<IDisposable>();
+    const a = vi.fn();
+    const b = vi.fn();
+    slot.value = toDisposable(a);
+    slot.value = toDisposable(b);
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).not.toHaveBeenCalled();
+  });
+
+  it("assigning the same value is a no-op", () => {
+    const slot = new MutableDisposable<IDisposable>();
+    const fn = vi.fn();
+    const handle = toDisposable(fn);
+    slot.value = handle;
+    slot.value = handle;
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("clear() disposes the current value", () => {
+    const slot = new MutableDisposable<IDisposable>();
+    const fn = vi.fn();
+    slot.value = toDisposable(fn);
+    slot.clear();
+    expect(fn).toHaveBeenCalledOnce();
+    expect(slot.value).toBeUndefined();
+  });
+
+  it("dispose() disposes the current value and ignores future assignments", () => {
+    const slot = new MutableDisposable<IDisposable>();
+    const a = vi.fn();
+    slot.value = toDisposable(a);
+    slot.dispose();
+    expect(a).toHaveBeenCalledOnce();
+
+    const b = vi.fn();
+    slot.value = toDisposable(b);
+    // After dispose, incoming values are immediately disposed and not retained.
+    expect(b).toHaveBeenCalledOnce();
+    expect(slot.value).toBeUndefined();
+  });
+
+  it("clearing an empty slot does not throw", () => {
+    const slot = new MutableDisposable<IDisposable>();
+    expect(() => slot.clear()).not.toThrow();
+  });
+});
+
+describe("Disposable base class", () => {
+  it("_register adds a child that disposes when dispose() runs", () => {
+    class Service extends Disposable {
+      readonly child: IDisposable;
+      constructor(onDispose: () => void) {
+        super();
+        this.child = this._register(toDisposable(onDispose));
+      }
+    }
+    const fn = vi.fn();
+    const svc = new Service(fn);
+    svc.dispose();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("dispose() is idempotent", () => {
+    class Service extends Disposable {
+      constructor(onDispose: () => void) {
+        super();
+        this._register(toDisposable(onDispose));
+      }
+    }
+    const fn = vi.fn();
+    const svc = new Service(fn);
+    svc.dispose();
+    svc.dispose();
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});

--- a/electron/utils/lifecycle.ts
+++ b/electron/utils/lifecycle.ts
@@ -47,26 +47,31 @@ export class DisposableStore implements IDisposable {
   dispose(): void {
     if (this._isDisposed) return;
     this._isDisposed = true;
-    for (const d of this._disposables) {
+    // Snapshot before iteration so a child's dispose() can mutate the Set
+    // (e.g. by disposing a sibling that was registered here) without skipping
+    // entries via in-flight Set iteration semantics.
+    const items = Array.from(this._disposables);
+    this._disposables.clear();
+    for (const d of items) {
       try {
         d.dispose();
       } catch {
         /* swallow — mirrors WindowRegistry.unregister() error handling */
       }
     }
-    this._disposables.clear();
   }
 
   /** Dispose all children but keep the store usable for new registrations. */
   clear(): void {
-    for (const d of this._disposables) {
+    const items = Array.from(this._disposables);
+    this._disposables.clear();
+    for (const d of items) {
       try {
         d.dispose();
       } catch {
         /* swallow */
       }
     }
-    this._disposables.clear();
   }
 
   get size(): number {

--- a/electron/utils/lifecycle.ts
+++ b/electron/utils/lifecycle.ts
@@ -1,0 +1,137 @@
+/**
+ * Disposable lifecycle primitives, modeled on VS Code's
+ * `vs/base/common/lifecycle.ts` (MIT-licensed). Trimmed to the subset this
+ * codebase actually consumes: a small `IDisposable` interface, a `toDisposable`
+ * adapter for legacy `() => void` cleanups, a `DisposableStore` aggregate, a
+ * single-slot `MutableDisposable`, and a `Disposable` base class.
+ *
+ * The shape of `IDisposable` is structurally compatible with `node-pty`'s
+ * `IDisposable` type — they never appear in the same import scope, but
+ * structural compatibility means handles obtained from node-pty can be added
+ * directly to a store without extra wrapping.
+ */
+
+export interface IDisposable {
+  dispose(): void;
+}
+
+export function toDisposable(fn: () => void): IDisposable {
+  return { dispose: fn };
+}
+
+export class DisposableStore implements IDisposable {
+  private readonly _disposables = new Set<IDisposable>();
+  private _isDisposed = false;
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  add<T extends IDisposable>(o: T): T {
+    if (this._isDisposed) {
+      console.error(
+        "[lifecycle] DisposableStore.add() called after dispose — disposing immediately to avoid leak"
+      );
+      try {
+        o.dispose();
+      } catch {
+        /* swallow — late teardown */
+      }
+      return o;
+    }
+    this._disposables.add(o);
+    return o;
+  }
+
+  /** Dispose every registered child. Safe to call multiple times. */
+  dispose(): void {
+    if (this._isDisposed) return;
+    this._isDisposed = true;
+    for (const d of this._disposables) {
+      try {
+        d.dispose();
+      } catch {
+        /* swallow — mirrors WindowRegistry.unregister() error handling */
+      }
+    }
+    this._disposables.clear();
+  }
+
+  /** Dispose all children but keep the store usable for new registrations. */
+  clear(): void {
+    for (const d of this._disposables) {
+      try {
+        d.dispose();
+      } catch {
+        /* swallow */
+      }
+    }
+    this._disposables.clear();
+  }
+
+  get size(): number {
+    return this._disposables.size;
+  }
+}
+
+export class MutableDisposable<T extends IDisposable = IDisposable> implements IDisposable {
+  private _value: T | undefined;
+  private _isDisposed = false;
+
+  get value(): T | undefined {
+    return this._isDisposed ? undefined : this._value;
+  }
+
+  set value(newValue: T | undefined) {
+    if (this._isDisposed) {
+      // Container is dead — dispose the incoming value immediately so callers
+      // can't accidentally retain a resource by assigning into a torn-down slot.
+      if (newValue !== undefined) {
+        try {
+          newValue.dispose();
+        } catch {
+          /* swallow */
+        }
+      }
+      return;
+    }
+    if (this._value === newValue) return;
+    if (this._value !== undefined) {
+      try {
+        this._value.dispose();
+      } catch {
+        /* swallow */
+      }
+    }
+    this._value = newValue;
+  }
+
+  clear(): void {
+    this.value = undefined;
+  }
+
+  dispose(): void {
+    if (this._isDisposed) return;
+    this._isDisposed = true;
+    if (this._value !== undefined) {
+      try {
+        this._value.dispose();
+      } catch {
+        /* swallow */
+      }
+      this._value = undefined;
+    }
+  }
+}
+
+export abstract class Disposable implements IDisposable {
+  protected readonly _store = new DisposableStore();
+
+  protected _register<T extends IDisposable>(o: T): T {
+    return this._store.add(o);
+  }
+
+  dispose(): void {
+    this._store.dispose();
+  }
+}

--- a/electron/window/WindowRegistry.ts
+++ b/electron/window/WindowRegistry.ts
@@ -3,6 +3,7 @@ import type { EventBuffer } from "../services/EventBuffer.js";
 import type { PortalManager } from "../services/PortalManager.js";
 import type { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
+import { DisposableStore } from "../utils/lifecycle.js";
 
 export interface WindowServices {
   portalManager?: PortalManager;
@@ -20,7 +21,7 @@ export interface WindowContext {
   projectPath: string | null;
   abortController: AbortController;
   services: WindowServices;
-  cleanup: Array<() => void>;
+  cleanup: DisposableStore;
   /** @internal Set to true after unregister runs to prevent double-cleanup from deferred event listeners. */
   _unregistered?: boolean;
 }
@@ -50,7 +51,7 @@ export class WindowRegistry {
       projectPath: opts?.projectPath ?? null,
       abortController: new AbortController(),
       services: {},
-      cleanup: [],
+      cleanup: new DisposableStore(),
     };
 
     this.windows.set(windowId, ctx);
@@ -103,13 +104,7 @@ export class WindowRegistry {
     ctx._unregistered = true;
     ctx.abortController.abort();
 
-    for (const fn of ctx.cleanup) {
-      try {
-        fn();
-      } catch {
-        // Ignore cleanup errors during disposal
-      }
-    }
+    ctx.cleanup.dispose();
 
     this.webContentsIndex.delete(ctx.webContentsId);
     const appViewWcIds = this.appViewWebContentsIds.get(windowId);

--- a/electron/window/__tests__/WindowRegistry.adversarial.test.ts
+++ b/electron/window/__tests__/WindowRegistry.adversarial.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { WindowRegistry } from "../WindowRegistry.js";
+import { toDisposable } from "../../utils/lifecycle.js";
 import type { BrowserWindow } from "electron";
 
 type Handler = () => void;
@@ -56,7 +57,7 @@ describe("WindowRegistry adversarial", () => {
     const cleanup = vi.fn();
 
     const ctx = registry.register(win);
-    ctx.cleanup.push(cleanup);
+    ctx.cleanup.add(toDisposable(cleanup));
 
     registry.unregister(1);
     win._fireClosed();
@@ -107,11 +108,11 @@ describe("WindowRegistry adversarial", () => {
     const cleanup = vi.fn();
 
     const firstCtx = registry.register(first);
-    firstCtx.cleanup.push(cleanup);
+    firstCtx.cleanup.add(toDisposable(cleanup));
     registry.unregister(1);
 
     const secondCtx = registry.register(second);
-    secondCtx.cleanup.push(cleanup);
+    secondCtx.cleanup.add(toDisposable(cleanup));
     second._fireClosed();
 
     expect(cleanup).toHaveBeenCalledTimes(2);

--- a/electron/window/__tests__/WindowRegistry.test.ts
+++ b/electron/window/__tests__/WindowRegistry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { WindowRegistry } from "../WindowRegistry.js";
+import { toDisposable } from "../../utils/lifecycle.js";
 import type { BrowserWindow } from "electron";
 
 function makeMockWindow(id: number, webContentsId: number) {
@@ -193,7 +194,7 @@ describe("WindowRegistry", () => {
     const cleanupSpy = vi.fn();
 
     const ctx = registry.register(win);
-    ctx.cleanup.push(cleanupSpy);
+    ctx.cleanup.add(toDisposable(cleanupSpy));
 
     win._fireClosed();
     win._fireDestroyed();
@@ -209,7 +210,8 @@ describe("WindowRegistry", () => {
     const fn2 = vi.fn();
 
     const ctx = registry.register(win);
-    ctx.cleanup.push(fn1, fn2);
+    ctx.cleanup.add(toDisposable(fn1));
+    ctx.cleanup.add(toDisposable(fn2));
 
     registry.unregister(1);
 
@@ -226,12 +228,30 @@ describe("WindowRegistry", () => {
     const fn2 = vi.fn();
 
     const ctx = registry.register(win);
-    ctx.cleanup.push(fn1, fn2);
+    ctx.cleanup.add(toDisposable(fn1));
+    ctx.cleanup.add(toDisposable(fn2));
 
     registry.unregister(1);
 
     expect(fn1).toHaveBeenCalledOnce();
     expect(fn2).toHaveBeenCalledOnce();
+  });
+
+  it("late add() after unregister disposes the new item immediately and does not retain it", () => {
+    const registry = new WindowRegistry();
+    const win = makeMockWindow(1, 100);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const ctx = registry.register(win);
+    registry.unregister(1);
+
+    const lateSpy = vi.fn();
+    ctx.cleanup.add(toDisposable(lateSpy));
+
+    expect(lateSpy).toHaveBeenCalledOnce();
+    expect(errSpy).toHaveBeenCalled();
+    expect(ctx.cleanup.size).toBe(0);
+    errSpy.mockRestore();
   });
 
   it("returns same context when registering the same window twice", () => {
@@ -265,7 +285,7 @@ describe("WindowRegistry", () => {
     const fn = vi.fn();
 
     const ctx = registry.register(win1);
-    ctx.cleanup.push(fn);
+    ctx.cleanup.add(toDisposable(fn));
     registry.register(win2);
 
     registry.dispose();
@@ -355,9 +375,11 @@ describe("WindowRegistry", () => {
 
       const ctx = registry.register(win);
       let signalAbortedDuringCleanup = false;
-      ctx.cleanup.push(() => {
-        signalAbortedDuringCleanup = ctx.abortController.signal.aborted;
-      });
+      ctx.cleanup.add(
+        toDisposable(() => {
+          signalAbortedDuringCleanup = ctx.abortController.signal.aborted;
+        })
+      );
 
       registry.unregister(1);
 

--- a/electron/window/__tests__/windowServicesScoping.test.ts
+++ b/electron/window/__tests__/windowServicesScoping.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { WindowRegistry } from "../WindowRegistry.js";
+import { toDisposable } from "../../utils/lifecycle.js";
 import type { BrowserWindow } from "electron";
 
 function makeMockWindow(id: number, webContentsId: number) {
@@ -91,15 +92,19 @@ describe("Per-window service scoping via WindowRegistry", () => {
       close: port4Close,
     } as unknown as import("electron").MessagePortMain;
 
-    // Push cleanup for each window (mimics what setupWindowServices does)
-    ctx1.cleanup.push(() => {
-      ctx1.services.activeRendererPort?.close();
-      ctx1.services.activePtyHostPort?.close();
-    });
-    ctx2.cleanup.push(() => {
-      ctx2.services.activeRendererPort?.close();
-      ctx2.services.activePtyHostPort?.close();
-    });
+    // Register cleanup for each window (mimics what setupWindowServices does)
+    ctx1.cleanup.add(
+      toDisposable(() => {
+        ctx1.services.activeRendererPort?.close();
+        ctx1.services.activePtyHostPort?.close();
+      })
+    );
+    ctx2.cleanup.add(
+      toDisposable(() => {
+        ctx2.services.activeRendererPort?.close();
+        ctx2.services.activePtyHostPort?.close();
+      })
+    );
 
     // Close window 1 only
     registry.unregister(1);
@@ -130,8 +135,8 @@ describe("Per-window service scoping via WindowRegistry", () => {
       destroy: destroy2,
     } as unknown as import("../../../electron/services/PortalManager.js").PortalManager;
 
-    ctx1.cleanup.push(() => ctx1.services.portalManager?.destroy());
-    ctx2.cleanup.push(() => ctx2.services.portalManager?.destroy());
+    ctx1.cleanup.add(toDisposable(() => ctx1.services.portalManager?.destroy()));
+    ctx2.cleanup.add(toDisposable(() => ctx2.services.portalManager?.destroy()));
 
     win1._fireClosed();
 
@@ -157,8 +162,8 @@ describe("Per-window service scoping via WindowRegistry", () => {
       stop: stop2,
     } as unknown as import("../../../electron/services/EventBuffer.js").EventBuffer;
 
-    ctx1.cleanup.push(() => ctx1.services.eventBuffer?.stop());
-    ctx2.cleanup.push(() => ctx2.services.eventBuffer?.stop());
+    ctx1.cleanup.add(toDisposable(() => ctx1.services.eventBuffer?.stop()));
+    ctx2.cleanup.add(toDisposable(() => ctx2.services.eventBuffer?.stop()));
 
     win1._fireClosed();
 
@@ -200,9 +205,11 @@ describe("Per-window service scoping via WindowRegistry", () => {
 
     ctx1.services.projectSwitchService =
       {} as unknown as import("../../../electron/services/ProjectSwitchService.js").ProjectSwitchService;
-    ctx1.cleanup.push(() => {
-      ctx1.services.projectSwitchService = undefined;
-    });
+    ctx1.cleanup.add(
+      toDisposable(() => {
+        ctx1.services.projectSwitchService = undefined;
+      })
+    );
 
     win1._fireClosed();
 
@@ -216,10 +223,12 @@ describe("Per-window service scoping via WindowRegistry", () => {
     const bufferUnsub = vi.fn();
 
     // This mimics the pattern from the refactored windowServices.ts
-    ctx1.cleanup.push(() => {
-      bufferUnsub();
-      // The key assertion: we use removeListener (per-function) not removeAllListeners
-    });
+    ctx1.cleanup.add(
+      toDisposable(() => {
+        bufferUnsub();
+        // The key assertion: we use removeListener (per-function) not removeAllListeners
+      })
+    );
 
     win1._fireClosed();
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -92,6 +92,7 @@ import {
   resetDeferredQueue,
 } from "./deferredInitQueue.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { toDisposable } from "../utils/lifecycle.js";
 
 const DEFAULT_TERMINAL_ID = "default";
 
@@ -624,7 +625,7 @@ export async function setupWindowServices(
 
   if (windowRegistry) {
     notificationService.initialize(windowRegistry);
-    ctx.cleanup.push(() => notificationService.detachWindowListeners(win.id));
+    ctx.cleanup.add(toDisposable(() => notificationService.detachWindowListeners(win.id)));
   }
   console.log("[MAIN] NotificationService initialized");
 
@@ -752,40 +753,42 @@ export async function setupWindowServices(
   } as HandlerDependencies);
 
   // Per-window cleanup: ports, portalManager, eventBuffer
-  ctx.cleanup.push(() => {
-    // Notify PTY host to disconnect this window's port before closing it
-    if (ptyClient) {
-      ptyClient.disconnectMessagePort(ctx.windowId);
-    }
-    if (ctx.services.activeRendererPort) {
-      try {
-        ctx.services.activeRendererPort.close();
-      } catch {
-        /* ignore */
+  ctx.cleanup.add(
+    toDisposable(() => {
+      // Notify PTY host to disconnect this window's port before closing it
+      if (ptyClient) {
+        ptyClient.disconnectMessagePort(ctx.windowId);
       }
-      ctx.services.activeRendererPort = undefined;
-    }
-    if (ctx.services.activePtyHostPort) {
-      try {
-        ctx.services.activePtyHostPort.close();
-      } catch {
-        /* ignore */
+      if (ctx.services.activeRendererPort) {
+        try {
+          ctx.services.activeRendererPort.close();
+        } catch {
+          /* ignore */
+        }
+        ctx.services.activeRendererPort = undefined;
       }
-      ctx.services.activePtyHostPort = undefined;
-    }
-    if (ctx.services.portalManager) {
-      ctx.services.portalManager.destroy();
-      ctx.services.portalManager = undefined;
-    }
-    if (ctx.services.eventBuffer) {
-      ctx.services.eventBuffer.stop();
-      ctx.services.eventBuffer = undefined;
-    }
-    ctx.services.projectSwitchService = undefined;
-    if (workspaceClient) {
-      workspaceClient.unregisterWindow(win.id);
-    }
-  });
+      if (ctx.services.activePtyHostPort) {
+        try {
+          ctx.services.activePtyHostPort.close();
+        } catch {
+          /* ignore */
+        }
+        ctx.services.activePtyHostPort = undefined;
+      }
+      if (ctx.services.portalManager) {
+        ctx.services.portalManager.destroy();
+        ctx.services.portalManager = undefined;
+      }
+      if (ctx.services.eventBuffer) {
+        ctx.services.eventBuffer.stop();
+        ctx.services.eventBuffer = undefined;
+      }
+      ctx.services.projectSwitchService = undefined;
+      if (workspaceClient) {
+        workspaceClient.unregisterWindow(win.id);
+      }
+    })
+  );
 
   console.log("[MAIN] Registering IPC handlers...");
   const handlerDeps: HandlerDependencies = {
@@ -1121,11 +1124,13 @@ export async function setupWindowServices(
     sendToRenderer(win, CHANNELS.EVENT_INSPECTOR_EVENT, record);
   });
 
-  ctx.cleanup.push(() => {
-    unsubscribeFromEventBuffer();
-    ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, onEventInspectorSubscribe);
-    ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, onEventInspectorUnsubscribe);
-  });
+  ctx.cleanup.add(
+    toDisposable(() => {
+      unsubscribeFromEventBuffer();
+      ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, onEventInspectorSubscribe);
+      ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, onEventInspectorUnsubscribe);
+    })
+  );
 
   // Smoke test
   if (isSmokeTest) {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -19,6 +19,7 @@ import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/in
 import { ensureSerializable } from "../../shared/utils/serialization.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitFileWatcher } from "../utils/gitFileWatcher.js";
+import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
 
 const GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS = 1000;
 const WATCHER_FALLBACK_POLL_INTERVAL_MS = 30_000;
@@ -98,8 +99,9 @@ export class WorktreeMonitor {
   private pollingEnabled: boolean = true;
   private _hasInitialStatus: boolean = false;
 
-  // File watcher state
-  private gitWatcher: (() => void) | null = null;
+  // File watcher state — MutableDisposable auto-disposes the previous watcher
+  // on reassignment, eliminating the manual stop-old-start-new dance.
+  private gitWatcher = new MutableDisposable<IDisposable>();
   private gitWatchDebounceTimer: NodeJS.Timeout | null = null;
   private gitWatchRefreshPending: boolean = false;
   private gitWatchEnabled: boolean;
@@ -293,7 +295,7 @@ export class WorktreeMonitor {
   }
 
   get hasWatcher(): boolean {
-    return this.gitWatcher !== null;
+    return this.gitWatcher.value !== undefined;
   }
 
   setIssueNumber(issueNumber: number | undefined): void {
@@ -702,15 +704,15 @@ export class WorktreeMonitor {
   }
 
   ensureWatcherState(): void {
-    if (!this.gitWatchEnabled && this.gitWatcher) {
+    if (!this.gitWatchEnabled && this.gitWatcher.value) {
       this.stopWatcher();
-    } else if (this.gitWatchEnabled && this._isRunning && !this.gitWatcher) {
+    } else if (this.gitWatchEnabled && this._isRunning && !this.gitWatcher.value) {
       this.startWatcher();
     }
   }
 
   restartWatcherIfRunning(): void {
-    if (this.gitWatcher) {
+    if (this.gitWatcher.value) {
       this.updateWatcher();
     }
   }
@@ -718,7 +720,7 @@ export class WorktreeMonitor {
   // --- File watcher management ---
 
   private startWatcher(): void {
-    if (!this._isRunning || !this.gitWatchEnabled || this.gitWatcher) {
+    if (!this._isRunning || !this.gitWatchEnabled || this.gitWatcher.value) {
       return;
     }
 
@@ -738,7 +740,7 @@ export class WorktreeMonitor {
 
     const started = watcher.start();
     if (started) {
-      this.gitWatcher = () => watcher.dispose();
+      this.gitWatcher.value = toDisposable(() => watcher.dispose());
       this.watcherRetryCount = 0;
     } else {
       watcher.dispose();
@@ -747,10 +749,7 @@ export class WorktreeMonitor {
   }
 
   private stopWatcher(): void {
-    if (this.gitWatcher) {
-      this.gitWatcher();
-      this.gitWatcher = null;
-    }
+    this.gitWatcher.clear();
     if (this.gitWatchDebounceTimer) {
       clearTimeout(this.gitWatchDebounceTimer);
       this.gitWatchDebounceTimer = null;
@@ -771,10 +770,7 @@ export class WorktreeMonitor {
   }
 
   private handleWatcherFailed(): void {
-    if (this.gitWatcher) {
-      this.gitWatcher();
-      this.gitWatcher = null;
-    }
+    this.gitWatcher.clear();
     this.scheduleWatcherRetry();
   }
 
@@ -790,7 +786,7 @@ export class WorktreeMonitor {
 
     this.watcherRetryTimer = setTimeout(() => {
       this.watcherRetryTimer = null;
-      if (this._isRunning && this.gitWatchEnabled && !this.gitWatcher) {
+      if (this._isRunning && this.gitWatchEnabled && !this.gitWatcher.value) {
         this.startWatcher();
       }
     }, WATCHER_RETRY_INTERVAL_MS);
@@ -895,7 +891,7 @@ export class WorktreeMonitor {
       return;
     }
 
-    const baseInterval = this.gitWatcher
+    const baseInterval = this.gitWatcher.value
       ? WATCHER_FALLBACK_POLL_INTERVAL_MS
       : this.pollingStrategy.calculateNextInterval();
     const jitterRange = Math.min(2000, Math.floor(baseInterval * 0.2));
@@ -926,7 +922,7 @@ export class WorktreeMonitor {
       const queueDelayMs = Math.max(0, startTime - queuedAt);
 
       try {
-        const forceRefresh = this._isCurrent && !this.gitWatcher;
+        const forceRefresh = this._isCurrent && !this.gitWatcher.value;
         await this.updateGitStatus(forceRefresh);
         this.pollingStrategy.recordSuccess(Date.now() - startTime, queueDelayMs);
       } catch (_error) {


### PR DESCRIPTION
## Summary

- Ports `DisposableStore`, `MutableDisposable`, and related primitives from VS Code's `lifecycle.ts` (MIT) into `electron/utils/lifecycle.ts`. This replaces the raw `Array<() => void>` cleanup pattern that has no add-after-dispose protection and no disposal hierarchy.
- Migrates `WindowContext.cleanup`, `WindowRegistry.unregister()`, and `windowServices.ts` to use the store. Migrates `WorktreeMonitor.gitWatcher`, `ProjectStatsService` poll interval, and `IdentityWatcher` timer to `MutableDisposable` — collapsing the manual stop-old/start-new dance in each.
- Snapshot-before-iterate in `dispose()`/`clear()` for re-entrant safety. Late `add()` after dispose logs an error and immediately disposes the item rather than silently leaking it.

Resolves #6027

## Changes

- `electron/utils/lifecycle.ts` (new, ~142 lines): `IDisposable`, `toDisposable`, `DisposableStore`, `MutableDisposable`, `Disposable` base class
- `electron/window/WindowRegistry.ts` + `windowServices.ts`: cleanup arrays replaced with `DisposableStore`
- `electron/main.ts`: `pvm.dispose()` now registered via `ctx.cleanup.add()` before window services so views close in the right order
- `electron/workspace-host/WorktreeMonitor.ts`: `gitWatcher` is now `MutableDisposable<IDisposable>`
- `electron/services/ProjectStatsService.ts` + `pty/IdentityWatcher.ts`: poll/timer slots migrated to `MutableDisposable`
- Tests: `lifecycle.test.ts` (16 tests, all primitives + re-entrant dispose), updated `WindowRegistry`, adversarial, `windowServicesScoping`, `IdentityWatcher`, and `project.*` tests

## Testing

16 new unit tests cover all primitives, re-entrant dispose, and post-dispose inertness. Existing `WindowRegistry` (30), adversarial (7), `windowServicesScoping` (8), `WorktreeMonitor`, `ProjectStatsService`, `IdentityWatcher`, and `project.getCurrent`/`project.switch` (14) tests all pass. Typecheck and lint clean.

Note: per-view listener leak in `ProjectViewManager` (`will-navigate`, `will-redirect`, etc. attached but never removed on LRU eviction) is a real follow-on bug worth fixing, but intentionally left for its own PR with focused testing rather than bundled here.