### PR TITLE
fix(store): replace bulk-spread slice writes with dot-path writes to preserve defaults

### DIFF
--- a/electron/__tests__/storeDotPathPersistence.test.ts
+++ b/electron/__tests__/storeDotPathPersistence.test.ts
@@ -13,6 +13,7 @@ import { initializeStore } from "../store.js";
 type AnyStore = {
   set: (key: string, value: unknown) => void;
   get: (key: string) => unknown;
+  delete: (key: string) => void;
 };
 
 describe("Store dot-path persistence", () => {
@@ -77,6 +78,25 @@ describe("Store dot-path persistence", () => {
     const store = makeStore();
     store.set("foo", { onlyField: "value" });
     expect(readConfig()).toEqual({ foo: { onlyField: "value" } });
+  });
+
+  it("dot-path delete clears a leaf without dropping siblings", () => {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ appState: { activeWorktreeId: "wt-old", sidebarWidth: 350 } }),
+      "utf8"
+    );
+    const store = makeStore();
+    store.delete("appState.activeWorktreeId");
+    const slice = readConfig().appState as Record<string, unknown>;
+    expect(slice).not.toHaveProperty("activeWorktreeId");
+    expect(slice.sidebarWidth).toBe(350);
+  });
+
+  it("set with undefined throws — callers must use delete to clear", () => {
+    const store = makeStore();
+    store.set("appState.sidebarWidth", 350);
+    expect(() => store.set("appState.activeWorktreeId", undefined)).toThrow();
   });
 
   it("preserves nested record fields not addressed by the dot-path", () => {

--- a/electron/__tests__/storeDotPathPersistence.test.ts
+++ b/electron/__tests__/storeDotPathPersistence.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+vi.mock("electron-store", async () => {
+  const conf = await import("conf");
+  return { default: conf.default };
+});
+
+import { initializeStore } from "../store.js";
+
+type AnyStore = {
+  set: (key: string, value: unknown) => void;
+  get: (key: string) => unknown;
+};
+
+describe("Store dot-path persistence", () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-store-dotpath-"));
+    configPath = path.join(tempDir, "config.json");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function readConfig(): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+  }
+
+  function makeStore(defaults: Record<string, unknown> = {}): AnyStore {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return initializeStore({ defaults, cwd: tempDir } as any) as unknown as AnyStore;
+  }
+
+  it("dot-path set writes only the leaf, not the whole slice", () => {
+    const store = makeStore();
+    store.set("foo.bar", 1);
+    expect(readConfig()).toEqual({ foo: { bar: 1 } });
+  });
+
+  it("dot-path set preserves siblings already on disk", () => {
+    fs.writeFileSync(configPath, JSON.stringify({ foo: { bar: 1, baz: 2 } }), "utf8");
+    const store = makeStore();
+    store.set("foo.bar", 99);
+    expect(readConfig()).toEqual({ foo: { bar: 99, baz: 2 } });
+  });
+
+  it("multiple dot-path sets accumulate without clobbering siblings", () => {
+    const store = makeStore();
+    store.set("foo.bar", 1);
+    store.set("foo.baz", 2);
+    expect(readConfig()).toEqual({ foo: { bar: 1, baz: 2 } });
+  });
+
+  it("nested dot-path set writes deeply without baking unrelated keys", () => {
+    const store = makeStore();
+    store.set("a.b.c", true);
+    expect(readConfig()).toEqual({ a: { b: { c: true } } });
+  });
+
+  it("dot-path set on a missing slice creates only that field, no defaults of siblings", () => {
+    // Simulate a user whose config existed before some new sibling defaults were added.
+    fs.writeFileSync(configPath, JSON.stringify({ foo: { existing: "user" } }), "utf8");
+    const store = makeStore();
+    store.set("foo.existing", "user-modified");
+    const slice = readConfig().foo as Record<string, unknown>;
+    expect(slice).toEqual({ existing: "user-modified" });
+  });
+
+  it("whole-slice replacement still works for explicit resets", () => {
+    fs.writeFileSync(configPath, JSON.stringify({ foo: { keep: 1, drop: 2 } }), "utf8");
+    const store = makeStore();
+    store.set("foo", { onlyField: "value" });
+    expect(readConfig()).toEqual({ foo: { onlyField: "value" } });
+  });
+
+  it("preserves nested record fields not addressed by the dot-path", () => {
+    // Models the agentSettings.agents pattern: writing the whole `agents` record
+    // at slice.field level instead of per-agent leaves (which would be unsafe for
+    // user-defined agent IDs containing dots).
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        agentSettings: {
+          rootField: "preserved",
+          agents: { claude: { customFlags: "--foo" } },
+        },
+      }),
+      "utf8"
+    );
+    const store = makeStore();
+    store.set("agentSettings.agents", {
+      claude: { customFlags: "--bar" },
+      gemini: { model: "gemini-2.0" },
+    });
+    const after = readConfig().agentSettings as Record<string, unknown>;
+    expect(after.rootField).toBe("preserved");
+    expect(after.agents).toEqual({
+      claude: { customFlags: "--bar" },
+      gemini: { model: "gemini-2.0" },
+    });
+  });
+});

--- a/electron/__tests__/storeDotPathPersistence.test.ts
+++ b/electron/__tests__/storeDotPathPersistence.test.ts
@@ -8,7 +8,7 @@ vi.mock("electron-store", async () => {
   return { default: conf.default };
 });
 
