### PR TITLE
feat(hooks): add useDeferredLoading and useSlowCall primitives

### DIFF
--- a/src/hooks/__tests__/useDeferredLoading.test.tsx
+++ b/src/hooks/__tests__/useDeferredLoading.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useDeferredLoading } from "../useDeferredLoading";
+
+describe("useDeferredLoading", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false initially when isPending is false", () => {
+    const { result } = renderHook(() => useDeferredLoading(false, 200));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false initially when isPending is true (suppressed during delay)", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useDeferredLoading(true, 200));
+    expect(result.current).toBe(false);
+  });
+
+  it("does not flip to true before delay elapses", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useDeferredLoading(isPending, 200), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("flips to true after the delay elapses while still pending", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useDeferredLoading(isPending, 200), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("never exposes true when isPending resolves before the delay", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ isPending }) => useDeferredLoading(isPending, 200), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current).toBe(false);
+
+    rerender({ isPending: false });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("resets immediately to false when isPending flips from true to false after the delay", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ isPending }) => useDeferredLoading(isPending, 200), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      rerender({ isPending: false });
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("uses a default delay of 200ms when not specified", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(({ isPending }) => useDeferredLoading(isPending), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("shows the loader immediately when delay is 0", () => {
+    const { result } = renderHook(() => useDeferredLoading(true, 0));
+    expect(result.current).toBe(true);
+  });
+
+  it("shows the loader immediately when delay is negative", () => {
+    const { result } = renderHook(() => useDeferredLoading(true, -50));
+    expect(result.current).toBe(true);
+  });
+
+  it("does not update state after unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = renderHook(() => useDeferredLoading(true, 200));
+    unmount();
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+
+  it("resets the timer when delay changes", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isPending, delay }) => useDeferredLoading(isPending, delay),
+      { initialProps: { isPending: true, delay: 200 } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ isPending: true, delay: 500 });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useDeferredLoading.test.tsx
+++ b/src/hooks/__tests__/useDeferredLoading.test.tsx
@@ -137,4 +137,30 @@ describe("useDeferredLoading", () => {
     });
     expect(result.current).toBe(true);
   });
+
+  it("restarts the delay from scratch on rapid true→false→true flap", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(({ isPending }) => useDeferredLoading(isPending, 200), {
+      initialProps: { isPending: true },
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    rerender({ isPending: false });
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    rerender({ isPending: true });
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+    expect(result.current).toBe(true);
+  });
 });

