### PR TITLE
feat(worktree): detect WSL-mounted worktrees and route git through wsl.exe

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -361,6 +361,8 @@ export const CHANNELS = {
 
   WORKTREE_CONFIG_GET: "worktree-config:get",
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
+  WORKTREE_CONFIG_SET_WSL_GIT: "worktree-config:set-wsl-git",
+  WORKTREE_CONFIG_DISMISS_WSL_BANNER: "worktree-config:dismiss-wsl-banner",
 
   WINDOW_TOGGLE_FULLSCREEN: "window:toggle-fullscreen",
   WINDOW_RELOAD: "window:reload",

--- a/electron/ipc/handlers/worktreeConfig.ts
+++ b/electron/ipc/handlers/worktreeConfig.ts
@@ -104,9 +104,7 @@ export function registerWorktreeConfigHandlers(deps: HandlerDependencies): () =>
     writeWslGitEntry(worktreeId, { enabled, dismissed: true });
     deps.worktreeService?.setWslOptIn(worktreeId, enabled, true);
   };
-  handlers.push(
-    typedHandle(CHANNELS.WORKTREE_CONFIG_DISMISS_WSL_BANNER, handleDismissWslBanner)
-  );
+  handlers.push(typedHandle(CHANNELS.WORKTREE_CONFIG_DISMISS_WSL_BANNER, handleDismissWslBanner));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/worktreeConfig.ts
+++ b/electron/ipc/handlers/worktreeConfig.ts
@@ -21,7 +21,21 @@ function getWorktreeConfig(): WorktreeConfig {
   };
 }
 
-export function registerWorktreeConfigHandlers(_deps: HandlerDependencies): () => void {
+function readWslGitMap(): Record<string, { enabled: boolean; dismissed: boolean }> {
+  const raw = store.get("wslGitByWorktree");
+  if (!raw || typeof raw !== "object") return {};
+  return raw as Record<string, { enabled: boolean; dismissed: boolean }>;
+}
+
+function writeWslGitEntry(
+  worktreeId: string,
+  entry: { enabled: boolean; dismissed: boolean }
+): void {
+  const map = { ...readWslGitMap(), [worktreeId]: entry };
+  store.set("wslGitByWorktree", map);
+}
+
+export function registerWorktreeConfigHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   const handleGetConfig = async (): Promise<WorktreeConfig> => {
@@ -51,6 +65,48 @@ export function registerWorktreeConfigHandlers(_deps: HandlerDependencies): () =
     return getWorktreeConfig();
   };
   handlers.push(typedHandle(CHANNELS.WORKTREE_CONFIG_SET_PATTERN, handleSetPattern));
+
+  const handleSetWslGit = async (payload: {
+    worktreeId: string;
+    enabled: boolean;
+  }): Promise<void> => {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid set-wsl-git payload");
+    }
+    const { worktreeId, enabled } = payload;
+    if (typeof worktreeId !== "string" || !worktreeId.trim()) {
+      throw new Error("Invalid worktreeId: must be a non-empty string");
+    }
+    if (typeof enabled !== "boolean") {
+      throw new Error("Invalid enabled: must be a boolean");
+    }
+
+    // Opting in implies the banner is no longer needed; opting out leaves
+    // dismissed alone (so the banner won't pop back unexpectedly).
+    const existing = readWslGitMap()[worktreeId];
+    const dismissed = enabled ? true : Boolean(existing?.dismissed);
+    writeWslGitEntry(worktreeId, { enabled, dismissed });
+    deps.worktreeService?.setWslOptIn(worktreeId, enabled, dismissed);
+  };
+  handlers.push(typedHandle(CHANNELS.WORKTREE_CONFIG_SET_WSL_GIT, handleSetWslGit));
+
+  const handleDismissWslBanner = async (payload: { worktreeId: string }): Promise<void> => {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid dismiss-wsl-banner payload");
+    }
+    const { worktreeId } = payload;
+    if (typeof worktreeId !== "string" || !worktreeId.trim()) {
+      throw new Error("Invalid worktreeId: must be a non-empty string");
+    }
+
+    const existing = readWslGitMap()[worktreeId];
+    const enabled = Boolean(existing?.enabled);
+    writeWslGitEntry(worktreeId, { enabled, dismissed: true });
+    deps.worktreeService?.setWslOptIn(worktreeId, enabled, true);
+  };
+  handlers.push(
+    typedHandle(CHANNELS.WORKTREE_CONFIG_DISMISS_WSL_BANNER, handleDismissWslBanner)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1851,6 +1851,12 @@ const api: ElectronAPI = {
 
     setPattern: (pattern: string) =>
       _unwrappingInvoke(CHANNELS.WORKTREE_CONFIG_SET_PATTERN, { pattern }),
+
+    setWslGit: (worktreeId: string, enabled: boolean) =>
+      _unwrappingInvoke(CHANNELS.WORKTREE_CONFIG_SET_WSL_GIT, { worktreeId, enabled }),
+
+    dismissWslBanner: (worktreeId: string) =>
+      _unwrappingInvoke(CHANNELS.WORKTREE_CONFIG_DISMISS_WSL_BANNER, { worktreeId }),
   },
 
   // Window API

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -673,7 +673,6 @@ export class CliAvailabilityService {
     });
   }
 
-
   private expandPath(input: string, home: string): string | null {
     if (!input) return null;
     let expanded = input;

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -18,6 +18,7 @@ import { refreshPath, expandWindowsEnvVars } from "../setup/environment.js";
 import { store } from "../store.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
+import { listFirstWslDistro } from "../utils/wsl.js";
 
 interface ProbeSuccess {
   status: "found";
@@ -81,7 +82,6 @@ export class CliAvailabilityService {
   private static readonly AUTH_CHECK_TIMEOUT_MS = 3_000;
   private static readonly WHICH_TIMEOUT_MS = 5_000;
   private static readonly NPM_PREFIX_TIMEOUT_MS = 4_000;
-  private static readonly WSL_LIST_TIMEOUT_MS = 5_000;
   private static readonly WSL_PROBE_TIMEOUT_MS = 8_000;
   private static readonly VALID_COMMAND_RE = /^[a-zA-Z0-9._-]+$/;
 
@@ -646,7 +646,7 @@ export class CliAvailabilityService {
   }
 
   private async probeWsl(command: string): Promise<ProbeResult> {
-    const distro = await this.listFirstWslDistro();
+    const distro = await listFirstWslDistro();
     if (!distro) return { status: "missing" };
 
     return new Promise((resolve) => {
@@ -673,54 +673,6 @@ export class CliAvailabilityService {
     });
   }
 
-  private listFirstWslDistro(): Promise<string | null> {
-    return new Promise((resolve) => {
-      execFile(
-        "wsl.exe",
-        ["--list", "--quiet"],
-        {
-          // Buffers are returned untouched — we decode below. Setting
-          // WSL_UTF8=1 asks WSL to emit UTF-8; older Windows builds still
-          // produce UTF-16LE so we fall back if UTF-8 looks empty.
-          env: { ...process.env, WSL_UTF8: "1" },
-          timeout: CliAvailabilityService.WSL_LIST_TIMEOUT_MS,
-          windowsHide: true,
-        },
-        (err, stdout) => {
-          if (err) {
-            resolve(null);
-            return;
-          }
-          const buf = Buffer.isBuffer(stdout)
-            ? stdout
-            : Buffer.from(typeof stdout === "string" ? stdout : "", "utf8");
-
-          // WSL has historically emitted UTF-16LE (with BOM) regardless of
-          // `WSL_UTF8=1`; recent Windows builds honor the env var and emit
-          // UTF-8. Pick the encoding heuristically: a UTF-16LE-encoded ASCII
-          // string is roughly half null bytes, and will also be prefixed by
-          // the FF FE BOM. Either signal is a strong indicator.
-          const sample = buf.subarray(0, Math.min(buf.length, 64));
-          let nullBytes = 0;
-          for (const byte of sample) {
-            if (byte === 0) nullBytes++;
-          }
-          const hasUtf16Bom = buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe;
-          const looksUtf16 = hasUtf16Bom || nullBytes > sample.length / 3;
-
-          const decoded = looksUtf16
-            ? buf.toString("utf16le").replace(/^\uFEFF/, "")
-            : buf.toString("utf8");
-
-          const lines = decoded
-            .split(/\r?\n/)
-            .map((l) => l.trim())
-            .filter(Boolean);
-          resolve(lines[0] ?? null);
-        }
-      );
-    });
-  }
 
   private expandPath(input: string, home: string): string | null {
     if (!input) return null;

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -383,7 +383,7 @@ export class WorkspaceClient extends EventEmitter {
       requestId,
       rootPath: entry.projectPath,
       globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
-        wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
+      wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
     });
 
     // Re-establish direct renderer ports after host restart

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -383,6 +383,7 @@ export class WorkspaceClient extends EventEmitter {
       requestId,
       rootPath: entry.projectPath,
       globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
+        wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
     });
 
     // Re-establish direct renderer ports after host restart
@@ -524,6 +525,7 @@ export class WorkspaceClient extends EventEmitter {
         requestId,
         rootPath: normalizedPath,
         globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
+        wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
       });
     })();
 