-import { initializeStore } from "../store.js";
+import { initializeStore, _resetStoreInstance } from "../store.js";
 
 type AnyStore = {
   set: (key: string, value: unknown) => void;
@@ -21,11 +21,13 @@ describe("Store dot-path persistence", () => {
   let configPath: string;
 
   beforeEach(() => {
+    _resetStoreInstance();
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-store-dotpath-"));
     configPath = path.join(tempDir, "config.json");
   });
 
   afterEach(() => {
+    _resetStoreInstance();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/electron/ipc/handlers/__tests__/ai.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/ai.handlers.test.ts
@@ -189,16 +189,11 @@ describe("ai handler payload validation", () => {
       } as never
     );
 
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "agentSettings",
-      expect.objectContaining({
-        agents: {
-          claude: {
-            customFlags: "--foo",
-          },
-        },
-      })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("agentSettings.agents", {
+      claude: {
+        customFlags: "--foo",
+      },
+    });
     expect(result).toEqual(
       expect.objectContaining({
         agents: expect.objectContaining({
@@ -225,13 +220,10 @@ describe("ai handler payload validation", () => {
     const result = await handler({} as never, "claude");
 
     expect(storeMock.set).toHaveBeenCalledWith(
-      "agentSettings",
+      "agentSettings.agents",
       expect.objectContaining({
-        misc: true,
-        agents: expect.objectContaining({
-          claude: expect.objectContaining({
-            dangerousEnabled: false,
-          }),
+        claude: expect.objectContaining({
+          dangerousEnabled: false,
         }),
       })
     );
@@ -269,13 +261,11 @@ describe("ai handler payload validation", () => {
     );
 
     expect(storeMock.set).toHaveBeenCalledWith(
-      "agentSettings",
+      "agentSettings.agents",
       expect.objectContaining({
-        agents: {
-          claude: expect.objectContaining({
-            pinned: false,
-          }),
-        },
+        claude: expect.objectContaining({
+          pinned: false,
+        }),
       })
     );
     expect(result).toEqual(
@@ -297,12 +287,10 @@ describe("ai handler payload validation", () => {
     await handler({} as never, " claude ");
 
     expect(storeMock.set).toHaveBeenCalledWith(
-      "agentSettings",
+      "agentSettings.agents",
       expect.objectContaining({
-        agents: expect.objectContaining({
-          claude: expect.objectContaining({
-            dangerousEnabled: false,
-          }),
+        claude: expect.objectContaining({
+          dangerousEnabled: false,
         }),
       })
     );

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -31,12 +31,39 @@ const storeState = vi.hoisted(() => ({
   data: {} as Record<string, unknown>,
 }));
 
-const storeMock = vi.hoisted(() => ({
-  get: vi.fn((key: string) => storeState.data[key]),
-  set: vi.fn((key: string, value: unknown) => {
-    storeState.data[key] = value;
-  }),
-}));
+const storeMock = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getDeep = (key: string): any => {
+    if (!key.includes(".")) return storeState.data[key];
+    const parts = key.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = storeState.data;
+    for (const p of parts) {
+      if (cur == null) return undefined;
+      cur = cur[p];
+    }
+    return cur;
+  };
+  const setDeep = (key: string, value: unknown): void => {
+    if (!key.includes(".")) {
+      storeState.data[key] = value;
+      return;
+    }
+    const parts = key.split(".");
+    const last = parts.pop()!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = storeState.data;
+    for (const p of parts) {
+      if (typeof cur[p] !== "object" || cur[p] === null) cur[p] = {};
+      cur = cur[p];
+    }
+    cur[last] = value;
+  };
+  return {
+    get: vi.fn(getDeep),
+    set: vi.fn(setDeep),
+  };
+});
 
 vi.mock("../../../store.js", () => ({
   store: storeMock,
@@ -167,10 +194,7 @@ describe("appTheme handlers", () => {
     const handler = getHandler(CHANNELS.APP_THEME_SET_FOLLOW_SYSTEM);
     await handler({}, true);
 
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "appTheme",
-      expect.objectContaining({ followSystem: true, colorSchemeId: "daintree" })
-    );
+    expect(storeState.data.appTheme).toEqual({ colorSchemeId: "daintree", followSystem: true });
   });
 
   it("setPreferredDarkScheme stores the scheme id", async () => {
@@ -180,10 +204,7 @@ describe("appTheme handlers", () => {
     const handler = getHandler(CHANNELS.APP_THEME_SET_PREFERRED_DARK_SCHEME);
     await handler({}, "custom-dark");
 
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "appTheme",
-      expect.objectContaining({ preferredDarkSchemeId: "custom-dark" })
-    );
+    expect(storeState.data.appTheme).toMatchObject({ preferredDarkSchemeId: "custom-dark" });
   });
 
   it("setPreferredLightScheme stores the scheme id", async () => {
@@ -193,10 +214,7 @@ describe("appTheme handlers", () => {
     const handler = getHandler(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME);
     await handler({}, "custom-light");
 
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "appTheme",
-      expect.objectContaining({ preferredLightSchemeId: "custom-light" })
-    );
+    expect(storeState.data.appTheme).toMatchObject({ preferredLightSchemeId: "custom-light" });
   });
 
   describe("setRecentSchemeIds", () => {
@@ -207,10 +225,9 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
       await handler({}, ["bondi", "dracula", "serengeti"]);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ recentSchemeIds: ["bondi", "dracula", "serengeti"] })
-      );
+      expect(storeState.data.appTheme).toMatchObject({
+        recentSchemeIds: ["bondi", "dracula", "serengeti"],
+      });
     });
 
     it("ignores non-array input without throwing", async () => {
@@ -222,8 +239,8 @@ describe("appTheme handlers", () => {
       await handler({}, null);
       await handler({}, 42);
 
-      const recentCalls = storeMock.set.mock.calls.filter(
-        (c: unknown[]) => (c[1] as { recentSchemeIds?: unknown }).recentSchemeIds !== undefined
+      const recentCalls = storeMock.set.mock.calls.filter((c: unknown[]) =>
+        String(c[0]).endsWith(".recentSchemeIds")
       );
       expect(recentCalls).toHaveLength(0);
     });
@@ -235,10 +252,7 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
       await handler({}, ["bondi", "", "  ", 42, null, undefined, " dracula "]);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ recentSchemeIds: ["bondi", "dracula"] })
-      );
+      expect(storeState.data.appTheme).toMatchObject({ recentSchemeIds: ["bondi", "dracula"] });
     });
 
     it("caps the persisted list at 5 entries", async () => {
@@ -248,10 +262,9 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
       await handler({}, ["a", "b", "c", "d", "e", "f", "g"]);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ recentSchemeIds: ["a", "b", "c", "d", "e"] })
-      );
+      expect(storeState.data.appTheme).toMatchObject({
+        recentSchemeIds: ["a", "b", "c", "d", "e"],
+      });
     });
 
     it("preserves other appTheme fields when persisting", async () => {
@@ -265,15 +278,12 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
       await handler({}, ["bondi"]);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({
-          colorSchemeId: "daintree",
-          followSystem: true,
-          preferredDarkSchemeId: "custom-dark",
-          recentSchemeIds: ["bondi"],
-        })
-      );
+      expect(storeState.data.appTheme).toEqual({
+        colorSchemeId: "daintree",
+        followSystem: true,
+        preferredDarkSchemeId: "custom-dark",
+        recentSchemeIds: ["bondi"],
+      });
     });
   });
 
@@ -285,10 +295,7 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
       await handler({}, "#AABBCC");
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ accentColorOverride: "#aabbcc" })
-      );
+      expect(storeState.data.appTheme).toMatchObject({ accentColorOverride: "#aabbcc" });
     });
 
     it("accepts a hex without leading #", async () => {
@@ -298,10 +305,7 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
       await handler({}, "ff8040");
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ accentColorOverride: "#ff8040" })
-      );
+      expect(storeState.data.appTheme).toMatchObject({ accentColorOverride: "#ff8040" });
     });
 
     it("persists null to clear the override", async () => {
@@ -314,10 +318,7 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
       await handler({}, null);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ accentColorOverride: null })
-      );
+      expect(storeState.data.appTheme).toMatchObject({ accentColorOverride: null });
     });
 
     it("ignores malformed strings without mutating the store", async () => {
@@ -329,9 +330,8 @@ describe("appTheme handlers", () => {
       await handler({}, "rgb(0,0,0)");
       await handler({}, 42);
 
-      const relevantCalls = storeMock.set.mock.calls.filter(
-        (c: unknown[]) =>
-          (c[1] as { accentColorOverride?: unknown }).accentColorOverride !== undefined
+      const relevantCalls = storeMock.set.mock.calls.filter((c: unknown[]) =>
+        String(c[0]).endsWith(".accentColorOverride")
       );
       expect(relevantCalls).toHaveLength(0);
     });
@@ -347,15 +347,12 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
       await handler({}, "#112233");
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({
-          colorSchemeId: "daintree",
-          followSystem: true,
-          recentSchemeIds: ["bondi"],
-          accentColorOverride: "#112233",
-        })
-      );
+      expect(storeState.data.appTheme).toEqual({
+        colorSchemeId: "daintree",
+        followSystem: true,
+        recentSchemeIds: ["bondi"],
+        accentColorOverride: "#112233",
+      });
     });
   });
 
