### PR TITLE
fix(github): fix stale green CI tick in PR list

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1380,9 +1380,11 @@ export async function listIssues(
 }
 
 /**
- * For PRs whose raw statusCheckRollup state is non-success, fetch per-PR contexts with
- * `isRequired` and derive an effective CI status based on required checks only.
- * Best-effort: on any error, returns the input PRs unchanged.
+ * For each open PR with a raw statusCheckRollup state and no cached ciSummary,
+ * fetch per-PR contexts with `isRequired` and derive an effective CI status
+ * based on required checks only. Re-runs on every list query so a SUCCESS PR
+ * that flips back to PENDING/FAILURE on a re-push refreshes within the
+ * `prRequiredStatusCache` TTL. Best-effort: on any error, returns input unchanged.
  */
 async function enrichPRsWithRequiredStatus(
   context: RepoContext,

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1391,11 +1391,7 @@ async function enrichPRsWithRequiredStatus(
   bypassCache = false
 ): Promise<GitHubPR[]> {
   const candidates = prs.filter(
-    (pr) =>
-      pr.state === "OPEN" &&
-      pr.ciStatus !== undefined &&
-      pr.ciStatus !== "SUCCESS" &&
-      pr.ciSummary === undefined
+    (pr) => pr.state === "OPEN" && pr.ciStatus !== undefined && pr.ciSummary === undefined
   );
   if (candidates.length === 0) return prs;
 

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -33,49 +33,54 @@ vi.mock("../ProjectStore.js", () => ({
   },
 }));
 
-vi.mock("../github/index.js", () => ({
-  GitHubAuth: {
-    createClient: shared.createClient,
-    getToken: () => shared.tokenState.token,
-    hasToken: () => !!shared.tokenState.token,
-    setToken: (token: string) => {
-      shared.tokenState.token = token;
+vi.mock("../github/index.js", async () => {
+  const actual = await vi.importActual<typeof import("../github/index.js")>("../github/index.js");
+  return {
+    GitHubAuth: {
+      createClient: shared.createClient,
+      getToken: () => shared.tokenState.token,
+      hasToken: () => !!shared.tokenState.token,
+      setToken: (token: string) => {
+        shared.tokenState.token = token;
+      },
+      clearToken: () => {
+        shared.tokenState.token = undefined;
+      },
+      getConfig: () => ({ token: shared.tokenState.token }),
+      getConfigAsync: () => Promise.resolve({ token: shared.tokenState.token }),
+      validate: vi.fn(),
     },
-    clearToken: () => {
-      shared.tokenState.token = undefined;
+    GITHUB_API_TIMEOUT_MS: 15_000,
+    REPO_STATS_QUERY: "REPO_STATS_QUERY",
+    PROJECT_HEALTH_QUERY: "PROJECT_HEALTH_QUERY",
+    LIST_ISSUES_QUERY: "LIST_ISSUES_QUERY",
+    LIST_PRS_QUERY: "LIST_PRS_QUERY",
+    SEARCH_QUERY: "SEARCH_QUERY",
+    GET_ISSUE_QUERY: "GET_ISSUE_QUERY",
+    GET_PR_QUERY: "GET_PR_QUERY",
+    buildBatchPRQuery: vi.fn(),
+    buildBatchRequiredChecksQuery: vi.fn(() => null),
+    deriveRequiredCIStatus: actual.deriveRequiredCIStatus,
+    gitHubRateLimitService: {
+      onStateChange: vi.fn().mockReturnValue(() => {}),
+      shouldBlockRequest: vi.fn().mockReturnValue({ blocked: false, reason: null }),
+      getState: vi.fn().mockReturnValue({ blocked: false, kind: null }),
+      clear: vi.fn(),
+      applyRemoteState: vi.fn(),
+      update: vi.fn(),
     },
-    getConfig: () => ({ token: shared.tokenState.token }),
-    getConfigAsync: () => Promise.resolve({ token: shared.tokenState.token }),
-    validate: vi.fn(),
-  },
-  GITHUB_API_TIMEOUT_MS: 15_000,
-  REPO_STATS_QUERY: "REPO_STATS_QUERY",
-  PROJECT_HEALTH_QUERY: "PROJECT_HEALTH_QUERY",
-  LIST_ISSUES_QUERY: "LIST_ISSUES_QUERY",
-  LIST_PRS_QUERY: "LIST_PRS_QUERY",
-  SEARCH_QUERY: "SEARCH_QUERY",
-  GET_ISSUE_QUERY: "GET_ISSUE_QUERY",
-  GET_PR_QUERY: "GET_PR_QUERY",
-  buildBatchPRQuery: vi.fn(),
-  gitHubRateLimitService: {
-    onStateChange: vi.fn().mockReturnValue(() => {}),
-    shouldBlockRequest: vi.fn().mockReturnValue({ blocked: false, reason: null }),
-    getState: vi.fn().mockReturnValue({ blocked: false, kind: null }),
-    clear: vi.fn(),
-    applyRemoteState: vi.fn(),
-    update: vi.fn(),
-  },
-  GitHubRateLimitError: class GitHubRateLimitError extends Error {
-    kind: "primary" | "secondary";
-    resumeAt: number;
-    constructor(kind: "primary" | "secondary", resumeAt: number) {
-      super("rate limited");
-      this.kind = kind;
-      this.resumeAt = resumeAt;
-      this.name = "GitHubRateLimitError";
-    }
-  },
-}));
+    GitHubRateLimitError: class GitHubRateLimitError extends Error {
+      kind: "primary" | "secondary";
+      resumeAt: number;
+      constructor(kind: "primary" | "secondary", resumeAt: number) {
+        super("rate limited");
+        this.kind = kind;
+        this.resumeAt = resumeAt;
+        this.name = "GitHubRateLimitError";
+      }
+    },
+  };
+});
 
 vi.mock("../GitHubStatsCache.js", () => ({
   GitHubStatsCache: {
@@ -614,5 +619,87 @@ describe("GitHubService adversarial", () => {
     ]);
 
     expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
+  });
+
+  // Regression: a PR whose raw rollup state flipped from SUCCESS back to
+  // PENDING/FAILURE on a re-push must be passed through the per-PR
+  // required-checks enrichment. Previously the enrichment filter excluded
+  // any PR whose ciStatus was "SUCCESS", which permanently froze the
+  // green tick once a PR had ever been green.
+  it("LISTPRS_ENRICHES_PRS_EVEN_WHEN_RAW_ROLLUP_IS_SUCCESS", async () => {
+    const githubIndex = await import("../github/index.js");
+    const buildBatch = vi.mocked(githubIndex.buildBatchRequiredChecksQuery);
+    buildBatch.mockReturnValueOnce("BATCH_REQ_QUERY");
+
+    shared.graphqlClient
+      .mockResolvedValueOnce({
+        repository: {
+          pullRequests: {
+            nodes: [
+              {
+                number: 42,
+                title: "PR 42",
+                url: "https://github.com/owner/repo/pull/42",
+                state: "OPEN",
+                isDraft: false,
+                updatedAt: "2026-01-01T00:00:00Z",
+                merged: false,
+                author: { login: "alice", avatarUrl: "" },
+                commits: {
+                  nodes: [
+                    {
+                      commit: {
+                        statusCheckRollup: {
+                          state: "SUCCESS",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        pr_42: {
+          pullRequest: {
+            commits: {
+              nodes: [
+                {
+                  commit: {
+                    statusCheckRollup: {
+                      state: "PENDING",
+                      contexts: {
+                        nodes: [
+                          {
+                            __typename: "CheckRun",
+                            conclusion: null,
+                            status: "IN_PROGRESS",
+                            isRequired: true,
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+    const result = await github.listPullRequests({ cwd: "/repo" });
+
+    expect(buildBatch).toHaveBeenCalledWith("owner", "repo", [42]);
+    expect(result.items[0]?.ciStatus).toBe("PENDING");
+    expect(result.items[0]?.ciSummary).toEqual({
+      requiredTotal: 1,
+      requiredFailing: 0,
+      requiredPending: 1,
+    });
   });
 });

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -218,6 +218,9 @@ export function GitHubResourceList({
   // Note: currentCursor is passed as a parameter (not read from state) to avoid
   // dependency cycle where updating cursor would recreate this callback
   const loadMoreAbortRef = useRef<AbortController | null>(null);
+  // Tracks the last time fetchData started a non-append fetch — used by the
+  // visibility/focus revalidation effect to throttle repeat refreshes.
+  const lastFetchAttemptRef = useRef<number>(0);
 
   const fetchData = useCallback(
     async (
@@ -242,6 +245,10 @@ export function GitHubResourceList({
         setLoading(true);
         setError(null);
         setLoadMoreError(null);
+      }
+
+      if (!append) {
+        lastFetchAttemptRef.current = Date.now();
       }
 
       // Retry only the primary fetch path. Load-more has its own Retry button,
@@ -383,6 +390,43 @@ export function GitHubResourceList({
 
     return () => abortController.abort();
   }, [debouncedSearch, filterState, projectPath, type, fetchData, numberQuery, cacheKey]);
+
+  // Background revalidation when the window regains focus or the tab becomes
+  // visible. CI status flips on every push, so a user returning from another
+  // app expects the list to refresh — without this, stale green ticks can
+  // linger for the full backend cache window.
+  useEffect(() => {
+    if (numberQuery !== null) {
+      return;
+    }
+
+    const REVALIDATE_THROTTLE_MS = 30_000;
+    const abortController = new AbortController();
+
+    const maybeRevalidate = () => {
+      if (typeof document !== "undefined" && document.visibilityState !== "visible") {
+        return;
+      }
+      if (Date.now() - lastFetchAttemptRef.current < REVALIDATE_THROTTLE_MS) {
+        return;
+      }
+      const gen = nextGeneration(cacheKey);
+      void fetchData(null, false, abortController.signal, {
+        revalidating: true,
+        generation: gen,
+        cacheKey,
+      });
+    };
+
+    document.addEventListener("visibilitychange", maybeRevalidate);
+    window.addEventListener("focus", maybeRevalidate);
+
+    return () => {
+      document.removeEventListener("visibilitychange", maybeRevalidate);
+      window.removeEventListener("focus", maybeRevalidate);
+      abortController.abort();
+    };
+  }, [fetchData, cacheKey, numberQuery]);
 
   useEffect(() => {
     if (numberQuery === null) {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -446,6 +446,78 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
     });
   });
 
+  it("revalidates a PR list on focus — the actual code path that ships ciStatus", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "pr", "open", "created");
+    const stalePR = {
+      ...makeIssue(7),
+      isDraft: false,
+      ciStatus: "SUCCESS" as const,
+    };
+    const updatedPR = { ...stalePR, ciStatus: "PENDING" as const };
+    setCache(cacheKey, {
+      items: [stalePR],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListPRs
+      .mockResolvedValueOnce({
+        items: [stalePR],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      })
+      .mockResolvedValueOnce({
+        items: [updatedPR],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      });
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListPRs).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => {
+      expect(mockListPRs).toHaveBeenCalledTimes(2);
+    });
+    // Focus revalidation must request a backend refresh, not a cache read.
+    expect(mockListPRs.mock.calls[1]?.[0]).toMatchObject({ bypassCache: true });
+  });
+
+  it("removes focus and visibilitychange listeners on unmount", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const { unmount } = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+
+    await vi.advanceTimersByTimeAsync(31_000);
+    window.dispatchEvent(new Event("focus"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+
   it("does not revalidate on visibilitychange when the document is hidden", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -344,6 +344,138 @@ describe("GitHubResourceList SWR behavior", () => {
   });
 });
 
+describe("GitHubResourceList focus/visibility revalidation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("revalidates in the background when the window regains focus after the throttle window", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(1)]))
+      .mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(2)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Initial mount triggers one background revalidation.
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Advance past the 30s revalidation throttle.
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("item-2")).toBeTruthy();
+    });
+  });
+
+  it("does not revalidate on focus inside the throttle window", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Within the 30s throttle window — focus must not trigger another fetch.
+    await vi.advanceTimersByTimeAsync(5_000);
+    window.dispatchEvent(new Event("focus"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates on visibilitychange when the document becomes visible", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(1)]))
+      .mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(3)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("item-3")).toBeTruthy();
+    });
+  });
+
+  it("does not revalidate on visibilitychange when the document is hidden", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("GitHubResourceList retry behavior", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });

--- a/src/lib/__tests__/githubResourceCache.test.ts
+++ b/src/lib/__tests__/githubResourceCache.test.ts
@@ -121,16 +121,16 @@ describe("githubResourceCache", () => {
       vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
       setCache("key1", { items: [], endCursor: null, hasNextPage: false, timestamp: 1 });
 
-      vi.advanceTimersByTime(4 * 60 * 1000);
+      vi.advanceTimersByTime(44 * 1000);
       expect(getCache("key1")).toBeDefined();
     });
 
-    it("evicts entries after 5 minute TTL", () => {
+    it("evicts entries after 45-second TTL", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
       setCache("key1", { items: [], endCursor: null, hasNextPage: false, timestamp: 1 });
 
-      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      vi.advanceTimersByTime(45 * 1000 + 1);
       expect(getCache("key1")).toBeUndefined();
     });
   });

--- a/src/lib/githubResourceCache.ts
+++ b/src/lib/githubResourceCache.ts
@@ -9,7 +9,9 @@ export interface GitHubResourceCacheEntry {
 }
 
 const CACHE_MAX_SIZE = 20;
-const CACHE_TTL_MS = 5 * 60 * 1000;
+// Held strictly below the backend list-cache TTL (60s) so the renderer
+// cache cannot stack on top of the backend cache and serve doubly-stale data.
+const CACHE_TTL_MS = 45 * 1000;
 
 const cache = new TtlCache<string, GitHubResourceCacheEntry>(CACHE_MAX_SIZE, CACHE_TTL_MS);
 const generationMap = new Map<string, number>();


### PR DESCRIPTION
## Summary

- The PR list was showing a green CI tick for up to ~6 minutes after a push triggered a new run, because a 5-minute frontend cache TTL was stacked on top of a 60-second backend TTL.
- On top of that, `enrichPRsWithRequiredStatus` was skipping PRs with `SUCCESS` status on re-enrichment, so a stale green result could never be overwritten.
- Added focus and `visibilitychange` revalidation on the PR list (throttled to once per 30 seconds), so switching back to the window after a push triggers a fresh fetch rather than serving whatever's in the cache.

Resolves #6140

## Changes

- `electron/services/GitHubService.ts` — dropped the `SUCCESS`-skip guard in `enrichPRsWithRequiredStatus`; enrichment now runs regardless of prior status
- `src/lib/githubResourceCache.ts` — reduced `CACHE_TTL_MS` from 5 minutes to 45 seconds (keeps a buffer below the backend's 60-second TTL)
- `src/components/GitHub/GitHubResourceList.tsx` — added focus and `visibilitychange` revalidation, gated on a 30-second throttle via `lastFetchAttemptRef`

## Testing

- Regression test added to the adversarial suite confirming `SUCCESS` PRs are no longer skipped during enrichment
- 6 new SWR tests covering focus/visibility revalidation, throttle behaviour, and unmount cleanup
- Updated TTL boundary tests to reflect the new 45-second value
- 73 tests passing across the 4 targeted suites; typecheck, lint, and build all clean