### PR TITLE
feat(agents): generalize registry schema and split per-agent files

### DIFF
--- a/electron/services/AgentUpdateHandler.ts
+++ b/electron/services/AgentUpdateHandler.ts
@@ -118,24 +118,21 @@ export class AgentUpdateHandler {
       return null;
     }
 
+    const updates = config.update as Record<string, string | undefined>;
+
     if (method) {
-      if (method === "npm") return config.update.npm ?? null;
-      if (method === "brew") return config.update.brew ?? null;
-      if (config.update.other && config.update.other[method]) return config.update.other[method];
-      return null;
+      return updates[method] ?? null;
     }
 
-    if (config.update.npm) {
-      return config.update.npm;
+    if (updates.npm) {
+      return updates.npm;
     }
-    if (config.update.brew) {
-      return config.update.brew;
+    if (updates.brew) {
+      return updates.brew;
     }
-    if (config.update.other) {
-      const otherMethods = Object.values(config.update.other);
-      if (otherMethods.length > 0) {
-        return otherMethods[0];
-      }
+    for (const [key, value] of Object.entries(updates)) {
+      if (key === "npm" || key === "brew") continue;
+      if (typeof value === "string" && value) return value;
     }
 
     return null;
@@ -147,14 +144,10 @@ export class AgentUpdateHandler {
       return [];
     }
 
+    const updates = config.update as Record<string, string | undefined>;
     const methods = new Set<string>();
-    if (config.update.npm) methods.add("npm");
-    if (config.update.brew) methods.add("brew");
-    if (config.update.other) {
-      for (const method of Object.keys(config.update.other)) {
-        if (method === "npm" || method === "brew") continue;
-        methods.add(method);
-      }
+    for (const [key, value] of Object.entries(updates)) {
+      if (typeof value === "string" && value) methods.add(key);
     }
     return [...methods];
   }

--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -271,8 +271,10 @@ export class AgentVersionService {
       } finally {
         clearTimeout(timeoutId);
       }
-    } catch (error: any) {
-      throw new Error(`Failed to fetch PyPI version: ${error.message}`);
+    } catch (error) {
+      throw new Error(`Failed to fetch PyPI version: ${this.toErrorString(error)}`, {
+        cause: error,
+      });
     }
   }
 

--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -234,7 +234,46 @@ export class AgentVersionService {
       return this.getLatestNpmVersion(config.version.npmPackage);
     }
 
+    if (config.version.pypiPackage) {
+      return this.getLatestPypiVersion(config.version.pypiPackage);
+    }
+
     return null;
+  }
+
+  private async getLatestPypiVersion(packageName: string): Promise<string | null> {
+    try {
+      const url = `https://pypi.org/pypi/${packageName}/json`;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.TIMEOUT_MS);
+
+      try {
+        const response = await fetch(url, {
+          signal: controller.signal,
+          headers: {
+            Accept: "application/json",
+            "User-Agent": "Daintree-Electron",
+          },
+        });
+
+        if (response.status === 404) {
+          throw new Error(`PyPI package not found: ${packageName}`);
+        }
+
+        if (!response.ok) {
+          throw new Error(`PyPI returned ${response.status}`);
+        }
+
+        const data = (await response.json()) as { info?: { version?: string } };
+        const version = data.info?.version;
+        if (typeof version !== "string" || !version) return null;
+        return this.parseVersion(version);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+    } catch (error: any) {
+      throw new Error(`Failed to fetch PyPI version: ${error.message}`);
+    }
   }
 
   private async getLatestNpmVersion(packageName: string): Promise<string | null> {

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -450,9 +450,7 @@ export class CliAvailabilityService {
     // through its primary install path first.
     const pypiPackage = config.packages?.pypi;
     if (pypiPackage) {
-      const pypiProbe = await this.probeNativePaths(
-        synthesisePypiProbePaths(command, pypiPackage)
-      );
+      const pypiProbe = await this.probeNativePaths(synthesisePypiProbePaths(command, pypiPackage));
       if (pypiProbe.status !== "missing") {
         return pypiProbe;
       }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -73,7 +73,9 @@ function synthesisePypiProbePaths(command: string, pypiPackage: string): string[
       `%USERPROFILE%\\.local\\bin\\${command}.exe`,
       // uv tool venv layout (Roaming AppData, since uv >= 0.4)
       `%APPDATA%\\uv\\tools\\${pypiPackage}\\Scripts\\${command}.exe`,
-      // pipx default on Windows (≥ 1.4)
+      // pipx ≥ 1.4 default on Windows: PIPX_HOME = %USERPROFILE%\.local\pipx
+      `%USERPROFILE%\\.local\\pipx\\venvs\\${pypiPackage}\\Scripts\\${command}.exe`,
+      // pipx legacy default on Windows (older releases)
       `%LOCALAPPDATA%\\pipx\\pipx\\venvs\\${pypiPackage}\\Scripts\\${command}.exe`,
     ];
   }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -57,6 +57,39 @@ interface AgentCheckOutcome {
 const SECURITY_ERROR_CODES = new Set(["EACCES", "EPERM"]);
 
 /**
+ * Synthesise probe paths for PyPI-distributed agents. Modern Python tool
+ * installs land in well-known per-user locations: uv tool, pipx (current
+ * and legacy layouts), and pip --user-shared `~/.local/bin`. We probe
+ * those before falling back to the npm-global / WSL probes so a uv-installed
+ * agent on a host without the tool dir on PATH still resolves.
+ *
+ * Returns paths in priority order. Tilde and `%VAR%` expansion is handled
+ * downstream by `expandPath()`.
+ */
+function synthesisePypiProbePaths(command: string, pypiPackage: string): string[] {
+  if (process.platform === "win32") {
+    return [
+      // uv tool publishes a launcher to `%USERPROFILE%\.local\bin\<cmd>.exe`
+      `%USERPROFILE%\\.local\\bin\\${command}.exe`,
+      // uv tool venv layout (Roaming AppData, since uv >= 0.4)
+      `%APPDATA%\\uv\\tools\\${pypiPackage}\\Scripts\\${command}.exe`,
+      // pipx default on Windows (≥ 1.4)
+      `%LOCALAPPDATA%\\pipx\\pipx\\venvs\\${pypiPackage}\\Scripts\\${command}.exe`,
+    ];
+  }
+  return [
+    // uv tool symlink + pip --user shared bin (also covers pipx ≥ 1.4 default)
+    `~/.local/bin/${command}`,
+    // uv tool venv bin
+    `~/.local/share/uv/tools/${pypiPackage}/bin/${command}`,
+    // pipx venv bin (modern path)
+    `~/.local/share/pipx/venvs/${pypiPackage}/bin/${command}`,
+    // pipx legacy path (kept for users on older pipx releases)
+    `~/.local/pipx/venvs/${pypiPackage}/bin/${command}`,
+  ];
+}
+
+/**
  * Collapse PATH-resolved binary candidates that live in the same install
  * directory. `where.exe` returns both `claude.cmd` and `claude.exe` for a
  * single npm-global install — counting them as two installations would
@@ -407,7 +440,24 @@ export class CliAvailabilityService {
       }
     }
 
-    if (config.npmGlobalPackage) {
+    // Synthesise PyPI install paths (uv tool / pipx / pip --user) from
+    // `packages.pypi`. Only fires when no `nativePaths` hit landed; agent
+    // authors can still pin exact paths via `nativePaths` when the synthesised
+    // set is wrong for their distribution. Runs before the npm-global probe
+    // so a Python-distributed agent that also has an npm wrapper is detected
+    // through its primary install path first.
+    const pypiPackage = config.packages?.pypi;
+    if (pypiPackage) {
+      const pypiProbe = await this.probeNativePaths(
+        synthesisePypiProbePaths(command, pypiPackage)
+      );
+      if (pypiProbe.status !== "missing") {
+        return pypiProbe;
+      }
+    }
+
+    const npmPackage = config.packages?.npm ?? config.npmGlobalPackage;
+    if (npmPackage) {
       const npmProbe = await this.probeNpmGlobal(command);
       if (npmProbe.status !== "missing") {
         return npmProbe;

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -29,13 +29,20 @@ function packageTail(pkg: string | undefined): string | undefined {
   return tail && tail.length > 0 ? tail : undefined;
 }
 
+/** Reads `packages.npm` first; falls back to deprecated top-level `npmGlobalPackage`. */
+function effectiveNpmPackage(config: { packages?: { npm?: string }; npmGlobalPackage?: string }):
+  | string
+  | undefined {
+  return config.packages?.npm ?? config.npmGlobalPackage;
+}
+
 const AGENT_CLI_NAMES: Record<string, BuiltInAgentId> = Object.fromEntries(
   Object.entries(AGENT_REGISTRY).flatMap(([id, config]) => {
     const entries: [string, BuiltInAgentId][] = [[config.command, id as BuiltInAgentId]];
     if (config.command !== id) {
       entries.push([id, id as BuiltInAgentId]);
     }
-    const tail = packageTail(config.npmGlobalPackage);
+    const tail = packageTail(effectiveNpmPackage(config));
     if (tail && tail !== config.command && tail !== id) {
       entries.push([tail, id as BuiltInAgentId]);
     }
@@ -51,7 +58,7 @@ const PROCESS_ICON_MAP: Record<string, string> = {
       if (config.command !== id) {
         entries.push([config.command, config.iconId]);
       }
-      const tail = packageTail(config.npmGlobalPackage);
+      const tail = packageTail(effectiveNpmPackage(config));
       if (tail && tail !== config.command && tail !== id) {
         entries.push([tail, config.iconId]);
       }

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -30,9 +30,10 @@ function packageTail(pkg: string | undefined): string | undefined {
 }
 
 /** Reads `packages.npm` first; falls back to deprecated top-level `npmGlobalPackage`. */
-function effectiveNpmPackage(config: { packages?: { npm?: string }; npmGlobalPackage?: string }):
-  | string
-  | undefined {
+function effectiveNpmPackage(config: {
+  packages?: { npm?: string };
+  npmGlobalPackage?: string;
+}): string | undefined {
   return config.packages?.npm ?? config.npmGlobalPackage;
 }
 

--- a/electron/services/__tests__/AgentUpdateHandler.test.ts
+++ b/electron/services/__tests__/AgentUpdateHandler.test.ts
@@ -48,10 +48,7 @@ describe("AgentUpdateHandler", () => {
         update: {
           npm: "npm install -g test-agent@latest",
           brew: "brew upgrade test-agent",
-          other: {
-            script: "./scripts/update-test-agent.sh",
-            npm: "./scripts/custom-npm-update.sh",
-          },
+          script: "./scripts/update-test-agent.sh",
         },
       },
     });

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -6,6 +6,17 @@ const registryMock = vi.hoisted(() => ({
   getEffectiveAgentConfig: vi.fn(),
 }));
 
+// Hoisted execFile mock — vi.spyOn can't redefine ESM-namespace exports of
+// `child_process`, so we substitute the whole module at hoist time. Tests
+// that need a custom impl mutate `execFileMock` via mockImplementationOnce.
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  execFile: execFileMock,
+}));
+
 vi.mock("../../../shared/config/agentRegistry.js", () => registryMock);
 
 import { AgentVersionService } from "../AgentVersionService.js";
@@ -16,7 +27,7 @@ describe("AgentVersionService resilience", () => {
     vi.clearAllMocks();
   });
 
-  function createService(checkAvailabilityImpl: () => Promise<Record<string, boolean>>) {
+  function createService(checkAvailabilityImpl: () => Promise<Record<string, unknown>>) {
     const cliAvailabilityService = {
       checkAvailability: vi.fn(checkAvailabilityImpl),
     } as unknown as CliAvailabilityService;
@@ -108,9 +119,8 @@ describe("AgentVersionService resilience", () => {
     // execFile is used for the installed-version probe; default to a synthetic
     // success so getInstalledVersion returns a parseable value and the
     // assertion focuses on the latest-version branch.
-    function mockExecFileVersion(): ReturnType<typeof vi.spyOn> {
-      const cp = require("child_process") as { execFile: typeof import("child_process").execFile };
-      return vi.spyOn(cp, "execFile").mockImplementation(((
+    function setExecFileSuccess(): void {
+      execFileMock.mockImplementation(((
         _cmd: string,
         _args: readonly string[],
         _opts: unknown,
@@ -119,6 +129,10 @@ describe("AgentVersionService resilience", () => {
         cb(null, "1.0.0\n", "");
       }) as never);
     }
+
+    beforeEach(() => {
+      execFileMock.mockReset();
+    });
 
     it("fetches the latest version from pypi.org/pypi/<pkg>/json", async () => {
       (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
@@ -134,7 +148,7 @@ describe("AgentVersionService resilience", () => {
         json: async () => ({ info: { version: "1.2.3" } }),
         headers: new Headers(),
       } as Response);
-      const execSpy = mockExecFileVersion();
+      setExecFileSuccess();
 
       const { service } = createService(async () => ({ "py-agent": "ready" }));
       const result = await service.getVersion("py-agent" as AgentId);
@@ -147,7 +161,6 @@ describe("AgentVersionService resilience", () => {
         })
       );
       fetchSpy.mockRestore();
-      execSpy.mockRestore();
     });
 
     it("returns null without erroring when PyPI returns 200 with missing version", async () => {
@@ -164,7 +177,7 @@ describe("AgentVersionService resilience", () => {
         json: async () => ({ info: {} }),
         headers: new Headers(),
       } as Response);
-      const execSpy = mockExecFileVersion();
+      setExecFileSuccess();
 
       const { service } = createService(async () => ({ "py-agent": "ready" }));
       const result = await service.getVersion("py-agent" as AgentId);
@@ -172,7 +185,6 @@ describe("AgentVersionService resilience", () => {
       expect(result.latestVersion).toBeNull();
       expect(result.error).toBeUndefined();
       fetchSpy.mockRestore();
-      execSpy.mockRestore();
     });
 
     it("surfaces an error when PyPI returns 404", async () => {
@@ -189,7 +201,7 @@ describe("AgentVersionService resilience", () => {
         json: async () => ({}),
         headers: new Headers(),
       } as Response);
-      const execSpy = mockExecFileVersion();
+      setExecFileSuccess();
 
       const { service } = createService(async () => ({ "py-agent": "ready" }));
       const result = await service.getVersion("py-agent" as AgentId);
@@ -197,7 +209,6 @@ describe("AgentVersionService resilience", () => {
       expect(result.latestVersion).toBeNull();
       expect(result.error ?? "").toMatch(/PyPI/);
       fetchSpy.mockRestore();
-      execSpy.mockRestore();
     });
   });
 });

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -150,6 +150,31 @@ describe("AgentVersionService resilience", () => {
       execSpy.mockRestore();
     });
 
+    it("returns null without erroring when PyPI returns 200 with missing version", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "py-agent",
+        name: "Py Agent",
+        command: "py-agent",
+        version: { args: ["--version"], pypiPackage: "py-agent-pkg" },
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ info: {} }),
+        headers: new Headers(),
+      } as Response);
+      const execSpy = mockExecFileVersion();
+
+      const { service } = createService(async () => ({ "py-agent": "ready" }));
+      const result = await service.getVersion("py-agent" as AgentId);
+
+      expect(result.latestVersion).toBeNull();
+      expect(result.error).toBeUndefined();
+      fetchSpy.mockRestore();
+      execSpy.mockRestore();
+    });
+
     it("surfaces an error when PyPI returns 404", async () => {
       (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
         id: "py-agent",

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -103,4 +103,76 @@ describe("AgentVersionService resilience", () => {
       })
     );
   });
+
+  describe("PyPI version feed", () => {
+    // execFile is used for the installed-version probe; default to a synthetic
+    // success so getInstalledVersion returns a parseable value and the
+    // assertion focuses on the latest-version branch.
+    function mockExecFileVersion(): ReturnType<typeof vi.spyOn> {
+      const cp = require("child_process") as { execFile: typeof import("child_process").execFile };
+      return vi.spyOn(cp, "execFile").mockImplementation(((
+        _cmd: string,
+        _args: readonly string[],
+        _opts: unknown,
+        cb: (err: unknown, stdout: string, stderr: string) => void
+      ) => {
+        cb(null, "1.0.0\n", "");
+      }) as never);
+    }
+
+    it("fetches the latest version from pypi.org/pypi/<pkg>/json", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "py-agent",
+        name: "Py Agent",
+        command: "py-agent",
+        version: { args: ["--version"], pypiPackage: "py-agent-pkg" },
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ info: { version: "1.2.3" } }),
+        headers: new Headers(),
+      } as Response);
+      const execSpy = mockExecFileVersion();
+
+      const { service } = createService(async () => ({ "py-agent": "ready" }));
+      const result = await service.getVersion("py-agent" as AgentId);
+
+      expect(result.latestVersion).toBe("1.2.3");
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://pypi.org/pypi/py-agent-pkg/json",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "User-Agent": "Daintree-Electron" }),
+        })
+      );
+      fetchSpy.mockRestore();
+      execSpy.mockRestore();
+    });
+
+    it("surfaces an error when PyPI returns 404", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "py-agent",
+        name: "Py Agent",
+        command: "py-agent",
+        version: { args: ["--version"], pypiPackage: "missing-pkg" },
+      });
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+        headers: new Headers(),
+      } as Response);
+      const execSpy = mockExecFileVersion();
+
+      const { service } = createService(async () => ({ "py-agent": "ready" }));
+      const result = await service.getVersion("py-agent" as AgentId);
+
+      expect(result.latestVersion).toBeNull();
+      expect(result.error ?? "").toMatch(/PyPI/);
+      fetchSpy.mockRestore();
+      execSpy.mockRestore();
+    });
+  });
 });

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -1489,6 +1489,29 @@ describe("CliAvailabilityService", () => {
       expect(service.getDetails()!["py-test"]?.resolvedPath).toBe(pipxBin);
     });
 
