### PR TITLE
feat(notifications): replace cloud-sync and GitHub-token toasts with persistent banners

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,8 @@ import { removeStartupSkeleton } from "./utils/removeStartupSkeleton";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
 import { SafeModeBanner } from "./components/Recovery/SafeModeBanner";
+import { CloudSyncBanner } from "./components/Recovery/CloudSyncBanner";
+import { GitHubTokenBanner } from "./components/Recovery/GitHubTokenBanner";
 import {
   useAppHydration,
   useProjectSwitchRehydration,
@@ -480,6 +482,8 @@ function App() {
         <TooltipProvider delayDuration={500} skipDelayDuration={150}>
           <E2EFaultInjector />
           {isSafeMode && <SafeModeBanner />}
+          <GitHubTokenBanner />
+          <CloudSyncBanner />
           <DndProvider>
             <VoiceRecordingAnnouncer />
             <AccessibilityAnnouncer />

--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { notify } from "@/lib/notify";
@@ -8,12 +9,22 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export function CloudSyncBanner() {
   const service = useCloudSyncBannerStore((s) => s.service);
-  const setService = useCloudSyncBannerStore((s) => s.setService);
+  const setBanner = useCloudSyncBannerStore((s) => s.setBanner);
   const { saveSettings } = useProjectSettings();
 
   if (!service) return null;
 
   const handleDismiss = async () => {
+    // Guard against project switch race: the store carries the projectId the
+    // banner was raised for; skip the save if it no longer matches the live
+    // project (saveSettings would otherwise persist to the wrong project).
+    const bannerProjectId = useCloudSyncBannerStore.getState().projectId;
+    const livePid = useProjectStore.getState().currentProject?.id ?? null;
+    if (!bannerProjectId || bannerProjectId !== livePid) {
+      setBanner({ service: null, projectId: null });
+      return;
+    }
+
     try {
       const latestSettings = useProjectSettingsStore.getState().settings;
       if (!latestSettings) return;
@@ -22,7 +33,7 @@ export function CloudSyncBanner() {
         ...latestSettings,
         cloudSyncWarningDismissed: true,
       });
-      setService(null);
+      setBanner({ service: null, projectId: null });
     } catch (err) {
       logError("Failed to save cloud sync warning preference", err);
       notify({

--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -1,0 +1,57 @@
+import { AlertTriangle } from "lucide-react";
+import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useProjectSettings } from "@/hooks/useProjectSettings";
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+export function CloudSyncBanner() {
+  const service = useCloudSyncBannerStore((s) => s.service);
+  const setService = useCloudSyncBannerStore((s) => s.setService);
+  const { saveSettings } = useProjectSettings();
+
+  if (!service) return null;
+
+  const handleDismiss = async () => {
+    try {
+      const latestSettings = useProjectSettingsStore.getState().settings;
+      if (!latestSettings) return;
+
+      await saveSettings({
+        ...latestSettings,
+        cloudSyncWarningDismissed: true,
+      });
+      setService(null);
+    } catch (err) {
+      logError("Failed to save cloud sync warning preference", err);
+      notify({
+        type: "error",
+        title: "Couldn't save preference",
+        message: formatErrorMessage(err, "Failed to save cloud sync warning preference"),
+        duration: 6000,
+      });
+    }
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
+    >
+      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
+      <span className="flex-1">
+        This project is in a {service}-synced folder, which can interfere with terminal operations
+        and git. Consider moving it to a local folder.
+      </span>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
+      >
+        Don&rsquo;t show again
+      </button>
+    </div>
+  );
+}

--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -1,0 +1,34 @@
+import { AlertTriangle } from "lucide-react";
+import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+
+export function GitHubTokenBanner() {
+  const isUnhealthy = useGitHubTokenHealthStore((s) => s.isUnhealthy);
+
+  if (!isUnhealthy) return null;
+
+  const handleReconnect = () => {
+    window.dispatchEvent(
+      new CustomEvent("daintree:open-settings-tab", { detail: { tab: "github" } })
+    );
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
+    >
+      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
+      <span className="flex-1">
+        GitHub token expired. Reconnect to restore issue, PR, and repository data.
+      </span>
+      <button
+        type="button"
+        onClick={handleReconnect}
+        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
+      >
+        Reconnect to GitHub
+      </button>
+    </div>
+  );
+}

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -17,14 +17,22 @@ vi.mock("@/lib/notify", () => ({
 import { CloudSyncBanner } from "../CloudSyncBanner";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useProjectStore } from "@/store/projectStore";
+
+function setProject(id: string | null) {
+  useProjectStore.setState({
+    currentProject: id ? ({ id, path: "/x" } as never) : null,
+  });
+}
 
 describe("CloudSyncBanner", () => {
   beforeEach(() => {
-    useCloudSyncBannerStore.setState({ service: null });
+    useCloudSyncBannerStore.setState({ service: null, projectId: null });
     useProjectSettingsStore.setState({
       settings: { runCommands: [], cloudSyncWarningDismissed: false },
       projectId: "p1",
     });
+    setProject("p1");
     saveSettingsMock.mockReset().mockResolvedValue(undefined);
     notifyMock.mockReset();
     cleanup();
@@ -36,14 +44,14 @@ describe("CloudSyncBanner", () => {
   });
 
   it("renders banner with detected service name", () => {
-    useCloudSyncBannerStore.setState({ service: "Dropbox" });
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
     render(<CloudSyncBanner />);
     expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: /Don.+t show again/i })).toBeTruthy();
   });
 
   it("persists dismiss preference and clears the banner", async () => {
-    useCloudSyncBannerStore.setState({ service: "iCloud Drive" });
+    useCloudSyncBannerStore.setState({ service: "iCloud Drive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
     fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
@@ -58,9 +66,49 @@ describe("CloudSyncBanner", () => {
     });
   });
 
+  it("preserves all existing project settings fields when persisting dismiss", async () => {
+    useProjectSettingsStore.setState({
+      settings: {
+        runCommands: [{ command: "npm start", label: "Start" }],
+        cloudSyncWarningDismissed: false,
+        projectIconSvg: "<svg/>",
+      } as never,
+      projectId: "p1",
+    });
+    useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
+    render(<CloudSyncBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+
+    await waitFor(() => {
+      expect(saveSettingsMock).toHaveBeenCalledOnce();
+    });
+    const saved = saveSettingsMock.mock.calls[0]![0] as Record<string, unknown>;
+    expect(saved).toEqual({
+      runCommands: [{ command: "npm start", label: "Start" }],
+      cloudSyncWarningDismissed: true,
+      projectIconSvg: "<svg/>",
+    });
+  });
+
+  it("does not save to a different project after a switch race", async () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    render(<CloudSyncBanner />);
+
+    // Simulate the race: live project flips to p2 before the click handler runs.
+    setProject("p2");
+
+    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+
+    await waitFor(() => {
+      expect(useCloudSyncBannerStore.getState().service).toBeNull();
+    });
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
   it("surfaces a toast when saving the dismiss preference fails", async () => {
     saveSettingsMock.mockRejectedValueOnce(new Error("disk full"));
-    useCloudSyncBannerStore.setState({ service: "OneDrive" });
+    useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
     fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -83,7 +83,7 @@ describe("CloudSyncBanner", () => {
     await waitFor(() => {
       expect(saveSettingsMock).toHaveBeenCalledOnce();
     });
-    const saved = saveSettingsMock.mock.calls[0]![0] as Record<string, unknown>;
+    const saved = (saveSettingsMock.mock.calls[0] as unknown[])?.[0] as Record<string, unknown>;
     expect(saved).toEqual({
       runCommands: [{ command: "npm start", label: "Start" }],
       cloudSyncWarningDismissed: true,

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+
+const saveSettingsMock = vi.fn(() => Promise.resolve());
+vi.mock("@/hooks/useProjectSettings", () => ({
+  useProjectSettings: () => ({
+    saveSettings: saveSettingsMock,
+  }),
+}));
+
+const notifyMock = vi.fn();
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: unknown) => notifyMock(payload),
+}));
+
+import { CloudSyncBanner } from "../CloudSyncBanner";
+import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+
+describe("CloudSyncBanner", () => {
+  beforeEach(() => {
+    useCloudSyncBannerStore.setState({ service: null });
+    useProjectSettingsStore.setState({
+      settings: { runCommands: [], cloudSyncWarningDismissed: false },
+      projectId: "p1",
+    });
+    saveSettingsMock.mockReset().mockResolvedValue(undefined);
+    notifyMock.mockReset();
+    cleanup();
+  });
+
+  it("renders nothing when no service detected", () => {
+    const { container } = render(<CloudSyncBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders banner with detected service name", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox" });
+    render(<CloudSyncBanner />);
+    expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Don.+t show again/i })).toBeTruthy();
+  });
+
+  it("persists dismiss preference and clears the banner", async () => {
+    useCloudSyncBannerStore.setState({ service: "iCloud Drive" });
+    render(<CloudSyncBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+
+    await waitFor(() => {
+      expect(saveSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ cloudSyncWarningDismissed: true })
+      );
+    });
+    await waitFor(() => {
+      expect(useCloudSyncBannerStore.getState().service).toBeNull();
+    });
+  });
+
+  it("surfaces a toast when saving the dismiss preference fails", async () => {
+    saveSettingsMock.mockRejectedValueOnce(new Error("disk full"));
+    useCloudSyncBannerStore.setState({ service: "OneDrive" });
+    render(<CloudSyncBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+
+    await waitFor(() => {
+      expect(notifyMock).toHaveBeenCalled();
+    });
+    expect(useCloudSyncBannerStore.getState().service).toBe("OneDrive");
+  });
+});

--- a/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
+++ b/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { GitHubTokenBanner } from "../GitHubTokenBanner";
+import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+
+describe("GitHubTokenBanner", () => {
+  beforeEach(() => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: false });
+    cleanup();
+  });
+
+  it("renders nothing when token is healthy", () => {
+    const { container } = render(<GitHubTokenBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders banner when token is unhealthy", () => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    render(<GitHubTokenBanner />);
+    expect(screen.getByText(/GitHub token expired/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Reconnect to GitHub/i })).toBeTruthy();
+  });
+
+  it("dispatches open-settings-tab event when reconnect clicked", () => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    const listener = vi.fn();
+    window.addEventListener("daintree:open-settings-tab", listener as EventListener);
+
+    render(<GitHubTokenBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /Reconnect to GitHub/i }));
+
+    expect(listener).toHaveBeenCalledOnce();
+    const event = listener.mock.calls[0]![0] as CustomEvent<{ tab: string }>;
+    expect(event.detail.tab).toBe("github");
+
+    window.removeEventListener("daintree:open-settings-tab", listener as EventListener);
+  });
+
+  it("hides automatically when store transitions back to healthy", () => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    const { container } = render(<GitHubTokenBanner />);
+    expect(container.firstChild).not.toBeNull();
+
+    act(() => {
+      useGitHubTokenHealthStore.setState({ isUnhealthy: false });
+    });
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useGitHubTokenHealth.test.ts
+++ b/src/hooks/__tests__/useGitHubTokenHealth.test.ts
@@ -12,7 +12,8 @@ const onTokenHealthChangedMock = vi.fn(
   }
 );
 const getTokenHealthMock = vi.fn(
-  (): Promise<GitHubTokenHealthPayload> => Promise.resolve({ status: "unknown" })
+  (): Promise<GitHubTokenHealthPayload> =>
+    Promise.resolve({ status: "unknown", tokenVersion: 0, checkedAt: 0 })
 );
 
 vi.mock("@/clients/githubClient", () => ({
@@ -32,7 +33,9 @@ describe("useGitHubTokenHealth", () => {
     healthListener = null;
     onTokenHealthChangedMock.mockClear();
     cleanupMock.mockClear();
-    getTokenHealthMock.mockReset().mockResolvedValue({ status: "unknown" });
+    getTokenHealthMock
+      .mockReset()
+      .mockResolvedValue({ status: "unknown", tokenVersion: 0, checkedAt: 0 });
     useGitHubTokenHealthStore.setState({ isUnhealthy: false });
     useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
   });
@@ -51,7 +54,7 @@ describe("useGitHubTokenHealth", () => {
     });
 
     act(() => {
-      healthListener?.({ status: "unhealthy" });
+      healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 });
     });
 
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
@@ -61,10 +64,10 @@ describe("useGitHubTokenHealth", () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
 
-    act(() => healthListener?.({ status: "healthy" }));
+    act(() => healthListener?.({ status: "healthy", tokenVersion: 0, checkedAt: 0 }));
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
   });
 
@@ -72,8 +75,8 @@ describe("useGitHubTokenHealth", () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
-    act(() => healthListener?.({ status: "unhealthy" }));
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     const entries = useNotificationHistoryStore.getState().entries;
     expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(1);
@@ -83,16 +86,20 @@ describe("useGitHubTokenHealth", () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
-    act(() => healthListener?.({ status: "unhealthy" }));
-    act(() => healthListener?.({ status: "healthy" }));
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
+    act(() => healthListener?.({ status: "healthy", tokenVersion: 0, checkedAt: 0 }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     const entries = useNotificationHistoryStore.getState().entries;
     expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(2);
   });
 
   it("replays initial state on mount via getTokenHealth", async () => {
-    getTokenHealthMock.mockResolvedValueOnce({ status: "unhealthy" });
+    getTokenHealthMock.mockResolvedValueOnce({
+      status: "unhealthy",
+      tokenVersion: 0,
+      checkedAt: 0,
+    });
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
@@ -104,7 +111,7 @@ describe("useGitHubTokenHealth", () => {
     await act(async () => {});
 
     unmount();
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
 
     // The store should remain false because the cancelled flag short-circuits apply().
     // (Note: cleanup() is called too, but our mock retains the listener reference for testing.)
@@ -115,10 +122,10 @@ describe("useGitHubTokenHealth", () => {
     renderHook(() => useGitHubTokenHealth());
     await act(async () => {});
 
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
 
-    act(() => healthListener?.({ status: "unknown" }));
+    act(() => healthListener?.({ status: "unknown", tokenVersion: 0, checkedAt: 0 }));
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
   });
 
@@ -136,12 +143,12 @@ describe("useGitHubTokenHealth", () => {
     await act(async () => {});
 
     // Live push lands first.
-    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy", tokenVersion: 0, checkedAt: 0 }));
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
 
     // Now the slow replay resolves with stale data — must NOT overwrite the live state.
     await act(async () => {
-      resolveReplay({ status: "healthy" });
+      resolveReplay({ status: "healthy", tokenVersion: 0, checkedAt: 0 });
     });
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
   });

--- a/src/hooks/__tests__/useGitHubTokenHealth.test.ts
+++ b/src/hooks/__tests__/useGitHubTokenHealth.test.ts
@@ -110,4 +110,39 @@ describe("useGitHubTokenHealth", () => {
     // (Note: cleanup() is called too, but our mock retains the listener reference for testing.)
     expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
   });
+
+  it("clears the store when payload status is unknown", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy" }));
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+
+    act(() => healthListener?.({ status: "unknown" }));
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
+  });
+
+  it("ignores a stale initial-replay response when a live push has already arrived", async () => {
+    let resolveReplay!: (payload: GitHubTokenHealthPayload) => void;
+    getTokenHealthMock.mockImplementationOnce(
+      () =>
+        new Promise<GitHubTokenHealthPayload>((resolve) => {
+          resolveReplay = resolve;
+        })
+    );
+
+    renderHook(() => useGitHubTokenHealth());
+    // Subscribe is sync; let the hook attach.
+    await act(async () => {});
+
+    // Live push lands first.
+    act(() => healthListener?.({ status: "unhealthy" }));
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+
+    // Now the slow replay resolves with stale data — must NOT overwrite the live state.
+    await act(async () => {
+      resolveReplay({ status: "healthy" });
+    });
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+  });
 });

--- a/src/hooks/__tests__/useGitHubTokenHealth.test.ts
+++ b/src/hooks/__tests__/useGitHubTokenHealth.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { GitHubTokenHealthPayload } from "@shared/types";
+
+let healthListener: ((payload: GitHubTokenHealthPayload) => void) | null = null;
+const cleanupMock = vi.fn();
+const onTokenHealthChangedMock = vi.fn(
+  (callback: (payload: GitHubTokenHealthPayload) => void): (() => void) => {
+    healthListener = callback;
+    return cleanupMock;
+  }
+);
+const getTokenHealthMock = vi.fn(
+  (): Promise<GitHubTokenHealthPayload> => Promise.resolve({ status: "unknown" })
+);
+
+vi.mock("@/clients/githubClient", () => ({
+  githubClient: {
+    onTokenHealthChanged: (cb: (payload: GitHubTokenHealthPayload) => void) =>
+      onTokenHealthChangedMock(cb),
+    getTokenHealth: () => getTokenHealthMock(),
+  },
+}));
+
+import { useGitHubTokenHealth } from "../useGitHubTokenHealth";
+import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+
+describe("useGitHubTokenHealth", () => {
+  beforeEach(() => {
+    healthListener = null;
+    onTokenHealthChangedMock.mockClear();
+    cleanupMock.mockClear();
+    getTokenHealthMock.mockReset().mockResolvedValue({ status: "unknown" });
+    useGitHubTokenHealthStore.setState({ isUnhealthy: false });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+  });
+
+  it("subscribes on mount and cleans up on unmount", () => {
+    const { unmount } = renderHook(() => useGitHubTokenHealth());
+    expect(onTokenHealthChangedMock).toHaveBeenCalledOnce();
+    unmount();
+    expect(cleanupMock).toHaveBeenCalledOnce();
+  });
+
+  it("flips the store to unhealthy on transition payload", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {
+      // flush initial getTokenHealth
+    });
+
+    act(() => {
+      healthListener?.({ status: "unhealthy" });
+    });
+
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+  });
+
+  it("clears the store when state returns to healthy", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy" }));
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+
+    act(() => healthListener?.({ status: "healthy" }));
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
+  });
+
+  it("adds an inbox entry exactly once per unhealthy transition", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "unhealthy" }));
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(1);
+  });
+
+  it("re-arms the inbox entry after recovery + a new failure", async () => {
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    act(() => healthListener?.({ status: "unhealthy" }));
+    act(() => healthListener?.({ status: "healthy" }));
+    act(() => healthListener?.({ status: "unhealthy" }));
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.filter((e) => e.correlationId === "github-token-health")).toHaveLength(2);
+  });
+
+  it("replays initial state on mount via getTokenHealth", async () => {
+    getTokenHealthMock.mockResolvedValueOnce({ status: "unhealthy" });
+    renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(true);
+  });
+
+  it("ignores payloads delivered after unmount", async () => {
+    const { unmount } = renderHook(() => useGitHubTokenHealth());
+    await act(async () => {});
+
+    unmount();
+    act(() => healthListener?.({ status: "unhealthy" }));
+
+    // The store should remain false because the cancelled flag short-circuits apply().
+    // (Note: cleanup() is called too, but our mock retains the listener reference for testing.)
+    expect(useGitHubTokenHealthStore.getState().isUnhealthy).toBe(false);
+  });
+});

--- a/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
+++ b/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
@@ -108,4 +108,17 @@ describe("useCloudSyncWarning", () => {
     const entries = useNotificationHistoryStore.getState().entries;
     expect(entries.filter((e) => e.title === "Cloud sync folder detected")).toHaveLength(1);
   });
+
+  it("populates the banner store with the project id alongside the service", () => {
+    setupProject({
+      projectId: "alpha",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox-Personal/work",
+      settings: { runCommands: [] },
+    });
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+
+    const state = useCloudSyncBannerStore.getState();
+    expect(state.service).toBe("Dropbox");
+    expect(state.projectId).toBe("alpha");
+  });
 });

