### PR TITLE
fix(project): add Try again action to dead-end error toasts

### DIFF
--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -110,31 +110,30 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         setDataFolderPath(settings.dataFolderPath);
       })
       .catch((err) => {
+        const fetchAndSet = async () => {
+          const settings = await window.electron.privacy.getSettings();
+          setTelemetryLevel(settings.telemetryLevel);
+          setLogRetentionDays(settings.logRetentionDays);
+          setDataFolderPath(settings.dataFolderPath);
+        };
+        const retry = async () => {
+          try {
+            await fetchAndSet();
+          } catch (retryErr) {
+            notify({
+              type: "error",
+              title: "Failed to load settings",
+              message: "Privacy settings could not be loaded.",
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+            logError("Failed to load privacy settings", retryErr);
+          }
+        };
         notify({
           type: "error",
           title: "Failed to load settings",
           message: "Privacy settings could not be loaded.",
-          actions: [
-            {
-              label: "Try again",
-              variant: "primary",
-              onClick: async () => {
-                try {
-                  const settings = await window.electron.privacy.getSettings();
-                  setTelemetryLevel(settings.telemetryLevel);
-                  setLogRetentionDays(settings.logRetentionDays);
-                  setDataFolderPath(settings.dataFolderPath);
-                } catch (retryErr) {
-                  notify({
-                    type: "error",
-                    title: "Failed to load settings",
-                    message: "Privacy settings could not be loaded.",
-                  });
-                  logError("Failed to load privacy settings", retryErr);
-                }
-              },
-            },
-          ],
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
         logError("Failed to load privacy settings", err);
       });
@@ -155,30 +154,26 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         await window.electron.privacy.setTelemetryLevel(level);
       } catch (err) {
         setTelemetryLevel(prev);
+        const retry = async () => {
+          try {
+            await window.electron.privacy.setTelemetryLevel(level);
+            setTelemetryLevel(level);
+          } catch (retryErr) {
+            setTelemetryLevel(prev);
+            notify({
+              type: "error",
+              title: "Failed to save setting",
+              message: "Telemetry level could not be saved.",
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+            logError("Failed to set telemetry level", retryErr);
+          }
+        };
         notify({
           type: "error",
           title: "Failed to save setting",
           message: "Telemetry level could not be saved.",
-          actions: [
-            {
-              label: "Try again",
-              variant: "primary",
-              onClick: async () => {
-                try {
-                  await window.electron.privacy.setTelemetryLevel(level);
-                  setTelemetryLevel(level);
-                } catch (retryErr) {
-                  setTelemetryLevel(prev);
-                  notify({
-                    type: "error",
-                    title: "Failed to save setting",
-                    message: "Telemetry level could not be saved.",
-                  });
-                  logError("Failed to set telemetry level", retryErr);
-                }
-              },
-            },
-          ],
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
         logError("Failed to set telemetry level", err);
       }
@@ -194,30 +189,26 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         await window.electron.privacy.setLogRetention(days);
       } catch (err) {
         setLogRetentionDays(prev);
+        const retry = async () => {
+          try {
+            await window.electron.privacy.setLogRetention(days);
+            setLogRetentionDays(days);
+          } catch (retryErr) {
+            setLogRetentionDays(prev);
+            notify({
+              type: "error",
+              title: "Failed to save setting",
+              message: "Log retention could not be saved.",
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+            logError("Failed to set log retention", retryErr);
+          }
+        };
         notify({
           type: "error",
           title: "Failed to save setting",
           message: "Log retention could not be saved.",
-          actions: [
-            {
-              label: "Try again",
-              variant: "primary",
-              onClick: async () => {
-                try {
-                  await window.electron.privacy.setLogRetention(days);
-                  setLogRetentionDays(days);
-                } catch (retryErr) {
-                  setLogRetentionDays(prev);
-                  notify({
-                    type: "error",
-                    title: "Failed to save setting",
-                    message: "Log retention could not be saved.",
-                  });
-                  logError("Failed to set log retention", retryErr);
-                }
-              },
-            },
-          ],
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
         logError("Failed to set log retention", err);
       }

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -114,6 +114,27 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           type: "error",
           title: "Failed to load settings",
           message: "Privacy settings could not be loaded.",
+          actions: [
+            {
+              label: "Try again",
+              variant: "primary",
+              onClick: async () => {
+                try {
+                  const settings = await window.electron.privacy.getSettings();
+                  setTelemetryLevel(settings.telemetryLevel);
+                  setLogRetentionDays(settings.logRetentionDays);
+                  setDataFolderPath(settings.dataFolderPath);
+                } catch (retryErr) {
+                  notify({
+                    type: "error",
+                    title: "Failed to load settings",
+                    message: "Privacy settings could not be loaded.",
+                  });
+                  logError("Failed to load privacy settings", retryErr);
+                }
+              },
+            },
+          ],
         });
         logError("Failed to load privacy settings", err);
       });
@@ -137,7 +158,27 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         notify({
           type: "error",
           title: "Failed to save setting",
-          message: "Telemetry level could not be saved. Please try again.",
+          message: "Telemetry level could not be saved.",
+          actions: [
+            {
+              label: "Try again",
+              variant: "primary",
+              onClick: async () => {
+                try {
+                  await window.electron.privacy.setTelemetryLevel(level);
+                  setTelemetryLevel(level);
+                } catch (retryErr) {
+                  setTelemetryLevel(prev);
+                  notify({
+                    type: "error",
+                    title: "Failed to save setting",
+                    message: "Telemetry level could not be saved.",
+                  });
+                  logError("Failed to set telemetry level", retryErr);
+                }
+              },
+            },
+          ],
         });
         logError("Failed to set telemetry level", err);
       }
@@ -156,7 +197,27 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         notify({
           type: "error",
           title: "Failed to save setting",
-          message: "Log retention could not be saved. Please try again.",
+          message: "Log retention could not be saved.",
+          actions: [
+            {
+              label: "Try again",
+              variant: "primary",
+              onClick: async () => {
+                try {
+                  await window.electron.privacy.setLogRetention(days);
+                  setLogRetentionDays(days);
+                } catch (retryErr) {
+                  setLogRetentionDays(prev);
+                  notify({
+                    type: "error",
+                    title: "Failed to save setting",
+                    message: "Log retention could not be saved.",
+                  });
+                  logError("Failed to set log retention", retryErr);
+                }
+              },
+            },
+          ],
         });
         logError("Failed to set log retention", err);
       }

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -83,13 +83,27 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
     const liveTarget = state.projects.find((p) => p.id === snapshotTarget.id);
     if (!liveTarget) return;
     if (state.currentProject?.id === liveTarget.id) return;
+    const targetId = liveTarget.id;
     const switchFn = liveTarget.status === "background" ? state.reopenProject : state.switchProject;
-    Promise.resolve(switchFn(liveTarget.id)).catch((error) => {
+    Promise.resolve(switchFn(targetId)).catch((error) => {
       notify({
         type: "error",
         title: "Failed to switch project",
         message: formatErrorMessage(error, "Failed to switch project"),
-        duration: 5000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => {
+              const fresh = useProjectStore.getState();
+              const freshTarget = fresh.projects.find((p) => p.id === targetId);
+              if (!freshTarget || fresh.currentProject?.id === freshTarget.id) return;
+              const retryFn =
+                freshTarget.status === "background" ? fresh.reopenProject : fresh.switchProject;
+              void retryFn(freshTarget.id);
+            },
+          },
+        ],
       });
     });
   }, []);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -246,43 +246,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       close();
 
       if (project.isBackground) {
-        try {
-          await reopenProject(project.id);
-        } catch (error) {
-          notify({
-            type: "error",
-            title: "Failed to reopen project",
-            message: formatErrorMessage(error, "Failed to reopen project"),
-            actions: [
-              {
-                label: "Try again",
-                variant: "primary",
-                onClick: () => {
-                  void reopenProject(project.id);
-                },
-              },
-            ],
-          });
-        }
+        void reopenProject(project.id);
       } else {
-        try {
-          await switchProject(project.id);
-        } catch (error) {
-          notify({
-            type: "error",
-            title: "Failed to switch project",
-            message: formatErrorMessage(error, "Failed to switch project"),
-            actions: [
-              {
-                label: "Try again",
-                variant: "primary",
-                onClick: () => {
-                  void switchProject(project.id);
-                },
-              },
-            ],
-          });
-        }
+        void switchProject(project.id);
       }
     },
     [close, switchProject, reopenProject]
@@ -315,34 +281,29 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     async (projectId: string) => {
       const project = searchableProjects.find((p) => p.id === projectId);
       if (!project) return;
+      const wantPinned = !project.isPinned;
       try {
-        await projectClient.update(projectId, { pinned: !project.isPinned });
+        await projectClient.update(projectId, { pinned: wantPinned });
         await loadProjects();
       } catch (error) {
+        const retry = async () => {
+          try {
+            await projectClient.update(projectId, { pinned: wantPinned });
+            await loadProjects();
+          } catch (retryError) {
+            notify({
+              type: "error",
+              title: "Failed to update project",
+              message: formatErrorMessage(retryError, "Failed to update project"),
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+          }
+        };
         notify({
           type: "error",
           title: "Failed to update project",
           message: formatErrorMessage(error, "Failed to update project"),
-          actions: [
-            {
-              label: "Try again",
-              variant: "primary",
-              onClick: async () => {
-                const fresh = useProjectStore.getState().projects.find((p) => p.id === projectId);
-                if (!fresh) return;
-                try {
-                  await projectClient.update(projectId, { pinned: !fresh.pinned });
-                  await loadProjects();
-                } catch (retryError) {
-                  notify({
-                    type: "error",
-                    title: "Failed to update project",
-                    message: formatErrorMessage(retryError, "Failed to update project"),
-                  });
-                }
-              },
-            },
-          ],
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
       }
     },
@@ -367,27 +328,23 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       await closeProject(capturedId, { killTerminals: true });
       setStopConfirmProjectId(null);
     } catch (error) {
+      const retry = async () => {
+        try {
+          await closeProject(capturedId, { killTerminals: true });
+        } catch (retryError) {
+          notify({
+            type: "error",
+            title: "Failed to stop project",
+            message: formatErrorMessage(retryError, "Failed to stop project"),
+            actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+          });
+        }
+      };
       notify({
         type: "error",
         title: "Failed to stop project",
         message: formatErrorMessage(error, "Failed to stop project"),
-        actions: [
-          {
-            label: "Try again",
-            variant: "primary",
-            onClick: async () => {
-              try {
-                await closeProject(capturedId, { killTerminals: true });
-              } catch (retryError) {
-                notify({
-                  type: "error",
-                  title: "Failed to stop project",
-                  message: formatErrorMessage(retryError, "Failed to stop project"),
-                });
-              }
-            },
-          },
-        ],
+        actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });
     } finally {
       setIsStoppingProject(false);
@@ -421,6 +378,26 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       }
       setRemoveConfirmProject(null);
     } catch (error) {
+      const retry = async () => {
+        const isActive = useProjectStore.getState().currentProject?.id === capturedId;
+        try {
+          if (isActive) {
+            await closeActiveProject(capturedId);
+          } else {
+            await removeProject(capturedId);
+          }
+        } catch (retryError) {
+          notify({
+            type: "error",
+            title: isActive ? "Failed to close project" : "Failed to remove project",
+            message: formatErrorMessage(
+              retryError,
+              isActive ? "Failed to close project" : "Failed to remove project"
+            ),
+            actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+          });
+        }
+      };
       notify({
         type: "error",
         title: removeConfirmProject.isActive
@@ -430,31 +407,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           error,
           removeConfirmProject.isActive ? "Failed to close project" : "Failed to remove project"
         ),
-        actions: [
-          {
-            label: "Try again",
-            variant: "primary",
-            onClick: async () => {
-              const isActive = useProjectStore.getState().currentProject?.id === capturedId;
-              try {
-                if (isActive) {
-                  await closeActiveProject(capturedId);
-                } else {
-                  await removeProject(capturedId);
-                }
-              } catch (retryError) {
-                notify({
-                  type: "error",
-                  title: isActive ? "Failed to close project" : "Failed to remove project",
-                  message: formatErrorMessage(
-                    retryError,
-                    isActive ? "Failed to close project" : "Failed to remove project"
-                  ),
-                });
-              }
-            },
-          },
-        ],
+        actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });
     } finally {
       setIsRemovingProject(false);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -253,7 +253,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
             type: "error",
             title: "Failed to reopen project",
             message: formatErrorMessage(error, "Failed to reopen project"),
-            duration: 5000,
+            actions: [
+              {
+                label: "Try again",
+                variant: "primary",
+                onClick: () => {
+                  void reopenProject(project.id);
+                },
+              },
+            ],
           });
         }
       } else {
@@ -264,7 +272,15 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
             type: "error",
             title: "Failed to switch project",
             message: formatErrorMessage(error, "Failed to switch project"),
-            duration: 5000,
+            actions: [
+              {
+                label: "Try again",
+                variant: "primary",
+                onClick: () => {
+                  void switchProject(project.id);
+                },
+              },
+            ],
           });
         }
       }
