### PR TITLE
feat(empty-states): first-run empty states for recipes, MCP, GitHub, agents

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -172,6 +172,13 @@ export function GitHubResourceList({
   const githubConfig = useGitHubConfigStore((s) => s.config);
   const showNoTokenEmptyState =
     githubConfigInitialized && githubConfig !== null && !githubConfig.hasToken;
+
+  // Self-init the GitHub config store so the no-token empty state can render
+  // before any other code path has triggered initialization. This mirrors the
+  // pattern used in BulkCreateWorktreeDialog.
+  useEffect(() => {
+    void useGitHubConfigStore.getState().initialize();
+  }, []);
   const cacheKey = useMemo(
     () => buildCacheKey(projectPath, type, filterState as string, sortOrder),
     [projectPath, type, filterState, sortOrder]

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect, useMemo, useCallback, useRef, type KeyboardEvent } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDebounce } from "@/hooks/useDebounce";
-import { Search, ExternalLink, RefreshCw, WifiOff, Plus, Settings, X, Filter } from "lucide-react";
+import {
+  Search,
+  ExternalLink,
+  RefreshCw,
+  WifiOff,
+  Plus,
+  Settings,
+  X,
+  Filter,
+  Github,
+} from "lucide-react";
 import {
   buildCacheKey,
   getCache,
@@ -11,6 +21,7 @@ import {
 } from "@/lib/githubResourceCache";
 import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients/githubClient";
@@ -25,6 +36,7 @@ import {
   type IssueStateFilter,
   type PRStateFilter,
 } from "@/store/githubFilterStore";
+import { useGitHubConfigStore } from "@/store/githubConfigStore";
 import type { GitHubIssue, GitHubPR, GitHubSortOrder } from "@shared/types/github";
 import { parseNumberQuery, MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
 import {
@@ -156,6 +168,10 @@ export function GitHubResourceList({
   const setSortOrder = useGitHubFilterStore((s) =>
     type === "issue" ? s.setIssueSortOrder : s.setPrSortOrder
   ) as (o: GitHubSortOrder) => void;
+  const githubConfigInitialized = useGitHubConfigStore((s) => s.isInitialized);
+  const githubConfig = useGitHubConfigStore((s) => s.config);
+  const showNoTokenEmptyState =
+    githubConfigInitialized && githubConfig !== null && !githubConfig.hasToken;
   const cacheKey = useMemo(
     () => buildCacheKey(projectPath, type, filterState as string, sortOrder),
     [projectPath, type, filterState, sortOrder]
@@ -230,6 +246,10 @@ export function GitHubResourceList({
       options?: { revalidating?: boolean; generation?: number; cacheKey?: string }
     ) => {
       if (!projectPath) return;
+      // Skip the fetch entirely when no token is configured. The render path
+      // shows a dedicated empty state; firing fetches here would just produce
+      // a token-error toast for users who haven't set up GitHub yet.
+      if (githubConfig && !githubConfig.hasToken) return;
 
       const isRevalidate = options?.revalidating ?? false;
 
@@ -349,7 +369,7 @@ export function GitHubResourceList({
         }
       }
     },
-    [projectPath, debouncedSearch, filterState, type, sortOrder, numberQuery]
+    [projectPath, debouncedSearch, filterState, type, sortOrder, numberQuery, githubConfig]
   );
 
   useEffect(() => {
@@ -430,6 +450,12 @@ export function GitHubResourceList({
 
   useEffect(() => {
     if (numberQuery === null) {
+      return;
+    }
+    // Skip numeric fetches when no token is configured — the empty state
+    // takes over the UI and any leftover store search would otherwise
+    // produce a token error.
+    if (githubConfig && !githubConfig.hasToken) {
       return;
     }
 
@@ -560,7 +586,7 @@ export function GitHubResourceList({
     return () => {
       abortController.abort();
     };
-  }, [numberQuery, projectPath, type, filterState, retryKey]);
+  }, [numberQuery, projectPath, type, filterState, retryKey, githubConfig]);
 
   const handleLoadMore = useCallback(() => {
     if (!loadingMore && hasMore) {
@@ -796,6 +822,26 @@ export function GitHubResourceList({
       </div>
     );
   };
+
+  if (showNoTokenEmptyState) {
+    return (
+      <div className="relative w-[450px] flex flex-col h-[500px]">
+        <EmptyState
+          variant="zero-data"
+          icon={<Github />}
+          title="GitHub not connected"
+          description="Add a personal access token to browse issues and pull requests for this project."
+          action={
+            <Button variant="outline" size="sm" onClick={handleOpenGitHubSettings}>
+              <Settings className="h-3.5 w-3.5" />
+              Add GitHub token
+            </Button>
+          }
+          className="flex-1 justify-center"
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="relative w-[450px] flex flex-col h-[500px]">

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -22,6 +22,19 @@ vi.mock("@/clients/githubClient", () => ({
   },
 }));
 
+let mockGitHubConfig: { hasToken: boolean } | null = { hasToken: true };
+let mockGitHubConfigInitialized = true;
+
+vi.mock("@/store/githubConfigStore", () => ({
+  useGitHubConfigStore: (
+    selector: (s: { isInitialized: boolean; config: { hasToken: boolean } | null }) => unknown
+  ) =>
+    selector({
+      isInitialized: mockGitHubConfigInitialized,
+      config: mockGitHubConfig,
+    }),
+}));
+
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: vi.fn() },
 }));
@@ -132,6 +145,8 @@ beforeEach(() => {
   mockGetPRByNumber.mockReset();
   formatTimeAgoMock.mockClear();
   formatTimeAgoMock.mockImplementation(() => "1m ago");
+  mockGitHubConfig = { hasToken: true };
+  mockGitHubConfigInitialized = true;
   const filterStore = useGitHubFilterStore.getState();
   filterStore.setIssueSearchQuery("");
   filterStore.setPrSearchQuery("");
@@ -545,6 +560,41 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GitHubResourceList no-token empty state", () => {
+  it("renders 'GitHub not connected' when no token is configured", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByText("GitHub not connected")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /add github token/i })).toBeTruthy();
+    expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("does not render the search input when the no-token empty state is active", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.queryByPlaceholderText(/search issues/i)).toBeNull();
+  });
+
+  it("renders normally once a token is configured", async () => {
+    mockGitHubConfig = { hasToken: true };
+    mockGitHubConfigInitialized = true;
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.queryByText("GitHub not connected")).toBeNull();
+    await waitFor(() => {
+      expect(screen.getByTestId("item-1")).toBeTruthy();
+    });
   });
 });
 

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -24,19 +24,34 @@ vi.mock("@/clients/githubClient", () => ({
 
 let mockGitHubConfig: { hasToken: boolean } | null = { hasToken: true };
 let mockGitHubConfigInitialized = true;
+const initializeMock = vi.fn().mockResolvedValue(undefined);
 
-vi.mock("@/store/githubConfigStore", () => ({
-  useGitHubConfigStore: (
-    selector: (s: { isInitialized: boolean; config: { hasToken: boolean } | null }) => unknown
+vi.mock("@/store/githubConfigStore", () => {
+  const useGitHubConfigStore = (
+    selector: (s: {
+      isInitialized: boolean;
+      config: { hasToken: boolean } | null;
+      initialize: () => Promise<void>;
+    }) => unknown
   ) =>
     selector({
       isInitialized: mockGitHubConfigInitialized,
       config: mockGitHubConfig,
-    }),
-}));
+      initialize: initializeMock,
+    });
+  // Mirror Zustand's hook + getState API surface used by the component.
+  (useGitHubConfigStore as unknown as { getState: () => unknown }).getState = () => ({
+    isInitialized: mockGitHubConfigInitialized,
+    config: mockGitHubConfig,
+    initialize: initializeMock,
+  });
+  return { useGitHubConfigStore };
+});
+
+const dispatchMock = vi.fn();
 
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: vi.fn() },
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
 }));
 
 vi.mock("@/hooks/useIssueSelection", () => ({
@@ -145,6 +160,8 @@ beforeEach(() => {
   mockGetPRByNumber.mockReset();
   formatTimeAgoMock.mockClear();
   formatTimeAgoMock.mockImplementation(() => "1m ago");
+  dispatchMock.mockReset();
+  initializeMock.mockClear();
   mockGitHubConfig = { hasToken: true };
   mockGitHubConfigInitialized = true;
   const filterStore = useGitHubFilterStore.getState();
@@ -595,6 +612,44 @@ describe("GitHubResourceList no-token empty state", () => {
     await waitFor(() => {
       expect(screen.getByTestId("item-1")).toBeTruthy();
     });
+  });
+
+  it("renders the empty state for type='pr' and skips listPullRequests", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    expect(screen.getByText("GitHub not connected")).toBeTruthy();
+    expect(mockListPRs).not.toHaveBeenCalled();
+  });
+
+  it("does not fire numeric fetches when the search store has a number but no token is set", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(mockGetIssueByNumber).not.toHaveBeenCalled();
+    expect(screen.getByText("GitHub not connected")).toBeTruthy();
+  });
+
+  it("'Add GitHub token' CTA dispatches the settings open action and closes", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+    const onClose = vi.fn();
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" onClose={onClose} />);
+
+    screen.getByRole("button", { name: /add github token/i }).click();
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "github", sectionId: "github-token" },
+      { source: "user" }
+    );
+    expect(onClose).toHaveBeenCalled();
   });
 });
 

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -619,7 +619,7 @@ export function AgentTrayButton({
                 data-testid="agent-tray-pin-hint"
                 className="text-daintree-text/50 font-normal text-[11px] -mt-1 pb-1.5"
               >
-                Press P on any agent to pin it to the toolbar.
+                Hover an agent and click the pin to keep it on the toolbar.
               </DropdownMenuLabel>
             )}
             {launchable.map((row) => renderLaunchItem(row))}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -614,6 +614,14 @@ export function AgentTrayButton({
         {launchable.length > 0 && (
           <>
             <DropdownMenuLabel>Launch</DropdownMenuLabel>
+            {hasNoPinnedAgents && !isAvailabilityLoading && (
+              <DropdownMenuLabel
+                data-testid="agent-tray-pin-hint"
+                className="text-daintree-text/50 font-normal text-[11px] -mt-1 pb-1.5"
+              >
+                Press P on any agent to pin it to the toolbar.
+              </DropdownMenuLabel>
+            )}
             {launchable.map((row) => renderLaunchItem(row))}
           </>
         )}

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -416,6 +416,47 @@ describe("AgentTrayButton", () => {
     expect(agentRows(container)).toEqual(["claude", "gemini", "codex"]);
   });
 
+  const PIN_HINT_TEXT = /press p on any agent to pin it to the toolbar/i;
+
+  it("shows the pin discovery hint when launchable agents are present but none are pinned", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({
+      claude: { pinned: false },
+      gemini: { pinned: false },
+    });
+
+    const { queryByText } = render(<AgentTrayButton agentAvailability={availability} />);
+
+    expect(queryByText(PIN_HINT_TEXT)).toBeTruthy();
+  });
+
+  it("hides the pin hint once at least one agent is pinned", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({
+      claude: { pinned: true },
+      gemini: { pinned: false },
+    });
+
+    const { queryByText } = render(<AgentTrayButton agentAvailability={availability} />);
+
+    expect(queryByText(PIN_HINT_TEXT)).toBeNull();
+  });
+
+  it("hides the pin hint while availability is still loading", () => {
+    mockSettings = settingsWith({ claude: { pinned: false } });
+    mockHasRealData = false;
+
+    const { queryByText } = render(<AgentTrayButton agentAvailability={undefined} />);
+
+    expect(queryByText(PIN_HINT_TEXT)).toBeNull();
+  });
+
   it("dispatches agent.launch when no active session exists", () => {
     const availability = { gemini: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ gemini: { pinned: false } });

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -295,6 +295,10 @@ function settingsWith(overrides: Record<string, { pinned?: boolean }>): AgentSet
   return { agents: overrides } as unknown as AgentSettings;
 }
 
+function avail(rows: Record<string, string>): CliAvailability {
+  return rows as unknown as CliAvailability;
+}
+
 function agentRows(container: HTMLElement): string[] {
   return Array.from(container.querySelectorAll('[data-testid^="agent-tray-row-"]'))
     .map((el) => el.getAttribute("data-testid")?.replace("agent-tray-row-", "") ?? "")
@@ -419,10 +423,7 @@ describe("AgentTrayButton", () => {
   const PIN_HINT_TEXT = /hover an agent and click the pin to keep it on the toolbar/i;
 
   it("shows the pin discovery hint when launchable agents are present but none are pinned", () => {
-    const availability = {
-      claude: "ready",
-      gemini: "ready",
-    } as unknown as CliAvailability;
+    const availability = avail({ claude: "ready", gemini: "ready" });
     mockSettings = settingsWith({
       claude: { pinned: false },
       gemini: { pinned: false },
@@ -434,10 +435,7 @@ describe("AgentTrayButton", () => {
   });
 
   it("hides the pin hint once at least one agent is pinned", () => {
-    const availability = {
-      claude: "ready",
-      gemini: "ready",
-    } as unknown as CliAvailability;
+    const availability = avail({ claude: "ready", gemini: "ready" });
     mockSettings = settingsWith({
       claude: { pinned: true },
       gemini: { pinned: false },

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -416,7 +416,7 @@ describe("AgentTrayButton", () => {
     expect(agentRows(container)).toEqual(["claude", "gemini", "codex"]);
   });
 
-  const PIN_HINT_TEXT = /press p on any agent to pin it to the toolbar/i;
+  const PIN_HINT_TEXT = /hover an agent and click the pin to keep it on the toolbar/i;
 
   it("shows the pin discovery hint when launchable agents are present but none are pinned", () => {
     const availability = {

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Copy, Check, AlertCircle, Key, Hash, Shield, Eye, EyeOff, RefreshCw } from "lucide-react";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -195,6 +197,22 @@ export function McpServerSettingsTab() {
         ariaLabel="Enable MCP server"
         disabled={loading}
       />
+
+      {!status.enabled && !loading && (
+        <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
+          <EmptyState
+            variant="zero-data"
+            icon={<McpServerIcon />}
+            title="MCP server is off"
+            description="Turn it on to expose Daintree's actions as MCP tools agents can call."
+            action={
+              <Button variant="outline" size="sm" onClick={() => void handleToggle()}>
+                Turn on MCP server
+              </Button>
+            }
+          />
+        </div>
+      )}
 
       {status.enabled && (
         <>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -198,7 +198,7 @@ export function McpServerSettingsTab() {
         disabled={loading}
       />
 
-      {!status.enabled && !loading && (
+      {!status.enabled && !loading && !error && (
         <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
           <EmptyState
             variant="zero-data"

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -226,6 +226,49 @@ describe("McpServerSettingsTab", () => {
     expect(screen.queryByText("MCP server is off")).toBeNull();
   });
 
+  it("does not show the empty state when MCP status load fails", async () => {
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+
+    await waitForContent(container, "IPC down");
+
+    expect(screen.queryByText("MCP server is off")).toBeNull();
+  });
+
+  it("hides the empty state once MCP is enabled via the CTA", async () => {
+    const setEnabledMock = vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 9020,
+      configuredPort: 9020,
+      apiKey: "",
+    });
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+        setEnabled: setEnabledMock,
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "MCP server is off");
+
+    fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("MCP server is off")).toBeNull();
+    });
+  });
+
   it("routes toggle IPC failure to inbox while keeping inline error", async () => {
     window.electron = {
       mcpServer: createMcpApi({

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -43,6 +43,12 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
 
 const writeText = vi.fn().mockResolvedValue(undefined);
 
+function installMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {}) {
+  window.electron = {
+    mcpServer: createMcpApi(overrides),
+  } as unknown as typeof window.electron;
+}
+
 describe("McpServerSettingsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,9 +58,7 @@ describe("McpServerSettingsTab", () => {
       writable: true,
       configurable: true,
     });
-    window.electron = {
-      mcpServer: createMcpApi(),
-    } as unknown as typeof window.electron;
+    installMcpApi();
   });
 
   const waitForContent = (container: HTMLElement, text: string) =>
@@ -140,11 +144,9 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("routes IPC failure to inbox via low-priority notify and inline error", async () => {
-    window.electron = {
-      mcpServer: createMcpApi({
-        getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
-      }),
-    } as unknown as typeof window.electron;
+    installMcpApi({
+      getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
+    });
 
     const { container } = render(<McpServerSettingsTab />);
 
@@ -161,16 +163,14 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("renders empty state with 'Turn on MCP server' CTA when MCP is disabled", async () => {
-    window.electron = {
-      mcpServer: createMcpApi({
-        getStatus: vi.fn().mockResolvedValue({
-          enabled: false,
-          port: null,
-          configuredPort: null,
-          apiKey: "",
-        }),
+    installMcpApi({
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: false,
+        port: null,
+        configuredPort: null,
+        apiKey: "",
       }),
-    } as unknown as typeof window.electron;
+    });
 
     const { container } = render(<McpServerSettingsTab />);
     await waitForContent(container, "MCP server is off");
@@ -185,17 +185,15 @@ describe("McpServerSettingsTab", () => {
       configuredPort: 9020,
       apiKey: "",
     });
-    window.electron = {
-      mcpServer: createMcpApi({
-        getStatus: vi.fn().mockResolvedValue({
-          enabled: false,
-          port: null,
-          configuredPort: null,
-          apiKey: "",
-        }),
-        setEnabled: setEnabledMock,
+    installMcpApi({
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: false,
+        port: null,
+        configuredPort: null,
+        apiKey: "",
       }),
-    } as unknown as typeof window.electron;
+      setEnabled: setEnabledMock,
+    });
 
     const { container } = render(<McpServerSettingsTab />);
     await waitForContent(container, "MCP server is off");
@@ -208,12 +206,10 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("does not render the empty state while MCP status is still loading", () => {
-    window.electron = {
-      mcpServer: createMcpApi({
-        // Pending forever so the loading state is the rendered state.
-        getStatus: vi.fn().mockReturnValue(new Promise(() => {})),
-      }),
-    } as unknown as typeof window.electron;
+    installMcpApi({
+      // Pending forever so the loading state is the rendered state.
+      getStatus: vi.fn().mockReturnValue(new Promise(() => {})),
+    });
 
     render(<McpServerSettingsTab />);
     expect(screen.queryByText("MCP server is off")).toBeNull();
@@ -227,11 +223,9 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("does not show the empty state when MCP status load fails", async () => {
-    window.electron = {
-      mcpServer: createMcpApi({
-        getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
-      }),
-    } as unknown as typeof window.electron;
+    installMcpApi({
+      getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
+    });
 
     const { container } = render(<McpServerSettingsTab />);
 
@@ -247,17 +241,15 @@ describe("McpServerSettingsTab", () => {
       configuredPort: 9020,
       apiKey: "",
     });
-    window.electron = {
-      mcpServer: createMcpApi({
-        getStatus: vi.fn().mockResolvedValue({
-          enabled: false,
-          port: null,
-          configuredPort: null,
-          apiKey: "",
-        }),
-        setEnabled: setEnabledMock,
+    installMcpApi({
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: false,
+        port: null,
+        configuredPort: null,
+        apiKey: "",
       }),
-    } as unknown as typeof window.electron;
+      setEnabled: setEnabledMock,
+    });
 
     const { container } = render(<McpServerSettingsTab />);
     await waitForContent(container, "MCP server is off");
@@ -270,11 +262,9 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("routes toggle IPC failure to inbox while keeping inline error", async () => {
-    window.electron = {
-      mcpServer: createMcpApi({
-        setEnabled: vi.fn().mockRejectedValue(new Error("toggle failed")),
-      }),
-    } as unknown as typeof window.electron;
+    installMcpApi({
+      setEnabled: vi.fn().mockRejectedValue(new Error("toggle failed")),
+    });
 
     const { container } = render(<McpServerSettingsTab />);
     await waitForContent(container, "MCP Server");

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -160,6 +160,72 @@ describe("McpServerSettingsTab", () => {
     expect(mockedLogError).toHaveBeenCalledWith("Failed to load MCP status", expect.any(Error));
   });
 
+  it("renders empty state with 'Turn on MCP server' CTA when MCP is disabled", async () => {
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "MCP server is off");
+
+    expect(screen.getByRole("button", { name: /turn on mcp server/i })).toBeTruthy();
+  });
+
+  it("clicking 'Turn on MCP server' from the empty state calls setEnabled(true)", async () => {
+    const setEnabledMock = vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 9020,
+      configuredPort: 9020,
+      apiKey: "",
+    });
+    window.electron = {
+      mcpServer: createMcpApi({
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+        setEnabled: setEnabledMock,
+      }),
+    } as unknown as typeof window.electron;
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "MCP server is off");
+
+    fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
+
+    await waitFor(() => {
+      expect(setEnabledMock).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it("does not render the empty state while MCP status is still loading", () => {
+    window.electron = {
+      mcpServer: createMcpApi({
+        // Pending forever so the loading state is the rendered state.
+        getStatus: vi.fn().mockReturnValue(new Promise(() => {})),
+      }),
+    } as unknown as typeof window.electron;
+
+    render(<McpServerSettingsTab />);
+    expect(screen.queryByText("MCP server is off")).toBeNull();
+  });
+
+  it("hides the empty state once MCP is enabled", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    expect(screen.queryByText("MCP server is off")).toBeNull();
+  });
+
   it("routes toggle IPC failure to inbox while keeping inline error", async () => {
     window.electron = {
       mcpServer: createMcpApi({

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { Workflow } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -303,20 +304,33 @@ export function RecipeManager({
             </h3>
             <p className="text-xs text-daintree-text/60 mb-3">Available across all projects</p>
             {globalRecipes.length === 0 ? (
-              <div className="text-sm text-daintree-text/60 text-center py-4 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-                No global recipes
+              <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
+                <EmptyState
+                  variant="zero-data"
+                  icon={<Workflow />}
+                  title="No global recipes"
+                  description="Save a terminal layout once and launch it in any project."
+                  action={
+                    <Button variant="outline" size="sm" onClick={() => onCreateRecipe("global")}>
+                      <Plus className="h-3 w-3" />
+                      New global recipe
+                    </Button>
+                  }
+                />
               </div>
             ) : (
-              <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">
-                {globalRecipes.map((r) => renderRecipeRow(r))}
-              </div>
+              <>
+                <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">
+                  {globalRecipes.map((r) => renderRecipeRow(r))}
+                </div>
+                <div className="flex gap-2 mt-2">
+                  <Button variant="outline" size="sm" onClick={() => onCreateRecipe("global")}>
+                    <Plus className="h-3 w-3" />
+                    New global recipe
+                  </Button>
+                </div>
+              </>
             )}
-            <div className="flex gap-2 mt-2">
-              <Button variant="outline" size="sm" onClick={() => onCreateRecipe("global")}>
-                <Plus className="h-3 w-3" />
-                New global recipe
-              </Button>
-            </div>
           </div>
 
           {/* Team Recipes Section (in-repo) */}
@@ -348,32 +362,59 @@ export function RecipeManager({
             </h3>
             <p className="text-xs text-daintree-text/60 mb-3">Specific to the current project</p>
             {projectRecipes.length === 0 ? (
-              <div className="text-sm text-daintree-text/60 text-center py-4 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-                No project recipes
+              <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
+                <EmptyState
+                  variant="zero-data"
+                  icon={<Workflow />}
+                  title="No project recipes"
+                  description="Project recipes stay private to this machine until you save them to the repo."
+                  action={
+                    <div className="flex flex-wrap gap-2 justify-center">
+                      <Button variant="outline" size="sm" onClick={() => onCreateRecipe("project")}>
+                        <Plus className="h-3 w-3" />
+                        New project recipe
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => setShowImportDialog(true)}>
+                        <FileDown className="h-3 w-3" />
+                        Import from clipboard
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void importRecipeFromFile(currentProject?.id)}
+                      >
+                        <FileUp className="h-3 w-3" />
+                        Import from file
+                      </Button>
+                    </div>
+                  }
+                />
               </div>
             ) : (
-              <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">
-                {projectRecipes.map((r) => renderRecipeRow(r))}
-              </div>
+              <>
+                <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">
+                  {projectRecipes.map((r) => renderRecipeRow(r))}
+                </div>
+                <div className="flex gap-2 mt-2">
+                  <Button variant="outline" size="sm" onClick={() => onCreateRecipe("project")}>
+                    <Plus className="h-3 w-3" />
+                    New project recipe
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={() => setShowImportDialog(true)}>
+                    <FileDown className="h-3 w-3" />
+                    Import from clipboard
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void importRecipeFromFile(currentProject?.id)}
+                  >
+                    <FileUp className="h-3 w-3" />
+                    Import from file
+                  </Button>
+                </div>
+              </>
             )}
-            <div className="flex gap-2 mt-2">
-              <Button variant="outline" size="sm" onClick={() => onCreateRecipe("project")}>
-                <Plus className="h-3 w-3" />
-                New project recipe
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => setShowImportDialog(true)}>
-                <FileDown className="h-3 w-3" />
-                Import from clipboard
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void importRecipeFromFile(currentProject?.id)}
-              >
-                <FileUp className="h-3 w-3" />
-                Import from file
-              </Button>
-            </div>
           </div>
         </AppDialog.Body>
       </AppDialog>


### PR DESCRIPTION
## Summary

- New users landing in the recipes manager, MCP settings tab, GitHub resource list, or agent tray with no data saw blank panels with no signal that the feature existed or how to get started. Each surface now renders a zero-data `EmptyState` with a one-line description and a primary action.
- `GitHubResourceList` gate is protected behind `useGitHubConfigStore` with self-initializing fetch guards so the auth prompt only appears when there's genuinely no token — not on transient errors.
- `AgentTrayButton` adds a `DropdownMenuLabel` hint when no agents are pinned, consistent with how the rest of the app surfaces first-run guidance.

Resolves #6036

## Changes

- `RecipeManager.tsx` — replace bare empty divs with `EmptyState` (zero-data variant)
- `McpServerSettingsTab.tsx` — `EmptyState` gated on `!error` so it doesn't appear alongside error copy
- `GitHubResourceList.tsx` — no-token `EmptyState` behind `useGitHubConfigStore`, fetch guards in both `useEffect`s
- `AgentTrayButton.tsx` — pin-discovery hint as `DropdownMenuLabel` when no agents are pinned
- 3 test files extended to cover the new states

## Testing

Typecheck clean, lint ratchet unchanged at 2425 warnings, prettier clean, 92 unit tests pass. No E2E specs cover these surfaces in the current core/full suites.