### PR TITLE
fix(terminal): guard against repeated WebGL context loss

### DIFF
--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -45,7 +45,7 @@ export class TerminalWebGLManager {
   ensureContext(id: string, managed: ManagedTerminal): void {
     if (WEBGL_DISABLED) return;
     if (!this.hardwareAvailable) {
-      if (!this.hasLoggedSoftwareSkip) {
+      if (!this.hasLoggedSoftwareSkip && !this.hasLoggedBreakerTrip) {
         console.warn("[TerminalWebGLManager] Skipping WebGL: software-only GPU detected");
         this.hasLoggedSoftwareSkip = true;
       }

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -16,6 +16,13 @@ export class TerminalWebGLManager {
   // <webview> partitions and have their own budgets).
   private static _maxContexts = 12;
 
+  // Circuit breaker: if N genuine context-loss events occur within W ms,
+  // disable WebGL for the rest of the session to avoid strobing reacquisition
+  // on systems with persistent GPU faults (e.g. M-series Macs on external
+  // displays at fractional scaling).
+  private static readonly LOSS_THRESHOLD = 3;
+  private static readonly LOSS_WINDOW_MS = 60_000;
+
   static get MAX_CONTEXTS(): number {
     return TerminalWebGLManager._maxContexts;
   }
@@ -28,6 +35,8 @@ export class TerminalWebGLManager {
   private lruOrder: string[] = [];
   private hardwareAvailable = true;
   private hasLoggedSoftwareSkip = false;
+  private lossTimestamps: number[] = [];
+  private hasLoggedBreakerTrip = false;
 
   setHardwareAvailable(available: boolean): void {
     this.hardwareAvailable = available;
@@ -63,6 +72,8 @@ export class TerminalWebGLManager {
       const ownAddon = addon;
       clDisposable = addon.onContextLoss(() => {
         if (this.pool.get(id)?.addon === ownAddon) {
+          // record before release; pool entry still valid here
+          this.recordContextLoss();
           this.releaseContext(id);
         }
       });
@@ -128,6 +139,23 @@ export class TerminalWebGLManager {
       entry.addon.dispose();
     } catch {
       // ignore
+    }
+  }
+
+  private recordContextLoss(): void {
+    const now = Date.now();
+    this.lossTimestamps = this.lossTimestamps.filter(
+      (t) => now - t < TerminalWebGLManager.LOSS_WINDOW_MS
+    );
+    this.lossTimestamps.push(now);
+    if (this.lossTimestamps.length >= TerminalWebGLManager.LOSS_THRESHOLD) {
+      this.setHardwareAvailable(false);
+      if (!this.hasLoggedBreakerTrip) {
+        console.warn(
+          "[TerminalWebGLManager] WebGL circuit breaker tripped — falling back to DOM renderer"
+        );
+        this.hasLoggedBreakerTrip = true;
+      }
     }
   }
 

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -376,16 +376,44 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t1", managed);
       manager.releaseContext("t1");
       manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+      manager.ensureContext("t1", managed);
 
-      // Fire stale handlers (the first two) — must NOT count toward breaker
+      // Fire all three stale handlers — must NOT trip the breaker
       handlers[0]();
       handlers[1]();
+      handlers[2]();
 
       const before = WebglAddonMock.mock.calls.length;
       const m2 = makeManagedTerminal();
       manager.ensureContext("t2", m2);
       expect(WebglAddonMock.mock.calls.length).toBe(before + 1);
       expect(manager.isActive("t2")).toBe(true);
+    });
+
+    it("does not log the software-GPU warning after the breaker trips", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      handlers[0]();
+      handlers[1]();
+      handlers[2]();
+
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t4", m4);
+
+      const softwareWarnings = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("software-only GPU")
+      );
+      expect(softwareWarnings).toHaveLength(0);
+      warnSpy.mockRestore();
     });
 
     it("logs the breaker-trip warning only once", () => {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ManagedTerminal } from "../types";
 
 let mockAddonDispose: ReturnType<typeof vi.fn>;
@@ -275,6 +275,150 @@ describe("TerminalWebGLManager", () => {
         (args) => typeof args[0] === "string" && args[0].includes("software-only GPU")
       );
       expect(softwareWarnings).toHaveLength(1);
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("circuit breaker", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function captureContextLossHandlers(): Array<() => void> {
+      const handlers: Array<() => void> = [];
+      WebglAddonMock.mockImplementation(function () {
+        return {
+          dispose: vi.fn(),
+          onContextLoss: vi.fn((handler: () => void) => {
+            handlers.push(handler);
+            return { dispose: vi.fn() };
+          }),
+        };
+      });
+      return handlers;
+    }
+
+    it("trips after LOSS_THRESHOLD rapid losses and disables WebGL for the session", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      handlers[0]();
+      handlers[1]();
+      handlers[2]();
+
+      const before = WebglAddonMock.mock.calls.length;
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t4", m4);
+      expect(WebglAddonMock.mock.calls.length).toBe(before);
+      expect(manager.isActive("t4")).toBe(false);
+    });
+
+    it("does not trip when losses fall outside the sliding window", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+
+      handlers[0]();
+      handlers[1]();
+
+      vi.setSystemTime(60_000);
+
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t3", m3);
+      handlers[2]();
+
+      const before = WebglAddonMock.mock.calls.length;
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t4", m4);
+      expect(WebglAddonMock.mock.calls.length).toBe(before + 1);
+      expect(manager.isActive("t4")).toBe(true);
+    });
+
+    it("does not evict already-active contexts when the breaker trips", () => {
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+      manager.ensureContext("t4", m4);
+
+      handlers[0]();
+      handlers[1]();
+      handlers[2]();
+
+      expect(manager.isActive("t4")).toBe(true);
+    });
+
+    it("stale handlers from recycled ids do not contribute to the loss count", () => {
+      const handlers = captureContextLossHandlers();
+
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+      manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+      manager.ensureContext("t1", managed);
+
+      // Fire stale handlers (the first two) — must NOT count toward breaker
+      handlers[0]();
+      handlers[1]();
+
+      const before = WebglAddonMock.mock.calls.length;
+      const m2 = makeManagedTerminal();
+      manager.ensureContext("t2", m2);
+      expect(WebglAddonMock.mock.calls.length).toBe(before + 1);
+      expect(manager.isActive("t2")).toBe(true);
+    });
+
+    it("logs the breaker-trip warning only once", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const handlers = captureContextLossHandlers();
+
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      handlers[0]();
+      handlers[1]();
+      handlers[2]();
+
+      // Re-acquire and trip again — should not log a second time
+      const m4 = makeManagedTerminal();
+      const m5 = makeManagedTerminal();
+      const m6 = makeManagedTerminal();
+      manager.setHardwareAvailable(true);
+      manager.ensureContext("t4", m4);
+      manager.ensureContext("t5", m5);
+      manager.ensureContext("t6", m6);
+      handlers[3]?.();
+      handlers[4]?.();
+      handlers[5]?.();
+
+      const breakerWarnings = warnSpy.mock.calls.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("circuit breaker")
+      );
+      expect(breakerWarnings).toHaveLength(1);
       warnSpy.mockRestore();
     });
   });

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -313,9 +313,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t2", m2);
       manager.ensureContext("t3", m3);
 
