### PR TITLE
fix(notifications): surface error notifications hidden by priority: "low" misuse

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, X } from "lucide-react";
 import { isMac } from "@/lib/platform";
 import { keybindingService, normalizeKeyForBinding } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
+import { notify } from "@/lib/notify";
 import { useNotificationStore } from "@/store/notificationStore";
 import { logError, logWarn } from "@/utils/logger";
 
@@ -228,11 +229,10 @@ export function SettingsShortcutCapture({
               setConflictRefreshKey((prev) => prev + 1);
             } catch (err) {
               logError("Failed to undo keybinding change", err);
-              useNotificationStore.getState().addNotification({
+              notify({
                 type: "error",
                 message: "Failed to undo keybinding change",
                 duration: 3000,
-                priority: "low",
               });
             }
           },
@@ -240,11 +240,10 @@ export function SettingsShortcutCapture({
       });
     } catch (err) {
       logError("Failed to unbind keybinding", err);
-      useNotificationStore.getState().addNotification({
+      notify({
         type: "error",
         message: "Failed to unbind keybinding",
         duration: 3000,
-        priority: "low",
       });
     } finally {
       setIsUnbinding(false);

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -5,7 +5,7 @@ import { SearchablePalette } from "@/components/ui/SearchablePalette";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
 import { useAppThemeStore, injectSchemeToDOM } from "@/store/appThemeStore";
-import { useNotificationStore } from "@/store/notificationStore";
+import { notify } from "@/lib/notify";
 import { appThemeClient } from "@/clients/appThemeClient";
 import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { resolveAppTheme } from "@shared/theme";
@@ -152,9 +152,8 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
       setSelectedSchemeId(scheme.id);
       appThemeClient.setColorScheme(scheme.id).catch((error) => {
         logError("Failed to persist theme selection", error);
-        useNotificationStore.getState().addNotification({
+        notify({
           type: "error",
-          priority: "low",
           message: `Failed to save theme: ${scheme.name}`,
           duration: 3000,
         });

--- a/src/services/actions/definitions/__tests__/themeActions.test.ts
+++ b/src/services/actions/definitions/__tests__/themeActions.test.ts
@@ -203,6 +203,7 @@ describe("app.theme.toggle", () => {
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", message: "Failed to save theme: Light A" })
     );
+    expect(mockNotify).not.toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
     expect(mockAddNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/__tests__/themeActions.test.ts
+++ b/src/services/actions/definitions/__tests__/themeActions.test.ts
@@ -19,6 +19,11 @@ vi.mock("@/store/notificationStore", () => ({
   useNotificationStore: { getState: () => ({ addNotification: mockAddNotification }) },
 }));
 
+const mockNotify = vi.fn().mockReturnValue("test-id");
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => mockNotify(...args),
+}));
+
 vi.mock("@/clients", () => ({ appClient: {} }));
 vi.mock("@/store/userAgentRegistryStore", () => ({
   useUserAgentRegistryStore: { getState: () => ({ refresh: vi.fn() }) },
@@ -194,8 +199,11 @@ describe("app.theme.toggle", () => {
     await toggle.run(undefined, stubCtx);
 
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("light-a");
-    expect(mockAddNotification).toHaveBeenCalledTimes(1);
-    expect(mockAddNotification).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", message: "Failed to save theme: Light A" })
+    );
+    expect(mockAddNotification).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -7,6 +7,7 @@ import { appThemeClient } from "@/clients/appThemeClient";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
+import { notify } from "@/lib/notify";
 import { useNotificationStore } from "@/store/notificationStore";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
@@ -190,9 +191,8 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
         await appThemeClient.setColorScheme(target.id);
       } catch (error) {
         logError("Failed to persist theme toggle", error);
-        useNotificationStore.getState().addNotification({
+        notify({
           type: "error",
-          priority: "low",
           message: `Failed to save theme: ${target.name}`,
           duration: 3000,
         });


### PR DESCRIPTION
## Summary
- Three direct `addNotification` calls set `priority: "low"` on `type: "error"` notifications, but `notify()` with low priority skips toasts entirely — so theme toggle failures, keybinding unbind errors, and keybinding undo errors were invisible to the user
- Route all four error sites through `notify()` with default priority so they surface as visible toasts
- Add a regression assertion in the theme toggle test that `notify()` is never called with `priority: "low"`

Resolves #6043

## Changes
- `appActions.ts`: route theme toggle errors through `notify()` instead of direct `addNotification` with `priority: "low"`
- `SettingsShortcutCapture.tsx`: route unbind and undo-keybinding errors through `notify()`
- `ThemePalette.tsx`: route theme palette errors through `notify()`
- `themeActions.test.ts`: assert `notify()` is not called with `priority: "low"` to guard against regression

## Testing
- Typecheck, lint, and format pass
- Existing themeActions test updated to assert on `notify()` calls and verify no low-priority leakage