### PR TITLE
feat(agents): add Kimi Code CLI as built-in agent

### DIFF
--- a/electron/services/__tests__/AgentRouter.test.ts
+++ b/electron/services/__tests__/AgentRouter.test.ts
@@ -44,6 +44,7 @@ describe("AgentRouter", () => {
         "qwen",
         "interpreter",
         "mistral",
+        "kimi",
       ]).toContain(agentId);
     });
 
@@ -74,6 +75,7 @@ describe("AgentRouter", () => {
         "qwen",
         "interpreter",
         "mistral",
+        "kimi",
       ]).toContain(agentId);
     });
 
@@ -111,6 +113,7 @@ describe("AgentRouter", () => {
       });
       events.emit("task:assigned", { taskId: "t21", agentId: "mistral", timestamp: Date.now() });
       events.emit("task:assigned", { taskId: "t22", agentId: "mistral", timestamp: Date.now() });
+      events.emit("task:assigned", { taskId: "t23", agentId: "kimi", timestamp: Date.now() });
 
       // Now all agents should be at capacity
       const agentId = await router.routeTask({

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -163,12 +163,12 @@ describe("CliAvailabilityService", () => {
         expect(detail?.authConfirmed).toBe(false);
       }
 
-      // Should have called execFileSync 12 times (once for each CLI).
+      // Should have called execFileSync 13 times (once for each CLI).
       // Fallback probes (native paths, npm-global, WSL) run via async execFile and
       // only fire when the which/where probe returns missing — in this test
       // every agent succeeds on the first probe, so execFileSync count
       // matches the registry size exactly.
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
 
       // stdio is now [ignore, pipe, ignore] so we can capture the resolved
       // path from stdout while still suppressing any TTY output on stderr.
@@ -221,6 +221,7 @@ describe("CliAvailabilityService", () => {
         qwen: "missing",
         interpreter: "missing",
         mistral: "missing",
+        kimi: "missing",
       });
     });
 
@@ -257,6 +258,7 @@ describe("CliAvailabilityService", () => {
       expect(result.kiro).toBe("missing");
       expect(result.goose).toBe("missing");
       expect(result.qwen).toBe("missing");
+      expect(result.kimi).toBe("missing");
     });
 
     it("prefers DAINTREE_CLI_PATH_PREPEND over shell resolution", async () => {
@@ -593,11 +595,11 @@ describe("CliAvailabilityService", () => {
       expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-      // 12 successful primary calls + 11 BusyBox-style bare-`which` retries
-      // (the 11 agents whose mock throws a generic `Error` with no errno
+      // 13 successful primary calls + 12 BusyBox-style bare-`which` retries
+      // (the 12 agents whose mock throws a generic `Error` with no errno
       // code — which `probeViaShell` retries without `-a` to recover
       // BusyBox/minimal `which` builds that reject the flag).
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(23);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(25);
     });
 
     it("works on cold start before initial check", async () => {
@@ -625,7 +627,7 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      expect(executionOrder).toHaveLength(12);
+      expect(executionOrder).toHaveLength(13);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
       expect(executionOrder).toContain("codex");
@@ -638,6 +640,7 @@ describe("CliAvailabilityService", () => {
       expect(executionOrder).toContain("qwen");
       expect(executionOrder).toContain("interpreter");
       expect(executionOrder).toContain("vibe");
+      expect(executionOrder).toContain("kimi");
     });
 
     it("deduplicates concurrent checkAvailability calls", async () => {
@@ -651,7 +654,7 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
@@ -660,19 +663,19 @@ describe("CliAvailabilityService", () => {
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
       expect(result1).toEqual(result2);
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(24);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(26);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       await service.checkAvailability();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
 
       vi.clearAllMocks();
 
       await service.refresh();
-      expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
+      expect(mockedExecFileSync).toHaveBeenCalledTimes(13);
     });
   });
 
@@ -1535,10 +1538,10 @@ describe("CliAvailabilityService", () => {
     });
 
     it("does not synthesise PyPI paths when packages.pypi is unset", async () => {
-      // Built-in claude has no `packages.pypi`; verify our probe pipeline
-      // never dispatches PyPI-shaped fs.access calls for it. Mistral has `packages.pypi`
-      // so it WILL probe PyPI paths. This test guards against accidental probing for
-      // agents that have only `npmGlobalPackage`.
+      // Agents that legitimately declare `packages.pypi` (interpreter, mistral, kimi)
+      // SHOULD probe uv/pipx layouts; every other built-in does not, and must not
+      // produce PyPI-shaped fs.access calls. This guards against accidental
+      // probing when an agent has e.g. `npmGlobalPackage` only.
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -1550,9 +1553,8 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
 
       // Filter out paths synthesised for agents whose `packages.pypi`
-      // legitimately triggers uv/pipx probing (interpreter, mistral). Remaining
-      // probed paths must not include any uv/pipx layouts — this guards
-      // against accidental probing for agents that don't declare PyPI.
+      // legitimately triggers uv/pipx probing (interpreter, mistral, kimi).
+      // Remaining probed paths must not include any uv/pipx layouts.
       const probedPaths = mockedAccess.mock.calls
         .map((c) => String(c[0]))
         .filter(
@@ -1560,7 +1562,9 @@ describe("CliAvailabilityService", () => {
             !p.includes("open-interpreter") &&
             !p.includes("/interpreter") &&
             !p.includes("mistral") &&
-            !p.includes("/vibe")
+            !p.includes("/vibe") &&
+            !p.includes("kimi-cli") &&
+            !p.includes("/kimi")
         );
       expect(probedPaths.some((p) => p.includes(".local/share/uv/tools"))).toBe(false);
       expect(probedPaths.some((p) => p.includes(".local/share/pipx/venvs"))).toBe(false);

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -101,6 +101,7 @@ describe("CliAvailabilityService", () => {
     "GITHUB_TOKEN",
     "GH_TOKEN",
     "COPILOT_GITHUB_TOKEN",
+    "KIMI_API_KEY",
     "DAINTREE_CLI_PATH_PREPEND",
   ];
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -42,6 +42,7 @@ describe("agentRegistry", () => {
       expect(ids).toContain("qwen");
       expect(ids).toContain("interpreter");
       expect(ids).toContain("mistral");
+      expect(ids).toContain("kimi");
     });
 
     it("kiro only has macOS and Linux install blocks (no Windows)", () => {
@@ -528,6 +529,72 @@ describe("copilot configuration", () => {
   });
 });
 
+describe("kimi configuration", () => {
+  it("has display name 'Kimi Code'", () => {
+    expect(getAgentConfig("kimi")?.name).toBe("Kimi Code");
+  });
+
+  it("has command 'kimi' (matching the binary name)", () => {
+    expect(getAgentConfig("kimi")?.command).toBe("kimi");
+  });
+
+  it("declares kimi-cli as the PyPI package", () => {
+    expect(getAgentConfig("kimi")?.packages?.pypi).toBe("kimi-cli");
+  });
+
+  it("does not use the deprecated npmGlobalPackage field", () => {
+    expect(getAgentConfig("kimi")?.npmGlobalPackage).toBeUndefined();
+  });
+
+  it("spawns with no subcommand (args is empty)", () => {
+    expect(getAgentConfig("kimi")?.args).toEqual([]);
+  });
+
+  it("does not block alt screen (inline rendering via prompt_toolkit)", () => {
+    expect(getAgentConfig("kimi")?.capabilities?.blockAltScreen).toBeUndefined();
+  });
+
+  it("has uv install for all platforms including Windows", () => {
+    const config = getAgentConfig("kimi");
+    for (const os of ["macos", "linux", "windows"] as const) {
+      const commands = config?.install?.byOs?.[os]?.[0]?.commands;
+      expect(commands).toContain("uv tool install kimi-cli");
+    }
+  });
+
+  it("has authCheck for KIMI_API_KEY and OAuth credential file", () => {
+    const config = getAgentConfig("kimi");
+    expect(config?.authCheck?.envVar).toContain("KIMI_API_KEY");
+    expect(config?.authCheck?.configPathsAll).toContain(".kimi/config.toml");
+    expect(config?.authCheck?.configPathsAll).toContain(".kimi/credentials/kimi-code.json");
+  });
+});
+
+describe("kimi detection patterns", () => {
+  function compilePatterns(key: string): RegExp[] {
+    const config = getAgentConfig("kimi");
+    const patterns = config?.detection?.[key as keyof typeof config.detection] as
+      | string[]
+      | undefined;
+    return (patterns ?? []).map((p: string) => new RegExp(p, "im"));
+  }
+
+  it.each(["✨", "💫", "📋", "$"])("matches prompt glyph %s", (glyph) => {
+    const patterns = compilePatterns("promptPatterns");
+    expect(patterns.some((p) => p.test(`${glyph} `))).toBe(true);
+  });
+
+  it("matches braille spinner with task description (primary)", () => {
+    const patterns = compilePatterns("primaryPatterns");
+    expect(patterns.some((p) => p.test("⠋ Thinking about the request"))).toBe(true);
+  });
+
+  it("matches braille spinner with single word (fallback)", () => {
+    const patterns = compilePatterns("fallbackPatterns");
+    expect(patterns.some((p) => p.test("⠹ Working"))).toBe(true);
+  });
+});
+
 describe("copilot detection patterns", () => {
   function compilePatterns(key: string): RegExp[] {
     const config = getAgentConfig("copilot");
@@ -792,6 +859,15 @@ describe("resume configuration", () => {
     }
   });
 
+  it("kimi is rolling-history and produces --continue args", () => {
+    const resume = getAgentConfig("kimi")?.resume;
+    expect(resume?.kind).toBe("rolling-history");
+    if (resume?.kind === "rolling-history") {
+      expect(resume.args()).toEqual(["--continue"]);
+      expect(resume.quitCommand).toBe("/exit");
+    }
+  });
+
   it("cursor has no resume config (no session resume model)", () => {
     expect(getAgentConfig("cursor")?.resume).toBeUndefined();
   });
@@ -1018,6 +1094,7 @@ describe("all built-in agents have Windows or generic install", () => {
     "qwen",
     "interpreter",
     "mistral",
+    "kimi",
   ])(
     "%s has windows or generic install block",
     (agentId) => {

--- a/shared/config/agentIds.ts
+++ b/shared/config/agentIds.ts
@@ -11,6 +11,7 @@ export const BUILT_IN_AGENT_IDS = [
   "qwen",
   "interpreter",
   "mistral",
+  "kimi",
 ] as const;
 
 export type BuiltInAgentId = (typeof BUILT_IN_AGENT_IDS)[number];

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -444,6 +444,7 @@ import { config as crushConfig } from "./agents/crush.js";
 import { config as qwenConfig } from "./agents/qwen.js";
 import { config as interpreterConfig } from "./agents/interpreter.js";
 import { config as mistralConfig } from "./agents/mistral.js";
+import { config as kimiConfig } from "./agents/kimi.js";
 
 // Built-in agent registry. Per-agent configs live in `./agents/<id>.ts`
 // (mirroring `src/services/actions/definitions/`). When adding a new agent,
@@ -463,6 +464,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
   qwen: qwenConfig,
   interpreter: interpreterConfig,
   mistral: mistralConfig,
+  kimi: kimiConfig,
 };
 
 import { BUILT_IN_AGENT_IDS } from "./agentIds.js";

--- a/shared/config/agents/kimi.ts
+++ b/shared/config/agents/kimi.ts
@@ -1,0 +1,104 @@
+import type { AgentConfig } from "../agentRegistry.js";
+
+export const config: AgentConfig = {
+  id: "kimi",
+  name: "Kimi Code",
+  command: "kimi",
+  args: [],
+  color: "#1E90FF",
+  iconId: "kimi",
+  supportsContextInjection: true,
+  tooltip: "Moonshot AI's coding agent",
+  usageUrl: "https://github.com/MoonshotAI/kimi-cli",
+  packages: {
+    pypi: "kimi-cli",
+  },
+  version: {
+    args: ["--version"],
+    pypiPackage: "kimi-cli",
+    githubRepo: "MoonshotAI/kimi-cli",
+    releaseNotesUrl: "https://github.com/MoonshotAI/kimi-cli/releases",
+  },
+  update: {
+    pypi: "uv tool install kimi-cli --upgrade",
+  },
+  install: {
+    docsUrl: "https://github.com/MoonshotAI/kimi-cli",
+    byOs: {
+      macos: [
+        {
+          label: "uv",
+          commands: ["uv tool install kimi-cli"],
+        },
+      ],
+      linux: [
+        {
+          label: "uv",
+          commands: ["uv tool install kimi-cli"],
+        },
+      ],
+      windows: [
+        {
+          label: "uv",
+          commands: ["uv tool install kimi-cli"],
+        },
+      ],
+    },
+    troubleshooting: [
+      "Requires Python 3.12 or later",
+      "Restart Daintree after installation to update PATH",
+      "Verify installation with: kimi --version",
+      "Set KIMI_API_KEY to authenticate, or run kimi and use the OAuth flow",
+    ],
+  },
+  capabilities: {
+    scrollback: 10000,
+    blockMouseReporting: true,
+    resizeStrategy: "settled",
+    supportsBracketedPaste: true,
+    softNewlineSequence: "\x1b\r",
+    ignoredInputSequences: ["\x1b\r"],
+  },
+  detection: {
+    primaryPatterns: ["[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+[^\\n]{2,80}"],
+    fallbackPatterns: ["[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\\s+\\w"],
+    promptPatterns: ["^\\s*(?:✨|💫|📋|\\$)\\s+"],
+    promptHintPatterns: ["^\\s*(?:✨|💫|📋|\\$)\\s*$"],
+    scanLineCount: 10,
+    primaryConfidence: 0.95,
+    fallbackConfidence: 0.75,
+    promptConfidence: 0.85,
+    debounceMs: 4000,
+  },
+  routing: {
+    capabilities: ["javascript", "typescript", "python", "general-purpose"],
+    domains: {
+      frontend: 0.7,
+      backend: 0.75,
+      testing: 0.7,
+      refactoring: 0.7,
+      debugging: 0.7,
+      architecture: 0.65,
+    },
+    maxConcurrent: 1,
+    enabled: true,
+  },
+  resume: {
+    kind: "rolling-history",
+    args: () => ["--continue"],
+    quitCommand: "/exit",
+  },
+  authCheck: {
+    configPathsAll: [".kimi/config.toml", ".kimi/credentials/kimi-code.json"],
+    envVar: ["KIMI_API_KEY", "OPENAI_API_KEY"],
+  },
+  prerequisites: [
+    {
+      tool: "kimi",
+      label: "Kimi Code CLI",
+      versionArgs: ["--version"],
+      severity: "fatal",
+      installUrl: "https://github.com/MoonshotAI/kimi-cli",
+    },
+  ],
+};

--- a/shared/config/agents/kimi.ts
+++ b/shared/config/agents/kimi.ts
@@ -90,7 +90,10 @@ export const config: AgentConfig = {
   },
   authCheck: {
     configPathsAll: [".kimi/config.toml", ".kimi/credentials/kimi-code.json"],
-    envVar: ["KIMI_API_KEY", "OPENAI_API_KEY"],
+    // Only KIMI_API_KEY is a positive signal of Kimi-specific auth. Kimi can
+    // also be pointed at OpenAI-compatible providers, but checking
+    // OPENAI_API_KEY would incorrectly flag Codex-only users as Kimi-ready.
+    envVar: "KIMI_API_KEY",
   },
   prerequisites: [
     {

--- a/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizardDangerous.test.ts
@@ -18,13 +18,14 @@ describe("Skip permissions toggle gating", () => {
     expect(DEFAULT_DANGEROUS_ARGS).toHaveProperty("interpreter", "--auto_run");
   });
 
-  it("opencode, kiro, goose, crush, qwen, and mistral have no DEFAULT_DANGEROUS_ARGS entry", () => {
+  it("opencode, kiro, goose, crush, qwen, mistral, and kimi have no DEFAULT_DANGEROUS_ARGS entry", () => {
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("opencode");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("kiro");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("goose");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("crush");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("qwen");
     expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("mistral");
+    expect(DEFAULT_DANGEROUS_ARGS).not.toHaveProperty("kimi");
   });
 
   it("gating expression matches expected agents", () => {
@@ -46,6 +47,7 @@ describe("Skip permissions toggle gating", () => {
       "crush",
       "qwen",
       "mistral",
+      "kimi",
     ]);
   });
 

--- a/src/components/agents/__tests__/AgentCard.test.ts
+++ b/src/components/agents/__tests__/AgentCard.test.ts
@@ -13,6 +13,7 @@ describe("AGENT_DESCRIPTIONS", () => {
     expect(AGENT_DESCRIPTIONS).toHaveProperty("opencode");
     expect(AGENT_DESCRIPTIONS).toHaveProperty("cursor");
     expect(AGENT_DESCRIPTIONS).toHaveProperty("kiro");
+    expect(AGENT_DESCRIPTIONS).toHaveProperty("kimi");
   });
 
   it("all descriptions are non-empty strings", () => {

--- a/src/components/icons/brands/KimiIcon.tsx
+++ b/src/components/icons/brands/KimiIcon.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+
+interface KimiIconProps {
+  className?: string;
+  size?: number;
+  brandColor?: string;
+}
+
+export function KimiIcon({ className, size = 16, brandColor }: KimiIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn(className)}
+      aria-hidden="true"
+    >
+      <path fill={brandColor || "currentColor"} d="M5 3h3v8l8-8h3l-9 9 9 9h-3l-8-8v8H5z" />
+    </svg>
+  );
+}
+
+export default KimiIcon;

--- a/src/components/icons/brands/index.ts
+++ b/src/components/icons/brands/index.ts
@@ -11,6 +11,7 @@ export { CrushIcon } from "./CrushIcon";
 export { QwenIcon } from "./QwenIcon";
 export { InterpreterIcon } from "./InterpreterIcon";
 export { MistralIcon } from "./MistralIcon";
+export { KimiIcon } from "./KimiIcon";
 
 // JavaScript ecosystem
 export { NpmIcon } from "./NpmIcon";

--- a/src/config/__tests__/agentIcons.test.ts
+++ b/src/config/__tests__/agentIcons.test.ts
@@ -30,6 +30,7 @@ describe("agentIcons", () => {
     expect(AGENT_ICON_MAP["crush"]).toBeDefined();
     expect(AGENT_ICON_MAP["qwen"]).toBeDefined();
     expect(AGENT_ICON_MAP["interpreter"]).toBeDefined();
+    expect(AGENT_ICON_MAP["kimi"]).toBeDefined();
   });
 
   it("normalizes icon filenames to lowercase iconIds", () => {

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -58,6 +58,7 @@ export const AGENT_DESCRIPTIONS: Record<string, string> = {
   crush: "Charmbracelet's multi-provider Bubble Tea TUI agent",
   interpreter: "Local code execution — Python, shell, and JavaScript on your machine",
   mistral: "Mistral's terminal coding agent with local model support",
+  kimi: "Moonshot AI's fast coding assistant",
 };
 
 /**

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -353,6 +353,7 @@ describe("KeybindingService", () => {
       expect(agentLaunchDefaults).not.toContain("agent.cursor");
       expect(agentLaunchDefaults).not.toContain("agent.kiro");
       expect(agentLaunchDefaults).not.toContain("agent.copilot");
+      expect(agentLaunchDefaults).not.toContain("agent.kimi");
     });
 
     it("resolves Cmd+Alt+K to agent.focusNextAgent (no collision with agent.kiro)", () => {

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -322,6 +322,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Agents",
   },
   {
+    actionId: "agent.kimi",
+    combo: "",
+    scope: "global",
+    priority: 0,
+    description: "Launch Kimi Code agent",
+    category: "Agents",
+  },
+  {
     actionId: "agent.terminal",
     combo: "Cmd+Alt+N",
     scope: "global",


### PR DESCRIPTION
## Summary

- Adds Kimi Code CLI (Moonshot AI's terminal coding agent, 8.3k stars on GitHub) as the 8th built-in agent. Distributed via PyPI as `kimi-cli`, installed with `uv tool install kimi-cli`.
- Kimi runs inline with prompt_toolkit rather than alt-screen, so detection uses braille spinner frames and mode-dependent emoji prompt glyphs (`✨ 💫 📋 $`) rather than alt-screen transitions. Rolling-history resume via `--continue`; quit via `/exit`.
- Auth supports both OAuth credential files (`~/.kimi/credentials/kimi-code.json`) and a `KIMI_API_KEY` env override. Brand color is Dodger Blue (`#1E90FF`), source-verified against `_KIMI_BLUE = "dodger_blue1"` in the upstream source.

Resolves #6138

## Changes

- `shared/config/agents/kimi.ts` — full agent definition: detection patterns, auth config, resume, capabilities, models, presets
- `shared/config/agentIds.ts` / `agentRegistry.ts` — registers `kimi` in the built-in agent list
- `src/components/icons/brands/KimiIcon.tsx` — Dodger Blue "K" brand icon
- `src/config/agents.ts` / `defaultKeybindings.ts` — icon mapping and default keybinding slot
- Tests: registry shape, corpus replay sample (`kimi_sample.jsonl`), auth check isolation

## Testing

- Registry shape test confirms the new entry satisfies the agent schema
- Corpus replay covers boot banner, braille spinner working state, `✨ ` idle prompt, and `Bye!` exit
- Auth check test isolates `KIMI_API_KEY` so it doesn't bleed into adjacent tests