--- a/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
+++ b/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("@/lib/platform", () => ({
+  isMac: () => true,
+  isLinux: () => false,
+}));
+
+import { useCloudSyncWarning } from "../useCloudSyncWarning";
+import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useProjectStore } from "@/store";
+import type { ProjectSettings } from "@/types";
+
+function setupProject(opts: {
+  projectId: string;
+  projectPath: string;
+  settings: ProjectSettings | null;
+  settingsProjectId?: string | null;
+}) {
+  useProjectStore.setState({
+    currentProject: {
+      id: opts.projectId,
+      path: opts.projectPath,
+      // Minimum viable Project shape — extra fields not used by the hook
+    } as never,
+  });
+  useProjectSettingsStore.setState({
+    settings: opts.settings,
+    projectId: opts.settingsProjectId ?? opts.projectId,
+  });
+}
+
+describe("useCloudSyncWarning", () => {
+  beforeEach(() => {
+    useCloudSyncBannerStore.setState({ service: null });
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    useProjectStore.setState({ currentProject: null });
+    useProjectSettingsStore.setState({ settings: null, projectId: null });
+  });
+
+  it("does nothing when homeDir is missing", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox/work",
+      settings: { runCommands: [] },
+    });
+    renderHook(() => useCloudSyncWarning(undefined));
+    expect(useCloudSyncBannerStore.getState().service).toBeNull();
+  });
+
+  it("clears banner when project is not in a cloud-synced folder", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Code/project",
+      settings: { runCommands: [] },
+    });
+    useCloudSyncBannerStore.setState({ service: "Dropbox" });
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+    expect(useCloudSyncBannerStore.getState().service).toBeNull();
+  });
+
+  it("sets banner when project is in a cloud-synced folder", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox-Personal/work",
+      settings: { runCommands: [] },
+    });
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+    expect(useCloudSyncBannerStore.getState().service).toBe("Dropbox");
+  });
+
+  it("respects cloudSyncWarningDismissed flag in project settings", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox-Personal/work",
+      settings: { runCommands: [], cloudSyncWarningDismissed: true },
+    });
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+    expect(useCloudSyncBannerStore.getState().service).toBeNull();
+  });
+
+  it("does not run when settings belong to a different project", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox-Personal/work",
+      settings: { runCommands: [] },
+      settingsProjectId: "p2",
+    });
+    renderHook(() => useCloudSyncWarning("/Users/foo"));
+    expect(useCloudSyncBannerStore.getState().service).toBeNull();
+  });
+
+  it("adds an inbox entry once per project when banner is shown", () => {
+    setupProject({
+      projectId: "p1",
+      projectPath: "/Users/foo/Library/CloudStorage/Dropbox-Personal/work",
+      settings: { runCommands: [] },
+    });
+    const { rerender } = renderHook(({ home }: { home: string }) => useCloudSyncWarning(home), {
+      initialProps: { home: "/Users/foo" },
+    });
+    rerender({ home: "/Users/foo" });
+    rerender({ home: "/Users/foo" });
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.filter((e) => e.title === "Cloud sync folder detected")).toHaveLength(1);
+  });
+});

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -18,27 +18,26 @@ export function useCloudSyncWarning(homeDir?: string) {
   const lastInboxedProjectRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const setService = useCloudSyncBannerStore.getState().setService;
+    const setBanner = useCloudSyncBannerStore.getState().setBanner;
 
     if (!currentProject?.id || settingsProjectId !== currentProject.id || !settings || !homeDir) {
-      setService(null);
+      setBanner({ service: null, projectId: null });
       return;
     }
 
     if (settings.cloudSyncWarningDismissed) {
-      setService(null);
+      setBanner({ service: null, projectId: null });
       return;
     }
 
     const service = detectCloudSyncService(currentProject.path, homeDir, getPlatform());
 
     if (!service) {
-      setService(null);
-      lastInboxedProjectRef.current = null;
+      setBanner({ service: null, projectId: null });
       return;
     }
 
-    setService(service);
+    setBanner({ service, projectId: currentProject.id });
 
     // Inbox entry once per project — banner is the live surface; the entry is an audit trail.
     if (lastInboxedProjectRef.current !== currentProject.id) {

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -1,13 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
-import { useProjectSettings } from "../useProjectSettings";
-import { notify } from "@/lib/notify";
-import { logError } from "@/utils/logger";
-import { useNotificationStore } from "@/store/notificationStore";
+import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { detectCloudSyncService, type Platform } from "@/utils/cloudSyncDetection";
 import { isMac, isLinux } from "@/lib/platform";
-import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 function getPlatform(): Platform {
   if (isMac()) return "mac";
@@ -18,82 +15,40 @@ function getPlatform(): Platform {
 export function useCloudSyncWarning(homeDir?: string) {
   const currentProject = useProjectStore((state) => state.currentProject);
   const { settings, projectId: settingsProjectId } = useProjectSettingsStore();
-  const { saveSettings } = useProjectSettings();
-  const removeNotification = useNotificationStore((s) => s.removeNotification);
-  const lastNotifiedProjectRef = useRef<string | null>(null);
-  const notificationIdRef = useRef<string | null>(null);
+  const lastInboxedProjectRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const setService = useCloudSyncBannerStore.getState().setService;
+
     if (!currentProject?.id || settingsProjectId !== currentProject.id || !settings || !homeDir) {
+      setService(null);
       return;
     }
 
     if (settings.cloudSyncWarningDismissed) {
-      return;
-    }
-
-    if (lastNotifiedProjectRef.current === currentProject.id) {
+      setService(null);
       return;
     }
 
     const service = detectCloudSyncService(currentProject.path, homeDir, getPlatform());
 
     if (!service) {
+      setService(null);
+      lastInboxedProjectRef.current = null;
       return;
     }
 
-    lastNotifiedProjectRef.current = currentProject.id;
+    setService(service);
 
-    const notificationId = notify({
-      type: "warning",
-      placement: "grid-bar",
-      title: "Cloud Sync Folder Detected",
-      message: `This project is in a ${service}-synced folder. File sync can interfere with terminal operations and git. Consider moving the project to a local folder.`,
-      inboxMessage: `Cloud sync warning: project is in a ${service}-synced folder`,
-      actions: [
-        {
-          label: "Don\u2019t Show Again",
-          variant: "secondary",
-          onClick: async () => {
-            try {
-              const latestSettings = useProjectSettingsStore.getState().settings;
-              if (!latestSettings) return;
-
-              await saveSettings({
-                ...latestSettings,
-                cloudSyncWarningDismissed: true,
-              });
-              removeNotification(notificationId);
-            } catch (err) {
-              logError("Failed to save cloud sync warning preference", err);
-              notify({
-                type: "error",
-                title: "Failed to save preference",
-                message: formatErrorMessage(err, "Failed to save cloud sync warning preference"),
-                duration: 6000,
-              });
-              lastNotifiedProjectRef.current = null;
-            }
-          },
-        },
-      ],
-      duration: 0,
-    });
-
-    notificationIdRef.current = notificationId;
-
-    return () => {
-      if (notificationIdRef.current) {
-        removeNotification(notificationIdRef.current);
-      }
-    };
-  }, [
-    currentProject?.id,
-    currentProject?.path,
-    settingsProjectId,
-    settings,
-    homeDir,
-    saveSettings,
-    removeNotification,
-  ]);
+    // Inbox entry once per project — banner is the live surface; the entry is an audit trail.
+    if (lastInboxedProjectRef.current !== currentProject.id) {
+      lastInboxedProjectRef.current = currentProject.id;
+      useNotificationHistoryStore.getState().addEntry({
+        type: "warning",
+        title: "Cloud sync folder detected",
+        message: `Project is in a ${service}-synced folder which can interfere with terminal operations and git.`,
+        countable: false,
+      });
+    }
+  }, [currentProject?.id, currentProject?.path, settingsProjectId, settings, homeDir]);
 }

