### PR TITLE
perf(motion): migrate framer-motion to LazyMotion pattern (#6173)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { isAgentLaunchable } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
-import { MotionConfig } from "framer-motion";
+import { LazyMotion, MotionConfig, domAnimation } from "framer-motion";
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
@@ -477,344 +477,346 @@ function App() {
   }
 
   return (
-    <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
-      <ErrorBoundary variant="fullscreen" componentName="App">
-        <TooltipProvider delayDuration={500} skipDelayDuration={150}>
-          <E2EFaultInjector />
-          {isSafeMode && <SafeModeBanner />}
-          <GitHubTokenBanner />
-          <CloudSyncBanner />
-          <DndProvider>
-            <VoiceRecordingAnnouncer />
-            <AccessibilityAnnouncer />
-            <Profiler id="app-layout" onRender={onLayoutRender}>
-              <AppLayout
-                sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
-                onLaunchAgent={handleLaunchAgent}
-                onSettings={handleSettings}
-                onPreloadSettings={handlePreloadSettings}
-                onRetry={handleErrorRetry}
-                onCancelRetry={handleCancelRetry}
-                agentAvailability={availability}
-                agentSettings={agentSettings}
-                isHydrated={isStateLoaded}
-                projectSwitcherPalette={projectSwitcherPalette}
-              >
-                <Profiler id="content-grid" onRender={onContentGridRender}>
-                  <ContentGrid
-                    className="h-full w-full"
-                    agentAvailability={availability}
-                    defaultCwd={defaultTerminalCwd}
-                    emptyContent={
-                      currentProject === null ? (
-                        <WelcomeScreen gettingStarted={gettingStarted} />
-                      ) : undefined
-                    }
-                  />
-                </Profiler>
-              </AppLayout>
-            </Profiler>
-          </DndProvider>
+    <LazyMotion features={domAnimation}>
+      <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
+        <ErrorBoundary variant="fullscreen" componentName="App">
+          <TooltipProvider delayDuration={500} skipDelayDuration={150}>
+            <E2EFaultInjector />
+            {isSafeMode && <SafeModeBanner />}
+            <GitHubTokenBanner />
+            <CloudSyncBanner />
+            <DndProvider>
+              <VoiceRecordingAnnouncer />
+              <AccessibilityAnnouncer />
+              <Profiler id="app-layout" onRender={onLayoutRender}>
+                <AppLayout
+                  sidebarContent={<SidebarContent onOpenOverview={openWorktreeOverview} />}
+                  onLaunchAgent={handleLaunchAgent}
+                  onSettings={handleSettings}
+                  onPreloadSettings={handlePreloadSettings}
+                  onRetry={handleErrorRetry}
+                  onCancelRetry={handleCancelRetry}
+                  agentAvailability={availability}
+                  agentSettings={agentSettings}
+                  isHydrated={isStateLoaded}
+                  projectSwitcherPalette={projectSwitcherPalette}
+                >
+                  <Profiler id="content-grid" onRender={onContentGridRender}>
+                    <ContentGrid
+                      className="h-full w-full"
+                      agentAvailability={availability}
+                      defaultCwd={defaultTerminalCwd}
+                      emptyContent={
+                        currentProject === null ? (
+                          <WelcomeScreen gettingStarted={gettingStarted} />
+                        ) : undefined
+                      }
+                    />
+                  </Profiler>
+                </AppLayout>
+              </Profiler>
+            </DndProvider>
 
-          <QuickSwitcher
-            isOpen={quickSwitcher.isOpen}
-            query={quickSwitcher.query}
-            results={quickSwitcher.results}
-            totalResults={quickSwitcher.totalResults}
-            selectedIndex={quickSwitcher.selectedIndex}
-            close={quickSwitcher.close}
-            setQuery={quickSwitcher.setQuery}
-            selectPrevious={quickSwitcher.selectPrevious}
-            selectNext={quickSwitcher.selectNext}
-            selectItem={quickSwitcher.selectItem}
-            confirmSelection={quickSwitcher.confirmSelection}
-          />
-          <SendToAgentPalette
-            isOpen={sendToAgentPalette.isOpen}
-            query={sendToAgentPalette.query}
-            results={sendToAgentPalette.results}
-            totalResults={sendToAgentPalette.totalResults}
-            selectedIndex={sendToAgentPalette.selectedIndex}
-            close={sendToAgentPalette.close}
-            setQuery={sendToAgentPalette.setQuery}
-            selectPrevious={sendToAgentPalette.selectPrevious}
-            selectNext={sendToAgentPalette.selectNext}
-            selectItem={sendToAgentPalette.selectItem}
-            confirmSelection={sendToAgentPalette.confirmSelection}
-          />
-          <NewTerminalPalette
-            isOpen={newTerminalPalette.isOpen}
-            query={newTerminalPalette.query}
-            results={newTerminalPalette.results}
-            totalResults={newTerminalPalette.totalResults}
-            selectedIndex={newTerminalPalette.selectedIndex}
-            onQueryChange={newTerminalPalette.setQuery}
-            onSelectPrevious={newTerminalPalette.selectPrevious}
-            onSelectNext={newTerminalPalette.selectNext}
-            onSelect={newTerminalPalette.handleSelect}
-            onConfirm={newTerminalPalette.confirmSelection}
-            onClose={newTerminalPalette.close}
-          />
-          <WorktreePalette
-            isOpen={worktreePalette.isOpen}
-            query={worktreePalette.query}
-            results={worktreePalette.results}
-            totalResults={worktreePalette.totalResults}
-            activeWorktreeId={worktreePalette.activeWorktreeId}
-            selectedIndex={worktreePalette.selectedIndex}
-            onQueryChange={worktreePalette.setQuery}
-            onSelectPrevious={worktreePalette.selectPrevious}
-            onSelectNext={worktreePalette.selectNext}
-            onSelect={worktreePalette.selectWorktree}
-            onConfirm={worktreePalette.confirmSelection}
-            onClose={worktreePalette.close}
-          />
-          <QuickCreatePalette palette={quickCreatePalette} />
-          <PanelPalette
-            isOpen={panelPalette.isOpen}
-            query={panelPalette.query}
-            results={panelPalette.results}
-            totalResults={panelPalette.totalResults}
-            selectedIndex={panelPalette.selectedIndex}
-            matchesById={panelPalette.matchesById}
-            onQueryChange={panelPalette.setQuery}
-            onSelectPrevious={panelPalette.selectPrevious}
-            onSelectNext={panelPalette.selectNext}
-            onSelect={(kind) => {
-              const result = panelPalette.handleSelect(kind);
-              if (!result) return;
-              if (result.resumeSession) {
-                const session = result.resumeSession;
-                const agentConfig = getEffectiveAgentConfig(session.agentId);
-                const command = buildResumeCommand(
-                  session.agentId,
-                  session.sessionId,
-                  session.agentLaunchFlags
-                );
-                if (command && agentConfig) {
+            <QuickSwitcher
+              isOpen={quickSwitcher.isOpen}
+              query={quickSwitcher.query}
+              results={quickSwitcher.results}
+              totalResults={quickSwitcher.totalResults}
+              selectedIndex={quickSwitcher.selectedIndex}
+              close={quickSwitcher.close}
+              setQuery={quickSwitcher.setQuery}
+              selectPrevious={quickSwitcher.selectPrevious}
+              selectNext={quickSwitcher.selectNext}
+              selectItem={quickSwitcher.selectItem}
+              confirmSelection={quickSwitcher.confirmSelection}
+            />
+            <SendToAgentPalette
+              isOpen={sendToAgentPalette.isOpen}
+              query={sendToAgentPalette.query}
+              results={sendToAgentPalette.results}
+              totalResults={sendToAgentPalette.totalResults}
+              selectedIndex={sendToAgentPalette.selectedIndex}
+              close={sendToAgentPalette.close}
+              setQuery={sendToAgentPalette.setQuery}
+              selectPrevious={sendToAgentPalette.selectPrevious}
+              selectNext={sendToAgentPalette.selectNext}
+              selectItem={sendToAgentPalette.selectItem}
+              confirmSelection={sendToAgentPalette.confirmSelection}
+            />
+            <NewTerminalPalette
+              isOpen={newTerminalPalette.isOpen}
+              query={newTerminalPalette.query}
+              results={newTerminalPalette.results}
+              totalResults={newTerminalPalette.totalResults}
+              selectedIndex={newTerminalPalette.selectedIndex}
+              onQueryChange={newTerminalPalette.setQuery}
+              onSelectPrevious={newTerminalPalette.selectPrevious}
+              onSelectNext={newTerminalPalette.selectNext}
+              onSelect={newTerminalPalette.handleSelect}
+              onConfirm={newTerminalPalette.confirmSelection}
+              onClose={newTerminalPalette.close}
+            />
+            <WorktreePalette
+              isOpen={worktreePalette.isOpen}
+              query={worktreePalette.query}
+              results={worktreePalette.results}
+              totalResults={worktreePalette.totalResults}
+              activeWorktreeId={worktreePalette.activeWorktreeId}
+              selectedIndex={worktreePalette.selectedIndex}
+              onQueryChange={worktreePalette.setQuery}
+              onSelectPrevious={worktreePalette.selectPrevious}
+              onSelectNext={worktreePalette.selectNext}
+              onSelect={worktreePalette.selectWorktree}
+              onConfirm={worktreePalette.confirmSelection}
+              onClose={worktreePalette.close}
+            />
+            <QuickCreatePalette palette={quickCreatePalette} />
+            <PanelPalette
+              isOpen={panelPalette.isOpen}
+              query={panelPalette.query}
+              results={panelPalette.results}
+              totalResults={panelPalette.totalResults}
+              selectedIndex={panelPalette.selectedIndex}
+              matchesById={panelPalette.matchesById}
+              onQueryChange={panelPalette.setQuery}
+              onSelectPrevious={panelPalette.selectPrevious}
+              onSelectNext={panelPalette.selectNext}
+              onSelect={(kind) => {
+                const result = panelPalette.handleSelect(kind);
+                if (!result) return;
+                if (result.resumeSession) {
+                  const session = result.resumeSession;
+                  const agentConfig = getEffectiveAgentConfig(session.agentId);
+                  const command = buildResumeCommand(
+                    session.agentId,
+                    session.sessionId,
+                    session.agentLaunchFlags
+                  );
+                  if (command && agentConfig) {
+                    addPanel({
+                      kind: "terminal",
+                      launchAgentId: session.agentId,
+                      title: agentConfig.name,
+                      cwd: defaultTerminalCwd,
+                      worktreeId: activeWorktreeId ?? undefined,
+                      command,
+                      location: "grid",
+                    });
+                  }
+                } else if (result.id.startsWith("agent:")) {
+                  const agentId = result.id.slice("agent:".length);
+                  if (agentId) {
+                    launchAgent(agentId);
+                  }
+                } else {
                   addPanel({
-                    kind: "terminal",
-                    launchAgentId: session.agentId,
-                    title: agentConfig.name,
+                    kind: result.id as BuiltInPanelKind,
                     cwd: defaultTerminalCwd,
                     worktreeId: activeWorktreeId ?? undefined,
-                    command,
                     location: "grid",
                   });
                 }
-              } else if (result.id.startsWith("agent:")) {
-                const agentId = result.id.slice("agent:".length);
-                if (agentId) {
-                  launchAgent(agentId);
-                }
-              } else {
-                addPanel({
-                  kind: result.id as BuiltInPanelKind,
-                  cwd: defaultTerminalCwd,
-                  worktreeId: activeWorktreeId ?? undefined,
-                  location: "grid",
-                });
-              }
-            }}
-            onConfirm={() => {
-              const selected = panelPalette.confirmSelection();
-              if (!selected) return;
-              if (selected.id === MORE_AGENTS_PANEL_ID) return;
-              if (selected.resumeSession) {
-                const session = selected.resumeSession;
-                const agentConfig = getEffectiveAgentConfig(session.agentId);
-                const command = buildResumeCommand(
-                  session.agentId,
-                  session.sessionId,
-                  session.agentLaunchFlags
-                );
-                if (command && agentConfig) {
+              }}
+              onConfirm={() => {
+                const selected = panelPalette.confirmSelection();
+                if (!selected) return;
+                if (selected.id === MORE_AGENTS_PANEL_ID) return;
+                if (selected.resumeSession) {
+                  const session = selected.resumeSession;
+                  const agentConfig = getEffectiveAgentConfig(session.agentId);
+                  const command = buildResumeCommand(
+                    session.agentId,
+                    session.sessionId,
+                    session.agentLaunchFlags
+                  );
+                  if (command && agentConfig) {
+                    addPanel({
+                      kind: "terminal",
+                      launchAgentId: session.agentId,
+                      title: agentConfig.name,
+                      cwd: defaultTerminalCwd,
+                      worktreeId: activeWorktreeId ?? undefined,
+                      command,
+                      location: "grid",
+                    });
+                  }
+                } else if (selected.id.startsWith("agent:")) {
+                  const agentId = selected.id.slice("agent:".length);
+                  if (agentId) {
+                    launchAgent(agentId);
+                  }
+                } else {
                   addPanel({
-                    kind: "terminal",
-                    launchAgentId: session.agentId,
-                    title: agentConfig.name,
+                    kind: selected.id as BuiltInPanelKind,
                     cwd: defaultTerminalCwd,
                     worktreeId: activeWorktreeId ?? undefined,
-                    command,
                     location: "grid",
                   });
                 }
-              } else if (selected.id.startsWith("agent:")) {
-                const agentId = selected.id.slice("agent:".length);
-                if (agentId) {
-                  launchAgent(agentId);
-                }
-              } else {
-                addPanel({
-                  kind: selected.id as BuiltInPanelKind,
-                  cwd: defaultTerminalCwd,
-                  worktreeId: activeWorktreeId ?? undefined,
-                  location: "grid",
-                });
-              }
-            }}
-            onClose={panelPalette.close}
-          />
-          <ProjectMruSwitcherOverlay
-            isVisible={mruSwitcher.isVisible}
-            projects={mruSwitcher.projects}
-            selectedIndex={mruSwitcher.selectedIndex}
-          />
-          <ProjectSwitcherPalette
-            isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
-            query={projectSwitcherPalette.query}
-            results={projectSwitcherPalette.results}
-            selectedIndex={projectSwitcherPalette.selectedIndex}
-            onQueryChange={projectSwitcherPalette.setQuery}
-            onSelectPrevious={projectSwitcherPalette.selectPrevious}
-            onSelectNext={projectSwitcherPalette.selectNext}
-            onSelect={projectSwitcherPalette.selectProject}
-            onClose={projectSwitcherPalette.close}
-            onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
-            onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}
-            removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
-            onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
-            onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
-            isRemovingProject={projectSwitcherPalette.isRemovingProject}
-            onSelectNewWindow={(project) => {
-              projectSwitcherPalette.close();
-              void actionService.dispatch(
-                "app.newWindow",
-                { projectPath: project.path },
-                { source: "user" }
-              );
-            }}
-          />
-          <ConfirmDialog
-            isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
-            onClose={() => {
-              if (projectSwitcherPalette.isStoppingProject) return;
-              projectSwitcherPalette.setStopConfirmProjectId(null);
-            }}
-            title={`Stop project?`}
-            description="This will terminate all running sessions in this project. This can't be undone."
-            confirmLabel="Stop project"
-            cancelLabel="Cancel"
-            onConfirm={projectSwitcherPalette.confirmStopProject}
-            isConfirmLoading={projectSwitcherPalette.isStoppingProject}
-            variant="destructive"
-          />
+              }}
+              onClose={panelPalette.close}
+            />
+            <ProjectMruSwitcherOverlay
+              isVisible={mruSwitcher.isVisible}
+              projects={mruSwitcher.projects}
+              selectedIndex={mruSwitcher.selectedIndex}
+            />
+            <ProjectSwitcherPalette
+              isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}
+              query={projectSwitcherPalette.query}
+              results={projectSwitcherPalette.results}
+              selectedIndex={projectSwitcherPalette.selectedIndex}
+              onQueryChange={projectSwitcherPalette.setQuery}
+              onSelectPrevious={projectSwitcherPalette.selectPrevious}
+              onSelectNext={projectSwitcherPalette.selectNext}
+              onSelect={projectSwitcherPalette.selectProject}
+              onClose={projectSwitcherPalette.close}
+              onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
+              onCloseProject={(projectId) => void projectSwitcherPalette.removeProject(projectId)}
+              removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
+              onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
+              onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
+              isRemovingProject={projectSwitcherPalette.isRemovingProject}
+              onSelectNewWindow={(project) => {
+                projectSwitcherPalette.close();
+                void actionService.dispatch(
+                  "app.newWindow",
+                  { projectPath: project.path },
+                  { source: "user" }
+                );
+              }}
+            />
+            <ConfirmDialog
+              isOpen={projectSwitcherPalette.stopConfirmProjectId != null}
+              onClose={() => {
+                if (projectSwitcherPalette.isStoppingProject) return;
+                projectSwitcherPalette.setStopConfirmProjectId(null);
+              }}
+              title={`Stop project?`}
+              description="This will terminate all running sessions in this project. This can't be undone."
+              confirmLabel="Stop project"
+              cancelLabel="Cancel"
+              onConfirm={projectSwitcherPalette.confirmStopProject}
+              isConfirmLoading={projectSwitcherPalette.isStoppingProject}
+              variant="destructive"
+            />
 
-          <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
+            <ThemePalette isOpen={isThemePaletteOpen} onClose={closeThemePalette} />
 
-          <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
+            <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
 
-          <ActionPalette
-            isOpen={actionPalette.isOpen}
-            query={actionPalette.query}
-            results={actionPalette.results}
-            totalResults={actionPalette.totalResults}
-            selectedIndex={actionPalette.selectedIndex}
-            close={actionPalette.close}
-            setQuery={actionPalette.setQuery}
-            selectPrevious={actionPalette.selectPrevious}
-            selectNext={actionPalette.selectNext}
-            executeAction={actionPalette.executeAction}
-            confirmSelection={actionPalette.confirmSelection}
-          />
+            <ActionPalette
+              isOpen={actionPalette.isOpen}
+              query={actionPalette.query}
+              results={actionPalette.results}
+              totalResults={actionPalette.totalResults}
+              selectedIndex={actionPalette.selectedIndex}
+              close={actionPalette.close}
+              setQuery={actionPalette.setQuery}
+              selectPrevious={actionPalette.selectPrevious}
+              selectNext={actionPalette.selectNext}
+              executeAction={actionPalette.executeAction}
+              confirmSelection={actionPalette.confirmSelection}
+            />
 
-          <WorktreeOverviewModal
-            isOpen={isWorktreeOverviewOpen}
-            onClose={closeWorktreeOverview}
-            worktrees={worktrees}
-            activeWorktreeId={activeWorktreeId}
-            focusedWorktreeId={focusedWorktreeId}
-            onSelectWorktree={selectWorktree}
-            onCopyTree={overviewWorktreeActions.handleCopyTree}
-            onOpenEditor={overviewWorktreeActions.handleOpenEditor}
-            onSaveLayout={undefined}
-            onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
-            agentAvailability={availability}
-            agentSettings={agentSettings}
-            homeDir={homeDir}
-          />
+            <WorktreeOverviewModal
+              isOpen={isWorktreeOverviewOpen}
+              onClose={closeWorktreeOverview}
+              worktrees={worktrees}
+              activeWorktreeId={activeWorktreeId}
+              focusedWorktreeId={focusedWorktreeId}
+              onSelectWorktree={selectWorktree}
+              onCopyTree={overviewWorktreeActions.handleCopyTree}
+              onOpenEditor={overviewWorktreeActions.handleOpenEditor}
+              onSaveLayout={undefined}
+              onLaunchAgent={overviewWorktreeActions.handleLaunchAgent}
+              agentAvailability={availability}
+              agentSettings={agentSettings}
+              homeDir={homeDir}
+            />
 
-          <CrossWorktreeDiff
-            isOpen={crossDiffDialog.isOpen}
-            onClose={closeCrossWorktreeDiff}
-            initialWorktreeId={crossDiffDialog.initialWorktreeId}
-          />
+            <CrossWorktreeDiff
+              isOpen={crossDiffDialog.isOpen}
+              onClose={closeCrossWorktreeDiff}
+              initialWorktreeId={crossDiffDialog.initialWorktreeId}
+            />
 
-          {(isSettingsOpen || hasOpenedSettings) && (
-            <Suspense fallback={null}>
-              <LazySettingsDialog
-                isOpen={isSettingsOpen}
-                onClose={() => setIsSettingsOpen(false)}
-                defaultTab={settingsTab}
-                defaultSubtab={settingsSubtab}
-                defaultSectionId={settingsSectionId}
-                onSettingsChange={refreshSettings}
-                projectId={currentProject?.id ?? null}
+            {(isSettingsOpen || hasOpenedSettings) && (
+              <Suspense fallback={null}>
+                <LazySettingsDialog
+                  isOpen={isSettingsOpen}
+                  onClose={() => setIsSettingsOpen(false)}
+                  defaultTab={settingsTab}
+                  defaultSubtab={settingsSubtab}
+                  defaultSectionId={settingsSectionId}
+                  onSettingsChange={refreshSettings}
+                  projectId={currentProject?.id ?? null}
+                />
+              </Suspense>
+            )}
+
+            <ShortcutReferenceDialog
+              isOpen={isShortcutsOpen}
+              onClose={() => setIsShortcutsOpen(false)}
+            />
+
+            <TerminalInfoDialogHost />
+            <FileViewerModalHost />
+
+            {gitInitDirectoryPath && (
+              <GitInitDialog
+                isOpen={gitInitDialogOpen}
+                directoryPath={gitInitDirectoryPath}
+                onSuccess={handleGitInitSuccess}
+                onCancel={closeGitInitDialog}
               />
-            </Suspense>
-          )}
+            )}
 
-          <ShortcutReferenceDialog
-            isOpen={isShortcutsOpen}
-            onClose={() => setIsShortcutsOpen(false)}
-          />
+            {onboardingProjectId && (
+              <ProjectOnboardingWizard
+                isOpen={onboardingWizardOpen}
+                projectId={onboardingProjectId}
+                onClose={closeOnboardingWizard}
+                onFinish={handleWizardFinish}
+              />
+            )}
 
-          <TerminalInfoDialogHost />
-          <FileViewerModalHost />
-
-          {gitInitDirectoryPath && (
-            <GitInitDialog
-              isOpen={gitInitDialogOpen}
-              directoryPath={gitInitDirectoryPath}
-              onSuccess={handleGitInitSuccess}
-              onCancel={closeGitInitDialog}
+            <CreateProjectFolderDialog
+              isOpen={createFolderDialogOpen}
+              onClose={closeCreateFolderDialog}
             />
-          )}
 
-          {onboardingProjectId && (
-            <ProjectOnboardingWizard
-              isOpen={onboardingWizardOpen}
-              projectId={onboardingProjectId}
-              onClose={closeOnboardingWizard}
-              onFinish={handleWizardFinish}
+            <CloneRepoDialog
+              isOpen={cloneRepoDialogOpen}
+              onSuccess={handleCloneSuccess}
+              onCancel={closeCloneRepoDialog}
             />
-          )}
 
-          <CreateProjectFolderDialog
-            isOpen={createFolderDialogOpen}
-            onClose={closeCreateFolderDialog}
-          />
+            <PanelTransitionOverlay />
+            <PanelLimitConfirmDialog />
 
-          <CloneRepoDialog
-            isOpen={cloneRepoDialogOpen}
-            onSuccess={handleCloneSuccess}
-            onCancel={closeCloneRepoDialog}
-          />
-
-          <PanelTransitionOverlay />
-          <PanelLimitConfirmDialog />
-
-          <Toaster />
-          <ShortcutHint />
-          <ReEntrySummary state={reEntrySummary} />
-          <OnboardingFlow
-            availability={availability}
-            onRefreshSettings={refreshSettings}
-            onComplete={gettingStarted.notifyOnboardingComplete}
-          />
-          {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
-            <GettingStartedChecklist
-              checklist={gettingStarted.checklist}
-              collapsed={gettingStarted.collapsed}
-              onDismiss={gettingStarted.dismiss}
-              onToggleCollapse={gettingStarted.toggleCollapse}
-              onMarkItem={gettingStarted.markItem}
+            <Toaster />
+            <ShortcutHint />
+            <ReEntrySummary state={reEntrySummary} />
+            <OnboardingFlow
+              availability={availability}
+              onRefreshSettings={refreshSettings}
+              onComplete={gettingStarted.notifyOnboardingComplete}
             />
-          )}
-          {gettingStarted.showCelebration && <CelebrationConfetti />}
-        </TooltipProvider>
-      </ErrorBoundary>
-    </MotionConfig>
+            {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (
+              <GettingStartedChecklist
+                checklist={gettingStarted.checklist}
+                collapsed={gettingStarted.collapsed}
+                onDismiss={gettingStarted.dismiss}
+                onToggleCollapse={gettingStarted.toggleCollapse}
+                onMarkItem={gettingStarted.markItem}
+              />
+            )}
+            {gettingStarted.showCelebration && <CelebrationConfetti />}
+          </TooltipProvider>
+        </ErrorBoundary>
+      </MotionConfig>
+    </LazyMotion>
   );
 }
 

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { MoreHorizontal, X } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { isMac } from "@/lib/platform";
@@ -636,7 +636,7 @@ export function FleetArmingRibbon(): ReactElement | null {
   return (
     <div data-testid="fleet-arming-ribbon-group">
       <AnimatePresence initial={false}>
-        <motion.div
+        <m.div
           ref={ribbonRef}
           key="fleet-arming-ribbon"
           role={isBroadcastConfirmActive ? "alertdialog" : "status"}
@@ -726,7 +726,7 @@ export function FleetArmingRibbon(): ReactElement | null {
               </button>
             </div>
           )}
-        </motion.div>
+        </m.div>
       </AnimatePresence>
     </div>
   );

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -3,19 +3,24 @@ import React from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, screen, act } from "@testing-library/react";
 
