### PR TITLE
fix(recovery): microcopy and a11y polish on recovery banners

### DIFF
--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -52,16 +52,19 @@ export function CloudSyncBanner() {
       className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
     >
       <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <span className="flex-1">
-        This project is in a {service}-synced folder, which can interfere with terminal operations
-        and git. Consider moving it to a local folder.
-      </span>
+      <div className="flex-1 flex flex-col gap-0.5">
+        <p className="font-medium">Cloud sync detected</p>
+        <p>
+          This project is in a {service}-synced folder, which can interfere with terminal operations
+          and git. Consider moving it to a local folder.
+        </p>
+      </div>
       <button
         type="button"
         onClick={handleDismiss}
         className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
       >
-        Don&rsquo;t show again
+        Got it
       </button>
     </div>
   );

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -151,7 +151,7 @@ export function CrashRecoveryDialog({
     >
       <AppDialog.Header>
         <AppDialog.Title icon={<AlertTriangle className="h-5 w-5 text-status-warning" />}>
-          Daintree Crashed
+          Daintree crashed
         </AppDialog.Title>
       </AppDialog.Header>
 
@@ -240,7 +240,7 @@ export function CrashRecoveryDialog({
               </div>
               <div>
                 <div className="text-sm font-medium text-daintree-text">
-                  Restore Previous Session
+                  Restore previous session
                 </div>
                 {backupDate ? (
                   <div className="text-xs text-daintree-text/60 mt-0.5">
@@ -265,7 +265,7 @@ export function CrashRecoveryDialog({
                 <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
               </div>
               <div>
-                <div className="text-sm font-medium text-daintree-text">Start Fresh</div>
+                <div className="text-sm font-medium text-daintree-text">Start fresh</div>
                 <div className="text-xs text-daintree-text/60 mt-0.5">
                   Reset to a clean layout — open panels will be cleared
                 </div>
@@ -281,7 +281,7 @@ export function CrashRecoveryDialog({
             className="cursor-pointer w-full flex items-center justify-between px-3 py-2 text-sm text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
             data-testid="details-toggle"
           >
-            <span className="font-medium">Error Details</span>
+            <span className="font-medium">Error details</span>
             {detailsOpen ? (
               <ChevronDown className="h-4 w-4" />
             ) : (

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -2,8 +2,12 @@ import { AlertTriangle } from "lucide-react";
 
 export function SafeModeBanner() {
   return (
-    <div className="flex items-center gap-2 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0">
-      <AlertTriangle className="w-4 h-4 shrink-0" />
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center gap-2 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
+    >
+      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
       <span>Safe mode — the app booted without restoring panels due to repeated crashes.</span>
     </div>
   );

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -46,6 +46,8 @@ describe("CloudSyncBanner", () => {
   it("renders banner with detected service name", () => {
     useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
     render(<CloudSyncBanner />);
+    const region = screen.getByRole("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
     expect(screen.getByText("Cloud sync detected")).toBeTruthy();
     expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Got it" })).toBeTruthy();

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -46,15 +46,16 @@ describe("CloudSyncBanner", () => {
   it("renders banner with detected service name", () => {
     useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
     render(<CloudSyncBanner />);
+    expect(screen.getByText("Cloud sync detected")).toBeTruthy();
     expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Don.+t show again/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Got it" })).toBeTruthy();
   });
 
   it("persists dismiss preference and clears the banner", async () => {
     useCloudSyncBannerStore.setState({ service: "iCloud Drive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
       expect(saveSettingsMock).toHaveBeenCalledWith(
@@ -78,7 +79,7 @@ describe("CloudSyncBanner", () => {
     useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
       expect(saveSettingsMock).toHaveBeenCalledOnce();
@@ -98,7 +99,7 @@ describe("CloudSyncBanner", () => {
     // Simulate the race: live project flips to p2 before the click handler runs.
     setProject("p2");
 
-    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
       expect(useCloudSyncBannerStore.getState().service).toBeNull();
@@ -111,7 +112,7 @@ describe("CloudSyncBanner", () => {
     useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Don.+t show again/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
 
     await waitFor(() => {
       expect(notifyMock).toHaveBeenCalled();

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -149,7 +149,7 @@ describe("CrashRecoveryDialog", () => {
   it("renders the dialog", () => {
     setup();
     expect(screen.getByTestId("crash-recovery-dialog")).toBeTruthy();
-    expect(screen.getByText("Daintree Crashed")).toBeTruthy();
+    expect(screen.getByText("Daintree crashed")).toBeTruthy();
   });
 
   describe("with panels (selective restore)", () => {

--- a/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
+++ b/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SafeModeBanner } from "../SafeModeBanner";
+
+describe("SafeModeBanner", () => {
+  it("exposes a polite live region for screen readers", () => {
+    render(<SafeModeBanner />);
+    const region = screen.getByRole("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("renders the safe-mode message", () => {
+    render(<SafeModeBanner />);
+    expect(screen.getByText(/Safe mode/i)).toBeTruthy();
+  });
+
+  it("hides the decorative icon from assistive tech", () => {
+    const { container } = render(<SafeModeBanner />);
+    const icon = container.querySelector("svg");
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

- `SafeModeBanner` was missing `role="status"` and `aria-live="polite"`, so screen readers got no announcement on safe-mode entry — the exact moment it matters most. Brought it in line with `CloudSyncBanner` and `GitHubTokenBanner` which already had this pattern.
- `CrashRecoveryDialog` had four Title Case strings (`Daintree Crashed`, `Restore Previous Session`, `Start Fresh`, `Error Details`) that didn't follow the sentence-case convention the rest of the app uses.
- `CloudSyncBanner` had no title (everything was body text) and a dismiss button labeled "Don't show again", which reads as a nuisance suppression rather than an acknowledgement of an unresolved state.

Resolves #6165

## Changes

- `SafeModeBanner` — added `role="status"`, `aria-live="polite"`, `aria-hidden` on the icon
- `CrashRecoveryDialog` — sentence-cased four strings: "Daintree crashed", "Restore previous session", "Start fresh", "Error details"
- `CloudSyncBanner` — added "Cloud sync detected" title, relabeled dismiss button to "Got it"
- Updated `CrashRecoveryDialog.test.tsx` assertion to match the corrected string
- Updated `CloudSyncBanner.test.tsx` — five button queries, title and `role="status"` assertions
- Added `SafeModeBanner.test.tsx` — three tests covering the new a11y attributes

## Testing

41 tests across the four Recovery test files all pass. Lint, typecheck, and format clean.