### PR TITLE
test(e2e): heap-snapshot regression test for evicted project views

### DIFF
--- a/e2e/helpers/heapSnapshot.ts
+++ b/e2e/helpers/heapSnapshot.ts
@@ -1,0 +1,67 @@
+import { readFileSync, rmSync } from "fs";
+
+// V8 heap snapshot format: a flat-array graph. `nodes` is a packed integer
+// array stepped by `node_fields.length`; field meaning comes from `node_fields`
+// and `node_types`. Strings (including class names) are interned in `strings`.
+//
+// Reference: https://v8.dev/blog/custom-startup-snapshots — the .heapsnapshot
+// JSON shape has been stable across V8 versions since 2016.
+export interface HeapSnapshot {
+  snapshot: {
+    meta: {
+      node_fields: string[];
+      node_types: Array<string[] | string>;
+    };
+  };
+  nodes: number[];
+  strings: string[];
+}
+
+export function parseHeapSnapshot(filePath: string): HeapSnapshot {
+  const raw = readFileSync(filePath, "utf8");
+  return JSON.parse(raw) as HeapSnapshot;
+}
+
+/**
+ * Count the number of object nodes in the snapshot whose constructor name
+ * matches `className`. Returns 0 if the class name does not appear in the
+ * snapshot's interned string table.
+ *
+ * Note: TypeScript `interface`s are erased at compile time and never appear
+ * here — only ES6 classes (or anything else with a real constructor name)
+ * are visible. Use this primarily as a diagnostic / observability signal.
+ */
+export function countInstancesByName(snapshot: HeapSnapshot, className: string): number {
+  const fields = snapshot.snapshot.meta.node_fields;
+  const nodeSize = fields.length;
+  const typeIdx = fields.indexOf("type");
+  const nameIdx = fields.indexOf("name");
+  if (typeIdx === -1 || nameIdx === -1) return 0;
+
+  const typeEnum = snapshot.snapshot.meta.node_types[typeIdx];
+  if (!Array.isArray(typeEnum)) return 0;
+  const objectTypeIndex = typeEnum.indexOf("object");
+  if (objectTypeIndex === -1) return 0;
+
+  const classNameStrIdx = snapshot.strings.indexOf(className);
+  if (classNameStrIdx === -1) return 0;
+
+  let count = 0;
+  for (let i = 0; i < snapshot.nodes.length; i += nodeSize) {
+    if (
+      snapshot.nodes[i + typeIdx] === objectTypeIndex &&
+      snapshot.nodes[i + nameIdx] === classNameStrIdx
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+export function cleanupHeapSnapshot(filePath: string): void {
+  try {
+    rmSync(filePath, { force: true });
+  } catch {
+    // best-effort cleanup
+  }
+}

--- a/e2e/nightly/nightly-evicted-view-leak.spec.ts
+++ b/e2e/nightly/nightly-evicted-view-leak.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- main-process globals are untyped in app.evaluate() */
 import { test, expect } from "@playwright/test";
 import path from "path";
 import { tmpdir } from "os";
@@ -95,36 +94,40 @@ test.describe.serial("Nightly: Evicted project view leak detection", () => {
       pvm?.setCachedViewLimit(1);
     });
 
-    // GC_DELAY_MS in ProjectViewManager is 100ms; give the close() handlers
-    // and any window.gc() injection a comfortable margin before reading state.
-    await ctx.window.waitForTimeout(800);
+    // Poll until eviction completes. GC_DELAY_MS in ProjectViewManager is
+    // 100ms but webContents.close() can be slower on loaded CI runners — a
+    // fixed sleep races there. Re-read state until the evicted view is gone
+    // or we hit a meaningful timeout.
+    const readEvictionState = () =>
+      app.evaluate(({ webContents }, wcId) => {
+        const g = globalThis as Record<string, unknown>;
+        const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+        const pvm = getPvm?.() as
+          | {
+              getAllViews: () => Array<{
+                view: { webContents: { id: number; isDestroyed: () => boolean } };
+                projectId: string;
+              }>;
+            }
+          | null
+          | undefined;
+        const evicted = webContents.fromId(wcId);
+        return {
+          viewCount: pvm?.getAllViews().length ?? -1,
+          viewProjectIds: pvm?.getAllViews().map((v) => v.projectId) ?? [],
+          evictedIsNullOrDestroyed: !evicted || evicted.isDestroyed(),
+        };
+      }, evictedWcId);
 
-    const afterEviction = await app.evaluate(({ webContents }, wcId) => {
-      const g = globalThis as Record<string, unknown>;
-      const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
-      const pvm = getPvm?.() as
-        | {
-            getAllViews: () => Array<{
-              view: { webContents: { id: number; isDestroyed: () => boolean } };
-              projectId: string;
-            }>;
-          }
-        | null
-        | undefined;
-      const evicted = webContents.fromId(wcId);
-      return {
-        viewCount: pvm?.getAllViews().length ?? -1,
-        viewProjectIds: pvm?.getAllViews().map((v) => v.projectId) ?? [],
-        evictedIsNullOrDestroyed: !evicted || evicted.isDestroyed(),
-      };
-    }, evictedWcId);
+    await expect
+      .poll(readEvictionState, { timeout: 10_000, intervals: [200, 400, 800, 1600] })
+      .toMatchObject({ viewCount: 1, evictedIsNullOrDestroyed: true });
 
+    const afterEviction = await readEvictionState();
     console.log(
       `[evicted-view] after eviction: viewCount=${afterEviction.viewCount}, projectIds=${JSON.stringify(afterEviction.viewProjectIds)}, evicted destroyed=${afterEviction.evictedIsNullOrDestroyed}`
     );
-    expect(afterEviction.viewCount).toBe(1);
     expect(afterEviction.viewProjectIds).toContain(activeId);
-    expect(afterEviction.evictedIsNullOrDestroyed).toBe(true);
   });
 
   test("main-process heap snapshot parses and surfaces diagnostic counts", async () => {
@@ -165,26 +168,31 @@ test.describe.serial("Nightly: Evicted project view leak detection", () => {
     expect(existsSync(snapshotPath)).toBe(true);
 
     const snapshot = parseHeapSnapshot(snapshotPath);
-    for (const className of DIAGNOSTIC_CLASS_NAMES) {
-      const count = countInstancesByName(snapshot, className);
-      console.log(`[evicted-view][heap] ${className}: ${count} instances`);
-    }
 
     // Sanity: the snapshot must be a valid V8 heap snapshot with the expected
     // shape. If parsing yields an empty/garbage object, fail loudly so a
     // future Electron upgrade that changes the snapshot schema is noticed.
+    // Run schema checks before the diagnostic loop so the failure points at
+    // the schema, not the lookup.
     expect(snapshot.snapshot.meta.node_fields).toContain("type");
     expect(snapshot.snapshot.meta.node_fields).toContain("name");
     expect(snapshot.nodes.length).toBeGreaterThan(0);
     expect(snapshot.strings.length).toBeGreaterThan(0);
 
+    for (const className of DIAGNOSTIC_CLASS_NAMES) {
+      const count = countInstancesByName(snapshot, className);
+      console.log(`[evicted-view][heap] ${className}: ${count} instances`);
+    }
+
     // ProjectViewManager is a per-window singleton — its instance count
     // should be exactly 1 in single-window E2E runs. We look it up by the
     // runtime constructor name to stay correct under production minification.
-    if (pvmRuntimeName) {
-      const pvmCount = countInstancesByName(snapshot, pvmRuntimeName);
-      console.log(`[evicted-view][heap] PVM (${pvmRuntimeName}): ${pvmCount} instances`);
-      expect(pvmCount).toBe(1);
-    }
+    // Asserting truthiness first ensures the hook working correctly is a
+    // hard requirement of the test rather than a best-effort skip — a falsy
+    // value (null, "", undefined) would otherwise silently pass.
+    expect(pvmRuntimeName).toBeTruthy();
+    const pvmCount = countInstancesByName(snapshot, pvmRuntimeName!);
+    console.log(`[evicted-view][heap] PVM (${pvmRuntimeName}): ${pvmCount} instances`);
+    expect(pvmCount).toBe(1);
   });
 });

--- a/e2e/nightly/nightly-evicted-view-leak.spec.ts
+++ b/e2e/nightly/nightly-evicted-view-leak.spec.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- main-process globals are untyped in app.evaluate() */
+import { test, expect } from "@playwright/test";
+import path from "path";
+import { tmpdir } from "os";
+import { existsSync } from "fs";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepos } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../helpers/workflows";
+import {
+  parseHeapSnapshot,
+  countInstancesByName,
+  cleanupHeapSnapshot,
+} from "../helpers/heapSnapshot";
+
+const PROJECT_A = "Heap A";
+const PROJECT_B = "Heap B";
+
+// Class names whose instance counts we log diagnostically. These are real
+// main-process ES6 classes — TypeScript interfaces (e.g. `ViewEntry`) are
+// erased at compile time and never appear in a heap snapshot. PortalManager
+// and EventBuffer are per-window services (not per-view), so their counts
+// are NOT expected to drop on view eviction; they're logged for trend
+// monitoring rather than gating the test.
+const DIAGNOSTIC_CLASS_NAMES = ["ProjectViewManager", "PortalManager", "EventBuffer"];
+
+let ctx: AppContext;
+let snapshotPath: string;
+
+test.describe.serial("Nightly: Evicted project view leak detection", () => {
+  test.beforeAll(async () => {
+    const [repoA, repoB] = createFixtureRepos(2);
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoB, PROJECT_B);
+    // Switch back to A so A is the active project; B will be the cached view
+    // that we capture and watch for proper destruction after eviction.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+
+    snapshotPath = path.join(tmpdir(), `daintree-evicted-view-${Date.now()}.heapsnapshot`);
+  });
+
+  test.afterAll(async () => {
+    if (snapshotPath) cleanupHeapSnapshot(snapshotPath);
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("evicted project view is destroyed and removed from PVM cache", async () => {
+    test.setTimeout(180_000);
+    const { app } = ctx;
+
+    const initial = await app.evaluate(() => {
+      const g = globalThis as Record<string, unknown>;
+      const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+      const pvm = getPvm?.() as
+        | {
+            getAllViews: () => Array<{
+              view: { webContents: { id: number; isDestroyed: () => boolean } };
+              projectId: string;
+              state: string;
+            }>;
+            getActiveProjectId: () => string | null;
+            setCachedViewLimit: (n: number) => void;
+          }
+        | null
+        | undefined;
+      if (!pvm) return null;
+      return {
+        activeProjectId: pvm.getActiveProjectId(),
+        views: pvm.getAllViews().map((v) => ({
+          projectId: v.projectId,
+          wcId: v.view.webContents.id,
+          state: v.state,
+        })),
+      };
+    });
+
+    expect(initial).not.toBeNull();
+    expect(initial!.views.length).toBeGreaterThanOrEqual(2);
+    const activeId = initial!.activeProjectId;
+    expect(activeId).not.toBeNull();
+    const activeView = initial!.views.find((v) => v.projectId === activeId);
+    const cachedView = initial!.views.find((v) => v.projectId !== activeId);
+    expect(activeView).toBeDefined();
+    expect(cachedView).toBeDefined();
+    const evictedWcId = cachedView!.wcId;
+    console.log(
+      `[evicted-view] active=${activeId} (wc=${activeView!.wcId}), evicting target wc=${evictedWcId} (project=${cachedView!.projectId})`
+    );
+
+    await app.evaluate(() => {
+      const g = globalThis as Record<string, unknown>;
+      const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+      const pvm = getPvm?.() as { setCachedViewLimit: (n: number) => void } | null | undefined;
+      pvm?.setCachedViewLimit(1);
+    });
+
+    // GC_DELAY_MS in ProjectViewManager is 100ms; give the close() handlers
+    // and any window.gc() injection a comfortable margin before reading state.
+    await ctx.window.waitForTimeout(800);
+
+    const afterEviction = await app.evaluate(({ webContents }, wcId) => {
+      const g = globalThis as Record<string, unknown>;
+      const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+      const pvm = getPvm?.() as
+        | {
+            getAllViews: () => Array<{
+              view: { webContents: { id: number; isDestroyed: () => boolean } };
+              projectId: string;
+            }>;
+          }
+        | null
+        | undefined;
+      const evicted = webContents.fromId(wcId);
+      return {
+        viewCount: pvm?.getAllViews().length ?? -1,
+        viewProjectIds: pvm?.getAllViews().map((v) => v.projectId) ?? [],
+        evictedIsNullOrDestroyed: !evicted || evicted.isDestroyed(),
+      };
+    }, evictedWcId);
+
+    console.log(
+      `[evicted-view] after eviction: viewCount=${afterEviction.viewCount}, projectIds=${JSON.stringify(afterEviction.viewProjectIds)}, evicted destroyed=${afterEviction.evictedIsNullOrDestroyed}`
+    );
+    expect(afterEviction.viewCount).toBe(1);
+    expect(afterEviction.viewProjectIds).toContain(activeId);
+    expect(afterEviction.evictedIsNullOrDestroyed).toBe(true);
+  });
+
+  test("main-process heap snapshot parses and surfaces diagnostic counts", async () => {
+    test.setTimeout(180_000);
+    const { app } = ctx;
+
+    // Force a GC pass before the snapshot to drop unreferenced eviction state.
+    await app.evaluate(async () => {
+      const g = globalThis as unknown as Record<string, unknown>;
+      const gcFn = (typeof g.__daintree_gc === "function" ? g.__daintree_gc : g.gc) as
+        | (() => void)
+        | undefined;
+      if (gcFn) {
+        gcFn();
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    });
+
+    // Capture the runtime constructor name of PVM. Production builds minify
+    // class identifiers (esbuild --minify), so the heap snapshot stores the
+    // mangled name rather than "ProjectViewManager". Reading constructor.name
+    // from a live instance gives us whatever name V8 will write, regardless
+    // of minification.
+    const pvmRuntimeName = await app.evaluate(() => {
+      const g = globalThis as Record<string, unknown>;
+      const pvm = (g.__daintreeGetPvm as (() => unknown) | undefined)?.();
+      return (pvm as { constructor?: { name?: string } })?.constructor?.name ?? null;
+    });
+    console.log(`[evicted-view][heap] PVM runtime constructor name: ${pvmRuntimeName}`);
+
+    await app.evaluate((_electron, target) => {
+      const g = globalThis as Record<string, unknown>;
+      const writer = g.__daintreeWriteHeapSnapshot as ((p: string) => void) | undefined;
+      if (!writer) throw new Error("__daintreeWriteHeapSnapshot is not registered");
+      writer(target);
+    }, snapshotPath);
+
+    expect(existsSync(snapshotPath)).toBe(true);
+
+    const snapshot = parseHeapSnapshot(snapshotPath);
+    for (const className of DIAGNOSTIC_CLASS_NAMES) {
+      const count = countInstancesByName(snapshot, className);
+      console.log(`[evicted-view][heap] ${className}: ${count} instances`);
+    }
+
+    // Sanity: the snapshot must be a valid V8 heap snapshot with the expected
+    // shape. If parsing yields an empty/garbage object, fail loudly so a
+    // future Electron upgrade that changes the snapshot schema is noticed.
+    expect(snapshot.snapshot.meta.node_fields).toContain("type");
+    expect(snapshot.snapshot.meta.node_fields).toContain("name");
+    expect(snapshot.nodes.length).toBeGreaterThan(0);
+    expect(snapshot.strings.length).toBeGreaterThan(0);
+
+    // ProjectViewManager is a per-window singleton — its instance count
+    // should be exactly 1 in single-window E2E runs. We look it up by the
+    // runtime constructor name to stay correct under production minification.
+    if (pvmRuntimeName) {
+      const pvmCount = countInstancesByName(snapshot, pvmRuntimeName);
+      console.log(`[evicted-view][heap] PVM (${pvmRuntimeName}): ${pvmCount} instances`);
+      expect(pvmCount).toBe(1);
+    }
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,7 @@
 // Environment setup must run first (GC exposure, userData, flags, sandbox)
 import "./setup/environment.js";
 
+import nodeV8 from "node:v8";
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
 import path from "path";
@@ -231,6 +232,16 @@ if (!gotTheLock) {
       },
     });
     setProjectViewManager(pvm);
+
+    // E2E hooks: expose PVM accessor and heap-snapshot writer so the
+    // nightly evicted-view leak spec can read main-process state and
+    // dump a v8 snapshot from app.evaluate(). Mirrors the
+    // __daintreeResetRateLimits / __daintreeFaultRegistry pattern.
+    if (process.env.DAINTREE_E2E_MODE === "1") {
+      (globalThis as Record<string, unknown>).__daintreeGetPvm = getProjectViewManager;
+      (globalThis as Record<string, unknown>).__daintreeWriteHeapSnapshot = (filePath: string) =>
+        nodeV8.writeHeapSnapshot(filePath);
+    }
 
     // Clean up ProjectViewManager when window closes
     win.once("closed", () => {


### PR DESCRIPTION
## Summary

- Adds a nightly E2E spec (`e2e/nightly/nightly-evicted-view-leak.spec.ts`) that opens two fixture projects, forces LRU eviction via `pvm.setCachedViewLimit(1)`, then asserts the evicted view is destroyed and the main-process heap contains exactly one `ProjectViewManager` instance.
- Adds `e2e/helpers/heapSnapshot.ts` with `parseHeapSnapshot`, `countInstancesByName`, and `cleanupHeapSnapshot` helpers that walk the flat V8 nodes array using `meta.node_fields` indices and the interned strings table.
- Hooks two `globalThis` helpers into `electron/main.ts` under the existing `DAINTREE_E2E_MODE === "1"` guard: `__daintreeGetPvm` (exposes `ProjectViewManager` to `app.evaluate()`) and `__daintreeWriteHeapSnapshot` (wraps `v8.writeHeapSnapshot()` for the ESM main bundle). Both are inert in production and mirror the existing `__daintreeResetRateLimits` / `__daintree_gc` pattern.

Resolves #6028

## Changes

- **`e2e/nightly/nightly-evicted-view-leak.spec.ts`** — two tests: (1) PVM cache shrinks to 1 and evicted webContents `isDestroyed() === true`, using `expect.poll` so slow CI runners aren't flaky; (2) heap snapshot parses cleanly, has the expected V8 schema, and contains exactly 1 `ProjectViewManager` instance looked up by runtime `constructor.name` (handles esbuild minification — production builds rename the class to `"hm"`).
- **`e2e/helpers/heapSnapshot.ts`** — snapshot helpers; counter returns 0 on malformed input instead of throwing.
- **`electron/main.ts`** — two E2E-mode `globalThis` hooks.

A few of the issue's original assertion targets turned out to be technically out of reach: `ViewEntry` is a TypeScript interface (erased at compile time), `WorktreeMonitor` lives in the workspace-host UtilityProcess (invisible to a main-process snapshot), and `PortalManager`/`EventBuffer` are per-window services that survive until the BrowserWindow closes by design. The spec adapts: it captures the evicted view's webContents ID before eviction and asserts `isDestroyed()` post-eviction, which is the strongest available signal that the eviction path actually freed the view. The heap snapshot still logs counts for those original names as a diagnostic artifact (useful for trend monitoring) while the hard assertion targets `ProjectViewManager` count via runtime constructor name.

## Testing

Passes locally on macOS, 2/2 tests:

```
[evicted-view] active=...(wc=3), evicting target wc=4 (project=...)
[evicted-view] after eviction: viewCount=1, projectIds=["..."], evicted destroyed=true
[evicted-view][heap] PVM runtime constructor name: hm
[evicted-view][heap] ProjectViewManager: 0 instances
[evicted-view][heap] PortalManager: 0 instances
[evicted-view][heap] EventBuffer: 0 instances
[evicted-view][heap] PVM (hm): 1 instances
```

Typecheck, ESLint, and Prettier all pass. Lint ratchet decreased by 2 warnings (net improvement).