+    it("surfaces 'blocked' when a PyPI path exists but execution is denied (EACCES)", async () => {
+      await setupPypiAgent();
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+
+      const uvSymlink = join(homedir(), ".local/bin/py-test");
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === uvSymlink) {
+          throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["py-test"]).toBe("blocked");
+      expect(service.getDetails()!["py-test"]?.via).toBe("native");
+      expect(service.getDetails()!["py-test"]?.resolvedPath).toBe(uvSymlink);
+    });
+
     it("returns missing when no PyPI install path resolves", async () => {
       await setupPypiAgent();
       mockedExecFileSync.mockImplementation(() => {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -1353,6 +1353,173 @@ describe("CliAvailabilityService", () => {
     });
   });
 
+  describe("packages.npm alias (replaces deprecated npmGlobalPackage)", () => {
+    afterEach(async () => {
+      const { setUserRegistry } = await import("../../../shared/config/agentRegistry.js");
+      setUserRegistry({});
+    });
+
+    it("activates the npm-global probe via packages.npm when npmGlobalPackage is unset", async () => {
+      const { setUserRegistry } = await import("../../../shared/config/agentRegistry.js");
+      setUserRegistry({
+        "npm-pkg-test": {
+          id: "npm-pkg-test",
+          name: "Npm Pkg Test",
+          command: "npm-pkg-test",
+          color: "#abcdef",
+          iconId: "npm-pkg-test",
+          supportsContextInjection: false,
+          packages: { npm: "@scope/npm-pkg-test" },
+        },
+      });
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      mockedExecFile.mockImplementation(((...args: unknown[]) => {
+        const file = args[0] as string;
+        const callback = args.find(
+          (a): a is (err: unknown, stdout?: string) => void => typeof a === "function"
+        );
+        if (file === "npm") {
+          queueMicrotask(() => callback?.(null, "/Users/test/.npm-global\n"));
+        } else {
+          const err = Object.assign(new Error("not found"), { code: "ENOENT" });
+          queueMicrotask(() => callback?.(err));
+        }
+        return {} as never;
+      }) as never);
+
+      const shim = join("/Users/test/.npm-global", "bin", "npm-pkg-test");
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === shim) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["npm-pkg-test"]).toBe("ready");
+      expect(service.getDetails()!["npm-pkg-test"]?.via).toBe("npm-global");
+    });
+  });
+
+  describe("PyPI probe synthesis (packages.pypi)", () => {
+    // Stand-up a user-defined agent with `packages.pypi`. CliAvailabilityService
+    // walks the effective registry, so userRegistry entries get the same probe
+    // pipeline as built-ins.
+    const setupPypiAgent = async () => {
+      const { setUserRegistry } = await import("../../../shared/config/agentRegistry.js");
+      setUserRegistry({
+        "py-test": {
+          id: "py-test",
+          name: "Py Test",
+          command: "py-test",
+          color: "#abcdef",
+          iconId: "py-test",
+          supportsContextInjection: false,
+          packages: { pypi: "py-test-pkg" },
+        },
+      });
+    };
+
+    afterEach(async () => {
+      const { setUserRegistry } = await import("../../../shared/config/agentRegistry.js");
+      setUserRegistry({});
+    });
+
+    it("detects a PyPI-distributed agent via uv tool symlink at ~/.local/bin/<cmd>", async () => {
+      await setupPypiAgent();
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+
+      const uvSymlink = join(homedir(), ".local/bin/py-test");
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === uvSymlink) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["py-test"]).toBe("ready");
+      expect(service.getDetails()!["py-test"]?.resolvedPath).toBe(uvSymlink);
+      expect(service.getDetails()!["py-test"]?.via).toBe("native");
+    });
+
+    it("falls through to ~/.local/share/uv/tools/<pkg>/bin/<cmd> when ~/.local/bin misses", async () => {
+      await setupPypiAgent();
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+
+      const uvVenvBin = join(homedir(), ".local/share/uv/tools/py-test-pkg/bin/py-test");
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === uvVenvBin) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["py-test"]).toBe("ready");
+      expect(service.getDetails()!["py-test"]?.resolvedPath).toBe(uvVenvBin);
+    });
+
+    it("detects pipx-installed agent at ~/.local/share/pipx/venvs/<pkg>/bin/<cmd>", async () => {
+      await setupPypiAgent();
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+
+      const pipxBin = join(homedir(), ".local/share/pipx/venvs/py-test-pkg/bin/py-test");
+      mockedAccess.mockImplementation(async (p) => {
+        if (String(p) === pipxBin) return;
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["py-test"]).toBe("ready");
+      expect(service.getDetails()!["py-test"]?.resolvedPath).toBe(pipxBin);
+    });
+
+    it("returns missing when no PyPI install path resolves", async () => {
+      await setupPypiAgent();
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+
+      const result = await service.checkAvailability();
+      expect(result["py-test"]).toBe("missing");
+    });
+
+    it("does not synthesise PyPI paths when packages.pypi is unset", async () => {
+      // Built-in claude has no `packages.pypi`; verify our probe pipeline
+      // never dispatches PyPI-shaped fs.access calls for it.
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      mockedExecFileSync.mockImplementation(() => {
+        throw Object.assign(new Error("not found"), { code: "ENOENT" });
+      });
+      mockedAccess.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+      await service.checkAvailability();
+
+      const probedPaths = mockedAccess.mock.calls.map((c) => String(c[0]));
+      // None of the built-ins use uv/pipx layouts; this guards against
+      // accidental probing when an agent has `npmGlobalPackage` only.
+      expect(probedPaths.some((p) => p.includes(".local/share/uv/tools"))).toBe(false);
+      expect(probedPaths.some((p) => p.includes(".local/share/pipx/venvs"))).toBe(false);
+    });
+  });
+
   describe("WSL fallback probe (Windows)", () => {
     const originalPlatform = process.platform;
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1046,8 +1046,7 @@ export class TerminalProcess {
     // capture loop for non-`session-id` agents — directory-scoped sessions
     // (Kiro) don't emit IDs and the ghost regex would either time out or
     // false-positive on unrelated output.
-    const pattern =
-      resume.kind === "session-id" ? new RegExp(resume.sessionIdPattern) : null;
+    const pattern = resume.kind === "session-id" ? new RegExp(resume.sessionIdPattern) : null;
 
     let shutdownBuffer = "";
     let resolved = false;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1027,13 +1027,27 @@ export class TerminalProcess {
 
     const liveAgentId = getLiveAgentId(terminal);
     const agentConfig = liveAgentId ? getEffectiveAgentConfig(liveAgentId) : undefined;
+    const resume = agentConfig?.resume;
 
-    if (!agentConfig?.shutdown) {
+    // Nothing to send — agent has no resume config or the config supplies
+    // neither a quit command nor a key sequence we can emit on shutdown.
+    if (!resume) {
+      return null;
+    }
+    const quitCommand = resume.quitCommand;
+    const shutdownKeySequence = resume.shutdownKeySequence;
+    if (!quitCommand && !shutdownKeySequence) {
       return null;
     }
 
-    const { quitCommand, sessionIdPattern } = agentConfig.shutdown;
-    const pattern = new RegExp(sessionIdPattern);
+    // Only `session-id` triggers the post-quit pattern-match capture loop —
+    // other kinds (rolling-history, named-target, project-scoped) just send
+    // the quit signal and resolve null. Lesson from #4781: never run the
+    // capture loop for non-`session-id` agents — directory-scoped sessions
+    // (Kiro) don't emit IDs and the ghost regex would either time out or
+    // false-positive on unrelated output.
+    const pattern =
+      resume.kind === "session-id" ? new RegExp(resume.sessionIdPattern) : null;
 
     let shutdownBuffer = "";
     let resolved = false;
@@ -1056,6 +1070,7 @@ export class TerminalProcess {
 
       const origOnData = terminal.ptyProcess.onData((data: string) => {
         if (resolved) return;
+        if (!pattern) return;
 
         shutdownBuffer += data;
         if (shutdownBuffer.length > GRACEFUL_SHUTDOWN_BUFFER_SIZE) {
@@ -1074,6 +1089,10 @@ export class TerminalProcess {
         origOnExit.dispose();
         origOnData.dispose();
 
+        if (!pattern) {
+          finish(null);
+          return;
+        }
         const stripped = stripAnsiCodes(shutdownBuffer);
         const match = pattern.exec(stripped);
         finish(match?.[1] ?? null);
@@ -1100,7 +1119,12 @@ export class TerminalProcess {
         if (resolved) return;
 
         try {
-          terminal.ptyProcess.write(quitCommand + "\r");
+          if (shutdownKeySequence) {
+            terminal.ptyProcess.write(shutdownKeySequence);
+          }
+          if (quitCommand) {
+            terminal.ptyProcess.write(quitCommand + "\r");
+          }
         } catch {
           origOnData.dispose();
           origOnExit.dispose();

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -245,4 +245,50 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     await expect(terminal.gracefulShutdown()).resolves.toBeNull();
     expect(handles.writeMock).not.toHaveBeenCalled();
   });
+
+  it("project-scoped (Kiro) skips the session-ID capture loop and resolves null", async () => {
+    // Lesson #4781: agents with directory-based sessions never emit session
+    // IDs. The capture regex must NOT run for `project-scoped` resume kinds
+    // — otherwise a stale match against unrelated terminal output could
+    // poison `terminal.agentSessionId` for the next launch.
+    const handles = createMockPty();
+    const opts: TerminalProcessOptions = {
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      kind: "terminal",
+      launchAgentId: "kiro",
+    };
+    const terminal = new TerminalProcess(
+      "t-kiro",
+      opts,
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+        } as never,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      defaultSpawnContext(),
+      handles.pty
+    );
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
+
+    // Emit a string that LOOKS like a Claude session-ID line — it must be
+    // ignored (Kiro doesn't have a sessionIdPattern at all in the new schema).
+    handles.emitData("claude --resume bogus-id\n");
+    handles.emitExit(0);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+    expect(terminal.getInfo().agentSessionId).toBeUndefined();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "perf:soak": "tsx scripts/perf/run.ts --mode soak",
     "perf:cold-start": "tsx scripts/perf/cold-start.ts",
     "pattern-discovery:run": "tsx scripts/pattern-discovery/runner.ts",
+    "pattern-discovery:record": "tsx scripts/pattern-discovery/runner.ts",
     "pattern-discovery:analyze": "tsx scripts/pattern-discovery/analyzer.ts",
     "pattern-discovery:update": "tsx scripts/pattern-discovery/update-registry.ts",
     "prepare": "husky"

--- a/scripts/pattern-discovery/runner.ts
+++ b/scripts/pattern-discovery/runner.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import fs from "node:fs";
-import { getAgentConfig } from "../../shared/config/agentRegistry.js";
+import { getAgentConfig, getAgentIds } from "../../shared/config/agentRegistry.js";
 import { buildPatternConfig } from "../../electron/services/pty/terminalActivityPatterns.js";
 import {
   createPatternDetector,
@@ -23,8 +23,6 @@ const DEFAULT_PROMPTS = [
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 
-const SUPPORTED_AGENTS = ["claude", "gemini", "codex", "opencode"];
-
 function parseArgs(argv: string[]): RunnerOptions {
   const args = new Map<string, string>();
   for (let i = 0; i < argv.length; i++) {
@@ -38,9 +36,10 @@ function parseArgs(argv: string[]): RunnerOptions {
     }
   }
 
+  const supportedAgents = getAgentIds();
   const agentId = args.get("agent");
-  if (!agentId || !SUPPORTED_AGENTS.includes(agentId)) {
-    throw new Error(`--agent required. Supported: ${SUPPORTED_AGENTS.join(", ")}`);
+  if (!agentId || !supportedAgents.includes(agentId)) {
+    throw new Error(`--agent required. Supported: ${supportedAgents.join(", ")}`);
   }
 
   return {
@@ -148,7 +147,7 @@ async function runSession(options: RunnerOptions): Promise<string> {
 
       if (promptIndex >= options.prompts.length && silenceMs > 5000 && bootDetected) {
         console.log("[runner] All prompts sent, sending quit command");
-        const quitCmd = agentConfig.shutdown?.quitCommand ?? "/quit";
+        const quitCmd = agentConfig.resume?.quitCommand ?? "/quit";
         ptyProcess.write(quitCmd + "\r");
         clearInterval(promptInterval);
       }

--- a/scripts/pattern-discovery/update-registry.ts
+++ b/scripts/pattern-discovery/update-registry.ts
@@ -4,7 +4,20 @@ import { readJson } from "../perf/lib/io.js";
 import { replayCorpus } from "./corpus-replay.js";
 import type { AnalyzerOutput, PatternCandidate } from "./types.js";
 
-const REGISTRY_PATH = path.resolve(import.meta.dirname, "../../shared/config/agentRegistry.ts");
+const AGENTS_DIR = path.resolve(import.meta.dirname, "../../shared/config/agents");
+
+/**
+ * Resolve the per-agent config file path. After the registry split (#6130),
+ * `@generated:` sentinels live in `shared/config/agents/<id>.ts`, not in the
+ * monolithic `agentRegistry.ts`. The id is validated to defeat path traversal
+ * — agents/<arbitrary>../foo.ts would otherwise escape the config dir.
+ */
+function getAgentConfigPath(agentId: string): string {
+  if (!/^[a-z0-9-]+$/.test(agentId)) {
+    throw new Error(`Invalid agent id: ${agentId}`);
+  }
+  return path.join(AGENTS_DIR, `${agentId}.ts`);
+}
 
 const CORPUS_DIR = path.resolve(import.meta.dirname, "corpus");
 
@@ -123,7 +136,8 @@ function main(): void {
   );
 
   const grouped = groupCandidatesByCategory(analysis.candidates);
-  let source = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  const registryPath = getAgentConfigPath(analysis.agentId);
+  let source = fs.readFileSync(registryPath, "utf-8");
   let changes = 0;
 
   for (const [field, patterns] of grouped) {
@@ -155,7 +169,7 @@ function main(): void {
   }
 
   // Validate with corpus replay BEFORE writing
-  const originalSource = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  const originalSource = fs.readFileSync(registryPath, "utf-8");
   const corpusFiles = fs.existsSync(CORPUS_DIR)
     ? fs
         .readdirSync(CORPUS_DIR)
@@ -164,7 +178,7 @@ function main(): void {
 
   if (corpusFiles.length > 0) {
     // Write temporarily to validate, restore on failure
-    fs.writeFileSync(REGISTRY_PATH, source, "utf-8");
+    fs.writeFileSync(registryPath, source, "utf-8");
     let validationFailed = false;
 
     console.log("[update-registry] Running corpus replay validation...");
@@ -182,7 +196,7 @@ function main(): void {
     }
 
     if (validationFailed) {
-      fs.writeFileSync(REGISTRY_PATH, originalSource, "utf-8");
+      fs.writeFileSync(registryPath, originalSource, "utf-8");
       console.error("[update-registry] Validation failed, registry restored to original");
       process.exitCode = 1;
       return;
@@ -190,7 +204,7 @@ function main(): void {
 
     console.log(`[update-registry] Registry updated and validated (${changes} fields)`);
   } else {
-    fs.writeFileSync(REGISTRY_PATH, source, "utf-8");
+    fs.writeFileSync(registryPath, source, "utf-8");
     console.log(`[update-registry] Registry updated (${changes} fields, no corpus for validation)`);
   }
 }

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -436,7 +436,10 @@ describe("copilot configuration", () => {
 
   it("produces --resume=id args (equals concatenation)", () => {
     const config = getAgentConfig("copilot");
-    expect(config?.resume?.args("abc-def-123")).toEqual(["--resume=abc-def-123"]);
+    expect(config?.resume?.kind).toBe("session-id");
+    if (config?.resume?.kind === "session-id") {
+      expect(config.resume.args("abc-def-123")).toEqual(["--resume=abc-def-123"]);
+    }
   });
 
   it("has npm install for all platforms including Windows", () => {
@@ -652,42 +655,71 @@ describe("blockAltScreen capabilities", () => {
 });
 
 describe("resume configuration", () => {
-  it("all built-in agents with shutdown config also have resume config", () => {
+  it("session-id agents have a quitCommand and a sessionIdPattern", () => {
     const ids = getAgentIds();
     for (const id of ids) {
-      const config = getAgentConfig(id);
-      if (config?.shutdown) {
-        expect(config.resume).toBeDefined();
-        expect(typeof config.resume?.args).toBe("function");
+      const resume = getAgentConfig(id)?.resume;
+      if (resume?.kind === "session-id") {
+        expect(typeof resume.args).toBe("function");
+        expect(resume.quitCommand).toBeTruthy();
+        expect(resume.sessionIdPattern).toBeTruthy();
       }
     }
   });
 
-  it("claude produces --resume flag args", () => {
-    const config = getAgentConfig("claude");
-    expect(config?.resume?.args("abc-123")).toEqual(["--resume", "abc-123"]);
+  it("claude is session-id and produces --resume flag args", () => {
+    const resume = getAgentConfig("claude")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.args("abc-123")).toEqual(["--resume", "abc-123"]);
+    }
   });
 
-  it("gemini produces --resume flag args", () => {
-    const config = getAgentConfig("gemini");
-    expect(config?.resume?.args("abc-123")).toEqual(["--resume", "abc-123"]);
+  it("gemini is session-id and produces --resume flag args", () => {
+    const resume = getAgentConfig("gemini")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.args("abc-123")).toEqual(["--resume", "abc-123"]);
+    }
   });
 
-  it("codex produces resume subcommand args (no leading dash)", () => {
-    const config = getAgentConfig("codex");
-    const args = config?.resume?.args("abc-123");
-    expect(args).toEqual(["resume", "abc-123"]);
-    expect(args?.[0]).not.toMatch(/^-/);
+  it("codex is session-id and produces resume subcommand args (no leading dash)", () => {
+    const resume = getAgentConfig("codex")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      const args = resume.args("abc-123");
+      expect(args).toEqual(["resume", "abc-123"]);
+      expect(args[0]).not.toMatch(/^-/);
+    }
   });
 
-  it("copilot produces --resume= flag args (equals concatenation)", () => {
-    const config = getAgentConfig("copilot");
-    expect(config?.resume?.args("abc-123")).toEqual(["--resume=abc-123"]);
+  it("copilot is session-id and produces --resume= flag args (equals concatenation)", () => {
+    const resume = getAgentConfig("copilot")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.args("abc-123")).toEqual(["--resume=abc-123"]);
+    }
   });
 
-  it("opencode produces -s flag args", () => {
-    const config = getAgentConfig("opencode");
-    expect(config?.resume?.args("ses_abc")).toEqual(["-s", "ses_abc"]);
+  it("opencode is session-id and produces -s flag args", () => {
+    const resume = getAgentConfig("opencode")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.args("ses_abc")).toEqual(["-s", "ses_abc"]);
+    }
+  });
+
+  it("kiro is project-scoped and produces --resume args without an ID", () => {
+    const resume = getAgentConfig("kiro")?.resume;
+    expect(resume?.kind).toBe("project-scoped");
+    if (resume?.kind === "project-scoped") {
+      expect(resume.args()).toEqual(["--resume"]);
+      expect(resume.quitCommand).toBe("/quit");
+    }
+  });
+
+  it("cursor has no resume config (no session resume model)", () => {
+    expect(getAgentConfig("cursor")?.resume).toBeUndefined();
   });
 });
 

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -318,9 +318,7 @@ export interface AgentConfig {
    * Recognised keys mirror {@link AgentPackages} plus shell-script flavours
    * (`curl`, `powershell`); unknown keys are surfaced verbatim by the UI.
    */
-  update?: Partial<
-    Record<keyof AgentPackages | "curl" | "powershell" | (string & {}), string>
-  >;
+  update?: Partial<Record<keyof AgentPackages | "curl" | "powershell" | (string & {}), string>>;
   /**
    * Routing configuration for intelligent agent dispatch.
    * Used by orchestrators to select the best agent for a given task.

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -179,6 +179,83 @@ export interface AgentProviderTemplate {
   inlineMode?: boolean;
 }
 
+/**
+ * Cross-package-manager install metadata for an agent. Each field names the
+ * package as known to that ecosystem; CliAvailabilityService and probe code
+ * use these to synthesize default lookup paths when `nativePaths` are not
+ * supplied. Fields are additive — none are mutually exclusive — and an agent
+ * may declare any subset relevant to how it ships.
+ */
+export interface AgentPackages {
+  /** npm package name (e.g. "@anthropic-ai/claude-code"). Probed via npm-global bin shim. */
+  npm?: string;
+  /** PyPI package name (e.g. "open-interpreter"). Drives uv/pipx path synthesis. */
+  pypi?: string;
+  /** Homebrew formula name (e.g. "opencode"). Surfaced by install/update help only today. */
+  brew?: string;
+  /** winget package id (e.g. "Anthropic.Claude"). Surfaced by install/update help only today. */
+  winget?: string;
+  /** Scoop package coordinates — bucket plus formula name. */
+  scoop?: { bucket: string; name: string };
+  /** Cargo crate name. Surfaced by install/update help only today. */
+  cargo?: string;
+  /** Go module path (e.g. "github.com/owner/repo/cmd/agent"). Surfaced by install/update help only today. */
+  go?: string;
+}
+
+/**
+ * Discriminated union describing how an agent's prior session can be resumed.
+ * The `kind` field selects the shape:
+ *
+ * - `session-id` — agent emits a session ID on quit (Claude/Gemini/Codex/etc.).
+ *   `quitCommand` is sent to the running process; `sessionIdPattern` (a regex
+ *   with one capture group) is matched against the post-quit output to harvest
+ *   the ID, which is then passed to `args(id)` on the next launch.
+ * - `rolling-history` — agent has no session model but records a chronological
+ *   history that can be resumed in order. `args()` returns the resume flags;
+ *   no ID is captured.
+ * - `named-target` — agent resumes a user-named target (e.g. a plan name).
+ *   `argsForTarget(name)` produces the launch args for the chosen target.
+ * - `project-scoped` — agent stores session state on disk keyed by project
+ *   directory. `args()` returns the resume flags; nothing is captured at
+ *   shutdown. Used by directory-aware CLIs like Kiro.
+ *
+ * `quitCommand` and `shutdownKeySequence` apply to all kinds — the PTY host
+ * sends the quit command (or the key sequence, if provided) on graceful
+ * shutdown. `sessionIdPattern` applies only to `session-id` and is the only
+ * field that triggers the PTY host's pattern-match capture loop.
+ */
+export type AgentResume =
+  | {
+      kind: "session-id";
+      /** Returns CLI args for resuming a captured session (e.g. ["--resume", id]). */
+      args: (sessionId: string) => string[];
+      /** Command sent to the running agent to trigger graceful exit (e.g. "/quit"). */
+      quitCommand: string;
+      /** Regex with a single capture group for the session ID emitted post-quit. */
+      sessionIdPattern: string;
+      /** Optional raw key sequence sent before `quitCommand` (e.g. Ctrl-C). */
+      shutdownKeySequence?: string;
+    }
+  | {
+      kind: "rolling-history";
+      args: () => string[];
+      quitCommand?: string;
+      shutdownKeySequence?: string;
+    }
+  | {
+      kind: "named-target";
+      argsForTarget: (target: string) => string[];
+      quitCommand?: string;
+      shutdownKeySequence?: string;
+    }
+  | {
+      kind: "project-scoped";
+      args: () => string[];
+      quitCommand?: string;
+      shutdownKeySequence?: string;
+    };
+
 export interface AgentConfig {
   id: string;
   name: string;
@@ -224,38 +301,31 @@ export interface AgentConfig {
     args: string[];
     /** npm package name for version lookup (e.g., "@anthropic-ai/claude-code") */
     npmPackage?: string;
+    /**
+     * PyPI package name for version lookup (e.g., "open-interpreter"). When
+     * set, AgentVersionService queries https://pypi.org/pypi/<pkg>/json after
+     * github/npm fall through.
+     */
+    pypiPackage?: string;
     /** GitHub repository for version lookup (e.g., "owner/repo") */
     githubRepo?: string;
     /** Release notes URL template (use {version} placeholder) */
     releaseNotesUrl?: string;
   };
   /**
-   * Update command configuration.
+   * Update command configuration. Each key names the install method whose
+   * upgrade command lives in the value (e.g. `npm: "npm install -g foo@latest"`).
+   * Recognised keys mirror {@link AgentPackages} plus shell-script flavours
+   * (`curl`, `powershell`); unknown keys are surfaced verbatim by the UI.
    */
-  update?: {
-    /** Update command for npm-based installs */
-    npm?: string;
-    /** Update command for Homebrew */
-    brew?: string;
-    /** Update command for other package managers or scripts */
-    other?: Record<string, string>;
-  };
+  update?: Partial<
+    Record<keyof AgentPackages | "curl" | "powershell" | (string & {}), string>
+  >;
   /**
    * Routing configuration for intelligent agent dispatch.
    * Used by orchestrators to select the best agent for a given task.
    */
   routing?: AgentRoutingConfig;
-  /**
-   * Graceful shutdown configuration for capturing session IDs.
-   * When present, the PTY host will send the quit command before killing,
-   * then scan output for the session ID pattern.
-   */
-  shutdown?: {
-    /** Command to send to trigger graceful exit (e.g., "/quit") */
-    quitCommand: string;
-    /** Regex pattern string with a capture group for the session ID */
-    sessionIdPattern: string;
-  };
   /**
    * Approximate context window size in tokens for this agent's model.
    * Used to warn when context usage is high.
@@ -268,14 +338,14 @@ export interface AgentConfig {
    */
   env?: Record<string, string>;
   /**
-   * Resume configuration for restoring a previous agent session.
-   * When present, Daintree can resume a prior session using the stored session ID
-   * instead of starting fresh.
+   * Resume + graceful-shutdown configuration. The `kind` discriminator
+   * selects how the PTY host treats this agent on quit: only `session-id`
+   * runs the post-quit pattern-match capture loop; the other kinds send
+   * `quitCommand` (or `shutdownKeySequence`) and exit without scraping IDs.
+   *
+   * See {@link AgentResume} for the full shape per variant.
    */
-  resume?: {
-    /** Returns CLI args for resuming a session (e.g. ["--resume", id] or ["resume", id]) */
-    args: (sessionId: string) => string[];
-  };
+  resume?: AgentResume;
   /**
    * Prerequisites required for this agent to function.
    * Merged with baseline prerequisites during health checks.
@@ -300,6 +370,24 @@ export interface AgentConfig {
    */
   nativePaths?: string[];
   /**
+   * Cross-package-manager install metadata. When set, the relevant
+   * `CliAvailabilityService` probes are activated automatically:
+   *  - `packages.npm` → npm-global bin-shim probe (replaces `npmGlobalPackage`).
+   *  - `packages.pypi` → uv/pipx/local-bin path synthesis on macOS/Linux and
+   *    `%USERPROFILE%`/`%APPDATA%`/`%LOCALAPPDATA%` paths on Windows.
+   *  - Other fields (`brew`/`winget`/`scoop`/`cargo`/`go`) are surfaced today
+   *    only by install-help UI; probe synthesis for those ecosystems may be
+   *    added later.
+   *
+   * Prefer `packages` over the deprecated top-level `npmGlobalPackage` when
+   * authoring new agents.
+   */
+  packages?: AgentPackages;
+  /**
+   * @deprecated Use `packages.npm` instead. Kept as a backward-compatible
+   * alias so persisted `UserAgentRegistryService` entries continue to work
+   * during the transition. Will be removed in a future release.
+   *
    * npm package name to use as a last-resort detection probe. When PATH and
    * native-path probes both miss, `CliAvailabilityService` queries
    * `npm config get prefix` and checks whether the package's installed bin
@@ -346,1102 +434,27 @@ export interface AgentConfig {
   providerTemplates?: AgentProviderTemplate[];
 }
 
+import { config as claudeConfig } from "./agents/claude.js";
+import { config as geminiConfig } from "./agents/gemini.js";
+import { config as codexConfig } from "./agents/codex.js";
+import { config as opencodeConfig } from "./agents/opencode.js";
+import { config as cursorConfig } from "./agents/cursor.js";
+import { config as kiroConfig } from "./agents/kiro.js";
+import { config as copilotConfig } from "./agents/copilot.js";
+
+// Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
+// (mirroring `src/services/actions/definitions/`). When adding a new agent,
+// create the per-agent file, import it here, add the entry below, and add
+// the ID to `BUILT_IN_AGENT_IDS` in `agentIds.ts` — the runtime check after
+// this declaration throws if any built-in is missing.
 export const AGENT_REGISTRY: Record<string, AgentConfig> = {
-  // NOTE: When adding a new agent here, also add its ID to BUILT_IN_AGENT_IDS in agentIds.ts.
-  // The _registryCheck below will produce a compile error if they get out of sync.
-  claude: {
-    id: "claude",
-    name: "Claude",
-    command: "claude",
-    // Anthropic's native installer places the symlink at ~/.local/bin/claude
-    // on macOS/Linux and a versioned binary under ~/.local/share/claude.
-    // Windows native installer places the binary under
-    // %LOCALAPPDATA%\claude-code\bin\claude.exe. Detect both so users who
-    // install via the native installer are not mis-reported as "missing"
-    // when ~/.local/bin isn't inherited by the Electron process PATH.
-    nativePaths: ["~/.local/bin/claude", "%LOCALAPPDATA%\\claude-code\\bin\\claude.exe"],
-    npmGlobalPackage: "@anthropic-ai/claude-code",
-    color: "#CC785C",
-    iconId: "claude",
-    supportsContextInjection: true,
-    shortcut: "Cmd/Ctrl+Alt+C",
-    usageUrl: "https://claude.ai/settings/usage",
-    version: {
-      args: ["--version"],
-      githubRepo: "anthropics/claude-code",
-      npmPackage: "@anthropic-ai/claude-code",
-      releaseNotesUrl: "https://github.com/anthropics/claude-code/releases/tag/v{version}",
-    },
-    update: {
-      npm: "npm install -g @anthropic-ai/claude-code@latest",
-    },
-    install: {
-      docsUrl: "https://github.com/anthropics/claude-code",
-      byOs: {
-        macos: [
-          {
-            label: "npm",
-            commands: ["npm install -g @anthropic-ai/claude-code"],
-          },
-        ],
-        windows: [
-          {
-            label: "npm",
-            commands: ["npm install -g @anthropic-ai/claude-code"],
-          },
-        ],
-        linux: [
-          {
-            label: "npm",
-            commands: ["npm install -g @anthropic-ai/claude-code"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Ensure Node.js and npm are installed first",
-        "Verify installation with: claude --version",
-        "Run 'claude auth login' to authenticate after installing",
-      ],
-    },
-    models: [
-      { id: "claude-sonnet-4-6", name: "Sonnet 4.6", shortLabel: "Sonnet" },
-      { id: "claude-opus-4-6", name: "Opus 4.6", shortLabel: "Opus" },
-      { id: "claude-haiku-4-5-20251001", name: "Haiku 4.5", shortLabel: "Haiku" },
-    ],
-    contextWindow: 200_000,
-    capabilities: {
-      scrollback: 10000,
-      supportsBracketedPaste: true,
-      softNewlineSequence: "\x1b\r",
-      ignoredInputSequences: ["\x1b\r"],
-    },
-    detection: {
-      primaryPatterns: [
-        // @generated:claude:primaryPatterns:start
-        "[·*✢✳✶✻✽●✼✾⟡◇◆○]\\s+[^()\\n]{2,80}\\s*\\(esc to interrupt",
-        "esc to interrupt[^)\\n]*\\)?$",
-        "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
-        // @generated:claude:primaryPatterns:end
-      ],
-      fallbackPatterns: [
-        // @generated:claude:fallbackPatterns:start
-        "[✢✳✶✻✽●]\\s+\\w+…",
-        // @generated:claude:fallbackPatterns:end
-      ],
-      bootCompletePatterns: [
-        // @generated:claude:bootCompletePatterns:start
-        "claude\\s+code\\s+v?\\d",
-        // @generated:claude:bootCompletePatterns:end
-      ],
-      promptPatterns: ["^\\s*>\\s*", "^\\s*❯\\s*"],
-      promptHintPatterns: ["bypass permissions", "^\\s*>\\s+Try\\b"],
-      completionPatterns: [
-        // @generated:claude:completionPatterns:start
-        "[✢✳✶✻✽●]\\s+\\w+\\s+for\\s+\\d",
-        "Total cost:\\s+\\$\\d",
-        "Total duration",
-        "\\$\\d+\\.\\d+\\s*·\\s*\\d+\\s*tokens",
-        "Task\\s+completed",
-        // @generated:claude:completionPatterns:end
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.75,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "python",
-        "rust",
-        "go",
-        "react",
-        "node",
-        "debugging",
-        "refactoring",
-        "code-review",
-      ],
-      domains: {
-        frontend: 0.85,
-        backend: 0.85,
-        testing: 0.8,
-        refactoring: 0.95,
-        debugging: 0.9,
-        architecture: 0.8,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/quit",
-      sessionIdPattern: "claude --resume ([\\w-]+)",
-    },
-    resume: {
-      args: (sessionId: string) => ["--resume", sessionId],
-    },
-    env: {
-      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-    },
-    help: {
-      args: [],
-    },
-    authCheck: {
-      // Claude Code CLI persists auth/session state in ~/.claude.json (the
-      // single file), not ~/.claude/config.json. ANTHROPIC_API_KEY is also a
-      // first-class auth signal supported directly by the CLI.
-      configPathsAll: [".claude.json", ".claude/config.json"],
-      envVar: "ANTHROPIC_API_KEY",
-    },
-    prerequisites: [
-      {
-        tool: "claude",
-        label: "Claude CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://github.com/anthropics/claude-code",
-      },
-    ],
-    envSuggestions: [
-      { key: "ANTHROPIC_AUTH_TOKEN", hint: "API key or auth token" },
-      {
-        key: "ANTHROPIC_BASE_URL",
-        hint: "Override API base URL (e.g. https://api.z.ai/api/anthropic)",
-      },
-      { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", hint: "Override Opus model ID" },
-      { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", hint: "Override Sonnet model ID" },
-      { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", hint: "Override Haiku model ID" },
-      { key: "API_TIMEOUT_MS", hint: "Request timeout in ms (e.g. 3000000)" },
-      { key: "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", hint: "1 to disable telemetry" },
-    ],
-    providerTemplates: [
-      {
-        id: "anthropic-native",
-        name: "Anthropic (native)",
-        description: "Direct Anthropic API connection.",
-        env: {
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-      {
-        id: "zai",
-        name: "Z.AI",
-        description: "Anthropic-compatible via Z.AI.",
-        env: {
-          ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
-          ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-5.1",
-          ANTHROPIC_DEFAULT_SONNET_MODEL: "glm-4.7",
-          ANTHROPIC_DEFAULT_HAIKU_MODEL: "glm-4.5-air",
-          API_TIMEOUT_MS: "3000000",
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-      {
-        id: "openrouter",
-        name: "OpenRouter",
-        description: "Model routing via OpenRouter.",
-        env: {
-          ANTHROPIC_BASE_URL: "https://openrouter.ai/api/v1",
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-      {
-        id: "deepseek",
-        name: "DeepSeek",
-        description: "OpenAI-compatible via DeepSeek.",
-        env: {
-          ANTHROPIC_BASE_URL: "https://api.deepseek.com/v1",
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-      {
-        id: "ollama",
-        name: "Ollama (local)",
-        description: "Local models via Ollama — no API key needed.",
-        env: {
-          ANTHROPIC_BASE_URL: "http://localhost:11434/v1",
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-      {
-        id: "custom-openai",
-        name: "Custom (OpenAI-compatible)",
-        description: "Custom OpenAI-compatible endpoint.",
-        env: {
-          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
-        },
-      },
-    ],
-  },
-  gemini: {
-    id: "gemini",
-    name: "Gemini",
-    command: "gemini",
-    npmGlobalPackage: "@google/gemini-cli",
-    color: "#4285F4",
-    iconId: "gemini",
-    supportsContextInjection: true,
-    shortcut: "Cmd/Ctrl+Alt+G",
-    tooltip: "quick exploration",
-    version: {
-      args: ["--version"],
-      githubRepo: "google-gemini/gemini-cli",
-      npmPackage: "@google/gemini-cli",
-      releaseNotesUrl: "https://github.com/google-gemini/gemini-cli/releases",
-    },
-    update: {
-      npm: "npm install -g @google/gemini-cli@latest",
-    },
-    install: {
-      docsUrl: "https://github.com/google-gemini/gemini-cli#readme",
-      byOs: {
-        macos: [
-          {
-            label: "npm",
-            commands: ["npm install -g @google/gemini-cli"],
-          },
-        ],
-        windows: [
-          {
-            label: "npm",
-            commands: ["npm install -g @google/gemini-cli"],
-          },
-        ],
-        linux: [
-          {
-            label: "npm",
-            commands: ["npm install -g @google/gemini-cli"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Verify installation with: gemini --version",
-        "Run 'gemini auth login' after installing to authenticate",
-      ],
-    },
-    models: [
-      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", shortLabel: "2.5 Pro" },
-      { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", shortLabel: "2.5 Flash" },
-    ],
-    contextWindow: 1_000_000,
-    capabilities: {
-      scrollback: 10000,
-      blockAltScreen: true,
-      blockMouseReporting: true,
-      resizeStrategy: "settled",
-      supportsBracketedPaste: false,
-      softNewlineSequence: "\x1b\r",
-      ignoredInputSequences: ["\x1b\r"],
-    },
-    detection: {
-      primaryPatterns: [
-        // @generated:gemini:primaryPatterns:start
-        "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^()\\n]{2,80}\\s*\\(esc to cancel",
-        "esc to cancel[^)\\n]*\\)?$",
-        "\\(\\d+s,?\\s*esc to cancel",
-        // @generated:gemini:primaryPatterns:end
-      ],
-      fallbackPatterns: [
-        // @generated:gemini:fallbackPatterns:start
-        "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
-        // @generated:gemini:fallbackPatterns:end
-      ],
-      bootCompletePatterns: [
-        // @generated:gemini:bootCompletePatterns:start
-        "type\\s+your\\s+message",
-        // @generated:gemini:bootCompletePatterns:end
-      ],
-      promptPatterns: ["^\\s*>\\s*", "type\\s+your\\s+message"],
-      promptHintPatterns: ["type\\s+your\\s+message"],
-      completionPatterns: [
-        // @generated:gemini:completionPatterns:start
-        "Response\\s+complete",
-        "Finished\\s+processing",
-        // @generated:gemini:completionPatterns:end
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.7,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-      titleStatePatterns: {
-        working: ["\u2726"],
-        waiting: ["\u25C7", "\u270B"],
-      },
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "python",
-        "go",
-        "java",
-        "kotlin",
-        "system-design",
-        "architecture",
-        "exploration",
-      ],
-      domains: {
-        frontend: 0.7,
-        backend: 0.85,
-        testing: 0.7,
-        refactoring: 0.75,
-        debugging: 0.75,
-        architecture: 0.9,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/quit",
-      sessionIdPattern: "gemini --resume ([\\w-]+)",
-    },
-    resume: {
-      args: (sessionId: string) => ["--resume", sessionId],
-    },
-    env: {
-      GEMINI_CLI_ALT_SCREEN: "false",
-    },
-    help: {
-      args: [],
-    },
-    authCheck: {
-      // Gemini CLI persists OAuth creds to ~/.gemini/oauth_creds.json on all
-      // platforms (Node CLI using os.homedir()). GEMINI_API_KEY is also a
-      // first-class auth signal supported directly by the CLI.
-      configPathsAll: [".gemini/oauth_creds.json", ".gemini/google_accounts.json"],
-      envVar: "GEMINI_API_KEY",
-    },
-    prerequisites: [
-      {
-        tool: "gemini",
-        label: "Gemini CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://github.com/google-gemini/gemini-cli#readme",
-      },
-    ],
-  },
-  codex: {
-    id: "codex",
-    name: "Codex",
-    command: "codex",
-    npmGlobalPackage: "@openai/codex",
-    // Codex Windows packaging lags behind Linux — Windows users commonly
-    // install via WSL. WSL probing surfaces the availability in diagnostics
-    // even when no native Windows binary exists.
-    supportsWsl: true,
-    color: "#10a37f",
-    iconId: "codex",
-    supportsContextInjection: true,
-    shortcut: "Cmd/Ctrl+Alt+X",
-    tooltip: "careful, methodical runs",
-    usageUrl: "https://chatgpt.com/codex/settings/usage",
-    version: {
-      args: ["--version"],
-      githubRepo: "openai/codex",
-      npmPackage: "@openai/codex",
-      releaseNotesUrl: "https://github.com/openai/codex/releases/tag/v{version}",
-    },
-    update: {
-      npm: "npm install -g @openai/codex@latest",
-    },
-    install: {
-      docsUrl: "https://github.com/openai/codex",
-      byOs: {
-        macos: [
-          {
-            label: "npm",
-            commands: ["npm install -g @openai/codex"],
-          },
-        ],
-        windows: [
-          {
-            label: "npm",
-            commands: ["npm install -g @openai/codex"],
-          },
-        ],
-        linux: [
-          {
-            label: "npm",
-            commands: ["npm install -g @openai/codex"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Verify installation with: codex --version",
-        "Run 'codex auth login' after installing to authenticate",
-      ],
-    },
-    models: [
-      { id: "gpt-5.4", name: "GPT-5.4", shortLabel: "GPT-5.4" },
-      { id: "o3", name: "o3", shortLabel: "o3" },
-      { id: "gpt-5.3-codex-spark", name: "Codex Spark", shortLabel: "Spark" },
-    ],
-    contextWindow: 128_000,
-    capabilities: {
-      scrollback: 10000,
-      blockAltScreen: true,
-      blockMouseReporting: true,
-      resizeStrategy: "settled",
-      inlineModeFlag: "--no-alt-screen",
-      supportsBracketedPaste: true,
-      softNewlineSequence: "\n",
-      ignoredInputSequences: ["\n", "\x1b\r"],
-    },
-    detection: {
-      primaryPatterns: [
-        // @generated:codex:primaryPatterns:start
-        "[•·]\\s+[^()\\n]{2,80}\\s+\\([^)]*esc to interrupt",
-        "esc to interrupt[^)\\n]*\\)?$",
-        "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
-        // @generated:codex:primaryPatterns:end
-      ],
-      fallbackPatterns: [
-        // @generated:codex:fallbackPatterns:start
-        "[•·]\\s+Working",
-        // @generated:codex:fallbackPatterns:end
-      ],
-      bootCompletePatterns: [
-        // @generated:codex:bootCompletePatterns:start
-        "openai[-\\s]+codex",
-        "codex\\s+v",
-        // @generated:codex:bootCompletePatterns:end
-      ],
-      promptPatterns: ["^\\s*[›❯>]\\s*", "^\\s*codex\\s*>\\s*"],
-      promptHintPatterns: ["context\\s+left"],
-      completionPatterns: [
-        // @generated:codex:completionPatterns:start
-        "Task\\s+completed\\s+successfully",
-        "\\d+\\s+files?\\s+changed",
-        "Created\\s+\\d+\\s+files?",
-        // @generated:codex:completionPatterns:end
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.75,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "react",
-        "node",
-        "testing",
-        "frontend",
-        "css",
-        "html",
-      ],
-      domains: {
-        frontend: 0.9,
-        backend: 0.7,
-        testing: 0.85,
-        refactoring: 0.8,
-        debugging: 0.75,
-        architecture: 0.65,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/quit",
-      sessionIdPattern: "codex resume ([\\w-]+)",
-    },
-    resume: {
-      args: (sessionId: string) => ["resume", sessionId],
-    },
-    help: {
-      args: [],
-    },
-    authCheck: {
-      // Codex CLI persists auth to ~/.codex/auth.json on all platforms.
-      // OPENAI_API_KEY is also a first-class auth signal for the CLI.
-      configPathsAll: [".codex/auth.json"],
-      envVar: "OPENAI_API_KEY",
-    },
-    prerequisites: [
-      {
-        tool: "codex",
-        label: "Codex CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://github.com/openai/codex",
-      },
-    ],
-  },
-  opencode: {
-    id: "opencode",
-    name: "OpenCode",
-    command: "opencode",
-    // OpenCode's curl installer (https://opencode.ai/install) lands the binary
-    // under ~/.opencode/bin when ~/.local/bin and XDG_BIN_DIR are unset;
-    // otherwise it uses ~/.local/bin (already covered by getUnixFallbackPaths).
-    nativePaths: ["~/.opencode/bin/opencode", "~/.local/bin/opencode"],
-    color: "#10b981",
-    iconId: "opencode",
-    supportsContextInjection: true,
-    tooltip: "provider-agnostic, open source",
-    usageUrl: "https://opencode.ai/",
-    version: {
-      args: ["--version"],
-      githubRepo: "opencode-ai/opencode",
-      npmPackage: "opencode-ai",
-      releaseNotesUrl: "https://github.com/opencode-ai/opencode/releases",
-    },
-    update: {
-      npm: "npm install -g opencode-ai@latest",
-      brew: "brew upgrade opencode",
-      other: {
-        curl: "curl -fsSL https://opencode.ai/install | bash",
-      },
-    },
-    install: {
-      docsUrl: "https://opencode.ai/docs/",
-      byOs: {
-        macos: [
-          {
-            label: "curl",
-            commands: ["curl -fsSL https://opencode.ai/install | bash"],
-          },
-          {
-            label: "npm",
-            commands: ["npm install -g opencode-ai@latest"],
-          },
-          {
-            label: "Homebrew",
-            commands: ["brew install opencode"],
-          },
-        ],
-        windows: [
-          {
-            label: "npm",
-            commands: ["npm install -g opencode-ai@latest"],
-          },
-          {
-            label: "Scoop",
-            commands: ["scoop bucket add extras", "scoop install extras/opencode"],
-          },
-          {
-            label: "Chocolatey",
-            commands: ["choco install opencode"],
-          },
-        ],
-        linux: [
-          {
-            label: "curl",
-            commands: ["curl -fsSL https://opencode.ai/install | bash"],
-          },
-          {
-            label: "npm",
-            commands: ["npm install -g opencode-ai@latest"],
-          },
-          {
-            label: "Homebrew",
-            commands: ["brew install opencode"],
-          },
-          {
-            label: "Paru (Arch)",
-            commands: ["paru -S opencode-bin"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Ensure Node.js is installed for npm-based installation",
-        "Verify installation with: opencode --version",
-        "Run '/connect' in OpenCode to configure LLM provider",
-        "For provider setup, authenticate at opencode.ai/auth",
-      ],
-    },
-    capabilities: {
-      scrollback: 10000,
-      blockAltScreen: false,
-      supportsBracketedPaste: true,
-      softNewlineSequence: "\n",
-      ignoredInputSequences: ["\n", "\x1b\r"],
-    },
-    env: {
-      COLORFGBG: "15;0",
-    },
-    detection: {
-      primaryPatterns: [
-        // @generated:opencode:primaryPatterns:start
-        "[⣾⣽⣻⢿⡿⣟⣯⣷]\\s+[^\\n]{2,80}\\s*\\(.*esc",
-        "[·•●]\\s+(Generating|Building tool call|Waiting for tool response)",
-        "press\\s+esc\\s+(again\\s+)?to\\s+(interrupt|exit\\s+cancel)",
-        "esc\\s*(again\\s+)?to\\s+(interrupt|cancel)",
-        // @generated:opencode:primaryPatterns:end
-      ],
-      fallbackPatterns: [
-        // @generated:opencode:fallbackPatterns:start
-        "[⣾⣽⣻⢿⡿⣟⣯⣷]\\s+\\w",
-        "working[…\\.]+",
-        "generating",
-        "waiting for tool response",
-        "building tool call",
-        // @generated:opencode:fallbackPatterns:end
-      ],
-      bootCompletePatterns: [
-        // @generated:opencode:bootCompletePatterns:start
-        "Ask anything",
-        "Build\\s+OpenCode",
-        // @generated:opencode:bootCompletePatterns:end
-      ],
-      promptPatterns: ["^\\s*[›❯>]\\s*", "Ask anything"],
-      promptHintPatterns: ["Ask anything"],
-      completionPatterns: [
-        // @generated:opencode:completionPatterns:start
-        "Task\\s+completed",
-        "\\d+\\s+files?\\s+changed",
-        // @generated:opencode:completionPatterns:end
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.7,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "python",
-        "go",
-        "rust",
-        "multi-provider",
-        "general-purpose",
-      ],
-      domains: {
-        frontend: 0.75,
-        backend: 0.75,
-        testing: 0.7,
-        refactoring: 0.7,
-        debugging: 0.7,
-        architecture: 0.7,
-      },
-      maxConcurrent: 1,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/quit",
-      sessionIdPattern: "opencode -s ([\\w-]+)",
-    },
-    resume: {
-      args: (sessionId: string) => ["-s", sessionId],
-    },
-    authCheck: {
-      // OpenCode v1.4.6+ uses XDG-compliant config paths on all platforms
-      configPathsAll: [".config/opencode/opencode.json", ".local/share/opencode/auth.json"],
-      // OpenCode is provider-agnostic and accepts provider credentials
-      // directly from env vars (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY),
-      // so any of these is a sufficient signal that the CLI is usable.
-      envVar: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
-    },
-    prerequisites: [
-      {
-        tool: "opencode",
-        label: "OpenCode CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://opencode.ai/docs/",
-      },
-    ],
-  },
-  cursor: {
-    id: "cursor",
-    name: "Cursor",
-    command: "cursor-agent",
-    // Cursor's curl installer (https://cursor.com/install) places the binary
-    // at ~/.local/bin/cursor-agent on macOS/Linux. macOS users who have only
-    // the Cursor.app GUI get the CLI sidecar inside the app bundle.
-    nativePaths: [
-      "~/.local/bin/cursor-agent",
-      "/Applications/Cursor.app/Contents/Resources/app/bin/cursor-agent",
-    ],
-    color: "#3ee6eb",
-    iconId: "cursor",
-    supportsContextInjection: true,
-    tooltip: "Cursor's agentic CLI",
-    version: {
-      args: ["-v"],
-    },
-    update: {
-      other: {
-        curl: "curl https://cursor.com/install -fsS | bash",
-      },
-    },
-    install: {
-      docsUrl: "https://cursor.com/features/cursor-agent",
-      byOs: {
-        macos: [
-          {
-            label: "curl",
-            commands: ["curl https://cursor.com/install -fsS | bash"],
-          },
-        ],
-        linux: [
-          {
-            label: "curl",
-            commands: ["curl https://cursor.com/install -fsS | bash"],
-          },
-        ],
-        windows: [
-          {
-            label: "PowerShell",
-            commands: ["irm 'https://cursor.com/install?win32=true' | iex"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Verify installation with: cursor-agent -v",
-        "Run 'cursor-agent login' to authenticate after installing",
-      ],
-    },
-    capabilities: {
-      scrollback: 10000,
-      blockMouseReporting: true,
-      resizeStrategy: "settled",
-      supportsBracketedPaste: true,
-      softNewlineSequence: "\x1b\r",
-      ignoredInputSequences: ["\x1b\r"],
-    },
-    detection: {
-      primaryPatterns: [
-        "\u2B22\\s*(Thinking|Reading|Planning|Searching|Running|Executing|Grepping|Editing|Listing)",
-        "esc to stop",
-      ],
-      fallbackPatterns: ["\u2B22\\s*\\w"],
-      bootCompletePatterns: ["Cursor Agent", "Welcome to Cursor Agent"],
-      promptPatterns: ["^\u2192\\s*$", "^\u2192\\s"],
-      promptHintPatterns: ["\u2192\\s+Add a follow-up"],
-      completionPatterns: [
-        "\u2B22\\s*(Thought|Read|Planned|Searched|Ran|Edited|Grepped|Listed)(?=[^a-zA-Z]|$)",
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.7,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-      promptFastPathMinQuietMs: 700,
-    },
-    routing: {
-      capabilities: ["javascript", "typescript", "python", "react", "node", "general-purpose"],
-      domains: {
-        frontend: 0.8,
-        backend: 0.8,
-        testing: 0.75,
-        refactoring: 0.8,
-        debugging: 0.8,
-        architecture: 0.75,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    authCheck: {
-      // Cursor may store tokens in OS Keychain on newer versions; file check
-      // is best-effort. Misses leave `authConfirmed: false` so the Settings
-      // auth nudge surfaces, but do not block launch.
-      configPaths: {
-        darwin: ["Library/Application Support/Cursor/User/globalStorage/storage.json"],
-        linux: [".config/Cursor/User/globalStorage/storage.json"],
-        win32: ["AppData/Roaming/Cursor/User/globalStorage/storage.json"],
-      },
-    },
-    prerequisites: [
-      {
-        tool: "cursor-agent",
-        label: "Cursor Agent CLI",
-        versionArgs: ["-v"],
-        severity: "fatal",
-        installUrl: "https://cursor.com/install",
-      },
-    ],
-  },
-  kiro: {
-    id: "kiro",
-    name: "Kiro",
-    command: "kiro-cli",
-    color: "#7C3AED",
-    iconId: "kiro",
-    supportsContextInjection: true,
-    tooltip: "Amazon's AI coding agent",
-    usageUrl: "https://kiro.dev/",
-    version: {
-      args: ["--version"],
-    },
-    update: {
-      other: {
-        curl: "curl -fsSL https://cli.kiro.dev/install | bash",
-      },
-    },
-    install: {
-      docsUrl: "https://kiro.dev/cli/",
-      byOs: {
-        macos: [
-          {
-            label: "curl",
-            commands: ["curl -fsSL https://cli.kiro.dev/install | bash"],
-          },
-        ],
-        linux: [
-          {
-            label: "curl",
-            commands: ["curl -fsSL https://cli.kiro.dev/install | bash"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Verify installation with: kiro-cli --version",
-        "Kiro CLI is only supported on macOS and Linux",
-        "Authenticate after installing via Kiro's login flow",
-      ],
-    },
-    capabilities: {
-      scrollback: 10000,
-      supportsBracketedPaste: true,
-      softNewlineSequence: "\x1b\r",
-      ignoredInputSequences: ["\x1b\r"],
-    },
-    detection: {
-      primaryPatterns: [
-        // @generated:kiro:primaryPatterns:start
-        "[·*✢✳✶✻✽●✼✾⟡◇◆○⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^()\\n]{2,80}\\s*\\(esc to interrupt",
-        "esc to interrupt[^)\\n]*\\)?$",
-        "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
-        "[·*✢✳✶✻✽●✼✾⟡◇◆○⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+Thinking",
-        // @generated:kiro:primaryPatterns:end
-      ],
-      fallbackPatterns: [
-        // @generated:kiro:fallbackPatterns:start
-        "[·•●⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+Thinking",
-        "[·•●]\\s+\\w+",
-        // @generated:kiro:fallbackPatterns:end
-      ],
-      bootCompletePatterns: [
-        // @generated:kiro:bootCompletePatterns:start
-        "Jump into building with Kiro",
-        "Use /help for more information and happy coding",
-        "Model: auto",
-        // @generated:kiro:bootCompletePatterns:end
-      ],
-      promptPatterns: ["^\\s*>\\s*"],
-      promptHintPatterns: ["^\\s*>\\s*$"],
-      completionPatterns: [
-        // @generated:kiro:completionPatterns:start
-        "Task\\s+completed",
-        "\\d+\\s+files?\\s+changed",
-        // @generated:kiro:completionPatterns:end
-      ],
-      completionConfidence: 0.9,
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.75,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "python",
-        "go",
-        "rust",
-        "react",
-        "node",
-        "debugging",
-        "refactoring",
-        "general-purpose",
-      ],
-      domains: {
-        frontend: 0.8,
-        backend: 0.8,
-        testing: 0.75,
-        refactoring: 0.8,
-        debugging: 0.8,
-        architecture: 0.75,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/quit",
-      // Kiro uses directory-based sessions; no session ID is emitted on exit.
-      // Pattern intentionally non-matching — graceful quit fires but no ID is captured.
-      sessionIdPattern: "kiro-cli --resume ([\\w-]+)",
-    },
-    resume: {
-      // Kiro's --resume is directory-based and requires no session ID argument.
-      args: (_sessionId: string) => ["--resume"],
-    },
-    help: {
-      args: [],
-    },
-    authCheck: {
-      // AWS SSO users authenticate via `kiro-cli login` (optionally with
-      // --use-device-flow for headless/SSH), which writes a Kiro-specific
-      // token cache to ~/.aws/sso/cache/kiro-auth-token.json. Probe that
-      // file so SSO-authenticated users get `authConfirmed: true`.
-      // Non-SSO Kiro auth is managed via the OS keychain and internal state
-      // directories (e.g. ~/Library/Application Support/kiro-cli/ on macOS,
-      // ~/.local/share/kiro-cli/ on Linux), which we cannot reliably probe —
-      // those users get `authConfirmed: false` but remain launchable.
-      configPathsAll: [".aws/sso/cache/kiro-auth-token.json"],
-    },
-    prerequisites: [
-      {
-        tool: "kiro-cli",
-        label: "Kiro CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://kiro.dev/cli/",
-      },
-    ],
-  },
-  copilot: {
-    id: "copilot",
-    name: "GitHub Copilot",
-    command: "copilot",
-    color: "#8957e5",
-    iconId: "copilot",
-    supportsContextInjection: true,
-    tooltip: "GitHub's AI coding agent",
-    usageUrl: "https://github.com/features/copilot",
-    contextWindow: 160_000,
-    models: [
-      { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", shortLabel: "Sonnet 4.6" },
-      { id: "claude-opus-4.6", name: "Claude Opus 4.6", shortLabel: "Opus 4.6" },
-      { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", shortLabel: "Haiku 4.5" },
-      { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", shortLabel: "Sonnet 4.5" },
-      { id: "claude-opus-4.5", name: "Claude Opus 4.5", shortLabel: "Opus 4.5" },
-      { id: "gpt-5.4", name: "GPT-5.4", shortLabel: "GPT-5.4" },
-      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", shortLabel: "GPT-5.3" },
-      { id: "gpt-5.2", name: "GPT-5.2", shortLabel: "GPT-5.2" },
-      { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", shortLabel: "5.4 Mini" },
-      { id: "gpt-5-mini", name: "GPT-5 Mini", shortLabel: "5 Mini" },
-      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", shortLabel: "Gem 2.5 Pro" },
-      { id: "gemini-3-pro-preview", name: "Gemini 3 Pro", shortLabel: "Gem 3 Pro" },
-      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro", shortLabel: "Gem 3.1 Pro" },
-    ],
-    version: {
-      args: ["--version"],
-      npmPackage: "@github/copilot",
-      githubRepo: "github/copilot-cli",
-      releaseNotesUrl: "https://github.com/github/copilot-cli/releases",
-    },
-    update: {
-      npm: "npm install -g @github/copilot@latest",
-    },
-    install: {
-      docsUrl: "https://github.com/github/copilot-cli#readme",
-      byOs: {
-        macos: [
-          {
-            label: "npm",
-            commands: ["npm install -g @github/copilot"],
-          },
-        ],
-        linux: [
-          {
-            label: "npm",
-            commands: ["npm install -g @github/copilot"],
-          },
-        ],
-        windows: [
-          {
-            label: "npm",
-            commands: ["npm install -g @github/copilot"],
-          },
-        ],
-      },
-      troubleshooting: [
-        "Restart Daintree after installation to update PATH",
-        "Verify installation with: copilot --version",
-        "Run 'copilot login' to authenticate after installing",
-      ],
-    },
-    capabilities: {
-      scrollback: 10000,
-      blockMouseReporting: true,
-      resizeStrategy: "settled",
-      supportsBracketedPaste: true,
-      submitEnterDelayMs: 0,
-    },
-    detection: {
-      primaryPatterns: ["\\(Esc to cancel\\)", "[∙∘○◎◉]\\s+.+\\(Esc to cancel\\)"],
-      fallbackPatterns: ["[∙∘○◎◉]\\s+\\w"],
-      bootCompletePatterns: ["Loading environment:"],
-      promptPatterns: ["^\\s*>\\s*$", "^\\s*>\\s"],
-      promptHintPatterns: ["^\\s*>\\s*$"],
-      scanLineCount: 10,
-      primaryConfidence: 0.95,
-      fallbackConfidence: 0.75,
-      promptConfidence: 0.85,
-      debounceMs: 4000,
-    },
-    routing: {
-      capabilities: [
-        "javascript",
-        "typescript",
-        "python",
-        "go",
-        "rust",
-        "react",
-        "node",
-        "github",
-        "general-purpose",
-      ],
-      domains: {
-        frontend: 0.8,
-        backend: 0.8,
-        testing: 0.75,
-        refactoring: 0.8,
-        debugging: 0.8,
-        architecture: 0.75,
-      },
-      maxConcurrent: 2,
-      enabled: true,
-    },
-    shutdown: {
-      quitCommand: "/exit",
-      sessionIdPattern: "copilot --resume=([\\w-]+)",
-    },
-    resume: {
-      args: (sessionId: string) => ["--resume=" + sessionId],
-    },
-    authCheck: {
-      // GitHub Copilot CLI primarily stores auth in the OS keychain
-      // (macOS Keychain under "copilot-cli", Linux libsecret/GNOME Keyring).
-      // ~/.copilot/config.json is written as a fallback when the keychain
-      // is unavailable (headless Linux, CI). We intentionally do NOT probe
-      // ~/.config/gh/hosts.yml — that file is populated by any `gh auth login`
-      // for general GitHub CLI use, not specifically Copilot, so presence
-      // does not imply a Copilot subscription or active auth. Keychain-auth
-      // users get `authConfirmed: false` but remain launchable.
-      configPathsAll: [".copilot/config.json"],
-    },
-    prerequisites: [
-      {
-        tool: "copilot",
-        label: "GitHub Copilot CLI",
-        versionArgs: ["--version"],
-        severity: "fatal",
-        installUrl: "https://github.com/github/copilot-cli",
-      },
-    ],
-  },
+  claude: claudeConfig,
+  gemini: geminiConfig,
+  codex: codexConfig,
+  opencode: opencodeConfig,
+  cursor: cursorConfig,
+  kiro: kiroConfig,
+  copilot: copilotConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -1,0 +1,228 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "claude",
+  name: "Claude",
+  command: "claude",
+  // Anthropic's native installer places the symlink at ~/.local/bin/claude
+  // on macOS/Linux and a versioned binary under ~/.local/share/claude.
+  // Windows native installer places the binary under
+  // %LOCALAPPDATA%\claude-code\bin\claude.exe. Detect both so users who
+  // install via the native installer are not mis-reported as "missing"
+  // when ~/.local/bin isn't inherited by the Electron process PATH.
+  nativePaths: ["~/.local/bin/claude", "%LOCALAPPDATA%\\claude-code\\bin\\claude.exe"],
+  npmGlobalPackage: "@anthropic-ai/claude-code",
+  color: "#CC785C",
+  iconId: "claude",
+  supportsContextInjection: true,
+  shortcut: "Cmd/Ctrl+Alt+C",
+  usageUrl: "https://claude.ai/settings/usage",
+  version: {
+    args: ["--version"],
+    githubRepo: "anthropics/claude-code",
+    npmPackage: "@anthropic-ai/claude-code",
+    releaseNotesUrl: "https://github.com/anthropics/claude-code/releases/tag/v{version}",
+  },
+  update: {
+    npm: "npm install -g @anthropic-ai/claude-code@latest",
+  },
+  install: {
+    docsUrl: "https://github.com/anthropics/claude-code",
+    byOs: {
+      macos: [
+        {
+          label: "npm",
+          commands: ["npm install -g @anthropic-ai/claude-code"],
+        },
+      ],
+      windows: [
+        {
+          label: "npm",
+          commands: ["npm install -g @anthropic-ai/claude-code"],
+        },
+      ],
+      linux: [
+        {
+          label: "npm",
+          commands: ["npm install -g @anthropic-ai/claude-code"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Ensure Node.js and npm are installed first",
+      "Verify installation with: claude --version",
+      "Run 'claude auth login' to authenticate after installing",
+    ],
+  },
+  models: [
+    { id: "claude-sonnet-4-6", name: "Sonnet 4.6", shortLabel: "Sonnet" },
+    { id: "claude-opus-4-6", name: "Opus 4.6", shortLabel: "Opus" },
+    { id: "claude-haiku-4-5-20251001", name: "Haiku 4.5", shortLabel: "Haiku" },
+  ],
+  contextWindow: 200_000,
+  capabilities: {
+    scrollback: 10000,
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:claude:primaryPatterns:start
+      "[·*✢✳✶✻✽●✼✾⟡◇◆○]\\s+[^()\\n]{2,80}\\s*\\(esc to interrupt",
+      "esc to interrupt[^)\\n]*\\)?$",
+      "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
+      // @generated:claude:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:claude:fallbackPatterns:start
+      "[✢✳✶✻✽●]\\s+\\w+…",
+      // @generated:claude:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:claude:bootCompletePatterns:start
+      "claude\\s+code\\s+v?\\d",
+      // @generated:claude:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*>\\s*", "^\\s*❯\\s*"],
+    promptHintPatterns: ["bypass permissions", "^\\s*>\\s+Try\\b"],
+    completionPatterns: [
+      // @generated:claude:completionPatterns:start
+      "[✢✳✶✻✽●]\\s+\\w+\\s+for\\s+\\d",
+      "Total cost:\\s+\\$\\d",
+      "Total duration",
+      "\\$\\d+\\.\\d+\\s*·\\s*\\d+\\s*tokens",
+      "Task\\s+completed",
+      // @generated:claude:completionPatterns:end
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "rust",
+      "go",
+      "react",
+      "node",
+      "debugging",
+      "refactoring",
+      "code-review",
+    ],
+    domains: {
+      frontend: 0.85,
+      backend: 0.85,
+      testing: 0.8,
+      refactoring: 0.95,
+      debugging: 0.9,
+      architecture: 0.8,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["--resume", sessionId],
+    quitCommand: "/quit",
+    sessionIdPattern: "claude --resume ([\\w-]+)",
+  },
+  env: {
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  },
+  help: {
+    args: [],
+  },
+  authCheck: {
+    // Claude Code CLI persists auth/session state in ~/.claude.json (the
+    // single file), not ~/.claude/config.json. ANTHROPIC_API_KEY is also a
+    // first-class auth signal supported directly by the CLI.
+    configPathsAll: [".claude.json", ".claude/config.json"],
+    envVar: "ANTHROPIC_API_KEY",
+  },
+  prerequisites: [
+    {
+      tool: "claude",
+      label: "Claude CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/anthropics/claude-code",
+    },
+  ],
+  envSuggestions: [
+    { key: "ANTHROPIC_AUTH_TOKEN", hint: "API key or auth token" },
+    {
+      key: "ANTHROPIC_BASE_URL",
+      hint: "Override API base URL (e.g. https://api.z.ai/api/anthropic)",
+    },
+    { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", hint: "Override Opus model ID" },
+    { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", hint: "Override Sonnet model ID" },
+    { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", hint: "Override Haiku model ID" },
+    { key: "API_TIMEOUT_MS", hint: "Request timeout in ms (e.g. 3000000)" },
+    { key: "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", hint: "1 to disable telemetry" },
+  ],
+  providerTemplates: [
+    {
+      id: "anthropic-native",
+      name: "Anthropic (native)",
+      description: "Direct Anthropic API connection.",
+      env: {
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+    {
+      id: "zai",
+      name: "Z.AI",
+      description: "Anthropic-compatible via Z.AI.",
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-5.1",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "glm-4.7",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "glm-4.5-air",
+        API_TIMEOUT_MS: "3000000",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+    {
+      id: "openrouter",
+      name: "OpenRouter",
+      description: "Model routing via OpenRouter.",
+      env: {
+        ANTHROPIC_BASE_URL: "https://openrouter.ai/api/v1",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+    {
+      id: "deepseek",
+      name: "DeepSeek",
+      description: "OpenAI-compatible via DeepSeek.",
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.deepseek.com/v1",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+    {
+      id: "ollama",
+      name: "Ollama (local)",
+      description: "Local models via Ollama — no API key needed.",
+      env: {
+        ANTHROPIC_BASE_URL: "http://localhost:11434/v1",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+    {
+      id: "custom-openai",
+      name: "Custom (OpenAI-compatible)",
+      description: "Custom OpenAI-compatible endpoint.",
+      env: {
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      },
+    },
+  ],
+};

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -1,0 +1,152 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "codex",
+  name: "Codex",
+  command: "codex",
+  npmGlobalPackage: "@openai/codex",
+  // Codex Windows packaging lags behind Linux — Windows users commonly
+  // install via WSL. WSL probing surfaces the availability in diagnostics
+  // even when no native Windows binary exists.
+  supportsWsl: true,
+  color: "#10a37f",
+  iconId: "codex",
+  supportsContextInjection: true,
+  shortcut: "Cmd/Ctrl+Alt+X",
+  tooltip: "careful, methodical runs",
+  usageUrl: "https://chatgpt.com/codex/settings/usage",
+  version: {
+    args: ["--version"],
+    githubRepo: "openai/codex",
+    npmPackage: "@openai/codex",
+    releaseNotesUrl: "https://github.com/openai/codex/releases/tag/v{version}",
+  },
+  update: {
+    npm: "npm install -g @openai/codex@latest",
+  },
+  install: {
+    docsUrl: "https://github.com/openai/codex",
+    byOs: {
+      macos: [
+        {
+          label: "npm",
+          commands: ["npm install -g @openai/codex"],
+        },
+      ],
+      windows: [
+        {
+          label: "npm",
+          commands: ["npm install -g @openai/codex"],
+        },
+      ],
+      linux: [
+        {
+          label: "npm",
+          commands: ["npm install -g @openai/codex"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: codex --version",
+      "Run 'codex auth login' after installing to authenticate",
+    ],
+  },
+  models: [
+    { id: "gpt-5.4", name: "GPT-5.4", shortLabel: "GPT-5.4" },
+    { id: "o3", name: "o3", shortLabel: "o3" },
+    { id: "gpt-5.3-codex-spark", name: "Codex Spark", shortLabel: "Spark" },
+  ],
+  contextWindow: 128_000,
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: true,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    inlineModeFlag: "--no-alt-screen",
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\n",
+    ignoredInputSequences: ["\n", "\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:codex:primaryPatterns:start
+      "[•·]\\s+[^()\\n]{2,80}\\s+\\([^)]*esc to interrupt",
+      "esc to interrupt[^)\\n]*\\)?$",
+      "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
+      // @generated:codex:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:codex:fallbackPatterns:start
+      "[•·]\\s+Working",
+      // @generated:codex:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:codex:bootCompletePatterns:start
+      "openai[-\\s]+codex",
+      "codex\\s+v",
+      // @generated:codex:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*[›❯>]\\s*", "^\\s*codex\\s*>\\s*"],
+    promptHintPatterns: ["context\\s+left"],
+    completionPatterns: [
+      // @generated:codex:completionPatterns:start
+      "Task\\s+completed\\s+successfully",
+      "\\d+\\s+files?\\s+changed",
+      "Created\\s+\\d+\\s+files?",
+      // @generated:codex:completionPatterns:end
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "react",
+      "node",
+      "testing",
+      "frontend",
+      "css",
+      "html",
+    ],
+    domains: {
+      frontend: 0.9,
+      backend: 0.7,
+      testing: 0.85,
+      refactoring: 0.8,
+      debugging: 0.75,
+      architecture: 0.65,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["resume", sessionId],
+    quitCommand: "/quit",
+    sessionIdPattern: "codex resume ([\\w-]+)",
+  },
+  help: {
+    args: [],
+  },
+  authCheck: {
+    // Codex CLI persists auth to ~/.codex/auth.json on all platforms.
+    // OPENAI_API_KEY is also a first-class auth signal for the CLI.
+    configPathsAll: [".codex/auth.json"],
+    envVar: "OPENAI_API_KEY",
+  },
+  prerequisites: [
+    {
+      tool: "codex",
+      label: "Codex CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/openai/codex",
+    },
+  ],
+};

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -1,0 +1,133 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "copilot",
+  name: "GitHub Copilot",
+  command: "copilot",
+  color: "#8957e5",
+  iconId: "copilot",
+  supportsContextInjection: true,
+  tooltip: "GitHub's AI coding agent",
+  usageUrl: "https://github.com/features/copilot",
+  contextWindow: 160_000,
+  models: [
+    { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", shortLabel: "Sonnet 4.6" },
+    { id: "claude-opus-4.6", name: "Claude Opus 4.6", shortLabel: "Opus 4.6" },
+    { id: "claude-haiku-4.5", name: "Claude Haiku 4.5", shortLabel: "Haiku 4.5" },
+    { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5", shortLabel: "Sonnet 4.5" },
+    { id: "claude-opus-4.5", name: "Claude Opus 4.5", shortLabel: "Opus 4.5" },
+    { id: "gpt-5.4", name: "GPT-5.4", shortLabel: "GPT-5.4" },
+    { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", shortLabel: "GPT-5.3" },
+    { id: "gpt-5.2", name: "GPT-5.2", shortLabel: "GPT-5.2" },
+    { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", shortLabel: "5.4 Mini" },
+    { id: "gpt-5-mini", name: "GPT-5 Mini", shortLabel: "5 Mini" },
+    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", shortLabel: "Gem 2.5 Pro" },
+    { id: "gemini-3-pro-preview", name: "Gemini 3 Pro", shortLabel: "Gem 3 Pro" },
+    { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro", shortLabel: "Gem 3.1 Pro" },
+  ],
+  version: {
+    args: ["--version"],
+    npmPackage: "@github/copilot",
+    githubRepo: "github/copilot-cli",
+    releaseNotesUrl: "https://github.com/github/copilot-cli/releases",
+  },
+  update: {
+    npm: "npm install -g @github/copilot@latest",
+  },
+  install: {
+    docsUrl: "https://github.com/github/copilot-cli#readme",
+    byOs: {
+      macos: [
+        {
+          label: "npm",
+          commands: ["npm install -g @github/copilot"],
+        },
+      ],
+      linux: [
+        {
+          label: "npm",
+          commands: ["npm install -g @github/copilot"],
+        },
+      ],
+      windows: [
+        {
+          label: "npm",
+          commands: ["npm install -g @github/copilot"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: copilot --version",
+      "Run 'copilot login' to authenticate after installing",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    supportsBracketedPaste: true,
+    submitEnterDelayMs: 0,
+  },
+  detection: {
+    primaryPatterns: ["\\(Esc to cancel\\)", "[∙∘○◎◉]\\s+.+\\(Esc to cancel\\)"],
+    fallbackPatterns: ["[∙∘○◎◉]\\s+\\w"],
+    bootCompletePatterns: ["Loading environment:"],
+    promptPatterns: ["^\\s*>\\s*$", "^\\s*>\\s"],
+    promptHintPatterns: ["^\\s*>\\s*$"],
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "react",
+      "node",
+      "github",
+      "general-purpose",
+    ],
+    domains: {
+      frontend: 0.8,
+      backend: 0.8,
+      testing: 0.75,
+      refactoring: 0.8,
+      debugging: 0.8,
+      architecture: 0.75,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["--resume=" + sessionId],
+    quitCommand: "/exit",
+    sessionIdPattern: "copilot --resume=([\\w-]+)",
+  },
+  authCheck: {
+    // GitHub Copilot CLI primarily stores auth in the OS keychain
+    // (macOS Keychain under "copilot-cli", Linux libsecret/GNOME Keyring).
+    // ~/.copilot/config.json is written as a fallback when the keychain
+    // is unavailable (headless Linux, CI). We intentionally do NOT probe
+    // ~/.config/gh/hosts.yml — that file is populated by any `gh auth login`
+    // for general GitHub CLI use, not specifically Copilot, so presence
+    // does not imply a Copilot subscription or active auth. Keychain-auth
+    // users get `authConfirmed: false` but remain launchable.
+    configPathsAll: [".copilot/config.json"],
+  },
+  prerequisites: [
+    {
+      tool: "copilot",
+      label: "GitHub Copilot CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/github/copilot-cli",
+    },
+  ],
+};

--- a/shared/config/agents/cursor.ts
+++ b/shared/config/agents/cursor.ts
@@ -1,0 +1,112 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "cursor",
+  name: "Cursor",
+  command: "cursor-agent",
+  // Cursor's curl installer (https://cursor.com/install) places the binary
+  // at ~/.local/bin/cursor-agent on macOS/Linux. macOS users who have only
+  // the Cursor.app GUI get the CLI sidecar inside the app bundle.
+  nativePaths: [
+    "~/.local/bin/cursor-agent",
+    "/Applications/Cursor.app/Contents/Resources/app/bin/cursor-agent",
+  ],
+  color: "#3ee6eb",
+  iconId: "cursor",
+  supportsContextInjection: true,
+  tooltip: "Cursor's agentic CLI",
+  version: {
+    args: ["-v"],
+  },
+  update: {
+    curl: "curl https://cursor.com/install -fsS | bash",
+  },
+  install: {
+    docsUrl: "https://cursor.com/features/cursor-agent",
+    byOs: {
+      macos: [
+        {
+          label: "curl",
+          commands: ["curl https://cursor.com/install -fsS | bash"],
+        },
+      ],
+      linux: [
+        {
+          label: "curl",
+          commands: ["curl https://cursor.com/install -fsS | bash"],
+        },
+      ],
+      windows: [
+        {
+          label: "PowerShell",
+          commands: ["irm 'https://cursor.com/install?win32=true' | iex"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: cursor-agent -v",
+      "Run 'cursor-agent login' to authenticate after installing",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      "⬢\\s*(Thinking|Reading|Planning|Searching|Running|Executing|Grepping|Editing|Listing)",
+      "esc to stop",
+    ],
+    fallbackPatterns: ["⬢\\s*\\w"],
+    bootCompletePatterns: ["Cursor Agent", "Welcome to Cursor Agent"],
+    promptPatterns: ["^→\\s*$", "^→\\s"],
+    promptHintPatterns: ["→\\s+Add a follow-up"],
+    completionPatterns: [
+      "⬢\\s*(Thought|Read|Planned|Searched|Ran|Edited|Grepped|Listed)(?=[^a-zA-Z]|$)",
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.7,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+    promptFastPathMinQuietMs: 700,
+  },
+  routing: {
+    capabilities: ["javascript", "typescript", "python", "react", "node", "general-purpose"],
+    domains: {
+      frontend: 0.8,
+      backend: 0.8,
+      testing: 0.75,
+      refactoring: 0.8,
+      debugging: 0.8,
+      architecture: 0.75,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  authCheck: {
+    // Cursor may store tokens in OS Keychain on newer versions; file check
+    // is best-effort. Misses leave `authConfirmed: false` so the Settings
+    // auth nudge surfaces, but do not block launch.
+    configPaths: {
+      darwin: ["Library/Application Support/Cursor/User/globalStorage/storage.json"],
+      linux: [".config/Cursor/User/globalStorage/storage.json"],
+      win32: ["AppData/Roaming/Cursor/User/globalStorage/storage.json"],
+    },
+  },
+  prerequisites: [
+    {
+      tool: "cursor-agent",
+      label: "Cursor Agent CLI",
+      versionArgs: ["-v"],
+      severity: "fatal",
+      installUrl: "https://cursor.com/install",
+    },
+  ],
+};

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -1,0 +1,152 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "gemini",
+  name: "Gemini",
+  command: "gemini",
+  npmGlobalPackage: "@google/gemini-cli",
+  color: "#4285F4",
+  iconId: "gemini",
+  supportsContextInjection: true,
+  shortcut: "Cmd/Ctrl+Alt+G",
+  tooltip: "quick exploration",
+  version: {
+    args: ["--version"],
+    githubRepo: "google-gemini/gemini-cli",
+    npmPackage: "@google/gemini-cli",
+    releaseNotesUrl: "https://github.com/google-gemini/gemini-cli/releases",
+  },
+  update: {
+    npm: "npm install -g @google/gemini-cli@latest",
+  },
+  install: {
+    docsUrl: "https://github.com/google-gemini/gemini-cli#readme",
+    byOs: {
+      macos: [
+        {
+          label: "npm",
+          commands: ["npm install -g @google/gemini-cli"],
+        },
+      ],
+      windows: [
+        {
+          label: "npm",
+          commands: ["npm install -g @google/gemini-cli"],
+        },
+      ],
+      linux: [
+        {
+          label: "npm",
+          commands: ["npm install -g @google/gemini-cli"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: gemini --version",
+      "Run 'gemini auth login' after installing to authenticate",
+    ],
+  },
+  models: [
+    { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", shortLabel: "2.5 Pro" },
+    { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", shortLabel: "2.5 Flash" },
+  ],
+  contextWindow: 1_000_000,
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: true,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    supportsBracketedPaste: false,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:gemini:primaryPatterns:start
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^()\\n]{2,80}\\s*\\(esc to cancel",
+      "esc to cancel[^)\\n]*\\)?$",
+      "\\(\\d+s,?\\s*esc to cancel",
+      // @generated:gemini:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:gemini:fallbackPatterns:start
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
+      // @generated:gemini:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:gemini:bootCompletePatterns:start
+      "type\\s+your\\s+message",
+      // @generated:gemini:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*>\\s*", "type\\s+your\\s+message"],
+    promptHintPatterns: ["type\\s+your\\s+message"],
+    completionPatterns: [
+      // @generated:gemini:completionPatterns:start
+      "Response\\s+complete",
+      "Finished\\s+processing",
+      // @generated:gemini:completionPatterns:end
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.7,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+    titleStatePatterns: {
+      working: ["✦"],
+      waiting: ["◇", "✋"],
+    },
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "java",
+      "kotlin",
+      "system-design",
+      "architecture",
+      "exploration",
+    ],
+    domains: {
+      frontend: 0.7,
+      backend: 0.85,
+      testing: 0.7,
+      refactoring: 0.75,
+      debugging: 0.75,
+      architecture: 0.9,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["--resume", sessionId],
+    quitCommand: "/quit",
+    sessionIdPattern: "gemini --resume ([\\w-]+)",
+  },
+  env: {
+    GEMINI_CLI_ALT_SCREEN: "false",
+  },
+  help: {
+    args: [],
+  },
+  authCheck: {
+    // Gemini CLI persists OAuth creds to ~/.gemini/oauth_creds.json on all
+    // platforms (Node CLI using os.homedir()). GEMINI_API_KEY is also a
+    // first-class auth signal supported directly by the CLI.
+    configPathsAll: [".gemini/oauth_creds.json", ".gemini/google_accounts.json"],
+    envVar: "GEMINI_API_KEY",
+  },
+  prerequisites: [
+    {
+      tool: "gemini",
+      label: "Gemini CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/google-gemini/gemini-cli#readme",
+    },
+  ],
+};

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -1,0 +1,139 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "kiro",
+  name: "Kiro",
+  command: "kiro-cli",
+  color: "#7C3AED",
+  iconId: "kiro",
+  supportsContextInjection: true,
+  tooltip: "Amazon's AI coding agent",
+  usageUrl: "https://kiro.dev/",
+  version: {
+    args: ["--version"],
+  },
+  update: {
+    curl: "curl -fsSL https://cli.kiro.dev/install | bash",
+  },
+  install: {
+    docsUrl: "https://kiro.dev/cli/",
+    byOs: {
+      macos: [
+        {
+          label: "curl",
+          commands: ["curl -fsSL https://cli.kiro.dev/install | bash"],
+        },
+      ],
+      linux: [
+        {
+          label: "curl",
+          commands: ["curl -fsSL https://cli.kiro.dev/install | bash"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: kiro-cli --version",
+      "Kiro CLI is only supported on macOS and Linux",
+      "Authenticate after installing via Kiro's login flow",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:kiro:primaryPatterns:start
+      "[·*✢✳✶✻✽●✼✾⟡◇◆○⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^()\\n]{2,80}\\s*\\(esc to interrupt",
+      "esc to interrupt[^)\\n]*\\)?$",
+      "\\(\\d+s\\s*[·•]\\s*esc to interrupt",
+      "[·*✢✳✶✻✽●✼✾⟡◇◆○⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+Thinking",
+      // @generated:kiro:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:kiro:fallbackPatterns:start
+      "[·•●⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+Thinking",
+      "[·•●]\\s+\\w+",
+      // @generated:kiro:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:kiro:bootCompletePatterns:start
+      "Jump into building with Kiro",
+      "Use /help for more information and happy coding",
+      "Model: auto",
+      // @generated:kiro:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*>\\s*"],
+    promptHintPatterns: ["^\\s*>\\s*$"],
+    completionPatterns: [
+      // @generated:kiro:completionPatterns:start
+      "Task\\s+completed",
+      "\\d+\\s+files?\\s+changed",
+      // @generated:kiro:completionPatterns:end
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "react",
+      "node",
+      "debugging",
+      "refactoring",
+      "general-purpose",
+    ],
+    domains: {
+      frontend: 0.8,
+      backend: 0.8,
+      testing: 0.75,
+      refactoring: 0.8,
+      debugging: 0.8,
+      architecture: 0.75,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  // Kiro uses directory-based sessions: no session ID is emitted on quit
+  // and `--resume` takes no argument. `project-scoped` skips the PTY host's
+  // session-ID capture loop while still firing the graceful `/quit`.
+  resume: {
+    kind: "project-scoped",
+    args: () => ["--resume"],
+    quitCommand: "/quit",
+  },
+  help: {
+    args: [],
+  },
+  authCheck: {
+    // AWS SSO users authenticate via `kiro-cli login` (optionally with
+    // --use-device-flow for headless/SSH), which writes a Kiro-specific
+    // token cache to ~/.aws/sso/cache/kiro-auth-token.json. Probe that
+    // file so SSO-authenticated users get `authConfirmed: true`.
+    // Non-SSO Kiro auth is managed via the OS keychain and internal state
+    // directories (e.g. ~/Library/Application Support/kiro-cli/ on macOS,
+    // ~/.local/share/kiro-cli/ on Linux), which we cannot reliably probe —
+    // those users get `authConfirmed: false` but remain launchable.
+    configPathsAll: [".aws/sso/cache/kiro-auth-token.json"],
+  },
+  prerequisites: [
+    {
+      tool: "kiro-cli",
+      label: "Kiro CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://kiro.dev/cli/",
+    },
+  ],
+};

--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -1,0 +1,178 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "opencode",
+  name: "OpenCode",
+  command: "opencode",
+  // OpenCode's curl installer (https://opencode.ai/install) lands the binary
+  // under ~/.opencode/bin when ~/.local/bin and XDG_BIN_DIR are unset;
+  // otherwise it uses ~/.local/bin (already covered by getUnixFallbackPaths).
+  nativePaths: ["~/.opencode/bin/opencode", "~/.local/bin/opencode"],
+  color: "#10b981",
+  iconId: "opencode",
+  supportsContextInjection: true,
+  tooltip: "provider-agnostic, open source",
+  usageUrl: "https://opencode.ai/",
+  version: {
+    args: ["--version"],
+    githubRepo: "opencode-ai/opencode",
+    npmPackage: "opencode-ai",
+    releaseNotesUrl: "https://github.com/opencode-ai/opencode/releases",
+  },
+  update: {
+    npm: "npm install -g opencode-ai@latest",
+    brew: "brew upgrade opencode",
+    curl: "curl -fsSL https://opencode.ai/install | bash",
+  },
+  install: {
+    docsUrl: "https://opencode.ai/docs/",
+    byOs: {
+      macos: [
+        {
+          label: "curl",
+          commands: ["curl -fsSL https://opencode.ai/install | bash"],
+        },
+        {
+          label: "npm",
+          commands: ["npm install -g opencode-ai@latest"],
+        },
+        {
+          label: "Homebrew",
+          commands: ["brew install opencode"],
+        },
+      ],
+      windows: [
+        {
+          label: "npm",
+          commands: ["npm install -g opencode-ai@latest"],
+        },
+        {
+          label: "Scoop",
+          commands: ["scoop bucket add extras", "scoop install extras/opencode"],
+        },
+        {
+          label: "Chocolatey",
+          commands: ["choco install opencode"],
+        },
+      ],
+      linux: [
+        {
+          label: "curl",
+          commands: ["curl -fsSL https://opencode.ai/install | bash"],
+        },
+        {
+          label: "npm",
+          commands: ["npm install -g opencode-ai@latest"],
+        },
+        {
+          label: "Homebrew",
+          commands: ["brew install opencode"],
+        },
+        {
+          label: "Paru (Arch)",
+          commands: ["paru -S opencode-bin"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Ensure Node.js is installed for npm-based installation",
+      "Verify installation with: opencode --version",
+      "Run '/connect' in OpenCode to configure LLM provider",
+      "For provider setup, authenticate at opencode.ai/auth",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: false,
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\n",
+    ignoredInputSequences: ["\n", "\x1b\r"],
+  },
+  env: {
+    COLORFGBG: "15;0",
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:opencode:primaryPatterns:start
+      "[⣾⣽⣻⢿⡿⣟⣯⣷]\\s+[^\\n]{2,80}\\s*\\(.*esc",
+      "[·•●]\\s+(Generating|Building tool call|Waiting for tool response)",
+      "press\\s+esc\\s+(again\\s+)?to\\s+(interrupt|exit\\s+cancel)",
+      "esc\\s*(again\\s+)?to\\s+(interrupt|cancel)",
+      // @generated:opencode:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:opencode:fallbackPatterns:start
+      "[⣾⣽⣻⢿⡿⣟⣯⣷]\\s+\\w",
+      "working[…\\.]+",
+      "generating",
+      "waiting for tool response",
+      "building tool call",
+      // @generated:opencode:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:opencode:bootCompletePatterns:start
+      "Ask anything",
+      "Build\\s+OpenCode",
+      // @generated:opencode:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*[›❯>]\\s*", "Ask anything"],
+    promptHintPatterns: ["Ask anything"],
+    completionPatterns: [
+      // @generated:opencode:completionPatterns:start
+      "Task\\s+completed",
+      "\\d+\\s+files?\\s+changed",
+      // @generated:opencode:completionPatterns:end
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.7,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "multi-provider",
+      "general-purpose",
+    ],
+    domains: {
+      frontend: 0.75,
+      backend: 0.75,
+      testing: 0.7,
+      refactoring: 0.7,
+      debugging: 0.7,
+      architecture: 0.7,
+    },
+    maxConcurrent: 1,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["-s", sessionId],
+    quitCommand: "/quit",
+    sessionIdPattern: "opencode -s ([\\w-]+)",
+  },
+  authCheck: {
+    // OpenCode v1.4.6+ uses XDG-compliant config paths on all platforms
+    configPathsAll: [".config/opencode/opencode.json", ".local/share/opencode/auth.json"],
+    // OpenCode is provider-agnostic and accepts provider credentials
+    // directly from env vars (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY),
+    // so any of these is a sufficient signal that the CLI is usable.
+    envVar: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
+  },
+  prerequisites: [
+    {
+      tool: "opencode",
+      label: "OpenCode CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://opencode.ai/docs/",
+    },
+  ],
+};

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -53,6 +53,13 @@ describe("buildResumeCommand", () => {
     expect(buildResumeCommand("my-custom-agent", "abc")).toBeUndefined();
   });
 
+  it("builds project-scoped (Kiro) resume command without using the sessionId param", () => {
+    // Kiro's `--resume` is directory-scoped — the session ID we pass in is
+    // ignored. Verify the schema dispatch correctly drops it instead of
+    // appending a stale ID after `--resume`.
+    expect(buildResumeCommand("kiro", "ignored-session-id")).toBe("kiro-cli --resume");
+  });
+
   it("escapes session IDs with special characters", () => {
     const cmd = buildResumeCommand("claude", "id with spaces");
     expect(cmd).toBeDefined();

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -423,6 +423,11 @@ export function buildAgentLaunchFlags(
  * When launchFlags are provided, they are prepended before the resume args
  * to restore the original process-level configuration.
  *
+ * Dispatches on `resume.kind` (see {@link AgentResume}). The `sessionId`
+ * parameter is passed verbatim — for `named-target` it is reinterpreted as
+ * the user-named target — so existing call sites that pass a session ID
+ * positionally continue to work without an API change.
+ *
  * @returns The resume command string, or undefined if the agent has no resume config.
  */
 export function buildResumeCommand(
@@ -431,7 +436,8 @@ export function buildResumeCommand(
   launchFlags?: string[]
 ): string | undefined {
   const agentConfig = getEffectiveAgentConfig(agentId);
-  if (!agentConfig?.resume) return undefined;
+  const resume = agentConfig?.resume;
+  if (!agentConfig || !resume) return undefined;
 
   const parts = [agentConfig.command];
 
@@ -446,7 +452,27 @@ export function buildResumeCommand(
     }
   }
 
-  const args = agentConfig.resume.args(sessionId);
+  let args: string[];
+  switch (resume.kind) {
+    case "session-id":
+      args = resume.args(sessionId);
+      break;
+    case "rolling-history":
+      args = resume.args();
+      break;
+    case "named-target":
+      args = resume.argsForTarget(sessionId);
+      break;
+    case "project-scoped":
+      args = resume.args();
+      break;
+    default: {
+      const _exhaustive: never = resume;
+      void _exhaustive;
+      return undefined;
+    }
+  }
+
   for (const arg of args) {
     if (arg.startsWith("-")) {
       parts.push(arg);


### PR DESCRIPTION
## Summary

- Splits the monolithic `shared/config/agentRegistry.ts` (~1,550 lines, 7 agents) into per-agent files under `shared/config/agents/<id>.ts`, following the same convention as `src/services/actions/definitions/`. Every future agent PR now touches a different file with no conflicts.
- Generalizes the package distribution field from `npmGlobalPackage` to a `packages` map (`npm`, `pypi`, `brew`, `winget`, `scoop`, `cargo`, `go`). `npmGlobalPackage` stays as a deprecated alias for one release. `CliAvailabilityService` now synthesizes uv/pipx probe paths automatically when `packages.pypi` is set.
- Replaces the ad-hoc `resume` + `shutdown` fields with a discriminated union (`session-id`, `rolling-history`, `named-target`, `project-scoped`). Kiro's fake never-matching `sessionIdPattern` hack is gone. A backward-compat adapter keeps existing persisted user-registry entries working.
- Adds `version.pypiPackage` support and wires `AgentVersionService` to query the PyPI JSON feed.
- Drops the hard-coded `SUPPORTED_AGENTS` allowlist in `scripts/pattern-discovery/runner.ts` — it now derives from `getAgentIds()`, so any newly registered agent is automatically accepted.
- Adds `pattern-discovery:record`, `pattern-discovery:analyze`, and `pattern-discovery:update` npm script aliases.

Resolves #6130

## Changes

- `shared/config/agentRegistry.ts` — trimmed to helpers, barrel imports, and the runtime integrity check
- `shared/config/agents/` — 7 new per-agent files (`claude.ts`, `gemini.ts`, `codex.ts`, `opencode.ts`, `copilot.ts`, `cursor.ts`, `kiro.ts`)
- `shared/types/agentSettings.ts` — `resume` discriminated union + backward-compat `buildResumeCommand` adapter
- `electron/services/CliAvailabilityService.ts` — pypi/uv/pipx probe synthesis
- `electron/services/AgentVersionService.ts` — PyPI feed lookup
- `scripts/pattern-discovery/runner.ts` + `update-registry.ts` — agent-agnostic, no more hardcoded list
- `package.json` — pattern-discovery script aliases
- Tests updated/extended throughout (`agentRegistry.test.ts`, `CliAvailabilityService.test.ts`, `AgentVersionService.resilience.test.ts`, `agentSettings.test.ts`)

## Testing

- Unit tests cover the full per-agent registry shape, PyPI probe paths (positive + missing-binary), the resume union exhaustiveness guard, and a smoke test for pattern-discovery accepting an unrecognized agent ID.
- Existing E2E tests for Claude/Codex/Gemini exercise the renamed fields end-to-end — no new online or E2E tests needed for a pure refactor + schema change.