### PR TITLE
feat(env): migrate environment resolution to markered shell probe

### DIFF
--- a/electron/setup/__tests__/refreshPath.test.ts
+++ b/electron/setup/__tests__/refreshPath.test.ts
@@ -376,7 +376,7 @@ describe("refreshPath — shell probe (DAINTREE_SHELL_PROBE=1)", () => {
     expect(call[1].slice(0, 3)).toEqual(["-i", "-l", "-c"]);
     expect(call[2].env.DAINTREE_RESOLVING_ENVIRONMENT).toBe("1");
     expect(call[2].env.ELECTRON_RUN_AS_NODE).toBe("1");
-    expect(call[2].stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(call[2].stdio).toEqual(["ignore", "pipe", "ignore"]);
 
     delete process.env.SHELL;
   });
@@ -647,6 +647,46 @@ describe("refreshPath — shell probe (DAINTREE_SHELL_PROBE=1)", () => {
 
       await refreshPromise;
       expect(process.env.PATH).toBe("/orig");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not clobber PATH if the probe closes during the SIGTERM grace window", async () => {
+    vi.useFakeTimers();
+    process.env.PATH = "/orig";
+
+    let mockChild: MockChild | undefined;
+    let mockMarker = "";
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      mockChild = createMockChild();
+      mockMarker = extractMarker(args[args.length - 1]);
+      return mockChild;
+    });
+
+    try {
+      const { refreshPath } = await import("../environment.js");
+      const refreshPromise = refreshPath();
+
+      // Trip the outer race timeout — refreshPath returns and applies its
+      // post-race fallback augmentation.
+      await vi.advanceTimersByTimeAsync(10_000);
+      await refreshPromise;
+      const pathAfterTimeout = process.env.PATH;
+
+      // Now simulate the shell finally responding to SIGTERM (within the
+      // 500ms grace window) with valid markers — this MUST NOT clobber the
+      // post-race PATH.
+      mockChild!.stdout.emit(
+        "data",
+        Buffer.from(`${mockMarker}${JSON.stringify({ PATH: "/late/clobber" })}${mockMarker}`)
+      );
+      mockChild!.emit("close", 0);
+      // Drain microtasks so any (incorrectly) pending PATH assignment runs.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(process.env.PATH).toBe(pathAfterTimeout);
+      expect(process.env.PATH).not.toBe("/late/clobber");
     } finally {
       vi.useRealTimers();
     }

--- a/electron/setup/__tests__/refreshPath.test.ts
+++ b/electron/setup/__tests__/refreshPath.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import path from "path";
 
@@ -33,21 +34,46 @@ vi.mock("shell-env", () => ({
 }));
 
 const execFileMock = vi.fn();
+const spawnMock = vi.fn();
 vi.mock("child_process", () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
 }));