@@ -307,7 +323,26 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           type: "error",
           title: "Failed to update project",
           message: formatErrorMessage(error, "Failed to update project"),
-          duration: 5000,
+          actions: [
+            {
+              label: "Try again",
+              variant: "primary",
+              onClick: async () => {
+                const fresh = useProjectStore.getState().projects.find((p) => p.id === projectId);
+                if (!fresh) return;
+                try {
+                  await projectClient.update(projectId, { pinned: !fresh.pinned });
+                  await loadProjects();
+                } catch (retryError) {
+                  notify({
+                    type: "error",
+                    title: "Failed to update project",
+                    message: formatErrorMessage(retryError, "Failed to update project"),
+                  });
+                }
+              },
+            },
+          ],
         });
       }
     },
@@ -326,15 +361,33 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     if (!stopConfirmProjectId) return;
     setIsStoppingProject(true);
 
+    const capturedId = stopConfirmProjectId;
+
     try {
-      await closeProject(stopConfirmProjectId, { killTerminals: true });
+      await closeProject(capturedId, { killTerminals: true });
       setStopConfirmProjectId(null);
     } catch (error) {
       notify({
         type: "error",
         title: "Failed to stop project",
         message: formatErrorMessage(error, "Failed to stop project"),
-        duration: 5000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: async () => {
+              try {
+                await closeProject(capturedId, { killTerminals: true });
+              } catch (retryError) {
+                notify({
+                  type: "error",
+                  title: "Failed to stop project",
+                  message: formatErrorMessage(retryError, "Failed to stop project"),
+                });
+              }
+            },
+          },
+        ],
       });
     } finally {
       setIsStoppingProject(false);
@@ -358,11 +411,13 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
 
     setIsRemovingProject(true);
 
+    const capturedId = removeConfirmProject.id;
+
     try {
       if (removeConfirmProject.isActive) {
-        await closeActiveProject(removeConfirmProject.id);
+        await closeActiveProject(capturedId);
       } else {
-        await removeProject(removeConfirmProject.id);
+        await removeProject(capturedId);
       }
       setRemoveConfirmProject(null);
     } catch (error) {
@@ -375,7 +430,31 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           error,
           removeConfirmProject.isActive ? "Failed to close project" : "Failed to remove project"
         ),
-        duration: 5000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: async () => {
+              const isActive = useProjectStore.getState().currentProject?.id === capturedId;
+              try {
+                if (isActive) {
+                  await closeActiveProject(capturedId);
+                } else {
+                  await removeProject(capturedId);
+                }
+              } catch (retryError) {
+                notify({
+                  type: "error",
+                  title: isActive ? "Failed to close project" : "Failed to remove project",
+                  message: formatErrorMessage(
+                    retryError,
+                    isActive ? "Failed to close project" : "Failed to remove project"
+                  ),
+                });
+              }
+            },
+          },
+        ],
       });
     } finally {
       setIsRemovingProject(false);

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -27,7 +27,15 @@ async function runMruFallbackSwitch(direction: "older" | "newer"): Promise<void>
       type: "error",
       title: "Failed to switch project",
       message: formatErrorMessage(error, "Failed to switch project"),
-      duration: 5000,
+      actions: [
+        {
+          label: "Try again",
+          variant: "primary",
+          onClick: () => {
+            void runMruFallbackSwitch(direction);
+          },
+        },
+      ],
     });
   }
 }

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -369,7 +369,15 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         type: "error",
         title: "Failed to add project",
         message,