@@ -509,10 +506,7 @@ describe("appTheme handlers", () => {
     themeHandler();
     vi.advanceTimersByTime(300);
 
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "appTheme",
-      expect.objectContaining({ colorSchemeId: "bondi" })
-    );
+    expect(storeState.data.appTheme).toMatchObject({ colorSchemeId: "bondi" });
   });
 
   describe("exportTheme", () => {

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -646,10 +646,7 @@ describe("appTheme handlers", () => {
       const handler = getHandler(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES);
       await handler({}, [validScheme]);
 
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({ customSchemes: [validScheme] })
-      );
+      expect(storeMock.set).toHaveBeenCalledWith("appTheme.customSchemes", [validScheme]);
     });
 
     it("rejects invalid scheme arrays", async () => {
@@ -689,12 +686,7 @@ describe("appTheme handlers", () => {
       expect(config.customSchemes).toHaveLength(1);
 
       // Verify it rewrote the store with the native array
-      expect(storeMock.set).toHaveBeenCalledWith(
-        "appTheme",
-        expect.objectContaining({
-          customSchemes: expect.any(Array),
-        })
-      );
+      expect(storeMock.set).toHaveBeenCalledWith("appTheme.customSchemes", expect.any(Array));
     });
 
     it("returns empty array for malformed legacy JSON", async () => {

--- a/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/notifications.adversarial.test.ts
@@ -99,12 +99,12 @@ describe("notifications IPC adversarial", () => {
       escalationSoundFile: "unknown-file.mp3",
     });
 
-    const call = storeMock.set.mock.calls[0];
-    expect(call[0]).toBe("notificationSettings");
-    const saved = call[1] as Record<string, unknown>;
-    expect(saved.completedSoundFile).toBe("completed.mp3");
-    expect(saved.waitingSoundFile).toBeUndefined();
-    expect(saved.escalationSoundFile).toBeUndefined();
+    // Dot-path writes only land for validated fields. Unsafe values must not
+    // reach the store at all — assert no call targets any sound-file leaf.
+    const writtenKeys = storeMock.set.mock.calls.map((c) => String(c[0]));
+    expect(writtenKeys).not.toContain("notificationSettings.completedSoundFile");
+    expect(writtenKeys).not.toContain("notificationSettings.waitingSoundFile");
+    expect(writtenKeys).not.toContain("notificationSettings.escalationSoundFile");
   });
 
   it("settingsSet accepts allowed sound file names", async () => {
@@ -112,24 +112,30 @@ describe("notifications IPC adversarial", () => {
       completedSoundFile: "waiting.mp3",
     });
 
-    const saved = storeMock.set.mock.calls[0][1] as Record<string, unknown>;
-    expect(saved.completedSoundFile).toBe("waiting.mp3");
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "notificationSettings.completedSoundFile",
+      "waiting.mp3"
+    );
   });
 
   it("settingsSet clamps waitingEscalationDelayMs below 30s up to 30s", async () => {
     await getHandler(CHANNELS.NOTIFICATION_SETTINGS_SET)(fakeEvent(), {
       waitingEscalationDelayMs: 0,
     });
-    const saved = storeMock.set.mock.calls[0][1] as Record<string, unknown>;
-    expect(saved.waitingEscalationDelayMs).toBe(30_000);
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "notificationSettings.waitingEscalationDelayMs",
+      30_000
+    );
   });
 
   it("settingsSet clamps waitingEscalationDelayMs above 1h down to 1h", async () => {
     await getHandler(CHANNELS.NOTIFICATION_SETTINGS_SET)(fakeEvent(), {
       waitingEscalationDelayMs: 3_600_001,
     });
-    const saved = storeMock.set.mock.calls[0][1] as Record<string, unknown>;
-    expect(saved.waitingEscalationDelayMs).toBe(3_600_000);
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "notificationSettings.waitingEscalationDelayMs",
+      3_600_000
+    );
   });
 
   it("settingsSet rejects non-finite escalation delay (NaN, Infinity)", async () => {
@@ -140,10 +146,8 @@ describe("notifications IPC adversarial", () => {
       waitingEscalationDelayMs: Number.POSITIVE_INFINITY,
     });
 
-    for (const call of storeMock.set.mock.calls) {
-      const saved = call[1] as Record<string, unknown>;
-      expect(saved.waitingEscalationDelayMs).toBeUndefined();
-    }
+    const writtenKeys = storeMock.set.mock.calls.map((c) => String(c[0]));
+    expect(writtenKeys).not.toContain("notificationSettings.waitingEscalationDelayMs");
   });
 
   it("settingsSet ignores non-object payloads silently", async () => {

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -9,11 +9,36 @@ vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
 
 const storeMock = vi.hoisted(() => {
   const data: Record<string, unknown> = {};
-  return {
-    get: vi.fn((key: string) => data[key]),
-    set: vi.fn((key: string, value: unknown) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getDeep = (key: string): any => {
+    if (!key.includes(".")) return data[key];
+    const parts = key.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = data;
+    for (const p of parts) {
+      if (cur == null) return undefined;
+      cur = cur[p];
+    }
+    return cur;
+  };
+  const setDeep = (key: string, value: unknown): void => {
+    if (!key.includes(".")) {
       data[key] = value;
-    }),
+      return;
+    }
+    const parts = key.split(".");
+    const last = parts.pop()!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = data;
+    for (const p of parts) {
+      if (typeof cur[p] !== "object" || cur[p] === null) cur[p] = {};
+      cur = cur[p];
+    }
+    cur[last] = value;
+  };
+  return {
+    get: vi.fn(getDeep),
+    set: vi.fn(setDeep),
     _data: data,
   };
 });
@@ -119,10 +144,8 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     };
     expect(result.seenAgentIds.sort()).toEqual(["claude", "codex", "gemini"]);
     expect(storeMock.set).toHaveBeenCalledWith(
-      "onboarding",
-      expect.objectContaining({
-        seenAgentIds: expect.arrayContaining(["claude", "codex", "gemini"]),
-      })
+      "onboarding.seenAgentIds",
+      expect.arrayContaining(["claude", "codex", "gemini"])
     );
   });
 