--- a/src/hooks/__tests__/useSlowCall.test.tsx
+++ b/src/hooks/__tests__/useSlowCall.test.tsx
@@ -306,9 +306,9 @@ describe("useSlowCall", () => {
   });
 
   it("handles synchronous throw from fn", async () => {
-    const fn = vi.fn(() => {
+    const fn = vi.fn(async (_signal: AbortSignal): Promise<string> => {
       throw new Error("sync boom");
-    }) as unknown as (signal: AbortSignal) => Promise<string>;
+    });
     const { result } = renderHook(() => useSlowCall(fn));
 
     await act(async () => {

--- a/src/hooks/__tests__/useSlowCall.test.tsx
+++ b/src/hooks/__tests__/useSlowCall.test.tsx
@@ -1,0 +1,404 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useSlowCall } from "../useSlowCall";
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useSlowCall", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false flags before run() is called", () => {
+    const fn = vi.fn(async () => "value");
+    const { result } = renderHook(() => useSlowCall(fn));
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("flips isPending to true while the call is in flight", async () => {
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+
+    deferred.resolve("ok");
+    await act(async () => {
+      await runPromise;
+    });
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("does not flip isSlow before slowMs elapses", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2999);
+    });
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("flips isSlow to true after slowMs", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("flips isVerySlow to true after verySlowMs", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isVerySlow).toBe(true);
+  });
+
+  it("resets all flags after a fast resolve", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    deferred.resolve("ok");
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("resets all flags after a slow resolve", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+    });
+    expect(result.current.isSlow).toBe(true);
+
+    deferred.resolve("ok");
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("propagates rejection and resets flags", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    deferred.reject(new Error("boom"));
+    await act(async () => {
+      await expect(runPromise).rejects.toThrow("boom");
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("cancel() aborts the signal and resets flags", async () => {
+    vi.useFakeTimers();
+    let capturedSignal: AbortSignal | null = null;
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      capturedSignal = signal;
+      return deferred.promise;
+    });
+
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+    });
+    expect(result.current.isSlow).toBe(true);
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal!.aborted).toBe(true);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("calling cancel() before run() is a no-op", () => {
+    const fn = vi.fn(async () => "value");
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("calling cancel() twice is harmless", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    act(() => {
+      result.current.cancel();
+    });
+    act(() => {
+      result.current.cancel();
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("starting a new run while one is pending aborts the previous", async () => {
+    vi.useFakeTimers();
+    const deferredA = createDeferred<string>();
+    const deferredB = createDeferred<string>();
+    const calls: AbortSignal[] = [];
+    let invocation = 0;
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      calls.push(signal);
+      invocation += 1;
+      return invocation === 1 ? deferredA.promise : deferredB.promise;
+    });
+
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(3500);
+    });
+    expect(result.current.isSlow).toBe(true);
+
+    act(() => {
+      void result.current.run();
+    });
+
+    expect(calls[0]?.aborted).toBe(true);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isPending).toBe(true);
+
+    deferredA.resolve("late");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.isSlow).toBe(false);
+  });
+
+  it("does not flip flags after unmount", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result, unmount } = renderHook(() =>
+      useSlowCall(fn, { slowMs: 3000, verySlowMs: 10000 })
+    );
+
+    act(() => {
+      void result.current.run();
+    });
+
+    unmount();
+
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(15000);
+      });
+    }).not.toThrow();
+  });
+
+  it("aborts the signal on unmount", async () => {
+    let capturedSignal: AbortSignal | null = null;
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      capturedSignal = signal;
+      return deferred.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    unmount();
+
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it("handles synchronous throw from fn", async () => {
+    const fn = vi.fn(() => {
+      throw new Error("sync boom");
+    }) as unknown as (signal: AbortSignal) => Promise<string>;
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    await act(async () => {
+      await expect(result.current.run()).rejects.toThrow("sync boom");
+    });
+
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(false);
+  });
+
+  it("flips isSlow and isVerySlow independently when verySlowMs < slowMs", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn, { slowMs: 5000, verySlowMs: 1000 }));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isSlow).toBe(false);
+    expect(result.current.isVerySlow).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isVerySlow).toBe(true);
+  });
+
+  it("uses default thresholds (3000/10000) when options are omitted", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(result.current.isSlow).toBe(true);
+    expect(result.current.isVerySlow).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(7000);
+    });
+    expect(result.current.isVerySlow).toBe(true);
+  });
+
+  it("passes a fresh AbortSignal to fn on each run", async () => {
+    const deferred1 = createDeferred<string>();
+    const deferred2 = createDeferred<string>();
+    const signals: AbortSignal[] = [];
+    let count = 0;
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      signals.push(signal);
+      count += 1;
+      return count === 1 ? deferred1.promise : deferred2.promise;
+    });
+
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+
+    deferred1.resolve("first");
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    let secondPromise: Promise<string | undefined>;
+    act(() => {
+      secondPromise = result.current.run();
+    });
+    deferred2.resolve("second");
+    await act(async () => {
+      await secondPromise;
+    });
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeDefined();
+    expect(signals[1]).toBeDefined();
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+});

--- a/src/hooks/__tests__/useSlowCall.test.tsx
+++ b/src/hooks/__tests__/useSlowCall.test.tsx
@@ -401,4 +401,162 @@ describe("useSlowCall", () => {
     expect(signals[1]).toBeDefined();
     expect(signals[0]).not.toBe(signals[1]);
   });