--- a/src/hooks/useGitHubTokenHealth.ts
+++ b/src/hooks/useGitHubTokenHealth.ts
@@ -15,9 +15,14 @@ export function useGitHubTokenHealth(): void {
 
   useEffect(() => {
     let cancelled = false;
+    let pushApplied = false;
 
-    const apply = (payload: GitHubTokenHealthPayload) => {
+    const apply = (payload: GitHubTokenHealthPayload, source: "push" | "replay") => {
       if (cancelled) return;
+      // If a live push already updated state, ignore a stale initial-replay
+      // response (the IPC race is rare but real — see review notes).
+      if (source === "replay" && pushApplied) return;
+      if (source === "push") pushApplied = true;
 
       const isUnhealthy = payload.status === "unhealthy";
       const wasUnhealthy = useGitHubTokenHealthStore.getState().isUnhealthy;
@@ -39,13 +44,13 @@ export function useGitHubTokenHealth(): void {
       }
     };
 
-    const cleanup = githubClient.onTokenHealthChanged(apply);
+    const cleanup = githubClient.onTokenHealthChanged((payload) => apply(payload, "push"));
 
     // Replay current state on mount so secondary windows / late mounts see the
     // unhealthy flag without waiting for a transition.
     void githubClient
       .getTokenHealth()
-      .then(apply)
+      .then((payload) => apply(payload, "replay"))
       .catch(() => {
         // Initial-state fetch is best-effort; transitions still work.
       });

--- a/src/hooks/useGitHubTokenHealth.ts
+++ b/src/hooks/useGitHubTokenHealth.ts
@@ -1,24 +1,17 @@
 import { useEffect, useRef } from "react";
 import { githubClient } from "@/clients/githubClient";
-import { useNotificationStore } from "@/store/notificationStore";
-import { notify } from "@/lib/notify";
-import { actionService } from "@/services/ActionService";
+import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import type { GitHubTokenHealthPayload } from "@shared/types";
 
 /**
- * Subscribes to main-process GitHub token health state pushes and surfaces a
- * non-blocking "Reconnect to GitHub" notification when the background probe
- * detects a 401. Dismisses the notification automatically when the token is
- * restored to a healthy state.
- *
- * The main-process service is the source of truth for state; this hook
- * simply reflects transitions into the shared notification store. On mount
- * it also invokes the main-process state getter so a second window (or a
- * window that mounted after the initial probe completed) can surface the
- * banner without waiting for the next transition.
+ * Subscribes to main-process GitHub token health state pushes and writes the
+ * unhealthy flag to a thin Zustand store. The renderer surfaces the state via
+ * `<GitHubTokenBanner />`, which is a persistent inline banner — toasts were a
+ * poor fit for state that persists until the user reconnects.
  */
 export function useGitHubTokenHealth(): void {
-  const notificationIdRef = useRef<string | null>(null);
+  const hasInboxedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -26,62 +19,30 @@ export function useGitHubTokenHealth(): void {
     const apply = (payload: GitHubTokenHealthPayload) => {
       if (cancelled) return;
 
-      if (payload.status === "unhealthy") {
-        if (notificationIdRef.current) {
-          const existing = useNotificationStore
-            .getState()
-            .notifications.find((n) => n.id === notificationIdRef.current);
-          if (existing && !existing.dismissed) {
-            return;
-          }
-        }
+      const isUnhealthy = payload.status === "unhealthy";
+      const wasUnhealthy = useGitHubTokenHealthStore.getState().isUnhealthy;
+      useGitHubTokenHealthStore.getState().setUnhealthy(isUnhealthy);
 
-        const id = notify({
+      if (isUnhealthy && !wasUnhealthy && !hasInboxedRef.current) {
+        hasInboxedRef.current = true;
+        useNotificationHistoryStore.getState().addEntry({
           type: "warning",
-          priority: "high",
-          title: "GitHub authentication required",
-          message:
-            "Your GitHub token isn't working. Reconnect in settings to restore issues, PRs, and stats.",
-          correlationId: "github:token-expiry",
-          duration: 0,
-          coalesce: {
-            key: "github:token-expiry",
-            windowMs: 30000,
-            buildMessage: () =>
-              "Your GitHub token isn't working. Reconnect in settings to restore issues, PRs, and stats.",
-          },
-          action: {
-            label: "Open GitHub settings",
-            actionId: "app.settings.openTab",
-            actionArgs: { tab: "github", sectionId: "github-token" },
-            onClick: () => {
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "github", sectionId: "github-token" },
-                { source: "user" }
-              );
-            },
-          },
+          title: "GitHub token expired",
+          message: "GitHub token expired — reconnect to restore GitHub features.",
+          correlationId: "github-token-health",
+          countable: false,
         });
-        notificationIdRef.current = id || null;
-        return;
       }
 
-      if (payload.status === "healthy" || payload.status === "unknown") {
-        const id = notificationIdRef.current;
-        if (id) {
-          useNotificationStore.getState().dismissNotification(id);
-          notificationIdRef.current = null;
-        }
+      if (!isUnhealthy) {
+        hasInboxedRef.current = false;
       }
     };
 
     const cleanup = githubClient.onTokenHealthChanged(apply);
 
-    // Replay current state on mount. If the initial probe fired before this
-    // hook subscribed — or this is a secondary window — the `unhealthy`
-    // state would otherwise never surface because the service only emits on
-    // transitions.
+    // Replay current state on mount so secondary windows / late mounts see the
+    // unhealthy flag without waiting for a transition.
     void githubClient
       .getTokenHealth()
       .then(apply)

--- a/src/store/cloudSyncBannerStore.ts
+++ b/src/store/cloudSyncBannerStore.ts
@@ -3,10 +3,14 @@ import type { CloudSyncService } from "@/utils/cloudSyncDetection";
 
 interface CloudSyncBannerState {
   service: CloudSyncService | null;
-  setService: (service: CloudSyncService | null) => void;
+  /** Project the detected service belongs to. Used by the banner to guard
+   *  against dismissing the wrong project after a quick switch. */
+  projectId: string | null;
+  setBanner: (state: { service: CloudSyncService | null; projectId: string | null }) => void;
 }
 
 export const useCloudSyncBannerStore = create<CloudSyncBannerState>((set) => ({
   service: null,
-  setService: (service) => set({ service }),
+  projectId: null,
+  setBanner: ({ service, projectId }) => set({ service, projectId }),
 }));

--- a/src/store/cloudSyncBannerStore.ts
+++ b/src/store/cloudSyncBannerStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import type { CloudSyncService } from "@/utils/cloudSyncDetection";
+
+interface CloudSyncBannerState {
+  service: CloudSyncService | null;
+  setService: (service: CloudSyncService | null) => void;
+}
+
+export const useCloudSyncBannerStore = create<CloudSyncBannerState>((set) => ({
+  service: null,
+  setService: (service) => set({ service }),
+}));

--- a/src/store/githubTokenHealthStore.ts
+++ b/src/store/githubTokenHealthStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface GitHubTokenHealthState {
+  isUnhealthy: boolean;
+  setUnhealthy: (value: boolean) => void;
+}
+
+export const useGitHubTokenHealthStore = create<GitHubTokenHealthState>((set) => ({
+  isUnhealthy: false,
+  setUnhealthy: (isUnhealthy) => set({ isUnhealthy }),
+}));


### PR DESCRIPTION
## Summary

- Toasts are wrong for state that persists or wasn't user-initiated. Cloud sync detection and GitHub token expiry both represent ongoing conditions, so they get inline banners that stay visible until the condition resolves or the user explicitly dismisses.
- New `CloudSyncBanner` and `GitHubTokenBanner` components mounted alongside `<SafeModeBanner />` in `App.tsx`. The existing hooks now write to thin Zustand stores instead of pushing toast notifications, preserving inbox parity via non-countable history entries.
- The cloud sync dismiss handler guards against persisting the dismissed flag to the wrong project after a quick switch. The GitHub token hook uses sequence-tagged apply() to prevent a stale initial-replay overwriting a fresher live push.

Resolves #6056

## Changes

- `src/components/Recovery/CloudSyncBanner.tsx` — new banner component with service name and per-project dismiss guard
- `src/components/Recovery/GitHubTokenBanner.tsx` — new banner with reconnect action wired to GitHub settings
- `src/store/cloudSyncBannerStore.ts` — carries `{ service, projectId }` for cross-project guard
- `src/store/githubTokenHealthStore.ts` — thin store for token health state
- `src/hooks/app/useCloudSyncWarning.tsx` — refactored to write store state; toast removed
- `src/hooks/useGitHubTokenHealth.ts` — refactored with sequence-tagged apply(); toast removed
- `src/App.tsx` — mounts both banners

## Testing

- 26 new unit tests across 4 test files covering both banners and both hooks
- Lint warnings 361 → 359 (two warnings removed by this change)
- Typecheck, lint, and build all clean