@@ -163,10 +186,7 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     const dismiss = getHandler("onboarding:dismiss-welcome-card");
     const result = dismiss(null) as { welcomeCardDismissed: boolean };
     expect(result.welcomeCardDismissed).toBe(true);
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "onboarding",
-      expect.objectContaining({ welcomeCardDismissed: true })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("onboarding.welcomeCardDismissed", true);
   });
 
   it("dismissWelcomeCard is idempotent once dismissed", () => {
@@ -204,10 +224,7 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     const dismiss = getHandler("onboarding:dismiss-setup-banner");
     const result = dismiss(null) as { setupBannerDismissed: boolean };
     expect(result.setupBannerDismissed).toBe(true);
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "onboarding",
-      expect.objectContaining({ setupBannerDismissed: true })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("onboarding.setupBannerDismissed", true);
   });
 
   it("dismissSetupBanner is idempotent once dismissed", () => {

--- a/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
@@ -20,12 +20,39 @@ const storeState = vi.hoisted(() => ({
   } as Record<string, unknown>,
 }));
 
-const storeMock = vi.hoisted(() => ({
-  get: vi.fn((key: string) => storeState.data[key]),
-  set: vi.fn((key: string, value: unknown) => {
-    storeState.data[key] = value;
-  }),
-}));
+const storeMock = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getDeep = (key: string): any => {
+    if (!key.includes(".")) return storeState.data[key];
+    const parts = key.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = storeState.data;
+    for (const p of parts) {
+      if (cur == null) return undefined;
+      cur = cur[p];
+    }
+    return cur;
+  };
+  const setDeep = (key: string, value: unknown): void => {
+    if (!key.includes(".")) {
+      storeState.data[key] = value;
+      return;
+    }
+    const parts = key.split(".");
+    const last = parts.pop()!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = storeState.data;
+    for (const p of parts) {
+      if (typeof cur[p] !== "object" || cur[p] === null) cur[p] = {};
+      cur = cur[p];
+    }
+    cur[last] = value;
+  };
+  return {
+    get: vi.fn(getDeep),
+    set: vi.fn(setDeep),
+  };
+});
 
 const osState = vi.hoisted(() => ({ totalmem: 8 * 1024 ** 3 }));
 

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -84,15 +84,19 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
     };
     // Strip retired legacy keys — never persist them back
     const { selected: _s, enabled: _e, ...safeEntry } = merged as Record<string, unknown>;
-    const updatedSettings = {
-      ...currentSettings.root,
-      agents: {
-        ...currentSettings.agents,
-        [safeAgentType]: safeEntry,
-      },
+    const updatedAgents = {
+      ...currentSettings.agents,
+      [safeAgentType]: safeEntry,
     };
-    store.set("agentSettings", updatedSettings);
-    return updatedSettings;
+    // Write the agents record at slice.field level rather than the whole slice,
+    // so other agentSettings root defaults aren't baked into config.json. We can't
+    // address per-agent leaves via dot-path because user-defined agent IDs may
+    // contain dots, which dot-prop would interpret as nested keys.
+    store.set("agentSettings.agents", updatedAgents);
+    return {
+      ...currentSettings.root,
+      agents: updatedAgents,
+    };
   };
   handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET, handleAgentSettingsSet));
 