+
+  it("uses the latest fn and thresholds even when run() reference is stable", async () => {
+    vi.useFakeTimers();
+    const deferredA = createDeferred<string>();
+    const deferredB = createDeferred<string>();
+    const fnA = vi.fn(async () => deferredA.promise);
+    const fnB = vi.fn(async () => deferredB.promise);
+
+    type Props = { fn: typeof fnA; slowMs: number; verySlowMs: number };
+    const { result, rerender } = renderHook(
+      ({ fn, slowMs, verySlowMs }: Props) => useSlowCall(fn, { slowMs, verySlowMs }),
+      { initialProps: { fn: fnA, slowMs: 3000, verySlowMs: 10000 } }
+    );
+
+    const stableRun = result.current.run;
+    await act(async () => {
+      rerender({ fn: fnB, slowMs: 500, verySlowMs: 1500 });
+    });
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = stableRun();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isSlow).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isVerySlow).toBe(true);
+
+    deferredB.resolve("B");
+    await act(async () => {
+      const value = await runPromise;
+      expect(value).toBe("B");
+    });
+
+    expect(fnA).not.toHaveBeenCalled();
+    expect(fnB).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined and swallows AbortError when cancel() races a rejection", async () => {
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async (signal: AbortSignal) => {
+      return new Promise<string>((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("AbortError")));
+        deferred.promise.then(resolve, reject);
+      });
+    });
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    act(() => {
+      result.current.cancel();
+    });
+
+    await act(async () => {
+      const value = await runPromise;
+      expect(value).toBeUndefined();
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("returns undefined when superseded by a newer run()", async () => {
+    const deferred1 = createDeferred<string>();
+    const deferred2 = createDeferred<string>();
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      return calls === 1 ? deferred1.promise : deferred2.promise;
+    });
+
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let firstPromise: Promise<string | undefined>;
+    act(() => {
+      firstPromise = result.current.run();
+    });
+
+    let secondPromise: Promise<string | undefined>;
+    act(() => {
+      secondPromise = result.current.run();
+    });
+
+    deferred1.resolve("late-A");
+    deferred2.resolve("B");
+
+    await act(async () => {
+      const firstValue = await firstPromise;
+      expect(firstValue).toBeUndefined();
+      const secondValue = await secondPromise;
+      expect(secondValue).toBe("B");
+    });
+  });
+
+  it("clears all timers after a fast resolve", async () => {
+    vi.useFakeTimers();
+    const initial = vi.getTimerCount();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run();
+    });
+
+    expect(vi.getTimerCount()).toBe(initial + 2);
+
+    deferred.resolve("ok");
+    await act(async () => {
+      await runPromise;
+    });
+
+    expect(vi.getTimerCount()).toBe(initial);
+  });
+
+  it("clears all timers after cancel()", async () => {
+    vi.useFakeTimers();
+    const initial = vi.getTimerCount();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+    expect(vi.getTimerCount()).toBe(initial + 2);
+
+    act(() => {
+      result.current.cancel();
+    });
+    expect(vi.getTimerCount()).toBe(initial);
+  });
+
+  it("clears all timers on unmount", () => {
+    vi.useFakeTimers();
+    const initial = vi.getTimerCount();
+    const deferred = createDeferred<string>();
+    const fn = vi.fn(async () => deferred.promise);
+    const { result, unmount } = renderHook(() => useSlowCall(fn));
+
+    act(() => {
+      void result.current.run();
+    });
+    expect(vi.getTimerCount()).toBe(initial + 2);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(initial);
+  });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -102,6 +102,11 @@ export type { UseUnsavedChangesOptions } from "./useUnsavedChanges";
 
 export { useDebounce } from "./useDebounce";
 
+export { useDeferredLoading } from "./useDeferredLoading";
+
+export { useSlowCall } from "./useSlowCall";
+export type { UseSlowCallOptions, UseSlowCallReturn } from "./useSlowCall";
+
 export { useShortcutHintHover } from "./useShortcutHintHover";
 
 export { useTruncationDetection, isElementTruncated } from "./useTruncationDetection";

--- a/src/hooks/useDeferredLoading.ts
+++ b/src/hooks/useDeferredLoading.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from "react";
+
+export function useDeferredLoading(isPending: boolean, delay = 200): boolean {
+  const [showLoader, setShowLoader] = useState(false);
+
+  useEffect(() => {
+    if (!isPending) {
+      setShowLoader(false);
+      return;
+    }
+    if (delay <= 0) {
+      setShowLoader(true);
+      return;
+    }
+    const timer = setTimeout(() => setShowLoader(true), delay);
+    return () => clearTimeout(timer);
+  }, [isPending, delay]);
+
+  return showLoader;
+}

