### PR TITLE
fix(worktree): consolidate resource action error notifications with shared helper

### DIFF
--- a/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
@@ -143,6 +143,10 @@ describe("worktree resource action definitions", () => {
         priority: "high",
         title: expectedTitle,
         message: "Command exited with code 1",
+        action: expect.objectContaining({
+          label: "Copy details",
+          onClick: expect.any(Function),
+        }),
       })
     );
   });
@@ -159,5 +163,42 @@ describe("worktree resource action definitions", () => {
     await def.run!({}, { activeWorktreeId: "/test" });
 
     expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["worktree.resource.provision", "Provision failed", "Resource provisioning failed"],
+    ["worktree.resource.teardown", "Teardown failed", "Resource teardown failed"],
+    ["worktree.resource.resume", "Resume failed", "Resource resume failed"],
+    ["worktree.resource.pause", "Pause failed", "Resource pause failed"],
+    ["worktree.resource.status", "Status check failed", "Resource status check failed"],
+  ] as const)(
+    "%s uses fallback message for non-Error rejections",
+    async (actionId, expectedTitle, fallbackMessage) => {
+      mockResourceAction.mockRejectedValueOnce(null);
+      const def = registry.get(actionId)!();
+      await def.run!({}, { activeWorktreeId: "/test" });
+
+      expect(mockNotify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expectedTitle,
+          message: fallbackMessage,
+        })
+      );
+    }
+  );
+
+  it("copy details action writes the error message to the clipboard", async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    mockResourceAction.mockRejectedValueOnce(new Error("Command exited with code 1"));
+    const def = registry.get("worktree.resource.provision")!();
+    await def.run!({}, { activeWorktreeId: "/test" });
+
+    const callArgs = mockNotify.mock.calls[0][0];
+    expect(callArgs.action.label).toBe("Copy details");
+    await callArgs.action.onClick();
+
+    expect(writeTextMock).toHaveBeenCalledWith("Command exited with code 1");
   });
 });

--- a/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
@@ -195,7 +195,7 @@ describe("worktree resource action definitions", () => {
     const def = registry.get("worktree.resource.provision")!();
     await def.run!({}, { activeWorktreeId: "/test" });
 
-    const callArgs = mockNotify.mock.calls[0][0];
+    const callArgs = mockNotify.mock.calls[0]![0];
     expect(callArgs.action.label).toBe("Copy details");
     await callArgs.action.onClick();
 

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -8,8 +8,29 @@ import { getCurrentViewStore, getCurrentViewStoreOrNull } from "@/store/createWo
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { getVisibleWorktreesForCycling } from "@/lib/worktreeCyclingOrder";
 import { logError, logWarn } from "@/utils/logger";
+
+function notifyWorktreeResourceError(err: unknown, title: string, fallbackMessage: string): void {
+  const message = formatErrorMessage(err, fallbackMessage);
+  notify({
+    type: "error",
+    priority: "high",
+    title,
+    message,
+    action: {
+      label: "Copy details",
+      onClick: async () => {
+        try {
+          await navigator.clipboard.writeText(message);
+        } catch {
+          // clipboard write is non-critical
+        }
+      },
+    },
+  });
+}
 
 export function registerWorktreeActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   // Query action: list all worktrees with metadata
@@ -916,12 +937,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           await worktreeClient.resourceAction(targetWorktreeId, "provision");
         } catch (err) {
-          notify({
-            type: "error",
-            priority: "high",
-            title: "Provision failed",
-            message: (err as Error).message || "Resource provisioning failed",
-          });
+          notifyWorktreeResourceError(err, "Provision failed", "Resource provisioning failed");
         }
       },
     })
@@ -950,12 +966,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           await worktreeClient.resourceAction(targetWorktreeId, "teardown");
         } catch (err) {
-          notify({
-            type: "error",
-            priority: "high",
-            title: "Teardown failed",
-            message: (err as Error).message || "Resource teardown failed",
-          });
+          notifyWorktreeResourceError(err, "Teardown failed", "Resource teardown failed");
         }
       },
     })
@@ -984,12 +995,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           await worktreeClient.resourceAction(targetWorktreeId, "resume");
         } catch (err) {
-          notify({
-            type: "error",
-            priority: "high",
-            title: "Resume failed",
-            message: (err as Error).message || "Resource resume failed",
-          });
+          notifyWorktreeResourceError(err, "Resume failed", "Resource resume failed");
         }
       },
     })
@@ -1018,12 +1024,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           await worktreeClient.resourceAction(targetWorktreeId, "pause");
         } catch (err) {
-          notify({
-            type: "error",
-            priority: "high",
-            title: "Pause failed",
-            message: (err as Error).message || "Resource pause failed",
-          });
+          notifyWorktreeResourceError(err, "Pause failed", "Resource pause failed");
         }
       },
     })
@@ -1052,12 +1053,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         try {
           await worktreeClient.resourceAction(targetWorktreeId, "status");
         } catch (err) {
-          notify({
-            type: "error",
-            priority: "high",
-            title: "Status check failed",
-            message: (err as Error).message || "Resource status check failed",
-          });
+          notifyWorktreeResourceError(err, "Status check failed", "Resource status check failed");
         }
       },
     })

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -13,7 +13,7 @@ import { getVisibleWorktreesForCycling } from "@/lib/worktreeCyclingOrder";
 import { logError, logWarn } from "@/utils/logger";
 
 function notifyWorktreeResourceError(err: unknown, title: string, fallbackMessage: string): void {
-  const message = formatErrorMessage(err, fallbackMessage);
+  const message = formatErrorMessage(err, fallbackMessage) || fallbackMessage;
   notify({
     type: "error",
     priority: "high",


### PR DESCRIPTION
## Summary
- Consolidated five near-duplicate notify calls in worktree resource actions (provision, teardown, resume, pause, status-check) into a single `notifyWorktreeResourceError` helper.
- The helper runs errors through `formatErrorMessage(err, fallback)` and automatically attaches a "Copy details" clipboard action, so every error pathway picks up humanization and debugging affordances for free.
- Added tests for the helper's action metadata, its non-Error fallback path, and clipboard write behavior.

Resolves #6052

## Changes
- `src/services/actions/definitions/worktreeActions.ts` — new `notifyWorktreeResourceError` file-local helper
- `src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts` — new test cases for action assertions, non-Error fallback, and clipboard write via `navigator.clipboard.writeText`

## Testing
- Typecheck, lint ratchet (warnings decreased by 2), and format check all pass.
- Unit tests cover the helper's notify call shape, the `formatErrorMessage` fallback path, and clipboard contents.