### PR TITLE
feat(fleet): add shift+click range select and pre-selection to arming dialog

### DIFF
--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -16,6 +16,9 @@ import { useEscapeStack } from "@/hooks";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { Kbd } from "@/components/ui/Kbd";
+import { isMac } from "@/lib/platform";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { SemanticSearchMatch, TerminalInstance } from "@shared/types";
@@ -98,18 +101,36 @@ export function FleetArmingDialog({
   // results. Incremented before each call; the response captures its issue
   // number and is dropped if the counter has since advanced.
   const searchRequestRef = useRef(0);
+  const rangeAnchorRef = useRef<string | null>(null);
 
   // Reset all dialog-local state on each open/close transition. Single
   // useEffect keyed on [isOpen] per lesson #4958.
   useEffect(() => {
     if (isOpen) {
-      setSelectedIds(new Set());
       setSearchTerm("");
       setActiveChip("all");
       setIsRegexMode(false);
       setSnippetMap(new Map());
       setRegexError(null);
       searchRequestRef.current = 0;
+      rangeAnchorRef.current = null;
+
+      // Pre-select terminals belonging to the active worktree.
+      const activeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      if (activeId) {
+        const preSelected = new Set<string>();
+        for (const tId of usePanelStore.getState().panelIds) {
+          const t = usePanelStore.getState().panelsById[tId];
+          if (t && isFleetArmEligible(t) && t.worktreeId === activeId) {
+            preSelected.add(t.id);
+          }
+        }
+        setSelectedIds(preSelected);
+      } else {
+        setSelectedIds(new Set());
+      }
+    } else {
+      rangeAnchorRef.current = null;
     }
   }, [isOpen]);
 
@@ -262,17 +283,39 @@ export function FleetArmingDialog({
   // is non-empty.
   useEscapeStack(isOpen && searchTerm !== "", clearSearch);
 
-  const toggleId = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
+  const handleToggleId = useCallback(
+    (id: string, event?: React.MouseEvent) => {
+      if (event) event.preventDefault();
+      if (event?.shiftKey && rangeAnchorRef.current !== null) {
+        const anchorIdx = visibleIds.indexOf(rangeAnchorRef.current);
+        const clickedIdx = visibleIds.indexOf(id);
+        if (anchorIdx !== -1 && clickedIdx !== -1 && anchorIdx !== clickedIdx) {
+          const lo = Math.min(anchorIdx, clickedIdx);
+          const hi = Math.max(anchorIdx, clickedIdx);
+          const rangeIds = visibleIds.slice(lo, hi + 1);
+          setSelectedIds((prev) => {
+            const next = new Set(prev);
+            for (const rid of rangeIds) next.add(rid);
+            return next;
+          });
+          rangeAnchorRef.current = id;
+          return;
+        }
       }
-      return next;
-    });
-  }, []);
+      // Plain toggle (no shift, or anchor invalid/filtered out).
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+      rangeAnchorRef.current = id;
+    },
+    [visibleIds]
+  );
 
   const handleGroupHeaderToggle = useCallback((group: WorktreeGroup) => {
     setSelectedIds((prev) => {
@@ -311,6 +354,22 @@ export function FleetArmingDialog({
 
   const confirmLabel =
     confirmedIds.length === 0 ? "Arm selected" : `Arm ${confirmedIds.length} selected`;
+
+  const footerHint = useMemo(() => {
+    if (visibleIds.length === 0) return null;
+    if (selectedIds.size === 0) {
+      return (
+        <>
+          <Kbd>{isMac() ? "⌘A" : "Ctrl+A"}</Kbd> Select all
+        </>
+      );
+    }
+    return (
+      <>
+        <Kbd>Shift</Kbd>+<Kbd>Click</Kbd> Select range
+      </>
+    );
+  }, [visibleIds.length, selectedIds.size]);
 
   return (
     <AppDialog
@@ -438,7 +497,7 @@ export function FleetArmingDialog({
                 selectedIds={selectedIds}
                 hideHeader={isSingleWorktree}
                 snippetMap={snippetMap}
-                onToggleId={toggleId}
+                onToggleId={handleToggleId}
                 onToggleGroup={handleGroupHeaderToggle}
               />
             ))
@@ -447,6 +506,7 @@ export function FleetArmingDialog({
       </div>
 
       <AppDialog.Footer
+        hint={footerHint}
         primaryAction={{
           label: confirmLabel,
           onClick: handleConfirm,
@@ -513,7 +573,7 @@ interface WorktreeGroupSectionProps {
   selectedIds: ReadonlySet<string>;
   hideHeader: boolean;
   snippetMap: ReadonlyMap<string, SemanticSearchMatch>;
-  onToggleId: (id: string) => void;
+  onToggleId: (id: string, event?: React.MouseEvent) => void;
   onToggleGroup: (group: WorktreeGroup) => void;
 }
 
@@ -567,7 +627,7 @@ function WorktreeGroupSection({
             terminal={t}
             checked={selectedIds.has(t.id)}
             snippet={snippetMap.get(t.id)}
-            onToggle={() => onToggleId(t.id)}
+            onToggle={(e) => onToggleId(t.id, e)}
           />
         ))}
       </ul>
@@ -579,7 +639,7 @@ interface TerminalRowProps {
   terminal: DialogTerminal;
   checked: boolean;
   snippet?: SemanticSearchMatch;
-  onToggle: () => void;
+  onToggle: (event?: React.MouseEvent) => void;
 }
 
 function TerminalRow({ terminal, checked, snippet, onToggle }: TerminalRowProps): ReactElement {
@@ -591,10 +651,11 @@ function TerminalRow({ terminal, checked, snippet, onToggle }: TerminalRowProps)
           "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer",
           "hover:bg-tint/[0.06]"
         )}
+        onClick={onToggle}
       >
         <DialogCheckbox
           checked={checked}
-          onCheckedChange={onToggle}
+          onCheckedChange={() => onToggle()}
           ariaLabel={`Select ${terminal.title}`}
         />
         <div className="flex-1 min-w-0">

--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -126,6 +126,12 @@ export function FleetArmingDialog({
           }
         }
         setSelectedIds(preSelected);
+        // Set anchor to the last pre-selected terminal so the first
+        // shift+click after open extends the range rather than
+        // falling through to a plain toggle.
+        if (preSelected.size > 0) {
+          rangeAnchorRef.current = [...preSelected].pop()!;
+        }
       } else {
         setSelectedIds(new Set());
       }

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/hooks/useAnimatedPresence", () => ({
 import { FleetArmingDialog } from "../FleetArmingDialog";
 import { usePanelStore } from "@/store/panelStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
@@ -88,6 +89,7 @@ function resetStores(): void {
     broadcastSignal: 0,
   });
   usePanelStore.setState({ panelsById: {}, panelIds: [], focusedId: null });
+  useWorktreeSelectionStore.setState({ activeWorktreeId: null });
   resetEscapeStack();
 }
 
@@ -613,5 +615,143 @@ describe("FleetArmingDialog", () => {
     // Click Main's header (indeterminate: 1/2 selected) — should deselect Main only.
     fireEvent.click(screen.getByLabelText("Select all 2 terminals in Main"));
     expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+  });
+
+  describe("pre-selection", () => {
+    it("pre-selects terminals belonging to the active worktree on open", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    });
+
+    it("opens empty when activeWorktreeId is null", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(screen.getByText("Arm selected")).toBeTruthy();
+    });
+
+    it("opens empty when active worktree has no eligible terminals", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-2" });
+      seedTerminals([makeTerminal("a", { title: "alpha", worktreeId: "wt-1" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "empty")]);
+      expect(screen.getByText("Arm selected")).toBeTruthy();
+    });
+  });
+
+  describe("shift+click range selection", () => {
+    it("selects inclusive range between anchor and shift-clicked terminal", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-1" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Plain click on "a" to set anchor.
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+      // Shift+click on "c" row — must click the label (not checkbox) so shiftKey propagates.
+      fireEvent.click(screen.getByText("gamma").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
+    it("shift+click across worktree groups selects intermediate terminals", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-2" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      fireEvent.click(screen.getByText("gamma").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
+    it("shift+click without prior anchor behaves as plain toggle", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Shift+click with no anchor — should just toggle "alpha".
+      fireEvent.click(screen.getByText("alpha").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+      // Now alpha is selected AND anchor is set. Shift+click beta.
+      fireEvent.click(screen.getByText("beta").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    });
+
+    it("shift+click falls back to plain toggle when anchor is filtered out", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1", agentState: "waiting" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1", agentState: "working" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-1", agentState: "working" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Click alpha to set anchor.
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      // Filter to "working" — anchor (alpha, "waiting") is now filtered out.
+      fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-working"));
+      // Shift+click gamma with anchor filtered out — should behave as plain toggle.
+      fireEvent.click(screen.getByText("gamma").closest("label")!, { shiftKey: true });
+      // alpha is still selected (not visible), gamma was toggled on.
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    });
+
+    it("anchor reset on dialog close/reopen allows fresh plain click", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha", worktreeId: "wt-1" })]);
+      const store = createWorktreeStore();
+      store.getState().applySnapshot([makeWorktreeSnap("wt-1", "Main")], 1);
+      const { rerender } = render(
+        <WorktreeStoreContext.Provider value={store}>
+          <FleetArmingDialog isOpen={true} onClose={() => {}} />
+        </WorktreeStoreContext.Provider>
+      );
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      // Close.
+      rerender(
+        <WorktreeStoreContext.Provider value={store}>
+          <FleetArmingDialog isOpen={false} onClose={() => {}} />
+        </WorktreeStoreContext.Provider>
+      );
+      // Reopen.
+      rerender(
+        <WorktreeStoreContext.Provider value={store}>
+          <FleetArmingDialog isOpen={true} onClose={() => {}} />
+        </WorktreeStoreContext.Provider>
+      );
+      // Shift+click without prior anchor in new session — plain toggle.
+      fireEvent.click(screen.getByText("alpha").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    });
+  });
+
+  describe("footer hint", () => {
+    it("shows Cmd+A hint when nothing is selected", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(screen.getByText("Select all")).toBeTruthy();
+    });
+
+    it("shows shift+click hint when at least one terminal is selected", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      expect(screen.getByText(/Select range/)).toBeTruthy();
+    });
+
+    it("shows no hint when no terminals are visible", () => {
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(screen.queryByText("Select all")).toBeNull();
+      expect(screen.queryByText("Select range")).toBeNull();
+    });
   });
 });

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -639,6 +639,19 @@ describe("FleetArmingDialog", () => {
       expect(screen.getByText("Arm selected")).toBeTruthy();
     });
 
+    it("first shift+click after pre-selection extends range, not plain toggle", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-2" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main"), makeWorktreeSnap("wt-2", "Other")]);
+      // a and b are pre-selected, anchor = b. Shift+click gamma (c) on wt-2.
+      fireEvent.click(screen.getByText("gamma").closest("label")!, { shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
     it("opens empty when active worktree has no eligible terminals", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-2" });
       seedTerminals([makeTerminal("a", { title: "alpha", worktreeId: "wt-1" })]);
@@ -731,6 +744,22 @@ describe("FleetArmingDialog", () => {
       // Shift+click without prior anchor in new session — plain toggle.
       fireEvent.click(screen.getByText("alpha").closest("label")!, { shiftKey: true });
       expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    });
+
+    it("reverse range confirms all 3 terminals selected", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", worktreeId: "wt-1" }),
+        makeTerminal("b", { title: "beta", worktreeId: "wt-1" }),
+        makeTerminal("c", { title: "gamma", worktreeId: "wt-1" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Click gamma (last), then shift-click alpha (first).
+      fireEvent.click(screen.getByLabelText("Select gamma"));
+      fireEvent.click(screen.getByText("alpha").closest("label")!, { shiftKey: true });
+      fireEvent.click(screen.getByText("Arm 3 selected"));
+      const order = useFleetArmingStore.getState().armOrder;
+      expect(order.length).toBe(3);
+      expect(new Set(order)).toEqual(new Set(["a", "b", "c"]));
     });
   });
 

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -354,6 +354,7 @@ interface AppDialogFooterProps {
   className?: string;
   primaryAction?: DialogAction;
   secondaryAction?: DialogAction;
+  hint?: React.ReactNode;
 }
 
 AppDialog.Footer = function AppDialogFooter({
@@ -361,6 +362,7 @@ AppDialog.Footer = function AppDialogFooter({
   className,
   primaryAction,
   secondaryAction,
+  hint,
 }: AppDialogFooterProps) {
   const context = useContext(AppDialogContext);
   const dialogVariant = context?.variant ?? "default";
@@ -375,31 +377,39 @@ AppDialog.Footer = function AppDialogFooter({
   return (
     <div
       className={cn(
-        "px-6 py-4 border-t border-daintree-border flex justify-end gap-3 shrink-0",
+        "px-6 py-4 border-t border-daintree-border flex items-center gap-3 shrink-0",
+        hint ? "justify-between" : "justify-end",
         className
       )}
     >
-      {children}
-      {!children && secondaryAction && (
-        <Button
-          variant="ghost"
-          onClick={secondaryAction.onClick}
-          disabled={secondaryAction.disabled || secondaryAction.loading}
-          className="text-daintree-text/70 hover:text-daintree-text"
-        >
-          {secondaryAction.loading && <Spinner />}
-          {secondaryAction.label}
-        </Button>
+      {hint && (
+        <div className="text-[12px] text-daintree-text/55 flex items-center gap-1">{hint}</div>
       )}
-      {!children && primaryAction && (
-        <Button
-          variant={getPrimaryVariant()}
-          onClick={primaryAction.onClick}
-          disabled={primaryAction.disabled || primaryAction.loading}
-        >
-          {primaryAction.loading && <Spinner />}
-          {primaryAction.label}
-        </Button>
+      {children}
+      {!children && (
+        <div className="flex items-center gap-3">
+          {secondaryAction && (
+            <Button
+              variant="ghost"
+              onClick={secondaryAction.onClick}
+              disabled={secondaryAction.disabled || secondaryAction.loading}
+              className="text-daintree-text/70 hover:text-daintree-text"
+            >
+              {secondaryAction.loading && <Spinner />}
+              {secondaryAction.label}
+            </Button>
+          )}
+          {primaryAction && (
+            <Button
+              variant={getPrimaryVariant()}
+              onClick={primaryAction.onClick}
+              disabled={primaryAction.disabled || primaryAction.loading}
+            >
+              {primaryAction.loading && <Spinner />}
+              {primaryAction.label}
+            </Button>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
This PR adds a fairly standard UX interaction to the fleet arming dialog — shift+click range selection — along with a couple of smaller improvements that reduce the friction of picking terminals to arm.

- **Shift+click range selection.** Click a terminal to set the anchor, shift+click another to select every terminal between them in visual order, across worktree boundaries. Falls back to a plain toggle when the anchor is filtered out or the dialog was just opened without one.
- **Active-worktree pre-selection.** When the dialog opens, terminals belonging to the current worktree are pre-checked. Sets the range anchor to the last pre-selected terminal so the first shift+click extends the range rather than replacing it. Falls back to empty when the active worktree has no eligible terminals.
- **Contextual footer hint.** Left-aligned kbd chips that toggle based on selection state: Cmd/Ctrl+A when nothing is selected, Shift+Click when something is.

Resolves #6019

## Changes
- `src/components/Fleet/FleetArmingDialog.tsx` — shift+click handler, pre-selection on open, footer hint
- `src/components/Fleet/__tests__/FleetArmingDialog.test.tsx` — 10 new tests
- `src/components/ui/AppDialog.tsx` — optional `hint` slot on Footer

## Testing
- 10 new unit tests in FleetArmingDialog.test.tsx covering all specified edge cases
- Manual verification of shift+click interactions in the running dialog