### PR TITLE
fix(recipes): add deep Zod validation for recipe loading

### DIFF
--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -3,6 +3,8 @@ import {
   AppStateTerminalEntrySchema,
   TerminalSnapshotSchema,
   TerminalSpawnOptionsSchema,
+  RecipeTerminalSchema,
+  TerminalRecipeSchema,
   filterValidTerminalEntries,
 } from "../ipc.js";
 
@@ -552,6 +554,402 @@ describe("Terminal Entry Validation Schemas", () => {
 
       expect(result).toEqual([]);
       expect(consoleSpy).toHaveBeenCalledTimes(7);
+    });
+  });
+});
+
+describe("Recipe Validation Schemas", () => {
+  describe("RecipeTerminalSchema", () => {
+    it("accepts minimal valid terminal entry", () => {
+      const entry = { type: "terminal" };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts terminal entry with all fields", () => {
+      const entry = {
+        type: "terminal",
+        title: "My Terminal",
+        command: "npm run dev",
+        env: { NODE_ENV: "development" },
+        initialPrompt: "Start coding",
+        args: "--model sonnet",
+        devCommand: "npm run dev",
+        exitBehavior: "keep",
+        agentModelId: "sonnet",
+        agentLaunchFlags: ["--verbose"],
+      };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.env).toEqual({ NODE_ENV: "development" });
+        expect(result.data.agentLaunchFlags).toEqual(["--verbose"]);
+      }
+    });
+
+    it("accepts agent type terminal entries", () => {
+      const agents = ["claude", "gemini", "codex", "opencode", "cursor", "custom-plugin-agent"];
+      for (const agent of agents) {
+        const entry = { type: agent };
+        const result = RecipeTerminalSchema.safeParse(entry);
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("accepts dev-preview type", () => {
+      const entry = { type: "dev-preview" };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects entry with empty type", () => {
+      const entry = { type: "" };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects entry with missing type", () => {
+      const entry = { title: "No type" };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-string type", () => {
+      expect(RecipeTerminalSchema.safeParse({ type: 123 }).success).toBe(false);
+      expect(RecipeTerminalSchema.safeParse({ type: true }).success).toBe(false);
+      expect(RecipeTerminalSchema.safeParse({ type: null }).success).toBe(false);
+    });
+
+    it("rejects invalid exitBehavior values", () => {
+      const result = RecipeTerminalSchema.safeParse({
+        type: "terminal",
+        exitBehavior: "invalid",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts all valid exitBehavior values", () => {
+      const behaviors = ["keep", "trash", "remove", "restart"];
+      for (const behavior of behaviors) {
+        const result = RecipeTerminalSchema.safeParse({
+          type: "terminal",
+          exitBehavior: behavior,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("rejects env with non-string values", () => {
+      const result = RecipeTerminalSchema.safeParse({
+        type: "terminal",
+        env: { KEY: 123 },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-object values", () => {
+      expect(RecipeTerminalSchema.safeParse(null).success).toBe(false);
+      expect(RecipeTerminalSchema.safeParse("string").success).toBe(false);
+      expect(RecipeTerminalSchema.safeParse(123).success).toBe(false);
+      expect(RecipeTerminalSchema.safeParse([]).success).toBe(false);
+    });
+
+    it("preserves unknown fields via passthrough", () => {
+      const entry = { type: "terminal", unknownField: "preserved", anotherExtra: 456 };
+      const result = RecipeTerminalSchema.safeParse(entry);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveProperty("unknownField", "preserved");
+        expect(result.data).toHaveProperty("anotherExtra", 456);
+      }
+    });
+  });
+
+  describe("TerminalRecipeSchema", () => {
+    it("accepts valid minimal recipe", () => {
+      const recipe = {
+        id: "recipe-1",
+        name: "My Recipe",
+        terminals: [{ type: "terminal" }],
+        createdAt: 1700000000000,
+      };
+      const result = TerminalRecipeSchema.safeParse(recipe);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts recipe with all fields", () => {
+      const recipe = {
+        id: "full-recipe",
+        name: "Full Recipe",
+        projectId: "proj-123",
+        worktreeId: "wt-456",
+        terminals: [
+          { type: "terminal", command: "npm start" },
+          { type: "claude", initialPrompt: "Review this code" },
+        ],
+        createdAt: 1700000000000,
+        showInEmptyState: true,
+        lastUsedAt: 1700100000000,
+        usageHistory: [1700000000000, 1700100000000],
+        autoAssign: "prompt",
+      };
+      const result = TerminalRecipeSchema.safeParse(recipe);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects recipe with empty id", () => {
+      const recipe = {
+        id: "",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+      };
+      const result = TerminalRecipeSchema.safeParse(recipe);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with empty name", () => {
+      const recipe = {
+        id: "r1",
+        name: "",
+        terminals: [],
+        createdAt: 0,
+      };
+      const result = TerminalRecipeSchema.safeParse(recipe);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with missing terminals", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        createdAt: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with non-array terminals", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: "not-an-array",
+        createdAt: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with invalid terminal in array", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [{ type: "ok" }, { type: "" }], // second terminal has empty type
+        createdAt: 0,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with non-number createdAt", () => {
+      expect(
+        TerminalRecipeSchema.safeParse({
+          id: "r1",
+          name: "Recipe",
+          terminals: [],
+          createdAt: "1700000000000",
+        }).success
+      ).toBe(false);
+    });
+
+    it("rejects invalid autoAssign values", () => {
+      expect(
+        TerminalRecipeSchema.safeParse({
+          id: "r1",
+          name: "Recipe",
+          terminals: [],
+          createdAt: 0,
+          autoAssign: "maybe",
+        }).success
+      ).toBe(false);
+    });
+
+    it("accepts all valid autoAssign values", () => {
+      for (const mode of ["always", "never", "prompt"]) {
+        const result = TerminalRecipeSchema.safeParse({
+          id: "r1",
+          name: "Recipe",
+          terminals: [],
+          createdAt: 0,
+          autoAssign: mode,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it("rejects recipe with non-array usageHistory", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        usageHistory: "not-array",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with non-number usageHistory items", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        usageHistory: [1700000000000, "not-a-number"],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-object recipe values", () => {
+      expect(TerminalRecipeSchema.safeParse(null).success).toBe(false);
+      expect(TerminalRecipeSchema.safeParse("string").success).toBe(false);
+      expect(TerminalRecipeSchema.safeParse(123).success).toBe(false);
+      expect(TerminalRecipeSchema.safeParse([]).success).toBe(false);
+    });
+
+    it("preserves unknown fields via passthrough", () => {
+      const recipe = {
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        unknownField: "kept",
+      };
+      const result = TerminalRecipeSchema.safeParse(recipe);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveProperty("unknownField", "kept");
+      }
+    });
+  });
+
+  describe("filterValidTerminalEntries with TerminalRecipeSchema", () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it("returns all valid recipes unchanged", () => {
+      const recipes = [
+        { id: "r1", name: "Recipe 1", terminals: [{ type: "terminal" }], createdAt: 1000 },
+        { id: "r2", name: "Recipe 2", terminals: [], createdAt: 2000 },
+      ];
+
+      const result = filterValidTerminalEntries(recipes, TerminalRecipeSchema, "test");
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(recipes);
+    });
+
+    it("filters out recipes with invalid terminals", () => {
+      const recipes = [
+        { id: "r1", name: "Valid", terminals: [{ type: "terminal" }], createdAt: 1 },
+        { id: "r2", name: "Invalid terminal", terminals: [{ type: "" }], createdAt: 2 }, // empty type
+        { id: "r3", name: "Also valid", terminals: [], createdAt: 3 },
+      ];
+
+      const result = filterValidTerminalEntries(recipes, TerminalRecipeSchema, "test");
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("r1");
+      expect(result[1].id).toBe("r3");
+    });
+
+    it("filters out recipes with deep field type errors", () => {
+      const recipes = [
+        { id: "r1", name: "Valid", terminals: [], createdAt: 1 },
+        {
+          id: "r2",
+          name: "command is number",
+          terminals: [{ type: "terminal", command: 123 }],
+          createdAt: 2,
+        }, // command should be string
+        {
+          id: "r3",
+          name: "env is array",
+          terminals: [{ type: "terminal", env: ["not", "a", "record"] }],
+          createdAt: 3,
+        },
+      ];
+
+      const result = filterValidTerminalEntries(recipes, TerminalRecipeSchema, "test");
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("r1");
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs warnings for each filtered recipe", () => {
+      const recipes = [
+        { id: "r1", name: "Valid", terminals: [], createdAt: 1 },
+        { id: "r2", terminals: [], createdAt: 2 }, // missing name
+        { id: "", name: "Empty ID", terminals: [], createdAt: 3 }, // empty id
+      ];
+
+      filterValidTerminalEntries(recipes, TerminalRecipeSchema, "recipe-test");
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles empty array", () => {
+      const result = filterValidTerminalEntries([], TerminalRecipeSchema, "test");
+      expect(result).toEqual([]);
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    it("handles null/undefined entries in recipes array", () => {
+      const recipes = [
+        { id: "r1", name: "Valid", terminals: [], createdAt: 1 },
+        null,
+        undefined,
+        { id: "r2", name: "Also valid", terminals: [], createdAt: 2 },
+      ];
+
+      const result = filterValidTerminalEntries(recipes as any[], TerminalRecipeSchema, "test");
+      expect(result).toHaveLength(2);
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("recovers valid recipes from heavily corrupted data", () => {
+      const corrupted = [
+        "string",
+        123,
+        null,
+        { id: "r1", name: "Good", terminals: [], createdAt: 1 },
+        {},
+        { partially: "wrong" },
+        { id: "r2", name: "Also good", terminals: [{ type: "claude" }], createdAt: 2 },
+        [],
+      ];
+
+      const result = filterValidTerminalEntries(
+        corrupted as any[],
+        TerminalRecipeSchema,
+        "corruption"
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("r1");
+      expect(result[1].id).toBe("r2");
+    });
+
+    it("preserves ordering of valid entries", () => {
+      const entries = [
+        { id: "first", name: "First", terminals: [], createdAt: 1 },
+        { id: "", name: "Bad", terminals: [], createdAt: 2 },
+        { id: "second", name: "Second", terminals: [], createdAt: 3 },
+        { invalid: "entry" },
+        { id: "third", name: "Third", terminals: [], createdAt: 4 },
+      ];
+
+      const result = filterValidTerminalEntries(entries as any[], TerminalRecipeSchema, "test");
+      expect(result.map((e) => e.id)).toEqual(["first", "second", "third"]);
     });
   });
 });

--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -912,7 +912,7 @@ describe("Recipe Validation Schemas", () => {
         { id: "r2", name: "Also valid", terminals: [], createdAt: 2 },
       ];
 
-      const result = filterValidTerminalEntries(recipes as any[], TerminalRecipeSchema, "test");
+      const result = filterValidTerminalEntries(recipes as unknown[], TerminalRecipeSchema, "test");
       expect(result).toHaveLength(2);
       expect(consoleSpy).toHaveBeenCalledTimes(2);
     });
@@ -930,7 +930,7 @@ describe("Recipe Validation Schemas", () => {
       ];
 
       const result = filterValidTerminalEntries(
-        corrupted as any[],
+        corrupted as unknown[],
         TerminalRecipeSchema,
         "corruption"
       );
@@ -948,7 +948,7 @@ describe("Recipe Validation Schemas", () => {
         { id: "third", name: "Third", terminals: [], createdAt: 4 },
       ];
 
-      const result = filterValidTerminalEntries(entries as any[], TerminalRecipeSchema, "test");
+      const result = filterValidTerminalEntries(entries as unknown[], TerminalRecipeSchema, "test");
       expect(result.map((e) => e.id)).toEqual(["first", "second", "third"]);
     });
   });

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -172,6 +172,53 @@ export const TerminalSnapshotSchema = z
 export type AppStateTerminalEntry = z.infer<typeof AppStateTerminalEntrySchema>;
 export type TerminalSnapshotEntry = z.infer<typeof TerminalSnapshotSchema>;
 
+// ============================================================================
+// Recipe Validation Schemas
+// ============================================================================
+
+/**
+ * Schema for a single terminal definition within a recipe.
+ * Matches the RecipeTerminal interface from shared/types/project.ts.
+ * Uses passthrough() to preserve unknown fields for forward compatibility.
+ */
+export const RecipeTerminalSchema = z
+  .object({
+    type: z.string().min(1),
+    title: z.string().optional(),
+    command: z.string().optional(),
+    env: z.record(z.string(), z.string()).optional(),
+    initialPrompt: z.string().optional(),
+    args: z.string().optional(),
+    devCommand: z.string().optional(),
+    exitBehavior: z.enum(["keep", "trash", "remove", "restart"]).optional(),
+    agentModelId: z.string().optional(),
+    agentLaunchFlags: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+/**
+ * Schema for a saved terminal recipe.
+ * Matches the TerminalRecipe interface from shared/types/project.ts.
+ * Uses passthrough() to preserve unknown fields for forward compatibility.
+ */
+export const TerminalRecipeSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    projectId: z.string().optional(),
+    worktreeId: z.string().optional(),
+    terminals: z.array(RecipeTerminalSchema),
+    createdAt: z.number(),
+    showInEmptyState: z.boolean().optional(),
+    lastUsedAt: z.number().optional(),
+    usageHistory: z.array(z.number()).optional(),
+    autoAssign: z.enum(["always", "never", "prompt"]).optional(),
+  })
+  .passthrough();
+
+export type RecipeTerminalEntry = z.infer<typeof RecipeTerminalSchema>;
+export type TerminalRecipeEntry = z.infer<typeof TerminalRecipeSchema>;
+
 /**
  * Validates an array of terminal entries and returns only the valid ones.
  * Logs warnings for any filtered invalid entries.

--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import { resilientRename, resilientAtomicWriteFile } from "../utils/fs.js";
+import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 
 const RECIPES_FILENAME = "recipes.json";
 
@@ -27,14 +28,7 @@ export class GlobalFileStore {
         return [];
       }
 
-      return parsed.filter(
-        (recipe: unknown): recipe is TerminalRecipe =>
-          recipe !== null &&
-          typeof recipe === "object" &&
-          typeof (recipe as TerminalRecipe).id === "string" &&
-          typeof (recipe as TerminalRecipe).name === "string" &&
-          Array.isArray((recipe as TerminalRecipe).terminals)
-      );
+      return filterValidTerminalEntries(parsed, TerminalRecipeSchema, "GlobalFileStore");
     } catch (error) {
       console.error("[GlobalFileStore] Failed to load recipes:", error);
       try {

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import { existsSync } from "fs";
 import { resilientRename, resilientAtomicWriteFile } from "../utils/fs.js";
 import { getProjectStateDir, recipesFilePath } from "./projectStorePaths.js";
+import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 
 export class ProjectFileStore {
   constructor(private projectsConfigDir: string) {}
@@ -24,13 +25,10 @@ export class ProjectFileStore {
         return [];
       }
 
-      return parsed.filter(
-        (recipe: unknown): recipe is TerminalRecipe =>
-          recipe !== null &&
-          typeof recipe === "object" &&
-          typeof (recipe as TerminalRecipe).id === "string" &&
-          typeof (recipe as TerminalRecipe).name === "string" &&
-          Array.isArray((recipe as TerminalRecipe).terminals)
+      return filterValidTerminalEntries(
+        parsed,
+        TerminalRecipeSchema,
+        `ProjectFileStore(${projectId})`
       );
     } catch (error) {
       console.error(`[ProjectFileStore] Failed to load recipes for ${projectId}:`, error);

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -6,6 +6,7 @@ import fs from "fs/promises";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { UTF8_BOM } from "./projectStorePaths.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
+import { TerminalRecipeSchema } from "../schemas/ipc.js";
 
 const MAX_PROJECT_NAME_LENGTH = 100;
 const DAINTREE_DIR = ".daintree";
@@ -258,12 +259,7 @@ export class ProjectIdentityFiles {
       try {
         const content = await fs.readFile(path.join(recipesDir, entry.name), "utf-8");
         const parsed = JSON.parse(content);
-        if (
-          typeof parsed !== "object" ||
-          parsed === null ||
-          typeof parsed.name !== "string" ||
-          !Array.isArray(parsed.terminals)
-        ) {
+        if (typeof parsed !== "object" || parsed === null) {
           continue;
         }
         if (!parsed.id) {
@@ -272,7 +268,15 @@ export class ProjectIdentityFiles {
         if (typeof parsed.createdAt !== "number") {
           parsed.createdAt = 0;
         }
-        recipes.push(parsed as TerminalRecipe);
+        const result = TerminalRecipeSchema.safeParse(parsed);
+        if (!result.success) {
+          console.warn(
+            `[ProjectIdentityFiles] Skipping invalid recipe: ${entry.name}`,
+            result.error.flatten()
+          );
+          continue;
+        }
+        recipes.push(result.data);
       } catch {
         console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`);
       }

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -64,12 +64,12 @@ describe("GlobalFileStore adversarial", () => {
     fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
-        { id: "r1", name: "valid", terminals: [] },
+        { id: "r1", name: "valid", terminals: [], createdAt: 1000 },
         null,
         "string",
         { id: "r2", name: "no terminals" },
-        { id: 42, name: "wrong id type", terminals: [] },
-        { id: "r3", name: "also valid", terminals: [{ title: "t" }] },
+        { id: 42, name: "wrong id type", terminals: [], createdAt: 1000 },
+        { id: "r3", name: "also valid", terminals: [{ type: "terminal" }], createdAt: 2000 },
       ])
     );
 
@@ -140,8 +140,8 @@ describe("GlobalFileStore adversarial", () => {
     fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
-        { id: "keep", name: "k", terminals: [] },
-        { id: "drop", name: "d", terminals: [] },
+        { id: "keep", name: "k", terminals: [], createdAt: 1000 },
+        { id: "drop", name: "d", terminals: [], createdAt: 1000 },
       ])
     );
 

--- a/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
@@ -83,18 +83,64 @@ describe("ProjectFileStore adversarial", () => {
     fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
-        { id: "r1", name: "valid", terminals: [] },
+        { id: "r1", name: "valid", terminals: [], createdAt: 1000 },
         null,
         "string",
-        { id: "r2" }, // missing name/terminals
+        { id: "r2" }, // missing name/terminals/createdAt
         { id: "r3", name: "no terminals array" },
-        { id: "r4", name: "valid again", terminals: [{ title: "t" }] },
+        { id: "r4", name: "valid again", terminals: [{ type: "terminal" }], createdAt: 1000 },
       ])
     );
 
     const result = await store.getRecipes(VALID_ID);
 
     expect(result.map((r) => r.id)).toEqual(["r1", "r4"]);
+  });
+
+  it("filters out recipes with deeply malformed terminal entries", async () => {
+    fsSyncMock.existsSync.mockReturnValue(true);
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify([
+        { id: "r1", name: "valid", terminals: [{ type: "terminal" }], createdAt: 1 },
+        {
+          id: "r2",
+          name: "command is number",
+          terminals: [{ type: "terminal", command: 123 }],
+          createdAt: 2,
+        },
+        {
+          id: "r3",
+          name: "env is not a record",
+          terminals: [{ type: "terminal", env: ["array", "not", "record"] }],
+          createdAt: 3,
+        },
+        {
+          id: "r4",
+          name: "invalid exitBehavior",
+          terminals: [{ type: "terminal", exitBehavior: "destroy" }],
+          createdAt: 4,
+        },
+        { id: "r5", name: "also valid", terminals: [], createdAt: 5 },
+      ])
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result.map((r) => r.id)).toEqual(["r1", "r5"]);
+  });
+
+  it("filters out recipes with missing terminal type", async () => {
+    fsSyncMock.existsSync.mockReturnValue(true);
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify([
+        { id: "r1", name: "valid", terminals: [{ type: "terminal" }], createdAt: 1 },
+        { id: "r2", name: "no terminal type", terminals: [{ title: "T" }], createdAt: 2 },
+      ])
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result.map((r) => r.id)).toEqual(["r1"]);
   });
 
   it("ENOENT on first write triggers mkdir + retry and eventually succeeds", async () => {
@@ -151,8 +197,8 @@ describe("ProjectFileStore adversarial", () => {
     fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
-        { id: "keep", name: "k", terminals: [] },
-        { id: "drop", name: "d", terminals: [] },
+        { id: "keep", name: "k", terminals: [], createdAt: 1000 },
+        { id: "drop", name: "d", terminals: [], createdAt: 1000 },
       ])
     );
 

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -357,6 +357,73 @@ describe("readInRepoRecipes", () => {
     const recipes = await identityFiles.readInRepoRecipes(tmpDir);
     expect(recipes[0]!.id).toBe("inrepo-my-recipe");
   });
+
+  it("defaults createdAt to 0 when missing", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "my-recipe.json"),
+      JSON.stringify({ name: "My Recipe", terminals: [{ type: "terminal" }] }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes[0]!.createdAt).toBe(0);
+  });
+
+  it("skips recipes with invalid terminal entries", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "bad-terminal.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Bad Terminal",
+        terminals: [{ type: "" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    await fs.writeFile(
+      path.join(recipesDir, "no-type.json"),
+      JSON.stringify({
+        id: "r2",
+        name: "No Terminal Type",
+        terminals: [{ title: "missing type" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(0);
+  });
+
+  it("skips recipes with deep field errors in terminals", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "command-number.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Command Number",
+        terminals: [{ type: "terminal", command: 12345 }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    await fs.writeFile(
+      path.join(recipesDir, "valid.json"),
+      JSON.stringify({
+        id: "r2",
+        name: "Valid",
+        terminals: [{ type: "terminal" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.id).toBe("r2");
+  });
 });
 
 describe("deleteInRepoRecipe", () => {


### PR DESCRIPTION
## Summary
- Corrupt or malformed recipe files could slip past the old typeof checks and cause runtime crashes. This replaces those shallow checks with Zod schemas that validate every field in loaded recipes, including nested terminal definitions.
- Invalid entries are filtered and logged with a source label so it's clear where the bad data came from.

Resolves #6051

## Changes
- Added RecipeTerminalSchema and TerminalRecipeSchema to electron/schemas/ipc.ts with passthrough for forward compatibility
- Added filterValidTerminalEntries helper for batch-safeParse with source-labeled warnings
- Replaced inline typeof guards in GlobalFileStore, ProjectFileStore, and ProjectIdentityFiles with Zod validation
- Added tests covering valid recipes, malformed JSON, missing required fields, invalid terminal arrays, and edge cases

## Testing
- Unit tests for the new validation schemas and the filter helper
- Adversarial test coverage for both file stores with invalid data