### PR TITLE
fix(css): scope reduced-motion rules away from Radix Presence state selectors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1406,11 +1406,11 @@ body,
     transition: none;
   }
 
-  button:not([data-state]),
-  [role="button"]:not([data-state]),
-  [type="button"]:not([data-state]),
-  [type="submit"]:not([data-state]),
-  [type="reset"]:not([data-state]) {
+  button:not([data-state="open"]):not([data-state="closed"]),
+  [role="button"]:not([data-state="open"]):not([data-state="closed"]),
+  [type="button"]:not([data-state="open"]):not([data-state="closed"]),
+  [type="submit"]:not([data-state="open"]):not([data-state="closed"]),
+  [type="reset"]:not([data-state="open"]):not([data-state="closed"]) {
     transform: none !important;
     transition: none !important;
   }
@@ -1478,11 +1478,11 @@ body[data-reduce-animations="true"]
 
 body[data-reduce-animations="true"]
   :is(
-    button:not([data-state]),
-    [role="button"]:not([data-state]),
-    [type="button"]:not([data-state]),
-    [type="submit"]:not([data-state]),
-    [type="reset"]:not([data-state])
+    button:not([data-state="open"]):not([data-state="closed"]),
+    [role="button"]:not([data-state="open"]):not([data-state="closed"]),
+    [type="button"]:not([data-state="open"]):not([data-state="closed"]),
+    [type="submit"]:not([data-state="open"]):not([data-state="closed"]),
+    [type="reset"]:not([data-state="open"]):not([data-state="closed"])
   ) {
   transform: none !important;
   transition: none !important;

--- a/src/index.css
+++ b/src/index.css
@@ -1406,11 +1406,11 @@ body,
     transition: none;
   }
 
-  button,
-  [role="button"],
-  [type="button"],
-  [type="submit"],
-  [type="reset"] {
+  button:not([data-state]),
+  [role="button"]:not([data-state]),
+  [type="button"]:not([data-state]),
+  [type="submit"]:not([data-state]),
+  [type="reset"]:not([data-state]) {
     transform: none !important;
     transition: none !important;
   }
@@ -1477,7 +1477,13 @@ body[data-reduce-animations="true"]
 }
 
 body[data-reduce-animations="true"]
-  :is(button, [role="button"], [type="button"], [type="submit"], [type="reset"]) {
+  :is(
+    button:not([data-state]),
+    [role="button"]:not([data-state]),
+    [type="button"]:not([data-state]),
+    [type="submit"]:not([data-state]),
+    [type="reset"]:not([data-state])
+  ) {
   transform: none !important;
   transition: none !important;
 }


### PR DESCRIPTION
## Summary

- The reduced-motion blocks (`@media prefers-reduced-motion` and `body[data-reduce-animations]`) applied `transition: none !important` broadly to `button`, `[role=button]`, and `[type=*]` selectors, which can match Radix trigger and content elements
- Radix popover, dropdown-menu, context-menu, select, and tooltip all defer unmounting by listening for `animationend` on `[data-state="closed"]` — killing the animation prevents that event from firing, leaving closed elements ghosted in the DOM (mounted, focusable, blocking pointer events)
- Scoped both reduced-motion blocks with `:not([data-state="open"]):not([data-state="closed"])` so `transition: none` only applies to elements that aren't in an active Radix Presence state

Resolves #6161

## Changes

- `src/index.css`: added `:not([data-state="open"]):not([data-state="closed"])` to the `button`, `[role=button]`, and `[type=*]` selectors in both the `@media (prefers-reduced-motion: reduce)` block and the `body[data-reduce-animations="true"]` block

## Testing

- Manually verified: with OS prefers-reduced-motion enabled, popovers and dropdown menus close cleanly and are removed from the DOM
- Checked the same with the in-app "Reduce UI animations" toggle
- Confirmed `.animate-*` keyframe suppressions are unaffected (those selectors don't carry Radix data-state attributes)