### PR TITLE
fix(agent-button): make chevron dropdown a pure preset configurer

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -266,7 +266,7 @@ export function AgentButton({
       : needsSetup
         ? `${config.name} needs setup. Click to configure.`
         : `${config.name} CLI not found. Click to install.`;
-  const chevronTooltip = `Choose ${config.name} preset`;
+  const chevronTooltip = `Set ${config.name} preset`;
 
   const ariaLabel = isLoading
     ? `Checking ${config.name} availability`
@@ -485,17 +485,12 @@ export function AgentButton({
                   value=""
                   onSelect={() => {
                     persistWorktreePick(undefined);
-                    void actionService.dispatch(
-                      "agent.launch",
-                      { agentId: type, presetId: null },
-                      { source: "user" }
-                    );
                   }}
                 >
                   <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
                     <config.icon brandColor={getBrandColorHex(type)} />
                   </span>
-                  Default
+                  Agent default
                 </DropdownMenuRadioItem>
                 {ccrPresetGroup.length > 0 && (
                   <>
@@ -507,11 +502,6 @@ export function AgentButton({
                         value={preset.id}
                         onSelect={() => {
                           persistWorktreePick(preset.id);
-                          void actionService.dispatch(
-                            "agent.launch",
-                            { agentId: type, presetId: preset.id },
-                            { source: "user" }
-                          );
                         }}
                       >
                         <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
@@ -534,11 +524,6 @@ export function AgentButton({
                         value={preset.id}
                         onSelect={() => {
                           persistWorktreePick(preset.id);
-                          void actionService.dispatch(
-                            "agent.launch",
-                            { agentId: type, presetId: preset.id },
-                            { source: "user" }
-                          );
                         }}
                       >
                         <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
@@ -559,11 +544,6 @@ export function AgentButton({
                         value={preset.id}
                         onSelect={() => {
                           persistWorktreePick(preset.id);
-                          void actionService.dispatch(
-                            "agent.launch",
-                            { agentId: type, presetId: preset.id },
-                            { source: "user" }
-                          );
                         }}
                       >
                         <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
@@ -635,7 +615,7 @@ export function AgentButton({
                     );
                   }}
                 >
-                  Default
+                  Agent default
                 </ContextMenuRadioItem>
                 {presets.map((preset) => (
                   <ContextMenuRadioItem

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -573,6 +573,25 @@ describe("AgentButton preset UX", () => {
       expect(updateWorktreePresetMock).not.toHaveBeenCalled();
       expect(dispatchMock).not.toHaveBeenCalled();
     });
+
+    it("dropdown CCR preset selection persists without launching (separate code path)", () => {
+      // The chevron renders CCR, project-shared, and custom presets in three
+      // independent onSelect closures. Cover the CCR path explicitly so a
+      // regression that reintroduces launch in only one group is caught.
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "ccr-sonnet", name: "CCR: Sonnet 4.5" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("preset-item") as HTMLElement[];
+      const ccrItem = items.find((el) => el.textContent?.includes("Sonnet 4.5"))!;
+      fireEvent.click(ccrItem);
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", "ccr-sonnet");
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("tooltip surfaces active preset", () => {
@@ -719,6 +738,31 @@ describe("AgentButton preset UX", () => {
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",
         { agentId: "claude", presetId: "user-blue" },
+        { source: "context-menu" }
+      );
+    });
+
+    it("context-menu Agent default clears the override and still launches with null preset", () => {
+      // The context-menu sub is intentionally a launcher (unlike the chevron).
+      // Verify the Agent default row mirrors that contract: clear the
+      // worktree-scoped override AND dispatch a null-preset launch.
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: { worktreePresets: { "wt-A": "user-blue" } },
+      });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("context-radio-item") as HTMLElement[];
+      const defaultItem = items.find((el) => el.textContent?.includes("Agent default"))!;
+      fireEvent.click(defaultItem);
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: null },
         { source: "context-menu" }
       );
     });

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -513,7 +513,7 @@ describe("AgentButton preset UX", () => {
       expect(container.textContent).toContain("Start Claude · Global");
     });
 
-    it("dropdown preset selection persists the pick to the worktree slot before dispatch", () => {
+    it("dropdown preset selection persists the pick without launching the agent", () => {
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({ claude: {} });
       mockMergedPresetsFn = () => [
@@ -524,23 +524,17 @@ describe("AgentButton preset UX", () => {
       const { getAllByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      // Dropdown items: 0 = Default, 1 = Alpha, 2 = Beta (first occurrence only
-      // — presets list is unsorted in tests so take items in render order).
       const items = getAllByTestId("preset-item") as HTMLElement[];
-      // Pick the preset that is not "Default". Items include one "Default"
-      // menu entry plus one per preset.
       const alphaItem = items.find((el) => el.textContent?.includes("Alpha"))!;
       fireEvent.click(alphaItem);
 
       expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", "user-alpha");
-      expect(dispatchMock).toHaveBeenCalledWith(
-        "agent.launch",
-        { agentId: "claude", presetId: "user-alpha" },
-        { source: "user" }
-      );
+      // Chevron dropdown is a pure configurer — selecting a preset must not
+      // launch. The primary button is the only launch surface.
+      expect(dispatchMock).not.toHaveBeenCalled();
     });
 
-    it("dropdown Default clears the worktree override before dispatching null", () => {
+    it("dropdown Agent default clears the worktree override without launching", () => {
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({
         claude: { worktreePresets: { "wt-A": "user-alpha" } },
@@ -554,18 +548,14 @@ describe("AgentButton preset UX", () => {
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       const items = getAllByTestId("preset-item") as HTMLElement[];
-      const defaultItem = items.find((el) => el.textContent?.includes("Default"))!;
+      const defaultItem = items.find((el) => el.textContent?.includes("Agent default"))!;
       fireEvent.click(defaultItem);
 
       expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
-      expect(dispatchMock).toHaveBeenCalledWith(
-        "agent.launch",
-        { agentId: "claude", presetId: null },
-        { source: "user" }
-      );
+      expect(dispatchMock).not.toHaveBeenCalled();
     });
 
-    it("no-ops the worktree persist when no active worktree is set", () => {
+    it("no-ops both persist and launch when no active worktree is set", () => {
       mockActiveWorktreeId = null;
       mockSettings = settingsWith({ claude: {} });
       mockMergedPresetsFn = () => [
@@ -581,11 +571,7 @@ describe("AgentButton preset UX", () => {
       fireEvent.click(alphaItem);
 
       expect(updateWorktreePresetMock).not.toHaveBeenCalled();
-      expect(dispatchMock).toHaveBeenCalledWith(
-        "agent.launch",
-        { agentId: "claude", presetId: "user-alpha" },
-        { source: "user" }
-      );
+      expect(dispatchMock).not.toHaveBeenCalled();
     });
   });
 
@@ -654,7 +640,7 @@ describe("AgentButton preset UX", () => {
       const { getAllByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      expect(tooltipTexts(getAllByTestId)).toContain("Choose Claude preset");
+      expect(tooltipTexts(getAllByTestId)).toContain("Set Claude preset");
     });
 
     it("preserves the preset segment when the sign-in probe is unconfirmed", () => {
@@ -696,7 +682,7 @@ describe("AgentButton preset UX", () => {
       const { getByTestId } = render(
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
-      // The Default radio item is rendered with value="" so the group
+      // The Agent default radio item is rendered with value="" so the group
       // resolves to that item when nothing is saved.
       expect(getByTestId("preset-radio-group").getAttribute("data-value")).toBe("");
     });


### PR DESCRIPTION
## Summary

- The chevron dropdown on toolbar agent buttons was conflating two separate actions: persisting the worktree's saved preset and launching the agent. Clicking any preset item did both, with no way to just change the saved preset without also kicking off a run.
- The dropdown is now a pure configurer. Selecting a preset only updates the worktree's saved pick. Launching still happens through the main button half (or the context menu's "Launch with Preset" sub, which is explicitly a launcher and stays that way).
- Renamed "Default" to "Agent default" throughout the chevron group and chevron tooltip updated from "Choose preset" to "Set preset" to reinforce the configurer intent.

Resolves #6121

## Changes

- `AgentButton.tsx`: stripped `agent.launch` dispatch from all four `onSelect` closures in the chevron `DropdownMenuRadioGroup` (Agent default, CCR group, Project Shared group, Custom group)
- Tooltip copy: "Choose ${name} preset" → "Set ${name} preset"
- Label copy: "Default" → "Agent default" in chevron group and context-menu sub (context-menu sub remains a launcher)
- `AgentButton.test.tsx`: updated 3 dropdown-selection tests to assert no-launch contract; added CCR chevron regression test and context-menu Agent default regression test (37/37 passing)

## Testing

- All 37 AgentButton unit tests pass
- Typecheck, lint, and format clean
- Manually verified: selecting a preset in the chevron only persists the pick, main button still launches with the saved preset, context menu "Launch with Preset" still launches as expected