+
+interface MockChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createMockChild(): MockChild {
+  const child = new EventEmitter() as MockChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+function extractMarker(probeCmd: string): string {
+  const match = /printf '%s' "([0-9a-f]+)"/.exec(probeCmd);
+  if (!match) throw new Error(`marker not found in probe command: ${probeCmd}`);
+  return match[1];
+}
 
 const originalPlatform = process.platform;
 let savedPath: string | undefined;
 
 describe("refreshPath", () => {
   beforeEach(() => {
+    vi.resetModules();
     savedPath = process.env.PATH;
     vi.clearAllMocks();
+    delete process.env.DAINTREE_SHELL_PROBE;
   });
 
   afterEach(() => {
     process.env.PATH = savedPath;
+    delete process.env.DAINTREE_SHELL_PROBE;
     Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
   });
 
@@ -89,7 +115,7 @@ describe("refreshPath", () => {
     await refreshPath();
 
     expect(process.env.PATH).toBe("/original/path");
-  }, 10_000);
+  }, 12_000);
 
   it("falls back to current PATH when shellEnv throws", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", writable: true });
@@ -271,5 +297,358 @@ describe("refreshPath", () => {
     await refreshPath();
 
     expect(process.env.PATH).toBe(shellPath);
+  });
+});
+
+describe("refreshPath — shell probe (DAINTREE_SHELL_PROBE=1)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    savedPath = process.env.PATH;
+    vi.clearAllMocks();
+    process.env.DAINTREE_SHELL_PROBE = "1";
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
+  afterEach(() => {
+    process.env.PATH = savedPath;
+    delete process.env.DAINTREE_SHELL_PROBE;
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("does not invoke spawn when DAINTREE_SHELL_PROBE is unset", async () => {
+    delete process.env.DAINTREE_SHELL_PROBE;
+    process.env.PATH = "/usr/bin";
+    shellEnvMock.mockResolvedValue({ PATH: "/from/shell-env" });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(shellEnvMock).toHaveBeenCalled();
+    expect(process.env.PATH).toBe("/from/shell-env");
+  });
+
+  it("updates PATH from a markered probe response", async () => {
+    process.env.PATH = "/usr/bin";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: "/probed/bin:/usr/bin" })}${marker}`)
+        );
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(shellEnvMock).not.toHaveBeenCalled();
+    expect(process.env.PATH).toBe("/probed/bin:/usr/bin");
+  });
+
+  it("passes -i -l -c flags and DAINTREE_RESOLVING_ENVIRONMENT to the shell", async () => {
+    process.env.SHELL = "/bin/zsh";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: "/x" })}${marker}`)
+        );
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    const call = spawnMock.mock.calls[0];
+    expect(call[0]).toBe("/bin/zsh");
+    expect(call[1].slice(0, 3)).toEqual(["-i", "-l", "-c"]);
+    expect(call[2].env.DAINTREE_RESOLVING_ENVIRONMENT).toBe("1");
+    expect(call[2].env.ELECTRON_RUN_AS_NODE).toBe("1");
+    expect(call[2].stdio).toEqual(["ignore", "pipe", "pipe"]);
+
+    delete process.env.SHELL;
+  });
+
+  it("falls back to /bin/zsh on darwin when SHELL is unset", async () => {
+    delete process.env.SHELL;
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: "/x" })}${marker}`)
+        );
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(spawnMock.mock.calls[0][0]).toBe("/bin/zsh");
+  });
+
+  it("accepts a non-zero exit code as long as markers + JSON are valid", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: "/from/probe" })}${marker}`)
+        );
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/from/probe");
+  });
+
+  it("ignores prompt-tool noise outside the markers", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        const noisy =
+          "powerlevel10k instant prompt loading...\n" +
+          `${marker}${JSON.stringify({ PATH: "/clean/bin" })}${marker}\n` +
+          "trailing motd line\n";
+        child.stdout.emit("data", Buffer.from(noisy));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/clean/bin");
+  });
+
+  it("preserves PATH when the probe stdout has no markers", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation(() => {
+      const child = createMockChild();
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from("no markers here, just garbage"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/orig");
+  });
+
+  it("preserves PATH when the JSON between markers is malformed", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from(`${marker}{not json${marker}`));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/orig");
+  });
+
+  it("preserves PATH when the probed PATH is empty or missing", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        child.stdout.emit("data", Buffer.from(`${marker}${JSON.stringify({ PATH: "" })}${marker}`));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/orig");
+  });
+
+  it("preserves PATH when the spawn emits an error event", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation(() => {
+      const child = createMockChild();
+      setImmediate(() => {
+        child.emit("error", new Error("ENOENT"));
+        child.emit("close", 127);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/orig");
+  });
+
+  it("preserves PATH when spawn() throws synchronously", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe("/orig");
+  });
+
+  it("deduplicates the probed PATH entries", async () => {
+    process.env.PATH = "/usr/bin";
+    const d = path.delimiter;
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      setImmediate(() => {
+        const probedPath = ["/a", "/b", "/a", "/b"].join(d);
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: probedPath })}${marker}`)
+        );
+        child.emit("close", 0);
+      });
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+
+    expect(process.env.PATH).toBe(["/a", "/b"].join(d));
+  });
+
+  it("spawns once for concurrent refreshPath() calls (singleton cache)", async () => {
+    let resolveChild: (() => void) | undefined;
+
+    spawnMock.mockImplementation((_shell: string, args: string[]) => {
+      const child = createMockChild();
+      const marker = extractMarker(args[args.length - 1]);
+      resolveChild = () => {
+        child.stdout.emit(
+          "data",
+          Buffer.from(`${marker}${JSON.stringify({ PATH: "/probed" })}${marker}`)
+        );
+        child.emit("close", 0);
+      };
+      return child;
+    });
+
+    const { refreshPath } = await import("../environment.js");
+    const p1 = refreshPath();
+    const p2 = refreshPath();
+    const p3 = refreshPath();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    resolveChild!();
+    await Promise.all([p1, p2, p3]);
+
+    expect(process.env.PATH).toBe("/probed");
+  });
+
+  it("re-spawns on a subsequent refreshPath() if the previous probe returned null", async () => {
+    process.env.PATH = "/orig";
+
+    spawnMock
+      .mockImplementationOnce(() => {
+        const child = createMockChild();
+        setImmediate(() => {
+          child.stdout.emit("data", Buffer.from("no markers"));
+          child.emit("close", 0);
+        });
+        return child;
+      })
+      .mockImplementationOnce((_shell: string, args: string[]) => {
+        const child = createMockChild();
+        const marker = extractMarker(args[args.length - 1]);
+        setImmediate(() => {
+          child.stdout.emit(
+            "data",
+            Buffer.from(`${marker}${JSON.stringify({ PATH: "/recovered" })}${marker}`)
+          );
+          child.emit("close", 0);
+        });
+        return child;
+      });
+
+    const { refreshPath } = await import("../environment.js");
+    await refreshPath();
+    expect(process.env.PATH).toBe("/orig");
+
+    await refreshPath();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    expect(process.env.PATH).toBe("/recovered");
+  });
+
+  it("kills the child with SIGTERM then SIGKILL on probe timeout", async () => {
+    vi.useFakeTimers();
+    process.env.PATH = "/orig";
+
+    let mockChild: MockChild | undefined;
+    spawnMock.mockImplementation(() => {
+      mockChild = createMockChild();
+      // never emits close — exercises both kill timers
+      return mockChild;
+    });
+
+    try {
+      const { refreshPath } = await import("../environment.js");
+      const refreshPromise = refreshPath();
+
+      // Advance to SIGTERM (REFRESH_TIMEOUT_MS = 10s).
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(mockChild!.kill).toHaveBeenCalledWith("SIGTERM");
+
+      // Advance the additional 500ms grace period to SIGKILL.
+      await vi.advanceTimersByTimeAsync(500);
+      expect(mockChild!.kill).toHaveBeenCalledWith("SIGKILL");
+
+      await refreshPromise;
+      expect(process.env.PATH).toBe("/orig");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -288,7 +288,10 @@ function applyWindowsExtraPaths(currentPath: string): string {
 }
 
 function parseMarkeredPath(stdout: string, marker: string): string | null {
-  const regex = new RegExp(marker + "([\\s\\S]+)" + marker);
+  // Non-greedy quantifier so the first balanced marker pair wins. With a
+  // 32-hex-char random marker a collision is astronomically improbable,
+  // but the lazy match is structurally clearer than relying on uniqueness.
+  const regex = new RegExp(marker + "([\\s\\S]+?)" + marker);
   const match = regex.exec(stdout);
   if (!match) return null;
   try {
@@ -337,8 +340,14 @@ function runShellProbe(): Promise<string | null> {
 
     let child: ReturnType<typeof spawn>;
     try {
+      // stderr is intentionally ignored: a noisy oh-my-zsh/.zshrc can write
+      // tens of KB to stderr (update banners, compliance scripts), and a
+      // piped-but-undrained stderr would block the child once the OS pipe
+      // buffer fills — preventing the marker probe from ever reaching its
+      // closing printf and forcing a guaranteed timeout. Mirrors VS Code's
+      // getUnixShellEnvironment.
       child = spawn(shell, ["-i", "-l", "-c", probeCmd], {
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "ignore"],
         env: childEnv,
       });
     } catch (err) {
@@ -412,12 +421,17 @@ function resolvePathViaShellProbe(): Promise<string | null> {
 export async function refreshPath(): Promise<void> {
   let timeoutId: NodeJS.Timeout | undefined;
   let shellEnvFailed = false;
+  // Guards against late inner-IIFE writes to process.env.PATH after the
+  // outer race has already resolved with "timeout". Without this guard a
+  // shell that closes during the SIGTERM→SIGKILL grace window can clobber
+  // the fallback-augmented PATH that the post-race block has already set.
+  let timedOut = false;
   try {
     const result = await Promise.race([
       (async () => {
         if (process.platform === "win32") {
           const registryPath = await readWindowsRegistryPath();
-          if (!registryPath) return;
+          if (!registryPath || timedOut) return;
           const withExtras = applyWindowsExtraPaths(registryPath);
           process.env.PATH = deduplicatePath(withExtras, true);
         } else if (process.env.DAINTREE_SHELL_PROBE === "1") {
@@ -428,6 +442,7 @@ export async function refreshPath(): Promise<void> {
           // are visible. Gated behind the flag so we can dogfood for one
           // release before flipping the default.
           const probedPath = await resolvePathViaShellProbe();
+          if (timedOut) return;
           if (probedPath) {
             process.env.PATH = deduplicatePath(probedPath, false);
           } else {
@@ -439,6 +454,7 @@ export async function refreshPath(): Promise<void> {
               shellEnv: () => Promise<Record<string, string>>;
             };
             const env = await shellEnv();
+            if (timedOut) return;
             if (env.PATH) {
               process.env.PATH = deduplicatePath(env.PATH, false);
             }
@@ -458,7 +474,10 @@ export async function refreshPath(): Promise<void> {
         }
       })(),
       new Promise<"timeout">((resolve) => {
-        timeoutId = setTimeout(() => resolve("timeout"), REFRESH_TIMEOUT_MS);
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          resolve("timeout");
+        }, REFRESH_TIMEOUT_MS);
       }),
     ]);
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -314,14 +314,14 @@ function parseMarkeredPath(stdout: string, marker: string): string | null {
 function runShellProbe(): Promise<string | null> {
   return new Promise((resolve) => {
     let resolved = false;
-    let termTimer: NodeJS.Timeout | undefined;
-    let killTimer: NodeJS.Timeout | undefined;
+    let termTimer: NodeJS.Timeout | undefined = undefined;
+    let killTimer: NodeJS.Timeout | undefined = undefined;
 
     const settle = (value: string | null) => {
       if (resolved) return;
       resolved = true;
-      if (termTimer) clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      if (termTimer !== undefined) clearTimeout(termTimer);
+      if (killTimer !== undefined) clearTimeout(killTimer);
       resolve(value);
     };
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -16,7 +16,8 @@ for (const stream of [process.stdout, process.stderr]) {
 
 import nodeV8 from "node:v8";
 import vm from "node:vm";
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
+import { randomBytes } from "crypto";
 import { app } from "electron";
 import path from "path";
 import fs from "fs";
@@ -113,12 +114,20 @@ if (process.platform === "win32") {
   }
 }
 
-// Bumped from 5s to 8s to tolerate slow corporate shells (VPN-delayed NFS
-// home dirs, heavy .zshrc). The common case is ~50ms; the timeout exists
-// purely to bound worst-case hangs. If the shell call still times out,
-// refreshPath() falls back to getUnixFallbackPaths() so CLIs installed via
+// Bumped from 8s to 10s to match the markered shell-probe budget specified
+// in #6063. The common case is ~50ms; the timeout exists purely to bound
+// worst-case hangs. If the shell call still times out, refreshPath()
+// falls back to getUnixFallbackPaths() so CLIs installed via
 // mise/asdf/Volta are still discoverable.
-const REFRESH_TIMEOUT_MS = 8_000;
+const REFRESH_TIMEOUT_MS = 10_000;
+const SHELL_PROBE_KILL_GRACE_MS = 500;
+
+// Module-level singleton: caches the in-flight or successful probe Promise
+// so concurrent refreshPath() calls don't spawn duplicate shells. On a null
+// (failed) result we clear the cache to allow a future retry — caching a
+// transient failure for the entire session is worse than the bounded cost
+// of one extra probe.
+let shellProbePromise: Promise<string | null> | null = null;
 
 function deduplicatePath(pathStr: string, caseInsensitive: boolean): string {
   const entries = pathStr.split(path.delimiter).filter(Boolean);
@@ -278,6 +287,128 @@ function applyWindowsExtraPaths(currentPath: string): string {
   return missing.length ? [...missing, currentPath].join(path.delimiter) : currentPath;
 }
 
+function parseMarkeredPath(stdout: string, marker: string): string | null {
+  const regex = new RegExp(marker + "([\\s\\S]+)" + marker);
+  const match = regex.exec(stdout);
+  if (!match) return null;
+  try {
+    const env = JSON.parse(match[1]) as Record<string, unknown>;
+    if (typeof env.PATH === "string" && env.PATH.trim().length > 0) {
+      return env.PATH;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Spawn $SHELL -i -l -c '<probe>' where <probe> brackets a JSON dump of
+// process.env between random hex markers. Parsing only what's between the
+// markers ignores prompt-tool noise (Powerlevel10k instant prompt,
+// oh-my-zsh update messages, fortune banners, motd output). Sets
+// DAINTREE_RESOLVING_ENVIRONMENT=1 in the child env so users can guard
+// slow .zshrc sections. Mirrors VS Code's getUnixShellEnvironment.
+function runShellProbe(): Promise<string | null> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    let termTimer: NodeJS.Timeout | undefined;
+    let killTimer: NodeJS.Timeout | undefined;
+
+    const settle = (value: string | null) => {
+      if (resolved) return;
+      resolved = true;
+      if (termTimer) clearTimeout(termTimer);
+      if (killTimer) clearTimeout(killTimer);
+      resolve(value);
+    };
+
+    const shell = process.env.SHELL ?? (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");
+    const marker = randomBytes(16).toString("hex");
+    // process.execPath is the Electron binary; ELECTRON_RUN_AS_NODE=1 in the
+    // child env makes it act as plain Node so we don't depend on `node`
+    // being on the user's PATH.
+    const probeCmd = `printf '%s' "${marker}"; "${process.execPath}" -e 'process.stdout.write(JSON.stringify(process.env))'; printf '%s' "${marker}"`;
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      DAINTREE_RESOLVING_ENVIRONMENT: "1",
+      ELECTRON_RUN_AS_NODE: "1",
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(shell, ["-i", "-l", "-c", probeCmd], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: childEnv,
+      });
+    } catch (err) {
+      console.warn(
+        "[refreshPath] shell probe spawn failed:",
+        // eslint-disable-next-line no-restricted-syntax -- diagnostic console.warn passes the raw error if not an Error; not a user-visible string.
+        err instanceof Error ? err.message : err
+      );
+      settle(null);
+      return;
+    }
+
+    let stdout = "";
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += typeof chunk === "string" ? chunk : chunk.toString();
+    });
+    child.on("error", (err: Error) => {
+      console.warn("[refreshPath] shell probe error:", err.message);
+      settle(null);
+    });
+    child.on("close", () => {
+      settle(parseMarkeredPath(stdout, marker));
+    });
+
+    termTimer = setTimeout(() => {
+      console.warn(
+        "[refreshPath] Shell probe timed out after",
+        REFRESH_TIMEOUT_MS,
+        "ms — sending SIGTERM"
+      );
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // ignore kill errors — the close handler or kill timer below will settle
+      }
+    }, REFRESH_TIMEOUT_MS);
+
+    killTimer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore — process may already be gone
+      }
+      settle(null);
+    }, REFRESH_TIMEOUT_MS + SHELL_PROBE_KILL_GRACE_MS);
+  });
+}
+
+function resolvePathViaShellProbe(): Promise<string | null> {
+  if (shellProbePromise) return shellProbePromise;
+
+  const probe = runShellProbe();
+  shellProbePromise = probe;
+
+  // Clear the singleton on null/rejection so a subsequent refreshPath() can retry.
+  probe
+    .then((result) => {
+      if (result === null && shellProbePromise === probe) {
+        shellProbePromise = null;
+      }
+    })
+    .catch(() => {
+      if (shellProbePromise === probe) {
+        shellProbePromise = null;
+      }
+    });
+
+  return probe;
+}
+
 export async function refreshPath(): Promise<void> {
   let timeoutId: NodeJS.Timeout | undefined;
   let shellEnvFailed = false;
@@ -289,6 +420,19 @@ export async function refreshPath(): Promise<void> {
           if (!registryPath) return;
           const withExtras = applyWindowsExtraPaths(registryPath);
           process.env.PATH = deduplicatePath(withExtras, true);
+        } else if (process.env.DAINTREE_SHELL_PROBE === "1") {
+          // Opt-in markered shell-probe path (#6063). Replaces shell-env
+          // with a real `$SHELL -i -l -c` invocation so lazy-loaded version
+          // managers (mise/asdf), eval-based activations (pyenv/rbenv,
+          // `eval "$(tool init)"`), and non-bashrc layouts (fnm, pnpm)
+          // are visible. Gated behind the flag so we can dogfood for one
+          // release before flipping the default.
+          const probedPath = await resolvePathViaShellProbe();
+          if (probedPath) {
+            process.env.PATH = deduplicatePath(probedPath, false);
+          } else {
+            shellEnvFailed = true;
+          }
         } else {
           try {
             const { shellEnv } = (await import("shell-env")) as {


### PR DESCRIPTION
## Summary

- Replaces the fragile bashrc-parsing approach with a markered shell probe, spawning `$SHELL -i -l` so the full interactive login environment is captured (mise/asdf shims, Homebrew on Apple Silicon, fnm/pnpm globals, and custom PATH entries all included)
- The probe wraps `env` output in random hex markers to strip shell startup noise (Powerlevel10k, oh-my-zsh, motd) and sets `DAINTREE_RESOLVING_ENVIRONMENT=1` so users with slow init sections can guard them
- Shipped behind `DAINTREE_SHELL_PROBE=1` for one release of dogfooding before it becomes the default; falls back to OS-inherited PATH on timeout (10 s) or parse failure

Resolves #6063

## Changes

- `electron/setup/environment.ts` — `resolveShellEnvironment()` adds the markered shell-probe path alongside the existing bashrc parser; flag routing selects which runs
- `electron/setup/__tests__/refreshPath.test.ts` — comprehensive test suite covering happy path, marker extraction, late-write safety, stderr deadlock prevention, concurrent-call deduplication, timeout fallback, and 10+ edge cases around marker collision and malformed output

## Testing

Unit tests cover the full probe lifecycle including timeout, stderr drain, marker-boundary edge cases, and concurrent call deduplication. Ran `npm run check` clean (no new errors). Manual smoke with `DAINTREE_SHELL_PROBE=1` on macOS with a mise-managed Node toolchain confirms the probe picks up shim paths the old parser missed.