### PR TITLE
fix(event-inspector): remove duplicate per-window IPC handler and dead singular channel

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -182,7 +182,6 @@ export const CHANNELS = {
   EVENT_INSPECTOR_GET_EVENTS: "event-inspector:get-events",
   EVENT_INSPECTOR_GET_FILTERED: "event-inspector:get-filtered",
   EVENT_INSPECTOR_CLEAR: "event-inspector:clear",
-  EVENT_INSPECTOR_EVENT: "event-inspector:event",
   EVENT_INSPECTOR_EVENT_BATCH: "event-inspector:event-batch",
   EVENT_INSPECTOR_SUBSCRIBE: "event-inspector:subscribe",
   EVENT_INSPECTOR_UNSUBSCRIBE: "event-inspector:unsubscribe",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1114,9 +1114,6 @@ const api: ElectronAPI = {
 
     unsubscribe: () => ipcRenderer.send(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE),
 
-    onEvent: (callback: (event: EventRecord) => void) =>
-      _typedOn(CHANNELS.EVENT_INSPECTOR_EVENT, callback),
-
     onEventBatch: (callback: (events: EventRecord[]) => void) =>
       _typedOn(CHANNELS.EVENT_INSPECTOR_EVENT_BATCH, callback),
   },

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -1108,30 +1108,6 @@ export async function setupWindowServices(
     }
   }
 
-  // Event inspector (per-window: uses named listeners for safe per-window cleanup)
-  let eventInspectorActive = false;
-  const onEventInspectorSubscribe = () => {
-    eventInspectorActive = true;
-  };
-  const onEventInspectorUnsubscribe = () => {
-    eventInspectorActive = false;
-  };
-  ipcMain.on(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, onEventInspectorSubscribe);
-  ipcMain.on(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, onEventInspectorUnsubscribe);
-
-  const unsubscribeFromEventBuffer = ctx.services.eventBuffer!.onRecord((record) => {
-    if (!eventInspectorActive) return;
-    sendToRenderer(win, CHANNELS.EVENT_INSPECTOR_EVENT, record);
-  });
-
-  ctx.cleanup.add(
-    toDisposable(() => {
-      unsubscribeFromEventBuffer();
-      ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, onEventInspectorSubscribe);
-      ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, onEventInspectorUnsubscribe);
-    })
-  );
-
   // Smoke test
   if (isSmokeTest) {
     if (opts.smokeTestTimer) clearTimeout(opts.smokeTestTimer);

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, session, webContents } from "electron";
+import { app, BrowserWindow, dialog, session, webContents } from "electron";
 import os from "os";
 import type { HandlerDependencies } from "../ipc/types.js";
 import { registerIpcHandlers, sendToRenderer } from "../ipc/handlers.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -421,7 +421,6 @@ export interface ElectronAPI {
     clear(): Promise<void>;
     subscribe(): void;
     unsubscribe(): void;
-    onEvent(callback: (event: EventRecord) => void): () => void;
     onEventBatch(callback: (events: EventRecord[]) => void): () => void;
   };
   events: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2248,7 +2248,6 @@ export interface IpcEventMap {
   "logs:batch": LogEntry[];
 
   // Event inspector events
-  "event-inspector:event": EventRecord;
   "event-inspector:event-batch": EventRecord[];
 
   // Project events

--- a/src/clients/eventInspectorClient.ts
+++ b/src/clients/eventInspectorClient.ts
@@ -21,10 +21,6 @@ export const eventInspectorClient = {
     window.electron.eventInspector.unsubscribe();
   },
 
-  onEvent: (callback: (event: EventRecord) => void): (() => void) => {
-    return window.electron.eventInspector.onEvent(callback);
-  },
-
   onEventBatch: (callback: (events: EventRecord[]) => void): (() => void) => {
     return window.electron.eventInspector.onEventBatch(callback);
   },


### PR DESCRIPTION
## Summary
- Removed a duplicate per-window event inspector IPC handler registration in `windowServices.ts` that shadowed the single `ipcMain` handler already registered in `electron/ipc/handlers/eventInspector.ts`. The per-window version maintained its own subscribe/unsubscribe state and forwarded events over a now-deleted singular `EVENT_INSPECTOR_EVENT` channel -- but nothing consumed that channel. Event delivery already goes through `EVENT_INSPECTOR_EVENT_BATCH`.
- Cleaned up the dead `EVENT_INSPECTOR_EVENT` channel constant, its preload bridge method (`onEvent`), the type definitions, and the renderer client wrapper. Six files, 33 lines out.

Resolves #6018

## Changes
- `electron/window/windowServices.ts`: removed duplicate subscribe/unsubscribe listener registration and the `onRecord` forwarder using the singular event channel
- `electron/ipc/channels.ts`: removed `EVENT_INSPECTOR_EVENT` channel constant
- `electron/preload.cts`: removed `onEvent` callback bridge
- `shared/types/ipc/api.ts`: removed `onEvent` from `ElectronAPI.eventInspector`
- `shared/types/ipc/maps.ts`: removed the `event-inspector:event` entry from `IpcEventMap`
- `src/clients/eventInspectorClient.ts`: removed `onEvent` client wrapper

## Testing
- Verified the existing `EVENT_INSPECTOR_EVENT_BATCH` handler in `electron/ipc/handlers/eventInspector.ts` is the sole event delivery path and remains untouched
- TypeScript typecheck passes with the removed type entries