### PR TITLE
feat(agents): add Mistral Vibe as a built-in agent

### DIFF
--- a/electron/services/__tests__/AgentRouter.test.ts
+++ b/electron/services/__tests__/AgentRouter.test.ts
@@ -43,6 +43,7 @@ describe("AgentRouter", () => {
         "crush",
         "qwen",
         "interpreter",
+        "mistral",
       ]).toContain(agentId);
     });
 
@@ -72,6 +73,7 @@ describe("AgentRouter", () => {
         "crush",
         "qwen",
         "interpreter",
+        "mistral",
       ]).toContain(agentId);
     });
 
@@ -107,6 +109,8 @@ describe("AgentRouter", () => {
         agentId: "interpreter",
         timestamp: Date.now(),
       });
+      events.emit("task:assigned", { taskId: "t21", agentId: "mistral", timestamp: Date.now() });
+      events.emit("task:assigned", { taskId: "t22", agentId: "mistral", timestamp: Date.now() });
 
       // Now all agents should be at capacity
       const agentId = await router.routeTask({

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -163,12 +163,12 @@ describe("CliAvailabilityService", () => {
         expect(detail?.authConfirmed).toBe(false);
       }
 
-      // Should have called execFileSync 11 times (once for each CLI).
+      // Should have called execFileSync 12 times (once for each CLI).
       // Fallback probes (native paths, npm-global, WSL) run via async execFile and
       // only fire when the which/where probe returns missing — in this test
       // every agent succeeds on the first probe, so execFileSync count
       // matches the registry size exactly.
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
 
       // stdio is now [ignore, pipe, ignore] so we can capture the resolved
       // path from stdout while still suppressing any TTY output on stderr.
@@ -220,6 +220,7 @@ describe("CliAvailabilityService", () => {
         crush: "missing",
         qwen: "missing",
         interpreter: "missing",
+        mistral: "missing",
       });
     });
 
@@ -592,11 +593,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      // 11 successful primary calls + 10 BusyBox-style bare-`which` retries
-      // (the 10 agents whose mock throws a generic `Error` with no errno
+      // 12 successful primary calls + 11 BusyBox-style bare-`which` retries
+      // (the 11 agents whose mock throws a generic `Error` with no errno
       // code — which `probeViaShell` retries without `-a` to recover
       // BusyBox/minimal `which` builds that reject the flag).
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(21);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(23);
     });
 
     it("works on cold start before initial check", async () => {
@@ -624,7 +625,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      expect(executionOrder).toHaveLength(11);
+      expect(executionOrder).toHaveLength(12);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
       expect(executionOrder).toContain("codex");
@@ -636,6 +637,7 @@ describe("CliAvailabilityService", () => {
       expect(executionOrder).toContain("crush");
       expect(executionOrder).toContain("qwen");
       expect(executionOrder).toContain("interpreter");
+      expect(executionOrder).toContain("vibe");
     });
 
     it("deduplicates concurrent checkAvailability calls", async () => {
@@ -649,7 +651,7 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
@@ -658,19 +660,19 @@ describe("CliAvailabilityService", () => {
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
       expect(result1).toEqual(result2);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(22);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(24);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       await service.checkAvailability();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
 
       vi.clearAllMocks();
 
       await service.refresh();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(11);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
     });
   });
 
@@ -1534,7 +1536,9 @@ describe("CliAvailabilityService", () => {
 
     it("does not synthesise PyPI paths when packages.pypi is unset", async () => {
       // Built-in claude has no `packages.pypi`; verify our probe pipeline
-      // never dispatches PyPI-shaped fs.access calls for it.
+      // never dispatches PyPI-shaped fs.access calls for it. Mistral has `packages.pypi`
+      // so it WILL probe PyPI paths. This test guards against accidental probing for
+      // agents that have only `npmGlobalPackage`.
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -1545,13 +1549,19 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      // Filter out paths synthesised for the `interpreter` agent, whose
-      // `packages.pypi` legitimately triggers uv/pipx probing. Remaining
+      // Filter out paths synthesised for agents whose `packages.pypi`
+      // legitimately triggers uv/pipx probing (interpreter, mistral). Remaining
       // probed paths must not include any uv/pipx layouts — this guards
       // against accidental probing for agents that don't declare PyPI.
       const probedPaths = mockedAccess.mock.calls
         .map((c) => String(c[0]))
-        .filter((p) => !p.includes("open-interpreter") && !p.includes("/interpreter"));
+        .filter(
+          (p) =>
+            !p.includes("open-interpreter") &&
+            !p.includes("/interpreter") &&
+            !p.includes("mistral") &&
+            !p.includes("/vibe")
+        );
       expect(probedPaths.some((p) => p.includes(".local/share/uv/tools"))).toBe(false);
       expect(probedPaths.some((p) => p.includes(".local/share/pipx/venvs"))).toBe(false);
     });

--- a/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
+++ b/scripts/pattern-discovery/__tests__/corpus-replay.test.ts
@@ -41,6 +41,14 @@ describe("corpus-replay", () => {
     });
   });
 
+  describe("mistral corpus replay", () => {
+    it("achieves >= 90% accuracy on mistral sample corpus", () => {
+      const result = replayCorpus(path.join(CORPUS_DIR, "mistral_sample.jsonl"), "mistral");
+      expect(result.total).toBeGreaterThan(0);
+      expect(result.accuracy).toBeGreaterThanOrEqual(MIN_ACCURACY);
+    });
+  });
+
   describe("replay result structure", () => {
     it("returns detailed wrong entries for debugging", () => {
       const result = replayCorpus(path.join(CORPUS_DIR, "claude_sample.jsonl"), "claude");

--- a/scripts/pattern-discovery/corpus/mistral_sample.jsonl
+++ b/scripts/pattern-discovery/corpus/mistral_sample.jsonl
@@ -1,0 +1,12 @@
+{"time":0.0,"chunk":"Mistral Vibe","detectedState":"initializing","confidence":0.9,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":0.3,"chunk":"v2.9.0 · Type /help for more information","detectedState":"waiting","confidence":0.85,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":0.5,"chunk":"> ","detectedState":"waiting","confidence":0.85,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":1.0,"chunk":"⠋ Generating (1s Esc/Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":2.0,"chunk":"⠙ Generating (2s Esc/Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":5.0,"chunk":"⠹ Reading files (5s Esc/Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":8.0,"chunk":"⠼ Vibing (8s Esc/Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":12.0,"chunk":"⠦ Generating (12s Esc/Ctrl+C to interrupt)","detectedState":"working","confidence":0.95,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":13.0,"chunk":"⠏ Thinking","detectedState":"working","confidence":0.75,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":15.0,"chunk":"> ","detectedState":"waiting","confidence":0.85,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":16.0,"chunk":"To continue this session, run: vibe --continue","detectedState":"waiting","confidence":0.0,"agentId":"mistral","agentVersion":"2.9.0"}
+{"time":16.5,"chunk":"Or: vibe --resume abc-123-def-456","detectedState":"waiting","confidence":0.0,"agentId":"mistral","agentVersion":"2.9.0"}

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -432,6 +432,58 @@ describe("AgentDomainWeightsSchema", () => {
   });
 });
 
+describe("mistral configuration", () => {
+  it("uses 'vibe' as the binary command", () => {
+    expect(getAgentConfig("mistral")?.command).toBe("vibe");
+  });
+
+  it("passes --trust by default to skip the trust-folder prompt", () => {
+    expect(getAgentConfig("mistral")?.args).toContain("--trust");
+  });
+
+  it("blocks alt-screen and mouse reporting for the Textual TUI", () => {
+    const config = getAgentConfig("mistral");
+    expect(config?.capabilities?.blockAltScreen).toBe(true);
+    expect(config?.capabilities?.blockMouseReporting).toBe(true);
+    expect(config?.capabilities?.resizeStrategy).toBe("settled");
+  });
+
+  it("uses /exit as the quitCommand (Vibe has no /quit alias)", () => {
+    const resume = getAgentConfig("mistral")?.resume;
+    expect(resume?.kind).toBe("session-id");
+    if (resume?.kind === "session-id") {
+      expect(resume.quitCommand).toBe("/exit");
+      expect(resume.args("abc-123-def-456")).toEqual(["--resume", "abc-123-def-456"]);
+    }
+  });
+
+  it("captures session IDs from 'vibe --resume {id}' output", () => {
+    const resume = getAgentConfig("mistral")?.resume;
+    if (resume?.kind === "session-id") {
+      const re = new RegExp(resume.sessionIdPattern);
+      const match = "Or: vibe --resume abc-123-def-456".match(re);
+      expect(match?.[1]).toBe("abc-123-def-456");
+      expect("vibe --continue".match(re)).toBeNull();
+    }
+  });
+
+  it("relies on prompt fast-path with no completion patterns", () => {
+    const detection = getAgentConfig("mistral")?.detection;
+    expect(detection?.completionPatterns).toBeUndefined();
+    expect(detection?.promptFastPathMinQuietMs).toBe(700);
+  });
+
+  it("declares the PyPI package for path synthesis", () => {
+    expect(getAgentConfig("mistral")?.packages?.pypi).toBe("mistral-vibe");
+  });
+
+  it("ships the local-llamacpp preset as a labeled placeholder", () => {
+    const preset = getAgentConfig("mistral")?.presets?.find((p) => p.id === "local-llamacpp");
+    expect(preset).toBeDefined();
+    expect(preset?.name).toBe("Local (llama.cpp)");
+  });
+});
+
 describe("copilot configuration", () => {
   it("has 160k context window", () => {
     expect(getAgentConfig("copilot")?.contextWindow).toBe(160_000);

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -41,6 +41,7 @@ describe("agentRegistry", () => {
       expect(ids).toContain("crush");
       expect(ids).toContain("qwen");
       expect(ids).toContain("interpreter");
+      expect(ids).toContain("mistral");
     });
 
     it("kiro only has macOS and Linux install blocks (no Windows)", () => {
@@ -964,6 +965,7 @@ describe("all built-in agents have Windows or generic install", () => {
     "goose",
     "qwen",
     "interpreter",
+    "mistral",
   ])(
     "%s has windows or generic install block",
     (agentId) => {

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -10,6 +10,7 @@ export const BUILT_IN_AGENT_IDS = [
   "crush",
   "qwen",
   "interpreter",
+  "mistral",
 ] as const;
 
 export type BuiltInAgentId = (typeof BUILT_IN_AGENT_IDS)[number];

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -443,6 +443,7 @@ import { config as gooseConfig } from "./agents/goose.js";
 import { config as crushConfig } from "./agents/crush.js";
 import { config as qwenConfig } from "./agents/qwen.js";
 import { config as interpreterConfig } from "./agents/interpreter.js";
+import { config as mistralConfig } from "./agents/mistral.js";
 
 // Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
 // (mirroring `src/services/actions/definitions/`). When adding a new agent,
@@ -461,6 +462,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
   crush: crushConfig,
   qwen: qwenConfig,
   interpreter: interpreterConfig,
+  mistral: mistralConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/mistral.ts
+++ b/shared/config/agents/mistral.ts
@@ -89,8 +89,6 @@ export const config: AgentConfig = {
     fallbackPatterns: [
       // @generated:mistral:fallbackPatterns:start
       "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
-      "Generating",
-      "Thinking",
       // @generated:mistral:fallbackPatterns:end
     ],
     bootCompletePatterns: [
@@ -172,7 +170,7 @@ export const config: AgentConfig = {
     {
       id: "local-llamacpp",
       name: "Local (llama.cpp)",
-      description: "Local Devstral via llama.cpp at http://127.0.0.1:8080/v1",
+      description: "Local Devstral via llama.cpp — configure provider in ~/.vibe/config.toml",
     },
   ],
 };

--- a/shared/config/agents/mistral.ts
+++ b/shared/config/agents/mistral.ts
@@ -1,0 +1,178 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "mistral",
+  name: "Mistral Vibe",
+  command: "vibe",
+  // Pass --trust by default so the first-launch trust-folder prompt doesn't
+  // block the agent state machine.
+  args: ["--trust"],
+  color: "#FA500F",
+  iconId: "mistral",
+  supportsContextInjection: true,
+  tooltip: "Mistral's official terminal coding agent (Textual TUI)",
+  usageUrl: "https://github.com/mistralai/mistral-vibe",
+  packages: { pypi: "mistral-vibe" },
+  version: {
+    args: ["--version"],
+    pypiPackage: "mistral-vibe",
+    githubRepo: "mistralai/mistral-vibe",
+    releaseNotesUrl: "https://github.com/mistralai/mistral-vibe/releases/tag/v{version}",
+  },
+  update: {
+    curl: "curl -LsSf https://mistral.ai/vibe/install.sh | bash",
+    pypi: "uv tool upgrade mistral-vibe",
+  },
+  install: {
+    docsUrl: "https://github.com/mistralai/mistral-vibe#readme",
+    byOs: {
+      macos: [
+        {
+          label: "curl",
+          commands: ["curl -LsSf https://mistral.ai/vibe/install.sh | bash"],
+        },
+        {
+          label: "uv",
+          commands: ["uv tool install mistral-vibe"],
+        },
+      ],
+      linux: [
+        {
+          label: "curl",
+          commands: ["curl -LsSf https://mistral.ai/vibe/install.sh | bash"],
+        },
+        {
+          label: "uv",
+          commands: ["uv tool install mistral-vibe"],
+        },
+      ],
+      windows: [
+        {
+          label: "uv",
+          commands: ["uv tool install mistral-vibe"],
+          notes: [
+            "Windows is best-effort — Mistral officially supports UNIX environments.",
+            "The curl installer rejects Windows; use uv-direct instead.",
+          ],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: vibe --version",
+      "Run 'vibe --setup' to configure MISTRAL_API_KEY or a local provider",
+      "Requires Python >= 3.12 (the curl installer bootstraps uv-managed Python automatically)",
+    ],
+  },
+  models: [
+    { id: "devstral-2", name: "Devstral 2", shortLabel: "Devstral" },
+    { id: "devstral-small", name: "Devstral Small", shortLabel: "Small" },
+    { id: "local", name: "Local (llama.cpp)", shortLabel: "Local" },
+  ],
+  capabilities: {
+    scrollback: 10000,
+    blockAltScreen: true,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: [
+      // @generated:mistral:primaryPatterns:start
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^\\n]{2,80}\\s*\\(\\d+s\\s+Esc",
+      "Esc/Ctrl\\+C\\s+to\\s+interrupt",
+      "\\(\\d+s\\s+Esc/Ctrl\\+C\\s+to\\s+interrupt",
+      // @generated:mistral:primaryPatterns:end
+    ],
+    fallbackPatterns: [
+      // @generated:mistral:fallbackPatterns:start
+      "[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w",
+      "Generating",
+      "Thinking",
+      // @generated:mistral:fallbackPatterns:end
+    ],
+    bootCompletePatterns: [
+      // @generated:mistral:bootCompletePatterns:start
+      "Mistral\\s+Vibe",
+      "Type\\s+/help",
+      // @generated:mistral:bootCompletePatterns:end
+    ],
+    promptPatterns: ["^\\s*>\\s*$", "^\\s*>\\s"],
+    promptHintPatterns: ["^\\s*>\\s*$"],
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+    promptFastPathMinQuietMs: 700,
+  },
+  routing: {
+    capabilities: ["javascript", "typescript", "python", "rust", "go", "general-purpose"],
+    domains: {
+      frontend: 0.7,
+      backend: 0.8,
+      testing: 0.7,
+      refactoring: 0.75,
+      debugging: 0.75,
+      architecture: 0.7,
+    },
+    maxConcurrent: 2,
+    enabled: true,
+  },
+  // Vibe emits "vibe --resume {session_id}" on exit (session_exit.py:21).
+  // Critical: Vibe has NO `/quit` slash command — only `/exit`.
+  resume: {
+    kind: "session-id",
+    args: (sessionId: string) => ["--resume", sessionId],
+    quitCommand: "/exit",
+    sessionIdPattern: "vibe --resume ([\\w-]+)",
+  },
+  help: {
+    args: [],
+  },
+  authCheck: {
+    // Vibe writes credentials via `--setup` to ~/.vibe/.env and stores main
+    // config in ~/.vibe/config.toml. MISTRAL_API_KEY is the canonical env var
+    // (DEFAULT_MISTRAL_API_ENV_KEY in vibe/core/config/_settings.py).
+    configPathsAll: [".vibe/.env", ".vibe/config.toml"],
+    envVar: "MISTRAL_API_KEY",
+  },
+  prerequisites: [
+    {
+      tool: "vibe",
+      label: "Mistral Vibe",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/mistralai/mistral-vibe",
+    },
+  ],
+  presets: [
+    { id: "default", name: "Default" },
+    {
+      id: "plan",
+      name: "Plan",
+      args: ["--agent", "plan"],
+      description: "Read-only exploration",
+    },
+    {
+      id: "accept-edits",
+      name: "Accept edits",
+      args: ["--agent", "accept-edits"],
+      description: "Auto-approve file edits",
+    },
+    {
+      id: "auto-approve",
+      name: "Auto-approve",
+      args: ["--agent", "auto-approve"],
+      description: "Auto-approve all tools (YOLO)",
+      dangerousEnabled: true,
+    },
+    {
+      id: "local-llamacpp",
+      name: "Local (llama.cpp)",
+      description: "Local Devstral via llama.cpp at http://127.0.0.1:8080/v1",
+    },
+  ],
+};

--- a/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
@@ -18,12 +18,13 @@ describe("Skip permissions toggle gating", () => {
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("interpreter", "--auto_run");
   });
 
-  it("opencode, kiro, goose, crush, and qwen have no DEFAULT_DANGEROUS_ARGS entry", () => {
+  it("opencode, kiro, goose, crush, qwen, and mistral have no DEFAULT_DANGEROUS_ARGS entry", () => {
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("opencode");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("kiro");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("goose");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("crush");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("qwen");
+    expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("mistral");
   });
 
   it("gating expression matches expected agents", () => {
@@ -37,7 +38,15 @@ describe("Skip permissions toggle gating", () => {
     );
 
     expect(agentsWithToggle).toEqual(["claude", "gemini", "codex", "cursor", "interpreter"]);
-    expect(agentsWithoutToggle).toEqual(["opencode", "kiro", "copilot", "goose", "crush", "qwen"]);
+    expect(agentsWithoutToggle).toEqual([
+      "opencode",
+      "kiro",
+      "copilot",
+      "goose",
+      "crush",
+      "qwen",
+      "mistral",
+    ]);
   });
 
   it("all dangerous args are non-empty strings starting with --", () => {

--- a/src/components/icons/brands/MistralIcon.tsx
+++ b/src/components/icons/brands/MistralIcon.tsx
@@ -1,0 +1,37 @@
+/**
+ * Source: https://docs.mistral.ai/img/logo.svg (M-cube portion only)
+ */
+
+import { cn } from "@/lib/utils";
+
+interface MistralIconProps {
+  className?: string;
+  size?: number;
+  brandColor?: string;
+}
+
+export function MistralIcon({ className, size = 16, brandColor }: MistralIconProps) {
+  const fill = brandColor || "currentColor";
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 213 152"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      <path fill={fill} d="M30.303 0h30.303v30.303H30.303zm121.212 0h30.303v30.303h-30.303z" />
+      <path fill={fill} d="M30.303 30.303h60.606v30.303H30.303zm90.909 0h60.606v30.303h-60.606z" />
+      <path fill={fill} d="M30.303 60.606h151.515v30.303H30.303z" />
+      <path
+        fill={fill}
+        d="M30.303 90.909h30.303v30.303H30.303zm60.606 0h30.303v30.303H90.909zm60.606 0h30.303v30.303h-30.303z"
+      />
+      <path fill={fill} d="M0 121.212h90.909v30.303H0zm121.212 0h90.909v30.303h-90.909z" />
+    </svg>
+  );
+}
+
+export default MistralIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -10,6 +10,7 @@ export { GooseIcon } from "./GooseIcon";
 export { CrushIcon } from "./CrushIcon";
 export { QwenIcon } from "./QwenIcon";
 export { InterpreterIcon } from "./InterpreterIcon";
+export { MistralIcon } from "./MistralIcon";
 
 // JavaScript ecosystem
 export { NpmIcon } from "./NpmIcon";

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -57,6 +57,7 @@ export const AGENT_DESCRIPTIONS: Record<string, string> = {
   copilot: "GitHub's AI assistant with broad model choice",
   crush: "Charmbracelet's multi-provider Bubble Tea TUI agent",
   interpreter: "Local code execution — Python, shell, and JavaScript on your machine",
+  mistral: "Mistral's terminal coding agent with local model support",
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds Mistral Vibe (id `mistral`, binary `vibe`) as a first-class built-in agent — PyPI install, `--trust` default arg, `/exit` quit command, and session-id resume via `vibe --resume <id>`
- Detection patterns are source-verified against the Vibe Python repo: braille spinner + `(Ns Esc/Ctrl+C to interrupt)` as primary, `bootCompletePatterns` from the M-cube banner, prompt fast-path at 700ms quiet
- Includes M-cube brand icon (`MistralIcon`), AGENT_DESCRIPTIONS entry, corpus replay sample, and Mistral-specific contract assertions in the registry test suite

Resolves #6135

## Changes

- `shared/config/agents/mistral.ts` — full AgentConfig: install (curl/uv/pip), auth (`MISTRAL_API_KEY`, `.vibe/.env`), capabilities (alt-screen Textual TUI), detection patterns, presets, models, resume
- `shared/config/agentIds.ts` / `agentRegistry.ts` — `"mistral"` added to `BUILT_IN_AGENT_IDS` and registry map
- `src/components/icons/brands/MistralIcon.tsx` — Lucide-style SVG from `docs.mistral.ai/img/logo.svg`, brand colour `#FA500F`
- `src/config/agents.ts` — AGENT_DESCRIPTIONS entry
- `shared/config/__tests__/agentRegistry.test.ts` — contract tests for Mistral-specific invariants (quitCommand `/exit`, `--trust` default arg, sessionId capture pattern)
- `electron/services/pattern-discovery/corpus/mistral_sample.jsonl` + corpus-replay test

## Testing

- `npm run check` passes clean (0 errors)
- Mistral contract tests added alongside the existing per-agent contract suite
- Corpus replay confirms boot, working, idle, and exit states are detected correctly from the sample transcript