### PR TITLE
fix(settings): replace native color panel with inline picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "better-sqlite3": "^12.8.0",
         "copytree": "^0.14.2",
         "js-yaml": "^4.1.1",
-        "node-pty": "1.2.0-beta.12"
+        "node-pty": "1.2.0-beta.12",
+        "react-colorful": "^5.6.1"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -15742,6 +15743,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-diff-view": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "better-sqlite3": "^12.8.0",
     "copytree": "^0.14.2",
     "js-yaml": "^4.1.1",
-    "node-pty": "1.2.0-beta.12"
+    "node-pty": "1.2.0-beta.12",
+    "react-colorful": "^5.6.1"
   },
   "optionalDependencies": {
     "ffmpeg-static": "^5.2.0"

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Check, X } from "lucide-react";
+import { HexColorInput, HexColorPicker } from "react-colorful";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
 /**
- * Preset color picker — replaces the hidden native `<input type="color">` that
- * opened macOS NSColorPanel (a heavyweight floating window that obscured the
- * settings panel and offered no "reset" affordance).
+ * Preset color picker — inline HSV picker with a curated palette.
  *
- * Shows a 2×5 grid of curated dark-mode swatches, a "Clear" (inherit from
- * agent) option, and a "Custom…" escape hatch that invokes the native picker
- * only when the user explicitly wants a non-palette color.
+ * Earlier revisions opened macOS NSColorPanel via a hidden `<input type="color">`,
+ * but Radix's DismissableLayer fires focus/pointer events when the OS-level panel
+ * steals focus, dismissing the popover before the user could pick a color (#6118).
+ * Keeping all interaction inside the renderer avoids that race entirely.
  *
  * Palette borrowed from popular dark-themed tools (Linear, Raycast, GitHub
  * labels) — tuned for sufficient contrast on the dark Daintree background.
@@ -28,6 +28,16 @@ const PALETTE = [
   "#7c8fa8", // blue-gray
   "#abb2bf", // light gray
 ] as const;
+
+const FALLBACK_COLOR = "#e06c75";
+
+const isValidHex = (value: string): value is `#${string}` => /^#[0-9a-f]{6}$/i.test(value);
+
+const resolveInitialDraft = (color: string | undefined, agentColor: string): string => {
+  if (color && isValidHex(color)) return color;
+  if (isValidHex(agentColor)) return agentColor;
+  return FALLBACK_COLOR;
+};
 
 export interface PresetColorPickerProps {
   /** Current color (hex) or undefined to inherit from the agent's default. */
