### PR TITLE
fix(ui): extend info toast duration and tighten entry/exit animation

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -383,7 +383,7 @@ describe("Toast accessibility", () => {
     // ~984ms instead of resetting to a fresh 3000ms.
     expect(screen.getByText("msg-4")).toBeTruthy();
 
-    // Cross the cap; timer fires, then 300ms fade-out removes the toast.
+    // Cross the cap; timer fires, then 200ms fade-out removes the toast.
     await act(async () => {
       vi.advanceTimersByTime(1500);
     });
@@ -442,7 +442,7 @@ describe("Toast accessibility", () => {
       useNotificationStore.getState().dismissNotification(toastId!);
     });
 
-    // User clicks X during the 300ms fade window before removeNotification.
+    // User clicks X during the 200ms fade window before removeNotification.
     const dismissButton = screen.getByLabelText("Dismiss notification");
     await act(async () => {
       fireEvent.click(dismissButton);
@@ -468,7 +468,7 @@ describe("Toast accessibility", () => {
       fireEvent.click(dismissButton);
     });
 
-    // Toast still enters the fade-out path; after the 300ms cleanup runs it
+    // Toast still enters the fade-out path; after the 200ms cleanup runs it
     // is removed from the store entirely.
     await act(async () => {
       vi.advanceTimersByTime(400);
@@ -680,7 +680,7 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     });
     expect(screen.getByText("Failed once")).toBeTruthy();
 
-    // Past 12s + the 300ms fade — gone.
+    // Past 12s + the 200ms fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
@@ -700,7 +700,7 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     });
     expect(screen.getByText("Saved!")).toBeTruthy();
 
-    // Past 4s + the 300ms fade — gone.
+    // Past 4s + the 200ms fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -97,7 +97,7 @@ function Toast({ notification }: { notification: Notification }) {
 
   const handleDismiss = useCallback(() => {
     // If the notification is already dismissed, this click came in during the
-    // 300ms fade after an eviction (or a double-click race). Skip the
+    // 200ms fade after an eviction (or a double-click race). Skip the
     // user-dismiss callback so eviction/reentrancy don't fire onDismiss.
     if (notification.dismissed) return;
     restoreFocus();
@@ -110,14 +110,14 @@ function Toast({ notification }: { notification: Notification }) {
     }
     dismissNotification(notification.id);
     setIsVisible(false);
-    setTimeout(() => removeNotification(notification.id), 300);
+    setTimeout(() => removeNotification(notification.id), 200);
   }, [notification, dismissNotification, removeNotification, restoreFocus]);
 
   useEffect(() => {
     if (notification.dismissed && isVisible) {
       restoreFocus();
       setIsVisible(false);
-      setTimeout(() => removeNotification(notification.id), 300);
+      setTimeout(() => removeNotification(notification.id), 200);
     }
   }, [notification.dismissed, notification.id, isVisible, removeNotification, restoreFocus]);
 
@@ -157,7 +157,7 @@ function Toast({ notification }: { notification: Notification }) {
         "text-sm text-daintree-text",
         "shadow-[var(--theme-shadow-floating)]",
         "ring-1 ring-inset ring-tint/[0.05]",
-        "transition-[transform,opacity] duration-300 ease-out",
+        "transition-[transform,opacity] duration-200 ease-out",
         "motion-reduce:transition-none motion-reduce:duration-0",
         isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
         accentClass

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -540,11 +540,11 @@ describe("notify()", () => {
       expect(notification!.duration).toBe(TOAST_DURATION.success);
     });
 
-    it("applies a 4s default for info notifications", () => {
+    it("applies an 8s default for info notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       notify({ type: "info", message: "FYI" });
       const notification = useNotificationStore.getState().notifications[0];
-      expect(notification!.duration).toBe(4000);
+      expect(notification!.duration).toBe(8000);
       expect(notification!.duration).toBe(TOAST_DURATION.info);
     });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -18,7 +18,9 @@ import type { ErrorType } from "@/store/errorStore";
  * Default auto-dismiss durations (ms) by notification type.
  *
  * Errors and warnings get a generous 12s so the user has time to read them;
- * success and info dismiss in 4s to match Sonner / Material 3 norms. The
+ * success dismisses in 4s (two-word confirmations need no more). Info gets
+ * 8s to match the Atlassian accessibility minimum for sentence-length
+ * content. The
  * persistent inbox is the WCAG 2.2.1 conforming alternative — users who miss
  * a toast can always recover it from the notification center.
  *
@@ -29,7 +31,7 @@ export const TOAST_DURATION: Record<NotificationType, number> = {
   error: 12000,
   warning: 12000,
   success: 4000,
-  info: 4000,
+  info: 8000,
 };
 
 export interface ComboOptions {

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -112,7 +112,6 @@ async function handleFallbackTriggered(data: {
           reason === "auth"
             ? `${fromName} authentication failed — now running "${nextPreset.name}".`
             : `${fromName} unreachable — now running "${nextPreset.name}".`,
-        duration: 4000,
       });
     } else {
       notify({


### PR DESCRIPTION
## Summary
Two small toast-system polish items.

- Info toasts now display for 8s (up from 4s), matching the Atlassian accessibility floor for sentence-length content. Success stays at 4s — two-word confirmations don't need more time.
- Entry/exit animation tightened from 300ms to 200ms so toasts follow the same motion convention as modals and popovers.

Resolves #6172

## Changes
- `notify.ts`: `TOAST_DURATION.info` 4000 -> 8000
- `toaster.tsx`: transition class and two `setTimeout` calls from `duration-300` / 300ms to 200ms
- `panel/lifecycle.ts`: removed stale `duration: 4000` override that was pinning info toasts below the new default
- Test expectations updated to match

## Testing
Existing toast unit tests pass with the updated values. No new coverage needed — these are parameter changes.