### PR TITLE
fix(browser): improve error handling and slow-load UX for Browser and DevPreview panels

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -3,8 +3,9 @@ import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
-import { AlertTriangle, ExternalLink } from "lucide-react";
+import { AlertTriangle, ExternalLink, RotateCw, Square } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
 import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
@@ -147,6 +148,8 @@ export function BrowserPane({
   // Track if webview has been mounted and is ready
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isSlowLoad, setIsSlowLoad] = useState(false);
+  const slowLoadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const hasBeenVisible = useHasBeenVisible(id, location);
 
@@ -272,25 +275,52 @@ export function BrowserPane({
       return;
     }
 
-    const handleDomReady = () => {
-      isInitialRestoredLoadRef.current = false;
-      setIsWebviewReady(true);
+    const clearAllTimers = () => {
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
     };
 
+    const handleDomReady = () => {
+      isInitialRestoredLoadRef.current = false;
+      setIsWebviewReady(true);
+      clearAllTimers();
+    };
+
     const handleDidStartLoading = () => {
       setIsLoading(true);
       setLoadError(null);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
-      loadTimeoutRef.current = setTimeout(() => {
+      slowLoadTimeoutRef.current = setTimeout(() => {
         try {
           if (webview.isLoading()) {
-            webview.reload();
+            setIsSlowLoad(true);
+          }
+        } catch {
+          // Webview detached before timeout fired
+        }
+      }, 5000);
+      loadTimeoutRef.current = setTimeout(() => {
+        loadTimeoutRef.current = null;
+        try {
+          if (webview.isLoading()) {
+            webview.stop();
+            setIsSlowLoad(false);
+            setIsLoading(false);
+            setLoadError(
+              `Load timed out after ${Math.round(loadTimeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
+            );
           }
         } catch {
           // Webview detached before timeout fired
@@ -300,6 +330,11 @@ export function BrowserPane({
 
     const handleDidStopLoading = () => {
       setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -307,6 +342,11 @@ export function BrowserPane({
     };
 
     const handleDidFailLoad = (event: Electron.DidFailLoadEvent) => {
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -317,6 +357,9 @@ export function BrowserPane({
       if (event.errorCode === -6) return;
       setIsLoading(false);
       const ERR_CONNECTION_REFUSED = -102;
+      const ERR_NAME_NOT_RESOLVED = -105;
+      const ERR_INTERNET_DISCONNECTED = -106;
+      const ERR_CONNECTION_TIMED_OUT = -118;
       if (
         event.isMainFrame &&
         event.errorCode === ERR_CONNECTION_REFUSED &&
@@ -325,8 +368,27 @@ export function BrowserPane({
         setLoadError(
           "The saved URL is no longer reachable. The server may have moved to a different port."
         );
+      } else if (event.errorCode === ERR_NAME_NOT_RESOLVED && event.validatedURL) {
+        let hostname = event.validatedURL;
+        try {
+          hostname = new URL(event.validatedURL).hostname;
+        } catch {
+          // Use raw validatedURL if parsing fails
+        }
+        setLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
+      } else if (event.errorCode === ERR_INTERNET_DISCONNECTED) {
+        setLoadError("No internet connection. Check your network.");
+      } else if (event.errorCode === ERR_CONNECTION_TIMED_OUT && event.validatedURL) {
+        setLoadError(
+          `Connection to ${event.validatedURL} timed out. The server may be unreachable.`
+        );
       } else {
-        setLoadError(event.errorDescription || "Failed to load page. The site may be unavailable.");
+        const urlContext = event.validatedURL ? ` at ${event.validatedURL}` : "";
+        setLoadError(
+          event.errorDescription
+            ? `${event.errorDescription}${urlContext}`
+            : `Failed to load page${urlContext}. The site may be unavailable.`
+        );
       }
     };
 
@@ -561,11 +623,35 @@ export function BrowserPane({
     setBlockedNav(null);
     setIsLoading(true);
     setLoadError(null);
-    const webview = webviewRef.current;
-    if (webview && isWebviewReady) {
-      webview.reload();
+    setIsSlowLoad(false);
+    webviewRef.current?.reload();
+  }, []);
+
+  const handleCancelLoad = useCallback(() => {
+    if (slowLoadTimeoutRef.current) {
+      clearTimeout(slowLoadTimeoutRef.current);
+      slowLoadTimeoutRef.current = null;
     }
-  }, [isWebviewReady]);
+    if (loadTimeoutRef.current) {
+      clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
+    setIsSlowLoad(false);
+    setIsLoading(false);
+    try {
+      webviewRef.current?.stop();
+    } catch {
+      // Webview detached
+    }
+    setLoadError("Load cancelled.");
+  }, []);
+
+  const handleRetryFromError = useCallback(() => {
+    setLoadError(null);
+    setIsSlowLoad(false);
+    setIsLoading(true);
+    webviewRef.current?.reload();
+  }, []);
 
   const handleHardReload = useCallback(() => {
     setBlockedNav(null);
@@ -626,6 +712,9 @@ export function BrowserPane({
     return () => {
       if (blockedNavTimerRef.current) {
         clearTimeout(blockedNavTimerRef.current);
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
       }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
@@ -946,30 +1035,48 @@ export function BrowserPane({
               Browser will load when this panel is first viewed
             </p>
           </div>
-        ) : loadError ? (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-            <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-            <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-              Unable to Display Page
-            </h3>
-            <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">{loadError}</p>
-            <button
-              type="button"
-              onClick={handleOpenExternal}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md hover:bg-overlay-soft transition-colors group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent/50"
-            >
-              <ExternalLink className="h-3.5 w-3.5 text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors" />
-              <span className="text-xs text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors">
-                Open in External Browser
-              </span>
-            </button>
-          </div>
         ) : isEvicted ? (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
             <p className="text-xs text-daintree-text/50">Reclaimed for memory</p>
           </div>
         ) : (
           <>
+            {loadError && (
+              <div className="absolute inset-0 z-30 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+                <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+                <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                  {loadError.startsWith("Load timed out")
+                    ? "Page Load Timed Out"
+                    : loadError.startsWith("Load cancelled")
+                      ? "Load Cancelled"
+                      : "Unable to Display Page"}
+                </h3>
+                <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
+                  {loadError}
+                </p>
+                <div className="flex items-center gap-1">
+                  <Button
+                    onClick={handleRetryFromError}
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                  >
+                    <RotateCw className="h-3.5 w-3.5" />
+                    <span className="text-xs">Retry</span>
+                  </Button>
+                  <button
+                    type="button"
+                    onClick={handleOpenExternal}
+                    className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md hover:bg-overlay-soft transition-colors group focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-daintree-accent/50"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5 text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors" />
+                    <span className="text-xs text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors">
+                      Open in External Browser
+                    </span>
+                  </button>
+                </div>
+              </div>
+            )}
             {blockedNav && (
               <div className="flex items-center gap-2 px-3 py-1.5 text-xs bg-status-warning/10 border-b border-status-warning/20 text-daintree-text/80">
                 <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
@@ -1012,8 +1119,22 @@ export function BrowserPane({
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
               {isLoading && (
-                <div className="absolute inset-0 flex items-center justify-center bg-daintree-bg z-10">
+                <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3">
                   <Spinner size="2xl" className="text-status-info" />
+                  {isSlowLoad && (
+                    <>
+                      <p className="text-xs text-daintree-text/50">Taking longer than usual...</p>
+                      <Button
+                        onClick={handleCancelLoad}
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                      >
+                        <Square className="h-3.5 w-3.5" />
+                        <span className="text-xs">Cancel</span>
+                      </Button>
+                    </>
+                  )}
                 </div>
               )}
               {findInPage.isOpen && <FindBar find={findInPage} />}

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -368,7 +368,11 @@ export function BrowserPane({
         setLoadError(
           "The saved URL is no longer reachable. The server may have moved to a different port."
         );
-      } else if (event.errorCode === ERR_NAME_NOT_RESOLVED && event.validatedURL) {
+      } else if (
+        event.isMainFrame &&
+        event.errorCode === ERR_NAME_NOT_RESOLVED &&
+        event.validatedURL
+      ) {
         let hostname = event.validatedURL;
         try {
           hostname = new URL(event.validatedURL).hostname;
@@ -376,13 +380,17 @@ export function BrowserPane({
           // Use raw validatedURL if parsing fails
         }
         setLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
-      } else if (event.errorCode === ERR_INTERNET_DISCONNECTED) {
+      } else if (event.isMainFrame && event.errorCode === ERR_INTERNET_DISCONNECTED) {
         setLoadError("No internet connection. Check your network.");
-      } else if (event.errorCode === ERR_CONNECTION_TIMED_OUT && event.validatedURL) {
+      } else if (
+        event.isMainFrame &&
+        event.errorCode === ERR_CONNECTION_TIMED_OUT &&
+        event.validatedURL
+      ) {
         setLoadError(
           `Connection to ${event.validatedURL} timed out. The server may be unreachable.`
         );
-      } else {
+      } else if (event.isMainFrame) {
         const urlContext = event.validatedURL ? ` at ${event.validatedURL}` : "";
         setLoadError(
           event.errorDescription
@@ -504,6 +512,14 @@ export function BrowserPane({
       if (faviconDebounceTimer) {
         clearTimeout(faviconDebounceTimer);
         faviconDebounceTimer = null;
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
       }
     };
   }, [
@@ -650,8 +666,12 @@ export function BrowserPane({
     setLoadError(null);
     setIsSlowLoad(false);
     setIsLoading(true);
-    webviewRef.current?.reload();
-  }, []);
+    if (currentUrl) {
+      webviewRef.current?.loadURL(currentUrl);
+    } else {
+      webviewRef.current?.reload();
+    }
+  }, [currentUrl]);
 
   const handleHardReload = useCallback(() => {
     setBlockedNav(null);

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -7,6 +7,7 @@ import { BrowserPane } from "../BrowserPane";
 type MockWebviewElement = HTMLElement & {
   reload: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
   setZoomFactor: ReturnType<typeof vi.fn>;
   getURL: ReturnType<typeof vi.fn>;
   isLoading: ReturnType<typeof vi.fn>;
@@ -28,6 +29,7 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   };
 
   webview.reload = vi.fn();
+  webview.stop = vi.fn();
   webview.loadURL = vi.fn((url: string) => {
     currentUrl = url;
     element.setAttribute("src", url);
@@ -260,7 +262,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     expect(webview.setZoomFactor).toHaveBeenCalledWith(1.35);
   });
 
-  it("reloads webview after 30s when loading is stuck", () => {
+  it("stops webview and shows timeout error after 30s when loading is stuck", () => {
     const { container } = render(<BrowserPane {...baseProps} />);
     const webview = getWebviewElement(container);
 
@@ -273,7 +275,9 @@ describe("BrowserPane webview lifecycle regression", () => {
       vi.advanceTimersByTime(30000);
     });
 
-    expect(webview.reload).toHaveBeenCalledTimes(1);
+    expect(webview.stop).toHaveBeenCalledTimes(1);
+    expect(webview.reload).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Page Load Timed Out");
   });
 
   it("clears stuck-load timeout on did-stop-loading", () => {
@@ -292,6 +296,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
   });
 
   it("clears stuck-load timeout on did-fail-load", () => {
@@ -304,6 +309,8 @@ describe("BrowserPane webview lifecycle regression", () => {
       emitWebviewEvent(webview, "did-fail-load", {
         errorCode: -105,
         errorDescription: "Name not resolved",
+        isMainFrame: true,
+        validatedURL: "http://badsite.test/",
       });
     });
 
@@ -312,6 +319,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
   });
 
   it("cleans pending timeout on unmount", () => {
@@ -330,6 +338,7 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
   });
 
   it("renders drag protection overlay and hides webview when isDragging is true", () => {
@@ -639,6 +648,215 @@ describe("BrowserPane webview lifecycle regression", () => {
       // Should show generic error since the user actively navigated
       expect(container.textContent).not.toContain("The saved URL is no longer reachable");
       expect(container.textContent).toContain("ERR_CONNECTION_REFUSED");
+    });
+  });
+
+  describe("slow-load and timeout escalation", () => {
+    it("shows slow-load message and Cancel after 5s of loading", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      // Before 5s, only spinner (no slow-load text)
+      expect(container.textContent).not.toContain("Taking longer than usual");
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).toContain("Taking longer than usual");
+      expect(container.textContent).toContain("Cancel");
+    });
+
+    it("Cancel stops the webview and shows cancelled error", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      const cancelButton = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Cancel")
+      );
+      expect(cancelButton).toBeDefined();
+
+      act(() => {
+        cancelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Load cancelled");
+      expect(container.textContent).toContain("Retry");
+    });
+
+    it("timeout calls webview.stop() instead of reload", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(webview.reload).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("Page Load Timed Out");
+    });
+
+    it("timeout error overlay shows Retry and Open External buttons", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(container.textContent).toContain("Retry");
+      expect(container.textContent).toContain("Open in External Browser");
+    });
+
+    it("Retry from timeout clears error and reloads", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      webview.stop.mockClear();
+
+      const retryButton = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Retry")
+      );
+      expect(retryButton).toBeDefined();
+
+      act(() => {
+        retryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears slow timer on did-stop-loading", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        webview.setMockLoading(false);
+        emitWebviewEvent(webview, "did-stop-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).not.toContain("Taking longer than usual");
+    });
+
+    it("clears slow timer on did-fail-load", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "Name not resolved",
+          isMainFrame: true,
+          validatedURL: "http://badsite.test/",
+        });
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).not.toContain("Taking longer than usual");
+    });
+
+    it("shows DNS failure message with hostname for -105", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "ERR_NAME_NOT_RESOLVED",
+          isMainFrame: true,
+          validatedURL: "http://nonexistent.example.com/page",
+        });
+      });
+
+      expect(container.textContent).toContain("Couldn't resolve");
+      expect(container.textContent).toContain("nonexistent.example.com");
+    });
+
+    it("shows no-internet message for -106", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -106,
+          errorDescription: "ERR_INTERNET_DISCONNECTED",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/",
+        });
+      });
+
+      expect(container.textContent).toContain("No internet connection");
+    });
+
+    it("cleans slow timer on unmount", () => {
+      const { container, unmount } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      // No error — timer was cleaned up
+      expect(container.textContent).not.toContain("Taking longer than usual");
     });
   });
 });

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -734,7 +734,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("Open in External Browser");
     });
 
-    it("Retry from timeout clears error and reloads", () => {
+    it("Retry from timeout clears error and loads current URL", () => {
       const { container } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -758,7 +758,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         retryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
 
-      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:5173/");
     });
 
     it("clears slow timer on did-stop-loading", () => {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,5 +1,12 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import { AlertTriangle, RotateCw, ExternalLink, Settings, WandSparkles } from "lucide-react";
+import {
+  AlertTriangle,
+  RotateCw,
+  ExternalLink,
+  Settings,
+  Square,
+  WandSparkles,
+} from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { usePanelStore } from "@/store";
@@ -245,6 +252,8 @@ export function DevPreviewPane({
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const [consoleTerminalId, setConsoleTerminalId] = useState<string | null>(terminalId);
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const slowLoadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isSlowLoad, setIsSlowLoad] = useState(false);
   const failLoadRetryRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryCountRef = useRef<number>(0);
   // Generation token to invalidate in-flight async scroll captures when the
@@ -401,6 +410,34 @@ export function DevPreviewPane({
   }, [canGoForward]);
 
   const handleReload = useCallback(() => {
+    setWebviewLoadError(null);
+    setIsSlowLoad(false);
+    webviewRef.current?.reload();
+  }, []);
+
+  const handleCancelLoad = useCallback(() => {
+    if (slowLoadTimeoutRef.current) {
+      clearTimeout(slowLoadTimeoutRef.current);
+      slowLoadTimeoutRef.current = null;
+    }
+    if (loadTimeoutRef.current) {
+      clearTimeout(loadTimeoutRef.current);
+      loadTimeoutRef.current = null;
+    }
+    setIsSlowLoad(false);
+    setIsLoading(false);
+    try {
+      webviewRef.current?.stop();
+    } catch {
+      // Webview detached
+    }
+    setWebviewLoadError("Load cancelled.");
+  }, []);
+
+  const handleRetryWebviewLoad = useCallback(() => {
+    setWebviewLoadError(null);
+    setIsSlowLoad(false);
+    setIsLoading(true);
     webviewRef.current?.reload();
   }, []);
 
@@ -441,6 +478,10 @@ export function DevPreviewPane({
     // stale data back over the cleared position.
     scrollCaptureGenerationRef.current += 1;
     setDevPreviewScrollPosition(id, undefined);
+    if (slowLoadTimeoutRef.current) {
+      clearTimeout(slowLoadTimeoutRef.current);
+      slowLoadTimeoutRef.current = null;
+    }
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);
       loadTimeoutRef.current = null;
@@ -449,6 +490,7 @@ export function DevPreviewPane({
     setBrowserUrl(id, "");
     lastSetUrlRef.current = "";
     setIsLoading(false);
+    setIsSlowLoad(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
     void restart();
@@ -509,13 +551,33 @@ export function DevPreviewPane({
 
     const handleDidStartLoading = () => {
       setIsLoading(true);
+      setWebviewLoadError(null);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
-      loadTimeoutRef.current = setTimeout(() => {
+      slowLoadTimeoutRef.current = setTimeout(() => {
         try {
           if (webview.isLoading()) {
-            webview.reload();
+            setIsSlowLoad(true);
+          }
+        } catch {
+          // Webview detached before timeout fired
+        }
+      }, 5000);
+      loadTimeoutRef.current = setTimeout(() => {
+        loadTimeoutRef.current = null;
+        try {
+          if (webview.isLoading()) {
+            webview.stop();
+            setIsSlowLoad(false);
+            setIsLoading(false);
+            setWebviewLoadError(
+              `Load timed out after ${Math.round(loadTimeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
+            );
           }
         } catch {
           // Webview detached before timeout fired
@@ -525,6 +587,11 @@ export function DevPreviewPane({
 
     const handleDidStopLoading = () => {
       setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -534,6 +601,11 @@ export function DevPreviewPane({
     const handleDidFinishLoad = () => {
       setIsLoading(false);
       setWebviewLoadError(null);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -547,15 +619,46 @@ export function DevPreviewPane({
 
     const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
       setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
 
-      // Retry on connection-refused errors: the readiness check may have passed
-      // a moment before the server was fully reachable from the webview.
       const ERR_CONNECTION_REFUSED = -102;
       const ERR_CONNECTION_RESET = -101;
+      const ERR_NAME_NOT_RESOLVED = -105;
+      const ERR_INTERNET_DISCONNECTED = -106;
+      const ERR_CONNECTION_TIMED_OUT = -118;
+
+      // Non-retryable errors: surface directly with friendly messages
+      if (e.isMainFrame && e.errorCode === ERR_NAME_NOT_RESOLVED && e.validatedURL) {
+        let hostname = e.validatedURL;
+        try {
+          hostname = new URL(e.validatedURL).hostname;
+        } catch {
+          // Use raw validatedURL if parsing fails
+        }
+        setWebviewLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
+        return;
+      }
+      if (e.isMainFrame && e.errorCode === ERR_INTERNET_DISCONNECTED) {
+        setWebviewLoadError("No internet connection. Check your network.");
+        return;
+      }
+      if (e.isMainFrame && e.errorCode === ERR_CONNECTION_TIMED_OUT && e.validatedURL) {
+        setWebviewLoadError(
+          `Connection to ${e.validatedURL} timed out. The server may be unreachable.`
+        );
+        return;
+      }
+
+      // Retry on connection-refused errors: the readiness check may have passed
+      // a moment before the server was fully reachable from the webview.
       if (
         e.isMainFrame &&
         (e.errorCode === ERR_CONNECTION_REFUSED || e.errorCode === ERR_CONNECTION_RESET)
@@ -563,8 +666,9 @@ export function DevPreviewPane({
         const MAX_RETRIES = 5;
         const retryCount = failLoadRetryCountRef.current;
         if (retryCount >= MAX_RETRIES) {
+          const urlContext = e.validatedURL ? ` at ${e.validatedURL}` : "";
           setWebviewLoadError(
-            "Unable to connect to dev server. The server may be on a different port."
+            `Unable to connect to dev server${urlContext}. The server may be on a different port.`
           );
         } else if (retryCount < MAX_RETRIES) {
           failLoadRetryCountRef.current += 1;
@@ -673,6 +777,10 @@ export function DevPreviewPane({
       } catch {
         // WebContents not available yet
       }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -759,6 +867,9 @@ export function DevPreviewPane({
 
   useEffect(() => {
     return () => {
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
@@ -789,6 +900,10 @@ export function DevPreviewPane({
         wv.src = "about:blank";
       } catch {
         // webview may already be detached
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
       }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
@@ -1089,20 +1204,47 @@ export function DevPreviewPane({
                     <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
                       <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                       <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        Dev Server Unreachable
+                        {webviewLoadError.startsWith("Load timed out")
+                          ? "Page Load Timed Out"
+                          : webviewLoadError.startsWith("Load cancelled")
+                            ? "Load Cancelled"
+                            : "Dev Server Unreachable"}
                       </h3>
                       <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
                         {webviewLoadError}
                       </p>
-                      <Button
-                        onClick={handleHardRestart}
-                        variant="ghost"
-                        size="sm"
-                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
-                      >
-                        <RotateCw className="h-3.5 w-3.5" />
-                        <span className="text-xs">Hard Restart</span>
-                      </Button>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          onClick={
+                            webviewLoadError.startsWith("Load cancelled") ||
+                            webviewLoadError.startsWith("Load timed out")
+                              ? handleRetryWebviewLoad
+                              : handleHardRestart
+                          }
+                          variant="ghost"
+                          size="sm"
+                          className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                        >
+                          <RotateCw className="h-3.5 w-3.5" />
+                          <span className="text-xs">
+                            {webviewLoadError.startsWith("Load cancelled") ||
+                            webviewLoadError.startsWith("Load timed out")
+                              ? "Retry"
+                              : "Hard Restart"}
+                          </span>
+                        </Button>
+                        {currentUrl && (
+                          <Button
+                            onClick={handleOpenExternal}
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            <span className="text-xs">Open External</span>
+                          </Button>
+                        )}
+                      </div>
                     </div>
                   )}
                   {blockedNav && (
@@ -1112,6 +1254,27 @@ export function DevPreviewPane({
                       webviewElement={webviewElement}
                       onDismiss={() => setBlockedNav(null)}
                     />
+                  )}
+                  {isLoading && (
+                    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-daintree-bg gap-3">
+                      <Spinner size="2xl" className="text-status-info" />
+                      {isSlowLoad && (
+                        <>
+                          <p className="text-xs text-daintree-text/50">
+                            Taking longer than usual...
+                          </p>
+                          <Button
+                            onClick={handleCancelLoad}
+                            variant="ghost"
+                            size="sm"
+                            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
+                          >
+                            <Square className="h-3.5 w-3.5" />
+                            <span className="text-xs">Cancel</span>
+                          </Button>
+                        </>
+                      )}
+                    </div>
                   )}
                   {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
                   {findInPage.isOpen && <FindBar find={findInPage} />}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -438,8 +438,12 @@ export function DevPreviewPane({
     setWebviewLoadError(null);
     setIsSlowLoad(false);
     setIsLoading(true);
-    webviewRef.current?.reload();
-  }, []);
+    if (currentUrl) {
+      webviewRef.current?.loadURL(currentUrl);
+    } else {
+      webviewRef.current?.reload();
+    }
+  }, [currentUrl]);
 
   const handleHardReload = useCallback(() => {
     const webview = webviewRef.current;
@@ -618,6 +622,10 @@ export function DevPreviewPane({
     };
 
     const handleDidFailLoad = (e: Electron.DidFailLoadEvent) => {
+      // Ignore aborted loads (e.g., navigation interrupted by another navigation)
+      if (e.errorCode === -3) return;
+      // Ignore cancellations
+      if (e.errorCode === -6) return;
       setIsLoading(false);
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
@@ -746,6 +754,14 @@ export function DevPreviewPane({
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
       }
     };
   }, [webviewElement, loadTimeoutMs, evictingRef]);
@@ -1204,7 +1220,8 @@ export function DevPreviewPane({
                     <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
                       <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                       <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                        {webviewLoadError.startsWith("Load timed out")
+                        {webviewLoadError.startsWith("Load timed out") ||
+                        webviewLoadError.startsWith("Connection to")
                           ? "Page Load Timed Out"
                           : webviewLoadError.startsWith("Load cancelled")
                             ? "Load Cancelled"
@@ -1217,7 +1234,8 @@ export function DevPreviewPane({
                         <Button
                           onClick={
                             webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out")
+                            webviewLoadError.startsWith("Load timed out") ||
+                            webviewLoadError.startsWith("Connection to")
                               ? handleRetryWebviewLoad
                               : handleHardRestart
                           }
@@ -1228,7 +1246,8 @@ export function DevPreviewPane({
                           <RotateCw className="h-3.5 w-3.5" />
                           <span className="text-xs">
                             {webviewLoadError.startsWith("Load cancelled") ||
-                            webviewLoadError.startsWith("Load timed out")
+                            webviewLoadError.startsWith("Load timed out") ||
+                            webviewLoadError.startsWith("Connection to")
                               ? "Retry"
                               : "Hard Restart"}
                           </span>

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -7,6 +7,7 @@ import { DevPreviewPane } from "../DevPreviewPane";
 type MockWebviewElement = HTMLElement & {
   reload: ReturnType<typeof vi.fn>;
   loadURL: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
   setZoomFactor: ReturnType<typeof vi.fn>;
   getURL: ReturnType<typeof vi.fn>;
   isLoading: ReturnType<typeof vi.fn>;
@@ -27,6 +28,7 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   };
 
   webview.reload = vi.fn();
+  webview.stop = vi.fn();
   webview.loadURL = vi.fn((url: string) => {
     currentUrl = url;
     element.setAttribute("src", url);
@@ -360,10 +362,11 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       vi.advanceTimersByTime(30000);
     });
 
-    expect(webview.reload).toHaveBeenCalledTimes(1);
+    expect(webview.stop).toHaveBeenCalledTimes(1);
+    expect(webview.reload).not.toHaveBeenCalled();
   });
 
-  it("reloads webview when loading remains stuck for 30s", () => {
+  it("stops webview and shows timeout error after 30s when loading is stuck", () => {
     const { container } = render(<DevPreviewPane {...baseProps} />);
     const webview = getWebviewElement(container);
 
@@ -376,7 +379,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       vi.advanceTimersByTime(30000);
     });
 
-    expect(webview.reload).toHaveBeenCalledTimes(1);
+    expect(webview.stop).toHaveBeenCalledTimes(1);
+    expect(webview.reload).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Page Load Timed Out");
   });
 
   it("clears stuck-load timeout when loading fails", () => {
@@ -388,6 +393,9 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       emitWebviewEvent(webview, "did-start-loading");
       emitWebviewEvent(webview, "did-fail-load", {
         errorCode: -105,
+        errorDescription: "Name not resolved",
+        isMainFrame: true,
+        validatedURL: "http://badsite.test/",
       });
     });
 
@@ -396,6 +404,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
   });
 
   it("clears pending timeout when hard restart is triggered", () => {
@@ -414,6 +423,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
     expect(devServerStateRef.current.restart).toHaveBeenCalledTimes(1);
     expect(terminalStoreState.setBrowserUrl).toHaveBeenCalledWith("dev-preview-panel-1", "");
   });
@@ -540,6 +550,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
 
     expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
   });
 
   it("uses configurable load timeout from project settings", () => {
@@ -570,17 +581,18 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       emitWebviewEvent(webview, "did-start-loading");
     });
 
-    // Should NOT reload at 30s
+    // Should NOT stop at 30s
     act(() => {
       vi.advanceTimersByTime(30000);
     });
-    expect(webview.reload).not.toHaveBeenCalled();
+    expect(webview.stop).not.toHaveBeenCalled();
 
-    // Should reload at 60s
+    // Should stop at 60s
     act(() => {
       vi.advanceTimersByTime(30000);
     });
-    expect(webview.reload).toHaveBeenCalledTimes(1);
+    expect(webview.stop).toHaveBeenCalledTimes(1);
+    expect(webview.reload).not.toHaveBeenCalled();
 
     if (origSettings) useProjectSettingsStoreMock.mockImplementation(origSettings);
   });
@@ -905,5 +917,196 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     fireEvent.click(screen.getByTestId("hard-restart"));
 
     expect(container.textContent).not.toContain("Dev Server Unreachable");
+  });
+
+  describe("slow-load and timeout escalation", () => {
+    it("shows slow-load message and Cancel after 5s of loading", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      expect(container.textContent).not.toContain("Taking longer than usual");
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).toContain("Taking longer than usual");
+      expect(container.textContent).toContain("Cancel");
+    });
+
+    it("Cancel stops the webview and shows cancelled error", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      const cancelButton = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Cancel")
+      );
+      expect(cancelButton).toBeDefined();
+
+      act(() => {
+        cancelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Load cancelled");
+    });
+
+    it("timeout calls webview.stop() instead of reload", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(webview.reload).not.toHaveBeenCalled();
+      expect(container.textContent).toContain("Page Load Timed Out");
+    });
+
+    it("Retry from timeout clears error and reloads", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      webview.stop.mockClear();
+
+      const retryButton = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Retry")
+      );
+      expect(retryButton).toBeDefined();
+
+      act(() => {
+        retryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(webview.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears slow timer when did-fail-load fires", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "Name not resolved",
+          isMainFrame: true,
+          validatedURL: "http://badsite.test/",
+        });
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).not.toContain("Taking longer than usual");
+    });
+
+    it("shows DNS failure for -105 in webviewLoadError", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "ERR_NAME_NOT_RESOLVED",
+          isMainFrame: true,
+          validatedURL: "http://nonexistent.example.com/page",
+        });
+      });
+
+      expect(container.textContent).toContain("Couldn't resolve");
+      expect(container.textContent).toContain("nonexistent.example.com");
+    });
+
+    it("shows no-internet for -106 in webviewLoadError", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -106,
+          errorDescription: "ERR_INTERNET_DISCONNECTED",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/",
+        });
+      });
+
+      expect(container.textContent).toContain("No internet connection");
+    });
+
+    it("retry-exhausted error includes URL", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      for (let i = 0; i < 6; i++) {
+        act(() => {
+          emitWebviewEvent(webview, "did-fail-load", {
+            errorCode: -102,
+            errorDescription: "ERR_CONNECTION_REFUSED",
+            isMainFrame: true,
+            validatedURL: "http://localhost:5173/",
+          });
+        });
+        if (i < 5) {
+          act(() => {
+            vi.advanceTimersByTime(Math.min(500 * 2 ** i, 8000));
+          });
+        }
+      }
+
+      expect(container.textContent).toContain("localhost:5173");
+    });
+
+    it("cleans slow timer on unmount", () => {
+      const { container, unmount } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(container.textContent).not.toContain("Taking longer than usual");
+    });
   });
 });

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -983,7 +983,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("Page Load Timed Out");
     });
 
-    it("Retry from timeout clears error and reloads", () => {
+    it("Retry from timeout clears error and loads current URL", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -1007,7 +1007,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         retryButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
 
-      expect(webview.reload).toHaveBeenCalledTimes(1);
+      expect(webview.loadURL).toHaveBeenCalledWith("http://localhost:5173/");
     });
 
     it("clears slow timer when did-fail-load fires", () => {

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -177,6 +177,7 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",
     "src/components/Commands/CommandPickerHost.tsx",
+    "src/components/Browser/BrowserPane.tsx",
     "src/components/DevPreview/DevPreviewPane.tsx",
     "src/components/Diagnostics/DiagnosticsDock.tsx",
     "src/components/Diagnostics/TelemetryContent.tsx",


### PR DESCRIPTION
## Summary
- Added slow-load escalation: shows a spinner with a "Taking longer than usual..." message after 5 seconds, with a cancel button so users aren't stuck watching a hung load
- Replaced the blind timeout-reload with a proper error state: timed-out loads now show a descriptive error with a Retry button, no longer firing a reload that might also hang
- Tightened `isMainFrame` guards across all error handlers to avoid subframe failures showing bogus error messages

Closes #6032

## Changes
- **Slow-load detection**: 5-second timeout fires `setIsSlowLoad(true)` if the webview is still loading, showing a cancel affordance instead of waiting silently for the full timeout
- **Timeout behavior**: instead of `webview.reload()` on timeout (which could loop infinitely), `webview.stop()` fires and shows an error state with a Retry button
- **Retry from error**: Retry button calls `loadURL(currentUrl)` when there's a tracked URL, or `reload()` as fallback -- previously retry wasn't available at all
- **Error message granularity**: `ERR_NAME_NOT_RESOLVED` (-105), `ERR_INTERNET_DISCONNECTED` (-106), `ERR_CONNECTION_TIMED_OUT` (-118) now produce specific messages; all main-frame errors include the validated URL for context
- **Timer hygiene**: `clearAllTimers()` helper cleans up both slow-load and load timeout refs consistently across all lifecycle paths (DOM ready, stop loading, fail, cancel, unmount)
- **DevPreview parity**: all of the above applied identically to `DevPreviewPane`

## Testing
- Unit tests for slow-load state appearing/disappearing on timer lifecycle
- Unit tests for timeout producing error state instead of reload
- Unit tests for retry, cancel, and timer cleanup on unmount
- Unit tests for error message specifics per error code