### PR TITLE
fix(git): set core.precomposeunicode=true in hardened config

### DIFF
--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -274,6 +274,8 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).toContain("protocol.ext.allow=never");
     expect(options.config).toContain("core.gitProxy=");
     expect(options.config).toContain("core.hooksPath=");
+    expect(options.config).toContain("core.quotepath=false");
+    expect(options.config).toContain("core.precomposeunicode=true");
   });
 
   it("sets GIT_TERMINAL_PROMPT and hardened GIT_SSH_COMMAND via .env()", () => {

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -138,6 +138,7 @@ describe("createHardenedGit", () => {
       "core.gitProxy=",
       "core.hooksPath=",
       "core.quotepath=false",
+      "core.precomposeunicode=true",
     ];
     for (const key of expectedKeys) {
       expect(options.config).toContain(key);
@@ -615,6 +616,7 @@ describe("config constants", () => {
       "core.gitProxy=",
       "core.hooksPath=",
       "core.quotepath=false",
+      "core.precomposeunicode=true",
     ];
     for (const entry of securityEntries) {
       expect(HARDENED_GIT_CONFIG).toContain(entry);

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -13,6 +13,11 @@ const SAFE_GIT_CONFIG = [
   // flow through to IPC consumers unquoted (e.g. conflict detection on
   // `café.txt` would otherwise be returned as `"caf\303\251.txt"`).
   "core.quotepath=false",
+  // macOS HFS+/APFS returns filenames as NFD (decomposed Unicode); without
+  // this flag git emits NFD paths in porcelain/status output, causing silent
+  // bitwise inequality against NFC paths from any other source. Pinning it
+  // forces NFC in all porcelain output. No-op on Linux/Windows.
+  "core.precomposeunicode=true",
 ] as const;
 
 /**

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -16,7 +16,8 @@ const SAFE_GIT_CONFIG = [
   // macOS HFS+/APFS returns filenames as NFD (decomposed Unicode); without
   // this flag git emits NFD paths in porcelain/status output, causing silent
   // bitwise inequality against NFC paths from any other source. Pinning it
-  // forces NFC in all porcelain output. No-op on Linux/Windows.
+  // ensures working-tree paths are reported as NFC; pre-existing NFD index
+  // entries from legacy repos are unaffected. No-op on Linux/Windows.
   "core.precomposeunicode=true",
 ] as const;
 


### PR DESCRIPTION
## Summary

- `SAFE_GIT_CONFIG` in `hardenedGit.ts` already pins `core.quotepath=false` so non-ASCII bytes survive IPC, but `core.precomposeunicode` was unset, leaving us dependent on the user's local git default
- On macOS, without this flag, git emits filenames in NFD (decomposed) Unicode — paths from `git status` compare unequal to NFC paths from any other source, silently breaking React keys, `previousStateHash` comparisons, and anything using a path as a `Map`/`Set` key
- Pinning it to `true` makes the behaviour deterministic regardless of the user's system config

Resolves #6171

## Changes

- `electron/utils/hardenedGit.ts` — added `core.precomposeunicode=true` to `SAFE_GIT_CONFIG`
- `electron/utils/__tests__/hardenedGit.test.ts` — updated snapshot to include the new flag, added factory coverage

## Testing

All 58 `hardenedGit` tests pass. Typecheck, lint, and format are clean.