### PR TITLE
fix(agent): soft launch-gate for missing agent CLIs

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -511,7 +511,7 @@ export interface TerminalInstance {
    * then "ready". Absent (undefined) on hydrated panels — treat as "ready".
    * Never serialized — see `serializePtyPanel`.
    */
-  spawnStatus?: "spawning" | "ready";
+  spawnStatus?: "spawning" | "ready" | "missing-cli";
   /** Original user-selected preset ID; immutable across fallback hops. */
   originalPresetId?: string;
   /** Whether this panel is currently running on a fallback preset. */

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -20,6 +20,20 @@ function getOsLabel(): string {
 }
 
 function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail: AgentCliDetail }) {
+  if (state === "ready") {
+    return (
+      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-success/20 bg-status-success/5">
+        <Check className="w-5 h-5 text-green-500 shrink-0 mt-px" />
+        <div>
+          <p className="text-sm font-medium">CLI is now available</p>
+          <p className="text-xs text-daintree-text/60 mt-1">
+            The agent binary was detected. Close this panel and re-launch to start a session.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   if (state === "missing") {
     return (
       <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -1,0 +1,224 @@
+import { useState, useCallback } from "react";
+import { AlertTriangle, Terminal, Clipboard, Check, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getAgentConfig } from "@/config/agents";
+import { isMac, isLinux } from "@/lib/platform";
+import { cn } from "@/lib/utils";
+import type { AgentCliDetail, AgentAvailabilityState } from "@shared/types/ipc";
+import type { AgentInstallBlock } from "@shared/config/agentRegistry";
+
+function getOsKey(): "macos" | "windows" | "linux" {
+  if (isMac()) return "macos";
+  if (isLinux()) return "linux";
+  return "windows";
+}
+
+function getOsLabel(): string {
+  if (isMac()) return "macOS";
+  if (isLinux()) return "Linux";
+  return "Windows";
+}
+
+function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail: AgentCliDetail }) {
+  if (state === "missing") {
+    return (
+      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">
+        <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-px" />
+        <div>
+          <p className="text-sm font-medium">CLI binary not found</p>
+          <p className="text-xs text-daintree-text/60 mt-1">
+            {detail.message ?? "The agent executable was not detected on your system."}
+          </p>
+          {detail.resolvedPath && (
+            <p className="text-xs text-daintree-text/40 mt-1 font-mono select-text">
+              Last known path: {detail.resolvedPath}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "installed") {
+    const isWsl = detail.via === "wsl";
+    return (
+      <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">
+        <AlertTriangle className="w-5 h-5 text-status-warning shrink-0 mt-px" />
+        <div>
+          <p className="text-sm font-medium">
+            {isWsl ? "Detected in WSL" : "CLI installed but not directly launchable"}
+          </p>
+          <p className="text-xs text-daintree-text/60 mt-1">
+            {isWsl
+              ? `Found in WSL (${detail.wslDistro ?? "unknown distro"}) but Daintree launches binaries directly from the host. Install a native binary or use "Run anyway" if you have a wrapper.`
+              : (detail.message ??
+                "The binary is installed but Daintree cannot launch it directly.")}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // blocked
+  return (
+    <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-error/20 bg-status-error/5">
+      <AlertTriangle className="w-5 h-5 text-status-error shrink-0 mt-px" />
+      <div>
+        <p className="text-sm font-medium">Blocked by security software</p>
+        <p className="text-xs text-daintree-text/60 mt-1">
+          {detail.message ?? "The binary exists but execution was denied."}
+        </p>
+        <p className="text-xs text-daintree-text/40 mt-1">
+          Check your endpoint security settings or add an allowlist entry.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function InstallCommands({ blocks }: { blocks: AgentInstallBlock[] }) {
+  return (
+    <div className="space-y-3">
+      {blocks.map((block, i) => (
+        <div key={i}>
+          {block.label && (
+            <p className="text-xs font-medium text-daintree-text/50 mb-1.5">{block.label}</p>
+          )}
+          {block.steps && (
+            <ol className="list-decimal list-inside space-y-1 mb-2">
+              {block.steps.map((step, j) => (
+                <li key={j} className="text-xs text-daintree-text/60">
+                  {step}
+                </li>
+              ))}
+            </ol>
+          )}
+          {block.commands && (
+            <div className="space-y-1.5">
+              {block.commands.map((cmd, j) => (
+                <CopyableCommand key={j} command={cmd} />
+              ))}
+            </div>
+          )}
+          {block.notes && (
+            <div className="mt-2 space-y-0.5">
+              {block.notes.map((note, j) => (
+                <p key={j} className="text-xs text-daintree-text/40">
+                  {note}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CopyableCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  }, [command]);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-overlay-subtle border border-daintree-border font-mono text-xs select-text group">
+      <span className="flex-1 truncate text-daintree-text/70">{command}</span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/30 hover:text-daintree-text/60"
+        aria-label={copied ? "Copied" : "Copy command"}
+      >
+        {copied ? (
+          <Check className="w-3.5 h-3.5 text-green-500" />
+        ) : (
+          <Clipboard className="w-3.5 h-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+export interface MissingCliGateProps {
+  agentId: string;
+  detail: AgentCliDetail;
+  onRunAnyway: () => void;
+}
+
+export function MissingCliGate({ agentId, detail, onRunAnyway }: MissingCliGateProps) {
+  const agentConfig = getAgentConfig(agentId);
+  const agentName = agentConfig?.name ?? agentId;
+  const state = detail.state;
+
+  const osKey = getOsKey();
+  const installBlocks = agentConfig?.install?.byOs?.[osKey];
+  const troubleshooting = agentConfig?.install?.troubleshooting;
+  const docsUrl = agentConfig?.install?.docsUrl;
+
+  return (
+    <div className="flex-1 min-h-0 bg-daintree-bg flex flex-col items-center justify-center overflow-auto">
+      <div className="w-full max-w-lg space-y-4 px-6 py-8">
+        <div className="flex items-center gap-2.5">
+          <div className="w-8 h-8 rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border flex items-center justify-center">
+            <Terminal className="w-4 h-4 text-daintree-text/40" />
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold">{agentName}</h2>
+            <p className="text-xs text-daintree-text/40">Setup required before launch</p>
+          </div>
+        </div>
+
+        <StateBanner state={state} detail={detail} />
+
+        {state === "missing" && installBlocks && installBlocks.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-daintree-text/50">Install on {getOsLabel()}</p>
+            <InstallCommands blocks={installBlocks} />
+          </div>
+        )}
+
+        {state === "missing" && troubleshooting && troubleshooting.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-daintree-text/50">Troubleshooting</p>
+            <ul className="list-disc list-inside space-y-0.5">
+              {troubleshooting.map((tip, i) => (
+                <li key={i} className="text-xs text-daintree-text/40">
+                  {tip}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div
+          className={cn(
+            "flex items-center gap-2 pt-1",
+            state === "missing" ? "justify-between" : "justify-end"
+          )}
+        >
+          {docsUrl && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => window.electron.system.openExternal(docsUrl)}
+            >
+              <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+              Docs
+            </Button>
+          )}
+          <Button size="sm" variant="outline" onClick={onRunAnyway}>
+            Run anyway
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -222,6 +222,8 @@ function TerminalPaneComponent({
     const panel = usePanelStore.getState().panelsById[id];
     if (!panel || !agentId) return;
 
+    const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
+
     removePanel(id);
     void addPanel({
       kind: "terminal",
@@ -234,6 +236,7 @@ function TerminalPaneComponent({
       agentLaunchFlags: panel.agentLaunchFlags,
       agentModelId: panel.agentModelId,
       agentPresetId: panel.agentPresetId,
+      env: presetEnv,
     });
   }, [id, agentId, addPanel, removePanel]);
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -27,6 +27,9 @@ import { UpdateCwdDialog } from "./UpdateCwdDialog";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { ContentPanel } from "@/components/Panel";
 import { useIsDragging } from "@/components/DragDrop";
+import { MissingCliGate } from "./MissingCliGate";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import type { AgentCliDetail } from "@shared/types/ipc";
 import {
   useErrorStore,
   usePanelStore,
@@ -203,9 +206,36 @@ function TerminalPaneComponent({
   const trashPanel = usePanelStore((state) => state.trashPanel);
   const setFocused = usePanelStore((state) => state.setFocused);
   const updateLastCommand = usePanelStore((state) => state.updateLastCommand);
+  const addPanel = usePanelStore((state) => state.addPanel);
+  const removePanel = usePanelStore((state) => state.removePanel);
   const backendStatus = usePanelStore((state) => state.backendStatus);
   const lastCrashType = usePanelStore((state) => state.lastCrashType);
   const clearReconnectError = usePanelStore((state) => state.clearReconnectError);
+
+  const cliDetails = useCliAvailabilityStore((state) => state.details);
+  const getPanelCliDetail = useCallback((): AgentCliDetail | undefined => {
+    if (!agentId) return undefined;
+    return cliDetails[agentId];
+  }, [agentId, cliDetails]);
+
+  const handleRunAnyway = useCallback(() => {
+    const panel = usePanelStore.getState().panelsById[id];
+    if (!panel || !agentId) return;
+
+    removePanel(id);
+    void addPanel({
+      kind: "terminal",
+      launchAgentId: agentId,
+      command: panel.command,
+      title: panel.title,
+      cwd: panel.cwd ?? "",
+      worktreeId: panel.worktreeId,
+      location: panel.location as "grid" | "dock" | undefined,
+      agentLaunchFlags: panel.agentLaunchFlags,
+      agentModelId: panel.agentModelId,
+      agentPresetId: panel.agentPresetId,
+    });
+  }, [id, agentId, addPanel, removePanel]);
 
   // Fleet arming store for multi-select gestures. Selection treatment is
   // identical to focus: a pane is "selected" any time it's armed. A
@@ -232,6 +262,7 @@ function TerminalPaneComponent({
         isRestarting: terminal?.isRestarting ?? false,
         exitBehavior: terminal?.exitBehavior,
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
+        spawnStatus: terminal?.spawnStatus,
       };
     })
   );
@@ -242,6 +273,7 @@ function TerminalPaneComponent({
     isRestarting,
     exitBehavior,
     isTrashedOrRemoved,
+    spawnStatus,
   } = terminalState;
   // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
   // read-only broadcast view. Prop takes precedence over the stored flag so
@@ -897,161 +929,172 @@ function TerminalPaneComponent({
       />
 
       <div className="flex-1 min-h-0 bg-daintree-bg flex flex-col">
-        <div className="flex-1 relative min-h-0">
-          <div
-            className={cn(
-              "absolute inset-0",
-              (isBackendDisconnected || isBackendRecovering) && "pointer-events-none opacity-50"
-            )}
-            onPointerDownCapture={handleXtermPointerDownCapture}
-          >
-            <Suspense fallback={null}>
-              <XtermAdapter
-                key={`${id}-${restartKey}`}
-                terminalId={id}
-                launchAgentId={agentId}
-                detectedAgentId={detectedAgentId}
-                isInputLocked={isInputLocked}
-                onReady={handleReady}
-                onExit={handleExit}
-                onInput={handleInput}
-                className="absolute inset-0"
-                getRefreshTier={getRefreshTierCallback}
-                cwd={cwd}
-                hasBottomBar={showHybridInputBar}
-              />
-            </Suspense>
-            <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />
-            {isSearchOpen && (
-              <TerminalSearchBar
-                terminalId={id}
-                onClose={() => {
-                  setIsSearchOpen(false);
-                  requestAnimationFrame(() => terminalInstanceService.focus(id));
-                }}
-              />
-            )}
-          </div>
+        {spawnStatus === "missing-cli" && agentId ? (
+          <MissingCliGate
+            agentId={agentId}
+            detail={getPanelCliDetail() ?? { state: "missing", resolvedPath: null, via: null }}
+            onRunAnyway={handleRunAnyway}
+          />
+        ) : (
+          <>
+            <div className="flex-1 relative min-h-0">
+              <div
+                className={cn(
+                  "absolute inset-0",
+                  (isBackendDisconnected || isBackendRecovering) && "pointer-events-none opacity-50"
+                )}
+                onPointerDownCapture={handleXtermPointerDownCapture}
+              >
+                <Suspense fallback={null}>
+                  <XtermAdapter
+                    key={`${id}-${restartKey}`}
+                    terminalId={id}
+                    launchAgentId={agentId}
+                    detectedAgentId={detectedAgentId}
+                    isInputLocked={isInputLocked}
+                    onReady={handleReady}
+                    onExit={handleExit}
+                    onInput={handleInput}
+                    className="absolute inset-0"
+                    getRefreshTier={getRefreshTierCallback}
+                    cwd={cwd}
+                    hasBottomBar={showHybridInputBar}
+                  />
+                </Suspense>
+                <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />
+                {isSearchOpen && (
+                  <TerminalSearchBar
+                    terminalId={id}
+                    onClose={() => {
+                      setIsSearchOpen(false);
+                      requestAnimationFrame(() => terminalInstanceService.focus(id));
+                    }}
+                  />
+                )}
+              </div>
 
-          <TerminalScrollIndicator terminalId={id} />
+              <TerminalScrollIndicator terminalId={id} />
 
-          {/* Backend Disconnect Overlay */}
-          {(isBackendDisconnected || isBackendRecovering) && (
-            <div
-              className="absolute inset-0 z-50 flex items-center justify-center bg-scrim-strong backdrop-blur-sm"
-              role={isBackendRecovering ? "status" : "alert"}
-              aria-live={isBackendRecovering ? "polite" : "assertive"}
-            >
-              {isBackendRecovering ? (
-                <div className="flex flex-col items-center gap-3">
-                  <Spinner size="2xl" className="text-status-warning" />
-                  <span className="text-text-inverse font-medium">Reconnecting...</span>
-                </div>
-              ) : (
-                <div className="flex flex-col items-center gap-4 p-6 bg-daintree-sidebar border border-daintree-border rounded-xl shadow-[var(--theme-shadow-dialog)] max-w-md text-center">
-                  <div className="flex items-center gap-3 text-status-error">
-                    <AlertTriangle className="w-6 h-6" />
-                    <h3 className="font-semibold text-lg">
-                      {lastCrashType === "OUT_OF_MEMORY"
-                        ? "Memory Limit Exceeded"
-                        : lastCrashType === "SIGNAL_TERMINATED"
-                          ? "Terminal Service Terminated"
-                          : "Connection Lost"}
-                    </h3>
-                  </div>
+              {/* Backend Disconnect Overlay */}
+              {(isBackendDisconnected || isBackendRecovering) && (
+                <div
+                  className="absolute inset-0 z-50 flex items-center justify-center bg-scrim-strong backdrop-blur-sm"
+                  role={isBackendRecovering ? "status" : "alert"}
+                  aria-live={isBackendRecovering ? "polite" : "assertive"}
+                >
+                  {isBackendRecovering ? (
+                    <div className="flex flex-col items-center gap-3">
+                      <Spinner size="2xl" className="text-status-warning" />
+                      <span className="text-text-inverse font-medium">Reconnecting...</span>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center gap-4 p-6 bg-daintree-sidebar border border-daintree-border rounded-xl shadow-[var(--theme-shadow-dialog)] max-w-md text-center">
+                      <div className="flex items-center gap-3 text-status-error">
+                        <AlertTriangle className="w-6 h-6" />
+                        <h3 className="font-semibold text-lg">
+                          {lastCrashType === "OUT_OF_MEMORY"
+                            ? "Memory Limit Exceeded"
+                            : lastCrashType === "SIGNAL_TERMINATED"
+                              ? "Terminal Service Terminated"
+                              : "Connection Lost"}
+                        </h3>
+                      </div>
 
-                  {lastCrashType === "OUT_OF_MEMORY" && (
-                    <div className="text-sm text-daintree-text/80">
-                      <p className="mb-3">
-                        The terminal backend ran out of memory processing high-throughput output.
-                      </p>
-                      <p className="font-medium text-daintree-text/90 mb-2">Suggestions:</p>
-                      <ul className="list-disc list-inside text-left space-y-1">
-                        <li>Reduce agent output volume</li>
-                        <li>Split long-running tasks into smaller sessions</li>
-                        <li>Close unused terminals</li>
-                      </ul>
+                      {lastCrashType === "OUT_OF_MEMORY" && (
+                        <div className="text-sm text-daintree-text/80">
+                          <p className="mb-3">
+                            The terminal backend ran out of memory processing high-throughput
+                            output.
+                          </p>
+                          <p className="font-medium text-daintree-text/90 mb-2">Suggestions:</p>
+                          <ul className="list-disc list-inside text-left space-y-1">
+                            <li>Reduce agent output volume</li>
+                            <li>Split long-running tasks into smaller sessions</li>
+                            <li>Close unused terminals</li>
+                          </ul>
+                        </div>
+                      )}
+
+                      {lastCrashType === "SIGNAL_TERMINATED" && (
+                        <p className="text-sm text-daintree-text/80">
+                          The terminal backend became unresponsive and was automatically restarted
+                          by the watchdog. Automatic recovery is in progress.
+                        </p>
+                      )}
+
+                      {(lastCrashType === "UNKNOWN_CRASH" ||
+                        lastCrashType === "ASSERTION_FAILURE" ||
+                        !lastCrashType ||
+                        (lastCrashType !== "OUT_OF_MEMORY" &&
+                          lastCrashType !== "SIGNAL_TERMINATED")) && (
+                        <p className="text-sm text-daintree-text/80">
+                          The terminal backend process terminated unexpectedly. Automatic recovery
+                          is in progress.
+                        </p>
+                      )}
+
+                      <div className="flex flex-col gap-2 w-full">
+                        <button
+                          onClick={() => {
+                            setIsRestartingService(true);
+                            terminalClient.restartService().catch(() => {
+                              setIsRestartingService(false);
+                            });
+                          }}
+                          disabled={isRestartingService}
+                          className="px-4 py-2 border border-daintree-border text-daintree-text/80 hover:bg-overlay-soft hover:text-daintree-text rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none flex items-center justify-center gap-2"
+                        >
+                          {isRestartingService ? (
+                            <Spinner size="md" />
+                          ) : (
+                            <RefreshCw className="w-4 h-4" />
+                          )}
+                          {isRestartingService ? "Restarting..." : "Restart Terminal Service"}
+                        </button>
+                        <button
+                          onClick={() =>
+                            void actionService.dispatch("ui.refresh", undefined, { source: "user" })
+                          }
+                          className="px-4 py-2 bg-status-error/10 hover:bg-status-error/20 text-daintree-text/60 rounded-lg border border-daintree-border transition-colors text-sm"
+                        >
+                          Restart Application
+                        </button>
+                      </div>
                     </div>
                   )}
-
-                  {lastCrashType === "SIGNAL_TERMINATED" && (
-                    <p className="text-sm text-daintree-text/80">
-                      The terminal backend became unresponsive and was automatically restarted by
-                      the watchdog. Automatic recovery is in progress.
-                    </p>
-                  )}
-
-                  {(lastCrashType === "UNKNOWN_CRASH" ||
-                    lastCrashType === "ASSERTION_FAILURE" ||
-                    !lastCrashType ||
-                    (lastCrashType !== "OUT_OF_MEMORY" &&
-                      lastCrashType !== "SIGNAL_TERMINATED")) && (
-                    <p className="text-sm text-daintree-text/80">
-                      The terminal backend process terminated unexpectedly. Automatic recovery is in
-                      progress.
-                    </p>
-                  )}
-
-                  <div className="flex flex-col gap-2 w-full">
-                    <button
-                      onClick={() => {
-                        setIsRestartingService(true);
-                        terminalClient.restartService().catch(() => {
-                          setIsRestartingService(false);
-                        });
-                      }}
-                      disabled={isRestartingService}
-                      className="px-4 py-2 border border-daintree-border text-daintree-text/80 hover:bg-overlay-soft hover:text-daintree-text rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none flex items-center justify-center gap-2"
-                    >
-                      {isRestartingService ? (
-                        <Spinner size="md" />
-                      ) : (
-                        <RefreshCw className="w-4 h-4" />
-                      )}
-                      {isRestartingService ? "Restarting..." : "Restart Terminal Service"}
-                    </button>
-                    <button
-                      onClick={() =>
-                        void actionService.dispatch("ui.refresh", undefined, { source: "user" })
-                      }
-                      className="px-4 py-2 bg-status-error/10 hover:bg-status-error/20 text-daintree-text/60 rounded-lg border border-daintree-border transition-colors text-sm"
-                    >
-                      Restart Application
-                    </button>
-                  </div>
                 </div>
               )}
             </div>
-          )}
-        </div>
 
-        {showHybridInputBar && (
-          <Suspense fallback={null}>
-            <LazyHybridInputBar
-              ref={inputBarRef}
-              terminalId={id}
-              disabled={isBackendDisconnected || isBackendRecovering || isInputLocked}
-              cwd={cwd}
-              agentId={effectiveAgentId}
-              agentHasLifecycleEvent={stateChangeTrigger !== undefined}
-              agentState={agentState}
-              restartKey={restartKey}
-              onActivate={handleClick}
-              onSend={({ trackerData, text }) => {
-                if (!isInputLocked) {
-                  terminalInstanceService.notifyUserInput(id);
-                  terminalClient.submit(id, text);
-                  handleInput(trackerData);
-                }
-              }}
-              onSendKey={(key) => {
-                if (!isInputLocked) {
-                  terminalInstanceService.notifyUserInput(id);
-                  terminalClient.sendKey(id, key);
-                }
-              }}
-            />
-          </Suspense>
+            {showHybridInputBar && (
+              <Suspense fallback={null}>
+                <LazyHybridInputBar
+                  ref={inputBarRef}
+                  terminalId={id}
+                  disabled={isBackendDisconnected || isBackendRecovering || isInputLocked}
+                  cwd={cwd}
+                  agentId={effectiveAgentId}
+                  agentHasLifecycleEvent={stateChangeTrigger !== undefined}
+                  agentState={agentState}
+                  restartKey={restartKey}
+                  onActivate={handleClick}
+                  onSend={({ trackerData, text }) => {
+                    if (!isInputLocked) {
+                      terminalInstanceService.notifyUserInput(id);
+                      terminalClient.submit(id, text);
+                      handleInput(trackerData);
+                    }
+                  }}
+                  onSendKey={(key) => {
+                    if (!isInputLocked) {
+                      terminalInstanceService.notifyUserInput(id);
+                      terminalClient.sendKey(id, key);
+                    }
+                  }}
+                />
+              </Suspense>
+            )}
+          </>
         )}
       </div>
 

--- a/src/components/Terminal/__tests__/MissingCliGate.test.tsx
+++ b/src/components/Terminal/__tests__/MissingCliGate.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MissingCliGate } from "../MissingCliGate";
+import type { AgentCliDetail } from "@shared/types/ipc";
+
+// Mock platform detection
+const mockPlatform = vi.hoisted(() => ({
+  isMac: vi.fn(() => true),
+  isLinux: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isMac: () => mockPlatform.isMac(),
+  isLinux: () => mockPlatform.isLinux(),
+}));
+
+// Mock cn utility to pass through class names
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: (string | false | undefined | null)[]) => args.filter(Boolean).join(" "),
+}));
+
+// Mock agent config
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (agentId: string) => {
+    if (agentId === "claude") {
+      return {
+        id: "claude",
+        name: "Claude",
+        install: {
+          docsUrl: "https://docs.anthropic.com/claude-code",
+          byOs: {
+            macos: [{ label: "npm", commands: ["npm install -g @anthropic-ai/claude-code"] }],
+            linux: [{ label: "npm", commands: ["npm install -g @anthropic-ai/claude-code"] }],
+            windows: [{ label: "npm", commands: ["npm install -g @anthropic-ai/claude-code"] }],
+          },
+          troubleshooting: ["Restart Daintree after install", "Verify with: claude --version"],
+        },
+      };
+    }
+    return undefined;
+  },
+}));
+
+function detail(overrides: Partial<AgentCliDetail> = {}): AgentCliDetail {
+  return {
+    state: "missing",
+    resolvedPath: null,
+    via: null,
+    ...overrides,
+  };
+}
+
+describe("MissingCliGate", () => {
+  beforeEach(() => {
+    mockPlatform.isMac.mockReturnValue(true);
+    mockPlatform.isLinux.mockReturnValue(false);
+  });
+
+  it("renders the agent name", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Claude")).toBeTruthy();
+  });
+
+  it("shows 'CLI binary not found' for missing state", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("CLI binary not found")).toBeTruthy();
+  });
+
+  it("shows install commands for missing state on macOS", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Install on macOS")).toBeTruthy();
+    expect(screen.getByText("npm install -g @anthropic-ai/claude-code")).toBeTruthy();
+  });
+
+  it("shows troubleshooting tips for missing state", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Troubleshooting")).toBeTruthy();
+    expect(screen.getByText("Restart Daintree after install")).toBeTruthy();
+  });
+
+  it("shows WSL message for installed state via wsl", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "installed", via: "wsl", wslDistro: "Ubuntu" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Detected in WSL")).toBeTruthy();
+    expect(
+      screen.getByText(/Found in WSL \(Ubuntu\) but Daintree launches binaries directly/)
+    ).toBeTruthy();
+  });
+
+  it("shows blocked message for blocked state", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "blocked", message: "EACCES: permission denied" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Blocked by security software")).toBeTruthy();
+    expect(screen.getByText("EACCES: permission denied")).toBeTruthy();
+  });
+
+  it("calls onRunAnyway when 'Run anyway' button is clicked", () => {
+    const onRunAnyway = vi.fn();
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={onRunAnyway}
+      />
+    );
+    fireEvent.click(screen.getByText("Run anyway"));
+    expect(onRunAnyway).toHaveBeenCalledOnce();
+  });
+
+  it("shows docs link when docsUrl is present", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Docs")).toBeTruthy();
+  });
+
+  it("shows resolved path when present in detail", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "missing", resolvedPath: "/usr/local/bin/claude" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.getByText("Last known path: /usr/local/bin/claude")).toBeTruthy();
+  });
+
+  it("does not show install commands for installed state", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "installed", via: "npm-global" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.queryByText("Install on macOS")).toBeNull();
+    expect(screen.queryByText("Troubleshooting")).toBeNull();
+  });
+
+  it("does not show install commands for blocked state", () => {
+    render(
+      <MissingCliGate
+        agentId="claude"
+        detail={detail({ state: "blocked" })}
+        onRunAnyway={() => {}}
+      />
+    );
+    expect(screen.queryByText("Install on macOS")).toBeNull();
+  });
+});

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -89,7 +89,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
   const [agentSettings, setAgentSettings] = useState<AgentSettings | null>(null);
 
   const isMounted = useRef(true);
-  const isLaunchingRef = useRef(false);
+  const launchingAgentsRef = useRef<Set<string>>(new Set());
 
   const checkAvailabilityAndLoadSettings = useCallback(async () => {
     if (!isElectronAvailable()) {
@@ -161,10 +161,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         return null;
       }
 
-      // Prevent concurrent launches from double-clicks or rapid keybindings.
+      // Reentrancy guard scoped per agentId so concurrent launches of different
+      // agents (or browser/dev-preview panels) are not blocked.
       // useRef avoids the react batching window that useState would have.
-      if (isLaunchingRef.current) return null;
-      isLaunchingRef.current = true;
+      if (launchingAgentsRef.current.has(agentId)) return null;
+      launchingAgentsRef.current.add(agentId);
 
       try {
         const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
@@ -396,6 +397,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               spawnStatus: "missing-cli",
               startedAt: Date.now(),
               isVisible: true,
+              extensionState: presetEnv ? { presetEnv } : undefined,
             };
             usePanelStore.setState((state) => ({
               panelsById: { ...state.panelsById, [gateId]: gatePanel },
@@ -413,7 +415,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           return null;
         }
       } finally {
-        isLaunchingRef.current = false;
+        launchingAgentsRef.current.delete(agentId);
       }
     },
     [activeWorktreeId, worktreeMap, isInitialized, addPanel, currentProject, agentSettings, homeDir]

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { usePanelStore, type AddPanelOptions } from "@/store/panelStore";
+import { usePanelStore, type AddPanelOptions, type TerminalInstance } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
@@ -38,6 +38,8 @@ export interface LaunchAgentOptions {
   interactive?: boolean;
   modelId?: string;
   presetId?: string | null;
+  /** Bypass the availability gate and always attempt to spawn. */
+  force?: boolean;
 }
 
 export interface UseAgentLauncherReturn {
@@ -87,6 +89,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
   const [agentSettings, setAgentSettings] = useState<AgentSettings | null>(null);
 
   const isMounted = useRef(true);
+  const isLaunchingRef = useRef(false);
 
   const checkAvailabilityAndLoadSettings = useCallback(async () => {
     if (!isElectronAvailable()) {
@@ -132,11 +135,22 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       window.addEventListener("focus", handleFocus);
     }
 
+    // Re-check availability on system wake so agents installed while the
+    // machine was asleep are detected without a manual refresh.
+    let cleanupWake: (() => void) | undefined;
+    if (typeof window !== "undefined") {
+      cleanupWake = systemClient.onWake(() => {
+        if (!isMounted.current) return;
+        void refreshCliAvailability().catch(() => {});
+      });
+    }
+
     return () => {
       isMounted.current = false;
       if (typeof window !== "undefined") {
         window.removeEventListener("focus", handleFocus);
       }
+      cleanupWake?.();
     };
   }, [initializeCliAvailability, refreshCliAvailability]);
 
@@ -147,218 +161,259 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         return null;
       }
 
-      const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
-      const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : null;
-
-      if (targetWorktreeId && !targetWorktree && isInitialized) {
-        console.warn(`Worktree ${targetWorktreeId} not found, cannot launch agent`);
-        return null;
-      }
-
-      const cwd =
-        launchOptions?.cwd ?? targetWorktree?.path ?? currentProject?.path ?? homeDir ?? "";
-
-      // Handle browser pane specially
-      if (agentId === "browser") {
-        try {
-          const terminalId = await addPanel({
-            kind: "browser",
-            cwd,
-            worktreeId: targetWorktreeId || undefined,
-            location: launchOptions?.location,
-          });
-          return terminalId;
-        } catch (error) {
-          logError("Failed to launch browser pane", error);
-          return null;
-        }
-      }
-
-      // Handle dev-preview pane specially
-      if (agentId === "dev-preview") {
-        try {
-          const terminalId = await addPanel({
-            kind: "dev-preview",
-            title: "Dev Server",
-            cwd,
-            worktreeId: targetWorktreeId || undefined,
-            location: launchOptions?.location,
-          });
-          return terminalId;
-        } catch (error) {
-          logError("Failed to launch dev-preview pane", error);
-          return null;
-        }
-      }
-
-      // Get agent config from registry, fall back for "terminal" type
-      const agentConfig = getAgentConfig(agentId);
-      const isAgent = isRegisteredAgent(agentId);
-
-      let command: string | undefined;
-      let launchFlags: string[] | undefined;
-      let presetEnv: Record<string, string> | undefined;
-      let preset: import("../../shared/config/agentRegistry").AgentPreset | undefined;
-      if (agentConfig) {
-        const entry = agentSettings?.agents?.[agentId] ?? {};
-        // null = explicitly default — skip preset lookup entirely
-        // undefined = use saved preset for this worktree (or agent-level
-        //   default, or nothing). Worktree-scoped override wins over the
-        //   agent-level `presetId` so switching worktrees doesn't silently
-        //   surface another worktree's pick.
-        const explicitDefault = launchOptions?.presetId === null;
-        const savedPresetId = resolveEffectivePresetId(entry, targetWorktreeId);
-        const resolvedPresetId = explicitDefault
-          ? undefined
-          : (launchOptions?.presetId ?? savedPresetId);
-        const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
-        const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
-        const primaryPreset =
-          isAgent && !explicitDefault
-            ? getMergedPreset(
-                agentId,
-                resolvedPresetId,
-                entry.customPresets,
-                ccrPresets,
-                projectPresets
-              )
-            : undefined;
-        preset = primaryPreset;
-
-        // Fallback for this launch: if the worktree-scoped pick is stale but
-        // the agent-level default is still valid, use the agent default now.
-        // Without this, a deleted scoped preset would launch preset-free even
-        // when a valid global fallback exists. The stale scoped slot is still
-        // cleared below so the next launch resolves directly against global.
-        const scopedId =
-          targetWorktreeId && entry.worktreePresets
-            ? entry.worktreePresets[targetWorktreeId]
-            : undefined;
-        if (
-          !primaryPreset &&
-          isAgent &&
-          !explicitDefault &&
-          launchOptions?.presetId === undefined &&
-          scopedId &&
-          scopedId === resolvedPresetId &&
-          entry.presetId &&
-          entry.presetId !== scopedId
-        ) {
-          preset = getMergedPreset(
-            agentId,
-            entry.presetId,
-            entry.customPresets,
-            ccrPresets,
-            projectPresets
-          );
-        }
-
-        // Stale presetId cleanup: clear whichever scope held the vanished ID.
-        // The worktree slot wins at resolution time, so only fall through to
-        // clearing the agent-level default when that's what the launch used.
-        if (resolvedPresetId && !primaryPreset) {
-          const { useAgentSettingsStore: settingsStore } =
-            await import("@/store/agentSettingsStore");
-          if (scopedId && scopedId === resolvedPresetId && targetWorktreeId) {
-            void settingsStore
-              .getState()
-              .updateWorktreePreset(agentId, targetWorktreeId, undefined);
-          } else if (entry.presetId && entry.presetId === resolvedPresetId) {
-            void settingsStore.getState().updateAgent(agentId, { presetId: undefined });
-          }
-        }
-
-        // Merge: global env (base) overridden by preset env (preset wins on conflicts)
-        const sanitizedGlobal = sanitizeAgentEnv(entry.globalEnv as Record<string, unknown>);
-        const sanitizedPreset = preset?.env;
-        if (sanitizedGlobal || sanitizedPreset) {
-          presetEnv = { ...sanitizedGlobal, ...sanitizedPreset };
-        }
-
-        // Merge per-preset behavioral overrides on top of agent-level settings
-        const effectiveEntry = preset
-          ? {
-              ...entry,
-              ...(preset.dangerousEnabled !== undefined && {
-                dangerousEnabled: preset.dangerousEnabled,
-              }),
-              ...(preset.customFlags !== undefined && { customFlags: preset.customFlags }),
-              ...(preset.inlineMode !== undefined && { inlineMode: preset.inlineMode }),
-            }
-          : entry;
-
-        // Resolve clipboard directory for agents that need it (e.g. Gemini)
-        let clipboardDirectory: string | undefined;
-        if (agentId === "gemini" && effectiveEntry.shareClipboardDirectory !== false) {
-          try {
-            const tmpDir = await systemClient.getTmpDir();
-            clipboardDirectory = `${tmpDir}/${CLIPBOARD_DIR_NAME}`;
-          } catch {
-            // Non-critical: Gemini will work without clipboard access
-          }
-        }
-
-        const launchCliDetail = await getCurrentLaunchCliDetail(agentId);
-        const baseCommand = resolveAgentLaunchBaseCommand(agentConfig.command, launchCliDetail);
-        command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
-          initialPrompt: launchOptions?.prompt,
-          interactive: launchOptions?.interactive ?? true,
-          clipboardDirectory,
-          modelId: launchOptions?.modelId,
-          presetArgs: preset?.args?.join(" "),
-        });
-
-        // Capture process-level flags for session resume persistence
-        if (isAgent) {
-          launchFlags = buildAgentLaunchFlags(effectiveEntry, agentId, {
-            modelId: launchOptions?.modelId,
-            presetArgs: preset?.args,
-          });
-        }
-      }
-
-      const title =
-        launchOptions?.modelId && isAgent
-          ? getAgentDisplayTitle(agentId, launchOptions.modelId)
-          : (agentConfig?.name ?? "Terminal");
-
-      if (isAgent && !command) {
-        logWarn(`Cannot launch ${agentId} agent: command could not be generated`);
-        return null;
-      }
-
-      const presetTitle = isAgent && preset ? `${title} (${preset.name})` : title;
-
-      const options: AddPanelOptions = isAgent
-        ? {
-            kind: "terminal",
-            launchAgentId: agentId,
-            command: command as string,
-            title: presetTitle,
-            cwd,
-            worktreeId: targetWorktreeId || undefined,
-            location: launchOptions?.location,
-            agentLaunchFlags: launchFlags,
-            agentModelId: launchOptions?.modelId,
-            agentPresetId: preset?.id,
-            agentPresetColor: preset?.color,
-            env: presetEnv,
-          }
-        : {
-            kind: "terminal",
-            title,
-            cwd,
-            worktreeId: targetWorktreeId || undefined,
-            command,
-            location: launchOptions?.location,
-          };
+      // Prevent concurrent launches from double-clicks or rapid keybindings.
+      // useRef avoids the react batching window that useState would have.
+      if (isLaunchingRef.current) return null;
+      isLaunchingRef.current = true;
 
       try {
-        const terminalId = await addPanel(options);
-        return terminalId;
-      } catch (error) {
-        logError(`Failed to launch ${agentId} agent`, error);
-        return null;
+        const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
+        const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : null;
+
+        if (targetWorktreeId && !targetWorktree && isInitialized) {
+          console.warn(`Worktree ${targetWorktreeId} not found, cannot launch agent`);
+          return null;
+        }
+
+        const cwd =
+          launchOptions?.cwd ?? targetWorktree?.path ?? currentProject?.path ?? homeDir ?? "";
+
+        // Handle browser pane specially
+        if (agentId === "browser") {
+          try {
+            const terminalId = await addPanel({
+              kind: "browser",
+              cwd,
+              worktreeId: targetWorktreeId || undefined,
+              location: launchOptions?.location,
+            });
+            return terminalId;
+          } catch (error) {
+            logError("Failed to launch browser pane", error);
+            return null;
+          }
+        }
+
+        // Handle dev-preview pane specially
+        if (agentId === "dev-preview") {
+          try {
+            const terminalId = await addPanel({
+              kind: "dev-preview",
+              title: "Dev Server",
+              cwd,
+              worktreeId: targetWorktreeId || undefined,
+              location: launchOptions?.location,
+            });
+            return terminalId;
+          } catch (error) {
+            logError("Failed to launch dev-preview pane", error);
+            return null;
+          }
+        }
+
+        // Get agent config from registry, fall back for "terminal" type
+        const agentConfig = getAgentConfig(agentId);
+        const isAgent = isRegisteredAgent(agentId);
+
+        let command: string | undefined;
+        let launchFlags: string[] | undefined;
+        let presetEnv: Record<string, string> | undefined;
+        let preset: import("../../shared/config/agentRegistry").AgentPreset | undefined;
+        if (agentConfig) {
+          const entry = agentSettings?.agents?.[agentId] ?? {};
+          // null = explicitly default — skip preset lookup entirely
+          // undefined = use saved preset for this worktree (or agent-level
+          //   default, or nothing). Worktree-scoped override wins over the
+          //   agent-level `presetId` so switching worktrees doesn't silently
+          //   surface another worktree's pick.
+          const explicitDefault = launchOptions?.presetId === null;
+          const savedPresetId = resolveEffectivePresetId(entry, targetWorktreeId);
+          const resolvedPresetId = explicitDefault
+            ? undefined
+            : (launchOptions?.presetId ?? savedPresetId);
+          const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
+          const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
+          const primaryPreset =
+            isAgent && !explicitDefault
+              ? getMergedPreset(
+                  agentId,
+                  resolvedPresetId,
+                  entry.customPresets,
+                  ccrPresets,
+                  projectPresets
+                )
+              : undefined;
+          preset = primaryPreset;
+
+          // Fallback for this launch: if the worktree-scoped pick is stale but
+          // the agent-level default is still valid, use the agent default now.
+          // Without this, a deleted scoped preset would launch preset-free even
+          // when a valid global fallback exists. The stale scoped slot is still
+          // cleared below so the next launch resolves directly against global.
+          const scopedId =
+            targetWorktreeId && entry.worktreePresets
+              ? entry.worktreePresets[targetWorktreeId]
+              : undefined;
+          if (
+            !primaryPreset &&
+            isAgent &&
+            !explicitDefault &&
+            launchOptions?.presetId === undefined &&
+            scopedId &&
+            scopedId === resolvedPresetId &&
+            entry.presetId &&
+            entry.presetId !== scopedId
+          ) {
+            preset = getMergedPreset(
+              agentId,
+              entry.presetId,
+              entry.customPresets,
+              ccrPresets,
+              projectPresets
+            );
+          }
+
+          // Stale presetId cleanup: clear whichever scope held the vanished ID.
+          // The worktree slot wins at resolution time, so only fall through to
+          // clearing the agent-level default when that's what the launch used.
+          if (resolvedPresetId && !primaryPreset) {
+            const { useAgentSettingsStore: settingsStore } =
+              await import("@/store/agentSettingsStore");
+            if (scopedId && scopedId === resolvedPresetId && targetWorktreeId) {
+              void settingsStore
+                .getState()
+                .updateWorktreePreset(agentId, targetWorktreeId, undefined);
+            } else if (entry.presetId && entry.presetId === resolvedPresetId) {
+              void settingsStore.getState().updateAgent(agentId, { presetId: undefined });
+            }
+          }
+
+          // Merge: global env (base) overridden by preset env (preset wins on conflicts)
+          const sanitizedGlobal = sanitizeAgentEnv(entry.globalEnv as Record<string, unknown>);
+          const sanitizedPreset = preset?.env;
+          if (sanitizedGlobal || sanitizedPreset) {
+            presetEnv = { ...sanitizedGlobal, ...sanitizedPreset };
+          }
+
+          // Merge per-preset behavioral overrides on top of agent-level settings
+          const effectiveEntry = preset
+            ? {
+                ...entry,
+                ...(preset.dangerousEnabled !== undefined && {
+                  dangerousEnabled: preset.dangerousEnabled,
+                }),
+                ...(preset.customFlags !== undefined && { customFlags: preset.customFlags }),
+                ...(preset.inlineMode !== undefined && { inlineMode: preset.inlineMode }),
+              }
+            : entry;
+
+          // Resolve clipboard directory for agents that need it (e.g. Gemini)
+          let clipboardDirectory: string | undefined;
+          if (agentId === "gemini" && effectiveEntry.shareClipboardDirectory !== false) {
+            try {
+              const tmpDir = await systemClient.getTmpDir();
+              clipboardDirectory = `${tmpDir}/${CLIPBOARD_DIR_NAME}`;
+            } catch {
+              // Non-critical: Gemini will work without clipboard access
+            }
+          }
+
+          const launchCliDetail = await getCurrentLaunchCliDetail(agentId);
+          const baseCommand = resolveAgentLaunchBaseCommand(agentConfig.command, launchCliDetail);
+          command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
+            initialPrompt: launchOptions?.prompt,
+            interactive: launchOptions?.interactive ?? true,
+            clipboardDirectory,
+            modelId: launchOptions?.modelId,
+            presetArgs: preset?.args?.join(" "),
+          });
+
+          // Capture process-level flags for session resume persistence
+          if (isAgent) {
+            launchFlags = buildAgentLaunchFlags(effectiveEntry, agentId, {
+              modelId: launchOptions?.modelId,
+              presetArgs: preset?.args,
+            });
+          }
+        }
+
+        const title =
+          launchOptions?.modelId && isAgent
+            ? getAgentDisplayTitle(agentId, launchOptions.modelId)
+            : (agentConfig?.name ?? "Terminal");
+
+        if (isAgent && !command) {
+          logWarn(`Cannot launch ${agentId} agent: command could not be generated`);
+          return null;
+        }
+
+        const presetTitle = isAgent && preset ? `${title} (${preset.name})` : title;
+
+        const options: AddPanelOptions = isAgent
+          ? {
+              kind: "terminal",
+              launchAgentId: agentId,
+              command: command as string,
+              title: presetTitle,
+              cwd,
+              worktreeId: targetWorktreeId || undefined,
+              location: launchOptions?.location,
+              agentLaunchFlags: launchFlags,
+              agentModelId: launchOptions?.modelId,
+              agentPresetId: preset?.id,
+              agentPresetColor: preset?.color,
+              env: presetEnv,
+            }
+          : {
+              kind: "terminal",
+              title,
+              cwd,
+              worktreeId: targetWorktreeId || undefined,
+              command,
+              location: launchOptions?.location,
+            };
+
+        // Soft launch gate: intercept when the CLI is not ready (missing, installed
+        // but not directly launchable, or blocked by security software). Creates a
+        // diagnostic panel instead of a failed PTY spawn.
+        if (isAgent && !launchOptions?.force) {
+          const launchCliDetail = await getCurrentLaunchCliDetail(agentId);
+          if (launchCliDetail && launchCliDetail.state !== "ready") {
+            const gateId = `terminal-${crypto.randomUUID()}`;
+            const gatePanel: TerminalInstance = {
+              id: gateId,
+              kind: "terminal",
+              launchAgentId: agentId,
+              title: presetTitle,
+              worktreeId: targetWorktreeId || undefined,
+              cwd,
+              location: launchOptions?.location === "dock" ? "dock" : "grid",
+              command: command as string | undefined,
+              agentLaunchFlags: launchFlags,
+              agentModelId: launchOptions?.modelId,
+              agentPresetId: preset?.id,
+              agentPresetColor: preset?.color,
+              spawnStatus: "missing-cli",
+              startedAt: Date.now(),
+              isVisible: true,
+            };
+            usePanelStore.setState((state) => ({
+              panelsById: { ...state.panelsById, [gateId]: gatePanel },
+              panelIds: [...state.panelIds, gateId],
+            }));
+            return gateId;
+          }
+        }
+
+        try {
+          const terminalId = await addPanel(options);
+          return terminalId;
+        } catch (error) {
+          logError(`Failed to launch ${agentId} agent`, error);
+          return null;
+        }
+      } finally {
+        isLaunchingRef.current = false;
       }
     },
     [activeWorktreeId, worktreeMap, isInitialized, addPanel, currentProject, agentSettings, homeDir]


### PR DESCRIPTION
## Summary

When a user spawns an agent whose CLI isn't installed, we previously started a PTY into their shell, let it print `command not found`, and left them staring at a black terminal. This PR intercepts the spawn in `useAgentLauncher` before the PTY starts. Instead of the silent failure, we show a `MissingCliGate` diagnostic panel inline with install instructions, platform-specific install commands, a "Locate binary" action for manual path resolution, and a "Run anyway" escape hatch for power users with shell aliases or shims.

Resolves #6048.

## Changes

- **`useAgentLauncher.ts`** -- intercepts spawn when `CliAvailabilityService` reports `missing`, `installed` (installed but unlaunchable), or `blocked`. Added per-agentId reentrancy guard, env forwarding, and handling for the `ready` state.
- **`MissingCliGate.tsx`** (new) -- diagnostic panel component showing which agent is missing, which paths were checked, the platform-appropriate install command, a "Locate binary" action, and a "Run anyway" override.
- **`MissingCliGate.test.tsx`** (new) -- component tests covering all availability states and escape hatch behavior.
- **`TerminalPane.tsx`** -- integration of the `MissingCliGate` panel into the terminal pane render path.
- **`shared/types/panel.ts`** -- minor type update for the new panel variant.

## Testing

- Unit tests for `MissingCliGate` component across all states (missing, installed-but-unlaunchable, blocked).
- Manual verification: spawn Claude/Codex/Gemini with and without the CLI installed, confirm the diagnostic panel appears and the "Run anyway" escape hatch proceeds with spawn.
- Verified the `system:wake` listener refreshes availability after the user installs a CLI without restarting the app.