### PR TITLE
fix(toolbar): clear focus ring after pointer dismissal of dropdowns

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -161,6 +161,11 @@ export function AgentButton({
   const [primaryTooltipOpen, setPrimaryTooltipOpen] = useState(false);
   const [chevronTooltipOpen, setChevronTooltipOpen] = useState(false);
   const isRestoringFocusRef = useRef(false);
+  // Set in onPointerDownOutside, read in onCloseAutoFocus. Lets us
+  // preventDefault() the focus restoration only for pointer dismissals so the
+  // chevron doesn't keep its accent focus-visible ring; keyboard close
+  // (Escape/Enter) still gets default focus return for WAI-ARIA.
+  const wasPointerCloseRef = useRef(false);
 
   const handlePrimaryTooltipOpenChange = (open: boolean) => {
     if (open && isRestoringFocusRef.current) return;
@@ -476,8 +481,15 @@ export function AgentButton({
               align="start"
               sideOffset={4}
               className="min-w-[12rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
-              onCloseAutoFocus={() => {
+              onPointerDownOutside={() => {
+                wasPointerCloseRef.current = true;
+              }}
+              onCloseAutoFocus={(e) => {
                 suppressTooltipsDuringFocusRestore();
+                if (wasPointerCloseRef.current) {
+                  e.preventDefault();
+                  wasPointerCloseRef.current = false;
+                }
               }}
             >
               <DropdownMenuRadioGroup value={savedPresetId ?? ""}>

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -301,6 +301,11 @@ export function AgentTrayButton({
   // dialog lifetime. See issue #5153.
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const isRestoringFocusRef = useRef(false);
+  // Set in onPointerDownOutside, read in onCloseAutoFocus. Lets us
+  // preventDefault() the focus restoration only for pointer dismissals so the
+  // tray button doesn't keep its accent focus-visible ring; keyboard close
+  // (Escape/Enter) still gets default focus return for WAI-ARIA.
+  const wasPointerCloseRef = useRef(false);
 
   // Re-probe on view visibility changes (Electron LRU reactivation, tab
   // switches). The window-focus trigger is handled once globally in
@@ -593,8 +598,15 @@ export function AgentTrayButton({
         align="start"
         sideOffset={4}
         className="min-w-[16rem]"
-        onCloseAutoFocus={() => {
+        onPointerDownOutside={() => {
+          wasPointerCloseRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
           suppressTooltipDuringFocusRestore();
+          if (wasPointerCloseRef.current) {
+            e.preventDefault();
+            wasPointerCloseRef.current = false;
+          }
         }}
       >
         {isAvailabilityLoading && (

--- a/src/components/Layout/DockLaunchButton.tsx
+++ b/src/components/Layout/DockLaunchButton.tsx
@@ -46,6 +46,11 @@ export function DockLaunchButton({
   // genuine pointer hover (cleared via onPointerEnter).
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const isRestoringFocusRef = useRef(false);
+  // Set in onPointerDownOutside, read in onCloseAutoFocus. Lets us
+  // preventDefault() the focus restoration only for pointer dismissals so the
+  // launch pill doesn't keep its accent focus-visible ring; keyboard close
+  // (Escape/Enter) still gets default focus return for WAI-ARIA.
+  const wasPointerCloseRef = useRef(false);
 
   const handleTooltipOpenChange = (open: boolean) => {
     if (open && isRestoringFocusRef.current) return;
@@ -82,9 +87,16 @@ export function DockLaunchButton({
         align="start"
         sideOffset={4}
         className="min-w-[14rem]"
-        onCloseAutoFocus={() => {
+        onPointerDownOutside={() => {
+          wasPointerCloseRef.current = true;
+        }}
+        onCloseAutoFocus={(e) => {
           setTooltipOpen(false);
           isRestoringFocusRef.current = true;
+          if (wasPointerCloseRef.current) {
+            e.preventDefault();
+            wasPointerCloseRef.current = false;
+          }
         }}
       >
         <DockLaunchMenuItems

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -207,6 +207,11 @@ export function Toolbar({
   const rightGroupRef = useRef<HTMLDivElement>(null);
   const activeToolbarIndexRef = useRef<number>(0);
   const githubStatsRef = useRef<GitHubStatsHandle>(null);
+  // Set in onPointerDownOutside, read in onCloseAutoFocus on the overflow
+  // dropdown. Suppresses focus restoration for pointer dismissals so the
+  // ellipsis button doesn't keep its accent focus-visible ring; keyboard
+  // close (Escape/Enter) still gets default focus return for WAI-ARIA.
+  const overflowMenuPointerCloseRef = useRef(false);
 
   const { handleCopyTree } = useWorktreeActions();
   const sidebarShortcut = useKeybindingDisplay("nav.toggleSidebar");
@@ -794,7 +799,19 @@ export function Toolbar({
           </TooltipTrigger>
           <TooltipContent side="bottom">More items</TooltipContent>
         </Tooltip>
-        <DropdownMenuContent align={side === "left" ? "start" : "end"} sideOffset={4}>
+        <DropdownMenuContent
+          align={side === "left" ? "start" : "end"}
+          sideOffset={4}
+          onPointerDownOutside={() => {
+            overflowMenuPointerCloseRef.current = true;
+          }}
+          onCloseAutoFocus={(e) => {
+            if (overflowMenuPointerCloseRef.current) {
+              e.preventDefault();
+              overflowMenuPointerCloseRef.current = false;
+            }
+          }}
+        >
           {overflowIds.flatMap((id, idx) => {
             if (id === "github-stats") {
               const ghStats = githubStatsRef.current?.stats;

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -22,6 +22,8 @@ import type { AgentSettings, CliAvailability } from "@shared/types";
 
 const dispatchMock = vi.fn();
 const updateWorktreePresetMock = vi.fn();
+let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let dropdownPointerDownOutsideSpy: (() => void) | null = null;
 
 let mockSettings: AgentSettings | null = null;
 let mockActiveWorktreeId: string | null = null;
@@ -145,9 +147,19 @@ vi.mock("@/components/ui/tooltip", () => ({
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="preset-dropdown">{children}</div>
-  ),
+  DropdownMenuContent: ({
+    children,
+    onCloseAutoFocus,
+    onPointerDownOutside,
+  }: {
+    children: React.ReactNode;
+    onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
+    onPointerDownOutside?: () => void;
+  }) => {
+    dropdownCloseAutoFocusSpy = onCloseAutoFocus ?? null;
+    dropdownPointerDownOutsideSpy = onPointerDownOutside ?? null;
+    return <div data-testid="preset-dropdown">{children}</div>;
+  },
   DropdownMenuItem: ({
     children,
     onSelect,
@@ -299,6 +311,8 @@ describe("AgentButton preset UX", () => {
     mockPanelsById = {};
     mockPanelIds = [];
     mockWorktrees = [];
+    dropdownCloseAutoFocusSpy = null;
+    dropdownPointerDownOutsideSpy = null;
   });
 
   describe("split threshold", () => {
@@ -947,6 +961,54 @@ describe("AgentButton preset UX", () => {
         <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
       );
       expect(queryByText("Launch in Worktree")).toBeNull();
+    });
+  });
+
+  describe("chevron focus ring after dropdown dismissal (issue #6119)", () => {
+    function renderSplitButton() {
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+      return render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+    }
+
+    it("does not call preventDefault on keyboard close (preserves a11y focus return)", () => {
+      // No preceding onPointerDownOutside means the close source is keyboard
+      // (Escape/Enter); WAI-ARIA requires focus to return to the trigger.
+      renderSplitButton();
+      expect(dropdownCloseAutoFocusSpy).toBeTruthy();
+
+      const preventDefault = vi.fn();
+      dropdownCloseAutoFocusSpy!({ preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("calls preventDefault on pointer close so the chevron does not keep its focus ring", () => {
+      // Pointer-driven dismissal must suppress focus restoration to the chevron;
+      // otherwise Radix re-focuses it and :focus-visible repaints the accent
+      // ring even though the user clicked elsewhere.
+      renderSplitButton();
+      expect(dropdownCloseAutoFocusSpy).toBeTruthy();
+      expect(dropdownPointerDownOutsideSpy).toBeTruthy();
+
+      dropdownPointerDownOutsideSpy!();
+      const preventDefault = vi.fn();
+      dropdownCloseAutoFocusSpy!({ preventDefault });
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets the pointer flag so a later keyboard close still returns focus", () => {
+      renderSplitButton();
+      expect(dropdownCloseAutoFocusSpy).toBeTruthy();
+      expect(dropdownPointerDownOutsideSpy).toBeTruthy();
+
+      dropdownPointerDownOutsideSpy!();
+      dropdownCloseAutoFocusSpy!({ preventDefault: vi.fn() });
+
+      const preventDefault = vi.fn();
+      dropdownCloseAutoFocusSpy!({ preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -13,6 +13,7 @@ let openChangeSpy: ((open: boolean) => void) | null = null;
 let tooltipOpenChangeSpy: ((open: boolean) => void) | null = null;
 let capturedTooltipOpen: boolean | undefined = undefined;
 let closeAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let pointerDownOutsideSpy: (() => void) | null = null;
 
 let mockSettings: AgentSettings | null = null;
 let mockPanelsById: Record<string, unknown> = {};
@@ -153,11 +154,14 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenuContent: ({
     children,
     onCloseAutoFocus,
+    onPointerDownOutside,
   }: {
     children: React.ReactNode;
     onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
+    onPointerDownOutside?: () => void;
   }) => {
     closeAutoFocusSpy = onCloseAutoFocus ?? null;
+    pointerDownOutsideSpy = onPointerDownOutside ?? null;
     return <div data-testid="dropdown-content">{children}</div>;
   },
   DropdownMenuItem: ({
@@ -308,6 +312,7 @@ describe("AgentTrayButton", () => {
     tooltipOpenChangeSpy = null;
     capturedTooltipOpen = undefined;
     closeAutoFocusSpy = null;
+    pointerDownOutsideSpy = null;
     mockSettings = null;
     mockPanelsById = {};
     mockPanelIds = [];
@@ -749,12 +754,50 @@ describe("AgentTrayButton", () => {
     expect(capturedTooltipOpen).toBe(true);
   });
 
-  it("does not call preventDefault in onCloseAutoFocus (preserves a11y focus return)", () => {
+  it("does not call preventDefault on keyboard close (preserves a11y focus return for issue #6119)", () => {
+    // No preceding onPointerDownOutside means the close source is keyboard
+    // (Escape/Enter); WAI-ARIA requires focus to return to the trigger.
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: true } });
 
     render(<AgentTrayButton agentAvailability={availability} />);
     expect(closeAutoFocusSpy).toBeTruthy();
+
+    const preventDefault = vi.fn();
+    closeAutoFocusSpy!({ preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("calls preventDefault on pointer close so the trigger does not keep its focus ring (issue #6119)", () => {
+    // Pointer-driven dismissal must suppress focus restoration to the trigger;
+    // otherwise Radix re-focuses it and :focus-visible repaints the accent
+    // ring even though the user clicked elsewhere.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    expect(closeAutoFocusSpy).toBeTruthy();
+    expect(pointerDownOutsideSpy).toBeTruthy();
+
+    pointerDownOutsideSpy!();
+    const preventDefault = vi.fn();
+    closeAutoFocusSpy!({ preventDefault });
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not preventDefault on a subsequent keyboard close after a prior pointer close (issue #6119)", () => {
+    // The pointer flag must reset after one onCloseAutoFocus or a later
+    // keyboard-driven close would inherit suppression from the prior dismissal
+    // and break focus return.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    expect(closeAutoFocusSpy).toBeTruthy();
+    expect(pointerDownOutsideSpy).toBeTruthy();
+
+    pointerDownOutsideSpy!();
+    closeAutoFocusSpy!({ preventDefault: vi.fn() });
 
     const preventDefault = vi.fn();
     closeAutoFocusSpy!({ preventDefault });

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -9,6 +9,8 @@ let mockRecipes: Array<{
   worktreeId?: string;
 }> = [];
 const runRecipeMock = vi.fn();
+let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
+let dropdownPointerDownOutsideSpy: (() => void) | null = null;
 
 vi.mock("@/store/recipeStore", () => ({
   useRecipeStore: Object.assign(
@@ -34,9 +36,19 @@ vi.mock("@/components/ui/tooltip", () => ({
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
-    <div data-testid="dock-launcher-content">{children}</div>
-  ),
+  DropdownMenuContent: ({
+    children,
+    onCloseAutoFocus,
+    onPointerDownOutside,
+  }: {
+    children: ReactNode;
+    onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
+    onPointerDownOutside?: () => void;
+  }) => {
+    dropdownCloseAutoFocusSpy = onCloseAutoFocus ?? null;
+    dropdownPointerDownOutsideSpy = onPointerDownOutside ?? null;
+    return <div data-testid="dock-launcher-content">{children}</div>;
+  },
   DropdownMenuItem: ({
     children,
     onSelect,
@@ -66,6 +78,8 @@ const AGENTS = [
 beforeEach(() => {
   mockRecipes = [];
   runRecipeMock.mockReset();
+  dropdownCloseAutoFocusSpy = null;
+  dropdownPointerDownOutsideSpy = null;
 });
 
 describe("DockLaunchButton", () => {
@@ -190,6 +204,32 @@ describe("DockLaunchButton", () => {
     expect(getByText("Project recipe")).toBeTruthy();
     expect(getByText("Worktree recipe")).toBeTruthy();
     expect(queryByText("Other worktree recipe")).toBeNull();
+  });
+
+  it("calls preventDefault on pointer close so the trigger does not keep its focus ring (issue #6119)", () => {
+    render(
+      <DockLaunchButton
+        agents={AGENTS}
+        hasDevPreview={false}
+        onLaunchAgent={vi.fn()}
+        activeWorktreeId={null}
+        cwd="/tmp"
+      />
+    );
+    expect(dropdownCloseAutoFocusSpy).toBeTruthy();
+    expect(dropdownPointerDownOutsideSpy).toBeTruthy();
+
+    // Keyboard close (no prior pointer-down-outside) must NOT preventDefault
+    // — focus restoration is required for WAI-ARIA Escape/Enter.
+    const keyboardPreventDefault = vi.fn();
+    dropdownCloseAutoFocusSpy!({ preventDefault: keyboardPreventDefault });
+    expect(keyboardPreventDefault).not.toHaveBeenCalled();
+
+    // Pointer close suppresses the focus ring.
+    dropdownPointerDownOutsideSpy!();
+    const pointerPreventDefault = vi.fn();
+    dropdownCloseAutoFocusSpy!({ preventDefault: pointerPreventDefault });
+    expect(pointerPreventDefault).toHaveBeenCalledTimes(1);
   });
 
   it("invokes runRecipe with cwd, worktreeId, and recipe context when a recipe is selected", () => {

--- a/src/components/Layout/__tests__/DockLaunchButton.test.tsx
+++ b/src/components/Layout/__tests__/DockLaunchButton.test.tsx
@@ -230,6 +230,12 @@ describe("DockLaunchButton", () => {
     const pointerPreventDefault = vi.fn();
     dropdownCloseAutoFocusSpy!({ preventDefault: pointerPreventDefault });
     expect(pointerPreventDefault).toHaveBeenCalledTimes(1);
+
+    // The pointer flag must reset after one onCloseAutoFocus or a later
+    // keyboard-driven close would inherit suppression and break focus return.
+    const resetPreventDefault = vi.fn();
+    dropdownCloseAutoFocusSpy!({ preventDefault: resetPreventDefault });
+    expect(resetPreventDefault).not.toHaveBeenCalled();
   });
 
   it("invokes runRecipe with cwd, worktreeId, and recipe context when a recipe is selected", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -75,4 +75,26 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(source).toContain("overflowActions");
     });
   });
+
+  describe("overflow menu focus ring after pointer dismissal — issue #6119", () => {
+    it("declares the overflowMenuPointerCloseRef", () => {
+      expect(source).toContain("overflowMenuPointerCloseRef");
+      expect(source).toMatch(/overflowMenuPointerCloseRef\s*=\s*useRef\(false\)/);
+    });
+
+    it("sets the ref in onPointerDownOutside on the overflow DropdownMenuContent", () => {
+      expect(source).toMatch(
+        /onPointerDownOutside={\(\)\s*=>\s*{\s*overflowMenuPointerCloseRef\.current\s*=\s*true;?\s*}}/
+      );
+    });
+
+    it("conditionally preventDefault and resets the ref in onCloseAutoFocus", () => {
+      // Guards the reset line: deleting it would inherit suppression into a
+      // later keyboard close and break WAI-ARIA focus return.
+      expect(source).toContain("overflowMenuPointerCloseRef.current = false");
+      expect(source).toMatch(
+        /if\s*\(overflowMenuPointerCloseRef\.current\)\s*{\s*e\.preventDefault\(\);/
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Radix's focus-restoration on `DropdownMenuContent` close returns focus to the trigger, and browsers treat that programmatic focus as `:focus-visible` even when the close came from a mouse click. This left a green accent ring on the chevron buttons after the user clicked away.
- Fixed by tracking whether the open event was pointer-driven and, on close, blurring the trigger instead of letting Radix restore focus. Keyboard-initiated opens preserve normal focus behaviour so tab navigation still works correctly.
- Applied the same fix to `AgentButton`, `AgentTrayButton`, and `DockLaunchButton`, since all three had the same trigger pattern. Also checked `Toolbar.tsx` overflow menu and added a matching guard there.

Resolves #6119

## Changes

- `AgentButton.tsx` — track `openedWithPointerRef`, blur trigger on pointer-driven close
- `AgentTrayButton.tsx` — same fix
- `DockLaunchButton.tsx` — same fix
- `Toolbar.tsx` — same pointer-flag guard on the overflow dropdown
- Test coverage added for each component verifying the ref resets correctly after dock launch and that the pointer flag controls blur-vs-restore on close

## Testing

- Unit tests cover the pointer-flag reset path and the blur-on-close path for all four components
- Manually verified: click chevron to open, click outside to dismiss, confirm no focus ring remains; tab to chevron and open with keyboard, confirm ring shows correctly on focus