### PR TITLE
feat(agents): add Open Interpreter as a built-in agent

### DIFF
--- a/electron/services/__tests__/AgentRouter.test.ts
+++ b/electron/services/__tests__/AgentRouter.test.ts
@@ -42,6 +42,7 @@ describe("AgentRouter", () => {
         "goose",
         "crush",
         "qwen",
+        "interpreter",
       ]).toContain(agentId);
     });
 
@@ -70,6 +71,7 @@ describe("AgentRouter", () => {
         "goose",
         "crush",
         "qwen",
+        "interpreter",
       ]).toContain(agentId);
     });
 
@@ -100,6 +102,11 @@ describe("AgentRouter", () => {
       events.emit("task:assigned", { taskId: "t17", agentId: "crush", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t18", agentId: "qwen", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t19", agentId: "qwen", timestamp: Date.now() });
+      events.emit("task:assigned", {
+        taskId: "t20",
+        agentId: "interpreter",
+        timestamp: Date.now(),
+      });
 
       // Now all agents should be at capacity
       const agentId = await router.routeTask({

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -163,12 +163,12 @@ describe("CliAvailabilityService", () => {
         expect(detail?.authConfirmed).toBe(false);
       }
 
-      // Should have called execFileSync 10 times (once for each CLI).
+      // Should have called execFileSync 11 times (once for each CLI).
       // Fallback probes (native paths, npm-global, WSL) run via async execFile and
       // only fire when the which/where probe returns missing — in this test
       // every agent succeeds on the first probe, so execFileSync count
       // matches the registry size exactly.
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(10);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
 
       // stdio is now [ignore, pipe, ignore] so we can capture the resolved
       // path from stdout while still suppressing any TTY output on stderr.
@@ -219,6 +219,7 @@ describe("CliAvailabilityService", () => {
         goose: "missing",
         crush: "missing",
         qwen: "missing",
+        interpreter: "missing",
       });
     });
 
@@ -591,11 +592,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      // 10 successful primary calls + 9 BusyBox-style bare-`which` retries
-      // (the 9 agents whose mock throws a generic `Error` with no errno
+      // 11 successful primary calls + 10 BusyBox-style bare-`which` retries
+      // (the 10 agents whose mock throws a generic `Error` with no errno
       // code — which `probeViaShell` retries without `-a` to recover
       // BusyBox/minimal `which` builds that reject the flag).
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(19);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(21);
     });
 
     it("works on cold start before initial check", async () => {
@@ -623,7 +624,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      expect(executionOrder).toHaveLength(10);
+      expect(executionOrder).toHaveLength(11);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
       expect(executionOrder).toContain("codex");
@@ -634,6 +635,7 @@ describe("CliAvailabilityService", () => {
       expect(executionOrder).toContain("goose");
       expect(executionOrder).toContain("crush");
       expect(executionOrder).toContain("qwen");
+      expect(executionOrder).toContain("interpreter");
     });
 
     it("deduplicates concurrent checkAvailability calls", async () => {
@@ -647,7 +649,7 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(10);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
@@ -656,19 +658,19 @@ describe("CliAvailabilityService", () => {
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
       expect(result1).toEqual(result2);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(20);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(22);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       await service.checkAvailability();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(10);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
 
       vi.clearAllMocks();
 
       await service.refresh();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(10);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
     });
   });
 
@@ -1543,9 +1545,13 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      const probedPaths = mockedAccess.mock.calls.map((c) => String(c[0]));
-      // None of the built-ins use uv/pipx layouts; this guards against
-      // accidental probing when an agent has `npmGlobalPackage` only.
+      // Filter out paths synthesised for the `interpreter` agent, whose
+      // `packages.pypi` legitimately triggers uv/pipx probing. Remaining
+      // probed paths must not include any uv/pipx layouts — this guards
+      // against accidental probing for agents that don't declare PyPI.
+      const probedPaths = mockedAccess.mock.calls
+        .map((c) => String(c[0]))
+        .filter((p) => !p.includes("open-interpreter") && !p.includes("/interpreter"));
       expect(probedPaths.some((p) => p.includes(".local/share/uv/tools"))).toBe(false);
       expect(probedPaths.some((p) => p.includes(".local/share/pipx/venvs"))).toBe(false);
     });

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -40,6 +40,7 @@ describe("agentRegistry", () => {
       expect(ids).toContain("goose");
       expect(ids).toContain("crush");
       expect(ids).toContain("qwen");
+      expect(ids).toContain("interpreter");
     });
 
     it("kiro only has macOS and Linux install blocks (no Windows)", () => {
@@ -953,7 +954,17 @@ describe("cursor install metadata", () => {
 });
 
 describe("all built-in agents have Windows or generic install", () => {
-  it.each(["claude", "gemini", "codex", "opencode", "cursor", "copilot", "goose", "qwen"])(
+  it.each([
+    "claude",
+    "gemini",
+    "codex",
+    "opencode",
+    "cursor",
+    "copilot",
+    "goose",
+    "qwen",
+    "interpreter",
+  ])(
     "%s has windows or generic install block",
     (agentId) => {
       const config = getAgentConfig(agentId);

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -9,6 +9,7 @@ export const BUILT_IN_AGENT_IDS = [
   "goose",
   "crush",
   "qwen",
+  "interpreter",
 ] as const;
 
 export type BuiltInAgentId = (typeof BUILT_IN_AGENT_IDS)[number];

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -442,6 +442,7 @@ import { config as copilotConfig } from "./agents/copilot.js";
 import { config as gooseConfig } from "./agents/goose.js";
 import { config as crushConfig } from "./agents/crush.js";
 import { config as qwenConfig } from "./agents/qwen.js";
+import { config as interpreterConfig } from "./agents/interpreter.js";
 
 // Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
 // (mirroring `src/services/actions/definitions/`). When adding a new agent,
@@ -459,6 +460,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
   goose: gooseConfig,
   crush: crushConfig,
   qwen: qwenConfig,
+  interpreter: interpreterConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/interpreter.ts
+++ b/shared/config/agents/interpreter.ts
@@ -113,6 +113,7 @@ export const config: AgentConfig = {
   },
   authCheck: {
     configPaths: {
+      darwin: ["Library/Application Support/open-interpreter/profiles/default.yaml"],
       win32: ["AppData/Roaming/Open Interpreter/profiles/default.yaml"],
     },
     configPathsAll: [".config/open-interpreter/profiles/default.yaml"],

--- a/shared/config/agents/interpreter.ts
+++ b/shared/config/agents/interpreter.ts
@@ -1,0 +1,130 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "interpreter",
+  name: "Open Interpreter",
+  command: "interpreter",
+  color: "#111111",
+  iconId: "interpreter",
+  supportsContextInjection: true,
+  tooltip: "general code execution — runs Python, shell, and JS on the host",
+  usageUrl: "https://docs.openinterpreter.com/",
+  packages: {
+    pypi: "open-interpreter",
+  },
+  version: {
+    args: ["--version"],
+    pypiPackage: "open-interpreter",
+    githubRepo: "openinterpreter/open-interpreter",
+    releaseNotesUrl: "https://github.com/openinterpreter/open-interpreter/releases",
+  },
+  update: {
+    pip: "pip install --upgrade open-interpreter",
+    pipx: "pipx upgrade open-interpreter",
+  },
+  install: {
+    docsUrl: "https://docs.openinterpreter.com/getting-started/setup",
+    byOs: {
+      macos: [
+        {
+          label: "pipx (recommended)",
+          commands: ["pipx install open-interpreter"],
+        },
+        {
+          label: "pip",
+          commands: ["pip install open-interpreter"],
+        },
+        {
+          label: "uv",
+          commands: ["uv tool install open-interpreter"],
+        },
+      ],
+      linux: [
+        {
+          label: "pipx (recommended)",
+          commands: ["pipx install open-interpreter"],
+        },
+        {
+          label: "pip",
+          commands: ["pip install open-interpreter"],
+        },
+        {
+          label: "uv",
+          commands: ["uv tool install open-interpreter"],
+        },
+      ],
+      windows: [
+        {
+          label: "pipx (recommended)",
+          commands: ["pipx install open-interpreter"],
+        },
+        {
+          label: "pip",
+          commands: ["pip install open-interpreter"],
+        },
+        {
+          label: "uv",
+          commands: ["uv tool install open-interpreter"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Requires Python 3.10 or newer",
+      "Verify installation with: interpreter --version",
+      "Set OPENAI_API_KEY (or ANTHROPIC_API_KEY / GOOGLE_API_KEY) before launch, or run 'interpreter' once to be prompted",
+      "Code runs locally — keep auto-run mode disabled unless you trust the prompt source",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: false,
+    blockMouseReporting: false,
+    resizeStrategy: "default",
+    supportsBracketedPaste: false,
+    softNewlineSequence: "\n",
+    ignoredInputSequences: ["\n", "\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: ["[•·]\\s+(Running|Executing|Generating)"],
+    fallbackPatterns: ["```(python|shell|javascript|applescript|html|r)\\b"],
+    bootCompletePatterns: ["Welcome to.*Open Interpreter", "Model set to"],
+    promptPatterns: ["^\\s*>\\s*$"],
+    promptHintPatterns: ["Would you like to run this code"],
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.7,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: ["python", "shell", "javascript", "code-execution", "general-purpose"],
+    domains: {
+      backend: 0.7,
+      debugging: 0.65,
+    },
+    maxConcurrent: 1,
+    enabled: true,
+  },
+  resume: {
+    kind: "rolling-history",
+    args: () => [],
+    shutdownKeySequence: "\x04",
+  },
+  authCheck: {
+    configPaths: {
+      win32: ["AppData/Roaming/Open Interpreter/profiles/default.yaml"],
+    },
+    configPathsAll: [".config/open-interpreter/profiles/default.yaml"],
+    envVar: ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"],
+  },
+  prerequisites: [
+    {
+      tool: "interpreter",
+      label: "Open Interpreter CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://docs.openinterpreter.com/getting-started/setup",
+    },
+  ],
+};

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -135,6 +135,7 @@ export const DEFAULT_DANGEROUS_ARGS: Record<string, string> = {
   gemini: "--yolo",
   codex: "--dangerously-bypass-approvals-and-sandbox",
   cursor: "--force",
+  interpreter: "--auto_run",
 };
 
 export const DEFAULT_AGENT_SETTINGS: AgentSettings = {

--- a/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
@@ -7,7 +7,7 @@ import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
  * The toggle should only appear for agents that have a DEFAULT_DANGEROUS_ARGS entry.
  */
 describe("Skip permissions toggle gating", () => {
-  it("DEFAULT_DANGEROUS_ARGS has entries for claude, gemini, codex, cursor", () => {
+  it("DEFAULT_DANGEROUS_ARGS has entries for claude, gemini, codex, cursor, interpreter", () => {
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("claude", "--dangerously-skip-permissions");
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("gemini", "--yolo");
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty(
@@ -15,6 +15,7 @@ describe("Skip permissions toggle gating", () => {
       "--dangerously-bypass-approvals-and-sandbox"
     );
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("cursor", "--force");
+    expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("interpreter", "--auto_run");
   });
 
   it("opencode, kiro, goose, crush, and qwen have no DEFAULT_DANGEROUS_ARGS entry", () => {
@@ -35,7 +36,7 @@ describe("Skip permissions toggle gating", () => {
       (id) => (DEFAULT_DANGEROUS_ARGS[id] ?? "") === ""
     );
 
-    expect(agentsWithToggle).toEqual(["claude", "gemini", "codex", "cursor"]);
+    expect(agentsWithToggle).toEqual(["claude", "gemini", "codex", "cursor", "interpreter"]);
     expect(agentsWithoutToggle).toEqual(["opencode", "kiro", "copilot", "goose", "crush", "qwen"]);
   });
 

--- a/src/components/icons/brands/InterpreterIcon.tsx
+++ b/src/components/icons/brands/InterpreterIcon.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface InterpreterIconProps {
+  className?: string;
+  size?: number;
+  brandColor?: string;
+}
+
+export function InterpreterIcon({ className, size = 16, brandColor }: InterpreterIconProps) {
+  // Open Interpreter mark: a dot above a rounded vertical capsule (terminal cursor).
+  // Source: https://www.openinterpreter.com/icon.svg (32x32, rescaled to 24x24).
+  const fill = brandColor || "currentColor";
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="5.12175" r="2.12175" fill={fill} />
+      <rect x="9.87825" y="9" width="4.24425" height="12" rx="2.12175" fill={fill} />
+    </svg>
+  );
+}
+
+export default InterpreterIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -9,6 +9,7 @@ export { CopilotIcon } from "./CopilotIcon";
 export { GooseIcon } from "./GooseIcon";
 export { CrushIcon } from "./CrushIcon";
 export { QwenIcon } from "./QwenIcon";
+export { InterpreterIcon } from "./InterpreterIcon";
 
 // JavaScript ecosystem
 export { NpmIcon } from "./NpmIcon";

--- a/src/config/__tests__/agentIcons.test.ts
+++ b/src/config/__tests__/agentIcons.test.ts
@@ -29,6 +29,7 @@ describe("agentIcons", () => {
     expect(AGENT_ICON_MAP["goose"]).toBeDefined();
     expect(AGENT_ICON_MAP["crush"]).toBeDefined();
     expect(AGENT_ICON_MAP["qwen"]).toBeDefined();
+    expect(AGENT_ICON_MAP["interpreter"]).toBeDefined();
   });
 
   it("normalizes icon filenames to lowercase iconIds", () => {

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -56,6 +56,7 @@ export const AGENT_DESCRIPTIONS: Record<string, string> = {
   kiro: "Spec-driven development with autonomous execution",
   copilot: "GitHub's AI assistant with broad model choice",
   crush: "Charmbracelet's multi-provider Bubble Tea TUI agent",
+  interpreter: "Local code execution — Python, shell, and JavaScript on your machine",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds Open Interpreter (`interpreter`) as a built-in agent, with a new per-agent config file, icon, registry entries, and type definitions
- Ships five presets covering OpenAI, Anthropic, Ollama, interactive-confirm (default), auto-run (dangerous), and safe-mode; default keeps code-execution confirmation enabled so the user opts in to auto-run explicitly
- Open Interpreter executes Python/Shell/JS/AppleScript on the host with no sandbox -- the threat model is materially different from file-editing agents, so it's surfaced in the tooltip, install troubleshooting, and the auto-run preset description

Resolves #6136

## Changes

- `shared/config/agents/interpreter.ts` -- full agent definition: detection patterns, presets, auth check, resume config, capabilities
- `src/components/icons/brands/InterpreterIcon.tsx` -- brand icon based on the Open Interpreter circle mark
- `shared/config/agentIds.ts`, `agentRegistry.ts`, `shared/types/agentSettings.ts`, `src/config/agents.ts`, `src/components/icons/brands/index.ts` -- registry and barrel wiring
- 5 test files updated for the registry cascade (AgentRouter, CliAvailabilityService, agentRegistry, AgentSetupWizardDangerous, agentIcons)

No source-level linking to the AGPL-3.0 library -- Daintree spawns the binary via PTY only, same posture as other third-party agents.

## Testing

- Unit tests pass (`npm test`) with updated snapshots and mocks covering the new agent ID
- Detection pattern coverage: boot banner (`Welcome to.*Open Interpreter`), code block headers (` ```python ` etc.), confirmation prompt (`Would you like to run this code`), idle prompt (`> `)
- Quit via `shutdownKeySequence: "\x04"` (Ctrl+D) since Open Interpreter has no `/exit` or `%exit` command