-vi.mock("framer-motion", () => ({
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  motion: {
-    div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-      ({ children, ...props }, ref) => (
-        <div ref={ref} {...props}>
-          {children}
-        </div>
-      )
-    ),
-  },
-  useReducedMotion: () => false,
-}));
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+    useReducedMotion: () => false,
+  };
+});
 
 vi.mock("@/hooks/useWorktreeColorMap", () => ({
   useWorktreeColorMap: () => null,

--- a/src/components/GitHub/BulkActionBar.tsx
+++ b/src/components/GitHub/BulkActionBar.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { X } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 import { Button } from "@/components/ui/button";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
@@ -45,7 +45,7 @@ export function BulkActionBar({
   return (
     <AnimatePresence>
       {count > 0 && (
-        <motion.div
+        <m.div
           key="bulk-bar"
           role="toolbar"
           aria-label="Bulk actions"
@@ -75,7 +75,7 @@ export function BulkActionBar({
           >
             <X className="w-3 h-3" />
           </Button>
-        </motion.div>
+        </m.div>
       )}
     </AnimatePresence>
   );

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -12,6 +12,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
+import { LayoutGroup, LazyMotion, domMax } from "framer-motion";
 import { Plus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
@@ -530,60 +531,64 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
         >
           <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-            <div
-              ref={tabListRef}
-              className="flex items-center border-b border-divider bg-daintree-sidebar shrink-0"
-              role="tablist"
-              aria-label="Dock panel tabs"
-              onKeyDown={handleTabListKeyDown}
-            >
-              {panels.map((panel) => {
-                const tabChrome = deriveTerminalChrome({
-                  kind: panel.kind,
-                  launchAgentId: panel.launchAgentId,
-                  runtimeIdentity: panel.runtimeIdentity,
-                  detectedAgentId: panel.detectedAgentId,
-                  detectedProcessId: panel.detectedProcessId,
-                  agentState: panel.agentState,
-                  runtimeStatus: panel.runtimeStatus,
-                  exitCode: panel.exitCode,
-                  presetColor: panelPresetColors.get(panel.id),
-                });
-                return (
-                  <SortableTabButton
-                    key={panel.id}
-                    id={panel.id}
-                    title={getBaseTitle(panel.title)}
-                    chrome={tabChrome}
-                    kind={panel.kind ?? "terminal"}
-                    agentState={tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined}
-                    isActive={panel.id === activeTabId}
-                    presetColor={panelPresetColors.get(panel.id)}
-                    isUsingFallback={panel.isUsingFallback}
-                    onClick={() => handleTabClick(panel.id)}
-                    onClose={() => handleTabClose(panel.id)}
-                    onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                  />
-                );
-              })}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleAddTab();
-                    }}
-                    onPointerDown={(e) => e.stopPropagation()}
-                    className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                    aria-label="Duplicate panel as new tab"
-                    type="button"
-                  >
-                    <Plus className="w-3 h-3" aria-hidden="true" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
-              </Tooltip>
-            </div>
+            <LazyMotion features={domMax}>
+              <LayoutGroup id={`dock-tabs-${group.id}`}>
+                <div
+                  ref={tabListRef}
+                  className="flex items-center border-b border-divider bg-daintree-sidebar shrink-0"
+                  role="tablist"
+                  aria-label="Dock panel tabs"
+                  onKeyDown={handleTabListKeyDown}
+                >
+                  {panels.map((panel) => {
+                    const tabChrome = deriveTerminalChrome({
+                      kind: panel.kind,
+                      launchAgentId: panel.launchAgentId,
+                      runtimeIdentity: panel.runtimeIdentity,
+                      detectedAgentId: panel.detectedAgentId,
+                      detectedProcessId: panel.detectedProcessId,
+                      agentState: panel.agentState,
+                      runtimeStatus: panel.runtimeStatus,
+                      exitCode: panel.exitCode,
+                      presetColor: panelPresetColors.get(panel.id),
+                    });
+                    return (
+                      <SortableTabButton
+                        key={panel.id}
+                        id={panel.id}
+                        title={getBaseTitle(panel.title)}
+                        chrome={tabChrome}
+                        kind={panel.kind ?? "terminal"}
+                        agentState={tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined}
+                        isActive={panel.id === activeTabId}
+                        presetColor={panelPresetColors.get(panel.id)}
+                        isUsingFallback={panel.isUsingFallback}
+                        onClick={() => handleTabClick(panel.id)}
+                        onClose={() => handleTabClose(panel.id)}
+                        onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                      />
+                    );
+                  })}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleAddTab();
+                        }}
+                        onPointerDown={(e) => e.stopPropagation()}
+                        className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                        aria-label="Duplicate panel as new tab"
+                        type="button"
+                      >
+                        <Plus className="w-3 h-3" aria-hidden="true" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                  </Tooltip>
+                </div>
+              </LayoutGroup>
+            </LazyMotion>
           </SortableContext>
         </DndContext>
 

--- a/src/components/Onboarding/CelebrationConfetti.tsx
+++ b/src/components/Onboarding/CelebrationConfetti.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, m } from "framer-motion";
 
 function getThemeParticleColors(): string[] {
   if (typeof document === "undefined") {
@@ -57,7 +57,7 @@ export function CelebrationConfetti() {
     <div className="fixed inset-0 pointer-events-none z-[var(--z-toast)] flex items-center justify-center">
       <AnimatePresence>
         {particles.map((p) => (
-          <motion.div
+          <m.div
             key={p.id}
             className="absolute rounded-full"
             style={{ width: p.size, height: p.size, backgroundColor: p.color }}

--- a/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
+++ b/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
@@ -3,10 +3,9 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-vi.mock("framer-motion", () => ({
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  motion: {
-    div: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) => {
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef(
+    (props: Record<string, unknown>, ref: React.Ref<HTMLDivElement>) => {
       const {
         initial: _initial,
         animate: _animate,
@@ -15,9 +14,17 @@ vi.mock("framer-motion", () => ({
         ...rest
       } = props;
       return <div ref={ref} {...rest} />;
-    }),
-  },
-}));
+    }
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+  };
+});
 
 import { CelebrationConfetti } from "../CelebrationConfetti";
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -38,7 +38,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
-import { LayoutGroup } from "framer-motion";
+import { LayoutGroup, LazyMotion, domMax } from "framer-motion";
 import type { PanelKind } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { formatShortcutForTooltip, createTooltipWithShortcut } from "@/lib/platform";
@@ -549,54 +549,56 @@ function PanelHeaderComponent({
                   aria-label="Panel tabs"
                   onKeyDown={handleTabListKeyDown}
                 >
-                  <LayoutGroup id={`panel-tabs-${id}`}>
-                    <div className="flex items-center">
-                      {tabs.map((tab) => (
-                        <SortableTabButton
-                          key={tab.id}
-                          id={tab.id}
-                          title={getBaseTitle(tab.title)}
-                          chrome={tab.chrome}
-                          kind={tab.kind}
-                          agentState={tab.agentState}
-                          isActive={tab.isActive}
-                          presetColor={tab.presetColor}
-                          isUsingFallback={tab.isUsingFallback}
-                          fallbackTooltip={tab.fallbackTooltip}
-                          hasDangerousFlags={tab.hasDangerousFlags}
-                          onClick={() => onTabClick?.(tab.id)}
-                          onClose={() => onTabClose?.(tab.id)}
-                          onRename={
-                            onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                          }
-                        />
-                      ))}
-                      {onAddTab && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onAddTab();
-                              }}
-                              onPointerDown={(e) => e.stopPropagation()}
-                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                              aria-label="Duplicate panel as new tab"
-                              type="button"
-                            >
-                              <Plus className="w-3 h-3" aria-hidden="true" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {createTooltipWithShortcut(
-                              "Duplicate panel as new tab",
-                              duplicateShortcut
-                            )}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                  </LayoutGroup>
+                  <LazyMotion features={domMax}>
+                    <LayoutGroup id={`panel-tabs-${id}`}>
+                      <div className="flex items-center">
+                        {tabs.map((tab) => (
+                          <SortableTabButton
+                            key={tab.id}
+                            id={tab.id}
+                            title={getBaseTitle(tab.title)}
+                            chrome={tab.chrome}
+                            kind={tab.kind}
+                            agentState={tab.agentState}
+                            isActive={tab.isActive}
+                            presetColor={tab.presetColor}
+                            isUsingFallback={tab.isUsingFallback}
+                            fallbackTooltip={tab.fallbackTooltip}
+                            hasDangerousFlags={tab.hasDangerousFlags}
+                            onClick={() => onTabClick?.(tab.id)}
+                            onClose={() => onTabClose?.(tab.id)}
+                            onRename={
+                              onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                            }
+                          />
+                        ))}
+                        {onAddTab && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  onAddTab();
+                                }}
+                                onPointerDown={(e) => e.stopPropagation()}
+                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                                aria-label="Duplicate panel as new tab"
+                                type="button"
+                              >
+                                <Plus className="w-3 h-3" aria-hidden="true" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">
+                              {createTooltipWithShortcut(
+                                "Duplicate panel as new tab",
+                                duplicateShortcut
+                              )}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                      </div>
+                    </LayoutGroup>
+                  </LazyMotion>
                 </div>
                 {tabsCanScrollRight && (
                   <div
@@ -646,51 +648,56 @@ function PanelHeaderComponent({
               aria-label="Panel tabs"
               onKeyDown={handleTabListKeyDown}
             >
-              <LayoutGroup id={`panel-tabs-${id}`}>
-                <div className="flex items-center">
-                  {tabs.map((tab) => (
-                    <TabButton
-                      key={tab.id}
-                      id={tab.id}
-                      title={getBaseTitle(tab.title)}
-                      chrome={tab.chrome}
-                      kind={tab.kind}
-                      agentState={tab.agentState}
-                      isActive={tab.isActive}
-                      presetColor={tab.presetColor}
-                      isUsingFallback={tab.isUsingFallback}
-                      fallbackTooltip={tab.fallbackTooltip}
-                      hasDangerousFlags={tab.hasDangerousFlags}
-                      onClick={() => onTabClick?.(tab.id)}
-                      onClose={() => onTabClose?.(tab.id)}
-                      onRename={
-                        onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                      }
-                    />
-                  ))}
-                  {onAddTab && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onAddTab();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
-                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                          aria-label="Duplicate panel as new tab"
-                          type="button"
-                        >
-                          <Plus className="w-3 h-3" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              </LayoutGroup>
+              <LazyMotion features={domMax}>
+                <LayoutGroup id={`panel-tabs-${id}`}>
+                  <div className="flex items-center">
+                    {tabs.map((tab) => (
+                      <TabButton
+                        key={tab.id}
+                        id={tab.id}
+                        title={getBaseTitle(tab.title)}
+                        chrome={tab.chrome}
+                        kind={tab.kind}
+                        agentState={tab.agentState}
+                        isActive={tab.isActive}
+                        presetColor={tab.presetColor}
+                        isUsingFallback={tab.isUsingFallback}
+                        fallbackTooltip={tab.fallbackTooltip}
+                        hasDangerousFlags={tab.hasDangerousFlags}
+                        onClick={() => onTabClick?.(tab.id)}
+                        onClose={() => onTabClose?.(tab.id)}
+                        onRename={
+                          onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                        }
+                      />
+                    ))}
+                    {onAddTab && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onAddTab();
+                            }}
+                            onPointerDown={(e) => e.stopPropagation()}
+                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                            aria-label="Duplicate panel as new tab"
+                            type="button"
+                          >
+                            <Plus className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                          {createTooltipWithShortcut(
+                            "Duplicate panel as new tab",
+                            duplicateShortcut
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                </LayoutGroup>
+              </LazyMotion>
             </div>
             {tabsCanScrollRight && (
               <div

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect, forwardRef } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
-import { motion } from "framer-motion";
+import { m } from "framer-motion";
 import { X, AlertTriangle } from "lucide-react";
 import type { PanelKind, AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
@@ -244,7 +244,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
           {...sortableListeners}
         >
           {isActive && (
-            <motion.div
+            <m.div
               layoutId="panel-tab-indicator"
               layout="position"
               className="absolute inset-x-0 bottom-0 h-0.5 bg-daintree-accent pointer-events-none"

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -11,26 +11,31 @@ vi.mock("react-dom", async () => {
   return { ...actual, createPortal: (children: React.ReactNode) => children };
 });
 
-vi.mock("framer-motion", () => ({
-  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  motion: {
-    div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-      ({ children, ...props }, ref) => {
-        const {
-          layoutId: _layoutId,
-          layout: _layout,
-          transition: _transition,
-          ...rest
-        } = props as Record<string, unknown>;
-        return (
-          <div ref={ref} {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
-            {children}
-          </div>
-        );
-      }
-    ),
-  },
-}));
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => {
+      const {
+        layoutId: _layoutId,
+        layout: _layout,
+        transition: _transition,
+        ...rest
+      } = props as Record<string, unknown>;
+      return (
+        <div ref={ref} {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      );
+    }
+  );
+  return {
+    LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+  };
+});
 
 const mockScrollLeft = vi.fn();
 const mockScrollRight = vi.fn();

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -10,29 +10,30 @@ vi.mock("react-dom", async () => {
   return { ...actual, createPortal: (children: React.ReactNode) => children };
 });
 
-vi.mock("framer-motion", () => ({
-  motion: {
-    div: React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-      ({ children, ...props }, ref) => {
-        const {
-          layoutId: _layoutId,
-          layout: _layout,
-          transition: _transition,
-          ...rest
-        } = props as Record<string, unknown>;
-        return (
-          <div
-            ref={ref}
-            data-testid="motion-div"
-            {...(rest as React.HTMLAttributes<HTMLDivElement>)}
-          >
-            {children}
-          </div>
-        );
-      }
-    ),
-  },
-}));
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => {
+      const {
+        layoutId: _layoutId,
+        layout: _layout,
+        transition: _transition,
+        ...rest
+      } = props as Record<string, unknown>;
+      return (
+        <div ref={ref} data-testid="motion-div" {...(rest as React.HTMLAttributes<HTMLDivElement>)}>
+          {children}
+        </div>
+      );
+    }
+  );
+  return {
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+  };
+});
 
 vi.mock("@/components/ui/tooltip", () => ({
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -14,7 +14,7 @@ import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion, type Variants } from "framer-motion";
+import { AnimatePresence, m, useReducedMotion, type Variants } from "framer-motion";
 import { Plug } from "@/components/icons";
 import { UI_ENTER_DURATION, UI_EXIT_DURATION } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
@@ -549,7 +549,7 @@ export function AgentSetupWizard({
       <AppDialog.Body>
         <div className="relative overflow-hidden">
           <AnimatePresence mode="wait" custom={directionRef.current}>
-            <motion.div
+            <m.div
               key={state.step.type}
               custom={directionRef.current}
               variants={prefersReducedMotion ? reducedStepVariants : stepVariants}
@@ -589,7 +589,7 @@ export function AgentSetupWizard({
                 />
               )}
               {state.step.type === "complete" && <CompleteStep installedAgents={installedAgents} />}
-            </motion.div>
+            </m.div>
           </AnimatePresence>
         </div>
       </AppDialog.Body>

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, CircleCheck, Loader2, RotateCw } from "lucide-react";
-import { motion, useReducedMotion } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import { UI_ENTER_DURATION } from "@/lib/animationUtils";
 import { useSystemHealthCheck } from "./useSystemHealthCheck";
 import { PrerequisiteCard } from "./SystemToolsStep";
@@ -91,7 +91,7 @@ export function SystemRequirementsSection({
         )}
       </button>
 
-      <motion.div
+      <m.div
         animate={{ height: isExpanded ? "auto" : 0 }}
         initial={false}
         transition={
@@ -149,7 +149,7 @@ export function SystemRequirementsSection({
             {isChecking ? "Checking..." : "Re-check"}
           </button>
         </div>
-      </motion.div>
+      </m.div>
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -295,7 +295,7 @@ export default defineConfig(({ command, mode }) => {
               },
               {
                 name: "vendor-motion",
-                test: /node_modules[\\/]framer-motion[\\/]/,
+                test: /node_modules[\\/](framer-motion|motion-dom|motion-utils)[\\/]/,
                 priority: 50,
               },
               {


### PR DESCRIPTION
## Summary

- Migrates all `motion.*` component usage to the `m.*` prefix pattern, with `<LazyMotion>` boundaries that defer feature loading until needed. This drops the synchronous upfront cost from ~34KB to under 5KB on initial render.
- `domAnimation` wraps the app root via `App.tsx`. Subtrees that use `layoutId` or `layout` props (`PanelHeader`, `DockedTabGroup`) get their own `<LazyMotion features={domMax}>` boundary since `domAnimation` doesn't include layout animation features.
- `MotionConfig`, `LayoutGroup`, `AnimatePresence` and type imports stay as direct `motion/react` imports — only the component primitives move to `m.*`.

Resolves #6173

## Changes

- `src/App.tsx` — wraps `<MotionConfig>` in `<LazyMotion features={domAnimation}>`
- `src/components/Panel/PanelHeader.tsx` — both LayoutGroup branches wrapped in `<LazyMotion features={domMax}>`, `motion` -> `m`
- `src/components/Layout/DockedTabGroup.tsx` — tab list wrapped in `<LazyMotion features={domMax}>`+`<LayoutGroup id="dock-tabs-${group.id}">`, `motion` -> `m`
- `src/components/Panel/TabButton.tsx` — `motion.div` -> `m.div`
- `src/components/Setup/SystemRequirementsSection.tsx` — `motion` -> `m`
- `src/components/Setup/AgentSetupWizard.tsx` — `motion` -> `m`
- `src/components/GitHub/BulkActionBar.tsx` — `motion` -> `m`
- `src/components/Fleet/FleetArmingRibbon.tsx` — `motion` -> `m`
- `src/components/Onboarding/CelebrationConfetti.tsx` — `motion` -> `m`
- 4 Vitest test mocks updated to pass through `m` and `LazyMotion`
- `vite.config.ts` — vendor-motion chunk regex widened to `(framer-motion|motion-dom|motion-utils)` to keep the split clean

## Testing

99 Vitest tests pass. `tsc --noEmit` clean. Lint, format, and build all pass. The `vendor-motion` chunk in the renderer bundle should shrink noticeably once the lazy features land as a separate async chunk rather than the synchronous upfront load.