@@ -102,16 +106,17 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
       const currentSettings = normalizeAgentSettings(
         store.get("agentSettings", DEFAULT_AGENT_SETTINGS)
       );
-      const updatedSettings = {
-        ...currentSettings.root,
-        agents: {
-          ...currentSettings.agents,
-          [safeAgentType]: DEFAULT_AGENT_SETTINGS.agents[safeAgentType] ?? {},
-        },
+      const updatedAgents = {
+        ...currentSettings.agents,
+        [safeAgentType]: DEFAULT_AGENT_SETTINGS.agents[safeAgentType] ?? {},
       };
-      store.set("agentSettings", updatedSettings);
-      return updatedSettings;
+      store.set("agentSettings.agents", updatedAgents);
+      return {
+        ...currentSettings.root,
+        agents: updatedAgents,
+      };
     } else {
+      // Full reset: replace the whole slice with defaults intentionally.
       store.set("agentSettings", DEFAULT_AGENT_SETTINGS);
       return DEFAULT_AGENT_SETTINGS;
     }

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -270,8 +270,6 @@ export function registerAppStateHandlers(): () => void {
       // store schema to keep the `updates` object compatible with persistence types.
       const partialState = incoming as Partial<typeof store.store.appState>;
 
-      const currentState = store.get("appState");
-
       const updates: Partial<typeof store.store.appState> = {};
 
       if ("sidebarWidth" in partialState) {
@@ -470,7 +468,9 @@ export function registerAppStateHandlers(): () => void {
         }
       }
 
-      store.set("appState", { ...currentState, ...updates });
+      for (const [field, value] of Object.entries(updates)) {
+        store.set(`appState.${field}`, value);
+      }
 
       // Note: We intentionally do NOT save per-project terminal state.
       // Terminals stay running in the backend and are discovered on hydration.

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -469,7 +469,15 @@ export function registerAppStateHandlers(): () => void {
       }
 
       for (const [field, value] of Object.entries(updates)) {
-        store.set(`appState.${field}`, value);
+        if (value === undefined) {
+          // electron-store v11 throws on `set(key, undefined)`. Use delete to
+          // clear the field — matches the prior bulk-spread behavior, where
+          // `JSON.stringify` silently omitted undefined values from the slice.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (store.delete as (k: string) => void)(`appState.${field}` as any);
+        } else {
+          store.set(`appState.${field}`, value);
+        }
       }
 
       // Note: We intentionally do NOT save per-project terminal state.

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -40,10 +40,10 @@ function getAppThemeConfig(): AppThemeConfig {
       );
       if (result.migrated) {
         try {
-          store.set("appTheme", {
-            ...cfg,
-            customSchemes: result.schemes.length > 0 ? (result.schemes as AppColorScheme[]) : [],
-          } satisfies AppThemeConfig);
+          store.set(
+            "appTheme.customSchemes",
+            result.schemes.length > 0 ? (result.schemes as AppColorScheme[]) : []
+          );
         } catch {
           // Non-fatal: config parsed but migration write failed
         }
@@ -77,11 +77,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         console.warn("Invalid app theme colorSchemeId:", schemeId);
         return;
       }
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        colorSchemeId: schemeId.trim(),
-      } satisfies AppThemeConfig);
+      store.set("appTheme.colorSchemeId", schemeId.trim());
     })
   );
 
@@ -92,11 +88,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         console.warn("Invalid app custom schemes:", result.error.message);
         return;
       }
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        customSchemes: result.data as AppColorScheme[],
-      } satisfies AppThemeConfig);
+      store.set("appTheme.customSchemes", result.data as AppColorScheme[]);
     })
   );
 
@@ -107,11 +99,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         console.warn("Invalid color vision mode:", mode);
         return;
       }
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        colorVisionMode: mode,
-      } satisfies AppThemeConfig);
+      store.set("appTheme.colorVisionMode", mode);
     })
   );
 
@@ -179,30 +167,21 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
   handlers.push(
     typedHandle(CHANNELS.APP_THEME_SET_FOLLOW_SYSTEM, async (enabled: boolean) => {
       if (typeof enabled !== "boolean") return;
-      const current = getAppThemeConfig();
-      store.set("appTheme", { ...current, followSystem: enabled } satisfies AppThemeConfig);
+      store.set("appTheme.followSystem", enabled);
     })
   );
 
   handlers.push(
     typedHandle(CHANNELS.APP_THEME_SET_PREFERRED_DARK_SCHEME, async (schemeId: string) => {
       if (typeof schemeId !== "string" || !schemeId.trim()) return;
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        preferredDarkSchemeId: schemeId.trim(),
-      } satisfies AppThemeConfig);
+      store.set("appTheme.preferredDarkSchemeId", schemeId.trim());
     })
   );
 
   handlers.push(
     typedHandle(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME, async (schemeId: string) => {
       if (typeof schemeId !== "string" || !schemeId.trim()) return;
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        preferredLightSchemeId: schemeId.trim(),
-      } satisfies AppThemeConfig);
+      store.set("appTheme.preferredLightSchemeId", schemeId.trim());
     })
   );
 
@@ -216,11 +195,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
         .map((id) => id.trim());
       const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        recentSchemeIds: sanitized,
-      } satisfies AppThemeConfig);
+      store.set("appTheme.recentSchemeIds", sanitized);
     })
   );
 
@@ -234,11 +209,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
           return;
         }
       }
-      const current = getAppThemeConfig();
-      store.set("appTheme", {
-        ...current,
-        accentColorOverride: normalized,
-      } satisfies AppThemeConfig);
+      store.set("appTheme.accentColorOverride", normalized);
     })
   );
 
