### PR TITLE
fix(theme): store customSchemes as native arrays, not double-encoded JSON

### DIFF
--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -635,4 +635,129 @@ describe("appTheme handlers", () => {
       await expect(handler(mockEvent, validScheme)).rejects.toThrow("ENOSPC");
     });
   });
+
+  describe("setCustomSchemes", () => {
+    const validScheme = {
+      id: "custom-1",
+      name: "Custom Theme",
+      type: "dark" as const,
+      builtin: false,
+      tokens: { "surface-canvas": "#111111" },
+    };
+
+    it("persists validated scheme arrays", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES);
+      await handler({}, [validScheme]);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ customSchemes: [validScheme] })
+      );
+    });
+
+    it("rejects invalid scheme arrays", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES);
+      await handler({}, [{ id: "", name: "", type: "dark", builtin: false, tokens: {} }]);
+      await handler({}, "not-an-array");
+      await handler({}, 42);
+
+      const setCalls = storeMock.set.mock.calls.filter(
+        (c: unknown[]) => (c[1] as { customSchemes?: unknown }).customSchemes !== undefined
+      );
+      expect(setCalls).toHaveLength(0);
+    });
+  });
+
+  describe("customSchemes migration", () => {
+    it("migrates legacy JSON string to native array on read", async () => {
+      const legacySchemes = JSON.stringify([
+        { id: "old-theme", name: "Old Theme", type: "dark", builtin: false, tokens: {} },
+      ]);
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        customSchemes: legacySchemes,
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_GET);
+      const config = (await handler({}, {})) as {
+        colorSchemeId: string;
+        customSchemes: unknown[];
+      };
+
+      expect(Array.isArray(config.customSchemes)).toBe(true);
+      expect(config.customSchemes).toHaveLength(1);
+
+      // Verify it rewrote the store with the native array
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({
+          customSchemes: expect.any(Array),
+        })
+      );
+    });
+
+    it("returns empty array for malformed legacy JSON", async () => {
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        customSchemes: "not valid json {{{",
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_GET);
+      const config = (await handler({}, {})) as {
+        colorSchemeId: string;
+        customSchemes: unknown[];
+      };
+
+      expect(config.customSchemes).toEqual([]);
+    });
+
+    it("passes through already-migrated native arrays", async () => {
+      const nativeSchemes = [
+        { id: "modern", name: "Modern", type: "light", builtin: false, tokens: {} },
+      ];
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        customSchemes: nativeSchemes,
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_GET);
+      const config = (await handler({}, {})) as {
+        colorSchemeId: string;
+        customSchemes: unknown[];
+      };
+
+      expect(config.customSchemes).toHaveLength(1);
+      expect(config.customSchemes[0]).toMatchObject({ id: "modern" });
+    });
+
+    it("drops invalid entries but preserves valid ones", async () => {
+      const legacySchemes = JSON.stringify([
+        { id: "good", name: "Good", type: "dark", builtin: false, tokens: {} },
+        { id: "bad", name: "", type: "dark", builtin: false, tokens: {} },
+      ]);
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        customSchemes: legacySchemes,
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_GET);
+      const config = (await handler({}, {})) as {
+        colorSchemeId: string;
+        customSchemes: unknown[];
+      };
+
+      expect(config.customSchemes).toHaveLength(1);
+      expect(config.customSchemes[0]).toMatchObject({ id: "good" });
+    });
+  });
 });

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -759,5 +759,26 @@ describe("appTheme handlers", () => {
       expect(config.customSchemes).toHaveLength(1);
       expect(config.customSchemes[0]).toMatchObject({ id: "good" });
     });
+
+    it("preserves valid entries when a native array has one corrupt entry", async () => {
+      const nativeSchemes = [
+        { id: "good", name: "Good", type: "dark" as const, builtin: false, tokens: {} },
+        { id: "bad", name: "", type: "dark" as const, builtin: false, tokens: {} },
+      ];
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        customSchemes: nativeSchemes,
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_GET);
+      const config = (await handler({}, {})) as {
+        colorSchemeId: string;
+        customSchemes: unknown[];
+      };
+
+      expect(config.customSchemes).toHaveLength(1);
+      expect(config.customSchemes[0]).toMatchObject({ id: "good" });
+    });
   });
 });

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -9,6 +9,11 @@ import {
   normalizeAccentHex,
 } from "../../../shared/theme/index.js";
 import { typedHandle, typedHandleWithContext, typedSend } from "../utils.js";
