### PR TITLE
fix(setup): use Plug icon in agent setup wizard title

### DIFF
--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -15,7 +15,7 @@ import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion, type Variants } from "framer-motion";
-import { Sprout } from "@/components/icons";
+import { Plug } from "@/components/icons";
 import { UI_ENTER_DURATION, UI_EXIT_DURATION } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
@@ -535,7 +535,7 @@ export function AgentSetupWizard({
       dismissible={!isSaving}
     >
       <AppDialog.Header>
-        <AppDialog.Title icon={<Sprout className="w-5 h-5 text-daintree-accent" />}>
+        <AppDialog.Title icon={<Plug className="w-5 h-5 text-daintree-accent" />}>
           Agent Setup
         </AppDialog.Title>
         <div className="flex items-center gap-3">

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -12,6 +12,6 @@ export {
   Folders, // copy tree / file hierarchy capture (two overlapping folders)
   Layers, // worktree overview (multiple worktrees, stacked)
   Plug, // agent (integration that plugs into the host system)
-  Sprout, // agent setup / first-time agent (planting a seed)
+  Sprout, // origin / first step (main worktree, first agent launch)
   Workflow, // terminal recipe / scripted command sequence
 } from "lucide-react";


### PR DESCRIPTION
## Summary

- The agent tray's "Setup agents" button uses the `Plug` icon, but the setup wizard's dialog title was using `Sprout` (a leaf). Switching icons mid-flow made the affordance feel disconnected.
- Swapped `Sprout` for `Plug` in `AgentSetupWizard` so the entry point and dialog title stay consistent.
- Also tidied the `Sprout` export comment in the icon barrel to reflect its actual usage (main worktree marker and onboarding first-agent launch).

Resolves #6141

## Changes

- `src/components/Setup/AgentSetupWizard.tsx` — replace `Sprout` import with `Plug` in the `AppDialog.Title` render
- `src/components/icons/index.ts` — remove stale "agent setup" annotation from `Sprout`, document real usage

## Testing

- Opened the agent setup wizard via the tray button — dialog title now shows the plug icon, matching the entry point
- Verified `npm run check` passes clean with no new warnings (baseline 2425 held)