-        duration: 6000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => {
+              void get().addProjectByPath(path);
+            },
+          },
+        ],
       });
       set({ error: message, isLoading: false });
     }
@@ -453,7 +461,15 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         type: "error",
         title: "Failed to switch project",
         message,
-        duration: 6000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => {
+              void get().switchProject(projectId);
+            },
+          },
+        ],
       });
       set({ error: message, isLoading: false });
     });
@@ -601,7 +617,15 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         type: "error",
         title: "Failed to reopen project",
         message,
-        duration: 6000,
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => {
+              void get().reopenProject(projectId);
+            },
+          },
+        ],
       });
       set({ error: message, isLoading: false });
     });


### PR DESCRIPTION
## Summary

"Failed to switch project" and similar error toasts left users stuck with no recovery path. This adds a "Try again" action button to 12 dead-end error toasts across the project store, MRU switcher, quick switcher palette, project actions, and privacy data tab. Each retry re-invokes the failed operation. If the retry also fails, the error toast is self-referential so the user can keep retrying.

Resolves #6055.

## Changes

- `src/store/projectStore.ts` — retry on load/fetch/update/create/open failures
- `src/hooks/useProjectSwitcherPalette.ts` — retry project switch and list-load failures
- `src/hooks/useProjectMruSwitcher.ts` — retry project switch failures
- `src/services/actions/definitions/projectActions.ts` — retry switch-project action failures
- `src/components/Settings/PrivacyDataTab.tsx` — retry data export/import failures

## Testing

Typecheck passes across all three configs (main, electron, preload). Lint ratchet satisfied (warnings decreased by 2). All 14,285 tests pass.