### PR TITLE
feat(error): introduce AppError class and migrate handlers off legacy ok/success false returns

### DIFF
--- a/electron/ipc/__tests__/define.test.ts
+++ b/electron/ipc/__tests__/define.test.ts
@@ -46,11 +46,10 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
       },
     });
 
@@ -69,12 +68,11 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
-        readSelection: op(CH.readSelection, async () => ({ ok: true as const, text: "" })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
+        readSelection: op(CH.readSelection, async () => ({ text: "" })),
       },
     });
 
@@ -93,11 +91,10 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
       },
     });
 
@@ -113,11 +110,10 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
       },
     });
 
@@ -142,11 +138,10 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
       },
     });
 
@@ -170,11 +165,10 @@ describe("defineIpcNamespace", () => {
       name: "clipboard",
       ops: {
         saveImage: op(CH.saveImage, async () => ({
-          ok: true as const,
           filePath: "/tmp/x.png",
           thumbnailDataUrl: "data:image/png;base64,AA",
         })),
-        writeText: op(CH.writeText, async (_text: string) => ({ ok: true as const })),
+        writeText: op(CH.writeText, async (_text: string) => undefined),
       },
     });
 

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -814,7 +814,7 @@ describe("errorHandlers", () => {
     });
   });
 
-  describe("recoveryHint via createAppError", () => {
+  describe("recoveryHint via createErrorRecord", () => {
     it("returns permissions hint for EACCES with file syscall", async () => {
       const CHANNELS = await getChannels();
       const mockWindow = createMockWindow();

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -19,7 +19,7 @@ import { store } from "../store.js";
 import { FAULT_MODE_ENABLED } from "./faultRegistry.js";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
-import type { AppError, ErrorType, RetryAction } from "../../shared/types/ipc/errors.js";
+import type { ErrorRecord, ErrorType, RetryAction } from "../../shared/types/ipc/errors.js";
 import type { SpawnResult } from "../../shared/types/pty-host.js";
 
 interface RetryPayload {
@@ -171,15 +171,15 @@ function generateErrorId(): string {
   return `error-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-function createAppError(
+function createErrorRecord(
   error: unknown,
   options: {
     source?: string;
-    context?: AppError["context"];
+    context?: ErrorRecord["context"];
     retryAction?: RetryAction;
     retryArgs?: Record<string, unknown>;
   } = {}
-): AppError {
+): ErrorRecord {
   const details = getErrorDetails(error);
   const correlationId = randomUUID();
 
@@ -216,7 +216,7 @@ function isAbortError(error: unknown): boolean {
 class ErrorService {
   private worktreeService: WorkspaceClient | null = null;
   private ptyClient: PtyClient | null = null;
-  private pendingQueue: AppError[] = [];
+  private pendingQueue: ErrorRecord[] = [];
   private isFlushing = false;
   private activeRetries = new Map<string, AbortController>();
 
@@ -231,7 +231,7 @@ class ErrorService {
     );
   }
 
-  private bufferError(error: AppError): void {
+  private bufferError(error: ErrorRecord): void {
     this.pendingQueue.push(error);
     if (this.pendingQueue.length > MAX_PENDING_ERRORS) {
       this.pendingQueue.shift();
@@ -242,9 +242,9 @@ class ErrorService {
     }
   }
 
-  private persistError(error: AppError): void {
+  private persistError(error: ErrorRecord): void {
     try {
-      const existing = (store.get("pendingErrors") as AppError[] | undefined) ?? [];
+      const existing = (store.get("pendingErrors") as ErrorRecord[] | undefined) ?? [];
       const updated = [...existing, error].slice(-MAX_PENDING_ERRORS);
       store.set("pendingErrors", updated);
     } catch {
@@ -260,7 +260,7 @@ class ErrorService {
     }
   }
 
-  sendError(error: AppError) {
+  sendError(error: ErrorRecord) {
     if (!this.canSendToRenderer()) {
       this.bufferError(error);
       return;
@@ -269,8 +269,8 @@ class ErrorService {
     broadcastToRenderer(CHANNELS.ERROR_NOTIFY, error);
   }
 
-  notifyError(error: unknown, options: Parameters<typeof createAppError>[1] = {}) {
-    const appError = createAppError(error, options);
+  notifyError(error: unknown, options: Parameters<typeof createErrorRecord>[1] = {}) {
+    const appError = createErrorRecord(error, options);
     logErrorUtil(`[${appError.correlationId}] ${appError.message}`, error, {
       correlationId: appError.correlationId,
       type: appError.type,
@@ -301,9 +301,9 @@ class ErrorService {
     }
   }
 
-  getPendingPersistedErrors(): AppError[] {
+  getPendingPersistedErrors(): ErrorRecord[] {
     try {
-      const persisted = (store.get("pendingErrors") as AppError[] | undefined) ?? [];
+      const persisted = (store.get("pendingErrors") as ErrorRecord[] | undefined) ?? [];
       this.clearPersistedErrors();
       return persisted.map((e) => ({ ...e, fromPreviousSession: true }));
     } catch {
@@ -514,8 +514,8 @@ export function flushPendingErrors(): void {
 
 export function notifyError(
   error: unknown,
-  options: Parameters<typeof createAppError>[1] = {}
-): AppError {
+  options: Parameters<typeof createErrorRecord>[1] = {}
+): ErrorRecord {
   return errorService.notifyError(error, options);
 }
 

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -63,7 +63,7 @@ describe("clipboard:write-image handler", () => {
     expect(channels).toContain("clipboard:write-image");
   });
 
-  it("writes valid PNG data to clipboard and returns ok", async () => {
+  it("writes valid PNG data to clipboard and returns void", async () => {
     const fakeImage = { isEmpty: () => false };
     nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
 
@@ -77,7 +77,7 @@ describe("clipboard:write-image handler", () => {
     expect([...bufferArg]).toEqual([0x89, 0x50, 0x4e, 0x47]);
 
     expect(clipboardMock.writeImage).toHaveBeenCalledWith(fakeImage);
-    expect(result).toEqual({ ok: true });
+    expect(result).toBeUndefined();
   });
 
   it("handles Uint8Array subarray with non-zero byteOffset correctly", async () => {
@@ -94,26 +94,27 @@ describe("clipboard:write-image handler", () => {
     expect([...bufferArg]).toEqual([0x89, 0x50, 0x4e, 0x47]);
   });
 
-  it("returns error for empty/invalid image data", async () => {
+  it("throws CLIPBOARD_INVALID for empty/invalid image data", async () => {
     const fakeImage = { isEmpty: () => true };
     nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
 
     const handler = getHandler("clipboard:write-image");
-    const result = await handler(fakeEvent, new Uint8Array([]));
+    await expect(handler(fakeEvent, new Uint8Array([]))).rejects.toMatchObject({
+      name: "AppError",
+      code: "CLIPBOARD_INVALID",
+      message: "Invalid image data",
+    });
 
     expect(clipboardMock.writeImage).not.toHaveBeenCalled();
-    expect(result).toEqual({ ok: false, error: "Invalid image data" });
   });
 
-  it("returns error when nativeImage.createFromBuffer throws", async () => {
+  it("propagates raw errors when nativeImage.createFromBuffer throws", async () => {
     nativeImageMock.createFromBuffer.mockImplementation(() => {
       throw new Error("Corrupt buffer");
     });
 
     const handler = getHandler("clipboard:write-image");
-    const result = await handler(fakeEvent, new Uint8Array([0xff]));
-
-    expect(result).toEqual({ ok: false, error: "Corrupt buffer" });
+    await expect(handler(fakeEvent, new Uint8Array([0xff]))).rejects.toThrow("Corrupt buffer");
   });
 
   it("cleanup removes the handler", () => {
@@ -140,33 +141,34 @@ describe("clipboard:write-text handler", () => {
     expect(channels).toContain("clipboard:write-text");
   });
 
-  it("writes text to the clipboard and returns ok", async () => {
+  it("writes text to the clipboard and returns void", async () => {
     const handler = getHandler("clipboard:write-text");
     const result = await handler(fakeEvent, "sudo sysctl fs.inotify.max_user_watches=524288");
 
     expect(clipboardMock.writeText).toHaveBeenCalledWith(
       "sudo sysctl fs.inotify.max_user_watches=524288"
     );
-    expect(result).toEqual({ ok: true });
+    expect(result).toBeUndefined();
   });
 
-  it("rejects non-string input without calling clipboard", async () => {
+  it("rejects non-string input with VALIDATION error", async () => {
     const handler = getHandler("clipboard:write-text");
-    const result = await handler(fakeEvent, 42 as unknown as string);
+    await expect(handler(fakeEvent, 42 as unknown as string)).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: "Text must be a string",
+    });
 
     expect(clipboardMock.writeText).not.toHaveBeenCalled();
-    expect(result).toEqual({ ok: false, error: "Text must be a string" });
   });
 
-  it("returns error when clipboard.writeText throws", async () => {
+  it("propagates raw errors when clipboard.writeText throws", async () => {
     clipboardMock.writeText.mockImplementationOnce(() => {
       throw new Error("clipboard unavailable");
     });
 
     const handler = getHandler("clipboard:write-text");
-    const result = await handler(fakeEvent, "hello");
-
-    expect(result).toEqual({ ok: false, error: "clipboard unavailable" });
+    await expect(handler(fakeEvent, "hello")).rejects.toThrow("clipboard unavailable");
   });
 
   it("cleanup removes the clipboard:write-text handler", () => {
@@ -200,72 +202,74 @@ describe("clipboard:write-selection handler", () => {
     expect(channels).toContain("clipboard:write-selection");
   });
 
-  it("writes to PRIMARY selection on Linux and returns ok", async () => {
+  it("writes to PRIMARY selection on Linux and returns void", async () => {
     const handler = getHandler("clipboard:write-selection");
     const result = await handler(fakeEvent, "selected text");
 
     expect(clipboardMock.writeText).toHaveBeenCalledWith("selected text", "selection");
-    expect(result).toEqual({ ok: true });
+    expect(result).toBeUndefined();
   });
 
-  it("rejects empty text without calling clipboard", async () => {
+  it("rejects empty text with VALIDATION error", async () => {
     const handler = getHandler("clipboard:write-selection");
-    const result = await handler(fakeEvent, "");
+    await expect(handler(fakeEvent, "")).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: "Text must not be empty",
+    });
 
     expect(clipboardMock.writeText).not.toHaveBeenCalled();
-    expect(result).toEqual({ ok: false, error: "Text must not be empty" });
   });
 
-  it("rejects non-string input without calling clipboard", async () => {
+  it("rejects non-string input with VALIDATION error", async () => {
     const handler = getHandler("clipboard:write-selection");
-    const result = await handler(fakeEvent, 42 as unknown as string);
+    await expect(handler(fakeEvent, 42 as unknown as string)).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: "Text must be a string",
+    });
 
     expect(clipboardMock.writeText).not.toHaveBeenCalled();
-    expect(result).toEqual({ ok: false, error: "Text must be a string" });
   });
 
-  it("short-circuits on macOS without calling clipboard", async () => {
+  it("throws UNSUPPORTED on macOS without calling clipboard", async () => {
     cleanup();
     setPlatform("darwin");
     cleanup = registerClipboardHandlers();
 
     const handler = getHandler("clipboard:write-selection");
-    const result = await handler(fakeEvent, "hello");
+    await expect(handler(fakeEvent, "hello")).rejects.toMatchObject({
+      name: "AppError",
+      code: "UNSUPPORTED",
+      message: "PRIMARY selection is only available on Linux",
+    });
 
     expect(clipboardMock.writeText).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      ok: false,
-      error: "PRIMARY selection is only available on Linux",
-    });
   });
 
-  it("short-circuits on Windows without calling clipboard", async () => {
+  it("throws UNSUPPORTED on Windows without calling clipboard", async () => {
     cleanup();
     setPlatform("win32");
     cleanup = registerClipboardHandlers();
 
     const handler = getHandler("clipboard:write-selection");
-    const result = await handler(fakeEvent, "hello");
+    await expect(handler(fakeEvent, "hello")).rejects.toMatchObject({
+      name: "AppError",
+      code: "UNSUPPORTED",
+    });
 
     expect(clipboardMock.writeText).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      ok: false,
-      error: "PRIMARY selection is only available on Linux",
-    });
   });
 
-  it("returns error when clipboard.writeText throws", async () => {
+  it("propagates raw errors when clipboard.writeText throws", async () => {
     clipboardMock.writeText.mockImplementationOnce(() => {
       throw new Error("wayland compositor lacks primary selection");
     });
 
     const handler = getHandler("clipboard:write-selection");
-    const result = await handler(fakeEvent, "hello");
-
-    expect(result).toEqual({
-      ok: false,
-      error: "wayland compositor lacks primary selection",
-    });
+    await expect(handler(fakeEvent, "hello")).rejects.toThrow(
+      "wayland compositor lacks primary selection"
+    );
   });
 });
 
@@ -300,7 +304,7 @@ describe("clipboard:read-selection handler", () => {
     const result = await handler(fakeEvent);
 
     expect(clipboardMock.readText).toHaveBeenCalledWith("selection");
-    expect(result).toEqual({ ok: true, text: "pasted text" });
+    expect(result).toEqual({ text: "pasted text" });
   });
 
   it("returns empty text when PRIMARY selection is empty", async () => {
@@ -309,35 +313,30 @@ describe("clipboard:read-selection handler", () => {
     const handler = getHandler("clipboard:read-selection");
     const result = await handler(fakeEvent);
 
-    expect(result).toEqual({ ok: true, text: "" });
+    expect(result).toEqual({ text: "" });
   });
 
-  it("short-circuits on macOS without calling clipboard", async () => {
+  it("throws UNSUPPORTED on macOS without calling clipboard", async () => {
     cleanup();
     setPlatform("darwin");
     cleanup = registerClipboardHandlers();
 
     const handler = getHandler("clipboard:read-selection");
-    const result = await handler(fakeEvent);
+    await expect(handler(fakeEvent)).rejects.toMatchObject({
+      name: "AppError",
+      code: "UNSUPPORTED",
+      message: "PRIMARY selection is only available on Linux",
+    });
 
     expect(clipboardMock.readText).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      ok: false,
-      error: "PRIMARY selection is only available on Linux",
-    });
   });
 
-  it("returns error when clipboard.readText throws", async () => {
+  it("propagates raw errors when clipboard.readText throws", async () => {
     clipboardMock.readText.mockImplementationOnce(() => {
       throw new Error("focus required for primary read");
     });
 
     const handler = getHandler("clipboard:read-selection");
-    const result = await handler(fakeEvent);
-
-    expect(result).toEqual({
-      ok: false,
-      error: "focus required for primary read",
-    });
+    await expect(handler(fakeEvent)).rejects.toThrow("focus required for primary read");
   });
 });

--- a/electron/ipc/handlers/__tests__/commands.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/commands.adversarial.test.ts
@@ -47,43 +47,45 @@ describe("commands IPC adversarial", () => {
   });
 
   it("commands:execute rejects null payload", async () => {
-    const result = (await getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), null)) as {
-      success: boolean;
-      error?: { code: string };
-    };
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe("INVALID_PAYLOAD");
+    await expect(getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), null)).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: expect.stringMatching(/Invalid command execution payload/),
+    });
     expect(commandServiceMock.execute).not.toHaveBeenCalled();
   });
 
   it("commands:execute rejects payload without commandId", async () => {
-    const result = (await getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), {})) as {
-      error?: { code: string };
-    };
-    expect(result.error?.code).toBe("INVALID_PAYLOAD");
+    await expect(getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), {})).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+    });
   });
 
   it("commands:execute rejects non-string commandId", async () => {
-    const result = (await getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), {
-      commandId: 42,
-    })) as { error?: { code: string } };
-    expect(result.error?.code).toBe("INVALID_PAYLOAD");
+    await expect(
+      getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), { commandId: 42 })
+    ).rejects.toMatchObject({ name: "AppError", code: "VALIDATION" });
   });
 
   it("commands:execute rejects array context", async () => {
-    const result = (await getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), {
-      commandId: "x",
-      context: [],
-    })) as { error?: { message: string } };
-    expect(result.error?.message).toMatch(/plain object/);
+    await expect(
+      getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), { commandId: "x", context: [] })
+    ).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: expect.stringMatching(/plain object/),
+    });
   });
 
   it("commands:execute rejects array args", async () => {
-    const result = (await getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), {
-      commandId: "x",
-      args: [],
-    })) as { error?: { message: string } };
-    expect(result.error?.message).toMatch(/plain object/);
+    await expect(
+      getHandler(CHANNELS.COMMANDS_EXECUTE)(fakeEvent(), { commandId: "x", args: [] })
+    ).rejects.toMatchObject({
+      name: "AppError",
+      code: "VALIDATION",
+      message: expect.stringMatching(/plain object/),
+    });
   });
 
   it("commands:execute treats absent context and args as empty plain objects", async () => {

--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -168,4 +168,42 @@ describe("files:read handler", () => {
       code: "NOT_FOUND",
     });
   });
+
+  it("throws AppError(NOT_FOUND) when stat succeeds but readFile raises ENOENT (TOCTOU)", async () => {
+    fsMock.stat.mockResolvedValue({ size: 100 });
+    fsMock.readFile.mockRejectedValue(
+      Object.assign(new Error("file disappeared"), { code: "ENOENT" })
+    );
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("throws AppError(PERMISSION) when readFile raises EACCES", async () => {
+    fsMock.stat.mockResolvedValue({ size: 100 });
+    fsMock.readFile.mockRejectedValue(
+      Object.assign(new Error("permission denied"), { code: "EACCES" })
+    );
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "PERMISSION",
+    });
+  });
+
+  it("throws AppError(PERMISSION) when stat raises EPERM", async () => {
+    fsMock.stat.mockRejectedValue(
+      Object.assign(new Error("operation not permitted"), { code: "EPERM" })
+    );
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "PERMISSION",
+    });
+  });
 });

--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -96,14 +96,15 @@ describe("files:read handler", () => {
     vi.clearAllMocks();
   });
 
-  it("returns LFS_POINTER when the file is a git-lfs v1 pointer", async () => {
+  it("throws AppError(LFS_POINTER) when the file is a git-lfs v1 pointer", async () => {
     fsMock.stat.mockResolvedValue({ size: VALID_POINTER.length });
     fsMock.readFile.mockResolvedValue(VALID_POINTER);
     registerFilesHandlers();
 
-    const result = await getReadHandler()({}, { path: file, rootPath: root });
-
-    expect(result).toEqual({ ok: false, code: "LFS_POINTER" });
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "LFS_POINTER",
+    });
   });
 
   it("returns plain content for a normal text file", async () => {
@@ -114,57 +115,57 @@ describe("files:read handler", () => {
 
     const result = await getReadHandler()({}, { path: file, rootPath: root });
 
-    expect(result).toEqual({ ok: true, content: "hello world\n" });
+    expect(result).toEqual({ content: "hello world\n" });
   });
 
-  it("returns BINARY_FILE before LFS detection when null bytes are present", async () => {
+  it("throws AppError(BINARY_FILE) before LFS detection when null bytes are present", async () => {
     const content = Buffer.concat([Buffer.from(LFS_HEADER, "ascii"), Buffer.from([0x00])]);
     fsMock.stat.mockResolvedValue({ size: content.length });
     fsMock.readFile.mockResolvedValue(content);
     registerFilesHandlers();
 
-    const result = await getReadHandler()({}, { path: file, rootPath: root });
-
-    expect(result).toEqual({ ok: false, code: "BINARY_FILE" });
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "BINARY_FILE",
+    });
   });
 
-  it("returns FILE_TOO_LARGE without reading the buffer for oversized files", async () => {
+  it("throws AppError(FILE_TOO_LARGE) without reading the buffer for oversized files", async () => {
     fsMock.stat.mockResolvedValue({ size: 600 * 1024 });
     registerFilesHandlers();
 
-    const result = await getReadHandler()({}, { path: file, rootPath: root });
-
-    expect(result).toEqual({ ok: false, code: "FILE_TOO_LARGE" });
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "FILE_TOO_LARGE",
+    });
     expect(fsMock.readFile).not.toHaveBeenCalled();
   });
 
-  it("returns OUTSIDE_ROOT when the file is not under rootPath", async () => {
+  it("throws AppError(OUTSIDE_ROOT) when the file is not under rootPath", async () => {
     registerFilesHandlers();
 
-    const result = await getReadHandler()(
-      {},
-      { path: path.resolve("/etc/passwd"), rootPath: root }
-    );
-
-    expect(result).toEqual({ ok: false, code: "OUTSIDE_ROOT" });
+    await expect(
+      getReadHandler()({}, { path: path.resolve("/etc/passwd"), rootPath: root })
+    ).rejects.toMatchObject({ name: "AppError", code: "OUTSIDE_ROOT" });
     expect(fsMock.stat).not.toHaveBeenCalled();
   });
 
-  it("returns INVALID_PATH for relative paths", async () => {
+  it("throws AppError(INVALID_PATH) for relative paths", async () => {
     registerFilesHandlers();
 
-    const result = await getReadHandler()({}, { path: "./relative", rootPath: root });
-
-    expect(result).toEqual({ ok: false, code: "INVALID_PATH" });
+    await expect(
+      getReadHandler()({}, { path: "./relative", rootPath: root })
+    ).rejects.toMatchObject({ name: "AppError", code: "INVALID_PATH" });
   });
 
-  it("returns NOT_FOUND when stat raises ENOENT", async () => {
+  it("throws AppError(NOT_FOUND) when stat raises ENOENT", async () => {
     const err = Object.assign(new Error("no such file"), { code: "ENOENT" });
     fsMock.stat.mockRejectedValue(err);
     registerFilesHandlers();
 
-    const result = await getReadHandler()({}, { path: file, rootPath: root });
-
-    expect(result).toEqual({ ok: false, code: "NOT_FOUND" });
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_FOUND",
+    });
   });
 });

--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -88,7 +88,7 @@ describe("project:close handler", () => {
       event: unknown,
       projectId: string,
       options?: { killTerminals?: boolean }
-    ) => Promise<{ success: boolean; terminalsKilled: number; processesKilled: number }>;
+    ) => Promise<{ terminalsKilled: number; processesKilled: number }>;
 
     const result = await handler(
       { senderFrame: { url: "http://localhost:5173" } },
@@ -96,7 +96,6 @@ describe("project:close handler", () => {
       { killTerminals: true }
     );
 
-    expect(result.success).toBe(true);
     expect(result.terminalsKilled).toBe(2);
     expect(result.processesKilled).toBe(2);
     expect(ptyClient.killByProject).toHaveBeenCalledWith("project-active");
@@ -186,13 +185,12 @@ describe("project:close handler", () => {
       event: unknown,
       projectId: string,
       options?: { killTerminals?: boolean }
-    ) => Promise<{ success: boolean; terminalsKilled: number; processesKilled: number }>;
+    ) => Promise<{ terminalsKilled: number; processesKilled: number }>;
 
     const result = await handler({ senderFrame: { url: "http://localhost:5173" } }, "project-bg", {
       killTerminals: false,
     });
 
-    expect(result.success).toBe(true);
     expect(result.terminalsKilled).toBe(0);
     expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-bg", "background");
     expect(worktreeService.pauseProject).toHaveBeenCalledWith("/test/project-bg");
@@ -241,7 +239,7 @@ describe("project:close handler", () => {
       event: unknown,
       projectId: string,
       options?: { killTerminals?: boolean }
-    ) => Promise<{ success: boolean }>;
+    ) => Promise<{ terminalsKilled: number; processesKilled: number }>;
 
     await handler({ senderFrame: { url: "http://localhost:5173" } }, "project-active", {
       killTerminals: true,

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -6,7 +6,7 @@ import * as crypto from "node:crypto";
 import * as os from "node:os";
 import { defineIpcNamespace, op } from "../define.js";
 import { CLIPBOARD_METHOD_CHANNELS } from "./clipboard.preload.js";
-import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { AppError } from "../../utils/errorTypes.js";
 
 const CLIPBOARD_DIR_NAME = "daintree-clipboard";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -52,123 +52,112 @@ async function cleanupOldClipboardImages(): Promise<void> {
   }
 }
 
-async function handleSaveImage(): Promise<
-  { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
-> {
-  try {
-    const image = clipboard.readImage();
-    if (image.isEmpty()) {
-      return { ok: false, error: "No image in clipboard" };
-    }
-
-    const pngBuffer = image.toPNG();
-    const dir = getClipboardDir();
-    await fs.mkdir(dir, { recursive: true });
-
-    const id = crypto.randomBytes(3).toString("hex");
-    const filename = `clipboard-${Date.now()}-${id}.png`;
-    const filePath = path.join(dir, filename);
-    await fs.writeFile(filePath, pngBuffer);
-
-    const size = image.getSize();
-    const thumbHeight = 40;
-    const thumbWidth = Math.max(1, Math.round((size.width / size.height) * thumbHeight));
-    const thumbnail = image.resize({ width: thumbWidth, height: thumbHeight });
-    const thumbnailDataUrl = `data:image/png;base64,${thumbnail.toPNG().toString("base64")}`;
-
-    return { ok: true, filePath, thumbnailDataUrl };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to save clipboard image");
-    return { ok: false, error: message };
+async function handleSaveImage(): Promise<{ filePath: string; thumbnailDataUrl: string }> {
+  const image = clipboard.readImage();
+  if (image.isEmpty()) {
+    throw new AppError({
+      code: "CLIPBOARD_EMPTY",
+      message: "No image in clipboard",
+      userMessage: "There's no image on the clipboard to save.",
+    });
   }
+
+  const pngBuffer = image.toPNG();
+  const dir = getClipboardDir();
+  await fs.mkdir(dir, { recursive: true });
+
+  const id = crypto.randomBytes(3).toString("hex");
+  const filename = `clipboard-${Date.now()}-${id}.png`;
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, pngBuffer);
+
+  const size = image.getSize();
+  const thumbHeight = 40;
+  const thumbWidth = Math.max(1, Math.round((size.width / size.height) * thumbHeight));
+  const thumbnail = image.resize({ width: thumbWidth, height: thumbHeight });
+  const thumbnailDataUrl = `data:image/png;base64,${thumbnail.toPNG().toString("base64")}`;
+
+  return { filePath, thumbnailDataUrl };
 }
 
 async function handleThumbnailFromPath(
   filePath: string
-): Promise<
-  { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
-> {
-  try {
-    const image = nativeImage.createFromPath(filePath);
-    if (image.isEmpty()) {
-      return { ok: false, error: "Unsupported image format or file not found" };
-    }
-
-    const size = image.getSize();
-    const thumbHeight = 40;
-    const thumbWidth = Math.max(1, Math.round((size.width / size.height) * thumbHeight));
-    const thumbnail = image.resize({ width: thumbWidth, height: thumbHeight });
-    const thumbnailDataUrl = `data:image/png;base64,${thumbnail.toPNG().toString("base64")}`;
-
-    return { ok: true, filePath, thumbnailDataUrl };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to generate clipboard thumbnail");
-    return { ok: false, error: message };
+): Promise<{ filePath: string; thumbnailDataUrl: string }> {
+  const image = nativeImage.createFromPath(filePath);
+  if (image.isEmpty()) {
+    throw new AppError({
+      code: "CLIPBOARD_INVALID",
+      message: "Unsupported image format or file not found",
+      userMessage: "Couldn't read that image — the format isn't supported or the file is missing.",
+      context: { filePath },
+    });
   }
+
+  const size = image.getSize();
+  const thumbHeight = 40;
+  const thumbWidth = Math.max(1, Math.round((size.width / size.height) * thumbHeight));
+  const thumbnail = image.resize({ width: thumbWidth, height: thumbHeight });
+  const thumbnailDataUrl = `data:image/png;base64,${thumbnail.toPNG().toString("base64")}`;
+
+  return { filePath, thumbnailDataUrl };
 }
 
-async function handleWriteImage(
-  pngData: Uint8Array
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  try {
-    const buffer = Buffer.from(pngData.buffer, pngData.byteOffset, pngData.byteLength);
-    const image = nativeImage.createFromBuffer(buffer);
-    if (image.isEmpty()) {
-      return { ok: false, error: "Invalid image data" };
-    }
-    clipboard.writeImage(image);
-    return { ok: true };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to write clipboard image");
-    return { ok: false, error: message };
+async function handleWriteImage(pngData: Uint8Array): Promise<void> {
+  const buffer = Buffer.from(pngData.buffer, pngData.byteOffset, pngData.byteLength);
+  const image = nativeImage.createFromBuffer(buffer);
+  if (image.isEmpty()) {
+    throw new AppError({
+      code: "CLIPBOARD_INVALID",
+      message: "Invalid image data",
+      userMessage: "Couldn't write the image — the data is corrupt or unsupported.",
+    });
   }
+  clipboard.writeImage(image);
 }
 
-function handleWriteText(text: string): { ok: true } | { ok: false; error: string } {
-  try {
-    if (typeof text !== "string") {
-      return { ok: false, error: "Text must be a string" };
-    }
-    clipboard.writeText(text);
-    return { ok: true };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to write clipboard text");
-    return { ok: false, error: message };
+async function handleWriteText(text: string): Promise<void> {
+  if (typeof text !== "string") {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Text must be a string",
+    });
   }
+  clipboard.writeText(text);
 }
 
 // Linux PRIMARY selection — underpins copy-on-select and middle-click paste.
 // The 'selection' clipboard type only exists on Linux; short-circuit elsewhere.
-function handleWriteSelection(text: string): { ok: true } | { ok: false; error: string } {
-  try {
-    if (process.platform !== "linux") {
-      return { ok: false, error: "PRIMARY selection is only available on Linux" };
-    }
-    if (typeof text !== "string") {
-      return { ok: false, error: "Text must be a string" };
-    }
-    if (text.length === 0) {
-      return { ok: false, error: "Text must not be empty" };
-    }
-    clipboard.writeText(text, "selection");
-    return { ok: true };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to write PRIMARY selection");
-    return { ok: false, error: message };
+async function handleWriteSelection(text: string): Promise<void> {
+  if (process.platform !== "linux") {
+    throw new AppError({
+      code: "UNSUPPORTED",
+      message: "PRIMARY selection is only available on Linux",
+    });
   }
+  if (typeof text !== "string") {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Text must be a string",
+    });
+  }
+  if (text.length === 0) {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Text must not be empty",
+    });
+  }
+  clipboard.writeText(text, "selection");
 }
 
-function handleReadSelection(): { ok: true; text: string } | { ok: false; error: string } {
-  try {
-    if (process.platform !== "linux") {
-      return { ok: false, error: "PRIMARY selection is only available on Linux" };
-    }
-    const text = clipboard.readText("selection");
-    return { ok: true, text };
-  } catch (err: unknown) {
-    const message = formatErrorMessage(err, "Failed to read PRIMARY selection");
-    return { ok: false, error: message };
+async function handleReadSelection(): Promise<{ text: string }> {
+  if (process.platform !== "linux") {
+    throw new AppError({
+      code: "UNSUPPORTED",
+      message: "PRIMARY selection is only available on Linux",
+    });
   }
+  const text = clipboard.readText("selection");
+  return { text };
 }
 
 export const clipboardNamespace = defineIpcNamespace({

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -14,6 +14,7 @@ import type {
   DaintreeCommand,
 } from "../../../shared/types/commands.js";
 import { typedHandle } from "../utils.js";
+import { AppError } from "../../utils/errorTypes.js";
 
 export function registerCommandHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -36,40 +37,32 @@ export function registerCommandHandlers(): () => void {
   };
   handlers.push(typedHandle(CHANNELS.COMMANDS_GET, handleCommandsGet));
 
-  // Execute command
+  // Execute command. Validation failures throw `AppError({code: "VALIDATION"})`;
+  // command-domain success/failure is still carried by the returned
+  // `CommandResult` (the commands system has its own structured result contract
+  // that includes optional `prompt` injection — intentional, not an envelope).
   const handleCommandsExecute = async (payload: CommandExecutePayload): Promise<CommandResult> => {
     if (!payload || typeof payload.commandId !== "string") {
-      return {
-        success: false,
-        error: {
-          code: "INVALID_PAYLOAD",
-          message: "Invalid command execution payload",
-        },
-      };
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Invalid command execution payload",
+      });
     }
 
-    // Validate context is a plain object
     const context = payload.context ?? {};
     if (typeof context !== "object" || Array.isArray(context)) {
-      return {
-        success: false,
-        error: {
-          code: "INVALID_PAYLOAD",
-          message: "Context must be a plain object",
-        },
-      };
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Context must be a plain object",
+      });
     }
 
-    // Validate args is a plain object
     const args = payload.args ?? {};
     if (args !== null && (typeof args !== "object" || Array.isArray(args))) {
-      return {
-        success: false,
-        error: {
-          code: "INVALID_PAYLOAD",
-          message: "Arguments must be a plain object",
-        },
-      };
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Arguments must be a plain object",
+      });
     }
 
     return commandService.execute(payload.commandId, context, args);

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -5,6 +5,7 @@ import { checkRateLimit, typedHandle } from "../utils.js";
 import { fileSearchService } from "../../services/FileSearchService.js";
 import { FileSearchPayloadSchema, FileReadPayloadSchema } from "../../schemas/ipc.js";
 import type { FileReadResult } from "../../../shared/types/ipc/files.js";
+import { AppError } from "../../utils/errorTypes.js";
 
 const FILE_SIZE_LIMIT = 512 * 1024; // 500 KB
 
@@ -48,13 +49,17 @@ export function registerFilesHandlers(): () => void {
     const parsed = FileReadPayloadSchema.safeParse(payload);
     if (!parsed.success) {
       console.error("[IPC] Invalid files:read payload:", parsed.error.format());
-      return { ok: false, code: "INVALID_PATH" };
+      throw new AppError({ code: "INVALID_PATH", message: "Invalid files:read payload" });
     }
 
     const { path: filePath, rootPath } = parsed.data;
 
     if (!path.isAbsolute(filePath) || !path.isAbsolute(rootPath)) {
-      return { ok: false, code: "INVALID_PATH" };
+      throw new AppError({
+        code: "INVALID_PATH",
+        message: "filePath and rootPath must be absolute",
+        context: { filePath, rootPath },
+      });
     }
 
     // Containment check: file must be inside rootPath
@@ -64,39 +69,68 @@ export function registerFilesHandlers(): () => void {
       !normalizedFile.startsWith(normalizedRoot + path.sep) &&
       normalizedFile !== normalizedRoot
     ) {
-      return { ok: false, code: "OUTSIDE_ROOT" };
+      throw new AppError({
+        code: "OUTSIDE_ROOT",
+        message: "File is outside the project root",
+        context: { filePath, rootPath },
+      });
     }
 
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
     try {
-      const stat = await fs.stat(normalizedFile);
-
-      if (stat.size > FILE_SIZE_LIMIT) {
-        return { ok: false, code: "FILE_TOO_LARGE" };
-      }
-
-      const buffer = await fs.readFile(normalizedFile);
-
-      // Binary detection: check for null bytes in first 8 KB
-      const checkLength = Math.min(buffer.length, 8192);
-      for (let i = 0; i < checkLength; i++) {
-        if (buffer[i] === 0) {
-          return { ok: false, code: "BINARY_FILE" };
-        }
-      }
-
-      if (isLfsPointer(buffer)) {
-        return { ok: false, code: "LFS_POINTER" };
-      }
-
-      return { ok: true, content: buffer.toString("utf-8") };
+      stat = await fs.stat(normalizedFile);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT") {
-        return { ok: false, code: "NOT_FOUND" };
+        throw new AppError({
+          code: "NOT_FOUND",
+          message: "File not found",
+          context: { filePath },
+          cause: error instanceof Error ? error : undefined,
+        });
       }
       console.error("[IPC] files:read failed:", error);
-      return { ok: false, code: "INVALID_PATH" };
+      throw new AppError({
+        code: "INVALID_PATH",
+        message: "Could not stat file",
+        context: { filePath },
+        cause: error instanceof Error ? error : undefined,
+      });
     }
+
+    if (stat.size > FILE_SIZE_LIMIT) {
+      throw new AppError({
+        code: "FILE_TOO_LARGE",
+        message: `File exceeds ${FILE_SIZE_LIMIT} byte limit`,
+        userMessage: "This file is too large to preview.",
+        context: { filePath, size: stat.size, limit: FILE_SIZE_LIMIT },
+      });
+    }
+
+    const buffer = await fs.readFile(normalizedFile);
+
+    // Binary detection: check for null bytes in first 8 KB
+    const checkLength = Math.min(buffer.length, 8192);
+    for (let i = 0; i < checkLength; i++) {
+      if (buffer[i] === 0) {
+        throw new AppError({
+          code: "BINARY_FILE",
+          message: "Binary file cannot be displayed as text",
+          context: { filePath },
+        });
+      }
+    }
+
+    if (isLfsPointer(buffer)) {
+      throw new AppError({
+        code: "LFS_POINTER",
+        message: "File is a Git LFS pointer",
+        userMessage: "This file is stored in Git LFS — fetch it locally to preview.",
+        context: { filePath },
+      });
+    }
+
+    return { content: buffer.toString("utf-8") };
   };
 
   handlers.push(typedHandle(CHANNELS.FILES_READ, handleRead));

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -76,26 +76,41 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
-    let stat: Awaited<ReturnType<typeof fs.stat>>;
-    try {
-      stat = await fs.stat(normalizedFile);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") {
-        throw new AppError({
+    // Map ENOENT/EACCES/EPERM the same way for both stat and readFile — the
+    // file can disappear or change permissions between the two calls (TOCTOU).
+    function fsErrorToAppError(error: unknown, fallbackMessage: string): AppError {
+      const errCode = (error as NodeJS.ErrnoException).code;
+      if (errCode === "ENOENT") {
+        return new AppError({
           code: "NOT_FOUND",
           message: "File not found",
           context: { filePath },
           cause: error instanceof Error ? error : undefined,
         });
       }
+      if (errCode === "EACCES" || errCode === "EPERM") {
+        return new AppError({
+          code: "PERMISSION",
+          message: "Permission denied",
+          userMessage: "You don't have permission to read this file.",
+          context: { filePath },
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
       console.error("[IPC] files:read failed:", error);
-      throw new AppError({
+      return new AppError({
         code: "INVALID_PATH",
-        message: "Could not stat file",
+        message: fallbackMessage,
         context: { filePath },
         cause: error instanceof Error ? error : undefined,
       });
+    }
+
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(normalizedFile);
+    } catch (error) {
+      throw fsErrorToAppError(error, "Could not stat file");
     }
 
     if (stat.size > FILE_SIZE_LIMIT) {
@@ -107,7 +122,12 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
-    const buffer = await fs.readFile(normalizedFile);
+    let buffer: Buffer;
+    try {
+      buffer = await fs.readFile(normalizedFile);
+    } catch (error) {
+      throw fsErrorToAppError(error, "Could not read file");
+    }
 
     // Binary detection: check for null bytes in first 8 KB
     const checkLength = Math.min(buffer.length, 8192);

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -27,12 +27,9 @@ function playSoundFireAndForget(id: SoundId): void {
 }
 import { preAgentSnapshotService } from "../../services/PreAgentSnapshotService.js";
 import type { SnapshotInfo, SnapshotRevertResult } from "../../../shared/types/ipc/git.js";
-import type { GitOperationReason, RecoveryAction } from "../../../shared/types/ipc/errors.js";
-import {
-  classifyGitError,
-  getGitRecoveryAction,
-} from "../../../shared/utils/gitOperationErrors.js";
+import { classifyGitError } from "../../../shared/utils/gitOperationErrors.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { GitOperationError } from "../../utils/errorTypes.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -323,15 +320,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   };
   handlers.push(typedHandle(CHANNELS.GIT_COMMIT, handleCommit));
 
-  const handlePush = async (payload: {
-    cwd: string;
-    setUpstream?: boolean;
-  }): Promise<{
-    success: boolean;
-    error?: string;
-    gitReason?: GitOperationReason;
-    recoveryAction?: RecoveryAction;
-  }> => {
+  const handlePush = async (payload: { cwd: string; setUpstream?: boolean }): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_PUSH, 5, 10_000);
     validateCwd(payload?.cwd);
 
@@ -360,19 +349,17 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
         playSoundFireAndForget("git-push");
       }
-      return { success: true };
     } catch (error) {
       if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
         playSoundFireAndForget("git-push-error");
       }
       const errorMessage = formatErrorMessage(error, "git push failed");
       const gitReason = classifyGitError(error);
-      return {
-        success: false,
-        error: errorMessage,
-        gitReason,
-        recoveryAction: getGitRecoveryAction(gitReason),
-      };
+      throw new GitOperationError(gitReason, errorMessage, {
+        cwd: payload.cwd,
+        op: "push",
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   };
   handlers.push(typedHandle(CHANNELS.GIT_PUSH, handlePush));

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -18,6 +18,7 @@ import {
 import type { FilterOptions as LogFilterOptions } from "../../services/LogBuffer.js";
 import { typedHandle } from "../utils.js";
 import { store } from "../../store.js";
+import { AppError } from "../../utils/errorTypes.js";
 import type { HandlerDependencies } from "../types.js";
 
 /**
@@ -115,10 +116,13 @@ export function registerLogsHandlers(
   };
   handlers.push(typedHandle(CHANNELS.LOGS_OPEN_FILE, handleLogsOpenFile));
 
-  const handleLogsSetVerbose = async (enabled: boolean) => {
+  const handleLogsSetVerbose = async (enabled: boolean): Promise<void> => {
     if (typeof enabled !== "boolean") {
       logError("Invalid verbose logging payload", undefined, { payload: enabled });
-      return { success: false };
+      throw new AppError({
+        code: "VALIDATION",
+        message: "logs:set-verbose requires a boolean",
+      });
     }
     // Verbose toggle maps to the `"*"` wildcard override so it flows through
     // the same persistence + utility-process propagation as explicit per-module
@@ -144,7 +148,6 @@ export function registerLogsHandlers(
     setLogLevelOverrides(current);
     fanOut(current, deps);
     logInfo(`Verbose logging ${enabled ? "enabled" : "disabled"} by user`);
-    return { success: true };
   };
   handlers.push(typedHandle(CHANNELS.LOGS_SET_VERBOSE, handleLogsSetVerbose));
 

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -7,6 +7,7 @@ import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../
 import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -157,7 +158,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     if (!killTerminals && project.status === "closed") {
-      return { success: true, processesKilled: 0, terminalsKilled: 0 };
+      return { processesKilled: 0, terminalsKilled: 0 };
     }
 
     try {
@@ -179,7 +180,6 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
         );
 
         return {
-          success: true,
           processesKilled: terminalsKilled,
           terminalsKilled,
         };
@@ -194,19 +194,18 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
         );
 
         return {
-          success: true,
           processesKilled: 0,
           terminalsKilled: 0,
         };
       }
     } catch (error) {
       console.error(`[IPC] project:close: Failed to close project ${projectId}:`, error);
-      return {
-        success: false,
-        error: formatErrorMessage(error, "Failed to close project"),
-        processesKilled: 0,
-        terminalsKilled: 0,
-      };
+      throw new AppError({
+        code: "INTERNAL",
+        message: formatErrorMessage(error, "Failed to close project"),
+        context: { projectId },
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_CLOSE, handleProjectClose));

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -14,6 +14,7 @@ import type {
   CloneRepoProgressEvent,
 } from "../../../../shared/types/ipc/gitClone.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerGitCloneHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -118,7 +119,7 @@ export function registerGitCloneHandlers(): () => void {
       await git.clone(url, trimmedFolder, shallowClone ? ["--depth", "1"] : []);
 
       emitProgress("complete", 100, "Clone complete");
-      return { success: true, clonedPath: targetPath };
+      return { clonedPath: targetPath };
     } catch (error) {
       const wasCancelled =
         cloneAbortController?.signal.aborted ||
@@ -135,12 +136,21 @@ export function registerGitCloneHandlers(): () => void {
 
       if (wasCancelled) {
         emitProgress("cancelled", 0, "Clone cancelled");
-        return { success: false, cancelled: true, error: "Clone cancelled" };
+        throw new AppError({
+          code: "CANCELLED",
+          message: "Clone cancelled",
+          context: { targetPath },
+        });
       }
 
       const errorMessage = formatErrorMessage(error, "Failed to clone repository");
       emitProgress("error", 0, `Clone failed: ${errorMessage}`);
-      return { success: false, error: errorMessage };
+      throw new AppError({
+        code: "INTERNAL",
+        message: errorMessage,
+        context: { targetPath },
+        cause: error instanceof Error ? error : undefined,
+      });
     } finally {
       cloneAbortController = null;
     }

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -14,6 +14,7 @@ import type {
   GitInitProgressEvent,
 } from "../../../../shared/types/ipc/gitInit.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerGitInitHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -146,25 +147,23 @@ export function registerGitInitHandlers(): () => void {
               "Please configure git user.name and user.email before creating commits"
             );
             emitProgress("complete", "success", "Git initialization complete (no initial commit)");
-            return {
-              success: true,
-              completedSteps,
-            };
+            return { completedSteps };
           }
           throw commitError;
         }
       }
 
       emitProgress("complete", "success", "Git initialization complete");
-      return { success: true, completedSteps };
+      return { completedSteps };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Git initialization failed");
       emitProgress("error", "error", "Git initialization failed", errorMessage);
-      return {
-        success: false,
-        error: errorMessage,
-        completedSteps,
-      };
+      throw new AppError({
+        code: "INTERNAL",
+        message: errorMessage,
+        context: { directoryPath, completedSteps },
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   };
   handlers.push(

--- a/electron/ipc/handlers/terminal/artifacts.ts
+++ b/electron/ipc/handlers/terminal/artifacts.ts
@@ -9,6 +9,7 @@ import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 import { typedHandle, typedHandleWithContext } from "../../utils.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerArtifactHandlers(deps: HandlerDependencies): () => void {
   const mainWindow = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
@@ -16,27 +17,34 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
 
   const handleArtifactSaveToFile = async (
     options: unknown
-  ): Promise<{ filePath: string; success: boolean } | null> => {
+  ): Promise<{ filePath: string } | null> => {
+    if (
+      typeof options !== "object" ||
+      options === null ||
+      !("content" in options) ||
+      typeof (options as Record<string, unknown>).content !== "string"
+    ) {
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Invalid saveToFile payload: missing or invalid content",
+      });
+    }
+
+    const { content, suggestedFilename, cwd } = options as {
+      content: string;
+      suggestedFilename?: string;
+      cwd?: string;
+    };
+
+    if (content.length > 10 * 1024 * 1024) {
+      throw new AppError({
+        code: "FILE_TOO_LARGE",
+        message: "Artifact content exceeds maximum size (10MB)",
+        userMessage: "This artifact is too large to save (10 MB limit).",
+      });
+    }
+
     try {
-      if (
-        typeof options !== "object" ||
-        options === null ||
-        !("content" in options) ||
-        typeof (options as Record<string, unknown>).content !== "string"
-      ) {
-        throw new Error("Invalid saveToFile payload: missing or invalid content");
-      }
-
-      const { content, suggestedFilename, cwd } = options as {
-        content: string;
-        suggestedFilename?: string;
-        cwd?: string;
-      };
-
-      if (content.length > 10 * 1024 * 1024) {
-        throw new Error("Artifact content exceeds maximum size (10MB)");
-      }
-
       let safeCwd = os.homedir();
       if (cwd && typeof cwd === "string") {
         const fs = await import("fs/promises");
@@ -71,12 +79,15 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
 
       return {
         filePath: result.filePath,
-        success: true,
       };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to save artifact");
       console.error("[Artifact] Failed to save to file:", errorMessage);
-      throw new Error(`Failed to save artifact: ${errorMessage}`);
+      throw new AppError({
+        code: "INTERNAL",
+        message: `Failed to save artifact: ${errorMessage}`,
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   };
   handlers.push(typedHandle(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile));
@@ -84,101 +95,112 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
   const handleArtifactApplyPatch = async (
     ctx: import("../../types.js").IpcContext,
     options: unknown
-  ): Promise<{ success: boolean; error?: string; modifiedFiles?: string[] }> => {
+  ): Promise<{ modifiedFiles: string[] }> => {
+    if (
+      typeof options !== "object" ||
+      options === null ||
+      !("patchContent" in options) ||
+      !("cwd" in options) ||
+      typeof (options as Record<string, unknown>).patchContent !== "string" ||
+      typeof (options as Record<string, unknown>).cwd !== "string"
+    ) {
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Invalid applyPatch payload: missing or invalid patchContent/cwd",
+      });
+    }
+
+    const { patchContent, cwd } = options as { patchContent: string; cwd: string };
+
+    if (patchContent.length > 5 * 1024 * 1024) {
+      throw new AppError({
+        code: "FILE_TOO_LARGE",
+        message: "Patch content exceeds maximum size (5MB)",
+      });
+    }
+
+    const fs = await import("fs/promises");
+    let resolvedCwd: string;
     try {
-      if (
-        typeof options !== "object" ||
-        options === null ||
-        !("patchContent" in options) ||
-        !("cwd" in options) ||
-        typeof (options as Record<string, unknown>).patchContent !== "string" ||
-        typeof (options as Record<string, unknown>).cwd !== "string"
-      ) {
-        throw new Error("Invalid applyPatch payload: missing or invalid patchContent/cwd");
+      resolvedCwd = path.resolve(cwd);
+
+      const stat = await fs.stat(resolvedCwd);
+      if (!stat.isDirectory()) {
+        throw new AppError({
+          code: "INVALID_PATH",
+          message: "Provided cwd is not a directory",
+          context: { cwd },
+        });
       }
 
-      const { patchContent, cwd } = options as { patchContent: string; cwd: string };
-
-      if (patchContent.length > 5 * 1024 * 1024) {
-        throw new Error("Patch content exceeds maximum size (5MB)");
-      }
-
-      const fs = await import("fs/promises");
-      let resolvedCwd: string;
+      const gitPath = path.join(resolvedCwd, ".git");
       try {
-        resolvedCwd = path.resolve(cwd);
-
-        const stat = await fs.stat(resolvedCwd);
-        if (!stat.isDirectory()) {
-          return {
-            success: false,
-            error: "Provided cwd is not a directory",
-          };
-        }
-
-        const gitPath = path.join(resolvedCwd, ".git");
-        try {
-          await fs.stat(gitPath);
-        } catch {
-          return {
-            success: false,
-            error: "Provided cwd is not a git repository",
-          };
-        }
-
-        if (deps.worktreeService) {
-          const senderWindowPatch = ctx.senderWindow;
-          const states = await deps.worktreeService.getAllStatesAsync(senderWindowPatch?.id);
-          const isValidWorktree = states.some(
-            (wt: { path: string }) => path.resolve(wt.path) === resolvedCwd
-          );
-
-          if (!isValidWorktree) {
-            return {
-              success: false,
-              error: "Directory is not a known worktree",
-            };
-          }
-        }
-      } catch (error) {
-        return {
-          success: false,
-          error: formatErrorMessage(error, "Invalid cwd"),
-        };
+        await fs.stat(gitPath);
+      } catch {
+        throw new AppError({
+          code: "VALIDATION",
+          message: "Provided cwd is not a git repository",
+          context: { cwd },
+        });
       }
 
-      const tmpPatchPath = path.join(os.tmpdir(), `daintree-patch-${Date.now()}.patch`);
-      await fs.writeFile(tmpPatchPath, patchContent, "utf-8");
+      if (deps.worktreeService) {
+        const senderWindowPatch = ctx.senderWindow;
+        const states = await deps.worktreeService.getAllStatesAsync(senderWindowPatch?.id);
+        const isValidWorktree = states.some(
+          (wt: { path: string }) => path.resolve(wt.path) === resolvedCwd
+        );
 
-      try {
-        const { execa } = await import("execa");
-        await execa("git", ["apply", tmpPatchPath], { cwd: resolvedCwd });
-
-        const modifiedFiles: string[] = [];
-        const lines = patchContent.split("\n");
-        for (const line of lines) {
-          if (line.startsWith("+++")) {
-            const match = line.match(/\+\+\+ b\/(.+)/);
-            if (match) {
-              modifiedFiles.push(match[1]);
-            }
-          }
+        if (!isValidWorktree) {
+          throw new AppError({
+            code: "VALIDATION",
+            message: "Directory is not a known worktree",
+            context: { cwd },
+          });
         }
-
-        return {
-          success: true,
-          modifiedFiles,
-        };
-      } finally {
-        await fs.unlink(tmpPatchPath).catch(() => {});
       }
     } catch (error) {
-      const errorMessage = formatErrorMessage(error, "Failed to apply patch");
-      console.error("[Artifact] Failed to apply patch:", errorMessage);
-      return {
-        success: false,
-        error: errorMessage,
-      };
+      if (error instanceof AppError) throw error;
+      throw new AppError({
+        code: "INVALID_PATH",
+        message: formatErrorMessage(error, "Invalid cwd"),
+        context: { cwd },
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+
+    const tmpPatchPath = path.join(os.tmpdir(), `daintree-patch-${Date.now()}.patch`);
+    await fs.writeFile(tmpPatchPath, patchContent, "utf-8");
+
+    try {
+      const { execa } = await import("execa");
+      try {
+        await execa("git", ["apply", tmpPatchPath], { cwd: resolvedCwd });
+      } catch (error) {
+        const errorMessage = formatErrorMessage(error, "Failed to apply patch");
+        console.error("[Artifact] Failed to apply patch:", errorMessage);
+        throw new AppError({
+          code: "INTERNAL",
+          message: errorMessage,
+          context: { cwd: resolvedCwd },
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+
+      const modifiedFiles: string[] = [];
+      const lines = patchContent.split("\n");
+      for (const line of lines) {
+        if (line.startsWith("+++")) {
+          const match = line.match(/\+\+\+ b\/(.+)/);
+          if (match) {
+            modifiedFiles.push(match[1]);
+          }
+        }
+      }
+
+      return { modifiedFiles };
+    } finally {
+      await fs.unlink(tmpPatchPath).catch(() => {});
     }
   };
   handlers.push(typedHandleWithContext(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch));

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -11,6 +11,7 @@ import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 import { typedHandle } from "../../utils.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerTerminalIOHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -206,19 +207,24 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     )
   );
 
-  const handleTerminalForceResume = async (
-    id: string
-  ): Promise<{ success: boolean; error?: string }> => {
+  const handleTerminalForceResume = async (id: string): Promise<void> => {
+    if (typeof id !== "string" || !id) {
+      throw new AppError({
+        code: "VALIDATION",
+        message: "Invalid terminal ID: must be a non-empty string",
+      });
+    }
     try {
-      if (typeof id !== "string" || !id) {
-        throw new Error("Invalid terminal ID: must be a non-empty string");
-      }
       ptyClient.forceResume(id);
-      return { success: true };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to force resume terminal");
       console.error(`[IPC] Failed to force resume terminal ${id}:`, errorMessage);
-      return { success: false, error: errorMessage };
+      throw new AppError({
+        code: "INTERNAL",
+        message: errorMessage,
+        context: { terminalId: id },
+        cause: error instanceof Error ? error : undefined,
+      });
     }
   };
   handlers.push(typedHandle(CHANNELS.TERMINAL_FORCE_RESUME, handleTerminalForceResume));

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -13,6 +13,7 @@ import type {
   CdpPropertyDescriptor,
 } from "../../../shared/types/ipc/webviewConsole.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { AppError } from "../../utils/errorTypes.js";
 
 interface CdpSession {
   runtimeEnabled: boolean;
@@ -550,7 +551,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     panelId: unknown,
     webContentsId: unknown,
     providedSessionStorageSnapshot: unknown
-  ): Promise<{ success: boolean; error?: string } | null> => {
+  ): Promise<{ success: true } | null> => {
     if (
       typeof authUrl !== "string" ||
       typeof panelId !== "string" ||
@@ -580,7 +581,11 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const wc = webContents.fromId(webContentsId);
     if (!wc || wc.isDestroyed()) {
       console.error("[OAuthLoopback] WebContents not found or destroyed:", webContentsId);
-      return { success: false, error: "WebView no longer available" };
+      throw new AppError({
+        code: "NOT_FOUND",
+        message: "WebView no longer available",
+        context: { webContentsId, panelId },
+      });
     }
 
     let sessionStorageSnapshot =
@@ -760,7 +765,12 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       // Still try to navigate even without interception — might work for providers
       // that don't enforce strict redirect_uri matching at token exchange
       wc.loadURL(callbackUrl).catch(() => {});
-      return { success: false, error: `CDP interception failed: ${msg}` };
+      throw new AppError({
+        code: "INTERNAL",
+        message: `CDP interception failed: ${msg}`,
+        context: { panelId },
+        cause: err instanceof Error ? err : undefined,
+      });
     } finally {
       // Clean up CDP Fetch — remove listener and disable
       if (interceptorListener) {

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -14,6 +14,7 @@ import {
   markPerformance,
   sampleIpcTiming,
 } from "../utils/performance.js";
+import { AppError } from "../utils/errorTypes.js";
 
 const rateLimitTimestamps = new Map<string, number[]>();
 
@@ -41,7 +42,12 @@ export function checkRateLimit(channel: string, maxCalls: number, windowMs: numb
   const now = Date.now();
   const timestamps = (rateLimitTimestamps.get(key) ?? []).filter((t) => now - t < windowMs);
   if (timestamps.length >= maxCalls) {
-    throw new Error("Rate limit exceeded");
+    throw new AppError({
+      code: "RATE_LIMITED",
+      message: "Rate limit exceeded",
+      userMessage: "Slow down — too many requests in a short window.",
+      context: { channel, maxCalls, windowMs },
+    });
   }
   timestamps.push(now);
   rateLimitTimestamps.set(key, timestamps);
@@ -178,7 +184,12 @@ async function waitForLeakyBucketSlot(key: string, intervalMs: number): Promise<
   const state = getOrCreateLeakyState(key);
 
   if (state.pendingCount >= MAX_QUEUE_DEPTH) {
-    throw new Error("Spawn queue full");
+    throw new AppError({
+      code: "RATE_LIMITED",
+      message: "Spawn queue full",
+      userMessage: "Too many pending operations — wait a moment and try again.",
+      context: { key, queueDepth: state.pendingCount, maxDepth: MAX_QUEUE_DEPTH },
+    });
   }
 
   // Synchronous slot reservation — MUST happen before any await so that
@@ -224,7 +235,12 @@ async function waitForSlidingWindowSlot(
   }
 
   if (state.queue.length >= MAX_QUEUE_DEPTH) {
-    throw new Error("Spawn queue full");
+    throw new AppError({
+      code: "RATE_LIMITED",
+      message: "Spawn queue full",
+      userMessage: "Too many pending operations — wait a moment and try again.",
+      context: { key, queueDepth: state.queue.length, maxDepth: MAX_QUEUE_DEPTH },
+    });
   }
 
   return new Promise<void>((resolve, reject) => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -13,6 +13,7 @@ import { contextBridge, ipcRenderer, webFrame, webUtils } from "electron";
 import { isTrustedRendererUrl } from "../shared/utils/trustedRenderer.js";
 import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
+import type { AppErrorCode } from "../shared/types/appError.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { buildClipboardPreloadBindings } from "./ipc/handlers/clipboard.preload.js";
 import { buildSlashCommandsPreloadBindings } from "./ipc/handlers/slashCommands.preload.js";
@@ -34,7 +35,7 @@ import type {
   EventFilterOptions,
   RetryAction,
   RetryProgressPayload,
-  AppError,
+  ErrorRecord,
   ElectronAPI,
   CreateWorktreeOptions,
   IpcInvokeMap,
@@ -487,11 +488,41 @@ ipcRenderer.on(
   }
 );
 
+/**
+ * Reconstruct `AppError` thrown in the main process. Electron's IPC strips
+ * Error subclass prototypes, so the renderer-side `ClientAppError` class
+ * (in `src/utils/clientAppError.ts`) provides the prototype identity. Here
+ * we throw a plain `Error` with `name === "AppError"` and the discriminant
+ * properties — the renderer's `isClientAppError(e)` guard duck-types on
+ * `e.name === "AppError" && typeof e.code === "string"`, which is the
+ * realm-safe pattern.
+ */
+function _reconstructAppError(serialized: {
+  name: string;
+  message: string;
+  code?: string;
+  userMessage?: string;
+}): Error {
+  const error = new Error(serialized.message);
+  error.name = "AppError";
+  (error as Error & { code: AppErrorCode }).code = serialized.code as AppErrorCode;
+  if (serialized.userMessage !== undefined) {
+    (error as Error & { userMessage: string }).userMessage = serialized.userMessage;
+  }
+  return error;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches ipcRenderer.invoke return type
 async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<any> {
   const response = await ipcRenderer.invoke(channel, ...args);
   if (isIpcEnvelope(response)) {
-    if (!response.ok) throw deserializeError(response.error);
+    if (!response.ok) {
+      const serialized = response.error;
+      if (serialized.name === "AppError" && typeof serialized.code === "string") {
+        throw _reconstructAppError(serialized);
+      }
+      throw deserializeError(serialized);
+    }
     return response.data;
   }
   return response;
@@ -763,7 +794,7 @@ const api: ElectronAPI = {
     getAnalysisBuffer: (): Promise<SharedArrayBuffer | null> =>
       _unwrappingInvoke(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER),
 
-    forceResume: (id: string): Promise<{ success: boolean; error?: string }> =>
+    forceResume: (id: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.TERMINAL_FORCE_RESUME, id),
 
     onStatus: (callback: (data: TerminalStatusPayload) => void) =>
@@ -1053,7 +1084,7 @@ const api: ElectronAPI = {
 
   // Error API
   errors: {
-    onError: (callback: (error: AppError) => void) => _typedOn(CHANNELS.ERROR_NOTIFY, callback),
+    onError: (callback: (error: ErrorRecord) => void) => _typedOn(CHANNELS.ERROR_NOTIFY, callback),
 
     retry: (errorId: string, action: RetryAction, args?: Record<string, unknown>) =>
       _unwrappingInvoke(CHANNELS.ERROR_RETRY, { errorId, action, args }),
@@ -1695,7 +1726,7 @@ const api: ElectronAPI = {
       panelId: string,
       webContentsId: number,
       sessionStorageSnapshot?: Array<[string, string]>
-    ): Promise<{ success: boolean; error?: string } | null> =>
+    ): Promise<{ success: true } | null> =>
       _unwrappingInvoke(
         CHANNELS.WEBVIEW_OAUTH_LOOPBACK,
         authUrl,

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -5,7 +5,7 @@ import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { store } from "../store.js";
-import type { AppError } from "../../shared/types/ipc/errors.js";
+import type { ErrorRecord } from "../../shared/types/ipc/errors.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 let handlingFatal = false;
@@ -15,7 +15,7 @@ export function _resetHandlingFatalForTesting(): void {
   handlingFatal = false;
 }
 
-function buildFatalAppError(kind: string, error: unknown): AppError {
+function buildFatalErrorRecord(kind: string, error: unknown): ErrorRecord {
   const message = formatErrorMessage(error, "Unknown fatal error");
   const id = `fatal-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -35,7 +35,7 @@ function buildFatalAppError(kind: string, error: unknown): AppError {
   };
 }
 
-function notifyRenderer(appError: AppError): void {
+function notifyRenderer(appError: ErrorRecord): void {
   try {
     broadcastToRenderer(CHANNELS.ERROR_NOTIFY, appError);
   } catch {
@@ -43,7 +43,7 @@ function notifyRenderer(appError: AppError): void {
   }
 }
 
-function persistPendingError(appError: AppError): void {
+function persistPendingError(appError: ErrorRecord): void {
   try {
     const existing = store.get("pendingErrors");
     const pending = Array.isArray(existing) ? existing : [];
@@ -79,7 +79,7 @@ export function registerGlobalErrorHandlers(): void {
       // silent
     }
 
-    const appError = buildFatalAppError("UNCAUGHT_EXCEPTION", error);
+    const appError = buildFatalErrorRecord("UNCAUGHT_EXCEPTION", error);
 
     try {
       persistPendingError(appError);
@@ -125,7 +125,7 @@ export function registerGlobalErrorHandlers(): void {
       // silent
     }
 
-    const appError = buildFatalAppError("UNHANDLED_REJECTION", reason);
+    const appError = buildFatalErrorRecord("UNHANDLED_REJECTION", reason);
 
     try {
       persistPendingError(appError);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -9,7 +9,7 @@ import type {
   AppAgentConfig,
 } from "../shared/types/index.js";
 import type { IssueAssociation } from "../shared/types/ipc/worktree.js";
-import type { AppError } from "../shared/types/ipc/errors.js";
+import type { ErrorRecord } from "../shared/types/ipc/errors.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
 import type { AgentId } from "../shared/types/agent.js";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_APP_AGENT_CONFIG } from "../shared/types/index.js";
@@ -170,7 +170,7 @@ export interface StoreSchema {
     port: number | null;
     apiKey: string;
   };
-  pendingErrors: AppError[];
+  pendingErrors: ErrorRecord[];
   gpu: {
     hardwareAccelerationDisabled: boolean;
   };

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
 import {
+  AppError,
   GitError,
   GitOperationError,
   WorktreeRemovedError,
   DaintreeError,
+  isAppError,
   toGitOperationError,
   getUserMessage,
 } from "../errorTypes.js";
+import { serializeError, deserializeError } from "../../../shared/utils/ipcErrorSerialization.js";
 
 describe("GitOperationError", () => {
   it("preserves the GitError -> DaintreeError -> Error hierarchy", () => {
@@ -73,6 +76,61 @@ describe("toGitOperationError", () => {
   });
 });
 
+describe("AppError", () => {
+  it("preserves the AppError -> DaintreeError -> Error hierarchy", () => {
+    const err = new AppError({ code: "BINARY_FILE", message: "binary" });
+    expect(err).toBeInstanceOf(AppError);
+    expect(err).toBeInstanceOf(DaintreeError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("sets name to 'AppError' so renderer-side duck-typing works after IPC", () => {
+    const err = new AppError({ code: "VALIDATION", message: "bad input" });
+    expect(err.name).toBe("AppError");
+  });
+
+  it("stamps code and userMessage onto own properties", () => {
+    const err = new AppError({
+      code: "FILE_TOO_LARGE",
+      message: "exceeds limit",
+      userMessage: "This file is too large to preview.",
+      context: { size: 600 * 1024, limit: 512 * 1024 },
+    });
+    expect(err.code).toBe("FILE_TOO_LARGE");
+    expect(err.userMessage).toBe("This file is too large to preview.");
+    expect(err.context).toEqual({ size: 600 * 1024, limit: 512 * 1024 });
+  });
+
+  it("exposes isAppError narrowing", () => {
+    expect(isAppError(new AppError({ code: "CANCELLED", message: "cancel" }))).toBe(true);
+    expect(isAppError(new GitError("git error"))).toBe(false);
+    expect(isAppError(new Error("plain"))).toBe(false);
+    expect(isAppError(null)).toBe(false);
+  });
+
+  it("survives the serialize → structuredClone → deserialize cycle with code preserved", () => {
+    const original = new AppError({
+      code: "RATE_LIMITED",
+      message: "Too many requests",
+      userMessage: "Slow down — try again in a moment.",
+    });
+
+    const serialized = serializeError(original);
+    expect(serialized.name).toBe("AppError");
+    expect(serialized.code).toBe("RATE_LIMITED");
+    expect(serialized.userMessage).toBe("Slow down — try again in a moment.");
+
+    const restored = deserializeError(structuredClone(serialized)) as Error & {
+      code: string;
+      userMessage?: string;
+    };
+    expect(restored.name).toBe("AppError");
+    expect(restored.message).toBe("Too many requests");
+    expect(restored.code).toBe("RATE_LIMITED");
+    expect(restored.userMessage).toBe("Slow down — try again in a moment.");
+  });
+});
+
 describe("getUserMessage", () => {
   it("returns the Daintree error's own message when given a DaintreeError", () => {
     const err = new GitOperationError("auth-failed", "permission denied", { op: "push" });
@@ -96,5 +154,19 @@ describe("getUserMessage", () => {
     expect(getUserMessage(null)).toBe("An unknown error occurred");
     expect(getUserMessage(undefined)).toBe("An unknown error occurred");
     expect(getUserMessage({ code: "EFAIL" })).toBe("An unknown error occurred");
+  });
+
+  it("prefers AppError.userMessage over message when present", () => {
+    const err = new AppError({
+      code: "BINARY_FILE",
+      message: "Binary file cannot be displayed as text",
+      userMessage: "This file can't be previewed.",
+    });
+    expect(getUserMessage(err)).toBe("This file can't be previewed.");
+  });
+
+  it("falls back to AppError.message when userMessage is absent", () => {
+    const err = new AppError({ code: "VALIDATION", message: "Invalid payload" });
+    expect(getUserMessage(err)).toBe("Invalid payload");
   });
 });

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -1,5 +1,6 @@
 import { classifyGitError, extractGitErrorMessage } from "../../shared/utils/gitOperationErrors.js";
 import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
+import type { AppErrorCode } from "../../shared/types/appError.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 export class DaintreeError extends Error {
@@ -106,6 +107,34 @@ export class WatcherError extends DaintreeError {
   }
 }
 
+/**
+ * Generic typed error thrown by IPC handlers. The `code` discriminant survives
+ * Electron's structured-clone strip in `electron/setup/security.ts` and is
+ * reconstructed in the renderer as a `ClientAppError` so consumers can do
+ * `if (e.code === "BINARY_FILE")` instead of substring-matching messages.
+ */
+export class AppError extends DaintreeError {
+  readonly code: AppErrorCode;
+  readonly userMessage?: string;
+
+  constructor(opts: {
+    code: AppErrorCode;
+    message: string;
+    userMessage?: string;
+    context?: Record<string, unknown>;
+    cause?: Error;
+  }) {
+    super(opts.message, opts.context, opts.cause);
+    this.name = "AppError";
+    this.code = opts.code;
+    this.userMessage = opts.userMessage;
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError;
+}
+
 export function isDaintreeError(error: unknown): error is DaintreeError {
   return error instanceof DaintreeError;
 }
@@ -128,6 +157,9 @@ export function isTransientError(error: unknown): boolean {
 }
 
 export function getUserMessage(error: unknown): string {
+  if (isAppError(error) && error.userMessage) {
+    return error.userMessage;
+  }
   if (isDaintreeError(error)) {
     return error.message;
   }

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -1,0 +1,21 @@
+/**
+ * Discriminated codes carried by `AppError` (main process) and
+ * `ClientAppError` (renderer) so callers can `e.code === "BINARY_FILE"`
+ * pattern-match instead of substring-matching `e.message`. These survive the
+ * IPC envelope and packaged-build serialization strip.
+ */
+export type AppErrorCode =
+  | "INVALID_PATH"
+  | "OUTSIDE_ROOT"
+  | "BINARY_FILE"
+  | "FILE_TOO_LARGE"
+  | "LFS_POINTER"
+  | "NOT_FOUND"
+  | "CLIPBOARD_EMPTY"
+  | "CLIPBOARD_INVALID"
+  | "UNSUPPORTED"
+  | "CANCELLED"
+  | "RATE_LIMITED"
+  | "VALIDATION"
+  | "PERMISSION"
+  | "INTERNAL";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -188,7 +188,7 @@ export type {
   // Error types
   ErrorType,
   RetryAction,
-  AppError,
+  ErrorRecord,
   RetryProgressPayload,
   // Agent session types
   Artifact,

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -141,12 +141,10 @@ export interface SaveArtifactOptions {
   cwd?: string;
 }
 
-/** Result from saving an artifact */
+/** Result from saving an artifact. `null` is returned when the user cancels the save dialog; failures throw `AppError`. */
 export interface SaveArtifactResult {
   /** Path where the file was saved */
   filePath: string;
-  /** Whether the operation succeeded */
-  success: boolean;
 }
 
 /** Options for applying a patch */
@@ -157,14 +155,10 @@ export interface ApplyPatchOptions {
   cwd: string;
 }
 
-/** Result from applying a patch */
+/** Result from applying a patch. Failures throw `AppError`. */
 export interface ApplyPatchResult {
-  /** Whether the patch applied successfully */
-  success: boolean;
-  /** Error message if the patch failed */
-  error?: string;
   /** Files that were modified */
-  modifiedFiles?: string[];
+  modifiedFiles: string[];
 }
 
 export interface AgentHelpRequest {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -81,13 +81,7 @@ import type {
 } from "./system.js";
 import type { AppState, HydrateResult } from "./app.js";
 import type { LogEntry, LogFilterOptions } from "./logs.js";
-import type {
-  RetryAction,
-  AppError,
-  RetryProgressPayload,
-  GitOperationReason,
-  RecoveryAction,
-} from "./errors.js";
+import type { RetryAction, ErrorRecord, RetryProgressPayload } from "./errors.js";
 import type { EventRecord, EventFilterOptions } from "./events.js";
 import type {
   ProjectCloseResult,
@@ -276,7 +270,7 @@ export interface ElectronAPI {
     onActivity(callback: (data: TerminalActivityPayload) => void): () => void;
     onTrashed(callback: (data: { id: string; expiresAt: number }) => void): () => void;
     onRestored(callback: (data: { id: string }) => void): () => void;
-    forceResume(id: string): Promise<{ success: boolean; error?: string }>;
+    forceResume(id: string): Promise<void>;
     onStatus(callback: (data: TerminalStatusPayload) => void): () => void;
     onResourceMetrics(
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void
@@ -399,7 +393,7 @@ export interface ElectronAPI {
     getSources(): Promise<string[]>;
     clear(): Promise<void>;
     openFile(): Promise<void>;
-    setVerbose(enabled: boolean): Promise<{ success: boolean }>;
+    setVerbose(enabled: boolean): Promise<void>;
     getVerbose(): Promise<boolean>;
     onEntry(callback: (entry: LogEntry) => void): () => void;
     onBatch(callback: (entries: LogEntry[]) => void): () => void;
@@ -414,12 +408,12 @@ export interface ElectronAPI {
     getRegistry(): Promise<string[]>;
   };
   errors: {
-    onError(callback: (error: AppError) => void): () => void;
+    onError(callback: (error: ErrorRecord) => void): () => void;
     retry(errorId: string, action: RetryAction, args?: Record<string, unknown>): Promise<void>;
     cancelRetry(errorId: string): void;
     onRetryProgress(callback: (payload: RetryProgressPayload) => void): () => void;
     openLogs(): Promise<void>;
-    getPending(): Promise<AppError[]>;
+    getPending(): Promise<ErrorRecord[]>;
   };
   eventInspector: {
     getEvents(): Promise<EventRecord[]>;
@@ -710,15 +704,7 @@ export interface ElectronAPI {
     stageAll(cwd: string): Promise<void>;
     unstageAll(cwd: string): Promise<void>;
     commit(cwd: string, message: string): Promise<{ hash: string; summary: string }>;
-    push(
-      cwd: string,
-      setUpstream?: boolean
-    ): Promise<{
-      success: boolean;
-      error?: string;
-      gitReason?: GitOperationReason;
-      recoveryAction?: RecoveryAction;
-    }>;
+    push(cwd: string, setUpstream?: boolean): Promise<void>;
     getStagingStatus(cwd: string): Promise<StagingStatus>;
     abortRepositoryOperation(cwd: string): Promise<void>;
     continueRepositoryOperation(cwd: string): Promise<void>;
@@ -821,7 +807,7 @@ export interface ElectronAPI {
       panelId: string,
       webContentsId: number,
       sessionStorageSnapshot?: Array<[string, string]>
-    ): Promise<{ success: boolean; error?: string } | null>;
+    ): Promise<{ success: true } | null>;
     /** Start CDP console capture for a webview panel */
     startConsoleCapture(webContentsId: number, paneId: string): Promise<void>;
     /** Stop CDP console capture for a webview panel */
@@ -1095,18 +1081,12 @@ export interface ElectronAPI {
     clear(worktreeId?: string): Promise<void>;
   };
   clipboard: {
-    saveImage(): Promise<
-      { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
-    >;
-    thumbnailFromPath(
-      filePath: string
-    ): Promise<
-      { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
-    >;
-    writeImage(pngData: Uint8Array): Promise<{ ok: true } | { ok: false; error: string }>;
-    writeText(text: string): Promise<{ ok: true } | { ok: false; error: string }>;
-    writeSelection(text: string): Promise<{ ok: true } | { ok: false; error: string }>;
-    readSelection(): Promise<{ ok: true; text: string } | { ok: false; error: string }>;
+    saveImage(): Promise<{ filePath: string; thumbnailDataUrl: string }>;
+    thumbnailFromPath(filePath: string): Promise<{ filePath: string; thumbnailDataUrl: string }>;
+    writeImage(pngData: Uint8Array): Promise<void>;
+    writeText(text: string): Promise<void>;
+    writeSelection(text: string): Promise<void>;
+    readSelection(): Promise<{ text: string }>;
   };
   webUtils: {
     getPathForFile(file: File): string;

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -4,6 +4,18 @@ export interface SerializedError {
   message: string;
   stack?: string;
   code?: string;
+  /**
+   * User-facing message carried by `AppError`. Promoted to a top-level field
+   * (rather than living in `properties`) so it survives the packaged-build
+   * strip in `electron/setup/security.ts`.
+   */
+  userMessage?: string;
+  /**
+   * Classified reason carried by `GitOperationError`. Promoted to a top-level
+   * field so it survives the packaged-build strip and lets the renderer drive
+   * recovery UI without relying on substring-matching the message.
+   */
+  gitReason?: GitOperationReason;
   errno?: number;
   syscall?: string;
   path?: string;
@@ -81,8 +93,8 @@ export interface RetryProgressPayload {
   maxAttempts: number;
 }
 
-/** Application error for UI display */
-export interface AppError {
+/** Application error record stored for UI display (errorStore / banners). */
+export interface ErrorRecord {
   /** Unique identifier */
   id: string;
   /** Timestamp when error occurred */

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -23,7 +23,8 @@ export type FileReadErrorCode =
   | "LFS_POINTER"
   | "NOT_FOUND"
   | "OUTSIDE_ROOT"
-  | "INVALID_PATH";
+  | "INVALID_PATH"
+  | "PERMISSION";
 
 export interface FileReadResult {
   content: string;

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -13,6 +13,10 @@ export interface FileReadPayload {
   rootPath: string;
 }
 
+/**
+ * Subset of `AppErrorCode` thrown by `files:read`. Renderer consumers narrow
+ * caught `AppError`s with `if (e.code === "BINARY_FILE") { ... }` style checks.
+ */
 export type FileReadErrorCode =
   | "BINARY_FILE"
   | "FILE_TOO_LARGE"
@@ -21,4 +25,6 @@ export type FileReadErrorCode =
   | "OUTSIDE_ROOT"
   | "INVALID_PATH";
 
-export type FileReadResult = { ok: true; content: string } | { ok: false; code: FileReadErrorCode };
+export interface FileReadResult {
+  content: string;
+}

--- a/shared/types/ipc/gitClone.ts
+++ b/shared/types/ipc/gitClone.ts
@@ -12,9 +12,10 @@ export interface CloneRepoProgressEvent {
   timestamp: number;
 }
 
+/**
+ * Successful clone result. Failures throw `AppError`:
+ * `code: "CANCELLED"` when the user aborted the clone, otherwise `INTERNAL`.
+ */
 export interface CloneRepoResult {
-  success: boolean;
-  clonedPath?: string;
-  error?: string;
-  cancelled?: boolean;
+  clonedPath: string;
 }

--- a/shared/types/ipc/gitInit.ts
+++ b/shared/types/ipc/gitInit.ts
@@ -27,10 +27,11 @@ export interface GitInitProgressEvent {
   timestamp: number;
 }
 
+/**
+ * Successful result from `project:init-git`. Failures throw `AppError` whose
+ * `context.completedSteps` carries the partial progress for diagnostics.
+ */
 export interface GitInitResult {
-  success: boolean;
-  /** Error message if initialization failed */
-  error?: string;
-  /** Steps completed before failure (if any) */
-  completedSteps?: GitInitStepType[];
+  /** Steps completed during a successful init */
+  completedSteps: GitInitStepType[];
 }

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -85,7 +85,7 @@ import type {
 } from "./system.js";
 import type { AppState, HydrateResult } from "./app.js";
 import type { LogEntry, LogFilterOptions } from "./logs.js";
-import type { RetryAction, AppError, RetryProgressPayload } from "./errors.js";
+import type { RetryAction, ErrorRecord, RetryProgressPayload } from "./errors.js";
 import type { EventRecord, EventFilterOptions } from "./events.js";
 import type {
   ProjectCloseResult,
@@ -381,7 +381,7 @@ export interface IpcInvokeMap {
   };
   "terminal:force-resume": {
     args: [id: string];
-    result: { success: boolean; error?: string };
+    result: void;
   };
   "terminal:restart-service": {
     args: [];
@@ -658,7 +658,7 @@ export interface IpcInvokeMap {
   };
   "logs:set-verbose": {
     args: [enabled: boolean];
-    result: { success: boolean };
+    result: void;
   };
   "logs:get-verbose": {
     args: [];
@@ -702,7 +702,7 @@ export interface IpcInvokeMap {
   };
   "error:get-pending": {
     args: [];
-    result: AppError[];
+    result: ErrorRecord[];
   };
 
   // Event inspector channels
@@ -1108,7 +1108,11 @@ export interface IpcInvokeMap {
   };
   "git:push": {
     args: [payload: { cwd: string; setUpstream?: boolean }];
-    result: { success: boolean; error?: string };
+    /**
+     * Resolves on success. Throws `GitOperationError` on failure — the renderer
+     * reads `caught.gitReason` to surface a classified recovery hint.
+     */
+    result: void;
   };
   "git:get-staging-status": {
     args: [cwd: string];
@@ -1394,30 +1398,32 @@ export interface IpcInvokeMap {
     result: CliInstallStatus;
   };
 
-  // Clipboard channels
+  // Clipboard channels — handlers throw `AppError` on failure (CLIPBOARD_EMPTY,
+  // CLIPBOARD_INVALID, UNSUPPORTED, VALIDATION). Renderer consumers use
+  // try/catch + isClientAppError(e) to branch on e.code.
   "clipboard:save-image": {
     args: [];
-    result: { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string };
+    result: { filePath: string; thumbnailDataUrl: string };
   };
   "clipboard:thumbnail-from-path": {
     args: [filePath: string];
-    result: { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string };
+    result: { filePath: string; thumbnailDataUrl: string };
   };
   "clipboard:write-image": {
     args: [pngData: Uint8Array];
-    result: { ok: true } | { ok: false; error: string };
+    result: void;
   };
   "clipboard:write-text": {
     args: [text: string];
-    result: { ok: true } | { ok: false; error: string };
+    result: void;
   };
   "clipboard:write-selection": {
     args: [text: string];
-    result: { ok: true } | { ok: false; error: string };
+    result: void;
   };
   "clipboard:read-selection": {
     args: [];
-    result: { ok: true; text: string } | { ok: false; error: string };
+    result: { text: string };
   };
 
   // Notification settings channels
@@ -2141,7 +2147,8 @@ export interface IpcInvokeMap {
       webContentsId: number,
       sessionStorageSnapshot?: Array<[string, string]>,
     ];
-    result: { success: boolean; error?: string } | null;
+    /** Resolves with `{ success: true }` on success or `null` if the loopback was aborted. Throws `AppError` on hard failure. */
+    result: { success: true } | null;
   };
 
   // Additional worktree channels
@@ -2215,7 +2222,7 @@ export interface IpcEventMap {
   "github:token-health-changed": GitHubTokenHealthPayload;
 
   // Error events
-  "error:notify": AppError;
+  "error:notify": ErrorRecord;
   "error:retry-progress": RetryProgressPayload;
 
   // Log events

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -28,16 +28,12 @@ export interface ProjectSwitchPayload {
   hydrateResult?: HydrateResult;
 }
 
-/** Result from project:close operation */
+/** Result from project:close operation. Failures throw `AppError`. */
 export interface ProjectCloseResult {
-  /** Whether the operation succeeded */
-  success: boolean;
   /** Total number of processes killed */
   processesKilled: number;
   /** Number of terminals killed */
   terminalsKilled: number;
-  /** Error message if operation failed */
-  error?: string;
 }
 
 /** Project resource statistics */

--- a/shared/utils/__tests__/ipcErrorSerialization.test.ts
+++ b/shared/utils/__tests__/ipcErrorSerialization.test.ts
@@ -227,12 +227,10 @@ describe("round-trip serialization", () => {
     // Shared-layer test synthesizes the GitOperationError shape without importing
     // the electron/ module — shared/ must not depend on electron/.
     //
-    // NOTE: electron/setup/security.ts strips `properties` from the IPC envelope in
-    // packaged builds. This test proves the `properties` bag survives a naive
-    // serialize/clone/deserialize cycle, which is what dev-mode IPC uses and what
-    // our renderer event payloads (e.g. fetch-pr-branch-result, handlePush return)
-    // use. In packaged builds we rely on top-level AppError.gitReason, not on the
-    // wrapped-error properties bag.
+    // The handler's `reason` field is promoted to the top-level `gitReason`
+    // slot on `SerializedError` so it survives the packaged-build strip in
+    // `electron/setup/security.ts` (which clears `context`/`cause`/`properties`
+    // but preserves named top-level fields).
     const original = Object.assign(new Error("fatal: not a git repository"), {
       name: "GitOperationError",
       context: { cwd: "/repo", op: "status", reason: "not-a-repository" },
@@ -242,16 +240,18 @@ describe("round-trip serialization", () => {
     });
 
     const serialized = serializeError(original);
+    expect(serialized.gitReason).toBe("not-a-repository");
+
     const cloned = structuredClone(serialized);
     const restored = deserializeError(cloned) as Error & {
-      reason: string;
+      gitReason: string;
       op: string;
       rawMessage: string;
       context: Record<string, unknown>;
     };
 
     expect(restored.name).toBe("GitOperationError");
-    expect(restored.reason).toBe("not-a-repository");
+    expect(restored.gitReason).toBe("not-a-repository");
     expect(restored.op).toBe("status");
     expect(restored.rawMessage).toBe("fatal: not a git repository");
     expect(restored.context).toEqual({
@@ -259,6 +259,29 @@ describe("round-trip serialization", () => {
       op: "status",
       reason: "not-a-repository",
     });
+  });
+
+  it("round-trips an AppError code + userMessage via serialize -> structuredClone -> deserialize", () => {
+    const original = Object.assign(new Error("Binary file"), {
+      name: "AppError",
+      code: "BINARY_FILE",
+      userMessage: "This file can't be displayed.",
+      context: { filePath: "/repo/asset.bin" },
+    });
+
+    const serialized = serializeError(original);
+    expect(serialized.code).toBe("BINARY_FILE");
+    expect(serialized.userMessage).toBe("This file can't be displayed.");
+
+    const cloned = structuredClone(serialized);
+    const restored = deserializeError(cloned) as Error & {
+      code: string;
+      userMessage: string;
+    };
+
+    expect(restored.name).toBe("AppError");
+    expect(restored.code).toBe("BINARY_FILE");
+    expect(restored.userMessage).toBe("This file can't be displayed.");
   });
 });
 

--- a/shared/utils/ipcErrorSerialization.ts
+++ b/shared/utils/ipcErrorSerialization.ts
@@ -5,6 +5,9 @@ const KNOWN_ERROR_KEYS = new Set([
   "message",
   "stack",
   "code",
+  "userMessage",
+  "gitReason",
+  "reason",
   "errno",
   "syscall",
   "path",
@@ -34,6 +37,14 @@ export function serializeError(error: unknown, seen = new WeakSet<object>()): Se
 
   if (typeof err.stack === "string") serialized.stack = err.stack;
   if (typeof err.code === "string") serialized.code = err.code;
+  if (typeof err.userMessage === "string") serialized.userMessage = err.userMessage;
+  // GitOperationError exposes `reason`; promote to a top-level `gitReason`
+  // field on the wire so it survives the packaged-build strip.
+  if (typeof err.gitReason === "string") {
+    serialized.gitReason = err.gitReason as SerializedError["gitReason"];
+  } else if (typeof err.reason === "string") {
+    serialized.gitReason = err.reason as SerializedError["gitReason"];
+  }
   if (typeof err.errno === "number") serialized.errno = err.errno;
   if (typeof err.syscall === "string") serialized.syscall = err.syscall;
   if (typeof err.path === "string") serialized.path = err.path;
@@ -66,6 +77,12 @@ export function deserializeError(serialized: SerializedError): Error {
 
   if (serialized.stack !== undefined) error.stack = serialized.stack;
   if (serialized.code !== undefined) (error as NodeJS.ErrnoException).code = serialized.code;
+  if (serialized.userMessage !== undefined) {
+    (error as unknown as Record<string, unknown>).userMessage = serialized.userMessage;
+  }
+  if (serialized.gitReason !== undefined) {
+    (error as unknown as Record<string, unknown>).gitReason = serialized.gitReason;
+  }
   if (serialized.errno !== undefined) (error as NodeJS.ErrnoException).errno = serialized.errno;
   if (serialized.syscall !== undefined)
     (error as NodeJS.ErrnoException).syscall = serialized.syscall;

--- a/src/clients/errorsClient.ts
+++ b/src/clients/errorsClient.ts
@@ -1,7 +1,7 @@
-import type { AppError, RetryAction, RetryProgressPayload } from "@shared/types";
+import type { ErrorRecord, RetryAction, RetryProgressPayload } from "@shared/types";
 
 export const errorsClient = {
-  onError: (callback: (error: AppError) => void): (() => void) => {
+  onError: (callback: (error: ErrorRecord) => void): (() => void) => {
     return window.electron.errors.onError(callback);
   },
 
@@ -21,7 +21,7 @@ export const errorsClient = {
     return window.electron.errors.openLogs();
   },
 
-  getPending: (): Promise<AppError[]> => {
+  getPending: (): Promise<ErrorRecord[]> => {
     return window.electron.errors.getPending();
   },
 } as const;

--- a/src/clients/logsClient.ts
+++ b/src/clients/logsClient.ts
@@ -27,7 +27,7 @@ export const logsClient = {
     return window.electron.logs.openFile();
   },
 
-  setVerbose: (enabled: boolean): Promise<{ success: boolean }> => {
+  setVerbose: (enabled: boolean): Promise<void> => {
     return window.electron.logs.setVerbose(enabled);
   },
 

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -405,7 +405,7 @@ export const terminalClient = {
    * Force resume a terminal that may be paused due to backpressure.
    * User-initiated action to unblock a terminal.
    */
-  forceResume: (id: string): Promise<{ success: boolean; error?: string }> => {
+  forceResume: (id: string): Promise<void> => {
     return window.electron.terminal.forceResume(id);
   },
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -118,12 +118,17 @@ function BlockedNavBanner({
               /* webview not ready */
             }
             if (wcId != null) {
-              await window.electron.webview.startOAuthLoopback(
-                url,
-                panelId,
-                wcId,
-                blockedNav.sessionStorageSnapshot
-              );
+              try {
+                await window.electron.webview.startOAuthLoopback(
+                  url,
+                  panelId,
+                  wcId,
+                  blockedNav.sessionStorageSnapshot
+                );
+              } catch {
+                // OAuth loopback may fail if the webview is gone or CDP setup
+                // breaks; silently fall through — the dialog has been dismissed.
+              }
             }
           }}
           className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { useErrorStore, type AppError, type RetryAction } from "@/store";
+import { useErrorStore, type ErrorRecord, type RetryAction } from "@/store";
 import { Copy, Check, Lightbulb } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { logError } from "@/utils/logger";
@@ -34,7 +34,7 @@ function formatTimestamp(timestamp: number): string {
 }
 
 interface ErrorRowProps {
-  error: AppError;
+  error: ErrorRecord;
   isExpanded: boolean;
   onToggleExpand: () => void;
   onDismiss: () => void;

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -11,10 +11,10 @@ import {
   XCircle,
   type LucideIcon,
 } from "lucide-react";
-import type { AppError, RetryAction } from "@/store/errorStore";
+import type { ErrorRecord, RetryAction } from "@/store/errorStore";
 
 export interface ErrorBannerProps {
-  error: AppError;
+  error: ErrorRecord;
   onDismiss: (id: string) => void;
   onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
   onCancelRetry?: (id: string) => void;

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -2,13 +2,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ErrorBanner } from "../ErrorBanner";
-import type { AppError } from "@/store/errorStore";
+import type { ErrorRecord } from "@/store/errorStore";
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));
 
-function makeError(overrides: Partial<AppError> = {}): AppError {
+function makeError(overrides: Partial<ErrorRecord> = {}): ErrorRecord {
   return {
     id: "err-1",
     timestamp: Date.now(),

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -54,6 +54,7 @@ const ERROR_MESSAGES: Record<FileReadErrorCode, string> = {
   NOT_FOUND: "File no longer exists",
   OUTSIDE_ROOT: "File is outside the project root",
   INVALID_PATH: "Invalid file path",
+  PERMISSION: "Permission denied — you don't have access to this file",
 };
 
 export function FileViewerModal({

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import { isClientAppError } from "@/utils/clientAppError";
 import { sanitizeSvg } from "@shared/utils/svgSanitizer";
 import { logError } from "@/utils/logger";
 
@@ -132,30 +133,26 @@ export function FileViewerModal({
 
     filesClient
       .read({ path: filePath, rootPath: effectiveRootPath })
-      .then((result) => {
+      .then(({ content: fileContent }) => {
         if (!isMountedRef.current || requestRef.current !== requestId) return;
-        if (result.ok) {
-          if (svgFile) {
-            const sanitized = sanitizeSvg(result.content);
-            if (sanitized.ok) {
-              setSanitizedSvg(sanitized.svg);
-              setLoadState("svg");
-            } else {
-              setErrorCode("INVALID_PATH");
-              setLoadState("error");
-            }
+        if (svgFile) {
+          const sanitized = sanitizeSvg(fileContent);
+          if (sanitized.ok) {
+            setSanitizedSvg(sanitized.svg);
+            setLoadState("svg");
           } else {
-            setContent(result.content);
-            setLoadState("loaded");
+            setErrorCode("INVALID_PATH");
+            setLoadState("error");
           }
         } else {
-          setErrorCode(result.code);
-          setLoadState("error");
+          setContent(fileContent);
+          setLoadState("loaded");
         }
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!isMountedRef.current || requestRef.current !== requestId) return;
-        setErrorCode("INVALID_PATH");
+        const code = isClientAppError(error) ? (error.code as FileReadErrorCode) : "INVALID_PATH";
+        setErrorCode(code);
         setLoadState("error");
       });
   });

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -73,7 +73,7 @@ vi.mock("@shared/utils/svgSanitizer", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockRead.mockResolvedValue({ ok: true, content: "file content" });
+  mockRead.mockResolvedValue({ content: "file content" });
 });
 
 describe("FileViewerModal", () => {
@@ -125,7 +125,6 @@ describe("FileViewerModal", () => {
 
   it("renders sanitized SVG inline", async () => {
     mockRead.mockResolvedValue({
-      ok: true,
       content: '<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>',
     });
 
@@ -143,7 +142,9 @@ describe("FileViewerModal", () => {
   });
 
   it("shows binary error with Open in Editor for non-image binaries", async () => {
-    mockRead.mockResolvedValue({ ok: false, code: "BINARY_FILE" });
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("Binary file"), { name: "AppError", code: "BINARY_FILE" })
+    );
 
     render(<FileViewerModal {...defaultProps} filePath="/project/app.wasm" />);
 
@@ -210,7 +211,7 @@ describe("FileViewerModal", () => {
   });
 
   it("renders metadata bar with line count, size, and encoding when file is loaded", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "line1\nline2\nline3" });
+    mockRead.mockResolvedValue({ content: "line1\nline2\nline3" });
 
     render(<FileViewerModal {...defaultProps} />);
 
@@ -232,7 +233,9 @@ describe("FileViewerModal", () => {
   });
 
   it("does not render metadata bar when file fails to load", async () => {
-    mockRead.mockResolvedValue({ ok: false, code: "NOT_FOUND" });
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("File not found"), { name: "AppError", code: "NOT_FOUND" })
+    );
 
     render(<FileViewerModal {...defaultProps} />);
 

--- a/src/components/FileViewer/__tests__/PlanFileViewer.test.tsx
+++ b/src/components/FileViewer/__tests__/PlanFileViewer.test.tsx
@@ -73,7 +73,7 @@ describe("PlanFileViewer", () => {
   });
 
   it("renders file content in CodeViewer after successful read", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "# My Plan\n- step 1" });
+    mockRead.mockResolvedValue({ content: "# My Plan\n- step 1" });
 
     render(
       <PlanFileViewer isOpen={true} filePath="TODO.md" rootPath="/project" onClose={() => {}} />
@@ -88,7 +88,9 @@ describe("PlanFileViewer", () => {
   });
 
   it("shows generic error state when read fails with non-NOT_FOUND code", async () => {
-    mockRead.mockResolvedValue({ ok: false, code: "FILE_TOO_LARGE" });
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("File too large"), { name: "AppError", code: "FILE_TOO_LARGE" })
+    );
 
     render(
       <PlanFileViewer isOpen={true} filePath="TODO.md" rootPath="/project" onClose={() => {}} />
@@ -100,7 +102,9 @@ describe("PlanFileViewer", () => {
   });
 
   it("shows empty state (not error) when NOT_FOUND is returned — plan file was deleted", async () => {
-    mockRead.mockResolvedValue({ ok: false, code: "NOT_FOUND" });
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("File not found"), { name: "AppError", code: "NOT_FOUND" })
+    );
 
     render(
       <PlanFileViewer isOpen={true} filePath="TODO.md" rootPath="/project" onClose={() => {}} />
@@ -113,7 +117,7 @@ describe("PlanFileViewer", () => {
   });
 
   it("shows the filename in the dialog title", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "content" });
+    mockRead.mockResolvedValue({ content: "content" });
 
     render(
       <PlanFileViewer isOpen={true} filePath="PLAN.md" rootPath="/project" onClose={() => {}} />

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -127,21 +127,21 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     hasFinalizedRef.current = false;
 
     try {
-      const result = await projectClient.cloneRepo({
+      const { clonedPath: resultPath } = await projectClient.cloneRepo({
         url: normalizeCloneUrl(url),
         parentPath,
         folderName: folderName.trim(),
         shallowClone,
       });
 
-      if (result.success && result.clonedPath) {
-        setClonedPath(result.clonedPath);
-        setIsComplete(true);
-      } else if (!result.cancelled) {
-        setError(result.error || "Clone failed");
-      }
+      setClonedPath(resultPath);
+      setIsComplete(true);
     } catch (err) {
-      setError(formatErrorMessage(err, "Failed to clone repository"));
+      // CANCELLED is the user aborting via the cancel button — not a failure.
+      const code = (err as { code?: string })?.code;
+      if (code !== "CANCELLED") {
+        setError(formatErrorMessage(err, "Failed to clone repository"));
+      }
     } finally {
       setIsCloning(false);
     }

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -71,17 +71,13 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     hasFinalizedSuccessRef.current = false;
 
     try {
-      const result = await projectClient.initGitGuided({
+      await projectClient.initGitGuided({
         directoryPath,
         createInitialCommit: true,
         initialCommitMessage: "Initial commit",
         createGitignore: true,
         gitignoreTemplate: "node",
       });
-
-      if (!result.success) {
-        setError(result.error || "Initialization failed");
-      }
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to initialize git repository"));
     } finally {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -87,7 +87,7 @@ describe("CloneRepoDialog", () => {
       return vi.fn();
     });
 
-    cloneRepoMock.mockResolvedValue({ success: true, clonedPath: "/tmp/my-repo" });
+    cloneRepoMock.mockResolvedValue({ clonedPath: "/tmp/my-repo" });
     openDialogMock.mockResolvedValue("/tmp");
   });
 
@@ -210,7 +210,9 @@ describe("CloneRepoDialog", () => {
   });
 
   it("shows error and retry button on clone failure", async () => {
-    cloneRepoMock.mockResolvedValue({ success: false, error: "Auth failed" });
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Auth failed"), { name: "AppError", code: "INTERNAL" })
+    );
 
     render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
 
@@ -357,7 +359,9 @@ describe("CloneRepoDialog", () => {
   });
 
   it("does not show error after cancelled clone", async () => {
-    cloneRepoMock.mockResolvedValue({ success: false, cancelled: true, error: "Clone cancelled" });
+    cloneRepoMock.mockRejectedValue(
+      Object.assign(new Error("Clone cancelled"), { name: "AppError", code: "CANCELLED" })
+    );
 
     render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
 

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -361,8 +361,7 @@ export function TroubleshootingTab() {
         { enabled: newState },
         { source: "user" }
       );
-      const payload = result.ok ? (result.result as { success: boolean }) : null;
-      if (!result.ok || !payload?.success) {
+      if (!result.ok) {
         logWarn("Backend rejected verbose logging toggle");
         setVerboseLogging(!newState);
       }

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -32,10 +32,10 @@ const ARTIFACT_TYPE_ICONS: Record<string, string> = {
 interface ArtifactItemProps {
   artifact: Artifact;
   onCopy: (artifact: Artifact) => Promise<boolean>;
-  onSave: (artifact: Artifact) => Promise<{ filePath: string; success: boolean } | null>;
+  onSave: (artifact: Artifact) => Promise<{ filePath: string } | null>;
   onApplyPatch: (
     artifact: Artifact
-  ) => Promise<{ success: boolean; error?: string; modifiedFiles?: string[] }>;
+  ) => Promise<{ success: true; modifiedFiles: string[] } | { success: false; error: string }>;
   canApplyPatch: boolean;
   isProcessing: boolean;
 }
@@ -77,7 +77,7 @@ function ArtifactItem({
 
   const handleSave = useCallback(async () => {
     const result = await onSave(artifact);
-    if (result?.success) {
+    if (result?.filePath) {
       showFeedback("Saved!", "success");
     } else {
       showFeedback("Save failed", "error");

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -263,10 +263,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       () =>
         createImagePasteHandler(async (view) => {
           try {
-            const result = await window.electron.clipboard.saveImage();
-            if (!result.ok) return;
+            const { filePath, thumbnailDataUrl } = await window.electron.clipboard.saveImage();
             const cursor = view.state.selection.main.head;
-            const { filePath, thumbnailDataUrl } = result;
             view.dispatch({
               changes: { from: cursor, insert: filePath + " " },
               effects: addImageChip.of({
@@ -278,7 +276,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               selection: { anchor: cursor + filePath.length + 1 },
             });
           } catch {
-            // Editor may have been destroyed before IPC returned
+            // Empty clipboard, editor destroyed mid-IPC, etc. — nothing to do.
           }
         }),
       []

--- a/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
+++ b/src/components/Terminal/__tests__/useTerminalFileTransfer.test.ts
@@ -63,7 +63,6 @@ describe("useTerminalFileTransfer hook", () => {
     (window as unknown as Record<string, unknown>).electron = {
       clipboard: {
         saveImage: vi.fn().mockResolvedValue({
-          ok: true,
           filePath: "/tmp/daintree-clipboard/clipboard-123-abc.png",
           thumbnailDataUrl: "data:image/png;base64,abc",
         }),
@@ -187,10 +186,12 @@ describe("useTerminalFileTransfer hook", () => {
   });
 
   it("image paste with saveImage failure does not write to terminal", async () => {
-    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: false,
-      error: "No image in clipboard",
-    });
+    (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockRejectedValue(
+      Object.assign(new Error("No image in clipboard"), {
+        name: "AppError",
+        code: "CLIPBOARD_EMPTY",
+      })
+    );
 
     renderFileTransferHook();
     const event = makePasteEvent(true);
@@ -218,7 +219,6 @@ describe("useTerminalFileTransfer hook", () => {
 
   it("image paste escapes paths with spaces", async () => {
     (window.electron.clipboard.saveImage as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
       filePath: "/tmp/daintree clipboard/my screenshot.png",
       thumbnailDataUrl: "data:image/png;base64,abc",
     });

--- a/src/components/Terminal/hooks/useDragDrop.ts
+++ b/src/components/Terminal/hooks/useDragDrop.ts
@@ -55,12 +55,9 @@ export function useDragDrop(editorViewRef: React.RefObject<EditorView | null>) {
 
         if (IMAGE_EXTENSIONS.test(file.name)) {
           try {
-            const result = await window.electron.clipboard.thumbnailFromPath(filePath);
-            if (result.ok) {
-              resolved.push({ type: "image", filePath, thumbnailDataUrl: result.thumbnailDataUrl });
-            } else {
-              resolved.push({ type: "file", filePath, fileName: name, fileSize: file.size });
-            }
+            const { thumbnailDataUrl } =
+              await window.electron.clipboard.thumbnailFromPath(filePath);
+            resolved.push({ type: "image", filePath, thumbnailDataUrl });
           } catch {
             resolved.push({ type: "file", filePath, fileName: name, fileSize: file.size });
           }

--- a/src/components/Terminal/useTerminalFileTransfer.ts
+++ b/src/components/Terminal/useTerminalFileTransfer.ts
@@ -57,15 +57,13 @@ export function useTerminalFileTransfer(
       event.stopPropagation();
 
       try {
-        const result = await window.electron.clipboard.saveImage();
-        if (!result.ok) return;
-
-        const escaped = escapeShellArgOptional(result.filePath);
+        const { filePath } = await window.electron.clipboard.saveImage();
+        const escaped = escapeShellArgOptional(filePath);
         terminalClient.write(terminalId, escaped);
         terminalInstanceService.notifyUserInput(terminalId);
         onInput?.(escaped);
       } catch {
-        // IPC may fail if window is closing
+        // Empty clipboard, IPC failure during window close, etc. — nothing to do.
       }
     };
 

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -415,18 +415,15 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
 
   const runPush = useCallback(async () => {
     try {
-      const result = await window.electron.git.push(worktreePath);
-      if (result.success) {
-        setPushError(null);
-      } else {
-        setPushError({
-          reason: result.gitReason ?? "unknown",
-          rawMessage: result.error ?? "",
-        });
-      }
+      await window.electron.git.push(worktreePath);
+      setPushError(null);
     } catch (err) {
+      const reason =
+        (err as { gitReason?: string }).gitReason ??
+        ((err as { code?: string }).code as string | undefined) ??
+        "unknown";
       setPushError({
-        reason: "unknown",
+        reason: reason as GitOperationReason,
         rawMessage: formatErrorMessage(err, "Failed to push"),
       });
     }

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import type { StagingStatus, GitStatus } from "@shared/types";
 import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
+import { isClientAppError } from "@/utils/clientAppError";
 import { cn } from "@/lib/utils";
 import { useOverlayState } from "@/hooks";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
@@ -418,13 +419,18 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       await window.electron.git.push(worktreePath);
       setPushError(null);
     } catch (err) {
-      const reason =
-        (err as { gitReason?: string }).gitReason ??
-        ((err as { code?: string }).code as string | undefined) ??
-        "unknown";
+      // GitOperationError carries `gitReason` (auth-failed, push-rejected-*, etc.).
+      // AppError carries `code` from a different union (RATE_LIMITED, etc.) — fall
+      // back to "unknown" so getPushBannerConfig surfaces the raw message rather
+      // than rendering an unmapped reason.
+      const gitReason = (err as { gitReason?: GitOperationReason }).gitReason;
+      const isRateLimited =
+        isClientAppError(err) && (err as { code?: string }).code === "RATE_LIMITED";
       setPushError({
-        reason: reason as GitOperationReason,
-        rawMessage: formatErrorMessage(err, "Failed to push"),
+        reason: gitReason ?? "unknown",
+        rawMessage: isRateLimited
+          ? "Too many push attempts in a short window — wait a moment and try again."
+          : formatErrorMessage(err, "Failed to push"),
       });
     }
   }, [worktreePath]);

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1214,6 +1214,22 @@ describe("ReviewHub", () => {
       expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
     });
 
+    it("shows a rate-limit message when push throws AppError(RATE_LIMITED)", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("Rate limit exceeded"), {
+          name: "AppError",
+          code: "RATE_LIMITED",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("unknown");
+      const details = screen.queryByTestId("review-hub-push-error-details");
+      expect(details?.textContent ?? "").toMatch(/Too many push attempts/i);
+    });
+
     it("does not render the banner on successful push", async () => {
       pushMock.mockResolvedValue(undefined);
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -229,7 +229,7 @@ describe("ReviewHub", () => {
     openInEditorMock.mockReset().mockResolvedValue(undefined);
     stageFileMock.mockReset().mockResolvedValue(undefined);
     commitMock.mockReset().mockResolvedValue({ hash: "abc123", summary: "commit" });
-    pushMock.mockReset().mockResolvedValue({ success: true });
+    pushMock.mockReset().mockResolvedValue(undefined);
     actionDispatchMock.mockReset().mockResolvedValue({ ok: true });
 
     Object.defineProperty(window, "electron", {
@@ -995,11 +995,12 @@ describe("ReviewHub", () => {
 
     it("shows auth-failed banner with Open GitHub settings CTA and dispatches settings tab", async () => {
       const rawError = "fatal: Authentication failed for 'https://github.com/foo/bar.git/'";
-      pushMock.mockResolvedValue({
-        success: false,
-        gitReason: "auth-failed",
-        error: rawError,
-      });
+      pushMock.mockRejectedValue(
+        Object.assign(new Error(rawError), {
+          name: "GitOperationError",
+          gitReason: "auth-failed",
+        })
+      );
 
       await triggerCommitAndPush();
 
@@ -1022,11 +1023,12 @@ describe("ReviewHub", () => {
     });
 
     it("shows push-rejected-outdated banner without a CTA", async () => {
-      pushMock.mockResolvedValue({
-        success: false,
-        gitReason: "push-rejected-outdated",
-        error: "! [rejected] main -> main (non-fast-forward)",
-      });
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("! [rejected] main -> main (non-fast-forward)"), {
+          name: "GitOperationError",
+          gitReason: "push-rejected-outdated",
+        })
+      );
 
       await triggerCommitAndPush();
 
@@ -1039,11 +1041,12 @@ describe("ReviewHub", () => {
 
     it("shows push-rejected-policy banner with raw stderr and no CTA", async () => {
       const rawError = "GH006: Protected branch update failed for refs/heads/main.";
-      pushMock.mockResolvedValue({
-        success: false,
-        gitReason: "push-rejected-policy",
-        error: rawError,
-      });
+      pushMock.mockRejectedValue(
+        Object.assign(new Error(rawError), {
+          name: "GitOperationError",
+          gitReason: "push-rejected-policy",
+        })
+      );
 
       await triggerCommitAndPush();
 
@@ -1056,11 +1059,12 @@ describe("ReviewHub", () => {
 
     it("shows hook-rejected banner with raw stderr", async () => {
       const rawError = "[remote rejected] main -> main (pre-receive hook declined)";
-      pushMock.mockResolvedValue({
-        success: false,
-        gitReason: "hook-rejected",
-        error: rawError,
-      });
+      pushMock.mockRejectedValue(
+        Object.assign(new Error(rawError), {
+          name: "GitOperationError",
+          gitReason: "hook-rejected",
+        })
+      );
 
       await triggerCommitAndPush();
 
@@ -1072,11 +1076,12 @@ describe("ReviewHub", () => {
 
     it("shows network-unavailable banner with Retry push button that re-pushes without re-committing", async () => {
       const rawError = "Could not resolve host: github.com";
-      pushMock.mockResolvedValueOnce({
-        success: false,
-        gitReason: "network-unavailable",
-        error: rawError,
-      });
+      pushMock.mockRejectedValueOnce(
+        Object.assign(new Error(rawError), {
+          name: "GitOperationError",
+          gitReason: "network-unavailable",
+        })
+      );
 
       await triggerCommitAndPush();
 
@@ -1087,7 +1092,7 @@ describe("ReviewHub", () => {
       expect(commitMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledTimes(1);
 
-      pushMock.mockResolvedValueOnce({ success: true });
+      pushMock.mockResolvedValueOnce(undefined);
 
       const retryBtn = screen.getByTestId("review-hub-push-error-cta");
       expect(retryBtn.textContent).toMatch(/Retry push/i);
@@ -1115,21 +1120,23 @@ describe("ReviewHub", () => {
     });
 
     it("updates the banner when a retry fails with a different reason", async () => {
-      pushMock.mockResolvedValueOnce({
-        success: false,
-        gitReason: "network-unavailable",
-        error: "Could not resolve host: github.com",
-      });
+      pushMock.mockRejectedValueOnce(
+        Object.assign(new Error("Could not resolve host: github.com"), {
+          name: "GitOperationError",
+          gitReason: "network-unavailable",
+        })
+      );
 
       await triggerCommitAndPush();
 
       await screen.findByTestId("review-hub-push-error");
 
-      pushMock.mockResolvedValueOnce({
-        success: false,
-        gitReason: "hook-rejected",
-        error: "[remote rejected] main -> main (pre-receive hook declined)",
-      });
+      pushMock.mockRejectedValueOnce(
+        Object.assign(new Error("[remote rejected] main -> main (pre-receive hook declined)"), {
+          name: "GitOperationError",
+          gitReason: "hook-rejected",
+        })
+      );
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
@@ -1145,11 +1152,12 @@ describe("ReviewHub", () => {
     });
 
     it("clears the push banner when the modal is closed and reopened", async () => {
-      pushMock.mockResolvedValue({
-        success: false,
-        gitReason: "auth-failed",
-        error: "Authentication failed",
-      });
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("Authentication failed"), {
+          name: "GitOperationError",
+          gitReason: "auth-failed",
+        })
+      );
 
       getStagingStatusMock.mockResolvedValue(makeStatus({ hasRemote: true }));
       const { rerender } = render(
@@ -1195,10 +1203,7 @@ describe("ReviewHub", () => {
 
     it("falls back to generic copy + raw stderr for an unclassified failure", async () => {
       const rawError = "unexpected: something weird happened";
-      pushMock.mockResolvedValue({
-        success: false,
-        error: rawError,
-      });
+      pushMock.mockRejectedValue(new Error(rawError));
 
       await triggerCommitAndPush();
 
@@ -1210,7 +1215,7 @@ describe("ReviewHub", () => {
     });
 
     it("does not render the banner on successful push", async () => {
-      pushMock.mockResolvedValue({ success: true });
+      pushMock.mockResolvedValue(undefined);
 
       await triggerCommitAndPush();
 

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import type { WorktreeState } from "@/types";
 import type { RetryAction } from "@/store";
-import type { AppError } from "@/store/errorStore";
+import type { ErrorRecord } from "@/store/errorStore";
 import { cn } from "@/lib/utils";
 import { ActivityLight } from "../ActivityLight";
 import { LiveTimeAgo } from "../LiveTimeAgo";
@@ -35,7 +35,7 @@ export interface WorktreeDetailsSectionProps {
   computedSubtitle: ComputedSubtitle;
   effectiveNote?: string;
   effectiveSummary?: string | null;
-  worktreeErrors: AppError[];
+  worktreeErrors: ErrorRecord[];
   isFocused: boolean;
   onToggleExpand: (e: React.MouseEvent) => void;
   onPathClick: () => void;

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useRef, useEffect } from "react";
 import type { WorktreeState } from "../../types";
-import type { AppError, RetryAction } from "../../store/errorStore";
+import type { ErrorRecord, RetryAction } from "../../store/errorStore";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { FileChangeList } from "./FileChangeList";
 import { ActivityLight } from "./ActivityLight";
@@ -17,7 +17,7 @@ export interface WorktreeDetailsProps {
   homeDir?: string;
   effectiveNote?: string;
   effectiveSummary?: string | null;
-  worktreeErrors: AppError[];
+  worktreeErrors: ErrorRecord[];
   hasChanges: boolean;
   isFocused: boolean;
   showLastCommit?: boolean;

--- a/src/hooks/__tests__/useErrors.test.ts
+++ b/src/hooks/__tests__/useErrors.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import type { AppError } from "@/store";
+import type { ErrorRecord } from "@/store";
 
 const { onErrorMock, getPendingMock, notifyMock, shouldEscalateMock, consumeEscalationMock } =
   vi.hoisted(() => ({
@@ -37,7 +37,7 @@ vi.mock("@/lib/notify", async (importOriginal) => {
   };
 });
 
-function makeError(overrides: Partial<AppError> = {}): AppError {
+function makeError(overrides: Partial<ErrorRecord> = {}): ErrorRecord {
   return {
     id: "err-1",
     timestamp: Date.now(),
@@ -91,7 +91,7 @@ describe("getErrorPriority", () => {
 });
 
 describe("useErrors — onError path", () => {
-  let capturedOnError: (error: AppError) => void;
+  let capturedOnError: (error: ErrorRecord) => void;
 
   beforeEach(() => {
     Object.defineProperty(window, "electron", {
@@ -100,7 +100,7 @@ describe("useErrors — onError path", () => {
       configurable: true,
     });
 
-    onErrorMock.mockImplementation((cb: (error: AppError) => void) => {
+    onErrorMock.mockImplementation((cb: (error: ErrorRecord) => void) => {
       capturedOnError = cb;
       return vi.fn();
     });
@@ -195,7 +195,7 @@ describe("useErrors — getPending path", () => {
 });
 
 describe("useErrors — escalation of persistent transient errors", () => {
-  let capturedOnError: (error: AppError) => void;
+  let capturedOnError: (error: ErrorRecord) => void;
 
   beforeEach(() => {
     Object.defineProperty(window, "electron", {
@@ -204,7 +204,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
       configurable: true,
     });
 
-    onErrorMock.mockImplementation((cb: (error: AppError) => void) => {
+    onErrorMock.mockImplementation((cb: (error: ErrorRecord) => void) => {
       capturedOnError = cb;
       return vi.fn();
     });

--- a/src/hooks/__tests__/usePlanFileContent.test.tsx
+++ b/src/hooks/__tests__/usePlanFileContent.test.tsx
@@ -35,7 +35,7 @@ describe("usePlanFileContent", () => {
   });
 
   it("reads file immediately on open and transitions to loaded", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "# Plan\n- item 1" });
+    mockRead.mockResolvedValue({ content: "# Plan\n- item 1" });
 
     const { result } = renderHook(() => usePlanFileContent(true, "TODO.md", "/project", 2000));
 
@@ -51,9 +51,7 @@ describe("usePlanFileContent", () => {
   });
 
   it("polls content at the given interval", async () => {
-    mockRead
-      .mockResolvedValueOnce({ ok: true, content: "v1" })
-      .mockResolvedValueOnce({ ok: true, content: "v2" });
+    mockRead.mockResolvedValueOnce({ content: "v1" }).mockResolvedValueOnce({ content: "v2" });
 
     const { result } = renderHook(() => usePlanFileContent(true, "PLAN.md", "/project", 2000));
 
@@ -71,7 +69,9 @@ describe("usePlanFileContent", () => {
   });
 
   it("transitions to error state on read failure", async () => {
-    mockRead.mockResolvedValue({ ok: false, code: "NOT_FOUND" });
+    mockRead.mockRejectedValue(
+      Object.assign(new Error("File not found"), { name: "AppError", code: "NOT_FOUND" })
+    );
 
     const { result } = renderHook(() => usePlanFileContent(true, "TODO.md", "/project", 2000));
 
@@ -85,7 +85,7 @@ describe("usePlanFileContent", () => {
   });
 
   it("clears content and resets to idle when isOpen becomes false", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "# Plan" });
+    mockRead.mockResolvedValue({ content: "# Plan" });
 
     const { result, rerender } = renderHook(
       ({ isOpen }: { isOpen: boolean }) => usePlanFileContent(isOpen, "TODO.md", "/project", 2000),
@@ -104,8 +104,10 @@ describe("usePlanFileContent", () => {
 
   it("transitions to error when a later poll returns NOT_FOUND (plan file deleted)", async () => {
     mockRead
-      .mockResolvedValueOnce({ ok: true, content: "# Plan" })
-      .mockResolvedValueOnce({ ok: false, code: "NOT_FOUND" });
+      .mockResolvedValueOnce({ content: "# Plan" })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("File not found"), { name: "AppError", code: "NOT_FOUND" })
+      );
 
     const { result } = renderHook(() => usePlanFileContent(true, "TODO.md", "/project", 2000));
 
@@ -125,7 +127,7 @@ describe("usePlanFileContent", () => {
   });
 
   it("stops polling after interval is cleared on unmount", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "content" });
+    mockRead.mockResolvedValue({ content: "content" });
 
     const { unmount } = renderHook(() => usePlanFileContent(true, "TODO.md", "/project", 2000));
 
@@ -145,7 +147,7 @@ describe("usePlanFileContent", () => {
   });
 
   it("uses absolute path directly when filePath is already absolute", async () => {
-    mockRead.mockResolvedValue({ ok: true, content: "content" });
+    mockRead.mockResolvedValue({ content: "content" });
 
     renderHook(() => usePlanFileContent(true, "/absolute/path/TODO.md", "/project", 2000));
 

--- a/src/hooks/useArtifacts.ts
+++ b/src/hooks/useArtifacts.ts
@@ -170,7 +170,9 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
   );
 
   const applyPatch = useCallback(
-    async (artifact: Artifact) => {
+    async (
+      artifact: Artifact
+    ): Promise<{ success: true; modifiedFiles: string[] } | { success: false; error: string }> => {
       if (!isElectronAvailable() || artifact.type !== "patch") {
         logErrorWithContext(new Error("Invalid artifact type or Electron not available"), {
           operation: "apply_patch",
@@ -202,9 +204,7 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
         if (!actionResult.ok) {
           throw new Error(actionResult.error.message);
         }
-        const result = actionResult.result;
-
-        return result;
+        return { success: true, modifiedFiles: actionResult.result.modifiedFiles };
       } catch (error) {
         logErrorWithContext(error, {
           operation: "apply_patch",
@@ -313,7 +313,7 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
           }
           const saveResult = actionResult.result;
 
-          if (saveResult?.success) {
+          if (saveResult?.filePath) {
             result.succeeded++;
           } else if (saveResult === null) {
             // Treat null as user cancellation - skip remaining saves
@@ -377,23 +377,8 @@ export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: stri
           }
           const applyResult = actionResult.result;
 
-          if (applyResult.success) {
-            result.succeeded++;
-            if (applyResult.modifiedFiles) {
-              applyResult.modifiedFiles.forEach((f) => modifiedFilesSet.add(f));
-            }
-          } else {
-            logErrorWithContext(new Error(applyResult.error || "Patch application failed"), {
-              operation: "bulk_apply_patch",
-              component: "useArtifacts",
-              details: { artifactId: artifact.id, worktreeId, cwd, terminalId },
-            });
-            result.failed++;
-            result.failures.push({
-              artifact,
-              error: applyResult.error || "Patch application failed",
-            });
-          }
+          result.succeeded++;
+          applyResult.modifiedFiles.forEach((f) => modifiedFilesSet.add(f));
         } catch (error) {
           logErrorWithContext(error, {
             operation: "bulk_apply_patch",

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef } from "react";
-import { useErrorStore, type AppError, type RetryAction } from "@/store";
+import { useErrorStore, type ErrorRecord, type RetryAction } from "@/store";
 import { isElectronAvailable } from "./useElectron";
 import { errorsClient } from "@/clients";
 import { logErrorWithContext } from "@/utils/errorContext";
@@ -7,13 +7,13 @@ import { notify, shouldEscalateTransientError, consumeEscalation } from "@/lib/n
 import type { NotificationPriority } from "@/store/notificationStore";
 
 export function getErrorPriority(
-  error: Pick<AppError, "type" | "isTransient">
+  error: Pick<ErrorRecord, "type" | "isTransient">
 ): NotificationPriority {
   if (error.isTransient) return "low";
   return "high";
 }
 
-function routeError(error: AppError): void {
+function routeError(error: ErrorRecord): void {
   const escalated = shouldEscalateTransientError(error);
   const priority = escalated ? "high" : getErrorPriority(error);
 
@@ -68,7 +68,7 @@ export function useErrors() {
     ipcListenerAttached = true;
     didAttachListener.current = true;
 
-    const unsubscribeError = errorsClient.onError((error: AppError) => {
+    const unsubscribeError = errorsClient.onError((error: ErrorRecord) => {
       routeError(error);
     });
 

--- a/src/hooks/usePlanFileContent.ts
+++ b/src/hooks/usePlanFileContent.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { filesClient } from "@/clients/filesClient";
 import type { FileReadErrorCode } from "@shared/types/ipc/files";
+import { isClientAppError } from "@/utils/clientAppError";
 
 type PlanContentStatus = "idle" | "loading" | "loaded" | "error";
 
@@ -47,21 +48,19 @@ export function usePlanFileContent(
       if (!isMountedRef.current) return;
 
       try {
-        const result = await filesClient.read({ path: absolutePath, rootPath });
+        const { content: fileContent } = await filesClient.read({
+          path: absolutePath,
+          rootPath,
+        });
         if (!isMountedRef.current || requestRef.current !== requestId) return;
 
-        if (result.ok) {
-          setContent(result.content);
-          setStatus("loaded");
-          setErrorCode(null);
-        } else {
-          setErrorCode(result.code);
-          setStatus("error");
-          setContent(null);
-        }
-      } catch {
+        setContent(fileContent);
+        setStatus("loaded");
+        setErrorCode(null);
+      } catch (error) {
         if (!isMountedRef.current || requestRef.current !== requestId) return;
-        setErrorCode("INVALID_PATH");
+        const code = isClientAppError(error) ? (error.code as FileReadErrorCode) : "INVALID_PATH";
+        setErrorCode(code);
         setStatus("error");
         setContent(null);
       }

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import type { WorktreeSnapshot, RecipeTerminal } from "@/types";
-import { useErrorStore, type AppError } from "@/store";
+import { useErrorStore, type ErrorRecord } from "@/store";
 import { useRecipeStore } from "@/store/recipeStore";
 import { logError } from "@/utils/logger";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -77,7 +77,7 @@ export async function copyContextWithFeedback(
       dismissed: false,
     });
 
-    let errorType: AppError["type"] = "process";
+    let errorType: ErrorRecord["type"] = "process";
     if (message.includes("not available") || message.includes("not installed")) {
       errorType = "config";
     } else if (
@@ -144,7 +144,7 @@ export function useWorktreeActions({
         const message = formatErrorMessage(e, "Failed to copy context to clipboard");
         const details = e instanceof Error ? e.stack : undefined;
 
-        let errorType: AppError["type"] = "process";
+        let errorType: ErrorRecord["type"] = "process";
         if (message.includes("not available") || message.includes("not installed")) {
           errorType = "config";
         } else if (

--- a/src/services/terminal/__tests__/primarySelection.test.ts
+++ b/src/services/terminal/__tests__/primarySelection.test.ts
@@ -2,13 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installLinuxPrimarySelectionListeners } from "../primarySelection";
 
-type ReadSelectionResult = { ok: true; text: string } | { ok: false; error: string };
+type ReadSelectionResult = { text: string };
 
 describe("installLinuxPrimarySelectionListeners", () => {
   let hostElement: HTMLElement;
   let writeToPty: ReturnType<typeof vi.fn<(id: string, data: string) => void>>;
   let notifyUserInput: ReturnType<typeof vi.fn<(id: string) => void>>;
-  let writeSelection: ReturnType<typeof vi.fn<(text: string) => Promise<unknown>>>;
+  let writeSelection: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
   let readSelection: ReturnType<typeof vi.fn<() => Promise<ReadSelectionResult>>>;
   let cachedSelection: string | undefined;
   let bracketedPasteMode: boolean;
@@ -21,10 +21,8 @@ describe("installLinuxPrimarySelectionListeners", () => {
     document.body.appendChild(hostElement);
     writeToPty = vi.fn<(id: string, data: string) => void>();
     notifyUserInput = vi.fn<(id: string) => void>();
-    writeSelection = vi.fn<(text: string) => Promise<unknown>>().mockResolvedValue({ ok: true });
-    readSelection = vi
-      .fn<() => Promise<ReadSelectionResult>>()
-      .mockResolvedValue({ ok: true, text: "" });
+    writeSelection = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    readSelection = vi.fn<() => Promise<ReadSelectionResult>>().mockResolvedValue({ text: "" });
     cachedSelection = undefined;
     bracketedPasteMode = false;
     disposed = false;
@@ -99,7 +97,7 @@ describe("installLinuxPrimarySelectionListeners", () => {
     });
 
     it("reads PRIMARY and writes to the PTY on middle-click", async () => {
-      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      readSelection.mockResolvedValueOnce({ text: "pasted" });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(readSelection).toHaveBeenCalledTimes(1);
@@ -109,7 +107,7 @@ describe("installLinuxPrimarySelectionListeners", () => {
 
     it("wraps the payload with bracketed-paste markers when the mode is active", async () => {
       bracketedPasteMode = true;
-      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      readSelection.mockResolvedValueOnce({ text: "pasted" });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(writeToPty).toHaveBeenCalledTimes(1);
@@ -122,22 +120,24 @@ describe("installLinuxPrimarySelectionListeners", () => {
     });
 
     it("normalizes newlines to carriage returns when bracketed paste is off", async () => {
-      readSelection.mockResolvedValueOnce({ ok: true, text: "line1\nline2\r\nline3" });
+      readSelection.mockResolvedValueOnce({ text: "line1\nline2\r\nline3" });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(writeToPty).toHaveBeenCalledWith("term-1", "line1\rline2\rline3");
     });
 
     it("skips PTY write when PRIMARY is empty", async () => {
-      readSelection.mockResolvedValueOnce({ ok: true, text: "" });
+      readSelection.mockResolvedValueOnce({ text: "" });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(writeToPty).not.toHaveBeenCalled();
       expect(notifyUserInput).not.toHaveBeenCalled();
     });
 
-    it("skips PTY write when readSelection returns an error", async () => {
-      readSelection.mockResolvedValueOnce({ ok: false, error: "no focus" });
+    it("skips PTY write when readSelection rejects", async () => {
+      readSelection.mockRejectedValueOnce(
+        Object.assign(new Error("no focus"), { name: "AppError", code: "UNSUPPORTED" })
+      );
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(writeToPty).not.toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe("installLinuxPrimarySelectionListeners", () => {
     it("skips PTY write when the terminal was disposed during the async read", async () => {
       readSelection.mockImplementationOnce(async () => {
         disposed = true;
-        return { ok: true, text: "pasted" };
+        return { text: "pasted" };
       });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
@@ -166,7 +166,7 @@ describe("installLinuxPrimarySelectionListeners", () => {
     it("skips PTY write when input becomes locked during the async read", async () => {
       readSelection.mockImplementationOnce(async () => {
         inputLocked = true;
-        return { ok: true, text: "pasted" };
+        return { text: "pasted" };
       });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
@@ -185,7 +185,7 @@ describe("installLinuxPrimarySelectionListeners", () => {
       // on hostElement guarantees we see the event before xterm stopPropagation()s.
       const child = document.createElement("div");
       hostElement.appendChild(child);
-      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      readSelection.mockResolvedValueOnce({ text: "pasted" });
       child.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(readSelection).toHaveBeenCalledTimes(1);
@@ -194,8 +194,8 @@ describe("installLinuxPrimarySelectionListeners", () => {
 
     it("handles two rapid middle-clicks without corrupting state", async () => {
       readSelection
-        .mockResolvedValueOnce({ ok: true, text: "first" })
-        .mockResolvedValueOnce({ ok: true, text: "second" });
+        .mockResolvedValueOnce({ text: "first" })
+        .mockResolvedValueOnce({ text: "second" });
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();

--- a/src/services/terminal/primarySelection.ts
+++ b/src/services/terminal/primarySelection.ts
@@ -9,8 +9,8 @@ export interface PrimarySelectionDeps {
   isInputLocked: () => boolean;
   writeToPty: (id: string, data: string) => void;
   notifyUserInput: (id: string) => void;
-  writeSelection: (text: string) => Promise<unknown>;
-  readSelection: () => Promise<{ ok: true; text: string } | { ok: false; error: string }>;
+  writeSelection: (text: string) => Promise<void>;
+  readSelection: () => Promise<{ text: string }>;
 }
 
 // Installs Linux PRIMARY selection listeners on the terminal host element:
@@ -51,16 +51,16 @@ export function installLinuxPrimarySelectionListeners(deps: PrimarySelectionDeps
     event.preventDefault();
     event.stopPropagation();
     try {
-      const result = await readSelection();
-      if (!result.ok || !result.text) return;
+      const { text } = await readSelection();
+      if (!text) return;
       if (isDisposed() || isInputLocked()) return;
       const payload = getBracketedPasteMode()
-        ? formatWithBracketedPaste(result.text)
-        : result.text.replace(/\r?\n/g, "\r");
+        ? formatWithBracketedPaste(text)
+        : text.replace(/\r?\n/g, "\r");
       writeToPty(terminalId, payload);
       notifyUserInput(terminalId);
     } catch {
-      // IPC can reject if the main process is unavailable.
+      // UNSUPPORTED on non-Linux, IPC failure during shutdown, etc.
     }
   };
 

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -4,7 +4,7 @@ export type ErrorType = "git" | "process" | "filesystem" | "network" | "config" 
 
 export type RetryAction = "terminal" | "git" | "worktree";
 
-export interface AppError {
+export interface ErrorRecord {
   id: string;
   timestamp: number;
   type: ErrorType;
@@ -28,19 +28,19 @@ export interface AppError {
 }
 
 interface ErrorStore {
-  errors: AppError[];
+  errors: ErrorRecord[];
   isPanelOpen: boolean;
   lastErrorTime: number;
 
-  addError: (error: Omit<AppError, "id" | "timestamp" | "dismissed">) => string;
+  addError: (error: Omit<ErrorRecord, "id" | "timestamp" | "dismissed">) => string;
   dismissError: (id: string) => void;
   clearAll: () => void;
   removeError: (id: string) => void;
   togglePanel: () => void;
   setPanelOpen: (open: boolean) => void;
-  getWorktreeErrors: (worktreeId: string) => AppError[];
-  getTerminalErrors: (terminalId: string) => AppError[];
-  getActiveErrors: () => AppError[];
+  getWorktreeErrors: (worktreeId: string) => ErrorRecord[];
+  getTerminalErrors: (terminalId: string) => ErrorRecord[];
+  getActiveErrors: () => ErrorRecord[];
   updateRetryProgress: (id: string, attempt: number, maxAttempts: number) => void;
   clearRetryProgress: (id: string) => void;
   reset: () => void;
@@ -82,7 +82,7 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
       return recentDuplicate.id;
     }
 
-    const newError: AppError = {
+    const newError: ErrorRecord = {
       ...error,
       id: generateErrorId(),
       timestamp: now,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ export { useLogsStore, filterLogs, collapseConsecutiveDuplicates } from "./logsS
 export type { DisplayEntry } from "./logsStore";
 
 export { useErrorStore } from "./errorStore";
-export type { AppError, ErrorType, RetryAction } from "./errorStore";
+export type { ErrorRecord, ErrorType, RetryAction } from "./errorStore";
 
 export { useEventStore } from "./eventStore";
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -531,10 +531,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     try {
       const result = await projectClient.close(projectId, options);
 
-      if (!result.success) {
-        throw new Error(result.error || "Failed to close project");
-      }
-
       const action = options?.killTerminals ? "killed" : "backgrounded";
       logDebug("[ProjectStore] Closed project", { action, projectId });
 
@@ -560,10 +556,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
 
     try {
       const result = await projectClient.close(projectId, { killTerminals: true });
-
-      if (!result.success) {
-        throw new Error(result.error || "Failed to close project");
-      }
 
       logDebug("[ProjectStore] Closed active project, transitioning to no-project state", {
         projectId,

--- a/src/utils/clientAppError.ts
+++ b/src/utils/clientAppError.ts
@@ -1,0 +1,39 @@
+import type { AppErrorCode } from "../../shared/types/appError";
+
+/**
+ * Renderer-side mirror of the main-process `AppError`. Reconstructed by the
+ * preload's `_unwrappingInvoke` when an IPC handler throws an `AppError`, so
+ * callers can do `if (isClientAppError(e) && e.code === "BINARY_FILE")` to
+ * pattern-match on the discriminated `code` instead of substring-matching
+ * `e.message`.
+ *
+ * `instanceof ClientAppError` is unreliable across the contextBridge realm
+ * boundary — use the `isClientAppError` guard, which duck-types on
+ * `e.name === "AppError" && typeof e.code === "string"`.
+ */
+export class ClientAppError extends Error {
+  readonly code: AppErrorCode;
+  readonly userMessage?: string;
+
+  constructor(code: AppErrorCode, message: string, userMessage?: string) {
+    super(message);
+    this.name = "AppError";
+    this.code = code;
+    this.userMessage = userMessage;
+    Object.setPrototypeOf(this, ClientAppError.prototype);
+  }
+}
+
+/**
+ * Realm-safe guard. Returns `true` for any Error whose `name === "AppError"`
+ * and which carries a string `code`, regardless of which realm constructed it.
+ */
+export function isClientAppError(
+  e: unknown
+): e is Error & { code: AppErrorCode; userMessage?: string } {
+  return (
+    e instanceof Error &&
+    e.name === "AppError" &&
+    typeof (e as { code?: unknown }).code === "string"
+  );
+}


### PR DESCRIPTION
## Summary

- Introduces `AppError` in `electron/utils/errorTypes.ts` with a discriminated `code` enum (`INVALID_PATH`, `BINARY_FILE`, `FILE_TOO_LARGE`, `RATE_LIMITED`, `VALIDATION`, `PERMISSION`, `INTERNAL`, etc.) alongside a renderer-side `ClientAppError` in `src/utils/clientAppError.ts` that the IPC unwrapper reconstructs so callers can pattern-match on `e.code`.
- Migrates 11 IPC handlers off the ad-hoc `{ ok: false }` / `{ success: false }` shapes, rewriting them to throw `AppError` and updating `~50 renderer and test files` from `if (!result.ok)` checks to `try/catch` on `ClientAppError`.
- Settings-import handlers (`appTheme.ts`, `terminalConfig.ts`, `keybinding.ts`) are intentionally left on their existing discriminated-union shapes since they carry multi-message validation payloads that don't map cleanly to a single error code.

Resolves #6024

## Changes

- `shared/types/appError.ts` -- `AppErrorCode` enum and `AppError` shape
- `electron/utils/errorTypes.ts` -- `AppError` class implementation
- `shared/utils/ipcErrorSerialization.ts` -- ensures `code` survives the envelope strip in packaged builds
- `electron/ipc/utils.ts` -- `checkRateLimit` and the spawn queue full path now throw `AppError({ code: "RATE_LIMITED" })` instead of bare `Error`
- `electron/ipc/handlers/` -- clipboard, commands, files, git-write, logs, projectCrud, terminal/artifacts, terminal/io, webview all migrated
- `electron/preload.cts` -- `ClientAppError` reconstruction wired into the invoke wrapper
- `src/utils/clientAppError.ts` -- renderer-side typed error class
- All renderer components and hooks updated to catch `ClientAppError` by code rather than checking result shapes
- Post-review fixes: readFile TOCTOU error path now handled correctly; rate-limit miscast in push corrected

## Testing

14,293 tests pass. `npm run check` passes (typecheck + lint + format). Production build passes.