@@ -258,7 +229,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         ? (config.preferredDarkSchemeId ?? DEFAULT_DARK_SCHEME)
         : (config.preferredLightSchemeId ?? DEFAULT_LIGHT_SCHEME);
 
-      store.set("appTheme", { ...config, colorSchemeId: schemeId } satisfies AppThemeConfig);
+      store.set("appTheme.colorSchemeId", schemeId);
 
       const win = mainWindow ?? BrowserWindow.getAllWindows()[0];
       if (!win || win.isDestroyed()) return;

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -121,8 +121,9 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
       allowed.quietHoursWeekdays = Array.from(new Set(days));
     }
 
-    const current = store.get("notificationSettings");
-    store.set("notificationSettings", { ...current, ...allowed });
+    for (const [field, value] of Object.entries(allowed)) {
+      store.set(`notificationSettings.${field}`, value);
+    }
   };
 
   const handlePlaySound = async (soundFile: unknown): Promise<void> => {

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -96,63 +96,46 @@ export function registerOnboardingHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_SET_STEP, (arg: unknown) => {
-      const state = getOnboardingState();
       if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
         const payload = arg as { step?: unknown; agentSetupIds?: unknown };
         const step = typeof payload.step === "string" ? payload.step : null;
-        const agentSetupIds = Array.isArray(payload.agentSetupIds)
-          ? (payload.agentSetupIds as string[]).filter((id) => typeof id === "string")
-          : state.agentSetupIds;
-        store.set("onboarding", { ...state, currentStep: step, agentSetupIds });
+        store.set("onboarding.currentStep", step);
+        if (Array.isArray(payload.agentSetupIds)) {
+          const agentSetupIds = (payload.agentSetupIds as unknown[]).filter(
+            (id): id is string => typeof id === "string"
+          );
+          store.set("onboarding.agentSetupIds", agentSetupIds);
+        }
       } else {
-        store.set("onboarding", {
-          ...state,
-          currentStep: typeof arg === "string" ? arg : null,
-        });
+        store.set("onboarding.currentStep", typeof arg === "string" ? arg : null);
       }
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_COMPLETE, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        completed: true,
-        currentStep: null,
-        agentSetupIds: [],
-      });
+      store.set("onboarding.completed", true);
+      store.set("onboarding.currentStep", null);
+      store.set("onboarding.agentSetupIds", []);
       setOnboardingCompleteTag(true);
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_MARK_TOAST_SEEN, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        firstRunToastSeen: true,
-      });
+      store.set("onboarding.firstRunToastSeen", true);
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_MARK_NEWSLETTER_SEEN, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        newsletterPromptSeen: true,
-      });
+      store.set("onboarding.newsletterPromptSeen", true);
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        waitingNudgeSeen: true,
-      });
+      store.set("onboarding.waitingNudgeSeen", true);
     })
   );
 
@@ -172,27 +155,23 @@ export function registerOnboardingHandlers(): () => void {
         }
       }
       if (!changed) return state;
-      const updated: OnboardingState = { ...state, seenAgentIds: Array.from(existing) };
-      store.set("onboarding", updated);
-      return updated;
+      const seenAgentIds = Array.from(existing);
+      store.set("onboarding.seenAgentIds", seenAgentIds);
+      return { ...state, seenAgentIds };
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD, () => {
-      const state = getOnboardingState();
-      const updated: OnboardingState = { ...state, welcomeCardDismissed: true };
-      store.set("onboarding", updated);
-      return updated;
+      store.set("onboarding.welcomeCardDismissed", true);
+      return { ...getOnboardingState(), welcomeCardDismissed: true };
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER, () => {
-      const state = getOnboardingState();
-      const updated: OnboardingState = { ...state, setupBannerDismissed: true };
-      store.set("onboarding", updated);
-      return updated;
+      store.set("onboarding.setupBannerDismissed", true);
+      return { ...getOnboardingState(), setupBannerDismissed: true };
     })
   );
 
@@ -200,21 +179,13 @@ export function registerOnboardingHandlers(): () => void {
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_CHECKLIST_DISMISS, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        checklist: { ...state.checklist, dismissed: true },
-      });
+      store.set("onboarding.checklist.dismissed", true);
     })
   );
 
   cleanups.push(
     typedHandle(CHANNELS.ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN, () => {
-      const state = getOnboardingState();
-      store.set("onboarding", {
-        ...state,
-        checklist: { ...state.checklist, celebrationShown: true },
-      });
+      store.set("onboarding.checklist.celebrationShown", true);
     })
   );
 
@@ -230,13 +201,7 @@ export function registerOnboardingHandlers(): () => void {
       const state = getOnboardingState();
       const key = item as keyof typeof state.checklist.items;
       if (state.checklist.items[key]) return;
-      store.set("onboarding", {
-        ...state,
-        checklist: {
-          ...state.checklist,
-          items: { ...state.checklist.items, [key]: true },
-        },
-      });
+      store.set(`onboarding.checklist.items.${key}`, true);
     })
   );
 

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -41,12 +41,7 @@ export function registerPrivacyHandlers(): () => void {
         !VALID_RETENTION.includes(days as (typeof VALID_RETENTION)[number])
       )
         return;
-      const privacy = store.get("privacy") ?? {
-        telemetryLevel: "off" as const,
-        hasSeenPrompt: false,
-        logRetentionDays: 30 as const,
-      };
-      store.set("privacy", { ...privacy, logRetentionDays: days as 7 | 30 | 90 | 0 });
+      store.set("privacy.logRetentionDays", days as 7 | 30 | 90 | 0);
     })
   );
 

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -35,10 +35,10 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
         );
         if (result.migrated) {
           try {
-            store.set("terminalConfig", {
-              ...config,
-              customSchemes: result.schemes.length > 0 ? result.schemes : [],
-            });
+            store.set(
+              "terminalConfig.customSchemes",
+              result.schemes.length > 0 ? result.schemes : []
+            );
           } catch {
             // Non-fatal: config parsed but migration write failed
           }
@@ -72,8 +72,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn(error);
       throw new Error(error);
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, scrollbackLines });
+    store.set("terminalConfig.scrollbackLines", scrollbackLines);
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK, handleTerminalConfigSetScrollback)
@@ -84,8 +83,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal performanceMode:", performanceMode);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, performanceMode });
+    store.set("terminalConfig.performanceMode", performanceMode);
   };
   handlers.push(
     typedHandle(
@@ -103,8 +101,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal fontSize (out of range 8-24):", fontSize);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, fontSize });
+    store.set("terminalConfig.fontSize", fontSize);
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_FONT_SIZE, handleTerminalConfigSetFontSize)
@@ -115,9 +112,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal fontFamily:", fontFamily);
       return;
     }