@@ -47,46 +57,31 @@ export function PresetColorPicker({
   ariaLabel = "Pick preset color",
 }: PresetColorPickerProps) {
   const [open, setOpen] = useState(false);
-  const nativeInputRef = useRef<HTMLInputElement>(null);
-  // True while the native `<input type="color">` has opened NSColorPanel and the
-  // renderer has lost focus. Used to suppress Radix's focus-outside dismissal so
-  // the hidden input stays mounted for the duration of the OS picker session.
-  const customColorOpenRef = useRef(false);
-
-  useEffect(() => {
-    const clearGuard = () => {
-      customColorOpenRef.current = false;
-    };
-    window.addEventListener("focus", clearGuard);
-    return () => window.removeEventListener("focus", clearGuard);
-  }, []);
+  const [draftColor, setDraftColor] = useState<string>(() =>
+    resolveInitialDraft(color, agentColor)
+  );
 
   const effectiveColor = color ?? agentColor;
 
-  const isValidHex = (value: string): value is `#${string}` => /^#[0-9a-f]{6}$/i.test(value);
+  const handleOpenChange = (next: boolean) => {
+    if (next) setDraftColor(resolveInitialDraft(color, agentColor));
+    setOpen(next);
+  };
 
-  const pickerValue =
-    color && isValidHex(color) ? color : isValidHex(agentColor) ? agentColor : "#e06c75";
+  const handleDone = () => {
+    if (isValidHex(draftColor)) {
+      onChange(draftColor);
+      setOpen(false);
+    }
+  };
 
-  const handleSelect = (next: string | undefined) => {
-    onChange(next);
+  const handleClear = () => {
+    onChange(undefined);
     setOpen(false);
   };
 
-  const handleCustomClick = () => {
-    if (!nativeInputRef.current) return;
-    customColorOpenRef.current = true;
-    nativeInputRef.current.click();
-  };
-
   return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        if (!next) customColorOpenRef.current = false;
-        setOpen(next);
-      }}
-    >
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -104,21 +99,18 @@ export function PresetColorPicker({
       <PopoverContent
         align="start"
         sideOffset={6}
-        className="w-auto p-2 space-y-2"
+        className="w-56 p-3 space-y-3"
         data-testid="preset-color-picker-popover"
-        onFocusOutside={(e) => {
-          // NSColorPanel opens an OS-level window that steals renderer focus
-          // without firing a pointerdown. Suppress Radix's focus-outside close
-          // only while the guard is set AND the document has actually lost focus.
-          // The hasFocus check is a self-recovery: if the guard is stuck true
-          // (e.g., the OS picker never opened), normal in-window dismissals
-          // still work because they fire with document.hasFocus() === true.
-          if (customColorOpenRef.current && !document.hasFocus()) e.preventDefault();
-        }}
       >
+        <HexColorPicker
+          color={draftColor}
+          onChange={setDraftColor}
+          className="!w-full"
+          data-testid="preset-color-hex-picker"
+        />
         <div className="grid grid-cols-5 gap-1">
           {PALETTE.map((c) => {
-            const isSelected = color?.toLowerCase() === c.toLowerCase();
+            const isSelected = draftColor.toLowerCase() === c.toLowerCase();
             return (
               <button
                 key={c}
@@ -130,7 +122,7 @@ export function PresetColorPicker({
                 style={{ backgroundColor: c }}
                 aria-label={`Color ${c}`}
                 aria-pressed={isSelected}
-                onClick={() => handleSelect(c)}
+                onClick={() => setDraftColor(c)}
                 data-testid={`preset-color-swatch-${c.replace("#", "")}`}
               >
                 {isSelected && (
@@ -144,11 +136,20 @@ export function PresetColorPicker({
             );
           })}
         </div>
-        <div className="flex items-center justify-between gap-2 pt-1 border-t border-daintree-border/50">
+        <div className="flex items-center gap-2 pt-1 border-t border-daintree-border/50">
+          <HexColorInput
+            color={draftColor}
+            onChange={setDraftColor}
+            prefixed
+            className="w-20 rounded border border-daintree-border/60 bg-daintree-bg px-1.5 py-0.5 text-[11px] font-mono uppercase text-daintree-text focus:outline-none focus:border-daintree-accent"
+            aria-label="Hex color"
+            data-testid="preset-color-hex-input"
+          />
+          <div className="flex-1" />
           <button
             type="button"
             className="flex items-center gap-1 text-[11px] text-daintree-text/60 hover:text-daintree-text transition-colors"
-            onClick={() => handleSelect(undefined)}
+            onClick={handleClear}
             data-testid="preset-color-clear"
           >
             <X size={11} />
@@ -156,24 +157,13 @@ export function PresetColorPicker({
           </button>
           <button
             type="button"
-            className="text-[11px] text-daintree-accent hover:text-daintree-accent/80 transition-colors"
-            onClick={handleCustomClick}
-            data-testid="preset-color-custom"
+            className="text-[11px] font-medium text-daintree-accent hover:text-daintree-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={handleDone}
+            disabled={!isValidHex(draftColor)}
+            data-testid="preset-color-done"
           >
-            Custom…
+            Done
           </button>
-          <input
-            ref={nativeInputRef}
-            type="color"
-            className="sr-only"
-            value={pickerValue}
-            onChange={(e) => {
-              customColorOpenRef.current = false;
-              handleSelect(e.target.value);
-            }}
-            aria-hidden="true"
-            tabIndex={-1}
-          />
         </div>
       </PopoverContent>
     </Popover>

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -31,11 +31,26 @@ const PALETTE = [
 
 const FALLBACK_COLOR = "#e06c75";
 
-const isValidHex = (value: string): value is `#${string}` => /^#[0-9a-f]{6}$/i.test(value);
+// Accept 3- or 6-digit hex. The preset sanitizer in `src/config/agents.ts`
+// stores 3-digit colors as-is, so a stored "#abc" must round-trip through the
+// picker without being treated as invalid (which would silently overwrite the
+// user's color on Done).
+const isValidHex = (value: string): value is `#${string}` =>
+  /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(value);
+
+const normalizeHex = (value: string): string => {
+  if (/^#[0-9a-f]{3}$/i.test(value)) {
+    const r = value[1];
+    const g = value[2];
+    const b = value[3];
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+  return value.toLowerCase();
+};
 
 const resolveInitialDraft = (color: string | undefined, agentColor: string): string => {
-  if (color && isValidHex(color)) return color;
-  if (isValidHex(agentColor)) return agentColor;
+  if (color && isValidHex(color)) return normalizeHex(color);
+  if (isValidHex(agentColor)) return normalizeHex(agentColor);
   return FALLBACK_COLOR;
 };
 
@@ -69,10 +84,9 @@ export function PresetColorPicker({
   };
 
   const handleDone = () => {
-    if (isValidHex(draftColor)) {
-      onChange(draftColor);
-      setOpen(false);
-    }
+    if (!isValidHex(draftColor)) return;
+    onChange(normalizeHex(draftColor));
+    setOpen(false);
   };
 
   const handleClear = () => {

--- a/src/components/Settings/__tests__/PresetColorPicker.test.tsx
+++ b/src/components/Settings/__tests__/PresetColorPicker.test.tsx
@@ -10,6 +10,10 @@ vi.mock("lucide-react", () => ({
 
 // Stub react-colorful: render simple controlled stand-ins so tests can drive
 // onChange directly without relying on pointer-event simulation in jsdom.
+// Note: the real HexColorInput only fires onChange for valid 3- or 6-char hex.
+// This mock is permissive (passes any string through) — the malformed-hex test
+// below exploits that to verify the Done-button guard, but in production the
+// guard defends against round-tripping legacy 3-digit data, not typed garbage.
 vi.mock("react-colorful", () => ({
   HexColorPicker: ({
     color,
@@ -47,18 +51,23 @@ vi.mock("react-colorful", () => ({
   ),
 }));
 
-// Capture onOpenChange so dismissal-without-Done can be simulated as a "cancel".
+// Capture onOpenChange (to simulate dismissal-without-Done as a "cancel") and
+// the latest `open` prop (to verify Done/Clear close the popover).
 let capturedOnOpenChange: ((next: boolean) => void) | undefined;
+let capturedOpen: boolean | undefined;
 
 vi.mock("@/components/ui/popover", () => ({
   Popover: ({
     children,
+    open,
     onOpenChange,
   }: {
     children: React.ReactNode;
+    open?: boolean;
     onOpenChange?: (next: boolean) => void;
   }) => {
     capturedOnOpenChange = onOpenChange;
+    capturedOpen = open;
     return <>{children}</>;
   },
   PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -71,6 +80,7 @@ describe("PresetColorPicker", () => {
   beforeEach(() => {
     onChange = vi.fn<(color: string | undefined) => void>();
     capturedOnOpenChange = undefined;
+    capturedOpen = undefined;
   });
 
   it("trigger swatch reflects the current color", () => {
@@ -158,6 +168,29 @@ describe("PresetColorPicker", () => {
     );
     const swatch = getByTestId("preset-color-swatch-e06c75");
     expect(swatch.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("clicking Done closes the popover", () => {
+    const { getByTestId, rerender } = render(
+      <PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888888" />
+    );
+    act(() => {
+      capturedOnOpenChange!(true);
+    });
+    rerender(<PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888888" />);
+    expect(capturedOpen).toBe(true);
+    fireEvent.click(getByTestId("preset-color-done"));
+    rerender(<PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888888" />);
+    expect(capturedOpen).toBe(false);
+    expect(onChange).toHaveBeenCalledWith("#ff0000");
+  });
+
+  it("3-digit hex prop is normalized to 6-digit on commit", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color="#abc" onChange={onChange} agentColor="#888888" />
+    );
+    fireEvent.click(getByTestId("preset-color-done"));
+    expect(onChange).toHaveBeenCalledWith("#aabbcc");
   });
 
   it("re-opening the popover resets the draft to the committed color", () => {

--- a/src/components/Settings/__tests__/PresetColorPicker.test.tsx
+++ b/src/components/Settings/__tests__/PresetColorPicker.test.tsx
@@ -8,26 +8,61 @@ vi.mock("lucide-react", () => ({
   X: () => <span data-testid="x-icon" />,
 }));
 
-// Captures the onFocusOutside callback passed to PopoverContent so tests can
-// invoke it directly (matches the dockPopoverGuard test pattern — assert on
-// preventDefault rather than relying on jsdom to wire up Radix dismissal).
-let capturedOnFocusOutside: ((e: { preventDefault: () => void }) => void) | undefined;
+// Stub react-colorful: render simple controlled stand-ins so tests can drive
+// onChange directly without relying on pointer-event simulation in jsdom.
+vi.mock("react-colorful", () => ({
+  HexColorPicker: ({
+    color,
+    onChange,
+    ...rest
+  }: {
+    color: string;
+    onChange: (next: string) => void;
+    [key: string]: unknown;
+  }) => (
+    <div
+      {...rest}
+      data-color={color}
+      data-testid="hex-color-picker"
+      onClick={() => onChange("#aabbcc")}
+    />
+  ),
+  HexColorInput: ({
+    color,
+    onChange,
+    prefixed,
+    ...rest
+  }: {
+    color: string;
+    onChange: (next: string) => void;
+    prefixed?: boolean;
+    [key: string]: unknown;
+  }) => (
+    <input
+      {...rest}
+      data-prefixed={prefixed ? "true" : "false"}
+      value={color}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
 
-// Radix Popover renders conditionally via portal — mock to render all children
-// inline so we can assert on the palette grid without real portal plumbing.
+// Capture onOpenChange so dismissal-without-Done can be simulated as a "cancel".
+let capturedOnOpenChange: ((next: boolean) => void) | undefined;
+
 vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  PopoverContent: ({
+  Popover: ({
     children,
-    onFocusOutside,
+    onOpenChange,
   }: {
     children: React.ReactNode;
-    onFocusOutside?: (e: { preventDefault: () => void }) => void;
+    onOpenChange?: (next: boolean) => void;
   }) => {
-    capturedOnFocusOutside = onFocusOutside;
+    capturedOnOpenChange = onOpenChange;
     return <>{children}</>;
   },
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 describe("PresetColorPicker", () => {
@@ -35,7 +70,7 @@ describe("PresetColorPicker", () => {
 
   beforeEach(() => {
     onChange = vi.fn<(color: string | undefined) => void>();
-    capturedOnFocusOutside = undefined;
+    capturedOnOpenChange = undefined;
   });
 
   it("trigger swatch reflects the current color", () => {
@@ -54,105 +89,93 @@ describe("PresetColorPicker", () => {
     expect(trigger.querySelector("span")?.getAttribute("style")).toContain("rgb(0, 0, 255)");
   });
 
-  it("clicking a palette swatch invokes onChange with that hex", () => {
+  it("clicking a palette swatch updates draft only — does not call onChange", () => {
     const { container } = render(
-      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888888" />
     );
-    // Find the first palette swatch button by data-testid prefix.
     const swatch = container.querySelector(
       '[data-testid^="preset-color-swatch-"]'
     ) as HTMLButtonElement;
     expect(swatch).toBeTruthy();
     fireEvent.click(swatch);
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const arg = onChange.mock.calls[0]![0];
-    expect(arg).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("clicking Clear invokes onChange with undefined (inherit)", () => {
+  it("clicking Done commits the draft color via onChange", () => {
     const { getByTestId } = render(
-      <PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888" />
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888888" />
+    );
+    fireEvent.click(getByTestId("preset-color-swatch-98c379"));
+    fireEvent.click(getByTestId("preset-color-done"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("#98c379");
+  });
+
+  it("HexColorPicker drag updates draft and Done commits the new color", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888888" />
+    );
+    fireEvent.click(getByTestId("hex-color-picker")); // mock fires onChange("#aabbcc")
+    fireEvent.click(getByTestId("preset-color-done"));
+    expect(onChange).toHaveBeenCalledWith("#aabbcc");
+  });
+
+  it("clicking Clear invokes onChange with undefined", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888888" />
     );
     fireEvent.click(getByTestId("preset-color-clear"));
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it("Custom… button programmatically opens the native color input", () => {
+  it("dismissing the popover without Done does not call onChange", () => {
     const { getByTestId } = render(
-      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888888" />
     );
-    // Spy on the hidden input's click handler — confirm the click propagates.
-    const customBtn = getByTestId("preset-color-custom") as HTMLButtonElement;
-    const nativeInput = customBtn.parentElement?.querySelector(
-      'input[type="color"]'
-    ) as HTMLInputElement;
-    expect(nativeInput).toBeTruthy();
-    const clickSpy = vi.spyOn(nativeInput, "click");
-    fireEvent.click(customBtn);
-    expect(clickSpy).toHaveBeenCalled();
+    fireEvent.click(getByTestId("preset-color-swatch-e06c75"));
+    expect(capturedOnOpenChange).toBeDefined();
+    act(() => {
+      capturedOnOpenChange!(false);
+    });
+    expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("selected palette swatch is marked aria-pressed", () => {
+  it("Done is disabled and a no-op when the draft hex is malformed", () => {
     const { getByTestId } = render(
-      <PresetColorPicker color="#e06c75" onChange={onChange} agentColor="#888" />
+      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888888" />
+    );
+    const hexInput = getByTestId("preset-color-hex-input") as HTMLInputElement;
+    fireEvent.change(hexInput, { target: { value: "#zzz" } });
+    const done = getByTestId("preset-color-done") as HTMLButtonElement;
+    expect(done.disabled).toBe(true);
+    fireEvent.click(done);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("selected palette swatch is marked aria-pressed for the draft color", () => {
+    const { getByTestId } = render(
+      <PresetColorPicker color="#e06c75" onChange={onChange} agentColor="#888888" />
     );
     const swatch = getByTestId("preset-color-swatch-e06c75");
     expect(swatch.getAttribute("aria-pressed")).toBe("true");
   });
 
-  it("Custom… suppresses focus-outside dismissal while the native picker is open", () => {
-    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(false);
-    try {
-      const { getByTestId } = render(
-        <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
-      );
-      fireEvent.click(getByTestId("preset-color-custom"));
-      expect(capturedOnFocusOutside).toBeDefined();
-      const preventDefault = vi.fn();
-      capturedOnFocusOutside!({ preventDefault });
-      expect(preventDefault).toHaveBeenCalledTimes(1);
-    } finally {
-      hasFocusSpy.mockRestore();
-    }
-  });
-
-  it("focus-outside dismissal is allowed when document still has focus (stuck-guard recovery)", () => {
-    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
-    try {
-      const { getByTestId } = render(
-        <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
-      );
-      fireEvent.click(getByTestId("preset-color-custom"));
-      const preventDefault = vi.fn();
-      capturedOnFocusOutside!({ preventDefault });
-      expect(preventDefault).not.toHaveBeenCalled();
-    } finally {
-      hasFocusSpy.mockRestore();
-    }
-  });
-
-  it("focus-outside dismissal is allowed again after a color is picked", () => {
-    const { getByTestId, container } = render(
-      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
-    );
-    fireEvent.click(getByTestId("preset-color-custom"));
-    const nativeInput = container.querySelector('input[type="color"]') as HTMLInputElement;
-    fireEvent.change(nativeInput, { target: { value: "#123456" } });
-    const preventDefault = vi.fn();
-    capturedOnFocusOutside!({ preventDefault });
-    expect(preventDefault).not.toHaveBeenCalled();
-  });
-
-  it("focus-outside dismissal is allowed again after window regains focus (cancel path)", () => {
+  it("re-opening the popover resets the draft to the committed color", () => {
     const { getByTestId } = render(
-      <PresetColorPicker color={undefined} onChange={onChange} agentColor="#888" />
+      <PresetColorPicker color="#ff0000" onChange={onChange} agentColor="#888888" />
     );
-    fireEvent.click(getByTestId("preset-color-custom"));
+    // Drag to a new draft color, then dismiss without committing.
+    fireEvent.click(getByTestId("hex-color-picker"));
     act(() => {
-      window.dispatchEvent(new FocusEvent("focus"));
+      capturedOnOpenChange!(false);
     });
-    const preventDefault = vi.fn();
-    capturedOnFocusOutside!({ preventDefault });
-    expect(preventDefault).not.toHaveBeenCalled();
+    // Re-open: draft should snap back to the prop color (#ff0000), not the
+    // dragged value. Verified via the hex input since the picker stub doesn't
+    // expose its color reactively.
+    act(() => {
+      capturedOnOpenChange!(true);
+    });
+    const hexInput = getByTestId("preset-color-hex-input") as HTMLInputElement;
+    expect(hexInput.value).toBe("#ff0000");
   });
 });

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -116,7 +116,7 @@ const DURABLE_ALLOWLIST = new Set([
   // Setup wizard step indicators, accent icon, telemetry toggle (one-time setup flow)
   "src/components/Setup/AgentSetupWizard.tsx",
 
-  // PresetColorPicker color swatch text accent (interactive state on color picker)
+  // PresetColorPicker Done CTA (primary commit action) + focus-visible ring
   "src/components/Settings/PresetColorPicker.tsx",
 ]);
 


### PR DESCRIPTION
## Summary

- The preset color picker in agent settings was dismissing on the first click. The native NSColorPanel is a separate OS window, and Radix's DismissableLayer treated the resulting focus shift as an outside click, closing the popover immediately.
- Replaced the hidden `<input type=color>` + "Custom..." button approach with an inline `react-colorful` HexColorPicker. No separate OS window means no focus race, no DismissableLayer conflict.
- Added a draft state so swatch and picker interactions update a local draft only. "Done" commits the value, "Clear" emits `undefined`, and dismissing the popover cancels without side effects.

Resolves #6118

## Changes

- `PresetColorPicker.tsx` rewritten around `HexColorPicker` + `HexColorInput` from `react-colorful`
- Removed `customColorOpenRef`, `nativeInputRef`, and the `window.focus` listener that were working around the OS-level race
- `isValidHex` now accepts 3-digit hex (`#abc`) in addition to 6-digit. The preset sanitizer at `src/config/agents.ts:164` stores both forms, so rejecting 3-digit was silently dropping values on commit
- `normalizeHex` added to expand `#abc` to `#aabbcc` on commit
- Tests rewritten to drive the draft/commit model; `react-colorful` and Popover mocked for unit test isolation
- `react-colorful ^5.6.1` added as a dependency

## Testing

- Vitest: 69/69 passing
- Typecheck, lint, format, and build all pass
- Manual: opened preset color picker, clicked swatches and dragged the picker without the popover dismissing, confirmed Done commits and Escape cancels