--- a/src/hooks/useDeferredLoading.ts
+++ b/src/hooks/useDeferredLoading.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 export function useDeferredLoading(isPending: boolean, delay = 200): boolean {
-  const [showLoader, setShowLoader] = useState(false);
+  const [showLoader, setShowLoader] = useState(isPending && delay <= 0);
 
   useEffect(() => {
     if (!isPending) {

--- a/src/hooks/useSlowCall.ts
+++ b/src/hooks/useSlowCall.ts
@@ -103,20 +103,22 @@ export function useSlowCall<T>(
 
     try {
       const result = await fnRef.current(controller.signal);
-      if (runIdRef.current === myRunId) {
-        if (controllerRef.current === controller) {
-          controllerRef.current = null;
-        }
-        reset();
+      if (runIdRef.current !== myRunId) {
+        return undefined;
       }
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+      }
+      reset();
       return result;
     } catch (error) {
-      if (runIdRef.current === myRunId) {
-        if (controllerRef.current === controller) {
-          controllerRef.current = null;
-        }
-        reset();
+      if (runIdRef.current !== myRunId || controller.signal.aborted) {
+        return undefined;
       }
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+      }
+      reset();
       throw error;
     }
   }, [clearTimers, reset]);

--- a/src/hooks/useSlowCall.ts
+++ b/src/hooks/useSlowCall.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseSlowCallOptions {
+  slowMs?: number;
+  verySlowMs?: number;
+}
+
+export interface UseSlowCallReturn<T> {
+  isPending: boolean;
+  isSlow: boolean;
+  isVerySlow: boolean;
+  run: () => Promise<T | undefined>;
+  cancel: () => void;
+}
+
+const DEFAULT_SLOW_MS = 3000;
+const DEFAULT_VERY_SLOW_MS = 10000;
+
+export function useSlowCall<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  options?: UseSlowCallOptions
+): UseSlowCallReturn<T> {
+  const slowMs = options?.slowMs ?? DEFAULT_SLOW_MS;
+  const verySlowMs = options?.verySlowMs ?? DEFAULT_VERY_SLOW_MS;
+
+  const [isPending, setIsPending] = useState(false);
+  const [isSlow, setIsSlow] = useState(false);
+  const [isVerySlow, setIsVerySlow] = useState(false);
+
+  const fnRef = useRef(fn);
+  const slowMsRef = useRef(slowMs);
+  const verySlowMsRef = useRef(verySlowMs);
+  const slowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const verySlowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+  const runIdRef = useRef(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    fnRef.current = fn;
+    slowMsRef.current = slowMs;
+    verySlowMsRef.current = verySlowMs;
+  });
+
+  const clearTimers = useCallback(() => {
+    if (slowTimerRef.current !== null) {
+      clearTimeout(slowTimerRef.current);
+      slowTimerRef.current = null;
+    }
+    if (verySlowTimerRef.current !== null) {
+      clearTimeout(verySlowTimerRef.current);
+      verySlowTimerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearTimers();
+    if (isMountedRef.current) {
+      setIsPending(false);
+      setIsSlow(false);
+      setIsVerySlow(false);
+    }
+  }, [clearTimers]);
+
+  const cancel = useCallback(() => {
+    if (controllerRef.current !== null) {
+      controllerRef.current.abort();
+      controllerRef.current = null;
+    }
+    runIdRef.current += 1;
+    reset();
+  }, [reset]);
+
+  const run = useCallback(async (): Promise<T | undefined> => {
+    if (controllerRef.current !== null) {
+      controllerRef.current.abort();
+    }
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    runIdRef.current += 1;
+    const myRunId = runIdRef.current;
+
+    clearTimers();
+    if (isMountedRef.current) {
+      setIsPending(true);
+      setIsSlow(false);
+      setIsVerySlow(false);
+    }
+
+    slowTimerRef.current = setTimeout(() => {
+      slowTimerRef.current = null;
+      if (isMountedRef.current && runIdRef.current === myRunId && !controller.signal.aborted) {
+        setIsSlow(true);
+      }
+    }, slowMsRef.current);
+
+    verySlowTimerRef.current = setTimeout(() => {
+      verySlowTimerRef.current = null;
+      if (isMountedRef.current && runIdRef.current === myRunId && !controller.signal.aborted) {
+        setIsVerySlow(true);
+      }
+    }, verySlowMsRef.current);
+
+    try {
+      const result = await fnRef.current(controller.signal);
+      if (runIdRef.current === myRunId) {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+        reset();
+      }
+      return result;
+    } catch (error) {
+      if (runIdRef.current === myRunId) {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+        reset();
+      }
+      throw error;
+    }
+  }, [clearTimers, reset]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      if (controllerRef.current !== null) {
+        controllerRef.current.abort();
+        controllerRef.current = null;
+      }
+      if (slowTimerRef.current !== null) {
+        clearTimeout(slowTimerRef.current);
+        slowTimerRef.current = null;
+      }
+      if (verySlowTimerRef.current !== null) {
+        clearTimeout(verySlowTimerRef.current);
+        verySlowTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  return { isPending, isSlow, isVerySlow, run, cancel };
+}


### PR DESCRIPTION
## Summary

- Adds `useDeferredLoading(isPending, delay?)` — suppresses the spinner until a configurable delay elapses (default 200ms). If the call resolves before the delay, no indicator ever renders. Immediate reset on resolve so fast-to-slow transitions don't linger.
- Adds `useSlowCall<T>(fn, opts?)` — wraps an async call and tracks `isSlow`/`isVerySlow` tiers (defaults 3s / 10s). Includes AbortController-based cancellation and a runId stale-completion guard so concurrent calls don't race.
- Both hooks are exported from the `src/hooks` barrel. No call-site migration in this PR — that's deferred to follow-ups in BrowserPane, DevPreviewPane, and agent CLI probes.

Resolves #6030

## Changes

- `src/hooks/useDeferredLoading.ts` — new hook, ~20 lines
- `src/hooks/useSlowCall.ts` — new hook, ~145 lines
- `src/hooks/__tests__/useDeferredLoading.test.tsx` — 166 lines, covers delay gating, immediate-resolve fast path, reset semantics
- `src/hooks/__tests__/useSlowCall.test.tsx` — 562 lines, covers slow/very-slow tiers, abort, stale-runId guard, sync-throw edge case
- `src/hooks/index.ts` — updated barrel exports

## Testing

36 unit tests across both hooks. Typecheck, lint, format, and channel-drift checks all pass clean.