### PR TITLE
feat(agents): add Aider as a built-in agent

### DIFF
--- a/electron/services/__tests__/AgentRouter.test.ts
+++ b/electron/services/__tests__/AgentRouter.test.ts
@@ -46,6 +46,7 @@ describe("AgentRouter", () => {
         "mistral",
         "kimi",
         "amp",
+        "aider",
       ]).toContain(agentId);
     });
 
@@ -78,6 +79,7 @@ describe("AgentRouter", () => {
         "mistral",
         "kimi",
         "amp",
+        "aider",
       ]).toContain(agentId);
     });
 
@@ -118,6 +120,7 @@ describe("AgentRouter", () => {
       events.emit("task:assigned", { taskId: "t23", agentId: "kimi", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t24", agentId: "amp", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t25", agentId: "amp", timestamp: Date.now() });
+      events.emit("task:assigned", { taskId: "t26", agentId: "aider", timestamp: Date.now() });
 
       // Now all agents should be at capacity
       const agentId = await router.routeTask({

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -165,12 +165,12 @@ describe("CliAvailabilityService", () => {
         expect(detail?.authConfirmed).toBe(false);
       }
 
-      // Should have called execFileSync 14 times (once for each CLI).
+      // Should have called execFileSync 15 times (once for each CLI).
       // Fallback probes (native paths, npm-global, WSL) run via async execFile and
       // only fire when the which/where probe returns missing — in this test
       // every agent succeeds on the first probe, so execFileSync count
       // matches the registry size exactly.
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(15);
 
       // stdio is now [ignore, pipe, ignore] so we can capture the resolved
       // path from stdout while still suppressing any TTY output on stderr.
@@ -211,6 +211,7 @@ describe("CliAvailabilityService", () => {
       const result = await service.checkAvailability();
 
       expect(result).toEqual({
+        aider: "missing",
         claude: "missing",
         gemini: "missing",
         codex: "missing",
@@ -253,6 +254,7 @@ describe("CliAvailabilityService", () => {
 
       const result = await service.checkAvailability();
 
+      expect(result.aider).toBe("missing");
       expect(result.claude).toBe("ready");
       expect(result.gemini).toBe("missing");
       expect(result.codex).toBe("missing");
@@ -598,11 +600,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      // 14 successful primary calls + 13 BusyBox-style bare-`which` retries
-      // (the 13 agents whose mock throws a generic `Error` with no errno
+      // 15 successful primary calls + 14 BusyBox-style bare-`which` retries
+      // (the 14 agents whose mock throws a generic `Error` with no errno
       // code — which `probeViaShell` retries without `-a` to recover
       // BusyBox/minimal `which` builds that reject the flag).
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(27);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(29);
     });
 
     it("works on cold start before initial check", async () => {
@@ -630,7 +632,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      expect(executionOrder).toHaveLength(14);
+      expect(executionOrder).toHaveLength(15);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
       expect(executionOrder).toContain("codex");
@@ -645,6 +647,7 @@ describe("CliAvailabilityService", () => {
       expect(executionOrder).toContain("vibe");
       expect(executionOrder).toContain("kimi");
       expect(executionOrder).toContain("amp");
+      expect(executionOrder).toContain("aider");
     });
 
     it("deduplicates concurrent checkAvailability calls", async () => {
@@ -658,7 +661,7 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(15);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
@@ -667,19 +670,19 @@ describe("CliAvailabilityService", () => {
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
       expect(result1).toEqual(result2);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(28);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(30);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       await service.checkAvailability();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(15);
 
       vi.clearAllMocks();
 
       await service.refresh();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(14);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(15);
     });
   });
 
@@ -1542,7 +1545,7 @@ describe("CliAvailabilityService", () => {
     });
 
     it("does not synthesise PyPI paths when packages.pypi is unset", async () => {
-      // Agents that legitimately declare `packages.pypi` (interpreter, mistral, kimi)
+      // Agents that legitimately declare `packages.pypi` (interpreter, mistral, kimi, aider)
       // SHOULD probe uv/pipx layouts; every other built-in does not, and must not
       // produce PyPI-shaped fs.access calls. This guards against accidental
       // probing when an agent has e.g. `npmGlobalPackage` only.
@@ -1557,21 +1560,30 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
 
       // Filter out paths synthesised for agents whose `packages.pypi`
-      // legitimately triggers uv/pipx probing (interpreter, mistral, kimi).
+      // legitimately triggers uv/pipx probing (interpreter, mistral, kimi, aider).
       // Remaining probed paths must not include any uv/pipx layouts.
-      const probedPaths = mockedAccess.mock.calls
-        .map((c) => String(c[0]))
-        .filter(
-          (p) =>
-            !p.includes("open-interpreter") &&
-            !p.includes("/interpreter") &&
-            !p.includes("mistral") &&
-            !p.includes("/vibe") &&
-            !p.includes("kimi-cli") &&
-            !p.includes("/kimi")
-        );
+      const allProbedPaths = mockedAccess.mock.calls.map((c) => String(c[0]));
+      const probedPaths = allProbedPaths.filter(
+        (p) =>
+          !p.includes("open-interpreter") &&
+          !p.includes("/interpreter") &&
+          !p.includes("mistral") &&
+          !p.includes("/vibe") &&
+          !p.includes("kimi-cli") &&
+          !p.includes("/kimi") &&
+          !p.includes("aider")
+      );
       expect(probedPaths.some((p) => p.includes(".local/share/uv/tools"))).toBe(false);
       expect(probedPaths.some((p) => p.includes(".local/share/pipx/venvs"))).toBe(false);
+
+      // Aider declares packages.pypi so its uv/pipx paths SHOULD be probed.
+      const aiderUvPaths = allProbedPaths.filter(
+        (p) => p.includes(".local/share/uv/tools") && p.includes("aider")
+      );
+      const aiderPipxPaths = allProbedPaths.filter(
+        (p) => p.includes(".local/share/pipx/venvs") && p.includes("aider")
+      );
+      expect(aiderUvPaths.length > 0 || aiderPipxPaths.length > 0).toBe(true);
     });
   });
 

--- a/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
+++ b/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
@@ -61,6 +61,14 @@ describe("corpus-replay", () => {
     });
   });
 
+  describe("aider corpus replay", () => {
+    it("achieves >= 90% accuracy on aider sample corpus", () => {
+      const result = replayCorpus(path.join(CORPUS_DIR, "aider_sample.jsonl"), "aider");
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.accuracy).toBeGreaterThanOrEqual(MIN_ACCURACY);
+    });
+  });
+
   describe("replay result structure", () => {
     it("returns detailed wrong entries for debugging", () => {
       const result = replayCorpus(path.join(CORPUS_DIR, "claude_sample.jsonl"), "claude");

--- a/scripts/pattern-discovery/corpus/aider_sample.jsonl
+++ b/scripts/pattern-discovery/corpus/aider_sample.jsonl
@@ -1,0 +1,15 @@
+{"time":0.0,"chunk":"Aider v0.86.0","detectedState":"initializing","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":0.2,"chunk":"Main model: claude-3-5-sonnet-20241022 with diff edit format, prompt cache","detectedState":"initializing","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":0.4,"chunk":"Git repo: .git with 142 files","detectedState":"initializing","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":0.6,"chunk":"Repo-map: using 1024 tokens, auto refresh","detectedState":"initializing","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":0.8,"chunk":"Use /help <question> for help, run \"aider --help\" to see cmd line args","detectedState":"waiting","confidence":0.85,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":1.0,"chunk":"> ","detectedState":"waiting","confidence":0.85,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":2.0,"chunk":"░░░░░░░░░█ Waiting for claude-3-5-sonnet-20241022","detectedState":"working","confidence":0.95,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":2.4,"chunk":"░░░░██░░░░ Waiting for claude-3-5-sonnet-20241022","detectedState":"working","confidence":0.95,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":2.8,"chunk":"█░░░░░░░░░ Waiting for claude-3-5-sonnet-20241022","detectedState":"working","confidence":0.95,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":3.2,"chunk":"=====#==== Waiting for gpt-4o","detectedState":"working","confidence":0.7,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":4.0,"chunk":"Applied edit to src/components/Button.tsx","detectedState":"completed","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":4.2,"chunk":"Applied edit to src/components/index.ts","detectedState":"completed","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":4.6,"chunk":"Commit a1b2c3d feat: add Button variant prop","detectedState":"completed","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":5.0,"chunk":"Tokens: 1.5k sent, 432 received. Cost: $0.02 message, $0.08 session.","detectedState":"completed","confidence":0.9,"agentId":"aider","agentVersion":"0.86.0"}
+{"time":5.4,"chunk":"architect> ","detectedState":"waiting","confidence":0.85,"agentId":"aider","agentVersion":"0.86.0"}

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1404,6 +1404,11 @@ describe("aider configuration", () => {
     const envVars = Array.isArray(auth?.envVar) ? auth?.envVar : [auth?.envVar];
     expect(envVars).toContain("OPENAI_API_KEY");
     expect(envVars).toContain("ANTHROPIC_API_KEY");
+    // AIDER_*_API_KEY variants are documented in envSuggestions; auth must
+    // recognise them so users who set only the AIDER_-prefixed key don't
+    // see a stale "unauthenticated" nudge.
+    expect(envVars).toContain("AIDER_OPENAI_API_KEY");
+    expect(envVars).toContain("AIDER_ANTHROPIC_API_KEY");
   });
 });
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -44,6 +44,7 @@ describe("agentRegistry", () => {
       expect(ids).toContain("mistral");
       expect(ids).toContain("kimi");
       expect(ids).toContain("amp");
+      expect(ids).toContain("aider");
     });
 
     it("kiro only has macOS and Linux install blocks (no Windows)", () => {
@@ -1219,6 +1220,7 @@ describe("all built-in agents have Windows or generic install", () => {
     "mistral",
     "kimi",
     "amp",
+    "aider",
   ])("%s has windows or generic install block", (agentId) => {
     const config = getAgentConfig(agentId);
     const hasWindows = (config?.install?.byOs?.windows?.length ?? 0) > 0;
@@ -1355,6 +1357,56 @@ describe("opencode detection patterns", () => {
   });
 });
 
+describe("aider configuration", () => {
+  it("uses pypi packaging with aider-chat", () => {
+    const config = getAgentConfig("aider");
+    expect(config?.packages?.pypi).toBe("aider-chat");
+    expect(config?.packages?.brew).toBe("aider");
+  });
+
+  it("looks up version from PyPI", () => {
+    const config = getAgentConfig("aider");
+    expect(config?.version?.pypiPackage).toBe("aider-chat");
+    expect(config?.version?.githubRepo).toBe("Aider-AI/aider");
+  });
+
+  it("defaults --no-auto-commits to keep worktree commits clean", () => {
+    const config = getAgentConfig("aider");
+    expect(config?.args).toContain("--no-auto-commits");
+  });
+
+  it("does not duplicate ~/.local/bin paths covered by pypi synthesis", () => {
+    const config = getAgentConfig("aider");
+    const paths = config?.nativePaths ?? [];
+    expect(paths.some((p) => p.includes(".local/bin/aider"))).toBe(false);
+    expect(paths).toContain("/opt/homebrew/bin/aider");
+    expect(paths).toContain("/usr/local/bin/aider");
+    expect(paths.some((p) => p.toLowerCase().includes("%userprofile%"))).toBe(true);
+  });
+
+  it("uses rolling-history resume with --restore-chat-history", () => {
+    const resume = getAgentConfig("aider")?.resume;
+    expect(resume?.kind).toBe("rolling-history");
+    if (resume?.kind === "rolling-history") {
+      expect(resume.args()).toEqual(["--restore-chat-history"]);
+      expect(resume.quitCommand).toBe("/exit");
+    }
+  });
+
+  it("streams to scrollback (no alt-screen block)", () => {
+    const config = getAgentConfig("aider");
+    expect(config?.capabilities?.blockAltScreen).toBe(false);
+  });
+
+  it("accepts any of the major provider env vars for auth", () => {
+    const auth = getAgentConfig("aider")?.authCheck;
+    expect(auth?.configPathsAll).toContain(".aider.conf.yml");
+    const envVars = Array.isArray(auth?.envVar) ? auth?.envVar : [auth?.envVar];
+    expect(envVars).toContain("OPENAI_API_KEY");
+    expect(envVars).toContain("ANTHROPIC_API_KEY");
+  });
+});
+
 describe("goose detection patterns", () => {
   function compileAgentPatterns(agentId: string, key: string): RegExp[] {
     const config = getAgentConfig(agentId);
@@ -1441,5 +1493,57 @@ describe("goose detection patterns", () => {
         patterns.some((p) => p.test("The websocket session closed unexpectedly; retrying..."))
       ).toBe(false);
     });
+  });
+});
+
+describe("aider detection patterns", () => {
+  function compileAgentPatterns(agentId: string, key: string): RegExp[] {
+    const config = getAgentConfig(agentId);
+    const patterns = config?.detection?.[key as keyof typeof config.detection] as
+      | string[]
+      | undefined;
+    return (patterns ?? []).map((p: string) => new RegExp(p, "im"));
+  }
+
+  it("matches Knight-Rider unicode scanner with Waiting for", () => {
+    const patterns = compileAgentPatterns("aider", "primaryPatterns");
+    expect(patterns.some((p) => p.test("░░░░░░░░░█ Waiting for claude-3-5-sonnet"))).toBe(true);
+    expect(patterns.some((p) => p.test("░░██░░░░░░ Waiting for gpt-4o"))).toBe(true);
+  });
+
+  it("does not match braille spinners (those belong to other agents)", () => {
+    const patterns = compileAgentPatterns("aider", "primaryPatterns");
+    expect(patterns.some((p) => p.test("⣾ Waiting for claude"))).toBe(false);
+  });
+
+  it("matches ASCII fallback scanner", () => {
+    const patterns = compileAgentPatterns("aider", "fallbackPatterns");
+    expect(patterns.some((p) => p.test("=====#==== Waiting for gpt-4o"))).toBe(true);
+  });
+
+  it("matches token summary completion", () => {
+    const patterns = compileAgentPatterns("aider", "completionPatterns");
+    expect(
+      patterns.some((p) => p.test("Tokens: 1.5k sent, 432 received. Cost: $0.02 message"))
+    ).toBe(true);
+  });
+
+  it("matches Applied edit and Commit completions", () => {
+    const patterns = compileAgentPatterns("aider", "completionPatterns");
+    expect(patterns.some((p) => p.test("Applied edit to src/foo.ts"))).toBe(true);
+    expect(patterns.some((p) => p.test("Commit a1b2c3d feat: add foo"))).toBe(true);
+  });
+
+  it("matches the version banner as boot complete", () => {
+    const patterns = compileAgentPatterns("aider", "bootCompletePatterns");
+    expect(patterns.some((p) => p.test("Aider v0.86.0"))).toBe(true);
+    expect(patterns.some((p) => p.test("Use /help for help"))).toBe(true);
+  });
+
+  it("matches default and architect prompt forms", () => {
+    const patterns = compileAgentPatterns("aider", "promptPatterns");
+    expect(patterns.some((p) => p.test("> "))).toBe(true);
+    expect(patterns.some((p) => p.test("architect> "))).toBe(true);
+    expect(patterns.some((p) => p.test("ask> "))).toBe(true);
   });
 });

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -13,6 +13,7 @@ export const BUILT_IN_AGENT_IDS = [
   "mistral",
   "kimi",
   "amp",
+  "aider",
 ] as const;
 
 export type BuiltInAgentId = (typeof BUILT_IN_AGENT_IDS)[number];

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -446,6 +446,7 @@ import { config as interpreterConfig } from "./agents/interpreter.js";
 import { config as mistralConfig } from "./agents/mistral.js";
 import { config as kimiConfig } from "./agents/kimi.js";
 import { config as ampConfig } from "./agents/amp.js";
+import { config as aiderConfig } from "./agents/aider.js";
 
 // Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
 // (mirroring `src/services/actions/definitions/`). When adding a new agent,
@@ -467,6 +468,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
   mistral: mistralConfig,
   kimi: kimiConfig,
   amp: ampConfig,
+  aider: aiderConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/aider.ts
+++ b/shared/config/agents/aider.ts
@@ -1,0 +1,189 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "aider",
+  name: "Aider",
+  command: "aider",
+  // --no-auto-commits is critical: Aider's default --auto-commits would
+  // muddy the user's intentional commit history inside a Daintree worktree.
+  args: ["--no-auto-commits"],
+  color: "#14B014",
+  iconId: "aider",
+  supportsContextInjection: true,
+  tooltip: "Pip-distributed, git-aware coding agent",
+  usageUrl: "https://aider.chat/",
+  // packages.pypi triggers uv/pipx path synthesis in CliAvailabilityService,
+  // which already covers ~/.local/bin/aider on POSIX hosts. nativePaths only
+  // adds destinations not synthesized automatically: macOS Homebrew bins and
+  // the Windows uv landing.
+  packages: { pypi: "aider-chat", brew: "aider" },
+  nativePaths: [
+    "/opt/homebrew/bin/aider",
+    "/usr/local/bin/aider",
+    "%USERPROFILE%\\.local\\bin\\aider.exe",
+  ],
+  models: [
+    { id: "sonnet", name: "Claude Sonnet", shortLabel: "Sonnet" },
+    { id: "gpt-5", name: "GPT-5", shortLabel: "GPT-5" },
+    { id: "deepseek", name: "DeepSeek", shortLabel: "DeepSeek" },
+    { id: "gemini/gemini-2.5-pro", name: "Gemini 2.5 Pro", shortLabel: "Gemini" },
+    { id: "o3", name: "OpenAI o3", shortLabel: "o3" },
+  ],
+  version: {
+    args: ["--version"],
+    pypiPackage: "aider-chat",
+    githubRepo: "Aider-AI/aider",
+    releaseNotesUrl: "https://github.com/Aider-AI/aider/releases",
+  },
+  update: {
+    brew: "brew upgrade aider",
+    pypi: "python -m pip install --upgrade aider-chat",
+  },
+  install: {
+    docsUrl: "https://aider.chat/docs/install.html",
+    byOs: {
+      macos: [
+        {
+          label: "pip (recommended)",
+          commands: ["python -m pip install aider-install", "aider-install"],
+        },
+        {
+          label: "pipx",
+          commands: ["pipx install aider-chat"],
+        },
+        {
+          label: "Homebrew",
+          commands: ["brew install aider"],
+        },
+        {
+          label: "curl",
+          commands: ["curl -LsSf https://aider.chat/install.sh | sh"],
+        },
+      ],
+      linux: [
+        {
+          label: "pip (recommended)",
+          commands: ["python -m pip install aider-install", "aider-install"],
+        },
+        {
+          label: "pipx",
+          commands: ["pipx install aider-chat"],
+        },
+        {
+          label: "curl",
+          commands: ["curl -LsSf https://aider.chat/install.sh | sh"],
+        },
+      ],
+      windows: [
+        {
+          label: "pip (recommended)",
+          commands: ["python -m pip install aider-install", "aider-install"],
+        },
+        {
+          label: "pipx",
+          commands: ["pipx install aider-chat"],
+        },
+        {
+          label: "PowerShell",
+          commands: [
+            'powershell -ExecutionPolicy ByPass -c "irm https://aider.chat/install.ps1 | iex"',
+          ],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: aider --version",
+      "Configure a model and API key — see https://aider.chat/docs/config/api-keys.html",
+      "On Windows, the uv installer lands aider in %USERPROFILE%\\.local\\bin",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: false,
+    blockMouseReporting: false,
+    resizeStrategy: "default",
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    // Knight-Rider scanner: U+2591 (░) light shade and U+2588 (█) full block
+    // sliding back and forth. Source: aider/waiting.py.
+    primaryPatterns: ["[░█]{2,}\\s+Waiting for"],
+    // ASCII fallback frames use = and # (e.g. [===#===]). Token summary
+    // line and bare "Waiting for ..." are weaker signals — fallback only.
+    fallbackPatterns: ["[=#]{2}\\s+Waiting for", "Waiting for\\s+\\w", "Tokens:\\s+\\d"],
+    // "Aider v\d" is the first banner line — version-stable. The "Use /help"
+    // hint appears at the prompt when the agent is ready.
+    bootCompletePatterns: ["Aider v\\d", "Use\\s+/help\\b"],
+    promptPatterns: ["^(architect|ask|help|code)?\\s*(multi)?>\\s*", "^>\\s*$"],
+    promptHintPatterns: ["Use\\s+/help\\b"],
+    completionPatterns: [
+      "Applied edit to ",
+      "Commit\\s+[0-9a-f]{7,}\\s+",
+      "Tokens:\\s+\\d.*received\\.",
+    ],
+    completionConfidence: 0.9,
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.7,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: [
+      "javascript",
+      "typescript",
+      "python",
+      "go",
+      "rust",
+      "git",
+      "multi-provider",
+      "general-purpose",
+    ],
+    domains: {
+      frontend: 0.7,
+      backend: 0.75,
+      testing: 0.7,
+      refactoring: 0.75,
+      debugging: 0.7,
+      architecture: 0.65,
+    },
+    maxConcurrent: 1,
+    enabled: true,
+  },
+  resume: {
+    kind: "rolling-history",
+    args: () => ["--restore-chat-history"],
+    quitCommand: "/exit",
+  },
+  authCheck: {
+    // Aider is provider-agnostic — any of these env vars is enough to launch.
+    // .aider.conf.yml and .env are project- or home-relative config files.
+    configPathsAll: [".aider.conf.yml", ".env"],
+    envVar: [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "GEMINI_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "OPENROUTER_API_KEY",
+      "AIDER_API_KEY",
+    ],
+  },
+  envSuggestions: [
+    { key: "AIDER_MODEL", hint: "Default model id (e.g. sonnet, gpt-5, deepseek)" },
+    { key: "AIDER_OPENAI_API_KEY", hint: "OpenAI key when not using OPENAI_API_KEY" },
+    { key: "AIDER_ANTHROPIC_API_KEY", hint: "Anthropic key when not using ANTHROPIC_API_KEY" },
+    { key: "OLLAMA_API_BASE", hint: "Local Ollama endpoint (e.g. http://127.0.0.1:11434)" },
+  ],
+  prerequisites: [
+    {
+      tool: "aider",
+      label: "Aider CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://aider.chat/docs/install.html",
+    },
+  ],
+};

--- a/shared/config/agents/aider.ts
+++ b/shared/config/agents/aider.ts
@@ -169,6 +169,8 @@ export const config: AgentConfig = {
       "DEEPSEEK_API_KEY",
       "OPENROUTER_API_KEY",
       "AIDER_API_KEY",
+      "AIDER_OPENAI_API_KEY",
+      "AIDER_ANTHROPIC_API_KEY",
     ],
   },
   envSuggestions: [

--- a/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
@@ -19,7 +19,7 @@ describe("Skip permissions toggle gating", () => {
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("amp", "--dangerously-allow-all");
   });
 
-  it("opencode, kiro, goose, crush, qwen, mistral, and kimi have no DEFAULT_DANGEROUS_ARGS entry", () => {
+  it("opencode, kiro, goose, crush, qwen, mistral, kimi, and aider have no DEFAULT_DANGEROUS_ARGS entry", () => {
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("opencode");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("kiro");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("goose");
@@ -27,6 +27,7 @@ describe("Skip permissions toggle gating", () => {
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("qwen");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("mistral");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("kimi");
+    expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("aider");
   });
 
   it("gating expression matches expected agents", () => {
@@ -49,6 +50,7 @@ describe("Skip permissions toggle gating", () => {
       "qwen",
       "mistral",
       "kimi",
+      "aider",
     ]);
   });
 

--- a/src/components/icons/brands/AiderIcon.tsx
+++ b/src/components/icons/brands/AiderIcon.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+interface AiderIconProps {
+  className?: string;
+  size?: number;
+  brandColor?: string;
+}
+
+export function AiderIcon({ className, size = 16, brandColor }: AiderIconProps) {
+  // Lucide-style 24x24 outline of a lowercase "a" letterform — the official
+  // aider.chat wordmark won't compose at icon size, so this distills it to
+  // the dominant glyph in the brand mark.
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={brandColor || "currentColor"}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      {/* Outer bowl of the lowercase "a" */}
+      <path d="M16 13a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
+      {/* Right-side stem from cap to baseline */}
+      <path d="M16 9v8" />
+    </svg>
+  );
+}
+
+export default AiderIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -13,6 +13,7 @@ export { InterpreterIcon } from "./InterpreterIcon";
 export { MistralIcon } from "./MistralIcon";
 export { KimiIcon } from "./KimiIcon";
 export { AmpIcon } from "./AmpIcon";
+export { AiderIcon } from "./AiderIcon";
 
 // JavaScript ecosystem
 export { NpmIcon } from "./NpmIcon";


### PR DESCRIPTION
## Summary

- Adds Aider (aider-chat, 44k stars) as the 8th built-in agent with a full per-agent config at `shared/config/agents/aider.ts`
- Wires Aider into `BUILT_IN_AGENT_IDS` and `AGENT_REGISTRY`, including distribution metadata (`pypi: "aider-chat"`, `brew: "aider"`), auth env var recognition (`AIDER_*_API_KEY`), and a `--no-auto-commits` default to protect worktree commit history
- Ships the `AiderIcon` brand component, pattern-discovery corpus sample, and registry + corpus replay tests

Resolves #6131

## Changes

- `shared/config/agents/aider.ts` — full agent definition: detection patterns sourced from `aider/waiting.py` and `base_coder.py`, rolling-history resume, shutdown via `/exit`, models list, presets
- `shared/config/agentIds.ts` + `agentRegistry.ts` — Aider wired in
- `src/components/icons/brands/AiderIcon.tsx` — Lucide-style 24x24 icon derived from the lowercase `a` in the Aider wordmark, brand color `#14B014`
- `scripts/pattern-discovery/corpus/aider_sample.jsonl` — 15-entry corpus covering boot, Knight-Rider working indicator, completion, and idle prompt
- `shared/config/__tests__/agentRegistry.test.ts` — shape + regex validity tests for Aider
- `scripts/pattern-discovery/__tests__/corpus-replay.test.ts` — corpus replay coverage for Aider

## Testing

- `npm run check` passes clean (no errors, pre-existing warnings only)
- Registry tests cover required fields and valid regex on all detection patterns
- Corpus replay test validates all 15 sample entries match the expected state transitions