-    const trimmedFontFamily = fontFamily.trim();
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, fontFamily: trimmedFontFamily });
+    store.set("terminalConfig.fontFamily", fontFamily.trim());
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_FONT_FAMILY, handleTerminalConfigSetFontFamily)
@@ -128,8 +123,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal hybridInputEnabled:", enabled);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, hybridInputEnabled: enabled });
+    store.set("terminalConfig.hybridInputEnabled", enabled);
   };
   handlers.push(
     typedHandle(
@@ -143,8 +137,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal hybridInputAutoFocus:", enabled);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, hybridInputAutoFocus: enabled });
+    store.set("terminalConfig.hybridInputAutoFocus", enabled);
   };
   handlers.push(
     typedHandle(
@@ -158,8 +151,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal colorScheme:", schemeId);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, colorSchemeId: schemeId.trim() });
+    store.set("terminalConfig.colorSchemeId", schemeId.trim());
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME, handleTerminalConfigSetColorScheme)
@@ -171,8 +163,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal custom schemes:", result.error.message);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, customSchemes: result.data });
+    store.set("terminalConfig.customSchemes", result.data);
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, handleTerminalConfigSetCustomSchemes)
@@ -187,8 +178,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
       .map((id) => id.trim());
     const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, recentSchemeIds: sanitized });
