### PR TITLE
feat(agents): add Goose as a built-in agent

### DIFF
--- a/electron/services/__tests__/AgentRouter.test.ts
+++ b/electron/services/__tests__/AgentRouter.test.ts
@@ -76,6 +76,8 @@ describe("AgentRouter", () => {
       events.emit("task:assigned", { taskId: "t11", agentId: "kiro", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t12", agentId: "copilot", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t13", agentId: "copilot", timestamp: Date.now() });
+      events.emit("task:assigned", { taskId: "t14", agentId: "goose", timestamp: Date.now() });
+      events.emit("task:assigned", { taskId: "t15", agentId: "goose", timestamp: Date.now() });
 
       // Now all agents should be at capacity
       const agentId = await router.routeTask({

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -163,12 +163,12 @@ describe("CliAvailabilityService", () => {
         expect(detail?.authConfirmed).toBe(false);
       }
 
-      // Should have called execFileSync 7 times (once for each CLI).
+      // Should have called execFileSync 8 times (once for each CLI).
       // Fallback probes (native paths, npm-global, WSL) run via async execFile and
       // only fire when the which/where probe returns missing — in this test
       // every agent succeeds on the first probe, so execFileSync count
       // matches the registry size exactly.
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
 
       // stdio is now [ignore, pipe, ignore] so we can capture the resolved
       // path from stdout while still suppressing any TTY output on stderr.
@@ -662,7 +662,7 @@ describe("CliAvailabilityService", () => {
       vi.clearAllMocks();
 
       await service.refresh();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
     });
   });
 

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -216,6 +216,7 @@ describe("CliAvailabilityService", () => {
         cursor: "missing",
         kiro: "missing",
         copilot: "missing",
+        goose: "missing",
       });
     });
 
@@ -586,11 +587,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      // 7 successful primary calls + 6 BusyBox-style bare-`which` retries
-      // (the 6 agents whose mock throws a generic `Error` with no errno
+      // 8 successful primary calls + 7 BusyBox-style bare-`which` retries
+      // (the 7 agents whose mock throws a generic `Error` with no errno
       // code — which `probeViaShell` retries without `-a` to recover
       // BusyBox/minimal `which` builds that reject the flag).
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(15);
     });
 
     it("works on cold start before initial check", async () => {
@@ -618,7 +619,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      expect(executionOrder).toHaveLength(7);
+      expect(executionOrder).toHaveLength(8);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
       expect(executionOrder).toContain("codex");
@@ -626,6 +627,7 @@ describe("CliAvailabilityService", () => {
       expect(executionOrder).toContain("cursor-agent");
       expect(executionOrder).toContain("kiro-cli");
       expect(executionOrder).toContain("copilot");
+      expect(executionOrder).toContain("goose");
     });
 
     it("deduplicates concurrent checkAvailability calls", async () => {
@@ -639,7 +641,7 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
@@ -648,14 +650,14 @@ describe("CliAvailabilityService", () => {
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
       expect(result1).toEqual(result2);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(16);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       await service.checkAvailability();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(7);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(8);
 
       vi.clearAllMocks();
 

--- a/scripts/pattern-discovery/corpus/goose_sample.jsonl
+++ b/scripts/pattern-discovery/corpus/goose_sample.jsonl
@@ -1,0 +1,15 @@
+{"time":0.0,"chunk":"   __( O)>","detectedState":"initializing","confidence":0.9,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":0.2,"chunk":"goose is ready — provider: anthropic, model: claude-sonnet-4-6","detectedState":"initializing","confidence":0.9,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":0.5,"chunk":"🪿 ","detectedState":"waiting","confidence":0.85,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":1.0,"chunk":"⠋ Thinking (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":2.0,"chunk":"⠙ Generating response (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":3.0,"chunk":"⠹ Reading files (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":4.0,"chunk":"▸ developer__shell","detectedState":"working","confidence":0.75,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":4.5,"chunk":"▸ developer__text_editor","detectedState":"working","confidence":0.75,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":5.0,"chunk":"⠸ Working on it (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":6.0,"chunk":"⠼ Calling tool (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":7.0,"chunk":"🪿 follow-up question?","detectedState":"waiting","confidence":0.85,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":8.0,"chunk":"⠴ Streaming (Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":9.0,"chunk":"● session closed · 20260429_1","detectedState":"completed","confidence":0.9,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":10.0,"chunk":"context left: 78%","detectedState":"waiting","confidence":0.0,"agentId":"goose","agentVersion":"1.0.0"}
+{"time":11.0,"chunk":"Done. Ready for next instruction.","detectedState":"waiting","confidence":0.0,"agentId":"goose","agentVersion":"1.0.0"}

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -37,6 +37,7 @@ describe("agentRegistry", () => {
       expect(ids).toContain("cursor");
       expect(ids).toContain("kiro");
       expect(ids).toContain("copilot");
+      expect(ids).toContain("goose");
     });
 
     it("kiro only has macOS and Linux install blocks (no Windows)", () => {
@@ -721,6 +722,30 @@ describe("resume configuration", () => {
   it("cursor has no resume config (no session resume model)", () => {
     expect(getAgentConfig("cursor")?.resume).toBeUndefined();
   });
+
+  it("goose is session-id and produces session subcommand resume args", () => {
+    const resume = getAgentConfig("goose")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.args("20260429_1")).toEqual([
+        "session",
+        "--resume",
+        "--session-id",
+        "20260429_1",
+      ]);
+      expect(resume.quitCommand).toBe("/exit");
+    }
+  });
+
+  it("goose sessionIdPattern extracts the id from the session-closed line", () => {
+    const resume = getAgentConfig("goose")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      const re = new RegExp(resume.sessionIdPattern);
+      const match = re.exec("● session closed · 20260429_1");
+      expect(match?.[1]).toBe("20260429_1");
+    }
+  });
 });
 
 describe("titleStatePatterns", () => {
@@ -902,7 +927,7 @@ describe("cursor install metadata", () => {
 });
 
 describe("all built-in agents have Windows or generic install", () => {
-  it.each(["claude", "gemini", "codex", "opencode", "cursor", "copilot"])(
+  it.each(["claude", "gemini", "codex", "opencode", "cursor", "copilot", "goose"])(
     "%s has windows or generic install block",
     (agentId) => {
       const config = getAgentConfig(agentId);
@@ -1038,5 +1063,87 @@ describe("opencode detection patterns", () => {
       const patterns = compileAgentPatterns("opencode", "fallbackPatterns");
       expect(patterns.some((p) => p.test("⠋ working"))).toBe(false);
     });
+  });
+});
+
+describe("goose detection patterns", () => {
+  function compileAgentPatterns(agentId: string, key: string): RegExp[] {
+    const config = getAgentConfig(agentId);
+    const patterns = config?.detection?.[key as keyof typeof config.detection] as
+      | string[]
+      | undefined;
+    return (patterns ?? []).map((p: string) => new RegExp(p, "im"));
+  }
+
+  describe("primaryPatterns", () => {
+    it.each([
+      "Thinking (Ctrl+C to interrupt)",
+      "Generating response (Ctrl+C to interrupt)",
+      "⠋ Reading files (Ctrl+C to interrupt)",
+    ])("matches Ctrl+C interrupt hint: %s", (line) => {
+      const patterns = compileAgentPatterns("goose", "primaryPatterns");
+      expect(patterns.some((p) => p.test(line))).toBe(true);
+    });
+
+    it("does not match plain text without the interrupt hint", () => {
+      const patterns = compileAgentPatterns("goose", "primaryPatterns");
+      expect(patterns.some((p) => p.test("Thinking about something"))).toBe(false);
+    });
+  });
+
+  describe("fallbackPatterns", () => {
+    it.each([
+      "⠋ Working",
+      "⠙ Generating",
+      "⠹ Reading",
+      "⠸ Thinking",
+      "⠼ Calling",
+      "⠴ Streaming",
+      "⠦ Planning",
+      "⠧ Analyzing",
+      "⠇ Searching",
+      "⠏ Editing",
+    ])("matches cliclack braille spinner: %s", (line) => {
+      const patterns = compileAgentPatterns("goose", "fallbackPatterns");
+      expect(patterns.some((p) => p.test(line))).toBe(true);
+    });
+
+    it.each(["▸ developer__shell", "▸ developer__text_editor"])(
+      "matches tool-call marker: %s",
+      (line) => {
+        const patterns = compileAgentPatterns("goose", "fallbackPatterns");
+        expect(patterns.some((p) => p.test(line))).toBe(true);
+      }
+    );
+
+    it("does not match Bubble Tea braille spinners (OpenCode set)", () => {
+      const patterns = compileAgentPatterns("goose", "fallbackPatterns");
+      expect(patterns.some((p) => p.test("⣾ working"))).toBe(false);
+      expect(patterns.some((p) => p.test("⣷ processing"))).toBe(false);
+    });
+  });
+
+  describe("promptPatterns", () => {
+    it.each(["🪿 ", "🪿 follow-up question?"])("matches goose emoji prompt: %s", (line) => {
+      const patterns = compileAgentPatterns("goose", "promptPatterns");
+      expect(patterns.some((p) => p.test(line))).toBe(true);
+    });
+  });
+
+  describe("bootCompletePatterns", () => {
+    it("matches 'goose is ready' boot line", () => {
+      const patterns = compileAgentPatterns("goose", "bootCompletePatterns");
+      expect(patterns.some((p) => p.test("goose is ready — provider: anthropic"))).toBe(true);
+    });
+  });
+
+  describe("completionPatterns", () => {
+    it.each(["● session closed · 20260429_1", "session closed · abc-123"])(
+      "matches session-closed line: %s",
+      (line) => {
+        const patterns = compileAgentPatterns("goose", "completionPatterns");
+        expect(patterns.some((p) => p.test(line))).toBe(true);
+      }
+    );
   });
 });

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1145,5 +1145,12 @@ describe("goose detection patterns", () => {
         expect(patterns.some((p) => p.test(line))).toBe(true);
       }
     );
+
+    it("does not match unrelated logs that mention 'session closed' mid-sentence", () => {
+      const patterns = compileAgentPatterns("goose", "completionPatterns");
+      expect(
+        patterns.some((p) => p.test("The websocket session closed unexpectedly; retrying..."))
+      ).toBe(false);
+    });
   });
 });

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -6,6 +6,7 @@ export const BUILT_IN_AGENT_IDS = [
   "cursor",
   "kiro",
   "copilot",
+  "goose",
 ] as const;
 
 export type BuiltInAgentId = (typeof BUILT_IN_AGENT_IDS)[number];

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -439,6 +439,7 @@ import { config as opencodeConfig } from "./agents/opencode.js";
 import { config as cursorConfig } from "./agents/cursor.js";
 import { config as kiroConfig } from "./agents/kiro.js";
 import { config as copilotConfig } from "./agents/copilot.js";
+import { config as gooseConfig } from "./agents/goose.js";
 
 // Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
 // (mirroring `src/services/actions/definitions/`). When adding a new agent,
@@ -453,6 +454,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
   cursor: cursorConfig,
   kiro: kiroConfig,
   copilot: copilotConfig,
+  goose: gooseConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -1,0 +1,150 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "goose",
+  name: "Goose",
+  command: "goose",
+  args: ["session"],
+  // Goose's curl installer (https://block.github.io/goose/install.sh) drops the
+  // binary at ~/.local/bin/goose on POSIX. The native PowerShell installer on
+  // Windows lands it at %USERPROFILE%\goose\goose.exe.
+  nativePaths: ["~/.local/bin/goose", "%USERPROFILE%\\goose\\goose.exe"],
+  color: "#1c1c1c",
+  iconId: "goose",
+  supportsContextInjection: true,
+  tooltip: "provider-agnostic, by Block Inc.",
+  usageUrl: "https://block.github.io/goose/",
+  version: {
+    args: ["--version"],
+    githubRepo: "block/goose",
+    releaseNotesUrl: "https://github.com/block/goose/releases",
+  },
+  update: {
+    brew: "brew upgrade block-goose-cli",
+    curl: "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash",
+  },
+  packages: {
+    brew: "block-goose-cli",
+  },
+  install: {
+    docsUrl: "https://block.github.io/goose/docs/getting-started/installation",
+    byOs: {
+      macos: [
+        {
+          label: "curl",
+          commands: [
+            "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash",
+          ],
+        },
+        {
+          label: "Homebrew",
+          commands: ["brew install block-goose-cli"],
+        },
+      ],
+      linux: [
+        {
+          label: "curl",
+          commands: [
+            "curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash",
+          ],
+        },
+        {
+          label: "Homebrew",
+          commands: ["brew install block-goose-cli"],
+        },
+      ],
+      windows: [
+        {
+          label: "PowerShell",
+          commands: [
+            "irm https://github.com/block/goose/releases/download/stable/download_cli.ps1 | iex",
+          ],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: goose --version",
+      "Run 'goose configure' to set provider, model, and credentials",
+      "Provider env vars (GOOSE_PROVIDER, GOOSE_MODEL, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY) take precedence over the on-disk config.",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: false,
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\n",
+    ignoredInputSequences: ["\n", "\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // Stable hint emitted by goose-cli on every "working" line; see
+      // crates/goose-cli/src/session/thinking.rs upstream.
+      "\\(Ctrl\\+C to interrupt\\)",
+    ],
+    fallbackPatterns: [
+      // cliclack braille spinner frames — distinct from Bubble Tea (OpenCode)
+      // and Ink (Gemini); copy-pasting between agents is a known footgun (#3941).
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
+      // Tool-call activity marker (U+25B8 BLACK RIGHT-POINTING SMALL TRIANGLE).
+      "▸\\s+\\S",
+    ],
+    bootCompletePatterns: ["goose is ready"],
+    promptPatterns: ["^🪿\\s"],
+    promptHintPatterns: ["^🪿\\s"],
+    // Goose prints "● session closed · <id>" at graceful exit (U+25CF marker);
+    // see crates/goose-cli/src/session/output.rs upstream.
+    completionPatterns: ["●\\s+session closed", "session closed"],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "multi-provider",
+      "general-purpose",
+    ],
+    domains: {
+      frontend: 0.75,
+      backend: 0.75,
+      testing: 0.7,
+      refactoring: 0.7,
+      debugging: 0.7,
+      architecture: 0.7,
+    },
+    maxConcurrent: 1,
+    enabled: true,
+  },
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["session", "--resume", "--session-id", sessionId],
+    quitCommand: "/exit",
+    sessionIdPattern: "session closed\\s*·\\s*([\\w-]+)",
+  },
+  authCheck: {
+    configPaths: {
+      // macOS uses Application Support, NOT ~/.config (#6132 source-verified).
+      darwin: ["Library/Application Support/Block/goose/config.yaml"],
+      linux: [".config/goose/config.yaml"],
+      win32: ["AppData/Roaming/Block/goose/config/config.yaml"],
+    },
+    envVar: ["GOOSE_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
+  },
+  prerequisites: [
+    {
+      tool: "goose",
+      label: "Goose CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://block.github.io/goose/docs/getting-started/installation",
+    },
+  ],
+};

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -5,10 +5,11 @@ export const config: AgentConfig = {
   name: "Goose",
   command: "goose",
   args: ["session"],
-  // Goose's curl installer (https://block.github.io/goose/install.sh) drops the
-  // binary at ~/.local/bin/goose on POSIX. The native PowerShell installer on
-  // Windows lands it at %USERPROFILE%\goose\goose.exe.
-  nativePaths: ["~/.local/bin/goose", "%USERPROFILE%\\goose\\goose.exe"],
+  // Goose's curl installer drops the binary at ~/.local/bin/goose on POSIX.
+  // The PS1 installer (download_cli.ps1) defaults GOOSE_BIN_DIR to
+  // $env:USERPROFILE\.local\bin so the binary lands at
+  // %USERPROFILE%\.local\bin\goose.exe on Windows.
+  nativePaths: ["~/.local/bin/goose", "%USERPROFILE%\\.local\\bin\\goose.exe"],
   color: "#1c1c1c",
   iconId: "goose",
   supportsContextInjection: true,
@@ -57,7 +58,7 @@ export const config: AgentConfig = {
         {
           label: "PowerShell",
           commands: [
-            "irm https://github.com/block/goose/releases/download/stable/download_cli.ps1 | iex",
+            "irm https://raw.githubusercontent.com/block/goose/main/download_cli.ps1 | iex",
           ],
         },
       ],
@@ -93,8 +94,11 @@ export const config: AgentConfig = {
     promptPatterns: ["^🪿\\s"],
     promptHintPatterns: ["^🪿\\s"],
     // Goose prints "● session closed · <id>" at graceful exit (U+25CF marker);
-    // see crates/goose-cli/src/session/output.rs upstream.
-    completionPatterns: ["●\\s+session closed", "session closed"],
+    // see crates/goose-cli/src/session/output.rs upstream. Anchored to start of
+    // line so unrelated logs that mention "session closed" mid-sentence
+    // (e.g. "The websocket session closed unexpectedly") don't trigger the
+    // brief completion transition.
+    completionPatterns: ["^\\s*●?\\s*session closed"],
     completionConfidence: 0.9,
     scanLineCount: 10,
     primaryConfidence: 0.95,

--- a/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
@@ -33,7 +33,7 @@ describe("Skip permissions toggle gating", () => {
     );
 
     expect(agentsWithToggle).toEqual(["claude", "gemini", "codex", "cursor"]);
-    expect(agentsWithoutToggle).toEqual(["opencode", "kiro", "copilot"]);
+    expect(agentsWithoutToggle).toEqual(["opencode", "kiro", "copilot", "goose"]);
   });
 
   it("all dangerous args are non-empty strings starting with --", () => {

--- a/src/components/icons/brands/GooseIcon.tsx
+++ b/src/components/icons/brands/GooseIcon.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+interface GooseIconProps {
+  className?: string;
+  size?: number;
+  brandColor?: string;
+}
+
+export function GooseIcon({ className, size = 16, brandColor }: GooseIconProps) {
+  // Stylized goose silhouette: head + curved neck + body, evoking the
+  // "__( O)>" boot banner ASCII glyph upstream uses for Block's Goose CLI.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      <path
+        fill={brandColor || "currentColor"}
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M14 3.5a3 3 0 0 0-3 3v.6a4.5 4.5 0 0 0-3.2 4.3v.5l-3.6 1.5a.8.8 0 0 0 .3 1.5h3.6a4.5 4.5 0 0 0 4.4 3.6h.7v2H7a.8.8 0 0 0 0 1.5h11a.8.8 0 0 0 0-1.5h-3.5v-2h.7a4.5 4.5 0 0 0 4.5-4.5V8a4.5 4.5 0 0 0-4-4.5V6.5a.8.8 0 0 1-1.5 0v-3a.5.5 0 0 0-.2 0Zm.7 5.7a.9.9 0 1 0 0-1.8.9.9 0 0 0 0 1.8Z"
+      />
+    </svg>
+  );
+}
+
+export default GooseIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -6,6 +6,7 @@ export { OpenCodeIcon } from "./OpenCodeIcon";
 export { CursorIcon } from "./CursorIcon";
 export { KiroIcon } from "./KiroIcon";
 export { CopilotIcon } from "./CopilotIcon";
+export { GooseIcon } from "./GooseIcon";
 
 // JavaScript ecosystem
 export { NpmIcon } from "./NpmIcon";

--- a/src/config/__tests__/agentIcons.test.ts
+++ b/src/config/__tests__/agentIcons.test.ts
@@ -26,6 +26,7 @@ describe("agentIcons", () => {
     expect(AGENT_ICON_MAP["cursor"]).toBeDefined();
     expect(AGENT_ICON_MAP["kiro"]).toBeDefined();
     expect(AGENT_ICON_MAP["copilot"]).toBeDefined();
+    expect(AGENT_ICON_MAP["goose"]).toBeDefined();
   });
 
   it("normalizes icon filenames to lowercase iconIds", () => {


### PR DESCRIPTION
## Summary

- Adds Goose (block/goose, Rust rewrite, 43.5k stars) as a first-class built-in agent with full `AgentConfig` — command, args, install paths, detection patterns, session-id resume, and auth check
- Detection is anchored on `(Ctrl+C to interrupt)` as the primary working signal, cliclack braille spinners as fallback, and `goose is ready` for boot complete — all source-verified against upstream `crates/goose-cli/src/session/output.rs`
- Install URLs were probed empirically during implementation; the Windows PS1 path was corrected after a 404 was caught in review

Resolves #6132

## Changes

- `shared/config/agents/goose.ts` — full `AgentConfig` with session-id resume, multi-provider auth check, and both POSIX and Windows native paths
- `src/components/icons/brands/GooseIcon.tsx` — Lucide-style 24x24 silhouette icon
- `scripts/pattern-discovery/corpus/goose_sample.jsonl` — 15 corpus lines covering boot, working spinner, tool-call, exit, and prompt states
- `shared/config/agentIds.ts` + `agentRegistry.ts` — wired up to the registry
- `shared/config/__tests__/agentRegistry.test.ts` + `src/config/__tests__/agentIcons.test.ts` — registry shape, Windows install, detection patterns, and resume contract tests

## Testing

Typecheck, lint (no new warnings on 2425 baseline), format, and 180 vitest tests pass. Install URLs confirmed live via curl probe. Pattern set reviewed against the cliclack braille sets used by OpenCode and Gemini to avoid false positives.