### PR TITLE
feat(worktree): detect stale snapshots via heartbeat gap

### DIFF
--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -909,7 +909,10 @@ export class WorktreeMonitor {
       // wall time since the last completed poll. Surface "stale" so the
       // card dims, then force-refresh — categorizeWorktree() on the
       // refreshed status will overwrite mood with the real value.
-      if (this.lastGitStatusCompletedAt > 0) {
+      // Skip the gap check while a refresh is already in flight: it would
+      // false-emit "stale" for any updateGitStatus that happens to take
+      // longer than the floor (e.g., a slow git on a frozen filesystem).
+      if (!this._isUpdating && this.lastGitStatusCompletedAt > 0) {
         const elapsedMs = Date.now() - this.lastGitStatusCompletedAt;
         const threshold = Math.max(delayMs * HEARTBEAT_GAP_MULTIPLIER, HEARTBEAT_GAP_FLOOR_MS);
         if (elapsedMs > threshold) {
@@ -925,10 +928,23 @@ export class WorktreeMonitor {
   }
 
   private async forceRefreshAfterGap(): Promise<void> {
+    // Route through pollQueue when present so wake-induced gap refreshes are
+    // serialized across sibling monitors instead of all racing simultaneously.
+    const run = (): Promise<void> =>
+      this.updateGitStatus(true).catch(() => {
+        // updateGitStatus's own error path emits "error" mood; nothing to do here.
+      });
     try {
-      await this.updateGitStatus(true);
+      if (this.pollQueue) {
+        await this.pollQueue.add(run, {
+          signal: this._pollAbortController.signal,
+          priority: this._isCurrent ? 1 : 0,
+        });
+      } else {
+        await run();
+      }
     } catch {
-      // updateGitStatus's own error path emits "error" mood; nothing to do here.
+      // Queue abort or task error — already swallowed by run() / signal.
     }
     if (this._isRunning && this.pollingEnabled) {
       this.scheduleNextPoll();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -31,6 +31,8 @@ const WATCHER_WORKTREE_MAX_WAIT_MS = 1500;
 const PLAN_FILE_CANDIDATES = ["TODO.md", "PLAN.md", "plan.md", "TASKS.md"] as const;
 const RESOURCE_POLL_DEFAULT_ACTIVE_MS = 30_000;
 const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 120_000;
+const HEARTBEAT_GAP_MULTIPLIER = 3;
+const HEARTBEAT_GAP_FLOOR_MS = 30_000;
 
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
@@ -900,8 +902,37 @@ export class WorktreeMonitor {
 
     this.pollingTimer = setTimeout(() => {
       this.pollingTimer = null;
+      if (!this._isRunning) return;
+
+      // Heartbeat gap: when the OS throttles or suspends the process, the
+      // timer fires far later than scheduled. Detect by measuring elapsed
+      // wall time since the last completed poll. Surface "stale" so the
+      // card dims, then force-refresh — categorizeWorktree() on the
+      // refreshed status will overwrite mood with the real value.
+      if (this.lastGitStatusCompletedAt > 0) {
+        const elapsedMs = Date.now() - this.lastGitStatusCompletedAt;
+        const threshold = Math.max(delayMs * HEARTBEAT_GAP_MULTIPLIER, HEARTBEAT_GAP_FLOOR_MS);
+        if (elapsedMs > threshold) {
+          this.mood = "stale";
+          this.emitUpdate();
+          void this.forceRefreshAfterGap();
+          return;
+        }
+      }
+
       void this.poll();
     }, delayMs);
+  }
+
+  private async forceRefreshAfterGap(): Promise<void> {
+    try {
+      await this.updateGitStatus(true);
+    } catch {
+      // updateGitStatus's own error path emits "error" mood; nothing to do here.
+    }
+    if (this._isRunning && this.pollingEnabled) {
+      this.scheduleNextPoll();
+    }
   }
 
   private async poll(force: boolean = false): Promise<void> {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1150,4 +1150,179 @@ describe("WorktreeMonitor", () => {
       }
     });
   });
+
+  describe("heartbeat gap detection", () => {
+    const CLEAN_CHANGES = {
+      worktreeId: "/test/worktree",
+      rootPath: "/test",
+      changes: [],
+      changedFileCount: 0,
+      lastUpdated: 0,
+    };
+
+    function getMoodSequence(callbacks: WorktreeMonitorCallbacks): Array<string | undefined> {
+      const fn = callbacks.onUpdate as ReturnType<typeof vi.fn>;
+      return fn.mock.calls.map((call) => (call[0] as { mood?: string }).mood);
+    }
+
+    it("emits stale and force-refreshes when gap exceeds multiplier and floor", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      mockGetWorktreeChangesWithStats.mockClear();
+      // Simulate that the last poll completion happened 60s ago in wall time —
+      // the OS effectively suspended the process between then and now.
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+      mockInvalidateGitStatusCache.mockClear();
+
+      // Fire the next pending poll timer (base interval 2000ms).
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).toContain("stale");
+      // Force refresh ran (forceRefresh=true invalidates the cache before fetching).
+      expect(mockInvalidateGitStatusCache).toHaveBeenCalled();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
+    it("does not mark stale before any git status has completed", async () => {
+      // Set the watcher to start successfully so that start() is a no-op for git
+      // status (startWithoutGitStatus path also leaves lastGitStatusCompletedAt = 0).
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      monitor.startWithoutGitStatus();
+
+      // Advance well past the gap floor without ever completing a poll.
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
+
+      monitor.stop();
+    });
+
+    it("does not mark stale when elapsed exceeds 3x interval but is below 30s floor", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      mockGetWorktreeChangesWithStats.mockClear();
+      // 10s gap > 3x base interval (6s) but < 30s floor.
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 10_000;
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
+
+      monitor.stop();
+    });
+
+    it("does not mark stale when elapsed exceeds 30s floor but is below 3x interval", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      // Use the watcher fallback path: base interval = 30s, threshold = 90s.
+      const watcherConfig: WorktreeMonitorConfig = {
+        ...TEST_CONFIG,
+        gitWatchEnabled: true,
+      };
+      mockWatcherStartResult = true;
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
+      await monitor.start();
+
+      mockGetWorktreeChangesWithStats.mockClear();
+      // 60s gap > 30s floor but < 3 * 30s base = 90s threshold.
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      await vi.advanceTimersByTimeAsync(35_000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
+
+      monitor.stop();
+    });
+
+    it("stale mood reverts after the forced refresh completes", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      await vi.advanceTimersByTimeAsync(5000);
+      // Drain any microtasks the forced refresh kicked off.
+      await vi.advanceTimersByTimeAsync(0);
+
+      const moods = getMoodSequence(callbacks);
+      const staleIndex = moods.indexOf("stale");
+      expect(staleIndex).toBeGreaterThanOrEqual(0);
+      // After the forced refresh, categorizeWorktree() returns "stable" (mocked),
+      // so the final mood should be back to the real value.
+      const finalMood = moods[moods.length - 1];
+      expect(finalMood).not.toBe("stale");
+
+      monitor.stop();
+    });
+
+    it("does not run heartbeat check after stop()", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      monitor.stop();
+      mockGetWorktreeChangesWithStats.mockClear();
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+    });
+
+    it("watcher fallback interval (30s) requires 90s+ gap to trigger stale", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockWatcherStartResult = true;
+
+      const watcherConfig: WorktreeMonitorConfig = {
+        ...TEST_CONFIG,
+        gitWatchEnabled: true,
+      };
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
+      await monitor.start();
+
+      // 100s gap exceeds the 90s threshold for the 30s watcher fallback interval.
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 100_000;
+
+      await vi.advanceTimersByTimeAsync(35_000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).toContain("stale");
+
+      monitor.stop();
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -35,8 +35,12 @@ vi.mock("simple-git", () => ({
   simpleGit: vi.fn(() => ({ raw: vi.fn(), log: vi.fn().mockResolvedValue({ latest: null }) })),
 }));
 
+const { mockCategorizeWorktree } = vi.hoisted(() => ({
+  mockCategorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
 vi.mock("../../services/worktree/mood.js", () => ({
-  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+  categorizeWorktree: mockCategorizeWorktree,
 }));
 
 vi.mock("../../services/issueExtractor.js", () => ({
@@ -141,6 +145,7 @@ describe("WorktreeMonitor", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mockCategorizeWorktree.mockReturnValue("stable");
     mockWatcherStartResult = false;
     mockWatcherStartFiresFailure = false;
     watcherStartCallCount = 0;
@@ -1322,6 +1327,82 @@ describe("WorktreeMonitor", () => {
       const moods = getMoodSequence(callbacks);
       expect(moods).toContain("stale");
 
+      monitor.stop();
+    });
+
+    it("does not emit stale while a refresh is already in flight", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      mockGetWorktreeChangesWithStats.mockClear();
+      // Simulate an in-flight refresh AND an aged completion timestamp.
+      (monitor as unknown as { _isUpdating: boolean })._isUpdating = true;
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
+      // Force-refresh path is gated behind the gap check, so it must not have
+      // kicked off a duplicate git call either.
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+
+      // Restore so stop() doesn't trip an in-flight assertion in teardown.
+      (monitor as unknown as { _isUpdating: boolean })._isUpdating = false;
+      monitor.stop();
+    });
+
+    it("retains 'error' mood when the forced refresh fails", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValueOnce(CLEAN_CHANGES);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      mockGetWorktreeChangesWithStats.mockReset();
+      mockGetWorktreeChangesWithStats.mockRejectedValue(new Error("git stalled"));
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      await vi.advanceTimersByTimeAsync(5000);
+      // Drain microtasks queued by the failing refresh.
+      await vi.advanceTimersByTimeAsync(0);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).toContain("stale");
+      // updateGitStatus's catch path emits "error" before throwing; the gap
+      // helper swallows the throw so the monitor stays alive.
+      expect(moods).toContain("error");
+      // Monitor is still running and a follow-up timer is pending.
+      expect((monitor as unknown as { _isRunning: boolean })._isRunning).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("forced refresh produces real categorized mood, not 'stale'", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      // After the gap-driven refresh runs, categorize as something non-trivial.
+      mockCategorizeWorktree.mockReturnValue("dirty");
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now() - 60_000;
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).toContain("stale");
+      expect(moods[moods.length - 1]).toBe("dirty");
+
+      mockCategorizeWorktree.mockReturnValue("stable");
       monitor.stop();
     });
   });


### PR DESCRIPTION
## Summary

- `powerMonitor` only fires `suspend` for full sleep, not for App Nap or CPU starvation. When the OS throttles our timers in the background, polls silently stop happening and the dashboard keeps showing confidently-rendered stale data.
- On each poll completion, `WorktreeMonitor` now records `lastGitStatusCompletedAt`. Before scheduling the next tick it checks the elapsed gap — if it exceeds `max(interval * 3, 30s)`, it marks `mood = "stale"`, dims the card immediately, then runs a cache-invalidating force-refresh via `forceRefreshAfterGap()`. Mood reverts through the existing `categorizeWorktree` path once the refresh completes.
- Complements #6157 (suspend/resume path) — that covers the explicit sleep event, this covers everything else: App Nap, swap pressure, debugger pauses, CPU starvation.

Resolves #6160

## Changes

- `WorktreeMonitor.ts`: added `HEARTBEAT_GAP_MULTIPLIER` (3) and `HEARTBEAT_GAP_FLOOR_MS` (30s) constants, gap-check logic in `scheduleNextPoll()`, and private `forceRefreshAfterGap()` helper that routes through `pollQueue` when one is present (so wake-induced refreshes serialize across sibling monitors)
- Gap check is skipped when `_isUpdating` is true to avoid false stale dims during a slow in-flight refresh
- No IPC, type, or renderer changes — `mood: "stale"` already flows to the dim via the existing `isMuted` path in `WorktreeCard`

## Testing

- 10 new unit tests in `WorktreeMonitor.test.ts` covering: gap detection at/below/above threshold, immediate stale dim, force-refresh scheduling, mood revert after refresh, false-stale guard during in-flight update, error mood retention on failed refresh, final mood matching real categorization
- 52 tests in `WorktreeMonitor.test.ts`, 254 workspace-host tests passing
- Typecheck, lint, and format clean