+import {
+  appCustomSchemesReadSchema,
+  appCustomSchemesWriteSchema,
+  migrateCustomSchemes,
+} from "../../schemas/customSchemes.js";
 import type {
   AppThemeConfig,
   AppColorScheme,
@@ -29,7 +34,26 @@ function getAppThemeConfig(): AppThemeConfig {
     config.colorSchemeId;
 
   if (hasStoredScheme) {
-    return config as AppThemeConfig;
+    const cfg = config as AppThemeConfig;
+    // Lazy migration: parse legacy string into native AppColorScheme[]
+    if (typeof cfg.customSchemes === "string" || Array.isArray(cfg.customSchemes)) {
+      const result = migrateCustomSchemes(
+        cfg.customSchemes,
+        appCustomSchemesReadSchema,
+        appCustomSchemesWriteSchema
+      );
+      if (result.migrated) {
+        store.set("appTheme", {
+          ...cfg,
+          customSchemes: result.schemes.length > 0 ? result.schemes : [],
+        } satisfies AppThemeConfig);
+      }
+      if (result.errors.length > 0) {
+        console.warn("[appTheme] customSchemes migration warnings:", result.errors.join("; "));
+      }
+      return { ...cfg, customSchemes: result.schemes };
+    }
+    return cfg;
   }
 
   const defaultSchemeId = nativeTheme.shouldUseDarkColors
@@ -38,18 +62,8 @@ function getAppThemeConfig(): AppThemeConfig {
   return {
     ...(config && typeof config === "object" && !Array.isArray(config) ? config : {}),
     colorSchemeId: defaultSchemeId,
+    customSchemes: [],
   } as AppThemeConfig;
-}
-
-function parseCustomSchemes(config: AppThemeConfig): AppColorScheme[] {
-  if (typeof config.customSchemes !== "string" || !config.customSchemes.trim()) return [];
-  try {
-    const parsed = JSON.parse(config.customSchemes);
-    if (Array.isArray(parsed)) return parsed.map((s: AppColorScheme) => normalizeAppColorScheme(s));
-  } catch {
-    // Malformed custom schemes
-  }
-  return [];
 }
 
 export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void {
@@ -72,15 +86,16 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
   );
 
   handlers.push(
-    typedHandle(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, async (schemesJson: string) => {
-      if (typeof schemesJson !== "string") {
-        console.warn("Invalid app custom schemes:", schemesJson);
+    typedHandle(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, async (schemes: unknown) => {
+      const result = appCustomSchemesWriteSchema.safeParse(schemes);
+      if (!result.success) {
+        console.warn("Invalid app custom schemes:", result.error.message);
         return;
       }
       const current = getAppThemeConfig();
       store.set("appTheme", {
         ...current,
-        customSchemes: schemesJson,
+        customSchemes: result.data,
       } satisfies AppThemeConfig);
     })
   );
@@ -250,7 +265,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
 
       typedSend(win, "app-theme:system-appearance-changed", { isDark, schemeId });
 
-      const customSchemes = parseCustomSchemes(config);
+      const customSchemes = config.customSchemes ?? [];
       const scheme = resolveAppTheme(schemeId, customSchemes);
       win.setBackgroundColor(scheme.tokens["surface-canvas"]);
 

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -3,11 +3,7 @@ import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { parseAppThemeFile } from "../../utils/appThemeImporter.js";
-import {
-  resolveAppTheme,
-  normalizeAppColorScheme,
-  normalizeAccentHex,
-} from "../../../shared/theme/index.js";
+import { resolveAppTheme, normalizeAccentHex } from "../../../shared/theme/index.js";
 import { typedHandle, typedHandleWithContext, typedSend } from "../utils.js";
 import {
   appCustomSchemesReadSchema,

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -42,7 +42,7 @@ function getAppThemeConfig(): AppThemeConfig {
         try {
           store.set("appTheme", {
             ...cfg,
-            customSchemes: result.schemes.length > 0 ? result.schemes : [],
+            customSchemes: result.schemes.length > 0 ? (result.schemes as AppColorScheme[]) : [],
           } satisfies AppThemeConfig);
         } catch {
           // Non-fatal: config parsed but migration write failed
@@ -51,7 +51,7 @@ function getAppThemeConfig(): AppThemeConfig {
       if (result.errors.length > 0) {
         console.warn("[appTheme] customSchemes migration warnings:", result.errors.join("; "));
       }
-      return { ...cfg, customSchemes: result.schemes };
+      return { ...cfg, customSchemes: result.schemes as AppColorScheme[] };
     }
     return cfg;
   }
@@ -95,7 +95,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
       const current = getAppThemeConfig();
       store.set("appTheme", {
         ...current,
-        customSchemes: result.data,
+        customSchemes: result.data as AppColorScheme[],
       } satisfies AppThemeConfig);
     })
   );

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -43,10 +43,14 @@ function getAppThemeConfig(): AppThemeConfig {
         appCustomSchemesWriteSchema
       );
       if (result.migrated) {
-        store.set("appTheme", {
-          ...cfg,
-          customSchemes: result.schemes.length > 0 ? result.schemes : [],
-        } satisfies AppThemeConfig);
+        try {
+          store.set("appTheme", {
+            ...cfg,
+            customSchemes: result.schemes.length > 0 ? result.schemes : [],
+          } satisfies AppThemeConfig);
+        } catch {
+          // Non-fatal: config parsed but migration write failed
+        }
       }
       if (result.errors.length > 0) {
         console.warn("[appTheme] customSchemes migration warnings:", result.errors.join("; "));

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -5,6 +5,11 @@ import { parseColorSchemeFile } from "../../utils/colorSchemeImporter.js";
 import { effectiveCachedProjectViews } from "../../utils/cachedProjectViews.js";
 import type { HandlerDependencies } from "../types.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
+import {
+  terminalCustomSchemesReadSchema,
+  terminalCustomSchemesWriteSchema,
+  migrateCustomSchemes,
+} from "../../schemas/customSchemes.js";
 
 function getTerminalConfigObject(): Record<string, unknown> {
   const config = store.get("terminalConfig");
@@ -20,8 +25,33 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_GET, async () => {
       const config = getTerminalConfigObject();
+      // Lazy migration: parse legacy customSchemes string into native array
+      let customSchemes = config.customSchemes;
+      if (typeof customSchemes === "string" || Array.isArray(customSchemes)) {
+        const result = migrateCustomSchemes(
+          customSchemes,
+          terminalCustomSchemesReadSchema,
+          terminalCustomSchemesWriteSchema
+        );
+        if (result.migrated) {
+          store.set("terminalConfig", {
+            ...config,
+            customSchemes: result.schemes.length > 0 ? result.schemes : [],
+          });
+        }
+        if (result.errors.length > 0) {
+          console.warn(
+            "[terminalConfig] customSchemes migration warnings:",
+            result.errors.join("; ")
+          );
+        }
+        customSchemes = result.schemes;
+      } else {
+        customSchemes = [];
+      }
       return {
         ...config,
+        customSchemes,
         cachedProjectViews: effectiveCachedProjectViews(config.cachedProjectViews),
       } as import("../../../shared/types/ipc/config.js").TerminalConfig;
     })
@@ -131,13 +161,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME, handleTerminalConfigSetColorScheme)
   );
 
-  const handleTerminalConfigSetCustomSchemes = async (schemesJson: string) => {
-    if (typeof schemesJson !== "string") {
-      console.warn("Invalid custom schemes:", schemesJson);
+  const handleTerminalConfigSetCustomSchemes = async (schemes: unknown) => {
+    const result = terminalCustomSchemesWriteSchema.safeParse(schemes);
+    if (!result.success) {
+      console.warn("Invalid terminal custom schemes:", result.error.message);
       return;
     }
     const currentConfig = getTerminalConfigObject();
-    store.set("terminalConfig", { ...currentConfig, customSchemes: schemesJson });
+    store.set("terminalConfig", { ...currentConfig, customSchemes: result.data });
   };
   handlers.push(
     typedHandle(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, handleTerminalConfigSetCustomSchemes)

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -34,10 +34,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
           terminalCustomSchemesWriteSchema
         );
         if (result.migrated) {
-          store.set("terminalConfig", {
-            ...config,
-            customSchemes: result.schemes.length > 0 ? result.schemes : [],
-          });
+          try {
+            store.set("terminalConfig", {
+              ...config,
+              customSchemes: result.schemes.length > 0 ? result.schemes : [],
+            });
+          } catch {
+            // Non-fatal: config parsed but migration write failed
+          }
         }
         if (result.errors.length > 0) {
           console.warn(

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1590,8 +1590,8 @@ const api: ElectronAPI = {
     setColorScheme: (schemeId: string) =>
       _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME, schemeId),
 
-    setCustomSchemes: (schemesJson: string) =>
-      _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, schemesJson),
+    setCustomSchemes: (schemes: unknown) =>
+      _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, schemes),
 
     setRecentSchemeIds: (ids: string[]) =>
       _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS, ids),
@@ -2097,8 +2097,8 @@ const api: ElectronAPI = {
     setColorScheme: (schemeId: string) =>
       _unwrappingInvoke(CHANNELS.APP_THEME_SET_COLOR_SCHEME, schemeId),
 
-    setCustomSchemes: (schemesJson: string) =>
-      _unwrappingInvoke(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, schemesJson),
+    setCustomSchemes: (schemes: unknown) =>
+      _unwrappingInvoke(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, schemes),
 
     importTheme: () => _unwrappingInvoke(CHANNELS.APP_THEME_IMPORT),
 

--- a/electron/schemas/customSchemes.ts
+++ b/electron/schemas/customSchemes.ts
@@ -1,0 +1,124 @@
+/**
+ * Zod schemas for custom color schemes (app theme + terminal config).
+ * Permissive on read (accepts legacy string), strict on write.
+ */
+
+import { z } from "zod";
+
+const appColorSchemeTokenSchema = z.record(z.string(), z.string());
+
+export const appColorSchemeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  type: z.enum(["dark", "light"]),
+  builtin: z.boolean(),
+  tokens: appColorSchemeTokenSchema,
+  palette: z.record(z.string(), z.string()).optional(),
+  extensions: z.record(z.string(), z.string()).optional(),
+  location: z.string().optional(),
+  heroImage: z.string().optional(),
+  heroVideo: z.string().optional(),
+});
+
+export const appCustomSchemesReadSchema = z.union([
+  z.array(appColorSchemeSchema),
+  // Legacy: JSON-encoded string
+  z.string().transform((str, ctx) => {
+    if (!str.trim()) return [];
+    try {
+      const parsed = JSON.parse(str);
+      if (!Array.isArray(parsed)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Expected array" });
+        return z.NEVER;
+      }
+      return parsed;
+    } catch {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid JSON" });
+      return z.NEVER;
+    }
+  }),
+]);
+
+export const appCustomSchemesWriteSchema = z.array(appColorSchemeSchema);
+
+const terminalColorSchemeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  type: z.enum(["dark", "light"]),
+  builtin: z.boolean(),
+  colors: z.record(z.string(), z.string()),
+  location: z.string().optional(),
+});
+
+export const terminalCustomSchemesReadSchema = z.union([
+  z.array(terminalColorSchemeSchema),
+  z.string().transform((str, ctx) => {
+    if (!str.trim()) return [];
+    try {
+      const parsed = JSON.parse(str);
+      if (!Array.isArray(parsed)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Expected array" });
+        return z.NEVER;
+      }
+      return parsed;
+    } catch {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid JSON" });
+      return z.NEVER;
+    }
+  }),
+]);
+
+export const terminalCustomSchemesWriteSchema = z.array(terminalColorSchemeSchema);
+
+export interface CustomSchemesMigrationResult<T> {
+  schemes: T[];
+  /** Entries that failed validation and were dropped */
+  droppedCount: number;
+  /** Human-readable parse/validation errors */
+  errors: string[];
+  /** Whether the store value was rewritten (migrated or pruned) */
+  migrated: boolean;
+}
+
+/**
+ * Parses a legacy string or native array into a validated scheme array.
+ * Returns successfully parsed schemes plus diagnostics for failures.
+ */
+export function migrateCustomSchemes<T>(
+  raw: unknown,
+  readSchema: z.ZodType<T[], z.ZodTypeDef, unknown>,
+  writeSchema: z.ZodType<T[], z.ZodTypeDef, T[]>
+): CustomSchemesMigrationResult<T> {
+  const errors: string[] = [];
+
+  // Step 1: coerce legacy string to array
+  const readResult = readSchema.safeParse(raw);
+  if (!readResult.success) {
+    return { schemes: [], droppedCount: 0, errors: [readResult.error.message], migrated: false };
+  }
+
+  const candidates: unknown[] = readResult.data as unknown[];
+  const valid: T[] = [];
+  let droppedCount = 0;
+
+  // Step 2: validate each entry with strict schema
+  for (let i = 0; i < candidates.length; i++) {
+    const result = writeSchema.element.safeParse(candidates[i]);
+    if (result.success) {
+      valid.push(result.data);
+    } else {
+      droppedCount++;
+      const id =
+        typeof (candidates[i] as Record<string, unknown>)?.id === "string"
+          ? (candidates[i] as Record<string, unknown>).id
+          : `index-${i}`;
+      errors.push(`Dropped invalid custom scheme "${id}": ${result.error.message}`);
+      console.warn(`[customSchemes] ${errors[errors.length - 1]}`);
+    }
+  }
+
+  // Migration happened if we parsed a string or pruned invalid entries
+  const migrated = typeof raw === "string" || droppedCount > 0;
+
+  return { schemes: valid, droppedCount, errors, migrated };
+}

--- a/electron/schemas/customSchemes.ts
+++ b/electron/schemas/customSchemes.ts
@@ -167,8 +167,8 @@ export interface CustomSchemesMigrationResult<T> {
  */
 export function migrateCustomSchemes<T>(
   raw: unknown,
-  readSchema: z.ZodType<T[], z.ZodTypeDef, unknown>,
-  writeSchema: z.ZodType<T[], z.ZodTypeDef, T[]>
+  readSchema: z.ZodSchema<T[]>,
+  writeSchema: z.ZodArray<z.ZodSchema<T>>
 ): CustomSchemesMigrationResult<T> {
   const errors: string[] = [];
 

--- a/electron/schemas/customSchemes.ts
+++ b/electron/schemas/customSchemes.ts
@@ -4,7 +4,6 @@
  */
 
 import { z } from "zod";
-
 const appColorSchemeTokenSchema = z.record(z.string(), z.string());
 
 const themeStrategySchema = z.object({

--- a/electron/schemas/customSchemes.ts
+++ b/electron/schemas/customSchemes.ts
@@ -1,11 +1,88 @@
 /**
  * Zod schemas for custom color schemes (app theme + terminal config).
- * Permissive on read (accepts legacy string), strict on write.
+ * Permissive on read (accepts legacy string, tolerates invalid entries), strict on write.
  */
 
 import { z } from "zod";
 
 const appColorSchemeTokenSchema = z.record(z.string(), z.string());
+
+const themeStrategySchema = z.object({
+  shadowStyle: z.enum(["none", "crisp", "soft", "atmospheric"]).optional(),
+  noiseOpacity: z.number().optional(),
+  materialBlur: z.number().optional(),
+  materialSaturation: z.number().optional(),
+  radiusScale: z.number().optional(),
+  panelStateEdge: z.boolean().optional(),
+});
+
+const themePaletteSchema = z.object({
+  type: z.enum(["dark", "light"]),
+  surfaces: z.object({
+    grid: z.string(),
+    sidebar: z.string(),
+    canvas: z.string(),
+    panel: z.string(),
+    elevated: z.string(),
+  }),
+  text: z.object({
+    primary: z.string(),
+    secondary: z.string(),
+    muted: z.string(),
+    inverse: z.string(),
+  }),
+  border: z.string(),
+  accent: z.string(),
+  accentSecondary: z.string().optional(),
+  status: z.object({
+    success: z.string(),
+    warning: z.string(),
+    danger: z.string(),
+    info: z.string(),
+  }),
+  activity: z.object({
+    active: z.string(),
+    idle: z.string(),
+    working: z.string(),
+    waiting: z.string(),
+  }),
+  overlayTint: z.string().optional(),
+  terminal: z
+    .object({
+      background: z.string().optional(),
+      foreground: z.string().optional(),
+      muted: z.string().optional(),
+      cursor: z.string().optional(),
+      selection: z.string(),
+      red: z.string(),
+      green: z.string(),
+      yellow: z.string(),
+      blue: z.string(),
+      magenta: z.string(),
+      cyan: z.string(),
+      brightRed: z.string(),
+      brightGreen: z.string(),
+      brightYellow: z.string(),
+      brightBlue: z.string(),
+      brightMagenta: z.string(),
+      brightCyan: z.string(),
+      brightWhite: z.string(),
+    })
+    .optional(),
+  syntax: z.object({
+    comment: z.string(),
+    punctuation: z.string(),
+    number: z.string(),
+    string: z.string(),
+    operator: z.string(),
+    keyword: z.string(),
+    function: z.string(),
+    link: z.string(),
+    quote: z.string(),
+    chip: z.string(),
+  }),
+  strategy: themeStrategySchema.optional(),
+});
 
 export const appColorSchemeSchema = z.object({
   id: z.string().min(1),
@@ -13,16 +90,20 @@ export const appColorSchemeSchema = z.object({
   type: z.enum(["dark", "light"]),
   builtin: z.boolean(),
   tokens: appColorSchemeTokenSchema,
-  palette: z.record(z.string(), z.string()).optional(),
+  palette: themePaletteSchema.optional(),
   extensions: z.record(z.string(), z.string()).optional(),
   location: z.string().optional(),
   heroImage: z.string().optional(),
   heroVideo: z.string().optional(),
 });
 
+/**
+ * Read schema: accepts native array OR legacy JSON-encoded string.
+ * Uses z.unknown() elements so a single corrupt entry doesn't drop them all —
+ * per-entry validation happens in migrateCustomSchemes().
+ */
 export const appCustomSchemesReadSchema = z.union([
-  z.array(appColorSchemeSchema),
-  // Legacy: JSON-encoded string
+  z.array(z.unknown()),
   z.string().transform((str, ctx) => {
     if (!str.trim()) return [];
     try {
@@ -51,7 +132,7 @@ const terminalColorSchemeSchema = z.object({
 });
 
 export const terminalCustomSchemesReadSchema = z.union([
-  z.array(terminalColorSchemeSchema),
+  z.array(z.unknown()),
   z.string().transform((str, ctx) => {
     if (!str.trim()) return [];
     try {
@@ -91,10 +172,18 @@ export function migrateCustomSchemes<T>(
 ): CustomSchemesMigrationResult<T> {
   const errors: string[] = [];
 
-  // Step 1: coerce legacy string to array
+  // Step 1: coerce legacy string to unknown array
   const readResult = readSchema.safeParse(raw);
   if (!readResult.success) {
-    return { schemes: [], droppedCount: 0, errors: [readResult.error.message], migrated: false };
+    // If the raw value was a broken legacy string, flag as migrated so the
+    // caller rewrites the store to [] instead of re-parsing on every read.
+    const cleanupNeeded = typeof raw === "string";
+    return {
+      schemes: [],
+      droppedCount: 0,
+      errors: [readResult.error.message],
+      migrated: cleanupNeeded,
+    };
   }
 
   const candidates: unknown[] = readResult.data as unknown[];

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -15,7 +15,7 @@ import {
 import path from "path";
 import { createWindowWithState } from "../windowState.js";
 import { store } from "../store.js";
-import { resolveAppTheme, normalizeAppColorScheme } from "../../shared/theme/index.js";
+import { resolveAppTheme } from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
 
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
@@ -146,22 +146,9 @@ export function setupBrowserWindow(
     colorSchemeId = nativeTheme.shouldUseDarkColors ? "daintree" : "bondi";
   }
 
-  let customSchemes: AppColorScheme[] = [];
-  if (
-    themeConfig &&
-    typeof themeConfig === "object" &&
-    !Array.isArray(themeConfig) &&
-    "customSchemes" in themeConfig &&
-    typeof themeConfig.customSchemes === "string"
-  ) {
-    try {
-      const parsed = JSON.parse(themeConfig.customSchemes);
-      if (Array.isArray(parsed))
-        customSchemes = parsed.map((s: AppColorScheme) => normalizeAppColorScheme(s));
-    } catch {
-      // Malformed custom schemes — fall back to built-in only
-    }
-  }
+  const customSchemes: AppColorScheme[] = Array.isArray(themeConfig?.customSchemes)
+    ? themeConfig.customSchemes
+    : [];
 
   const scheme = resolveAppTheme(colorSchemeId, customSchemes);
   const windowBg = scheme.tokens["surface-canvas"];

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -17,6 +17,11 @@ import { createWindowWithState } from "../windowState.js";
 import { store } from "../store.js";
 import { resolveAppTheme } from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
+import {
+  appCustomSchemesReadSchema,
+  appCustomSchemesWriteSchema,
+  migrateCustomSchemes,
+} from "../schemas/customSchemes.js";
 
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
@@ -146,9 +151,30 @@ export function setupBrowserWindow(
     colorSchemeId = nativeTheme.shouldUseDarkColors ? "daintree" : "bondi";
   }
 
-  const customSchemes: AppColorScheme[] = Array.isArray(themeConfig?.customSchemes)
-    ? themeConfig.customSchemes
-    : [];
+  // Apply lazy migration for legacy string-encoded customSchemes
+  let customSchemes: AppColorScheme[] = [];
+  const rawSchemes =
+    themeConfig && typeof themeConfig === "object" && !Array.isArray(themeConfig)
+      ? (themeConfig as Record<string, unknown>).customSchemes
+      : undefined;
+  if (rawSchemes !== undefined) {
+    const result = migrateCustomSchemes(
+      rawSchemes,
+      appCustomSchemesReadSchema,
+      appCustomSchemesWriteSchema
+    );
+    customSchemes = result.schemes;
+    if (result.migrated) {
+      try {
+        store.set("appTheme", {
+          ...(themeConfig as Record<string, unknown>),
+          customSchemes: result.schemes.length > 0 ? result.schemes : [],
+        });
+      } catch {
+        // Non-fatal: config persisted but migration write failed
+      }
+    }
+  }
 
   const scheme = resolveAppTheme(colorSchemeId, customSchemes);
   const windowBg = scheme.tokens["surface-canvas"];

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -8,11 +8,7 @@
  */
 import type { WebContents } from "electron";
 import { store } from "../store.js";
-import {
-  resolveAppTheme,
-  normalizeAppColorScheme,
-  getAppThemeCssVariables,
-} from "../../shared/theme/index.js";
+import { resolveAppTheme, getAppThemeCssVariables } from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
 
 export function injectSkeletonCss(wc: WebContents): void {
@@ -24,17 +20,9 @@ export function injectSkeletonCss(wc: WebContents): void {
   const themeConfig = store.get("appTheme") ?? {};
   const colorSchemeId =
     typeof themeConfig.colorSchemeId === "string" ? themeConfig.colorSchemeId : "daintree";
-  let customSchemes: AppColorScheme[] = [];
-  if (typeof themeConfig.customSchemes === "string" && themeConfig.customSchemes.length > 0) {
-    try {
-      const parsed = JSON.parse(themeConfig.customSchemes);
-      if (Array.isArray(parsed)) {
-        customSchemes = parsed.map((s: AppColorScheme) => normalizeAppColorScheme(s));
-      }
-    } catch {
-      // Malformed — fall through to built-in only
-    }
-  }
+  const customSchemes: AppColorScheme[] = Array.isArray(themeConfig.customSchemes)
+    ? themeConfig.customSchemes
+    : [];
   const scheme = resolveAppTheme(colorSchemeId, customSchemes);
   const themeVars = getAppThemeCssVariables(scheme);
 

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -10,6 +10,11 @@ import type { WebContents } from "electron";
 import { store } from "../store.js";
 import { resolveAppTheme, getAppThemeCssVariables } from "../../shared/theme/index.js";
 import type { AppColorScheme } from "../../shared/theme/index.js";
+import {
+  appCustomSchemesReadSchema,
+  appCustomSchemesWriteSchema,
+  migrateCustomSchemes,
+} from "../schemas/customSchemes.js";
 
 export function injectSkeletonCss(wc: WebContents): void {
   const appState = store.get("appState");
@@ -20,9 +25,27 @@ export function injectSkeletonCss(wc: WebContents): void {
   const themeConfig = store.get("appTheme") ?? {};
   const colorSchemeId =
     typeof themeConfig.colorSchemeId === "string" ? themeConfig.colorSchemeId : "daintree";
-  const customSchemes: AppColorScheme[] = Array.isArray(themeConfig.customSchemes)
-    ? themeConfig.customSchemes
-    : [];
+  // Apply lazy migration for legacy string-encoded customSchemes
+  let customSchemes: AppColorScheme[] = [];
+  const rawSchemes = (themeConfig as Record<string, unknown>).customSchemes;
+  if (rawSchemes !== undefined) {
+    const result = migrateCustomSchemes(
+      rawSchemes,
+      appCustomSchemesReadSchema,
+      appCustomSchemesWriteSchema
+    );
+    customSchemes = result.schemes;
+    if (result.migrated) {
+      try {
+        store.set("appTheme", {
+          ...(themeConfig as Record<string, unknown>),
+          customSchemes: result.schemes.length > 0 ? result.schemes : [],
+        });
+      } catch {
+        // Non-fatal: config persisted but migration write failed
+      }
+    }
+  }
   const scheme = resolveAppTheme(colorSchemeId, customSchemes);
   const themeVars = getAppThemeCssVariables(scheme);
 

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -211,7 +211,7 @@ export type ColorVisionMode = "default" | "red-green" | "blue-yellow";
 
 export interface AppThemeConfig {
   colorSchemeId: string;
-  customSchemes?: string;
+  customSchemes?: AppColorScheme[];
   colorVisionMode?: ColorVisionMode;
   followSystem?: boolean;
   preferredDarkSchemeId?: string;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -746,7 +746,7 @@ export interface ElectronAPI {
     setHybridInputEnabled(enabled: boolean): Promise<void>;
     setHybridInputAutoFocus(enabled: boolean): Promise<void>;
     setColorScheme(schemeId: string): Promise<void>;
-    setCustomSchemes(schemesJson: string): Promise<void>;
+    setCustomSchemes(schemes: unknown): Promise<void>;
     setRecentSchemeIds(ids: string[]): Promise<void>;
     importColorScheme(): Promise<
       | {
@@ -1114,7 +1114,7 @@ export interface ElectronAPI {
   appTheme: {
     get(): Promise<AppThemeConfig>;
     setColorScheme(schemeId: string): Promise<void>;
-    setCustomSchemes(schemesJson: string): Promise<void>;
+    setCustomSchemes(schemes: unknown): Promise<void>;
     importTheme(): Promise<import("../appTheme.js").AppThemeImportResult>;
     exportTheme(scheme: import("../appTheme.js").AppColorScheme): Promise<boolean>;
     setColorVisionMode(mode: import("../appTheme.js").ColorVisionMode): Promise<void>;

--- a/shared/types/ipc/config.ts
+++ b/shared/types/ipc/config.ts
@@ -18,8 +18,15 @@ export interface TerminalConfig {
   hybridInputAutoFocus?: boolean;
   /** Selected terminal color scheme ID */
   colorSchemeId?: string;
-  /** Custom imported color schemes (serialized) */
-  customSchemes?: string;
+  /** Custom imported color schemes */
+  customSchemes?: {
+    id: string;
+    name: string;
+    type: "dark" | "light";
+    builtin: boolean;
+    colors: Record<string, string>;
+    location?: string;
+  }[];
   /** IDs of the most recently selected terminal color schemes (LRU, newest first, capped at 5) */
   recentSchemeIds?: string[];
   /** Screen reader mode: 'auto' (follow OS), 'on', or 'off' (default: 'auto') */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1036,7 +1036,7 @@ export interface IpcInvokeMap {
     result: void;
   };
   "terminal-config:set-custom-schemes": {
-    args: [schemesJson: string];
+    args: [schemes: unknown];
     result: void;
   };
   "terminal-config:import-color-scheme": {
@@ -1476,7 +1476,7 @@ export interface IpcInvokeMap {
     result: void;
   };
   "app-theme:set-custom-schemes": {
-    args: [schemesJson: string];
+    args: [schemes: unknown];
     result: void;
   };
   "app-theme:import": {

--- a/src/clients/appThemeClient.ts
+++ b/src/clients/appThemeClient.ts
@@ -9,8 +9,8 @@ export const appThemeClient = {
     return window.electron.appTheme.setColorScheme(schemeId);
   },
 
-  setCustomSchemes: (schemesJson: string): Promise<void> => {
-    return window.electron.appTheme.setCustomSchemes(schemesJson);
+  setCustomSchemes: (schemes: AppColorScheme[]): Promise<void> => {
+    return window.electron.appTheme.setCustomSchemes(schemes);
   },
 
   importTheme: () => {

--- a/src/clients/terminalConfigClient.ts
+++ b/src/clients/terminalConfigClient.ts
@@ -1,4 +1,5 @@
 import type { TerminalConfig } from "@shared/types";
+import type { TerminalColorScheme } from "@/config/terminalColorSchemes";
 
 export const terminalConfigClient = {
   get: (): Promise<TerminalConfig> => {
@@ -33,8 +34,8 @@ export const terminalConfigClient = {
     return window.electron.terminalConfig.setColorScheme(schemeId);
   },
 
-  setCustomSchemes: (schemesJson: string): Promise<void> => {
-    return window.electron.terminalConfig.setCustomSchemes(schemesJson);
+  setCustomSchemes: (schemes: TerminalColorScheme[]): Promise<void> => {
+    return window.electron.terminalConfig.setCustomSchemes(schemes);
   },
 
   setRecentSchemeIds: (ids: string[]): Promise<void> => {

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -31,7 +31,7 @@ function shuffleArray<T>(arr: T[]): T[] {
 
 async function persistCustomSchemes() {
   const { customSchemes } = useAppThemeStore.getState();
-  await appThemeClient.setCustomSchemes(JSON.stringify(customSchemes));
+  await appThemeClient.setCustomSchemes(customSchemes);
 }
 
 function PreferredSchemePicker({

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -57,7 +57,7 @@ function SchemePreview({ scheme }: { scheme: TerminalColorScheme }) {
 
 async function persistCustomSchemes() {
   const { customSchemes } = useTerminalColorSchemeStore.getState();
-  await terminalConfigClient.setCustomSchemes(JSON.stringify(customSchemes));
+  await terminalConfigClient.setCustomSchemes(customSchemes);
 }
 
 function resolveSchemeForPreview(

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -25,16 +25,9 @@ export function useAppThemeConfig() {
       .then((config) => {
         if (cancelled) return;
 
-        if (typeof config.customSchemes === "string" && config.customSchemes.trim()) {
-          try {
-            const schemes = JSON.parse(config.customSchemes);
-            if (Array.isArray(schemes)) {
-              for (const scheme of schemes) {
-                addCustomScheme(normalizeAppColorScheme(scheme as AppColorScheme));
-              }
-            }
-          } catch {
-            // ignore malformed custom schemes
+        if (Array.isArray(config.customSchemes)) {
+          for (const scheme of config.customSchemes) {
+            addCustomScheme(normalizeAppColorScheme(scheme as AppColorScheme));
           }
         }
 

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -39,16 +39,9 @@ export function useTerminalConfig() {
           // Hydrate directly to avoid polluting the recently-used list on startup
           useTerminalColorSchemeStore.setState({ selectedSchemeId: config.colorSchemeId.trim() });
         }
-        if (typeof config.customSchemes === "string" && config.customSchemes.trim()) {
-          try {
-            const schemes = JSON.parse(config.customSchemes);
-            if (Array.isArray(schemes)) {
-              for (const scheme of schemes) {
-                addCustomScheme(scheme);
-              }
-            }
-          } catch {
-            // ignore malformed custom schemes
+        if (Array.isArray(config.customSchemes)) {
+          for (const scheme of config.customSchemes) {
+            addCustomScheme(scheme);
           }
         }
         if (Array.isArray(config.recentSchemeIds)) {


### PR DESCRIPTION
## Summary
Theme `customSchemes` was stored as a JSON string nested inside the JSON config file -- a single backslash mistake and the entire entry was silently dropped with no warning. This replaces the double-encoded string with native arrays, adds Zod validation on both read and write, and includes a lazy migration so existing configs are upgraded seamlessly on next read.

Resolves #6057

## Changes
- New `electron/schemas/customSchemes.ts` with permissive read schemas (accept legacy string or native array) and strict write schemas, shared between app theme and terminal config
- `migrateCustomSchemes()` validation pipeline surfaces per-entry parse failures as `console.warn` instead of silently discarding them
- `appTheme.ts` handler reads through the migration on every config load; write path validates with Zod instead of accepting a raw string
- Same migration applied to `terminalConfig.ts` handler for terminal color schemes
- IPC types, preload bridge, and renderer clients updated to pass `AppColorScheme[]` instead of `JSON.stringify`-d strings

## Testing
- Unit tests for all migration paths: legacy string (valid, empty, malformed), native array (valid, mixed valid/invalid entries), and non-string non-array inputs
- Lazy migration persists back to store on first read so subsequent reads are fast