-      handlers[0]();
-      handlers[1]();
-      handlers[2]();
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
 
       const before = WebglAddonMock.mock.calls.length;
       const m4 = makeManagedTerminal();
@@ -332,14 +332,14 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t1", m1);
       manager.ensureContext("t2", m2);
 
-      handlers[0]();
-      handlers[1]();
+      handlers[0]!();
+      handlers[1]!();
 
       vi.setSystemTime(60_000);
 
       const m3 = makeManagedTerminal();
       manager.ensureContext("t3", m3);
-      handlers[2]();
+      handlers[2]!();
 
       const before = WebglAddonMock.mock.calls.length;
       const m4 = makeManagedTerminal();
@@ -360,9 +360,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t3", m3);
       manager.ensureContext("t4", m4);
 
-      handlers[0]();
-      handlers[1]();
-      handlers[2]();
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
 
       expect(manager.isActive("t4")).toBe(true);
     });
@@ -380,9 +380,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t1", managed);
 
       // Fire all three stale handlers — must NOT trip the breaker
-      handlers[0]();
-      handlers[1]();
-      handlers[2]();
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
 
       const before = WebglAddonMock.mock.calls.length;
       const m2 = makeManagedTerminal();
@@ -402,9 +402,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t2", m2);
       manager.ensureContext("t3", m3);
 
-      handlers[0]();
-      handlers[1]();
-      handlers[2]();
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
 
       const m4 = makeManagedTerminal();
       manager.ensureContext("t4", m4);
@@ -427,9 +427,9 @@ describe("TerminalWebGLManager", () => {
       manager.ensureContext("t2", m2);
       manager.ensureContext("t3", m3);
 
-      handlers[0]();
-      handlers[1]();
-      handlers[2]();
+      handlers[0]!();
+      handlers[1]!();
+      handlers[2]!();
 
       // Re-acquire and trip again — should not log a second time
       const m4 = makeManagedTerminal();


### PR DESCRIPTION
## Summary

- Adds a sliding-window circuit breaker to `TerminalWebGLManager` that permanently disables WebGL for the rest of the session when a terminal loses its context 3 times within 60 seconds
- Stops the strobing reacquisition loop that affects M-series Macs driving external displays at fractional scaling, where Chromium emits `GL_INVALID_OPERATION` and xterm.js bounces between WebGL and DOM indefinitely
- Existing pool entries are left intact; only future `ensureContext` calls are gated, so healthy terminals are unaffected

Resolves #6163

## Changes

- `src/services/terminal/TerminalWebGLManager.ts`: two private static readonly constants (`LOSS_THRESHOLD = 3`, `LOSS_WINDOW_MS = 60_000`), a `lossTimestamps` array, a `hasLoggedBreakerTrip` flag to keep the warning to one log line, and a `recordContextLoss()` helper called inside the existing identity guard on `onContextLoss`
- `src/services/terminal/__tests__/TerminalWebGLManager.test.ts`: new `describe("circuit breaker")` block with 6 tests covering trip behaviour, sliding-window reset, no pool eviction on trip, stale-handler immunity, once-only warning log, and no software-GPU log after the breaker fires

## Testing

27 unit tests pass via `npx vitest run src/services/terminal/__tests__/TerminalWebGLManager.test.ts`. Typecheck, lint, and format clean via `npm run check`.