+    store.set("terminalConfig.recentSchemeIds", sanitized);
   };
   handlers.push(
     typedHandle(
@@ -202,8 +192,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid screen reader mode:", mode);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, screenReaderMode: mode });
+    store.set("terminalConfig.screenReaderMode", mode);
   };
   handlers.push(
     typedHandle(
@@ -217,8 +206,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal resourceMonitoringEnabled:", enabled);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, resourceMonitoringEnabled: enabled });
+    store.set("terminalConfig.resourceMonitoringEnabled", enabled);
     deps?.ptyClient?.setResourceMonitoring(enabled);
   };
   handlers.push(
@@ -233,8 +221,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal memoryLeakDetectionEnabled:", enabled);
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, memoryLeakDetectionEnabled: enabled });
+    store.set("terminalConfig.memoryLeakDetectionEnabled", enabled);
   };
   handlers.push(
     typedHandle(
@@ -255,11 +242,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       );
       return;
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", {
-      ...currentConfig,
-      memoryLeakAutoRestartThresholdMb: thresholdMb,
-    });
+    store.set("terminalConfig.memoryLeakAutoRestartThresholdMb", thresholdMb);
   };
   handlers.push(
     typedHandle(
@@ -279,8 +262,7 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn(error);
       throw new Error(error);
     }
-    const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, cachedProjectViews });
+    store.set("terminalConfig.cachedProjectViews", cachedProjectViews);
     deps?.projectViewManager?.setCachedViewLimit(cachedProjectViews);
   };
   handlers.push(

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -443,8 +443,11 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   const handleSetSettings = async (patch: Partial<VoiceInputSettings>) => {
-    const current = getVoiceSettings();
-    store.set("voiceInput", { ...current, ...patch });
+    if (!patch || typeof patch !== "object") return;
+    for (const [field, value] of Object.entries(patch)) {
+      if (value === undefined) continue;
+      store.set(`voiceInput.${field}`, value);
+    }
   };
 
   const handleStart = async (ctx: IpcContext) => {

--- a/electron/services/AppAgentService.ts
+++ b/electron/services/AppAgentService.ts
@@ -12,8 +12,11 @@ export class AppAgentService {
   }
 
   setConfig(config: Partial<AppAgentConfig>): void {
-    const currentConfig = store.get("appAgentConfig");
-    store.set("appAgentConfig", { ...currentConfig, ...config });
+    if (!config || typeof config !== "object") return;
+    for (const [field, value] of Object.entries(config)) {
+      if (value === undefined) continue;
+      store.set(`appAgentConfig.${field}`, value);
+    }
   }
 
   hasApiKey(): boolean {

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -223,12 +223,6 @@ export async function initializeTelemetry(): Promise<void> {
 
 export type TelemetryLevel = "off" | "errors" | "full";
 
-const DEFAULT_PRIVACY = {
-  telemetryLevel: "off" as const,
-  hasSeenPrompt: false,
-  logRetentionDays: 30 as const,
-};
-
 export function getTelemetryLevel(): TelemetryLevel {
   return store.get("privacy")?.telemetryLevel ?? "off";
 }
@@ -238,8 +232,7 @@ export function isTelemetryEnabled(): boolean {
 }
 
 export async function setTelemetryLevel(level: TelemetryLevel): Promise<void> {
-  const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
-  store.set("privacy", { ...privacy, telemetryLevel: level });
+  store.set("privacy.telemetryLevel", level);
 
   if (level === "full") {
     await initializeTelemetry();
@@ -410,8 +403,7 @@ export function setOnboardingCompleteTag(completed: boolean): void {
 }
 
 export function markTelemetryPromptShown(): void {
-  const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
-  store.set("privacy", { ...privacy, hasSeenPrompt: true });
+  store.set("privacy.hasSeenPrompt", true);
 }
 
 export function _getPreConsentBufferLength(): number {

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -11,12 +11,44 @@ const storeMock = vi.hoisted(() => {
   const data: Record<string, unknown> = {
     privacy: { telemetryLevel: "off", hasSeenPrompt: false, logRetentionDays: 30 },
   };
-  return {
-    get: vi.fn((key: string) => data[key]),
-    set: vi.fn((key: string, value: unknown) => {
+  // Mirror conf's dot-notation semantics so production code that does
+  // `store.set("privacy.telemetryLevel", level)` updates the nested object
+  // rather than a flat key — otherwise reads via `store.get("privacy")` see
+  // stale state and code paths gated on the new value (e.g. mid-session
+  // telemetry init) skip themselves in tests.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getDeep = (key: string): any => {
+    if (!key.includes(".")) return data[key];
+    const parts = key.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = data;
+    for (const p of parts) {
+      if (cur == null) return undefined;
+      cur = cur[p];
+    }
+    return cur;
+  };
+  const setDeep = (key: string, value: unknown): void => {
+    if (!key.includes(".")) {
       data[key] = value;
-    }),
+      return;
+    }
+    const parts = key.split(".");
+    const last = parts.pop()!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let cur: any = data;
+    for (const p of parts) {
+      if (typeof cur[p] !== "object" || cur[p] === null) cur[p] = {};
+      cur = cur[p];
+    }
+    cur[last] = value;
+  };
+  return {
+    get: vi.fn(getDeep),
+    set: vi.fn(setDeep),
     _data: data,
+    _getDeep: getDeep,
+    _setDeep: setDeep,
   };
 });
 
@@ -60,7 +92,11 @@ function setPrivacy(patch: {
     ...(storeMock._data.privacy as Record<string, unknown>),
     ...patch,
   };
-  storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+  // Restore the deep impls — tests that override `get` via `mockReturnValue`
+  // would otherwise leak across test boundaries (vi.clearAllMocks doesn't
+  // reset implementations).
+  storeMock.get.mockImplementation(storeMock._getDeep);
+  storeMock.set.mockImplementation(storeMock._setDeep);
 }
 
 describe("sanitizePath", () => {
@@ -397,22 +433,20 @@ describe("setTelemetryLevel", () => {
 
   it("writes telemetryLevel to privacy without touching any legacy telemetry key", async () => {
     await setTelemetryLevel("errors");
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ telemetryLevel: "errors" })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.telemetryLevel", "errors");
     for (const call of storeMock.set.mock.calls) {
       expect(call[0]).not.toBe("telemetry");
+      expect(call[0]).not.toMatch(/^telemetry($|\.)/);
     }
   });
 
   it("preserves hasSeenPrompt when writing telemetryLevel", async () => {
     setPrivacy({ telemetryLevel: "off", hasSeenPrompt: true });
     await setTelemetryLevel("full");
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.telemetryLevel", "full");
+    // Dot-path writes don't touch sibling fields — hasSeenPrompt stays true.
+    expect((storeMock._data.privacy as { hasSeenPrompt: boolean }).hasSeenPrompt).toBe(true);
+    expect((storeMock._data.privacy as { telemetryLevel: string }).telemetryLevel).toBe("full");
   });
 });
 
@@ -500,19 +534,13 @@ describe("setTelemetryEnabled (compat shim)", () => {
 
   it("maps true to 'errors'", async () => {
     await setTelemetryEnabled(true);
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ telemetryLevel: "errors" })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.telemetryLevel", "errors");
   });
 
   it("maps false to 'off'", async () => {
     setPrivacy({ telemetryLevel: "errors" });
     await setTelemetryEnabled(false);
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ telemetryLevel: "off" })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.telemetryLevel", "off");
   });
 });
 
@@ -545,22 +573,20 @@ describe("markTelemetryPromptShown", () => {
 
   it("writes hasSeenPrompt=true on the privacy object (not telemetry)", () => {
     markTelemetryPromptShown();
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ hasSeenPrompt: true })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.hasSeenPrompt", true);
     for (const call of storeMock.set.mock.calls) {
       expect(call[0]).not.toBe("telemetry");
+      expect(call[0]).not.toMatch(/^telemetry($|\.)/);
     }
   });
 
   it("preserves telemetryLevel and other privacy fields", () => {
     setPrivacy({ telemetryLevel: "full", hasSeenPrompt: false });
     markTelemetryPromptShown();
-    expect(storeMock.set).toHaveBeenCalledWith(
-      "privacy",
-      expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
-    );
+    expect(storeMock.set).toHaveBeenCalledWith("privacy.hasSeenPrompt", true);
+    // Dot-path write must not touch sibling fields.
+    expect((storeMock._data.privacy as { telemetryLevel: string }).telemetryLevel).toBe("full");
+    expect((storeMock._data.privacy as { hasSeenPrompt: boolean }).hasSeenPrompt).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Bulk `store.set("slice", {...store.get("slice"), field})` calls were re-writing the entire slice on every update, baking in whatever electron-store had initialised as defaults at first launch. Any future default changes would be silently ignored for existing users.
- Replaced with surgical dot-path writes (`store.set("slice.field", value)`) across 10 main-process files: `terminalConfig`, `appTheme`, `privacy`, `notifications`, `voiceInput`, `ai`, `onboarding`, `app/state`, `AppAgentService`, and `TelemetryService`.
- `agentSettings.agents` is written at the record level (per-agent dot-path writes are unsafe because agent IDs can contain dots that dot-prop parses as nested paths). Full-slice `agentSettings` reset is retained as-is.

Resolves #6046

## Changes

- `electron/ipc/handlers/` -- dot-path writes in all 8 handler files; `handleAppSetState` now calls `store.delete` for `undefined` values (electron-store v11 throws on `set(path, undefined)`)
- `electron/services/AppAgentService.ts` + `TelemetryService.ts` -- same dot-path treatment
- `electron/__tests__/storeDotPathPersistence.test.ts` -- new test file (9 tests) covering the surgical-write contract: verifies that updating one field does not overwrite sibling fields or bake in defaults
- 5 existing handler test files updated with dot-path-aware mocks

## Testing

14,294 tests pass. Typecheck, lint, format, and channel-check all clean.