### PR TITLE
feat(agents): add 'unauthenticated' availability state for installed-but-not-authenticated agents

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -215,18 +215,20 @@ export class CliAvailabilityService {
     }
 
     // Binary found on PATH (or via native/npx) = launchable. Auth discovery
-    // runs in parallel only to populate `authConfirmed` for onboarding UI;
-    // it never gates the state. Agents without an `authCheck` config leave
-    // `authConfirmed` undefined so consumers can distinguish "no check
-    // applicable" from "check ran, nothing found".
+    // runs in parallel only to populate `authConfirmed` for onboarding UI.
+    // When auth discovery explicitly returns false (credential check ran and
+    // found nothing), classify as `unauthenticated` — the binary exists but
+    // will require login on first launch. The CLI handles auth at runtime.
     const authConfirmed = config.authCheck
       ? await this.checkAuth(config.name, config.authCheck)
       : undefined;
 
+    const state: AgentAvailabilityState = authConfirmed === false ? "unauthenticated" : "ready";
+
     return {
-      state: "ready",
+      state,
       detail: {
-        state: "ready",
+        state,
         resolvedPath: probe.path,
         via: probe.via,
         authConfirmed,

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -101,25 +101,24 @@ describe("CliAvailabilityService", () => {
   });
 
   describe("checkAvailability", () => {
-    it("returns 'ready' when binary found even when no auth file exists (decoupled from auth)", async () => {
+    it("returns 'unauthenticated' when binary found but no auth file exists (decoupled from auth)", async () => {
       // Mock all CLIs as available (binary found)
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       const result = await service.checkAvailability();
 
-      // Binary-on-PATH is sufficient for "ready"; auth discovery populates
-      // `detail.authConfirmed` but never blocks launch (see #5483).
+      // Binary-on-PATH without auth is now `unauthenticated`, not `ready`.
+      // The CLI is still launchable — auth discovery populates
+      // `detail.authConfirmed` but the state signalled is distinct so
+      // the UI can show a "Login required" nudge.
       for (const state of Object.values(result)) {
-        expect(state).toBe("ready");
+        expect(state).toBe("unauthenticated");
       }
 
       const details = service.getDetails();
       expect(details).not.toBeNull();
-      // All built-in agents ship with an authCheck config, so without any
-      // auth file or env var they surface `authConfirmed: false` for the
-      // onboarding nudge while still being launchable.
       for (const detail of Object.values(details!)) {
-        expect(detail?.state).toBe("ready");
+        expect(detail?.state).toBe("unauthenticated");
         expect(detail?.authConfirmed).toBe(false);
       }
 
@@ -233,7 +232,7 @@ describe("CliAvailabilityService", () => {
 
       const result = await service.checkAvailability();
 
-      expect(result.claude).toBe("ready");
+      expect(result.claude).toBe("unauthenticated");
       expect(service.getDetails()?.claude?.resolvedPath).toBe("/tmp/daintree-fake-bin/claude");
       expect(mockedExecFileSync).not.toHaveBeenCalledWith("which", ["claude"], expect.any(Object));
     });
@@ -456,7 +455,7 @@ describe("CliAvailabilityService", () => {
       const result = await service.checkAvailability();
       // Binary on PATH is sufficient for `ready`; the missing credential
       // surfaces as `authConfirmed: false` for onboarding UI.
-      expect(result.opencode).toBe("ready");
+      expect(result.opencode).toBe("unauthenticated");
       expect(service.getDetails()!.opencode?.authConfirmed).toBe(false);
     });
 
@@ -507,7 +506,7 @@ describe("CliAvailabilityService", () => {
       expect(cached).not.toBeNull();
       // All agents should have some state (not null)
       for (const state of Object.values(cached!)) {
-        expect(["missing", "installed", "ready", "blocked"]).toContain(state);
+        expect(["missing", "installed", "ready", "blocked", "unauthenticated"]).toContain(state);
       }
     });
   });
@@ -552,7 +551,7 @@ describe("CliAvailabilityService", () => {
       const result = await freshService.refresh();
 
       for (const state of Object.values(result)) {
-        expect(["missing", "installed", "ready", "blocked"]).toContain(state);
+        expect(["missing", "installed", "ready", "blocked", "unauthenticated"]).toContain(state);
       }
       expect(freshService.getAvailability()).toEqual(result);
     });
@@ -631,9 +630,8 @@ describe("CliAvailabilityService", () => {
 
       const result = await service.checkAvailability();
 
-      // Binary on PATH is now always `ready`; the missing SSO token cache
-      // surfaces as `authConfirmed: false` for the setup nudge.
-      expect(result.kiro).toBe("ready");
+      // Binary on PATH + no credential detected → `unauthenticated`.
+      expect(result.kiro).toBe("unauthenticated");
       expect(service.getDetails()!.kiro?.authConfirmed).toBe(false);
 
       const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
@@ -683,7 +681,7 @@ describe("CliAvailabilityService", () => {
       // Binary on PATH is launchable regardless of auth; keychain-auth users
       // still reach `ready` and see `authConfirmed: false` until the CLI
       // prompts them to sign in.
-      expect(result.copilot).toBe("ready");
+      expect(result.copilot).toBe("unauthenticated");
       expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
       const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
@@ -721,8 +719,8 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      // Binary on PATH = ready; authConfirmed: false drives the nudge.
-      expect(result.copilot).toBe("ready");
+      // Binary on PATH, no auth detected → `unauthenticated`.
+      expect(result.copilot).toBe("unauthenticated");
       expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
       const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
@@ -803,8 +801,8 @@ describe("CliAvailabilityService", () => {
         await vi.advanceTimersByTimeAsync(4_000);
         const result = await checkPromise;
 
-        // Binary found, auth inconclusive due to timeout → ready + authConfirmed: false.
-        expect(result.copilot).toBe("ready");
+        // Binary found, auth inconclusive due to timeout → unauthenticated.
+        expect(result.copilot).toBe("unauthenticated");
         expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
         const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
@@ -943,10 +941,10 @@ describe("CliAvailabilityService", () => {
       const result = await service.checkAvailability();
       // Binary discovered via native path → "ready" (auth not a launch gate).
       // The missing auth file surfaces as `authConfirmed: false` in the detail.
-      expect(result.claude).toBe("ready");
+      expect(result.claude).toBe("unauthenticated");
 
       const details = service.getDetails();
-      expect(details!.claude?.state).toBe("ready");
+      expect(details!.claude?.state).toBe("unauthenticated");
       expect(details!.claude?.resolvedPath).toBe(claudeNative);
       expect(details!.claude?.via).toBe("native");
       expect(details!.claude?.authConfirmed).toBe(false);
@@ -1055,10 +1053,10 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.gemini).toBe("ready");
+      expect(result.gemini).toBe("unauthenticated");
 
       const details = service.getDetails();
-      expect(details!.gemini?.state).toBe("ready");
+      expect(details!.gemini?.state).toBe("unauthenticated");
       expect(details!.gemini?.via).toBe("npm-global");
       expect(details!.gemini?.resolvedPath).toBe(geminiShim);
 
@@ -1144,7 +1142,7 @@ describe("CliAvailabilityService", () => {
         });
 
         const result = await service.checkAvailability();
-        expect(result.gemini).toBe("ready");
+        expect(result.gemini).toBe("unauthenticated");
 
         const details = service.getDetails();
         expect(details!.gemini?.via).toBe("npm-global");
@@ -1255,7 +1253,7 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.cursor).toBe("ready");
+      expect(result.cursor).toBe("unauthenticated");
 
       const details = service.getDetails();
       expect(details!.cursor?.via).toBe("native");
@@ -1277,7 +1275,7 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.cursor).toBe("ready");
+      expect(result.cursor).toBe("unauthenticated");
 
       const details = service.getDetails();
       expect(details!.cursor?.resolvedPath).toBe(appBundleNative);
@@ -1299,7 +1297,7 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.opencode).toBe("ready");
+      expect(result.opencode).toBe("unauthenticated");
 
       const details = service.getDetails();
       expect(details!.opencode?.via).toBe("native");

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -31,15 +31,16 @@ export interface SystemWakePayload {
  *
  * - `missing`: binary not found via any probe (PATH, native installer path, npm global bin).
  * - `installed`: binary found but cannot be launched directly (e.g. WSL-detected on
- *   Windows, where direct spawn isn't wired up yet). Agents whose binary is on PATH
- *   are always `ready`, regardless of whether a credential file was detected.
- * - `ready`: binary found and launchable. Auth discovery runs in parallel and is
- *   surfaced via {@link AgentCliDetail.authConfirmed} for onboarding nudges; it does
- *   not gate launch.
+ *   Windows, where direct spawn isn't wired up yet).
+ * - `ready`: binary found, launchable, and credentials confirmed. Auth discovery
+ *   succeeded — the agent can start without a login prompt.
  * - `blocked`: binary exists but execution was denied (security software like Santa,
  *   CrowdStrike, SentinelOne, or Windows Defender, or missing execute permission).
  *   Distinct from `missing` because the fix is a permissions/allowlist change, not
  *   a reinstall.
+ * - `unauthenticated`: binary found and launchable, but the passive auth probe found
+ *   no credentials. The CLI will prompt for login on first launch. Distinct from
+ *   `ready` so the UI can show a "Login required" nudge without gating launch.
  */
 export type AgentAvailabilityState =
   | "missing"

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -41,7 +41,12 @@ export interface SystemWakePayload {
  *   Distinct from `missing` because the fix is a permissions/allowlist change, not
  *   a reinstall.
  */
-export type AgentAvailabilityState = "missing" | "installed" | "ready" | "blocked";
+export type AgentAvailabilityState =
+  | "missing"
+  | "installed"
+  | "ready"
+  | "blocked"
+  | "unauthenticated";
 
 /** CLI availability status for AI agents */
 export type CliAvailability = Record<AgentId, AgentAvailabilityState>;

--- a/shared/utils/__tests__/agentAvailability.test.ts
+++ b/shared/utils/__tests__/agentAvailability.test.ts
@@ -6,7 +6,7 @@ import {
   isAgentBlocked,
   isAgentUnauthenticated,
   isAgentLaunchable,
-} from "../agentAvailability";
+} from "../agentAvailability.js";
 
 const ALL_STATES = ["missing", "installed", "ready", "blocked", "unauthenticated"] as const;
 

--- a/shared/utils/__tests__/agentAvailability.test.ts
+++ b/shared/utils/__tests__/agentAvailability.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAgentReady,
+  isAgentInstalled,
+  isAgentMissing,
+  isAgentBlocked,
+  isAgentUnauthenticated,
+  isAgentLaunchable,
+} from "../agentAvailability";
+
+const ALL_STATES = ["missing", "installed", "ready", "blocked", "unauthenticated"] as const;
+
+describe("isAgentReady", () => {
+  it("returns true only for ready", () => {
+    expect(isAgentReady("ready")).toBe(true);
+    for (const s of ALL_STATES) {
+      if (s !== "ready") expect(isAgentReady(s)).toBe(false);
+    }
+    expect(isAgentReady(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentInstalled", () => {
+  it("returns true for installed, ready, blocked, and unauthenticated", () => {
+    expect(isAgentInstalled("installed")).toBe(true);
+    expect(isAgentInstalled("ready")).toBe(true);
+    expect(isAgentInstalled("blocked")).toBe(true);
+    expect(isAgentInstalled("unauthenticated")).toBe(true);
+    expect(isAgentInstalled("missing")).toBe(false);
+    expect(isAgentInstalled(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentMissing", () => {
+  it("returns true only for missing or undefined", () => {
+    expect(isAgentMissing("missing")).toBe(true);
+    expect(isAgentMissing(undefined)).toBe(true);
+    for (const s of ALL_STATES) {
+      if (s !== "missing") expect(isAgentMissing(s)).toBe(false);
+    }
+  });
+});
+
+describe("isAgentBlocked", () => {
+  it("returns true only for blocked", () => {
+    expect(isAgentBlocked("blocked")).toBe(true);
+    for (const s of ALL_STATES) {
+      if (s !== "blocked") expect(isAgentBlocked(s)).toBe(false);
+    }
+    expect(isAgentBlocked(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentUnauthenticated", () => {
+  it("returns true only for unauthenticated", () => {
+    expect(isAgentUnauthenticated("unauthenticated")).toBe(true);
+    for (const s of ALL_STATES) {
+      if (s !== "unauthenticated") expect(isAgentUnauthenticated(s)).toBe(false);
+    }
+    expect(isAgentUnauthenticated(undefined)).toBe(false);
+  });
+});
+
+describe("isAgentLaunchable", () => {
+  it("returns true for ready and unauthenticated", () => {
+    expect(isAgentLaunchable("ready")).toBe(true);
+    expect(isAgentLaunchable("unauthenticated")).toBe(true);
+    expect(isAgentLaunchable("installed")).toBe(false);
+    expect(isAgentLaunchable("blocked")).toBe(false);
+    expect(isAgentLaunchable("missing")).toBe(false);
+    expect(isAgentLaunchable(undefined)).toBe(false);
+  });
+});

--- a/shared/utils/agentAvailability.ts
+++ b/shared/utils/agentAvailability.ts
@@ -13,7 +13,19 @@ export function isAgentReady(state: AgentAvailabilityState | undefined): boolean
  * alongside truly uninstalled agents.
  */
 export function isAgentInstalled(state: AgentAvailabilityState | undefined): boolean {
-  return state === "installed" || state === "ready" || state === "blocked";
+  return (
+    state === "installed" || state === "ready" || state === "blocked" || state === "unauthenticated"
+  );
+}
+
+/** True when the binary is on PATH but no credentials were detected. */
+export function isAgentUnauthenticated(state: AgentAvailabilityState | undefined): boolean {
+  return state === "unauthenticated";
+}
+
+/** True when the binary can be launched (CLI handles auth at runtime). */
+export function isAgentLaunchable(state: AgentAvailabilityState | undefined): boolean {
+  return state === "ready" || state === "unauthenticated";
 }
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,7 +128,7 @@ import {
   usePreferencesStore,
 } from "./store";
 import { useAgentSettingsStore } from "./store/agentSettingsStore";
-import { isAgentReady } from "../shared/utils/agentAvailability";
+import { isAgentLaunchable } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
 import { MotionConfig } from "framer-motion";
@@ -349,7 +349,7 @@ function App() {
         : [];
       const primaryAgent = defaultAgent ?? selected[0];
 
-      if (primaryAgent && isAgentReady(availability[primaryAgent])) {
+      if (primaryAgent && isAgentLaunchable(availability[primaryAgent])) {
         launchAgent(primaryAgent, {
           worktreeId: activeWorktreeId ?? undefined,
         }).catch(() => {});

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -33,9 +33,13 @@ import {
 import { ChevronDown, PanelBottom, Unplug } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
-import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
+import {
+  isAgentLaunchable,
+  isAgentInstalled,
+  isAgentUnauthenticated,
+} from "../../../shared/utils/agentAvailability";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
-import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -145,7 +149,6 @@ export function AgentButton({
   const { worktrees } = useWorktrees();
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
-  const cliDetail = useCliAvailabilityStore((s) => s.details[type]);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
@@ -245,21 +248,21 @@ export function AgentButton({
   const tooltipDetails = config.tooltip ? ` — ${config.tooltip}` : "";
   const shortcut = displayCombo ? ` (${displayCombo})` : "";
   const isLoading = availability === undefined;
-  const isReady = isAgentReady(availability);
+  const isLaunchable = isAgentLaunchable(availability);
   // `installed` now only fires for WSL-capped binaries (launch not wired
   // through wsl.exe yet); all other binary-on-PATH agents reach `ready`.
   // `needsSetup` dims the button and routes clicks to Settings for these
   // genuinely non-launchable cases.
-  const needsSetup = isAgentInstalled(availability) && !isReady;
+  const needsSetup = isAgentInstalled(availability) && !isLaunchable;
   // Surfaced in the tooltip only — launchable agents whose passive auth
   // probe came back empty get a soft cue rather than a disabled look,
   // because the CLI itself will prompt for sign-in on first run.
-  const signInUnconfirmed = isReady && cliDetail?.authConfirmed === false;
+  const signInUnconfirmed = isAgentUnauthenticated(availability);
 
   const presetSegment = activePresetName ? ` · ${activePresetName}` : "";
   const tooltip = isLoading
     ? `Checking ${config.name} CLI availability...`
-    : isReady
+    : isLaunchable
       ? signInUnconfirmed
         ? `Start ${config.name}${presetSegment} — sign-in not detected${shortcut}`
         : `Start ${config.name}${presetSegment}${tooltipDetails}${shortcut}`
@@ -270,14 +273,14 @@ export function AgentButton({
 
   const ariaLabel = isLoading
     ? `Checking ${config.name} availability`
-    : isReady
+    : isLaunchable
       ? `Start ${config.name} Agent`
       : needsSetup
         ? `${config.name} needs setup`
         : `${config.name} CLI not installed`;
 
   const handleClick = () => {
-    if (isReady) {
+    if (isLaunchable) {
       // Defer all preset resolution to useAgentLauncher. Forwarding the
       // resolved savedPresetId explicitly would block the launcher's
       // stale-fallback path: when a worktree-scoped pick references a
@@ -355,7 +358,7 @@ export function AgentButton({
         </ContextMenuTrigger>
         <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
           <ContextMenuItem
-            disabled={!isReady}
+            disabled={!isLaunchable}
             onSelect={() =>
               void actionService.dispatch(
                 "agent.launch",
@@ -367,7 +370,7 @@ export function AgentButton({
             Launch {config.name}
           </ContextMenuItem>
           <ContextMenuItem
-            disabled={!isReady}
+            disabled={!isLaunchable}
             onSelect={() =>
               void actionService.dispatch(
                 "agent.launch",
@@ -380,7 +383,9 @@ export function AgentButton({
           </ContextMenuItem>
           {worktrees.length > 0 && (
             <ContextMenuSub>
-              <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
+              <ContextMenuSubTrigger disabled={!isLaunchable}>
+                Launch in Worktree
+              </ContextMenuSubTrigger>
               <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
                 <WorktreeMenuItems agentType={type} worktrees={worktrees} />
               </ContextMenuSubContent>
@@ -456,13 +461,13 @@ export function AgentButton({
                 <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
-                    disabled={isLoading || !isReady}
+                    disabled={isLoading || !isLaunchable}
                     data-toolbar-item={dataToolbarItem}
                     onPointerEnter={clearFocusRestoreSuppression}
                     className={cn(
                       "toolbar-agent-button text-daintree-text transition-colors rounded-l-none",
                       "h-8 w-6 p-0 flex items-center justify-center",
-                      !isReady && !isLoading && "opacity-60"
+                      !isLaunchable && !isLoading && "opacity-60"
                     )}
                     aria-label={chevronTooltip}
                   >
@@ -593,7 +598,7 @@ export function AgentButton({
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
         <ContextMenuItem
-          disabled={!isReady}
+          disabled={!isLaunchable}
           onSelect={() =>
             void actionService.dispatch(
               "agent.launch",
@@ -605,7 +610,7 @@ export function AgentButton({
           Launch {config.name}
         </ContextMenuItem>
         <ContextMenuItem
-          disabled={!isReady}
+          disabled={!isLaunchable}
           onSelect={() =>
             void actionService.dispatch(
               "agent.launch",
@@ -618,7 +623,9 @@ export function AgentButton({
         </ContextMenuItem>
         {hasPresets && (
           <ContextMenuSub>
-            <ContextMenuSubTrigger disabled={!isReady}>Launch with Preset</ContextMenuSubTrigger>
+            <ContextMenuSubTrigger disabled={!isLaunchable}>
+              Launch with Preset
+            </ContextMenuSubTrigger>
             <ContextMenuSubContent
               data-testid="context-submenu-content"
               className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto"
@@ -659,7 +666,9 @@ export function AgentButton({
         )}
         {worktrees.length > 0 && (
           <ContextMenuSub>
-            <ContextMenuSubTrigger disabled={!isReady}>Launch in Worktree</ContextMenuSubTrigger>
+            <ContextMenuSubTrigger disabled={!isLaunchable}>
+              Launch in Worktree
+            </ContextMenuSubTrigger>
             <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
               <WorktreeMenuItems agentType={type} worktrees={worktrees} />
             </ContextMenuSubContent>

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -46,7 +46,7 @@ import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboar
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
 import { resolveEffectivePresetId } from "@shared/types";
-import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
+import { isAgentLaunchable, isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import {
   getDominantAgentState,
@@ -358,7 +358,7 @@ export function AgentTrayButton({
   }, [panelsById, panelIds, activeWorktreeId]);
 
   const readyAgentIds = useMemo(() => {
-    return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(agentAvailability?.[id]));
+    return BUILT_IN_AGENT_IDS.filter((id) => isAgentLaunchable(agentAvailability?.[id]));
   }, [agentAvailability]);
 
   const hasNoPinnedAgents = useMemo(() => {
@@ -416,17 +416,15 @@ export function AgentTrayButton({
       if (!row) continue;
 
       const state = agentAvailability?.[id];
-      if (isAgentReady(state)) {
+      if (isAgentLaunchable(state)) {
         // Launchable. Passive auth discovery (`authConfirmed: false`) never
         // moves an agent out of Launch — clicking starts the CLI, which
         // prompts for sign-in on first run. The decoupling goal of
         // #5483 requires this path to stay hot.
         launchable.push(row);
       } else if (isAgentInstalled(state)) {
-        // Reached only for the WSL `installed` cap (direct launch isn't
-        // wired through wsl.exe yet) and any future non-launchable
-        // installed state. These belong in "Needs Setup" — routing to
-        // Settings gives the user actionable install docs.
+        // Reached for WSL `installed`, blocked agents, and any future
+        // non-launchable installed state.
         needsSetup.push(row);
       }
       // Always build a fallback row so we can offer discovery when

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -45,7 +45,7 @@ import {
 } from "@/components/ui/context-menu";
 
 import { getAgentConfig, getAgentIds } from "@/config/agents";
-import { isAgentInstalled, isAgentReady } from "@shared/utils/agentAvailability";
+import { isAgentInstalled, isAgentLaunchable } from "@shared/utils/agentAvailability";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { buildDockRenderItems, type DockRenderItem } from "./dockRenderItems";
 import type { DockDensity } from "@/store/preferencesStore";
@@ -126,7 +126,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
           name: config?.name ?? id,
           icon: config?.icon,
           brandColor: config?.color,
-          isEnabled: isAgentReady(agentAvailability?.[id]),
+          isEnabled: isAgentLaunchable(agentAvailability?.[id]),
         };
       });
   }, [agentAvailability, agentSettings]);

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -658,15 +658,17 @@ describe("AgentButton preset UX", () => {
     });
 
     it("preserves the preset segment when the sign-in probe is unconfirmed", () => {
-      // Edge case: agent is `ready` but the auth probe came back empty.
+      // Agent is `unauthenticated` — binary found but no credential detected.
       // The user still has an armed preset that will fire on click — the
       // tooltip should surface it rather than silently dropping the segment.
       mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
-      mockCliDetails = { claude: { authConfirmed: false } };
 
       const { getAllByTestId } = render(
-        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+        <AgentButton
+          type="claude"
+          availability={"unauthenticated" as unknown as CliAvailability[string]}
+        />
       );
       const texts = tooltipTexts(getAllByTestId);
       const launchTooltip = texts.find((t) => t.startsWith("Start "));

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -27,7 +27,7 @@ import { CHECKLIST_ITEMS } from "@/components/Onboarding/checklistItems";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { getAgentConfig } from "@/config/agents";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
-import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
 
@@ -307,7 +307,7 @@ function AgentWelcomeCard() {
   const [pinError, setPinError] = useState(false);
 
   const readyAgentIds = useMemo<BuiltInAgentId[]>(() => {
-    return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(availability?.[id]));
+    return BUILT_IN_AGENT_IDS.filter((id) => isAgentLaunchable(availability?.[id]));
   }, [availability]);
 
   const hasNoPinnedAgents = useMemo(() => {

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -31,6 +31,7 @@ import {
   isAgentInstalled,
   isAgentReady,
   isAgentBlocked,
+  isAgentUnauthenticated,
 } from "../../../shared/utils/agentAvailability";
 import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
@@ -497,17 +498,26 @@ export function GeneralTab({
                       const config = getAgentConfig(id);
                       const name = config?.name ?? id;
                       const ready = isAgentReady(cliAvailability[id]);
+                      const unauthenticated = isAgentUnauthenticated(cliAvailability[id]);
                       const blocked = isAgentBlocked(cliAvailability[id]);
                       // A blocked agent is installed but can't run — show it
                       // distinctly from the authentication-needed case so the
                       // user doesn't waste time re-authenticating a binary
                       // that an endpoint security tool is blocking.
-                      const statusLabel = blocked ? "Blocked" : ready ? "Ready" : "Needs setup";
+                      const statusLabel = blocked
+                        ? "Blocked"
+                        : unauthenticated
+                          ? "Login required"
+                          : ready
+                            ? "Ready"
+                            : "Needs setup";
                       const statusClass = blocked
                         ? "text-status-warning"
-                        : ready
-                          ? "text-status-success"
-                          : "text-status-warning";
+                        : unauthenticated
+                          ? "text-status-warning"
+                          : ready
+                            ? "text-status-success"
+                            : "text-status-warning";
 
                       return (
                         <button

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -12,11 +12,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
 import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
-import {
-  isAgentInstalled,
-  isAgentReady,
-  isAgentLaunchable,
-} from "../../../shared/utils/agentAvailability";
+import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion, type Variants } from "framer-motion";
 import { Sprout } from "@/components/icons";
@@ -261,7 +257,8 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
     case "SELECTION_CONTINUE": {
       const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
       const allSelectedInstalled =
-        selectedIds.length > 0 && selectedIds.every((id) => isAgentReady(state.availability[id]));
+        selectedIds.length > 0 &&
+        selectedIds.every((id) => isAgentLaunchable(state.availability[id]));
       return {
         ...state,
         step: allSelectedInstalled ? { type: "complete" } : { type: "cli" },
@@ -411,7 +408,7 @@ export function AgentSetupWizard({
     initRef.current = true;
     const initial: Record<string, boolean> = {};
     for (const agentId of AGENT_ORDER) {
-      initial[agentId] = isAgentReady(state.availability[agentId]);
+      initial[agentId] = isAgentLaunchable(state.availability[agentId]);
     }
     dispatch({ type: "INIT_SELECTIONS", payload: initial });
   }, [isOpen, isAvailabilityLoading, state.availability, state.selectionsInitialized]);

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -12,7 +12,11 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
 import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
-import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
+import {
+  isAgentInstalled,
+  isAgentReady,
+  isAgentLaunchable,
+} from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion, type Variants } from "framer-motion";
 import { Sprout } from "@/components/icons";
@@ -453,7 +457,7 @@ export function AgentSetupWizard({
   }, []);
 
   const installedAgents = useMemo(
-    () => AGENT_ORDER.filter((id) => isAgentReady(state.availability[id])),
+    () => AGENT_ORDER.filter((id) => isAgentLaunchable(state.availability[id])),
     [state.availability]
   );
 

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -16,7 +16,7 @@ import {
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
-import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { computeGridCanLaunch, computeGridSelectedAgentIds } from "./contentGridAgentFilter";
 import { buildFleetPanels } from "./contentGridFleetPanels";
 import { GridPanel } from "./GridPanel";
@@ -203,7 +203,7 @@ function RotatingTip() {
     () =>
       TIPS.filter(
         (tip) =>
-          !tip.requiredAgents || tip.requiredAgents.some((a) => isAgentReady(availability[a]))
+          !tip.requiredAgents || tip.requiredAgents.some((a) => isAgentLaunchable(availability[a]))
       ),
     [availability]
   );

--- a/src/components/Terminal/contentGridAgentFilter.ts
+++ b/src/components/Terminal/contentGridAgentFilter.ts
@@ -1,5 +1,5 @@
 import type { CliAvailability } from "@shared/types";
-import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 
 /**
  * Compute the set of agent IDs visible in the grid's right-click launch menu.
@@ -33,5 +33,5 @@ export function computeGridCanLaunch(
 ): boolean {
   if (id === "terminal") return true;
   if (!isAvailabilityInitialized || !agentAvailability) return true;
-  return isAgentReady(agentAvailability[id]);
+  return isAgentLaunchable(agentAvailability[id]);
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -21,7 +21,7 @@ import { cn } from "../../lib/utils";
 import { getAgentConfig, getAgentIds } from "@/config/agents";
 import { getAgentSettingsEntry } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
-import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import { WorktreeDetailsSection } from "./WorktreeCard/WorktreeDetailsSection";
 import { WorktreeDialogs } from "./WorktreeCard/WorktreeDialogs";
@@ -616,7 +616,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
       .filter((agentId) => isAgentPinned(getAgentSettingsEntry(agentSettings, agentId)))
       .map((agentId) => {
         const config = getAgentConfig(agentId);
-        const available = isAgentReady(agentAvailability?.[agentId]);
+        const available = isAgentLaunchable(agentAvailability?.[agentId]);
 
         return {
           id: agentId,

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -1,7 +1,11 @@
 import type { ComponentType, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { AGENT_DESCRIPTIONS, getAgentConfig, type AgentIconProps } from "@/config/agents";
-import { isAgentInstalled, isAgentBlocked } from "@shared/utils/agentAvailability";
+import {
+  isAgentInstalled,
+  isAgentBlocked,
+  isAgentUnauthenticated,
+} from "@shared/utils/agentAvailability";
 import type { AgentAvailabilityState, AgentCliDetail } from "@shared/types";
 import { Button } from "@/components/ui/button";
 import { RefreshCw, ExternalLink } from "lucide-react";
@@ -200,9 +204,10 @@ export function AgentInstallSection({
   // section (as "Authentication") so users see the sign-in cue and install
   // docs. `undefined` means no auth probe applies — hide the section when
   // availability is `ready`.
-  const authMissing = availability === "ready" && detail?.authConfirmed === false;
+  const authMissing = isAgentUnauthenticated(availability);
 
   // "ready" + confirmed-or-no-probe hides the whole install section.
+  // "unauthenticated" keeps it visible for the auth nudge.
   // "blocked" keeps it visible so the user gets actionable info (allowlist
   // guidance, resolved path) — the binary exists, reinstall instructions
   // would be misleading, but we do want to show why it isn't runnable and

--- a/src/components/agents/__tests__/AgentInstallSection.test.tsx
+++ b/src/components/agents/__tests__/AgentInstallSection.test.tsx
@@ -81,14 +81,14 @@ describe("AgentInstallSection tri-state rendering", () => {
     expect(container.textContent).toBe("");
   });
 
-  it("renders the Authentication header when ready and authConfirmed is false", () => {
+  it("renders the Authentication header when state is unauthenticated", () => {
     const detail: AgentCliDetail = {
-      state: "ready",
+      state: "unauthenticated",
       resolvedPath: "/usr/local/bin/claude",
       via: "which",
       authConfirmed: false,
     };
-    const { container } = renderSection({ availability: "ready", detail });
+    const { container } = renderSection({ availability: "unauthenticated", detail });
     expect(container.textContent).toContain("Authentication");
     expect(container.textContent).toContain("not signed in");
   });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -52,13 +52,22 @@ export function resolveAgentLaunchBaseCommand(
   registryCommand: string,
   detail: AgentCliDetail | undefined
 ): string {
-  const resolvedPath = detail?.state === "ready" ? detail.resolvedPath?.trim() : undefined;
+  const resolvedPath =
+    detail &&
+    detail.state !== "missing" &&
+    detail.state !== "blocked" &&
+    detail.state !== "installed"
+      ? detail.resolvedPath?.trim()
+      : undefined;
   return resolvedPath ? escapeShellArgOptional(resolvedPath) : registryCommand;
 }
 
 async function getCurrentLaunchCliDetail(agentId: string): Promise<AgentCliDetail | undefined> {
   const current = useCliAvailabilityStore.getState().details[agentId];
-  if (current?.state === "ready" && current.resolvedPath?.trim()) {
+  if (
+    (current?.state === "ready" || current?.state === "unauthenticated") &&
+    current.resolvedPath?.trim()
+  ) {
     return current;
   }
 

--- a/src/lib/resolveAgentId.ts
+++ b/src/lib/resolveAgentId.ts
@@ -1,6 +1,6 @@
 import type { CliAvailability } from "@shared/types";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
-import { isAgentReady } from "../../shared/utils/agentAvailability";
+import { isAgentLaunchable } from "../../shared/utils/agentAvailability";
 
 /**
  * Resolve which agent to use given a user preference, an optional secondary
@@ -14,7 +14,7 @@ export function getDefaultAgentId(
   selectedAgents?: Set<string>
 ): BuiltInAgentId | null {
   const isUsable = (id: string) =>
-    isAgentReady(availability[id as keyof CliAvailability]) &&
+    isAgentLaunchable(availability[id as keyof CliAvailability]) &&
     (!selectedAgents || selectedAgents.has(id));
 
   if (

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -281,7 +281,7 @@ describe("persistence boundary hardening", () => {
   it("cliAvailabilityStore loadCache discards corrupt persisted cache without throwing", async () => {
     installLocalStorage(
       createStorageMock({
-        getItem: (key) => (key === "daintree:cliAvailability:v2" ? "{corrupt" : null),
+        getItem: (key) => (key === "daintree:cliAvailability:v3" ? "{corrupt" : null),
       })
     );
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -50,7 +50,7 @@ function defaultAvailability(): CliAvailability {
 // v2 evicts stale false-positive `ready` states cached under the pre-#5641
 // npx-cache probe (see CliAvailabilityService.probeNpmGlobal). Bump on any
 // future probe semantics change that could invert a prior verdict.
-const CACHE_STORAGE_KEY = "daintree:cliAvailability:v2";
+const CACHE_STORAGE_KEY = "daintree:cliAvailability:v3";
 // Stale cache is still shown but triggers a synchronous refresh on init.
 const CACHE_STALE_AFTER_MS = 24 * 60 * 60 * 1000; // 24h
 // Short-window throttle for mid-session refreshes (tray-open, visibility,
@@ -63,6 +63,7 @@ const VALID_STATES: ReadonlySet<AgentAvailabilityState> = new Set<AgentAvailabil
   "installed",
   "missing",
   "blocked",
+  "unauthenticated",
 ]);
 
 interface PersistedCache {


### PR DESCRIPTION
## Summary

The agent availability model had `ready`, `installed`, `missing`, and `blocked` but no way to represent "installed but not authenticated." That meant users who'd installed a CLI but hadn't logged in saw the same UX as a missing binary — the agent would spawn, crash on an auth error, and the user had no idea why.

This adds `unauthenticated` to the availability state union and migrates all consumers to what's now `isAgentLaunchable` (was `isAgentReady`). The renderer side shows "Login required" with an amber indicator so the user knows what's wrong and can launch a login flow rather than re-running the installer.

Resolves #6058.

## Changes

- Added `unauthenticated` to the `AgentAvailability` union in shared types
- Renamed `isAgentReady` to `isAgentLaunchable` (returns true for both `ready` and `installed`) and updated all 12+ call sites
- Added a `CliAvailabilityService` check that detects the unauthenticated state
- Added unit tests for the new availability state resolution
- Updated all UI surfaces (AgentButton, AgentTrayButton, AgentCard, WelcomeScreen, ContentDock, etc.) to handle the new state

## Testing

Unit tests pass for both the shared availability util and the backend service. The new `agentAvailability.test.ts` covers the state transitions. All existing agent button and install section tests were updated and pass.