@@ -588,6 +590,7 @@ export class WorkspaceClient extends EventEmitter {
         requestId,
         rootPath: normalizedPath,
         globalEnvVars: store.get("globalEnvironmentVariables") ?? {},
+        wslGitByWorktree: store.get("wslGitByWorktree") ?? {},
       });
     })();
 
@@ -879,6 +882,17 @@ export class WorkspaceClient extends EventEmitter {
   setPollingEnabled(enabled: boolean): void {
     for (const entry of this.entries.values()) {
       entry.host.send({ type: "set-polling-enabled", enabled });
+    }
+  }
+
+  /**
+   * Forward a per-worktree WSL git opt-in / dismissed change to every host.
+   * Each host filters by worktree id internally — broadcasting is cheaper
+   * than tracking which host owns which worktree from this layer.
+   */
+  setWslOptIn(worktreeId: string, enabled: boolean, dismissed: boolean): void {
+    for (const entry of this.entries.values()) {
+      entry.host.send({ type: "set-wsl-opt-in", worktreeId, enabled, dismissed });
     }
   }
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -148,6 +148,12 @@ export interface StoreSchema {
     }
   >;
   worktreeIssueMap: Record<string, IssueAssociation>;
+  /**
+   * Per-worktree WSL git routing state. Key is the worktree id (UNC path on
+   * Windows). `enabled` opts into routing git through `wsl.exe git`; `dismissed`
+   * hides the suggestion banner without enabling. Only meaningful on Windows.
+   */
+  wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }>;
   appTheme: Partial<AppThemeConfig>;
   privacy: {
     telemetryLevel: "off" | "errors" | "full";
@@ -284,6 +290,7 @@ const storeOptions = {
     appAgentConfig: DEFAULT_APP_AGENT_CONFIG,
     windowStates: {},
     worktreeIssueMap: {},
+    wslGitByWorktree: {},
     appTheme: {},
     privacy: {
       telemetryLevel: "off" as const,

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -400,41 +400,59 @@ describe("createWslHardenedGit", () => {
   it("throws on non-Windows platforms", () => {
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     expect(() =>
-      createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" })
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+        posixPath: "/home/user/proj",
+      })
     ).toThrow("only available on Windows");
   });
 
   it("throws when distro is empty", () => {
     expect(() =>
-      createWslHardenedGit({ distro: "", posixPath: "/home/user/proj" })
+      createWslHardenedGit({ distro: "", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" })
     ).toThrow("WSL distro");
   });
 
   it("throws when posix path does not start with /", () => {
     expect(() =>
-      createWslHardenedGit({ distro: "Ubuntu", posixPath: "home/user/proj" })
+      createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "home/user/proj" })
     ).toThrow("posix path");
   });
 
-  it("uses the POSIX path as baseDir", () => {
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+  it("throws when UNC path is not a WSL UNC", () => {
+    expect(() =>
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "C:\\repos\\proj",
+        posixPath: "/home/user/proj",
+      })
+    ).toThrow("UNC path");
+  });
+
+  it("uses the UNC path as baseDir so simple-git's statSync succeeds on Windows", () => {
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
 
     expect(simpleGit).toHaveBeenCalledWith(
       expect.objectContaining({
-        baseDir: "/home/user/proj",
+        baseDir: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       })
     );
   });
 
   it("sets binary to wsl.exe + git two-tuple", () => {
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.binary).toEqual(["wsl.exe", "git"]);
   });
 
   it("carries the full HARDENED_GIT_CONFIG", () => {
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     for (const entry of HARDENED_GIT_CONFIG) {
@@ -444,7 +462,7 @@ describe("createWslHardenedGit", () => {
   });
 
   it("sets WSL_DISTRO_NAME in env for diagnostics", () => {
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.WSL_DISTRO_NAME).toBe("Ubuntu");
@@ -454,14 +472,14 @@ describe("createWslHardenedGit", () => {
 
   it("forwards abort signal when provided", () => {
     const controller = new AbortController();
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" }, controller.signal);
+    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" }, controller.signal);
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.abort).toBe(controller.signal);
   });
 
   it("enables allowUnsafe flags matching createHardenedGit", () => {
-    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.unsafe).toEqual({

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockGitInstance: Record<string, ReturnType<typeof vi.fn>> = {
   raw: vi.fn(),
@@ -18,6 +18,7 @@ import {
   validateCwd,
   createHardenedGit,
   createAuthenticatedGit,
+  createWslHardenedGit,
   HARDENED_GIT_CONFIG,
   AUTHENTICATED_GIT_CONFIG,
 } from "../hardenedGit.js";
@@ -375,6 +376,100 @@ describe("createAuthenticatedGit", () => {
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("transfer.bundleURI=false");
+  });
+});
+
+describe("createWslHardenedGit", () => {
+  const ORIGINAL_PLATFORM = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", {
+      value: "win32",
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      value: ORIGINAL_PLATFORM,
+      configurable: true,
+    });
+  });
+
+  it("throws on non-Windows platforms", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    expect(() =>
+      createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" })
+    ).toThrow("only available on Windows");
+  });
+
+  it("throws when distro is empty", () => {
+    expect(() =>
+      createWslHardenedGit({ distro: "", posixPath: "/home/user/proj" })
+    ).toThrow("WSL distro");
+  });
+
+  it("throws when posix path does not start with /", () => {
+    expect(() =>
+      createWslHardenedGit({ distro: "Ubuntu", posixPath: "home/user/proj" })
+    ).toThrow("posix path");
+  });
+
+  it("uses the POSIX path as baseDir", () => {
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+
+    expect(simpleGit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseDir: "/home/user/proj",
+      })
+    );
+  });
+
+  it("sets binary to wsl.exe + git two-tuple", () => {
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.binary).toEqual(["wsl.exe", "git"]);
+  });
+
+  it("carries the full HARDENED_GIT_CONFIG", () => {
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    for (const entry of HARDENED_GIT_CONFIG) {
+      expect(options.config).toContain(entry);
+    }
+    expect(options.config).toHaveLength(HARDENED_GIT_CONFIG.length);
+  });
+
+  it("sets WSL_DISTRO_NAME in env for diagnostics", () => {
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.WSL_DISTRO_NAME).toBe("Ubuntu");
+    expect(envArg.LC_MESSAGES).toBe("C");
+    expect(envArg.LANGUAGE).toBe("");
+  });
+
+  it("forwards abort signal when provided", () => {
+    const controller = new AbortController();
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" }, controller.signal);
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.abort).toBe(controller.signal);
+  });
+
+  it("enables allowUnsafe flags matching createHardenedGit", () => {
+    createWslHardenedGit({ distro: "Ubuntu", posixPath: "/home/user/proj" });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.unsafe).toEqual({
+      allowUnsafeProtocolOverride: true,
+      allowUnsafeSshCommand: true,
+      allowUnsafeGitProxy: true,
+      allowUnsafeHooksPath: true,
+    });
   });
 });
 

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -410,13 +410,21 @@ describe("createWslHardenedGit", () => {
 
   it("throws when distro is empty", () => {
     expect(() =>
-      createWslHardenedGit({ distro: "", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" })
+      createWslHardenedGit({
+        distro: "",
+        uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+        posixPath: "/home/user/proj",
+      })
     ).toThrow("WSL distro");
   });
 
   it("throws when posix path does not start with /", () => {
     expect(() =>
-      createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "home/user/proj" })
+      createWslHardenedGit({
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+        posixPath: "home/user/proj",
+      })
     ).toThrow("posix path");
   });
 
@@ -445,14 +453,22 @@ describe("createWslHardenedGit", () => {
   });
 
   it("sets binary to wsl.exe + git two-tuple", () => {
-    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.binary).toEqual(["wsl.exe", "git"]);
   });
 
   it("carries the full HARDENED_GIT_CONFIG", () => {
-    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     for (const entry of HARDENED_GIT_CONFIG) {
@@ -462,7 +478,11 @@ describe("createWslHardenedGit", () => {
   });
 
   it("sets WSL_DISTRO_NAME in env for diagnostics", () => {
-    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.WSL_DISTRO_NAME).toBe("Ubuntu");
@@ -472,14 +492,25 @@ describe("createWslHardenedGit", () => {
 
   it("forwards abort signal when provided", () => {
     const controller = new AbortController();
-    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" }, controller.signal);
+    createWslHardenedGit(
+      {
+        distro: "Ubuntu",
+        uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+        posixPath: "/home/user/proj",
+      },
+      controller.signal
+    );
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.abort).toBe(controller.signal);
   });
 
   it("enables allowUnsafe flags matching createHardenedGit", () => {
-    createWslHardenedGit({ distro: "Ubuntu", uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj", posixPath: "/home/user/proj" });
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.unsafe).toEqual({

--- a/electron/utils/__tests__/wsl.test.ts
+++ b/electron/utils/__tests__/wsl.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { detectWslPath } from "../wsl.js";
+
+describe("detectWslPath", () => {
+  it("returns null for plain Windows drive paths", () => {
+    expect(detectWslPath("C:\\repos\\project")).toBeNull();
+  });
+
+  it("returns null for POSIX paths", () => {
+    expect(detectWslPath("/home/user/project")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(detectWslPath("")).toBeNull();
+  });
+
+  it("returns null for non-string input", () => {
+    expect(detectWslPath(undefined as unknown as string)).toBeNull();
+    expect(detectWslPath(null as unknown as string)).toBeNull();
+  });
+
+  it("parses \\\\wsl$\\<distro>\\<path>", () => {
+    const result = detectWslPath("\\\\wsl$\\Ubuntu\\home\\user\\project");
+    expect(result).toEqual({ distro: "Ubuntu", posixPath: "/home/user/project" });
+  });
+
+  it("parses \\\\wsl.localhost\\<distro>\\<path>", () => {
+    const result = detectWslPath("\\\\wsl.localhost\\Debian\\home\\dev\\app");
+    expect(result).toEqual({ distro: "Debian", posixPath: "/home/dev/app" });
+  });
+
+  it("preserves distro name case", () => {
+    const result = detectWslPath("\\\\wsl$\\Ubuntu-22.04\\repos\\app");
+    expect(result?.distro).toBe("Ubuntu-22.04");
+  });
+
+  it("matches case-insensitively on the wsl prefix", () => {
+    expect(detectWslPath("\\\\WSL$\\Ubuntu\\home")).toEqual({
+      distro: "Ubuntu",
+      posixPath: "/home",
+    });
+    expect(detectWslPath("\\\\Wsl.LocalHost\\Ubuntu\\home")).toEqual({
+      distro: "Ubuntu",
+      posixPath: "/home",
+    });
+  });
+
+  it("returns / for the distro root", () => {
+    expect(detectWslPath("\\\\wsl$\\Ubuntu")).toEqual({
+      distro: "Ubuntu",
+      posixPath: "/",
+    });
+    expect(detectWslPath("\\\\wsl$\\Ubuntu\\")).toEqual({
+      distro: "Ubuntu",
+      posixPath: "/",
+    });
+  });
+
+  it("translates separators inside subpaths", () => {
+    expect(detectWslPath("\\\\wsl$\\Ubuntu\\home\\user\\my repo\\src")).toEqual({
+      distro: "Ubuntu",
+      posixPath: "/home/user/my repo/src",
+    });
+  });
+});

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -5,7 +5,8 @@ import type { FileChangeDetail, GitStatus, WorktreeChanges } from "../types/inde
 import { WorktreeRemovedError, toGitOperationError } from "./errorTypes.js";
 import { logWarn, logError } from "./logger.js";
 import { Cache } from "./cache.js";
-import { createHardenedGit } from "./hardenedGit.js";
+import { createHardenedGit, createWslHardenedGit } from "./hardenedGit.js";
+import type { WslGitInvocation } from "./hardenedGit.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const GIT_WORKTREE_CHANGES_CACHE = new Cache<string, WorktreeChanges>({
@@ -176,6 +177,24 @@ export async function getLatestTrackedFileMtime(worktreePath: string): Promise<n
 export interface GetWorktreeChangesOptions {
   forceRefresh?: boolean;
   cacheTTL?: number;
+  /**
+   * When set, route git through WSL using `createWslHardenedGit`. The caller
+   * must provide the distro name and POSIX path (already translated from the
+   * UNC). Set only on Windows for worktrees the user has opted into.
+   */
+  wsl?: WslGitInvocation;
+}
+
+function gitForChanges(cwd: string, opts: GetWorktreeChangesOptions): SimpleGit {
+  if (opts.wsl) {
+    try {
+      return createWslHardenedGit(opts.wsl);
+    } catch {
+      // Fall back to native git if the WSL invocation is rejected (e.g. wrong
+      // platform, missing distro). Polling continues using the slower path.
+    }
+  }
+  return createHardenedGit(cwd);
 }
 
 export async function getWorktreeChangesWithStats(
@@ -220,7 +239,7 @@ export async function getWorktreeChangesWithStats(
     }
 
     try {
-      const git: SimpleGit = createHardenedGit(cwd);
+      const git: SimpleGit = gitForChanges(cwd, options);
       const status: StatusResult = await git.status();
       const gitRoot = realpathSync((await git.revparse(["--show-toplevel"])).trim());
 

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -63,7 +63,18 @@ export function createHardenedGit(cwd: string, signal?: AbortSignal): SimpleGit 
 export interface WslGitInvocation {
   /** WSL distro name extracted from the worktree's UNC path. */
   distro: string;
-  /** POSIX path inside the distro (must start with `/`). */
+  /**
+   * Original Windows UNC path (e.g. `\\wsl$\Ubuntu\home\user\repo`). Passed
+   * as `baseDir` so simple-git's synchronous folder-exists check (which calls
+   * `fs.statSync`) succeeds via the Windows-side 9P mount. `wsl.exe` then
+   * receives this UNC path as its spawn cwd and translates it automatically.
+   */
+  uncPath: string;
+  /**
+   * POSIX path inside the distro (must start with `/`). Retained for
+   * diagnostics and for future invocation strategies that need to issue
+   * `--cd` to wsl.exe directly.
+   */
   posixPath: string;
 }
 
@@ -81,8 +92,13 @@ export interface WslGitInvocation {
  * non-default distros are filtered out before reaching this factory by the
  * caller (see `wslGitEligible` in WorkspaceService).
  *
- * `baseDir` is set to the POSIX path inside the distro. `wsl.exe` inherits
- * this `cwd` from Node's spawn and translates it correctly.
+ * `baseDir` MUST be the Windows-side UNC path: simple-git validates the
+ * directory via `fs.statSync` synchronously at construction time, and a
+ * POSIX path like `/home/user/repo` resolves to a non-existent path on the
+ * current drive (`C:\home\user\repo`) on Windows, throwing
+ * `GitConstructError`. The UNC form (e.g. `\\wsl$\Ubuntu\home\user\repo`)
+ * resolves through the 9P mount and `wsl.exe` translates it back to POSIX
+ * internally when spawning the git child process.
  *
  * Windows-only: throws on other platforms.
  */
@@ -90,16 +106,19 @@ export function createWslHardenedGit(invocation: WslGitInvocation, signal?: Abor
   if (process.platform !== "win32") {
     throw new Error("createWslHardenedGit is only available on Windows");
   }
-  const { distro, posixPath } = invocation;
+  const { distro, uncPath, posixPath } = invocation;
   if (typeof distro !== "string" || !distro.trim()) {
     throw new Error("WSL distro name is required");
   }
   if (typeof posixPath !== "string" || !posixPath.startsWith("/")) {
     throw new Error("WSL posix path must start with /");
   }
+  if (typeof uncPath !== "string" || !uncPath.startsWith("\\\\wsl")) {
+    throw new Error("WSL UNC path must start with \\\\wsl");
+  }
 
   return simpleGit({
-    baseDir: posixPath,
+    baseDir: uncPath,
     binary: ["wsl.exe", "git"],
     config: [...HARDENED_GIT_CONFIG],
     timeout: { block: GIT_BLOCK_TIMEOUT_MS },

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -102,7 +102,10 @@ export interface WslGitInvocation {
  *
  * Windows-only: throws on other platforms.
  */
-export function createWslHardenedGit(invocation: WslGitInvocation, signal?: AbortSignal): SimpleGit {
+export function createWslHardenedGit(
+  invocation: WslGitInvocation,
+  signal?: AbortSignal
+): SimpleGit {
   if (process.platform !== "win32") {
     throw new Error("createWslHardenedGit is only available on Windows");
   }

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -60,6 +60,63 @@ export function createHardenedGit(cwd: string, signal?: AbortSignal): SimpleGit 
   });
 }
 
+export interface WslGitInvocation {
+  /** WSL distro name extracted from the worktree's UNC path. */
+  distro: string;
+  /** POSIX path inside the distro (must start with `/`). */
+  posixPath: string;
+}
+
+/**
+ * Create a hardened SimpleGit instance whose underlying git binary runs inside
+ * a WSL distro. Used for worktrees mounted at `\\wsl$\<distro>\...` so that
+ * git status polling stays inside the Linux filesystem and avoids the 9P
+ * boundary penalty (5-10x slowdown for `git status` from Windows-side git).
+ *
+ * Implementation note: simple-git's `binary` option accepts a 1-2 element
+ * tuple. The 2-element form prepends `binary[1]` as a single positional arg
+ * to every spawn, so `["wsl.exe", "git"]` produces `wsl.exe git <args>` and
+ * routes through the WSL default distro. Spaces are forbidden in the second
+ * element, so a `-d <distro>` selector cannot be passed via this path —
+ * non-default distros are filtered out before reaching this factory by the
+ * caller (see `wslGitEligible` in WorkspaceService).
+ *
+ * `baseDir` is set to the POSIX path inside the distro. `wsl.exe` inherits
+ * this `cwd` from Node's spawn and translates it correctly.
+ *
+ * Windows-only: throws on other platforms.
+ */
+export function createWslHardenedGit(invocation: WslGitInvocation, signal?: AbortSignal): SimpleGit {
+  if (process.platform !== "win32") {
+    throw new Error("createWslHardenedGit is only available on Windows");
+  }
+  const { distro, posixPath } = invocation;
+  if (typeof distro !== "string" || !distro.trim()) {
+    throw new Error("WSL distro name is required");
+  }
+  if (typeof posixPath !== "string" || !posixPath.startsWith("/")) {
+    throw new Error("WSL posix path must start with /");
+  }
+
+  return simpleGit({
+    baseDir: posixPath,
+    binary: ["wsl.exe", "git"],
+    config: [...HARDENED_GIT_CONFIG],
+    timeout: { block: GIT_BLOCK_TIMEOUT_MS },
+    ...(signal ? { abort: signal } : {}),
+    unsafe: UNSAFE_FLAGS,
+  }).env({
+    ...process.env,
+    LC_MESSAGES: "C",
+    LANGUAGE: "",
+    // Surface the targeted distro to wsl.exe via env. wsl.exe doesn't honour
+    // WSL_DISTRO_NAME for selection (it uses the default distro), but having
+    // this env var present makes diagnostic output unambiguous if the user
+    // captures process state during a hang.
+    WSL_DISTRO_NAME: distro,
+  });
+}
+
 export interface AuthenticatedGitOptions {
   signal?: AbortSignal;
   progress?: (data: SimpleGitProgressEvent) => void;

--- a/electron/utils/wsl.ts
+++ b/electron/utils/wsl.ts
@@ -55,6 +55,11 @@ export function listFirstWslDistro(): Promise<string | null> {
         env: { ...process.env, WSL_UTF8: "1" },
         timeout: WSL_LIST_TIMEOUT_MS,
         windowsHide: true,
+        // Receive raw bytes so the UTF-16LE heuristic below can actually run.
+        // Without `encoding: "buffer"`, Node's execFile decodes stdout as
+        // UTF-8 by default — which on older WSL builds (pre-WSL_UTF8) yields
+        // a corrupted string before we ever see the bytes.
+        encoding: "buffer",
       },
       (err, stdout) => {
         if (err) {

--- a/electron/utils/wsl.ts
+++ b/electron/utils/wsl.ts
@@ -1,0 +1,88 @@
+import { execFile } from "child_process";
+
+/**
+ * UNC path pattern for both Windows-side mount points exposed by WSL:
+ *   \\wsl$\<distro>\...
+ *   \\wsl.localhost\<distro>\...
+ * Both forms are equivalent — they expose the WSL distro filesystem at the
+ * UNC share root.
+ */
+const WSL_UNC_RE = /^\\\\wsl(?:\$|\.localhost)\\([^\\]+)(.*)/i;
+
+const WSL_LIST_TIMEOUT_MS = 5_000;
+
+export interface WslPathInfo {
+  /** WSL distro name as captured from the UNC path (case preserved). */
+  distro: string;
+  /** POSIX path inside the distro filesystem (always starts with `/`). */
+  posixPath: string;
+}
+
+/**
+ * If `p` is a `\\wsl$\` or `\\wsl.localhost\` UNC path, return the distro name
+ * and POSIX path inside that distro. Otherwise return null.
+ *
+ * The translation is purely string-based — both WSL UNC mount forms expose
+ * the Linux filesystem root at the share root, so the path remainder is a
+ * direct POSIX path with `\` rewritten to `/`.
+ */
+export function detectWslPath(p: string): WslPathInfo | null {
+  if (typeof p !== "string" || !p) return null;
+  const match = WSL_UNC_RE.exec(p);
+  if (!match) return null;
+  const distro = match[1];
+  const remainder = match[2] ?? "";
+  const posix = remainder.replace(/\\/g, "/") || "/";
+  if (!distro) return null;
+  return { distro, posixPath: posix };
+}
+
+/**
+ * Return the name of the first WSL distro listed by `wsl.exe --list --quiet`.
+ * On non-Windows or when wsl.exe is unavailable, returns `null`.
+ *
+ * Encoding handling mirrors the CliAvailabilityService probe: WSL has
+ * historically emitted UTF-16LE (with BOM); newer Windows builds honour
+ * `WSL_UTF8=1`. We pick the encoding heuristically.
+ */
+export function listFirstWslDistro(): Promise<string | null> {
+  if (process.platform !== "win32") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    execFile(
+      "wsl.exe",
+      ["--list", "--quiet"],
+      {
+        env: { ...process.env, WSL_UTF8: "1" },
+        timeout: WSL_LIST_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        const buf = Buffer.isBuffer(stdout)
+          ? stdout
+          : Buffer.from(typeof stdout === "string" ? stdout : "", "utf8");
+
+        const sample = buf.subarray(0, Math.min(buf.length, 64));
+        let nullBytes = 0;
+        for (const byte of sample) {
+          if (byte === 0) nullBytes++;
+        }
+        const hasUtf16Bom = buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe;
+        const looksUtf16 = hasUtf16Bom || nullBytes > sample.length / 3;
+
+        const decoded = looksUtf16
+          ? buf.toString("utf16le").replace(/^\uFEFF/, "")
+          : buf.toString("utf8");
+
+        const lines = decoded
+          .split(/\r?\n/)
+          .map((l) => l.trim())
+          .filter(Boolean);
+        resolve(lines[0] ?? null);
+      }
+    );
+  });
+}

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -300,8 +300,13 @@ port.on("message", async (rawMsg: any) => {
         await workspaceService.loadProject(
           request.requestId,
           request.rootPath,
-          request.globalEnvVars
+          request.globalEnvVars,
+          request.wslGitByWorktree
         );
+        break;
+
+      case "set-wsl-opt-in":
+        workspaceService.setWslOptIn(request.worktreeId, request.enabled, request.dismissed);
         break;
 
       case "sync":

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -235,7 +235,10 @@ export class WorkspaceService {
     try {
       this.projectRootPath = projectRootPath;
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
-        this.wslGitByWorktree = { ...wslGitByWorktree };
+        // Merge instead of replacing: a `set-wsl-opt-in` message arriving
+        // during this load-project's async work would otherwise be silently
+        // overwritten. The most recent in-memory value wins on conflict.
+        this.wslGitByWorktree = { ...wslGitByWorktree, ...this.wslGitByWorktree };
       }
       // Merge: global (lowest priority) < project-level < DAINTREE_* (set in buildEnv)
       const projectEnvVars = await this.loadProjectEnvVars(projectRootPath);
@@ -420,7 +423,11 @@ export class WorkspaceService {
       this.wslDefaultDistroPromise = listFirstWslDistro().catch(() => null);
     }
     const defaultDistro = await this.wslDefaultDistroPromise;
-    const eligible = defaultDistro !== null && defaultDistro === detected.distro;
+    // UNC paths are case-insensitive on Windows; `wsl --list --quiet` returns
+    // the canonical case (e.g. "Ubuntu"). Normalize before comparing so a
+    // worktree opened via `\\wsl$\ubuntu\...` still matches the default.
+    const eligible =
+      defaultDistro !== null && defaultDistro.toLowerCase() === detected.distro.toLowerCase();
     const persisted = this.wslGitByWorktree[wt.id];
 
     return {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -17,6 +17,7 @@ import type {
   PRServiceStatus,
 } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
+import { detectWslPath, listFirstWslDistro } from "../utils/wsl.js";
 import { getGitDir, clearGitDirCache } from "../utils/gitUtils.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
@@ -142,6 +143,11 @@ export class WorkspaceService {
    *  descriptor ceiling only once, even if many worktrees hit EMFILE concurrently. */
   private emfileLimitNotified = false;
 
+  /** Per-worktree WSL git opt-in state forwarded from main on load and toggle. */
+  private wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }> = {};
+  /** Cached default WSL distro (populated lazily on first WSL-path detection). */
+  private wslDefaultDistroPromise: Promise<string | null> | null = null;
+
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.prService = new PRIntegrationService(pullRequestService, events, {
       onPRDetected: (worktreeId, data) => {
@@ -223,10 +229,14 @@ export class WorkspaceService {
   async loadProject(
     requestId: string,
     projectRootPath: string,
-    globalEnvVars?: Record<string, string>
+    globalEnvVars?: Record<string, string>,
+    wslGitByWorktree?: Record<string, { enabled: boolean; dismissed: boolean }>
   ): Promise<void> {
     try {
       this.projectRootPath = projectRootPath;
+      if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
+        this.wslGitByWorktree = { ...wslGitByWorktree };
+      }
       // Merge: global (lowest priority) < project-level < DAINTREE_* (set in buildEnv)
       const projectEnvVars = await this.loadProjectEnvVars(projectRootPath);
       this.projectEnvVars = { ...(globalEnvVars ?? {}), ...projectEnvVars };
@@ -395,6 +405,48 @@ export class WorkspaceService {
    * If a monitor already exists for `wt.id`, this is a no-op (race safety for
    * overlapping create/delete on the same path).
    */
+  /**
+   * Detect whether a worktree is mounted via WSL and, if so, attach the
+   * detection metadata + persisted opt-in state. No-op on non-Windows. Bind
+   * time only — the result is folded into the `Worktree` passed to
+   * `WorktreeMonitor`.
+   */
+  private async enrichWorktreeWithWsl(wt: Worktree): Promise<Worktree> {
+    if (process.platform !== "win32") return wt;
+    const detected = detectWslPath(wt.path);
+    if (!detected) return wt;
+
+    if (!this.wslDefaultDistroPromise) {
+      this.wslDefaultDistroPromise = listFirstWslDistro().catch(() => null);
+    }
+    const defaultDistro = await this.wslDefaultDistroPromise;
+    const eligible = defaultDistro !== null && defaultDistro === detected.distro;
+    const persisted = this.wslGitByWorktree[wt.id];
+
+    return {
+      ...wt,
+      isWslPath: true,
+      wslDistro: detected.distro,
+      wslGitEligible: eligible,
+      wslGitOptIn: Boolean(persisted?.enabled),
+      wslGitDismissed: Boolean(persisted?.dismissed),
+    };
+  }
+
+  /**
+   * Update WSL git routing state for a single worktree. Persists the new
+   * preference into the in-memory map and forwards to the matching monitor
+   * (which re-emits its snapshot). Called by the workspace-host message
+   * handler in response to renderer-driven IPC.
+   */
+  setWslOptIn(worktreeId: string, enabled: boolean, dismissed: boolean): void {
+    this.wslGitByWorktree[worktreeId] = { enabled, dismissed };
+    const monitor = this.monitors.get(worktreeId);
+    if (monitor) {
+      monitor.setWslOptIn(enabled, dismissed);
+    }
+  }
+
   private async addNewWorktreeMonitor(
     wt: Worktree,
     isActive: boolean,
@@ -403,6 +455,9 @@ export class WorkspaceService {
     if (this.monitors.has(wt.id)) {
       return;
     }
+
+    const enrichedWt = await this.enrichWorktreeWithWsl(wt);
+    wt = enrichedWt;
 
     await ensureNoteFile(wt.path);
     const issueNumber = wt.branch ? extractIssueNumberSync(wt.branch, wt.name) : null;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -199,7 +199,11 @@ export class WorktreeMonitor {
     if (process.platform !== "win32") return undefined;
     if (!this._isWslPath || !this._wslGitEligible || !this._wslGitOptIn) return undefined;
     if (!this._wslDistro || !this._wslPosixPath) return undefined;
-    return { distro: this._wslDistro, posixPath: this._wslPosixPath };
+    return {
+      distro: this._wslDistro,
+      uncPath: this.path,
+      posixPath: this._wslPosixPath,
+    };
   }
 
   /**

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1,7 +1,8 @@
 import { readFile } from "fs/promises";
 import { join as pathJoin } from "path";
 import { existsSync } from "fs";
-import { createHardenedGit } from "../utils/hardenedGit.js";
+import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
+import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import type PQueue from "p-queue";
 import type { WorktreeChanges, FileChangeDetail } from "../../shared/types/git.js";
 import type {
@@ -134,6 +135,14 @@ export class WorktreeMonitor {
   private _pendingPollPromise: Promise<void> | null = null;
   private _pollAbortController: AbortController = new AbortController();
 
+  // WSL routing state (Windows only)
+  private _isWslPath: boolean = false;
+  private _wslDistro: string | undefined;
+  private _wslGitEligible: boolean = false;
+  private _wslGitOptIn: boolean = false;
+  private _wslGitDismissed: boolean = false;
+  private _wslPosixPath: string | undefined;
+
   // Components
   private pollingStrategy: AdaptivePollingStrategy;
   private noteReader: NoteFileReader;
@@ -167,6 +176,50 @@ export class WorktreeMonitor {
     );
 
     this.noteReader = new NoteFileReader(worktree.path);
+
+    this._isWslPath = Boolean(worktree.isWslPath);
+    this._wslDistro = worktree.wslDistro;
+    this._wslGitEligible = Boolean(worktree.wslGitEligible);
+    this._wslGitOptIn = Boolean(worktree.wslGitOptIn);
+    this._wslGitDismissed = Boolean(worktree.wslGitDismissed);
+    if (this._isWslPath && this._wslDistro) {
+      const m = /^\\\\wsl(?:\$|\.localhost)\\[^\\]+(.*)/i.exec(worktree.path);
+      const remainder = m ? (m[1] ?? "") : "";
+      this._wslPosixPath = remainder.replace(/\\/g, "/") || "/";
+    }
+  }
+
+  /**
+   * Build the WSL invocation passed to `createWslHardenedGit` /
+   * `getWorktreeChangesWithStats({ wsl })`. Returns `undefined` when this
+   * worktree should keep using the native git path: not on Windows, not a
+   * WSL path, ineligible distro (not the default), or user hasn't opted in.
+   */
+  private get wslInvocation(): WslGitInvocation | undefined {
+    if (process.platform !== "win32") return undefined;
+    if (!this._isWslPath || !this._wslGitEligible || !this._wslGitOptIn) return undefined;
+    if (!this._wslDistro || !this._wslPosixPath) return undefined;
+    return { distro: this._wslDistro, posixPath: this._wslPosixPath };
+  }
+
+  /**
+   * Update the WSL opt-in / dismissed state at runtime (called by the
+   * workspace-host message handler). Re-emits a snapshot so the renderer's
+   * banner state stays in sync.
+   */
+  setWslOptIn(enabled: boolean, dismissed: boolean): void {
+    let changed = false;
+    if (this._wslGitOptIn !== enabled) {
+      this._wslGitOptIn = enabled;
+      changed = true;
+    }
+    if (this._wslGitDismissed !== dismissed) {
+      this._wslGitDismissed = dismissed;
+      changed = true;
+    }
+    if (changed && this._hasInitialStatus) {
+      this.emitUpdate();
+    }
   }
 
   get name(): string {
@@ -598,6 +651,11 @@ export class WorktreeMonitor {
       planFilePath: this.planFilePath,
       aheadCount: this.aheadCount,
       behindCount: this.behindCount,
+      isWslPath: this._isWslPath || undefined,
+      wslDistro: this._wslDistro,
+      wslGitEligible: this._wslGitEligible || undefined,
+      wslGitOptIn: this._wslGitOptIn || undefined,
+      wslGitDismissed: this._wslGitDismissed || undefined,
     };
 
     return ensureSerializable(snapshot) as WorktreeSnapshot;
@@ -929,6 +987,7 @@ export class WorktreeMonitor {
       const newChanges = await getWorktreeChangesWithStats(this.path, {
         forceRefresh,
         cacheTTL,
+        wsl: this.wslInvocation,
       });
 
       if (!this._isRunning) {
@@ -1110,7 +1169,10 @@ export class WorktreeMonitor {
     }
 
     try {
-      const git = createHardenedGit(this.path, this._pollAbortController.signal);
+      const wsl = this.wslInvocation;
+      const git = wsl
+        ? createWslHardenedGit(wsl, this._pollAbortController.signal)
+        : createHardenedGit(this.path, this._pollAbortController.signal);
       const output = await git.raw(["rev-list", "--left-right", "--count", "HEAD...@{u}"]);
       const [aheadStr, behindStr] = output.trim().split(/\s+/);
       return {
@@ -1137,7 +1199,10 @@ export class WorktreeMonitor {
     }
 
     try {
-      const git = createHardenedGit(this.path, this._pollAbortController.signal);
+      const wsl = this.wslInvocation;
+      const git = wsl
+        ? createWslHardenedGit(wsl, this._pollAbortController.signal)
+        : createHardenedGit(this.path, this._pollAbortController.signal);
       const log = await git.log({ maxCount: 1 });
       const lastCommitMsg = log.latest?.message;
 

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1107,6 +1107,7 @@ describe("WorktreeMonitor", () => {
           ];
         expect(lastCall[1]?.wsl).toEqual({
           distro: "Ubuntu",
+          uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
           posixPath: "/home/user/repo",
         });
 
@@ -1116,7 +1117,7 @@ describe("WorktreeMonitor", () => {
       }
     });
 
-    it("setWslOptIn re-emits snapshot when value changes", async () => {
+    it("setWslOptIn re-emits snapshot with updated fields when value changes", async () => {
       const original = process.platform;
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       try {
@@ -1136,6 +1137,11 @@ describe("WorktreeMonitor", () => {
         monitor.setWslOptIn(true, true);
         const updateCallsAfter = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
         expect(updateCallsAfter).toBeGreaterThan(updateCallsBefore);
+
+        const snapshot = monitor.getSnapshot();
+        expect(snapshot.wslGitOptIn).toBe(true);
+        expect(snapshot.wslGitDismissed).toBe(true);
+        expect(snapshot.isWslPath).toBe(true);
 
         monitor.stop();
       } finally {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -6,11 +6,23 @@ const mockGetWorktreeChangesWithStats = vi.fn();
 const mockInvalidateGitStatusCache = vi.fn();
 const mockGitRaw = vi.fn();
 
+const { mockCreateHardenedGit, mockCreateWslHardenedGit } = vi.hoisted(() => ({
+  mockCreateHardenedGit: vi.fn(),
+  mockCreateWslHardenedGit: vi.fn(),
+}));
+
+mockCreateHardenedGit.mockImplementation(() => ({
+  raw: (...args: unknown[]) => mockGitRaw(...args),
+  log: vi.fn().mockResolvedValue({ latest: null }),
+}));
+mockCreateWslHardenedGit.mockImplementation(() => ({
+  raw: (...args: unknown[]) => mockGitRaw(...args),
+  log: vi.fn().mockResolvedValue({ latest: null }),
+}));
+
 vi.mock("../../utils/hardenedGit.js", () => ({
-  createHardenedGit: vi.fn(() => ({
-    raw: (...args: unknown[]) => mockGitRaw(...args),
-    log: vi.fn().mockResolvedValue({ latest: null }),
-  })),
+  createHardenedGit: mockCreateHardenedGit,
+  createWslHardenedGit: mockCreateWslHardenedGit,
   validateCwd: vi.fn(),
 }));
 
@@ -1036,6 +1048,99 @@ describe("WorktreeMonitor", () => {
       expect(callCount).toBe(3);
 
       monitor.stop();
+    });
+  });
+
+  describe("WSL git routing", () => {
+    beforeEach(() => {
+      mockCreateHardenedGit.mockClear();
+      mockCreateWslHardenedGit.mockClear();
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        changes: [],
+        changedFileCount: 0,
+        totalInsertions: 0,
+        totalDeletions: 0,
+        latestFileMtime: null,
+        lastUpdated: Date.now(),
+      });
+    });
+
+    it("does not pass wsl invocation when not opted in", async () => {
+      const wsl: Worktree = {
+        ...TEST_WORKTREE,
+        path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+        isWslPath: true,
+        wslDistro: "Ubuntu",
+        wslGitEligible: true,
+        wslGitOptIn: false,
+      };
+      const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+
+      const lastCall =
+        mockGetWorktreeChangesWithStats.mock.calls[
+          mockGetWorktreeChangesWithStats.mock.calls.length - 1
+        ];
+      expect(lastCall[1]?.wsl).toBeUndefined();
+
+      monitor.stop();
+    });
+
+    it("passes wsl invocation when eligible + opted in (Windows only)", async () => {
+      const original = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        const wsl: Worktree = {
+          ...TEST_WORKTREE,
+          path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+          isWslPath: true,
+          wslDistro: "Ubuntu",
+          wslGitEligible: true,
+          wslGitOptIn: true,
+        };
+        const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, makeCallbacks(), "main");
+        await monitor.start();
+
+        const lastCall =
+          mockGetWorktreeChangesWithStats.mock.calls[
+            mockGetWorktreeChangesWithStats.mock.calls.length - 1
+          ];
+        expect(lastCall[1]?.wsl).toEqual({
+          distro: "Ubuntu",
+          posixPath: "/home/user/repo",
+        });
+
+        monitor.stop();
+      } finally {
+        Object.defineProperty(process, "platform", { value: original, configurable: true });
+      }
+    });
+
+    it("setWslOptIn re-emits snapshot when value changes", async () => {
+      const original = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        const wsl: Worktree = {
+          ...TEST_WORKTREE,
+          path: "\\\\wsl$\\Ubuntu\\home\\user\\repo",
+          isWslPath: true,
+          wslDistro: "Ubuntu",
+          wslGitEligible: true,
+          wslGitOptIn: false,
+        };
+        const callbacks = makeCallbacks();
+        const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, callbacks, "main");
+        await monitor.start();
+
+        const updateCallsBefore = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+        monitor.setWslOptIn(true, true);
+        const updateCallsAfter = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+        expect(updateCallsAfter).toBeGreaterThan(updateCallsBefore);
+
+        monitor.stop();
+      } finally {
+        Object.defineProperty(process, "platform", { value: original, configurable: true });
+      }
     });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1133,7 +1133,8 @@ describe("WorktreeMonitor", () => {
         const monitor = new WorktreeMonitor(wsl, TEST_CONFIG, callbacks, "main");
         await monitor.start();
 
-        const updateCallsBefore = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
+        const updateCallsBefore = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls
+          .length;
         monitor.setWslOptIn(true, true);
         const updateCallsAfter = (callbacks.onUpdate as ReturnType<typeof vi.fn>).mock.calls.length;
         expect(updateCallsAfter).toBeGreaterThan(updateCallsBefore);

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -881,6 +881,14 @@ export interface ElectronAPI {
     get(): Promise<WorktreeConfig>;
     /** Set worktree path pattern */
     setPattern(pattern: string): Promise<WorktreeConfig>;
+    /**
+     * Toggle WSL-routed git for a single worktree. Persists the preference
+     * and forwards to the workspace host so the next git invocation uses the
+     * matching factory. Windows-only.
+     */
+    setWslGit(worktreeId: string, enabled: boolean): Promise<void>;
+    /** Hide the WSL git suggestion banner for this worktree without enabling. */
+    dismissWslBanner(worktreeId: string): Promise<void>;
   };
   window: {
     /** Subscribe to fullscreen state changes */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1279,6 +1279,14 @@ export interface IpcInvokeMap {
     args: [payload: { pattern: string }];
     result: WorktreeConfig;
   };
+  "worktree-config:set-wsl-git": {
+    args: [payload: { worktreeId: string; enabled: boolean }];
+    result: void;
+  };
+  "worktree-config:dismiss-wsl-banner": {
+    args: [payload: { worktreeId: string }];
+    result: void;
+  };
 
   // Gemini channels
   "gemini:get-status": {

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -141,6 +141,21 @@ export interface WorktreeSnapshot {
 
   /** Cached display label for the environment (e.g., "Docker", "Akash") */
   worktreeEnvironmentLabel?: string;
+
+  /** True when the worktree path is mounted via \\wsl$\ or \\wsl.localhost\. */
+  isWslPath?: boolean;
+
+  /** Distro name parsed from the WSL UNC mount, when `isWslPath` is true. */
+  wslDistro?: string;
+
+  /** Whether `wslDistro` matches the WSL default distro (gates "Enable" UI). */
+  wslGitEligible?: boolean;
+
+  /** User has opted in to WSL-routed git for this worktree. */
+  wslGitOptIn?: boolean;
+
+  /** User dismissed the WSL git suggestion banner without opting in. */
+  wslGitDismissed?: boolean;
 }
 
 /** Monitor configuration for polling intervals */
@@ -166,6 +181,12 @@ export type WorkspaceHostRequest =
       requestId: string;
       rootPath: string;
       globalEnvVars?: Record<string, string>;
+      /**
+       * Persisted per-worktree WSL git opt-in state (Windows only). Map key is
+       * the worktree id; values capture the user's previous Enable/Dismiss
+       * decisions so the host can apply them when constructing monitors.
+       */
+      wslGitByWorktree?: Record<string, { enabled: boolean; dismissed: boolean }>;
     }
   | {
       type: "sync";
@@ -218,6 +239,13 @@ export type WorkspaceHostRequest =
     }
   // Polling control
   | { type: "set-polling-enabled"; enabled: boolean }
+  // WSL-routed git opt-in / banner dismissal (Windows only)
+  | {
+      type: "set-wsl-opt-in";
+      worktreeId: string;
+      enabled: boolean;
+      dismissed: boolean;
+    }
   // Background/foreground lifecycle
   | { type: "background" }
   | { type: "foreground" }

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -177,6 +177,37 @@ export interface Worktree {
 
   /** Cached display label for the environment (e.g., "Docker", "Akash") */
   worktreeEnvironmentLabel?: string;
+
+  /**
+   * True when the worktree path is mounted via WSL (\\wsl$\… or
+   * \\wsl.localhost\…). Detected at bind time on Windows; never set on
+   * macOS/Linux.
+   */
+  isWslPath?: boolean;
+
+  /** WSL distro name parsed from the UNC mount, when `isWslPath` is true. */
+  wslDistro?: string;
+
+  /**
+   * True when the detected `wslDistro` matches the WSL default distro and
+   * Daintree can therefore route git operations through `wsl.exe git` (which
+   * always targets the default distro). When false, the banner shows a
+   * read-only informational note instead of an enable button.
+   */
+  wslGitEligible?: boolean;
+
+  /**
+   * User has opted in to routing this worktree's git operations through WSL.
+   * Persisted main-side in `wslGitByWorktree`; mirrored into the snapshot so
+   * the renderer can hide the banner without a separate IPC round-trip.
+   */
+  wslGitOptIn?: boolean;
+
+  /**
+   * User has dismissed the WSL git banner without opting in. Banner stays
+   * hidden until they explicitly enable WSL git from settings (future).
+   */
+  wslGitDismissed?: boolean;
 }
 
 /** Runtime worktree state (internal to WorktreeService) */

--- a/src/clients/worktreeConfigClient.ts
+++ b/src/clients/worktreeConfigClient.ts
@@ -8,4 +8,12 @@ export const worktreeConfigClient = {
   setPattern: (pattern: string): Promise<WorktreeConfig> => {
     return window.electron.worktreeConfig.setPattern(pattern);
   },
+
+  setWslGit: (worktreeId: string, enabled: boolean): Promise<void> => {
+    return window.electron.worktreeConfig.setWslGit(worktreeId, enabled);
+  },
+
+  dismissWslBanner: (worktreeId: string): Promise<void> => {
+    return window.electron.worktreeConfig.dismissWslBanner(worktreeId);
+  },
 } as const;

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -890,15 +890,13 @@ export const WorktreeCard = React.memo(function WorktreeCard({
 
               {!effectiveIsCollapsed && (
                 <div id={`worktree-body-${worktree.id}`}>
-                  {worktree.isWslPath &&
-                    !worktree.wslGitOptIn &&
-                    !worktree.wslGitDismissed && (
-                      <WslGitBanner
-                        worktreeId={worktree.id}
-                        wslDistro={worktree.wslDistro}
-                        wslGitEligible={worktree.wslGitEligible}
-                      />
-                    )}
+                  {worktree.isWslPath && !worktree.wslGitOptIn && !worktree.wslGitDismissed && (
+                    <WslGitBanner
+                      worktreeId={worktree.id}
+                      wslDistro={worktree.wslDistro}
+                      wslGitEligible={worktree.wslGitEligible}
+                    />
+                  )}
                   {isMainWorktree && (
                     <MainWorktreeSummaryRows
                       aggregateCounts={aggregateCounts}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -27,6 +27,7 @@ import { WorktreeDetailsSection } from "./WorktreeCard/WorktreeDetailsSection";
 import { WorktreeDialogs } from "./WorktreeCard/WorktreeDialogs";
 import { WorktreeHeader } from "./WorktreeCard/WorktreeHeader";
 import { WorktreeTerminalSection } from "./WorktreeCard/WorktreeTerminalSection";
+import { WslGitBanner } from "./WorktreeCard/WslGitBanner";
 import {
   MainWorktreeSummaryRows,
   type AggregateCounts,
@@ -81,6 +82,11 @@ export function worktreeCardPropsAreEqual(
       a.taskId !== b.taskId ||
       a.hasPlanFile !== b.hasPlanFile ||
       a.planFilePath !== b.planFilePath ||
+      a.isWslPath !== b.isWslPath ||
+      a.wslDistro !== b.wslDistro ||
+      a.wslGitEligible !== b.wslGitEligible ||
+      a.wslGitOptIn !== b.wslGitOptIn ||
+      a.wslGitDismissed !== b.wslGitDismissed ||
       a.worktreeChanges !== b.worktreeChanges
     ) {
       return false;
@@ -884,6 +890,15 @@ export const WorktreeCard = React.memo(function WorktreeCard({
 
               {!effectiveIsCollapsed && (
                 <div id={`worktree-body-${worktree.id}`}>
+                  {worktree.isWslPath &&
+                    !worktree.wslGitOptIn &&
+                    !worktree.wslGitDismissed && (
+                      <WslGitBanner
+                        worktreeId={worktree.id}
+                        wslDistro={worktree.wslDistro}
+                        wslGitEligible={worktree.wslGitEligible}
+                      />
+                    )}
                   {isMainWorktree && (
                     <MainWorktreeSummaryRows
                       aggregateCounts={aggregateCounts}

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback, useState } from "react";
+import { worktreeConfigClient } from "@/clients/worktreeConfigClient";
+import { logError } from "@/utils/logger";
+import { cn } from "../../../lib/utils";
+
+export interface WslGitBannerProps {
+  worktreeId: string;
+  wslDistro?: string;
+  wslGitEligible?: boolean;
+}
+
+/**
+ * Inline banner shown on WSL-mounted worktrees suggesting the user route git
+ * through `wsl git` to avoid the 9P boundary slowdown. Two variants:
+ *
+ * - Eligible (`wslGitEligible === true`): "Enable WSL git" + "Not now" buttons.
+ *   Enabling persists the opt-in and re-routes git invocations on the next
+ *   poll cycle.
+ *
+ * - Ineligible (`wslGitEligible === false`): read-only informational note —
+ *   the worktree is in a non-default distro and we can't safely route through
+ *   `wsl.exe git` without distro-specific args.
+ */
+export const WslGitBanner = React.memo(function WslGitBanner({
+  worktreeId,
+  wslDistro,
+  wslGitEligible,
+}: WslGitBannerProps) {
+  const [busy, setBusy] = useState(false);
+
+  const handleEnable = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await worktreeConfigClient.setWslGit(worktreeId, true);
+    } catch (err) {
+      logError("Failed to enable WSL git for worktree", { worktreeId, err });
+    } finally {
+      setBusy(false);
+    }
+  }, [worktreeId, busy]);
+
+  const handleDismiss = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await worktreeConfigClient.dismissWslBanner(worktreeId);
+    } catch (err) {
+      logError("Failed to dismiss WSL git banner", { worktreeId, err });
+    } finally {
+      setBusy(false);
+    }
+  }, [worktreeId, busy]);
+
+  if (wslGitEligible) {
+    return (
+      <div
+        role="status"
+        className={cn(
+          "mx-3 my-2 rounded-md border border-daintree-border bg-overlay-subtle px-3 py-2",
+          "flex items-start gap-3 text-sm"
+        )}
+      >
+        <div className="flex-1">
+          <div className="font-medium text-daintree-text-primary">Speed up git on this WSL worktree</div>
+          <div className="mt-0.5 text-daintree-text-secondary">
+            This worktree lives in WSL ({wslDistro ?? "unknown distro"}). Routing git through{" "}
+            <code className="rounded bg-overlay-subtle px-1 py-0.5">wsl git</code> avoids the
+            Windows–Linux filesystem boundary and can make status polling 5–10× faster.
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            onClick={handleEnable}
+            disabled={busy}
+            className={cn(
+              "rounded border border-daintree-border bg-overlay-strong px-2 py-1 text-xs",
+              "transition-colors duration-150 hover:bg-overlay-strong-hover",
+              "disabled:cursor-not-allowed disabled:opacity-60"
+            )}
+          >
+            Enable WSL git
+          </button>
+          <button
+            type="button"
+            onClick={handleDismiss}
+            disabled={busy}
+            className={cn(
+              "rounded px-2 py-1 text-xs text-daintree-text-secondary",
+              "transition-colors duration-150 hover:text-daintree-text-primary",
+              "disabled:cursor-not-allowed disabled:opacity-60"
+            )}
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        "mx-3 my-2 rounded-md border border-daintree-border bg-overlay-subtle px-3 py-2",
+        "flex items-start gap-3 text-sm"
+      )}
+    >
+      <div className="flex-1">
+        <div className="font-medium text-daintree-text-primary">WSL worktree (non-default distro)</div>
+        <div className="mt-0.5 text-daintree-text-secondary">
+          This worktree is in <code className="rounded bg-overlay-subtle px-1 py-0.5">{wslDistro ?? "WSL"}</code>,
+          which isn't the default WSL distro. Daintree can't yet route git through this distro
+          automatically — git will run from Windows and may be slower than usual.
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        disabled={busy}
+        className={cn(
+          "shrink-0 rounded px-2 py-1 text-xs text-daintree-text-secondary",
+          "transition-colors duration-150 hover:text-daintree-text-primary",
+          "disabled:cursor-not-allowed disabled:opacity-60"
+        )}
+      >
+        Got it
+      </button>
+    </div>
+  );
+});

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -62,7 +62,9 @@ export const WslGitBanner = React.memo(function WslGitBanner({
         )}
       >
         <div className="flex-1">
-          <div className="font-medium text-daintree-text-primary">Speed up git on this WSL worktree</div>
+          <div className="font-medium text-daintree-text-primary">
+            Speed up git on this WSL worktree
+          </div>
           <div className="mt-0.5 text-daintree-text-secondary">
             This worktree lives in WSL ({wslDistro ?? "unknown distro"}). Routing git through{" "}
             <code className="rounded bg-overlay-subtle px-1 py-0.5">wsl git</code> avoids the
@@ -108,10 +110,13 @@ export const WslGitBanner = React.memo(function WslGitBanner({
       )}
     >
       <div className="flex-1">
-        <div className="font-medium text-daintree-text-primary">WSL worktree (non-default distro)</div>
+        <div className="font-medium text-daintree-text-primary">
+          WSL worktree (non-default distro)
+        </div>
         <div className="mt-0.5 text-daintree-text-secondary">
-          This worktree is in <code className="rounded bg-overlay-subtle px-1 py-0.5">{wslDistro ?? "WSL"}</code>,
-          which isn't the default WSL distro. Daintree can't yet route git through this distro
+          This worktree is in{" "}
+          <code className="rounded bg-overlay-subtle px-1 py-0.5">{wslDistro ?? "WSL"}</code>, which
+          isn't the default WSL distro. Daintree can't yet route git through this distro
           automatically — git will run from Windows and may be slower than usual.
         </div>
       </div>

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -34,7 +34,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
     try {
       await worktreeConfigClient.setWslGit(worktreeId, true);
     } catch (err) {
-      logError("Failed to enable WSL git for worktree", { worktreeId, err });
+      logError("Failed to enable WSL git for worktree", err, { worktreeId });
     } finally {
       setBusy(false);
     }
@@ -46,7 +46,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
     try {
       await worktreeConfigClient.dismissWslBanner(worktreeId);
     } catch (err) {
-      logError("Failed to dismiss WSL git banner", { worktreeId, err });
+      logError("Failed to dismiss WSL git banner", err, { worktreeId });
     } finally {
       setBusy(false);
     }

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -62,10 +62,10 @@ export const WslGitBanner = React.memo(function WslGitBanner({
         )}
       >
         <div className="flex-1">
-          <div className="font-medium text-daintree-text-primary">
+          <div className="font-medium text-text-primary">
             Speed up git on this WSL worktree
           </div>
-          <div className="mt-0.5 text-daintree-text-secondary">
+          <div className="mt-0.5 text-text-secondary">
             This worktree lives in WSL ({wslDistro ?? "unknown distro"}). Routing git through{" "}
             <code className="rounded bg-overlay-subtle px-1 py-0.5">wsl git</code> avoids the
             Windows–Linux filesystem boundary and can make status polling 5–10× faster.
@@ -78,7 +78,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
             disabled={busy}
             className={cn(
               "rounded border border-daintree-border bg-overlay-strong px-2 py-1 text-xs",
-              "transition-colors duration-150 hover:bg-overlay-strong-hover",
+              "transition-colors duration-150 hover:bg-overlay-hover",
               "disabled:cursor-not-allowed disabled:opacity-60"
             )}
           >
@@ -89,8 +89,8 @@ export const WslGitBanner = React.memo(function WslGitBanner({
             onClick={handleDismiss}
             disabled={busy}
             className={cn(
-              "rounded px-2 py-1 text-xs text-daintree-text-secondary",
-              "transition-colors duration-150 hover:text-daintree-text-primary",
+              "rounded px-2 py-1 text-xs text-text-secondary",
+              "transition-colors duration-150 hover:text-text-primary",
               "disabled:cursor-not-allowed disabled:opacity-60"
             )}
           >
@@ -110,10 +110,10 @@ export const WslGitBanner = React.memo(function WslGitBanner({
       )}
     >
       <div className="flex-1">
-        <div className="font-medium text-daintree-text-primary">
+        <div className="font-medium text-text-primary">
           WSL worktree (non-default distro)
         </div>
-        <div className="mt-0.5 text-daintree-text-secondary">
+        <div className="mt-0.5 text-text-secondary">
           This worktree is in{" "}
           <code className="rounded bg-overlay-subtle px-1 py-0.5">{wslDistro ?? "WSL"}</code>, which
           isn't the default WSL distro. Daintree can't yet route git through this distro
@@ -125,8 +125,8 @@ export const WslGitBanner = React.memo(function WslGitBanner({
         onClick={handleDismiss}
         disabled={busy}
         className={cn(
-          "shrink-0 rounded px-2 py-1 text-xs text-daintree-text-secondary",
-          "transition-colors duration-150 hover:text-daintree-text-primary",
+          "shrink-0 rounded px-2 py-1 text-xs text-text-secondary",
+          "transition-colors duration-150 hover:text-text-primary",
           "disabled:cursor-not-allowed disabled:opacity-60"
         )}
       >

--- a/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
+++ b/src/components/Worktree/WorktreeCard/WslGitBanner.tsx
@@ -62,9 +62,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
         )}
       >
         <div className="flex-1">
-          <div className="font-medium text-text-primary">
-            Speed up git on this WSL worktree
-          </div>
+          <div className="font-medium text-text-primary">Speed up git on this WSL worktree</div>
           <div className="mt-0.5 text-text-secondary">
             This worktree lives in WSL ({wslDistro ?? "unknown distro"}). Routing git through{" "}
             <code className="rounded bg-overlay-subtle px-1 py-0.5">wsl git</code> avoids the
@@ -110,9 +108,7 @@ export const WslGitBanner = React.memo(function WslGitBanner({
       )}
     >
       <div className="flex-1">
-        <div className="font-medium text-text-primary">
-          WSL worktree (non-default distro)
-        </div>
+        <div className="font-medium text-text-primary">WSL worktree (non-default distro)</div>
         <div className="mt-0.5 text-text-secondary">
           This worktree is in{" "}
           <code className="rounded bg-overlay-subtle px-1 py-0.5">{wslDistro ?? "WSL"}</code>, which

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -195,6 +195,11 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.hasResumeCommand === b.hasResumeCommand &&
     a.hasTeardownCommand === b.hasTeardownCommand &&
     a.resourceConnectCommand === b.resourceConnectCommand &&
+    a.isWslPath === b.isWslPath &&
+    a.wslDistro === b.wslDistro &&
+    a.wslGitEligible === b.wslGitEligible &&
+    a.wslGitOptIn === b.wslGitOptIn &&
+    a.wslGitDismissed === b.wslGitDismissed &&
     resourceStatusEqual(a.resourceStatus, b.resourceStatus) &&
     worktreeChangesEqual(a.worktreeChanges, b.worktreeChanges) &&
     lifecycleStatusEqual(a.lifecycleStatus, b.lifecycleStatus)


### PR DESCRIPTION
## Summary

- WSL-mounted worktrees (paths under `\\wsl$\` or `\\wsl.localhost\`) cross the 9P boundary on Windows, making git status polling 5-10x slower. This PR detects them at bind time and routes git operations through `wsl.exe git` for users who opt in.
- The opt-in is per-worktree and persisted in electron-store. Non-default distros get a read-only info banner rather than the enable prompt, since routing through the wrong distro would break things silently.
- All changes are win32-gated. macOS and Linux are untouched.

Resolves #6064

## Changes

- `electron/utils/wsl.ts` — `detectWslPath` helper and `listFirstWslDistro` extracted from `CliAvailabilityService`
- `electron/utils/hardenedGit.ts` — `createWslHardenedGit` factory using `["wsl.exe", "git"]` binary tuple, passes UNC path as `baseDir` so simple-git's synchronous `folderExists` check resolves correctly on Windows
- `WorkspaceService` — enriches `Worktree` with WSL fields at bind time, matches against the default distro (case-insensitive)
- `WorktreeMonitor` — uses WSL git binary when the worktree has opted in, falls back to standard hardened git otherwise
- `electron/store.ts` — `wslGitByWorktree` map for opt-in persistence
- `WslGitBanner.tsx` — inline banner on `WorktreeCard` with "Enable WSL git" / "Not now" actions
- IPC plumbing: `set-wsl-opt-in` message, preload exposure, client, store slice update

## Testing

19 new unit tests covering `createWslHardenedGit`, `detectWslPath`, and WSL routing in `WorktreeMonitor`. 760 tests across 39 touched files all passing. Typecheck, lint, format, and build all clean.