### PR TITLE
feat(terminal): enable rescaleOverlappingGlyphs and reflowCursorLine xterm options

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -767,6 +767,8 @@ class TerminalInstanceService {
 
     const terminalOptions = {
       ...options,
+      rescaleOverlappingGlyphs: true,
+      reflowCursorLine: true,
       linkHandler: {
         activate: (event: MouseEvent, text: string) => openLink(text, event),
         hover: (_event: MouseEvent, text: string, range: IBufferRange) => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@xterm/addon-canvas", () => ({
+  CanvasAddon: class {
+    dispose() {}
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffer: vi.fn(() => null),
+  },
+  systemClient: {
+    openExternal: vi.fn(),
+  },
+  appClient: {
+    getHydrationState: vi.fn(),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+const mockDocument = {
+  createElement: vi.fn(() => ({
+    style: {},
+    className: "",
+    appendChild: vi.fn(),
+    removeChild: vi.fn(),
+    parentElement: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    remove: vi.fn(),
+    getBoundingClientRect: vi.fn(() => ({ width: 800, height: 600 })),
+  })),
+  body: {
+    appendChild: vi.fn(),
+  },
+};
+
+(global as any).document = mockDocument;
+
+describe("TerminalInstanceService - options", () => {
+  it("sets rescaleOverlappingGlyphs and reflowCursorLine on constructed Terminal", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    // Mock matchMedia for xterm's Terminal.open()
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options",
+      "terminal",
+      {},
+      () => 3 as any,
+      undefined
+    );
+
+    expect(managed.terminal.options).toEqual(
+      expect.objectContaining({
+        rescaleOverlappingGlyphs: true,
+        reflowCursorLine: true,
+      })
+    );
+
+    terminalInstanceService.destroy("test-options");
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 vi.mock("@xterm/addon-canvas", () => ({
   CanvasAddon: class {
@@ -66,6 +67,7 @@ const mockDocument = {
   },
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
 (global as any).document = mockDocument;
 
 describe("TerminalInstanceService - options", () => {
@@ -85,7 +87,7 @@ describe("TerminalInstanceService - options", () => {
       "test-options",
       "terminal",
       {},
-      () => 3 as any,
+      () => TerminalRefreshTier.FOCUSED,
       undefined
     );
 


### PR DESCRIPTION
## Summary
Enables two xterm.js 6.0 rendering options that were previously left at their defaults. Both are correctness wins with no schema impact and no downside.

- `rescaleOverlappingGlyphs` fixes ambiguous-width characters (GB18030 roman numerals, Powerline glyphs, certain emoji) that currently bleed across adjacent cells under WebGL/WebGPU. Silent no-op under the DOM fallback.
- `reflowCursorLine` lets the cursor's line participate in resize reflow, eliminating visible jank when dragging panel dividers with an active prompt or TUI on screen.

Resolves #6159

## Changes
- Set `rescaleOverlappingGlyphs: true` and `reflowCursorLine: true` on `Terminal` construction
- Both options propagate to rehydrated instances automatically via the hibernation manager's options clone

## Testing
- Unit test asserts both options are present on the constructed `Terminal` instance