### PR TITLE
feat(connectivity): add per-service connectivity awareness for GitHub, agents, MCP

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -617,6 +617,10 @@ export const CHANNELS = {
 
   // Performance capture channels
   PERF_FLUSH_RENDERER_MARKS: "perf:flush-renderer-marks",
+
+  // Per-service connectivity channels
+  CONNECTIVITY_GET_STATE: "connectivity:get-state",
+  CONNECTIVITY_SERVICE_CHANGED: "connectivity:service-changed",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -52,6 +52,7 @@ import { registerAccessibilityHandlers } from "./handlers/accessibility.js";
 import { registerDemoHandlers } from "./handlers/demo.js";
 import { registerRecoveryHandlers } from "./handlers/recovery.js";
 import { registerPluginHandlers } from "./handlers/plugin.js";
+import { registerConnectivityHandlers } from "./handlers/connectivity.js";
 import { events } from "../services/events.js";
 import {
   typedHandle,
@@ -148,6 +149,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerRecoveryHandlers(deps));
     register(() => registerPluginHandlers());
     register(() => registerPerfHandlers());
+    register(() => registerConnectivityHandlers());
   } catch (error) {
     runCleanups(cleanupFunctions);
     throw error;

--- a/electron/ipc/handlers/connectivity.ts
+++ b/electron/ipc/handlers/connectivity.ts
@@ -1,0 +1,23 @@
+import { CHANNELS } from "../channels.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
+import { getServiceConnectivityRegistry } from "../../services/connectivity/index.js";
+
+export function registerConnectivityHandlers(): () => void {
+  const handlers: Array<() => void> = [];
+  const registry = getServiceConnectivityRegistry();
+
+  // Push every state change to all renderers. The registry already guards
+  // against silent seeding so this only fires on real transitions.
+  handlers.push(
+    registry.onChange((payload) => {
+      broadcastToRenderer(CHANNELS.CONNECTIVITY_SERVICE_CHANGED, payload);
+    })
+  );
+
+  // Mount-time state replay. Each `WebContentsView` has an isolated Zustand
+  // store, so a window that mounts after the initial probes settled would
+  // never see the current state through push events alone.
+  handlers.push(typedHandle(CHANNELS.CONNECTIVITY_GET_STATE, async () => registry.getSnapshot()));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -49,6 +49,8 @@ import type {
   IssueNotFoundPayload,
   GitHubRateLimitPayload,
   GitHubTokenHealthPayload,
+  ServiceConnectivityPayload,
+  ServiceConnectivitySnapshot,
   GitStatus,
   KeyAction,
   TerminalRecipe,
@@ -1487,6 +1489,15 @@ const api: ElectronAPI = {
       _typedOn(CHANNELS.GITHUB_TOKEN_HEALTH_CHANGED, callback),
 
     getTokenHealth: () => _unwrappingInvoke(CHANNELS.GITHUB_GET_TOKEN_HEALTH),
+  },
+
+  // Per-service connectivity API
+  connectivity: {
+    getState: (): Promise<ServiceConnectivitySnapshot> =>
+      _unwrappingInvoke(CHANNELS.CONNECTIVITY_GET_STATE) as Promise<ServiceConnectivitySnapshot>,
+
+    onServiceChanged: (callback: (payload: ServiceConnectivityPayload) => void) =>
+      _typedOn(CHANNELS.CONNECTIVITY_SERVICE_CHANGED, callback),
   },
 
   // Dev Preview API

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -84,9 +84,33 @@ export class McpServerService {
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
+  private statusListeners = new Set<(running: boolean) => void>();
 
   get isRunning(): boolean {
     return this.httpServer !== null && this.port !== null;
+  }
+
+  /**
+   * Register a subscriber that fires whenever the server transitions between
+   * running and stopped. Used by `ServiceConnectivityRegistry` to surface MCP
+   * reachability without polling.
+   */
+  onStatusChange(listener: (running: boolean) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => {
+      this.statusListeners.delete(listener);
+    };
+  }
+
+  private emitStatusChange(): void {
+    const running = this.isRunning;
+    for (const listener of this.statusListeners) {
+      try {
+        listener(running);
+      } catch (err) {
+        console.error("[MCP] Status change listener threw:", err);
+      }
+    }
   }
 
   get currentPort(): number | null {
@@ -176,6 +200,7 @@ export class McpServerService {
     this.httpServer = server;
     await this.writeDiscoveryFile();
     console.log(`[MCP] Server started on http://127.0.0.1:${this.port}/sse`);
+    this.emitStatusChange();
   }
 
   async stop(): Promise<void> {
@@ -204,7 +229,9 @@ export class McpServerService {
       this.pendingDispatches.delete(id);
     }
 
+    let wasRunning = false;
     if (this.httpServer) {
+      wasRunning = true;
       await new Promise<void>((resolve) => {
         this.httpServer!.close(() => resolve());
       });
@@ -214,6 +241,9 @@ export class McpServerService {
 
     await this.removeDiscoveryFile();
     console.log("[MCP] Server stopped");
+    if (wasRunning) {
+      this.emitStatusChange();
+    }
   }
 
   getStatus(): {

--- a/electron/services/connectivity/AgentConnectivityService.ts
+++ b/electron/services/connectivity/AgentConnectivityService.ts
@@ -64,6 +64,7 @@ class AgentConnectivityServiceImpl {
   private readonly state: Record<AgentConnectivityProvider, ProviderState>;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private readonly listeners = new Set<StateChangeListener>();
+  private disposed = false;
 
   private fetchImpl: FetchFn;
   private now: () => number;
@@ -118,6 +119,7 @@ class AgentConnectivityServiceImpl {
   dispose(): void {
     this.stop();
     this.listeners.clear();
+    this.disposed = true;
     for (const provider of this.providers) {
       this.state[provider] = { status: "unknown", checkedAt: 0, pendingCheck: null };
     }
@@ -139,6 +141,7 @@ class AgentConnectivityServiceImpl {
   _resetForTests(): void {
     this.stop();
     this.listeners.clear();
+    this.disposed = false;
     for (const provider of this.providers) {
       this.state[provider] = { status: "unknown", checkedAt: 0, pendingCheck: null };
     }
@@ -207,6 +210,10 @@ class AgentConnectivityServiceImpl {
     provider: AgentConnectivityProvider,
     status: ServiceConnectivityStatus
   ): void {
+    // Stale completion after dispose() — ignore so we don't overwrite the
+    // freshly-reset state or notify listeners that have been re-attached to
+    // a recreated service instance.
+    if (this.disposed) return;
     const entry = this.state[provider];
     const previous = entry.status;
     entry.status = status;

--- a/electron/services/connectivity/AgentConnectivityService.ts
+++ b/electron/services/connectivity/AgentConnectivityService.ts
@@ -1,0 +1,241 @@
+import type { ServiceConnectivityStatus } from "../../../shared/types/ipc/connectivity.js";
+import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+
+/** How often background reachability probes run when the app is actively used. */
+export const AGENT_CONNECTIVITY_INTERVAL_MS = 30 * 60 * 1000;
+
+/** Minimum gap between probes triggered by focus/wake events. */
+export const AGENT_CONNECTIVITY_FOCUS_COOLDOWN_MS = 5 * 60 * 1000;
+
+/** Timeout on the probe's fetch call. */
+export const AGENT_CONNECTIVITY_FETCH_TIMEOUT_MS = 10_000;
+
+export type AgentConnectivityProvider = "claude" | "gemini" | "codex";
+
+const PROBE_ENDPOINTS: Record<AgentConnectivityProvider, string> = {
+  claude: "https://api.anthropic.com/v1/models",
+  gemini: "https://generativelanguage.googleapis.com/v1beta/models",
+  codex: "https://api.openai.com/v1/models",
+};
+
+interface ProviderState {
+  status: ServiceConnectivityStatus;
+  checkedAt: number;
+  pendingCheck: Promise<void> | null;
+}
+
+export interface AgentConnectivityChange {
+  provider: AgentConnectivityProvider;
+  status: ServiceConnectivityStatus;
+  checkedAt: number;
+}
+
+type StateChangeListener = (change: AgentConnectivityChange) => void;
+
+type FetchFn = typeof globalThis.fetch;
+
+interface AgentConnectivityServiceOptions {
+  /** Override for tests — inject a mock fetch. */
+  fetchImpl?: FetchFn;
+  /** Override for tests — inject a deterministic clock. */
+  now?: () => number;
+}
+
+/**
+ * Background reachability probes for agent provider APIs (Claude, Gemini, Codex).
+ *
+ * The probes deliberately send unauthenticated GET requests to each provider's
+ * `/models` endpoint. Daintree does not own the agent CLI's API keys, so we
+ * cannot — and should not — attempt token-validity checks here. The only
+ * question this service answers is "can the network reach the provider?".
+ *
+ * Classification:
+ *   - Any HTTP response (including 4xx/5xx) → `reachable`. A 401 from Anthropic
+ *     without an `x-api-key` header still confirms the API host is up.
+ *   - Network-level failures (DNS resolution, timeouts, connection refused,
+ *     `AbortError`, etc.) → `unreachable`.
+ *
+ * This contrasts with `GitHubTokenHealthService`, which DOES care about token
+ * validity. Don't conflate the two — they serve different UX needs.
+ */
+class AgentConnectivityServiceImpl {
+  private readonly providers: AgentConnectivityProvider[] = ["claude", "gemini", "codex"];
+  private readonly state: Record<AgentConnectivityProvider, ProviderState>;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly listeners = new Set<StateChangeListener>();
+
+  private fetchImpl: FetchFn;
+  private now: () => number;
+
+  constructor(options: AgentConnectivityServiceOptions = {}) {
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.now = options.now ?? (() => Date.now());
+
+    this.state = {
+      claude: { status: "unknown", checkedAt: 0, pendingCheck: null },
+      gemini: { status: "unknown", checkedAt: 0, pendingCheck: null },
+      codex: { status: "unknown", checkedAt: 0, pendingCheck: null },
+    };
+  }
+
+  onStateChange(listener: StateChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Snapshot of one provider's current state. */
+  getProviderState(provider: AgentConnectivityProvider): {
+    status: ServiceConnectivityStatus;
+    checkedAt: number;
+  } {
+    const entry = this.state[provider];
+    return { status: entry.status, checkedAt: entry.checkedAt };
+  }
+
+  /**
+   * Begin polling. Safe to call multiple times — subsequent calls are no-ops.
+   * Fires immediate probes asynchronously so initial state is available soon
+   * after startup without blocking the caller.
+   */
+  start(): void {
+    if (this.pollTimer) return;
+    this.pollTimer = setInterval(() => {
+      void this.refresh({ reason: "interval" });
+    }, AGENT_CONNECTIVITY_INTERVAL_MS);
+    void this.refresh({ reason: "start", force: true });
+  }
+
+  stop(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  dispose(): void {
+    this.stop();
+    this.listeners.clear();
+    for (const provider of this.providers) {
+      this.state[provider] = { status: "unknown", checkedAt: 0, pendingCheck: null };
+    }
+  }
+
+  /**
+   * Run probes for every provider, subject to a per-provider cooldown unless
+   * `force` is set. Returns once every issued probe has settled — providers
+   * that are skipped due to cooldown resolve immediately.
+   */
+  refresh(options: { force?: boolean; reason?: string } = {}): Promise<void> {
+    const reason = options.reason ?? "refresh";
+    const force = options.force === true;
+    const probes = this.providers.map((provider) => this.runCheck(provider, { force, reason }));
+    return Promise.all(probes).then(() => undefined);
+  }
+
+  /** Test-only helper. */
+  _resetForTests(): void {
+    this.stop();
+    this.listeners.clear();
+    for (const provider of this.providers) {
+      this.state[provider] = { status: "unknown", checkedAt: 0, pendingCheck: null };
+    }
+  }
+
+  /** Test-only helper. */
+  _setFetchForTests(fetchImpl: FetchFn): void {
+    this.fetchImpl = fetchImpl;
+  }
+
+  /** Test-only helper. */
+  _setNowForTests(now: () => number): void {
+    this.now = now;
+  }
+
+  private async runCheck(
+    provider: AgentConnectivityProvider,
+    context: { force: boolean; reason: string }
+  ): Promise<void> {
+    const entry = this.state[provider];
+
+    // Coalesce concurrent probes for the same provider.
+    if (entry.pendingCheck) return entry.pendingCheck;
+
+    if (!context.force) {
+      const elapsed = this.now() - entry.checkedAt;
+      if (entry.checkedAt > 0 && elapsed < AGENT_CONNECTIVITY_FOCUS_COOLDOWN_MS) {
+        logDebug("Agent connectivity: skipping refresh within cooldown", {
+          provider,
+          elapsed,
+        });
+        return;
+      }
+    }
+
+    const url = PROBE_ENDPOINTS[provider];
+
+    const probe = (async () => {
+      try {
+        await this.fetchImpl(url, {
+          method: "GET",
+          signal: AbortSignal.timeout(AGENT_CONNECTIVITY_FETCH_TIMEOUT_MS),
+        });
+        // Any HTTP response — including 4xx — means the host is reachable.
+        // We send no auth headers, so 401/403 are expected and authoritative
+        // about network reachability, not token validity.
+        this.transitionTo(provider, "reachable");
+      } catch (err) {
+        // Network-layer failures: DNS, timeout, connection refused, abort.
+        logDebug("Agent connectivity: probe failed (network/transport)", {
+          provider,
+          error: formatErrorMessage(err, "Agent connectivity probe failed"),
+          reason: context.reason,
+        });
+        this.transitionTo(provider, "unreachable");
+      }
+    })().finally(() => {
+      entry.pendingCheck = null;
+    });
+
+    entry.pendingCheck = probe;
+    return probe;
+  }
+
+  private transitionTo(
+    provider: AgentConnectivityProvider,
+    status: ServiceConnectivityStatus
+  ): void {
+    const entry = this.state[provider];
+    const previous = entry.status;
+    entry.status = status;
+    entry.checkedAt = this.now();
+
+    if (previous !== status) {
+      if (status === "reachable") {
+        logInfo("Agent connectivity: reachable", { provider });
+      } else if (status === "unreachable") {
+        logInfo("Agent connectivity: unreachable", { provider });
+      }
+      this.notifyListeners({ provider, status, checkedAt: entry.checkedAt });
+    } else {
+      logDebug("Agent connectivity: unchanged", { provider, status });
+    }
+  }
+
+  private notifyListeners(change: AgentConnectivityChange): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(change);
+      } catch (err) {
+        logWarn("Agent connectivity listener threw", {
+          error: formatErrorMessage(err, "Connectivity listener failed"),
+        });
+      }
+    }
+  }
+}
+
+export { AgentConnectivityServiceImpl };
+export const agentConnectivityService = new AgentConnectivityServiceImpl();

--- a/electron/services/connectivity/ServiceConnectivityRegistry.ts
+++ b/electron/services/connectivity/ServiceConnectivityRegistry.ts
@@ -131,7 +131,15 @@ export class ServiceConnectivityRegistry {
     // Seed from existing state so secondary windows don't see `unknown` for a
     // service that has already settled.
     this.applyGitHubState(this.gitHubHealth.getState(), { silent: true });
-    this.applyMcpState(this.mcpServer.isRunning, { silent: true });
+    // MCP is started by a deferred task that runs *after* this registry, so
+    // `isRunning === false` here means "not started yet" — distinct from
+    // "was running, now stopped". Leave the snapshot at `unknown` and let
+    // the first live emitStatusChange define the initial state. Otherwise
+    // every normal launch with MCP enabled would see an unreachable→reachable
+    // transition fire a spurious "Connection restored" toast.
+    if (this.mcpServer.isRunning) {
+      this.applyMcpState(true, { silent: true });
+    }
     for (const provider of ["claude", "gemini", "codex"] as const) {
       const state = this.agentConnectivity.getProviderState(provider);
       this.applyAgentState(provider, state, { silent: true });
@@ -173,11 +181,15 @@ export class ServiceConnectivityRegistry {
     // `useGitHubTokenHealth` hook handles the token-revoked UX.
     const status: ServiceConnectivityStatus =
       payload.status === "healthy" ? "reachable" : "unknown";
-    this.update("github", status, payload.checkedAt || this.now(), options);
+    // Pass `payload.checkedAt` through as-is — `0` is the documented value
+    // for "no probe has run yet" and must reach the snapshot intact.
+    this.update("github", status, payload.checkedAt, options);
   }
 
   private applyMcpState(running: boolean, options: { silent?: boolean } = {}): void {
     const status: ServiceConnectivityStatus = running ? "reachable" : "unreachable";
+    // MCP has no native checkedAt — use now() since this is a real transition
+    // observation (silent seeding only calls us when running === true).
     this.update("mcp", status, this.now(), options);
   }
 
@@ -187,7 +199,7 @@ export class ServiceConnectivityRegistry {
     options: { silent?: boolean } = {}
   ): void {
     const key = PROVIDER_TO_KEY[provider];
-    this.update(key, state.status, state.checkedAt || this.now(), options);
+    this.update(key, state.status, state.checkedAt, options);
   }
 
   private update(

--- a/electron/services/connectivity/ServiceConnectivityRegistry.ts
+++ b/electron/services/connectivity/ServiceConnectivityRegistry.ts
@@ -1,0 +1,233 @@
+import type {
+  ConnectivityServiceKey,
+  ServiceConnectivityPayload,
+  ServiceConnectivitySnapshot,
+  ServiceConnectivityStatus,
+} from "../../../shared/types/ipc/connectivity.js";
+import { CONNECTIVITY_SERVICE_KEYS } from "../../../shared/types/ipc/connectivity.js";
+import type { GitHubTokenHealthPayload } from "../../../shared/types/ipc/github.js";
+import { logWarn } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import {
+  agentConnectivityService as defaultAgentConnectivityService,
+  type AgentConnectivityChange,
+  type AgentConnectivityProvider,
+} from "./AgentConnectivityService.js";
+
+interface GitHubHealthLike {
+  getState(): GitHubTokenHealthPayload;
+  onStateChange(listener: (payload: GitHubTokenHealthPayload) => void): () => void;
+}
+
+interface McpServerLike {
+  readonly isRunning: boolean;
+  onStatusChange(listener: (running: boolean) => void): () => void;
+}
+
+interface AgentConnectivityLike {
+  getProviderState(provider: AgentConnectivityProvider): {
+    status: ServiceConnectivityStatus;
+    checkedAt: number;
+  };
+  onStateChange(listener: (change: AgentConnectivityChange) => void): () => void;
+}
+
+type SnapshotChangeListener = (payload: ServiceConnectivityPayload) => void;
+type RecoveryNotifier = (serviceKey: ConnectivityServiceKey, label: string) => void;
+
+const PROVIDER_TO_KEY: Record<AgentConnectivityProvider, ConnectivityServiceKey> = {
+  claude: "agent:claude",
+  gemini: "agent:gemini",
+  codex: "agent:codex",
+};
+
+const SERVICE_LABELS: Record<ConnectivityServiceKey, string> = {
+  github: "GitHub",
+  "agent:claude": "Claude",
+  "agent:gemini": "Gemini",
+  "agent:codex": "Codex",
+  mcp: "MCP server",
+};
+
+export interface ServiceConnectivityRegistryOptions {
+  gitHubHealth: GitHubHealthLike;
+  mcpServer: McpServerLike;
+  agentConnectivity?: AgentConnectivityLike;
+  /**
+   * Called when a service flips from `unreachable` to `reachable`. Receives the
+   * service key and a human-readable label. Optional — when omitted, recovery
+   * notifications are silently dropped.
+   */
+  onRecovery?: RecoveryNotifier;
+  /** Override for tests. */
+  now?: () => number;
+}
+
+/**
+ * Aggregates connectivity health from multiple underlying services into one
+ * snapshot keyed by `ConnectivityServiceKey`.
+ *
+ * - `agent:claude|gemini|codex` is sourced from `AgentConnectivityService`.
+ * - `github` is derived from `GitHubTokenHealthService`. A 401 (token revoked)
+ *   maps to `unknown` here, not `unreachable` — token validity is a separate
+ *   concern surfaced via `GitHubTokenHealthPayload`.
+ * - `mcp` is derived synchronously from `mcpServerService.isRunning`.
+ *
+ * The renderer subscribes to a single broadcast channel and reads a fixed-shape
+ * map. Dev-server connectivity is intentionally excluded — it's per-session and
+ * already broadcast through `DEV_PREVIEW_STATE_CHANGED`.
+ */
+export class ServiceConnectivityRegistry {
+  private readonly snapshot: ServiceConnectivitySnapshot;
+  private readonly listeners = new Set<SnapshotChangeListener>();
+  private readonly cleanups: Array<() => void> = [];
+  private readonly gitHubHealth: GitHubHealthLike;
+  private readonly mcpServer: McpServerLike;
+  private readonly agentConnectivity: AgentConnectivityLike;
+  private readonly onRecovery: RecoveryNotifier | null;
+  private readonly now: () => number;
+  private started = false;
+
+  constructor(options: ServiceConnectivityRegistryOptions) {
+    this.gitHubHealth = options.gitHubHealth;
+    this.mcpServer = options.mcpServer;
+    this.agentConnectivity = options.agentConnectivity ?? defaultAgentConnectivityService;
+    this.onRecovery = options.onRecovery ?? null;
+    this.now = options.now ?? (() => Date.now());
+
+    this.snapshot = Object.fromEntries(
+      CONNECTIVITY_SERVICE_KEYS.map((key) => [
+        key,
+        { serviceKey: key, status: "unknown" as ServiceConnectivityStatus, checkedAt: 0 },
+      ])
+    ) as ServiceConnectivitySnapshot;
+  }
+
+  /** Subscribe to per-service state changes. */
+  onChange(listener: SnapshotChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Snapshot of every service's current state — safe to call before any probe has run. */
+  getSnapshot(): ServiceConnectivitySnapshot {
+    // Return a shallow clone so consumers can't mutate internal state.
+    return Object.fromEntries(
+      CONNECTIVITY_SERVICE_KEYS.map((key) => [key, { ...this.snapshot[key] }])
+    ) as ServiceConnectivitySnapshot;
+  }
+
+  /**
+   * Wire up listeners on every underlying service and seed initial snapshot
+   * values from their current state. Safe to call multiple times — subsequent
+   * calls are no-ops.
+   */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+
+    // Seed from existing state so secondary windows don't see `unknown` for a
+    // service that has already settled.
+    this.applyGitHubState(this.gitHubHealth.getState(), { silent: true });
+    this.applyMcpState(this.mcpServer.isRunning, { silent: true });
+    for (const provider of ["claude", "gemini", "codex"] as const) {
+      const state = this.agentConnectivity.getProviderState(provider);
+      this.applyAgentState(provider, state, { silent: true });
+    }
+
+    this.cleanups.push(
+      this.gitHubHealth.onStateChange((payload) => this.applyGitHubState(payload))
+    );
+    this.cleanups.push(this.mcpServer.onStatusChange((running) => this.applyMcpState(running)));
+    this.cleanups.push(
+      this.agentConnectivity.onStateChange((change) =>
+        this.applyAgentState(change.provider, change)
+      )
+    );
+  }
+
+  dispose(): void {
+    for (const cleanup of this.cleanups) {
+      try {
+        cleanup();
+      } catch (err) {
+        logWarn("ServiceConnectivityRegistry: cleanup threw", {
+          error: formatErrorMessage(err, "Cleanup failed"),
+        });
+      }
+    }
+    this.cleanups.length = 0;
+    this.listeners.clear();
+    this.started = false;
+  }
+
+  private applyGitHubState(
+    payload: GitHubTokenHealthPayload,
+    options: { silent?: boolean } = {}
+  ): void {
+    // Deliberately collapse `healthy` → `reachable` and `unhealthy|unknown`
+    // → `unknown`. A 401 means GitHub is reachable but the token is dead;
+    // surfacing that as "unreachable" would be misleading. The dedicated
+    // `useGitHubTokenHealth` hook handles the token-revoked UX.
+    const status: ServiceConnectivityStatus =
+      payload.status === "healthy" ? "reachable" : "unknown";
+    this.update("github", status, payload.checkedAt || this.now(), options);
+  }
+
+  private applyMcpState(running: boolean, options: { silent?: boolean } = {}): void {
+    const status: ServiceConnectivityStatus = running ? "reachable" : "unreachable";
+    this.update("mcp", status, this.now(), options);
+  }
+
+  private applyAgentState(
+    provider: AgentConnectivityProvider,
+    state: { status: ServiceConnectivityStatus; checkedAt: number },
+    options: { silent?: boolean } = {}
+  ): void {
+    const key = PROVIDER_TO_KEY[provider];
+    this.update(key, state.status, state.checkedAt || this.now(), options);
+  }
+
+  private update(
+    serviceKey: ConnectivityServiceKey,
+    status: ServiceConnectivityStatus,
+    checkedAt: number,
+    options: { silent?: boolean } = {}
+  ): void {
+    const previous = this.snapshot[serviceKey];
+    if (previous.status === status && previous.checkedAt === checkedAt) {
+      return;
+    }
+
+    const next: ServiceConnectivityPayload = { serviceKey, status, checkedAt };
+    this.snapshot[serviceKey] = next;
+
+    if (options.silent) return;
+
+    if (previous.status === "unreachable" && status === "reachable" && this.onRecovery) {
+      try {
+        this.onRecovery(serviceKey, SERVICE_LABELS[serviceKey]);
+      } catch (err) {
+        logWarn("ServiceConnectivityRegistry: recovery notifier threw", {
+          error: formatErrorMessage(err, "Recovery notifier failed"),
+        });
+      }
+    }
+
+    this.notifyListeners(next);
+  }
+
+  private notifyListeners(payload: ServiceConnectivityPayload): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(payload);
+      } catch (err) {
+        logWarn("ServiceConnectivityRegistry: listener threw", {
+          error: formatErrorMessage(err, "Connectivity listener failed"),
+        });
+      }
+    }
+  }
+}

--- a/electron/services/connectivity/__tests__/AgentConnectivityService.test.ts
+++ b/electron/services/connectivity/__tests__/AgentConnectivityService.test.ts
@@ -169,5 +169,43 @@ describe("AgentConnectivityService", () => {
       service.dispose();
       expect(service.getProviderState("claude").status).toBe("unknown");
     });
+
+    it("does not let an in-flight probe overwrite reset state after dispose()", async () => {
+      const resolvers: Array<(value: Response) => void> = [];
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolvers.push(resolve);
+          })
+      );
+
+      const probe = service.refresh({ force: true });
+      service.dispose();
+      // Resolve the in-flight fetches AFTER dispose. Without the disposed
+      // guard in transitionTo(), these would overwrite the reset state.
+      for (const resolve of resolvers) {
+        resolve(buildResponse(200));
+      }
+      await probe;
+
+      expect(service.getProviderState("claude").status).toBe("unknown");
+      expect(service.getProviderState("gemini").status).toBe("unknown");
+      expect(service.getProviderState("codex").status).toBe("unknown");
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("classifies each provider independently when one resolves and another rejects", async () => {
+      fetchMock.mockImplementation((url: string) => {
+        if (url.includes("anthropic")) return Promise.resolve(buildResponse(200));
+        if (url.includes("googleapis")) return Promise.reject(new Error("ENOTFOUND"));
+        return Promise.resolve(buildResponse(200));
+      });
+
+      await service.refresh({ force: true });
+
+      expect(service.getProviderState("claude").status).toBe("reachable");
+      expect(service.getProviderState("gemini").status).toBe("unreachable");
+      expect(service.getProviderState("codex").status).toBe("reachable");
+    });
   });
 });

--- a/electron/services/connectivity/__tests__/AgentConnectivityService.test.ts
+++ b/electron/services/connectivity/__tests__/AgentConnectivityService.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import {
+  AgentConnectivityServiceImpl,
+  AGENT_CONNECTIVITY_FOCUS_COOLDOWN_MS,
+  type AgentConnectivityChange,
+} from "../AgentConnectivityService.js";
+
+function buildResponse(status: number): Response {
+  return new Response("{}", { status });
+}
+
+describe("AgentConnectivityService", () => {
+  let service: AgentConnectivityServiceImpl;
+  let fetchMock: Mock;
+  let listener: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    listener = vi.fn();
+    service = new AgentConnectivityServiceImpl({
+      fetchImpl: fetchMock as unknown as typeof globalThis.fetch,
+    });
+    service.onStateChange(listener as (change: AgentConnectivityChange) => void);
+  });
+
+  afterEach(() => {
+    service.dispose();
+  });
+
+  describe("refresh()", () => {
+    it("marks every provider reachable on a 2xx probe response", async () => {
+      fetchMock.mockResolvedValue(buildResponse(200));
+
+      await service.refresh({ force: true });
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.anthropic.com/v1/models",
+        expect.objectContaining({ method: "GET", signal: expect.any(AbortSignal) })
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        expect.any(Object)
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.openai.com/v1/models",
+        expect.any(Object)
+      );
+
+      expect(service.getProviderState("claude").status).toBe("reachable");
+      expect(service.getProviderState("gemini").status).toBe("reachable");
+      expect(service.getProviderState("codex").status).toBe("reachable");
+    });
+
+    it("treats a 401 response as reachable (auth state is not a network signal)", async () => {
+      fetchMock.mockResolvedValue(buildResponse(401));
+
+      await service.refresh({ force: true });
+
+      expect(service.getProviderState("claude").status).toBe("reachable");
+    });
+
+    it("treats a 5xx response as reachable (host responded)", async () => {
+      fetchMock.mockResolvedValue(buildResponse(503));
+
+      await service.refresh({ force: true });
+
+      expect(service.getProviderState("claude").status).toBe("reachable");
+    });
+
+    it("marks providers unreachable on network failures (DNS, timeout, abort)", async () => {
+      fetchMock.mockRejectedValue(new Error("ENOTFOUND api.anthropic.com"));
+
+      await service.refresh({ force: true });
+
+      expect(service.getProviderState("claude").status).toBe("unreachable");
+      expect(service.getProviderState("gemini").status).toBe("unreachable");
+      expect(service.getProviderState("codex").status).toBe("unreachable");
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "claude", status: "unreachable" })
+      );
+    });
+
+    it("coalesces concurrent probes for the same provider into one in-flight request", async () => {
+      const resolvers: Array<(value: Response) => void> = [];
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolvers.push(resolve);
+          })
+      );
+
+      const first = service.refresh({ force: true });
+      const second = service.refresh({ force: true });
+
+      // Three providers, but each provider's refresh should coalesce — so
+      // exactly three fetches even though refresh was called twice.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      for (const resolve of resolvers) {
+        resolve(buildResponse(200));
+      }
+      await Promise.all([first, second]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("respects the per-provider focus cooldown by default", async () => {
+      let now = 1_000_000;
+      service._setNowForTests(() => now);
+      fetchMock.mockResolvedValue(buildResponse(200));
+
+      await service.refresh({ force: true });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      now += AGENT_CONNECTIVITY_FOCUS_COOLDOWN_MS - 1_000;
+      await service.refresh();
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      now += 2_000;
+      await service.refresh();
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    });
+
+    it("force refresh bypasses the cooldown", async () => {
+      const now = 1_000_000;
+      service._setNowForTests(() => now);
+      fetchMock.mockResolvedValue(buildResponse(200));
+
+      await service.refresh({ force: true });
+      await service.refresh({ force: true });
+
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe("transitions", () => {
+    it("emits exactly once per real state change", async () => {
+      fetchMock.mockResolvedValue(buildResponse(200));
+
+      await service.refresh({ force: true });
+      // unknown → reachable for each of the three providers.
+      expect(listener).toHaveBeenCalledTimes(3);
+      listener.mockClear();
+
+      await service.refresh({ force: true });
+      // No transitions on the second probe — already reachable.
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("emits when a provider transitions from reachable back to unreachable", async () => {
+      fetchMock.mockResolvedValue(buildResponse(200));
+      await service.refresh({ force: true });
+      listener.mockClear();
+
+      fetchMock.mockReset();
+      fetchMock.mockRejectedValue(new Error("ETIMEDOUT"));
+      await service.refresh({ force: true });
+
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "claude", status: "unreachable" })
+      );
+    });
+  });
+
+  describe("dispose()", () => {
+    it("clears listeners and resets state", () => {
+      service.dispose();
+      expect(service.getProviderState("claude").status).toBe("unknown");
+    });
+  });
+});

--- a/electron/services/connectivity/__tests__/ServiceConnectivityRegistry.test.ts
+++ b/electron/services/connectivity/__tests__/ServiceConnectivityRegistry.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ServiceConnectivityRegistry } from "../ServiceConnectivityRegistry.js";
+import type { GitHubTokenHealthPayload } from "../../../../shared/types/ipc/github.js";
+import type {
+  ConnectivityServiceKey,
+  ServiceConnectivityStatus,
+} from "../../../../shared/types/ipc/connectivity.js";
+
+interface FakeGitHubHealth {
+  state: GitHubTokenHealthPayload;
+  listeners: Set<(payload: GitHubTokenHealthPayload) => void>;
+  getState(): GitHubTokenHealthPayload;
+  onStateChange(listener: (payload: GitHubTokenHealthPayload) => void): () => void;
+  emit(payload: GitHubTokenHealthPayload): void;
+}
+
+interface FakeMcpServer {
+  isRunning: boolean;
+  listeners: Set<(running: boolean) => void>;
+  onStatusChange(listener: (running: boolean) => void): () => void;
+  setRunning(running: boolean): void;
+}
+
+interface FakeAgentConnectivity {
+  state: Record<
+    "claude" | "gemini" | "codex",
+    { status: ServiceConnectivityStatus; checkedAt: number }
+  >;
+  listeners: Set<
+    (change: {
+      provider: "claude" | "gemini" | "codex";
+      status: ServiceConnectivityStatus;
+      checkedAt: number;
+    }) => void
+  >;
+  getProviderState(provider: "claude" | "gemini" | "codex"): {
+    status: ServiceConnectivityStatus;
+    checkedAt: number;
+  };
+  onStateChange(
+    listener: (change: {
+      provider: "claude" | "gemini" | "codex";
+      status: ServiceConnectivityStatus;
+      checkedAt: number;
+    }) => void
+  ): () => void;
+  emit(change: {
+    provider: "claude" | "gemini" | "codex";
+    status: ServiceConnectivityStatus;
+    checkedAt: number;
+  }): void;
+}
+
+function createFakeGitHubHealth(initial: GitHubTokenHealthPayload): FakeGitHubHealth {
+  const fake: FakeGitHubHealth = {
+    state: initial,
+    listeners: new Set(),
+    getState: () => fake.state,
+    onStateChange: (listener) => {
+      fake.listeners.add(listener);
+      return () => {
+        fake.listeners.delete(listener);
+      };
+    },
+    emit: (payload) => {
+      fake.state = payload;
+      for (const listener of fake.listeners) listener(payload);
+    },
+  };
+  return fake;
+}
+
+function createFakeMcpServer(initial: boolean): FakeMcpServer {
+  const fake: FakeMcpServer = {
+    isRunning: initial,
+    listeners: new Set(),
+    onStatusChange: (listener) => {
+      fake.listeners.add(listener);
+      return () => {
+        fake.listeners.delete(listener);
+      };
+    },
+    setRunning: (running: boolean) => {
+      fake.isRunning = running;
+      for (const listener of fake.listeners) listener(running);
+    },
+  };
+  return fake;
+}
+
+function createFakeAgentConnectivity(): FakeAgentConnectivity {
+  const fake: FakeAgentConnectivity = {
+    state: {
+      claude: { status: "unknown", checkedAt: 0 },
+      gemini: { status: "unknown", checkedAt: 0 },
+      codex: { status: "unknown", checkedAt: 0 },
+    },
+    listeners: new Set(),
+    getProviderState: (provider) => fake.state[provider],
+    onStateChange: (listener) => {
+      fake.listeners.add(listener);
+      return () => {
+        fake.listeners.delete(listener);
+      };
+    },
+    emit: (change) => {
+      fake.state[change.provider] = { status: change.status, checkedAt: change.checkedAt };
+      for (const listener of fake.listeners) listener(change);
+    },
+  };
+  return fake;
+}
+
+describe("ServiceConnectivityRegistry", () => {
+  let gitHubHealth: FakeGitHubHealth;
+  let mcpServer: FakeMcpServer;
+  let agentConnectivity: FakeAgentConnectivity;
+  let registry: ServiceConnectivityRegistry;
+  let onRecovery: ReturnType<
+    typeof vi.fn<(serviceKey: ConnectivityServiceKey, label: string) => void>
+  >;
+
+  beforeEach(() => {
+    gitHubHealth = createFakeGitHubHealth({
+      status: "unknown",
+      tokenVersion: -1,
+      checkedAt: 0,
+    });
+    mcpServer = createFakeMcpServer(false);
+    agentConnectivity = createFakeAgentConnectivity();
+    onRecovery = vi.fn();
+    registry = new ServiceConnectivityRegistry({
+      gitHubHealth,
+      mcpServer,
+      agentConnectivity,
+      onRecovery,
+      now: () => 1_000_000,
+    });
+  });
+
+  afterEach(() => {
+    registry.dispose();
+  });
+
+  describe("getSnapshot()", () => {
+    it("returns all five service keys with status `unknown` before start()", () => {
+      const snapshot = registry.getSnapshot();
+
+      expect(snapshot.github.status).toBe("unknown");
+      expect(snapshot["agent:claude"].status).toBe("unknown");
+      expect(snapshot["agent:gemini"].status).toBe("unknown");
+      expect(snapshot["agent:codex"].status).toBe("unknown");
+      expect(snapshot.mcp.status).toBe("unknown");
+    });
+
+    it("returns a fresh clone — mutating the result does not affect internal state", () => {
+      const snapshot = registry.getSnapshot();
+      snapshot.github.status = "reachable";
+
+      const second = registry.getSnapshot();
+      expect(second.github.status).toBe("unknown");
+    });
+  });
+
+  describe("start()", () => {
+    it("seeds initial state silently from each underlying service", () => {
+      gitHubHealth.state = {
+        status: "healthy",
+        tokenVersion: 1,
+        checkedAt: 500_000,
+      };
+      mcpServer.isRunning = true;
+      agentConnectivity.state.claude = { status: "reachable", checkedAt: 600_000 };
+      const listener = vi.fn();
+      registry.onChange(listener);
+
+      registry.start();
+
+      const snapshot = registry.getSnapshot();
+      expect(snapshot.github.status).toBe("reachable");
+      expect(snapshot.mcp.status).toBe("reachable");
+      expect(snapshot["agent:claude"].status).toBe("reachable");
+
+      // Seeding should NOT emit change events — those are reserved for real
+      // post-start transitions.
+      expect(listener).not.toHaveBeenCalled();
+      expect(onRecovery).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent — calling start() twice does not double-subscribe", () => {
+      registry.start();
+      registry.start();
+
+      const listener = vi.fn();
+      registry.onChange(listener);
+
+      gitHubHealth.emit({ status: "healthy", tokenVersion: 1, checkedAt: 1_000_000 });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("derived states", () => {
+    beforeEach(() => {
+      registry.start();
+    });
+
+    it("maps GitHub `healthy` to `reachable`", () => {
+      gitHubHealth.emit({ status: "healthy", tokenVersion: 1, checkedAt: 1_000_000 });
+
+      expect(registry.getSnapshot().github.status).toBe("reachable");
+    });
+
+    it("maps GitHub `unhealthy` (token revoked) to `unknown`, NOT `unreachable`", () => {
+      // Seed reachable first so we can confirm the transition.
+      gitHubHealth.emit({ status: "healthy", tokenVersion: 1, checkedAt: 1_000_000 });
+      gitHubHealth.emit({ status: "unhealthy", tokenVersion: 1, checkedAt: 1_000_000 });
+
+      expect(registry.getSnapshot().github.status).toBe("unknown");
+    });
+
+    it("maps MCP isRunning=true to `reachable` and false to `unreachable`", () => {
+      mcpServer.setRunning(true);
+      expect(registry.getSnapshot().mcp.status).toBe("reachable");
+
+      mcpServer.setRunning(false);
+      expect(registry.getSnapshot().mcp.status).toBe("unreachable");
+    });
+
+    it("propagates agent reachability changes", () => {
+      agentConnectivity.emit({
+        provider: "gemini",
+        status: "reachable",
+        checkedAt: 1_000_000,
+      });
+
+      expect(registry.getSnapshot()["agent:gemini"].status).toBe("reachable");
+    });
+  });
+
+  describe("recovery notifications", () => {
+    beforeEach(() => {
+      registry.start();
+    });
+
+    it("fires onRecovery when a service transitions from `unreachable` to `reachable`", () => {
+      mcpServer.setRunning(false);
+      onRecovery.mockClear();
+
+      mcpServer.setRunning(true);
+
+      expect(onRecovery).toHaveBeenCalledWith("mcp", "MCP server");
+    });
+
+    it("does NOT fire onRecovery on `unknown` → `reachable` transitions (initial probes)", () => {
+      // Default state is `unknown`. Going to `reachable` should NOT trigger
+      // a recovery toast — that would be noise on every app startup.
+      agentConnectivity.emit({
+        provider: "claude",
+        status: "reachable",
+        checkedAt: 1_000_000,
+      });
+
+      expect(onRecovery).not.toHaveBeenCalled();
+    });
+
+    it("fires onRecovery for agent providers on unreachable → reachable", () => {
+      agentConnectivity.emit({
+        provider: "claude",
+        status: "unreachable",
+        checkedAt: 1_000_000,
+      });
+      onRecovery.mockClear();
+
+      agentConnectivity.emit({
+        provider: "claude",
+        status: "reachable",
+        checkedAt: 1_000_000,
+      });
+
+      expect(onRecovery).toHaveBeenCalledWith("agent:claude", "Claude");
+    });
+
+    it("does not fire onRecovery on `unhealthy` GitHub → `healthy` (token-validity flow)", () => {
+      gitHubHealth.emit({ status: "unhealthy", tokenVersion: 1, checkedAt: 1_000_000 });
+      onRecovery.mockClear();
+
+      gitHubHealth.emit({ status: "healthy", tokenVersion: 1, checkedAt: 1_000_000 });
+
+      // unhealthy maps to `unknown`, so a transition to `healthy` is
+      // `unknown` → `reachable` — not a recovery in our model. The dedicated
+      // GitHub token-health hook handles the token-revoked banner UX.
+      expect(onRecovery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("change events", () => {
+    beforeEach(() => {
+      registry.start();
+    });
+
+    it("emits exactly once per real state change", () => {
+      const listener = vi.fn();
+      registry.onChange(listener);
+
+      mcpServer.setRunning(true);
+      mcpServer.setRunning(true); // no-op
+      mcpServer.setRunning(false);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("dispose()", () => {
+    it("unsubscribes from underlying services and clears listeners", () => {
+      registry.start();
+      const listener = vi.fn();
+      registry.onChange(listener);
+
+      registry.dispose();
+
+      mcpServer.setRunning(true);
+      gitHubHealth.emit({ status: "healthy", tokenVersion: 1, checkedAt: 1_000_000 });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/services/connectivity/__tests__/ServiceConnectivityRegistry.test.ts
+++ b/electron/services/connectivity/__tests__/ServiceConnectivityRegistry.test.ts
@@ -244,12 +244,26 @@ describe("ServiceConnectivityRegistry", () => {
     });
 
     it("fires onRecovery when a service transitions from `unreachable` to `reachable`", () => {
+      // Force MCP into the unreachable state by simulating a real stop after
+      // it had been running. Initial seed treats `false` as `unknown`.
+      mcpServer.setRunning(true);
       mcpServer.setRunning(false);
       onRecovery.mockClear();
 
       mcpServer.setRunning(true);
 
       expect(onRecovery).toHaveBeenCalledWith("mcp", "MCP server");
+    });
+
+    it("does NOT fire onRecovery for MCP starting up on a fresh launch (regression)", () => {
+      // Repro of the startup spurious-toast bug: registry starts before the
+      // deferred MCP task. isRunning is false at seed time. When MCP later
+      // starts, it must be unknown→reachable (no toast), not unreachable→reachable.
+      onRecovery.mockClear();
+      mcpServer.setRunning(true);
+
+      expect(onRecovery).not.toHaveBeenCalled();
+      expect(registry.getSnapshot().mcp.status).toBe("reachable");
     });
 
     it("does NOT fire onRecovery on `unknown` → `reachable` transitions (initial probes)", () => {
@@ -291,6 +305,34 @@ describe("ServiceConnectivityRegistry", () => {
       // `unknown` → `reachable` — not a recovery in our model. The dedicated
       // GitHub token-health hook handles the token-revoked banner UX.
       expect(onRecovery).not.toHaveBeenCalled();
+    });
+
+    it("still emits the change event when onRecovery throws", () => {
+      const throwing = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const isolatedRegistry = new ServiceConnectivityRegistry({
+        gitHubHealth,
+        mcpServer,
+        agentConnectivity,
+        onRecovery: throwing,
+      });
+      isolatedRegistry.start();
+      const changeListener = vi.fn();
+      isolatedRegistry.onChange(changeListener);
+
+      // Force MCP unreachable then reachable.
+      mcpServer.setRunning(true);
+      mcpServer.setRunning(false);
+      changeListener.mockClear();
+      throwing.mockClear();
+      mcpServer.setRunning(true);
+
+      expect(throwing).toHaveBeenCalled();
+      expect(changeListener).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceKey: "mcp", status: "reachable" })
+      );
+      isolatedRegistry.dispose();
     });
   });
 

--- a/electron/services/connectivity/index.ts
+++ b/electron/services/connectivity/index.ts
@@ -1,0 +1,57 @@
+import { CHANNELS } from "../../ipc/channels.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
+import { gitHubTokenHealthService } from "../github/GitHubTokenHealthService.js";
+import { mcpServerService } from "../McpServerService.js";
+import { agentConnectivityService } from "./AgentConnectivityService.js";
+import { ServiceConnectivityRegistry } from "./ServiceConnectivityRegistry.js";
+import type { MainProcessToastPayload } from "../../../shared/types/ipc/maps.js";
+
+export {
+  agentConnectivityService,
+  AgentConnectivityServiceImpl,
+  AGENT_CONNECTIVITY_INTERVAL_MS,
+  AGENT_CONNECTIVITY_FOCUS_COOLDOWN_MS,
+  AGENT_CONNECTIVITY_FETCH_TIMEOUT_MS,
+} from "./AgentConnectivityService.js";
+export type {
+  AgentConnectivityChange,
+  AgentConnectivityProvider,
+} from "./AgentConnectivityService.js";
+
+export { ServiceConnectivityRegistry } from "./ServiceConnectivityRegistry.js";
+export type { ServiceConnectivityRegistryOptions } from "./ServiceConnectivityRegistry.js";
+
+let registryInstance: ServiceConnectivityRegistry | null = null;
+
+/**
+ * Returns the process-wide `ServiceConnectivityRegistry` singleton, creating
+ * it on first call. The registry wires together `gitHubTokenHealthService`,
+ * `mcpServerService`, and `agentConnectivityService`, and emits a single
+ * "Connection restored" toast on `unreachable → reachable` transitions.
+ */
+export function getServiceConnectivityRegistry(): ServiceConnectivityRegistry {
+  if (!registryInstance) {
+    registryInstance = new ServiceConnectivityRegistry({
+      gitHubHealth: gitHubTokenHealthService,
+      mcpServer: mcpServerService,
+      agentConnectivity: agentConnectivityService,
+      onRecovery: (_serviceKey, label) => {
+        const payload: MainProcessToastPayload = {
+          type: "info",
+          title: "Connection restored",
+          message: `Reconnected to ${label}.`,
+        };
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, payload);
+      },
+    });
+  }
+  return registryInstance;
+}
+
+/** Test-only helper to reset the singleton between cases. */
+export function _resetServiceConnectivityRegistryForTests(): void {
+  if (registryInstance) {
+    registryInstance.dispose();
+    registryInstance = null;
+  }
+}

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -5,6 +5,7 @@ import type { ProjectStatsService } from "../services/ProjectStatsService.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
+import { agentConnectivityService } from "../services/connectivity/AgentConnectivityService.js";
 
 let resumeTimeout: NodeJS.Timeout | null = null;
 
@@ -63,6 +64,10 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
         // during a long laptop sleep would otherwise sit undetected until the
         // next 30-minute poll tick.
         void gitHubTokenHealthService.refresh({ force: true });
+        // Re-probe agent provider reachability on wake. A long sleep across a
+        // network change (Wi-Fi swap, airplane mode toggle) often invalidates
+        // the cached "reachable" state.
+        void agentConnectivityService.refresh({ force: true, reason: "resume" });
         BrowserWindow.getAllWindows().forEach((win) => {
           if (win && !win.isDestroyed()) {
             const wc = getAppWebContents(win);
@@ -162,6 +167,9 @@ function removeThrottle(): void {
   // service's own 5-minute cooldown so rapid window switching doesn't
   // hammer the API.
   void gitHubTokenHealthService.refresh();
+  // Same opportunistic re-check for agent reachability — internal cooldown
+  // prevents the alt-tab path from fanning out probes.
+  void agentConnectivityService.refresh({ reason: "focus" });
 }
 
 export function setupWindowFocusThrottle(deps: WindowFocusThrottleDeps): void {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -30,6 +30,10 @@ import {
 import { initializeTelemetry, setOnboardingCompleteTag } from "../services/TelemetryService.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
+import {
+  agentConnectivityService,
+  getServiceConnectivityRegistry,
+} from "../services/connectivity/index.js";
 import { secureStorage } from "../services/SecureStorage.js";
 import { notificationService } from "../services/NotificationService.js";
 import type { agentNotificationService as AgentNotificationServiceType } from "../services/AgentNotificationService.js";
@@ -338,6 +342,13 @@ export async function setupWindowServices(
     // so a stale probe cannot clobber a freshly-set token.
     gitHubTokenHealthService.start();
     console.log("[MAIN] GitHubTokenHealthService started");
+
+    // Start background agent provider reachability probes (Claude, Gemini,
+    // Codex). Then wire up the registry that aggregates GitHub, agents, and
+    // MCP into a single per-service connectivity snapshot for renderers.
+    agentConnectivityService.start();
+    getServiceConnectivityRegistry().start();
+    console.log("[MAIN] ServiceConnectivityRegistry started");
 
     // Notifications (global singletons)
     // AgentNotificationService is deferred — agents can't emit state events
@@ -1258,6 +1269,8 @@ export async function setupWindowServices(
     getCrashRecoveryService().stopBackupTimer();
     getSystemSleepService().dispose();
     gitHubTokenHealthService.dispose();
+    agentConnectivityService.dispose();
+    getServiceConnectivityRegistry().dispose();
     notificationService.dispose();
     if (agentNotificationServiceRef) {
       agentNotificationServiceRef.dispose();

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -161,6 +161,11 @@ export type {
   GitHubRateLimitKind,
   GitHubTokenHealthPayload,
   GitHubTokenHealthStatus,
+  // Per-service connectivity types
+  ConnectivityServiceKey,
+  ServiceConnectivityStatus,
+  ServiceConnectivityPayload,
+  ServiceConnectivitySnapshot,
   // Hibernation types
   HibernationConfig,
   HibernationProjectHibernatedPayload,
@@ -291,6 +296,9 @@ export {
 // User agent registry types - user-defined agent configuration
 export type { UserAgentConfig, UserAgentRegistry } from "./userAgentRegistry.js";
 export { UserAgentConfigSchema, UserAgentRegistrySchema } from "./userAgentRegistry.js";
+
+// Per-service connectivity helpers
+export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";
 
 // Event types - event context for correlation
 export type { EventContext } from "./events.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -674,6 +674,12 @@ export interface ElectronAPI {
     onTokenHealthChanged(callback: (data: GitHubTokenHealthPayload) => void): () => void;
     getTokenHealth(): Promise<GitHubTokenHealthPayload>;
   };
+  connectivity: {
+    getState(): Promise<import("./connectivity.js").ServiceConnectivitySnapshot>;
+    onServiceChanged(
+      callback: (payload: import("./connectivity.js").ServiceConnectivityPayload) => void
+    ): () => void;
+  };
   devPreview: {
     ensure(request: DevPreviewEnsureRequest): Promise<DevPreviewSessionState>;
     restart(request: DevPreviewSessionRequest): Promise<DevPreviewSessionState>;

--- a/shared/types/ipc/connectivity.ts
+++ b/shared/types/ipc/connectivity.ts
@@ -1,0 +1,59 @@
+/**
+ * Per-service connectivity health.
+ *
+ * The main process probes a fixed set of remote dependencies (GitHub, agent
+ * provider APIs, the local MCP server) and publishes one snapshot keyed by
+ * service. The renderer consumes this map via the `useConnectivity` hook to
+ * surface degraded-mode UI affordances and "reconnected" toasts.
+ *
+ * Probes are reachability-only for agent providers — Daintree does not own
+ * the agent CLI's API keys, so any non-network HTTP response (including 4xx)
+ * confirms the service is reachable. Only network-level errors flip a
+ * service to `unreachable`.
+ *
+ * GitHub `unhealthy` (token revoked) deliberately maps to `unknown` here,
+ * not `unreachable` — token validity is a distinct concern from network
+ * reachability and is surfaced separately via `GitHubTokenHealthPayload`.
+ */
+
+/** Fixed set of services that are tracked. Dev-server connectivity is per-session and lives outside this snapshot. */
+export type ConnectivityServiceKey =
+  | "github"
+  | "agent:claude"
+  | "agent:gemini"
+  | "agent:codex"
+  | "mcp";
+
+/** All known service keys in canonical order. */
+export const CONNECTIVITY_SERVICE_KEYS: readonly ConnectivityServiceKey[] = [
+  "github",
+  "agent:claude",
+  "agent:gemini",
+  "agent:codex",
+  "mcp",
+] as const;
+
+/**
+ * Network reachability of a service.
+ *
+ * - `unknown`: no probe has completed yet, or a token-validity issue (not a network failure)
+ * - `reachable`: the most recent probe succeeded or returned a non-network HTTP response
+ * - `unreachable`: the most recent probe failed at the transport layer (DNS, timeout, connection refused)
+ */
+export type ServiceConnectivityStatus = "unknown" | "reachable" | "unreachable";
+
+/** Push payload describing the current state of one service. */
+export interface ServiceConnectivityPayload {
+  /** Which service this update is for. */
+  serviceKey: ConnectivityServiceKey;
+  /** Current reachability status. */
+  status: ServiceConnectivityStatus;
+  /** Unix epoch milliseconds at which the last probe completed (0 if no probe has run). */
+  checkedAt: number;
+}
+
+/** Fixed-shape map of every tracked service's current state. */
+export type ServiceConnectivitySnapshot = Record<
+  ConnectivityServiceKey,
+  ServiceConnectivityPayload
+>;

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -17,6 +17,7 @@ export * from "./git.js";
 export * from "./files.js";
 export * from "./config.js";
 export * from "./devPreview.js";
+export * from "./connectivity.js";
 export * from "./maps.js";
 export * from "./agentSessionHistory.js";
 export * from "./api.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -132,6 +132,7 @@ import type {
   DevPreviewStateChangedPayload,
   DevPreviewGetByWorktreeRequest,
 } from "./devPreview.js";
+import type { ServiceConnectivityPayload, ServiceConnectivitySnapshot } from "./connectivity.js";
 import type { SanitizedTelemetryEvent, TelemetryPreviewState } from "./telemetryPreview.js";
 import type { ProjectPulse, PulseRangeDays } from "../pulse.js";
 import type {
@@ -1950,6 +1951,12 @@ export interface IpcInvokeMap {
     result: GitHubTokenHealthPayload;
   };
 
+  // Per-service connectivity channels
+  "connectivity:get-state": {
+    args: [];
+    result: ServiceConnectivitySnapshot;
+  };
+
   // Global env channels
   "global-env:get": {
     args: [];
@@ -2220,6 +2227,9 @@ export interface IpcEventMap {
 
   // GitHub token health state push (expiry/revocation detection)
   "github:token-health-changed": GitHubTokenHealthPayload;
+
+  // Per-service connectivity state push
+  "connectivity:service-changed": ServiceConnectivityPayload;
 
   // Error events
   "error:notify": ErrorRecord;

--- a/src/clients/connectivityClient.ts
+++ b/src/clients/connectivityClient.ts
@@ -1,0 +1,11 @@
+import type { ServiceConnectivityPayload, ServiceConnectivitySnapshot } from "@shared/types";
+
+export const connectivityClient = {
+  getState: (): Promise<ServiceConnectivitySnapshot> => {
+    return window.electron.connectivity.getState();
+  },
+
+  onServiceChanged: (callback: (payload: ServiceConnectivityPayload) => void): (() => void) => {
+    return window.electron.connectivity.onServiceChanged(callback);
+  },
+};

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -24,3 +24,4 @@ export { editorClient } from "./editorClient";
 export { appThemeClient } from "./appThemeClient";
 export { globalRecipesClient } from "./globalRecipesClient";
 export { telemetryPreviewClient } from "./telemetryPreviewClient";
+export { connectivityClient } from "./connectivityClient";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -105,3 +105,5 @@ export { useDebounce } from "./useDebounce";
 export { useShortcutHintHover } from "./useShortcutHintHover";
 
 export { useTruncationDetection, isElementTruncated } from "./useTruncationDetection";
+
+export { useConnectivity, useConnectivitySnapshot } from "./useConnectivity";

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -51,10 +51,13 @@ export function useConnectivitySnapshot(): ServiceConnectivitySnapshot {
         if (cancelled) return;
         setSnapshot((prev) => {
           // Preserve any payload that arrived via push after we issued the
-          // mount-time getState() — push events represent newer truth.
+          // mount-time getState() — push events represent newer truth. Use
+          // `>=` so push-delivered status wins on `checkedAt` ties; the
+          // alternative ('>') drops a same-millisecond push update if
+          // getState() resolves later with stale data.
           const merged = { ...next };
           for (const key of CONNECTIVITY_SERVICE_KEYS) {
-            if (prev[key].checkedAt > merged[key].checkedAt) {
+            if (prev[key].checkedAt >= merged[key].checkedAt && prev[key].checkedAt > 0) {
               merged[key] = prev[key];
             }
           }

--- a/src/hooks/useConnectivity.ts
+++ b/src/hooks/useConnectivity.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { connectivityClient } from "@/clients/connectivityClient";
+import type {
+  ConnectivityServiceKey,
+  ServiceConnectivityPayload,
+  ServiceConnectivitySnapshot,
+  ServiceConnectivityStatus,
+} from "@shared/types";
+import { CONNECTIVITY_SERVICE_KEYS } from "@shared/types";
+
+function buildInitialSnapshot(): ServiceConnectivitySnapshot {
+  return Object.fromEntries(
+    CONNECTIVITY_SERVICE_KEYS.map((key) => [
+      key,
+      { serviceKey: key, status: "unknown" as ServiceConnectivityStatus, checkedAt: 0 },
+    ])
+  ) as ServiceConnectivitySnapshot;
+}
+
+/**
+ * Subscribes to per-service connectivity health pushed from the main process.
+ *
+ * Mount-time hydration is mandatory: each `WebContentsView` has an isolated
+ * Zustand store, so a window that mounts after the initial probes settled
+ * would never receive the current state through push events alone. The
+ * `cancelled` guard prevents a late-arriving `getState()` from clobbering a
+ * push event that landed first on a slow main-process round trip.
+ */
+export function useConnectivitySnapshot(): ServiceConnectivitySnapshot {
+  const [snapshot, setSnapshot] = useState<ServiceConnectivitySnapshot>(buildInitialSnapshot);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const applyDelta = (payload: ServiceConnectivityPayload) => {
+      if (cancelled) return;
+      setSnapshot((prev) => {
+        const existing = prev[payload.serviceKey];
+        if (existing.status === payload.status && existing.checkedAt === payload.checkedAt) {
+          return prev;
+        }
+        return { ...prev, [payload.serviceKey]: payload };
+      });
+    };
+
+    const cleanup = connectivityClient.onServiceChanged(applyDelta);
+
+    void connectivityClient
+      .getState()
+      .then((next) => {
+        if (cancelled) return;
+        setSnapshot((prev) => {
+          // Preserve any payload that arrived via push after we issued the
+          // mount-time getState() — push events represent newer truth.
+          const merged = { ...next };
+          for (const key of CONNECTIVITY_SERVICE_KEYS) {
+            if (prev[key].checkedAt > merged[key].checkedAt) {
+              merged[key] = prev[key];
+            }
+          }
+          return merged;
+        });
+      })
+      .catch(() => {
+        // Initial-state fetch is best-effort; transitions still work.
+      });
+
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, []);
+
+  return snapshot;
+}
+
+/**
+ * Reactive accessor for a single service's connectivity. Backed by the same
+ * subscription as {@link useConnectivitySnapshot} but only returns the slice
+ * for the requested service key.
+ */
+export function useConnectivity(serviceKey: ConnectivityServiceKey): ServiceConnectivityPayload {
+  const snapshot = useConnectivitySnapshot();
+  return snapshot[serviceKey];
+}


### PR DESCRIPTION
## Summary

- Adds `AgentConnectivityService` and `ServiceConnectivityRegistry` to track reachability for GitHub, Claude/Gemini/Codex, and MCP independently. Any HTTP response counts as reachable; only network-layer failures (DNS, timeout, connection refused) count as unreachable.
- Aggregates all service states into a fixed-shape snapshot consumed via a single IPC channel (`CONNECTIVITY_GET_STATE` for mount hydration, `CONNECTIVITY_SERVICE_CHANGED` for push updates). The `useConnectivity` / `useConnectivitySnapshot` hooks handle the renderer side.
- Recovery toasts only fire on unreachable→reachable transitions; unknown→reachable at startup is silent to avoid noise. `powerMonitor` wires agent probe refresh into focus-regain and resume events alongside the existing GitHub probe.

Resolves #6044

## Changes

- `electron/services/connectivity/AgentConnectivityService.ts` — probes Claude/Gemini/Codex via unauthenticated GET /v1/models on a 30-min interval with cooldown, coalescing, and `AbortSignal.timeout`. Mirrors `GitHubTokenHealthService` for consistency.
- `electron/services/connectivity/ServiceConnectivityRegistry.ts` — aggregates GitHub token health + agent reachability + MCP status. MCP seeded conservatively (skipped when `isRunning=false` at startup to avoid spurious toast). GitHub `unhealthy` maps to `unknown` since token issues are not network issues.
- `McpServerService` gains an `onStatusChange` listener for real start/stop transitions.
- `shared/types/ipc/connectivity.ts` — IPC types for the fixed 5-key snapshot shape.
- `src/hooks/useConnectivity.ts` — `useConnectivity(serviceKey)` and `useConnectivitySnapshot()` hooks with mount-time invoke and cancelled-flag guard.
- `electron/services/connectivity/__tests__/` — 28 unit tests covering reachable/unreachable classification, coalescing, cooldown, force-refresh, dispose-during-probe, mixed outcomes, snapshot shape, silent seeding, recovery toast emission, and MCP startup regression.

## Testing

- `npm run check` passes (typecheck, lint, format).
- `npm run build` passes.
- 28 connectivity unit tests pass (12 `AgentConnectivityService`, 16 `ServiceConnectivityRegistry`).
- GitHub service tests 72/72 pass, `McpServerService` tests 6/6 pass — no regressions.