### PR TITLE
fix(worktree): hover-gate cleanup button on merged rows, drop purple idle color

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -108,9 +108,9 @@ const IssueBadge = memo(function IssueBadge({
     (open: boolean) => {
       setIsOpen(open);
       if (open) {
-        fetchTooltip();
+        void fetchTooltip();
       } else {
-        reset();
+        void reset();
       }
     },
     [fetchTooltip, reset]
@@ -214,9 +214,9 @@ const PRBadge = memo(function PRBadge({
     (open: boolean) => {
       setIsOpen(open);
       if (open) {
-        fetchTooltip();
+        void fetchTooltip();
       } else {
-        reset();
+        void reset();
       }
     },
     [fetchTooltip, reset]

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -635,26 +635,6 @@ export function WorktreeHeader({
           </Tooltip>
         )}
 
-        {onCleanupWorktree && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onCleanupWorktree();
-                }}
-                className="sidebar-action-button p-1.5 text-github-merged hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent shrink-0"
-                aria-label="Delete worktree"
-                data-testid="worktree-cleanup-button"
-              >
-                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="top">Delete worktree</TooltipContent>
-          </Tooltip>
-        )}
-
         <div
           data-testid="worktree-actions-wrapper"
           className={cn(
@@ -666,6 +646,25 @@ export function WorktreeHeader({
                 : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:opacity-100 group-focus-within/card:pointer-events-auto"
           )}
         >
+          {onCleanupWorktree && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onCleanupWorktree();
+                  }}
+                  className="sidebar-action-button p-1.5 text-status-error/70 hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  aria-label="Delete worktree"
+                  data-testid="worktree-cleanup-button"
+                >
+                  <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top">Delete worktree</TooltipContent>
+            </Tooltip>
+          )}
           {canCollapse && (
             <button
               onClick={onToggleCollapse}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -852,6 +852,31 @@ describe("WorktreeHeader cleanup button", () => {
     expect(wrapper.contains(button)).toBe(true);
   });
 
+  it("shows the cleanup button on active cards", () => {
+    renderHeader({ onCleanupWorktree: vi.fn(), isActive: true, isCollapsed: false });
+    const wrapper = screen.getByTestId("worktree-actions-wrapper");
+    expect(wrapper.className).toContain("opacity-100");
+    expect(wrapper.className).not.toContain("opacity-0");
+  });
+
+  it("shows the cleanup button on collapsed cards", () => {
+    renderHeader({ onCleanupWorktree: vi.fn(), isActive: false, isCollapsed: true });
+    const wrapper = screen.getByTestId("worktree-actions-wrapper");
+    expect(wrapper.className).toContain("opacity-100");
+    expect(wrapper.className).not.toContain("opacity-0");
+  });
+
+  it("renders the cleanup button as the first action in the wrapper", () => {
+    renderHeader({
+      onCleanupWorktree: vi.fn(),
+      canCollapse: true,
+      onToggleCollapse: noop,
+    });
+    const wrapper = screen.getByTestId("worktree-actions-wrapper");
+    const cleanupButton = screen.getByTestId("worktree-cleanup-button");
+    expect(wrapper.firstElementChild).toBe(cleanupButton);
+  });
+
   it("uses muted destructive coloring at idle and full red on hover", () => {
     renderHeader({ onCleanupWorktree: vi.fn() });
     const button = screen.getByTestId("worktree-cleanup-button");

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -832,23 +832,32 @@ describe("WorktreeHeader cleanup button", () => {
     expect(screen.queryByTestId("worktree-cleanup-button")).toBeNull();
   });
 
-  it("places the cleanup button outside the hover-gated actions wrapper", () => {
+  it("places the cleanup button inside the hover-gated actions wrapper", () => {
     renderHeader({ onCleanupWorktree: vi.fn() });
     const button = screen.getByTestId("worktree-cleanup-button");
     const wrapper = screen.getByTestId("worktree-actions-wrapper");
-    expect(wrapper.contains(button)).toBe(false);
+    expect(wrapper.contains(button)).toBe(true);
   });
 
-  it("keeps the cleanup button visible on inactive, non-collapsed cards", () => {
+  it("hides the cleanup button alongside other actions on inactive, non-collapsed cards", () => {
     renderHeader({ onCleanupWorktree: vi.fn(), isActive: false, isCollapsed: false });
     const button = screen.getByTestId("worktree-cleanup-button");
     const wrapper = screen.getByTestId("worktree-actions-wrapper");
-    // The hover-gated wrapper should be hidden when inactive…
+    // The hover-gated wrapper hides on inactive cards and reveals on group hover/focus.
     expect(wrapper.className).toContain("opacity-0");
     expect(wrapper.className).toContain("pointer-events-none");
-    // …but the cleanup button is a sibling and must not inherit those classes.
-    expect(button.className).not.toContain("opacity-0");
-    expect(button.className).not.toContain("pointer-events-none");
+    expect(wrapper.className).toContain("group-hover/card:opacity-100");
+    expect(wrapper.className).toContain("group-focus-within/card:opacity-100");
+    // The cleanup button inherits visibility through the wrapper, not its own classes.
+    expect(wrapper.contains(button)).toBe(true);
+  });
+
+  it("uses muted destructive coloring at idle and full red on hover", () => {
+    renderHeader({ onCleanupWorktree: vi.fn() });
+    const button = screen.getByTestId("worktree-cleanup-button");
+    expect(button.className).toContain("text-status-error/70");
+    expect(button.className).toContain("hover:text-status-error");
+    expect(button.className).not.toContain("text-github-merged");
   });
 
   it("calls onCleanupWorktree and stops propagation when clicked", () => {


### PR DESCRIPTION
## Summary

- The trash/cleanup button on merged worktree rows was always visible, while every other action in the row (collapse chevron, more-actions menu) only appears on hover. Moved it inside the `worktree-actions-wrapper` as the first child so it follows the same reveal pattern.
- Dropped the `text-github-merged` idle color. The row is already badged as merged — the trash icon doesn't need to repeat that signal. It now uses `text-status-error/70` at rest and `text-status-error` on hover, which reads clearly as a destructive action.
- Removed the redundant `shrink-0` class that was left over from when the button sat outside the flex wrapper.

Resolves #6127

## Changes

- `WorktreeHeader.tsx` — moved cleanup button inside `worktree-actions-wrapper`, recolored it, dropped `shrink-0`
- `WorktreeHeader.test.tsx` — updated two existing tests to reflect the new DOM order, added three new tests covering hover reveal behavior, active/collapsed worktree reveal, and first-child ordering within the actions wrapper

## Testing

Existing tests updated and passing. New tests cover: cleanup button hidden until row hover, button visible when worktree is active (actions always shown), button visible when worktree is active+collapsed (reveal still works), and cleanup button is first child inside the actions wrapper.