### PR TITLE
fix(ui): refresh microcopy across recovery and error UI

### DIFF
--- a/e2e/full/core-error-boundaries.spec.ts
+++ b/e2e/full/core-error-boundaries.spec.ts
@@ -33,15 +33,15 @@ test.describe.serial("Core: Error Boundaries", () => {
 
     // Verify fullscreen variant content
     await expect(fallback).toHaveAttribute("data-variant", "fullscreen");
-    await expect(window.locator(SEL.errorBoundary.title)).toContainText("Application Error");
-    await expect(window.locator(SEL.errorBoundary.restartButton)).toContainText(
-      "Restart Application"
+    await expect(window.locator(SEL.errorBoundary.title)).toContainText(
+      "Daintree hit an unrecoverable error"
     );
+    await expect(window.locator(SEL.errorBoundary.restartButton)).toContainText("Reload window");
     await expect(window.locator(SEL.errorBoundary.reportButton)).toBeVisible();
     await expect(window.locator(SEL.errorBoundary.logsButton)).toBeVisible();
   });
 
-  test("Restart Application button recovers the app", async () => {
+  test("Reload window button recovers the app", async () => {
     const { window } = ctx;
 
     // Fallback should still be visible from previous test

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -69,27 +69,24 @@ export function ErrorFallback({
             className={cn("font-semibold text-status-error", sizes.title)}
             data-testid="error-fallback-title"
           >
-            {variant === "fullscreen" && "Application Error"}
-            {variant === "section" && "Section Error"}
-            {variant === "component" && `${componentName || "Component"} Error`}
+            {variant === "fullscreen" && "Daintree hit an unrecoverable error"}
+            {variant === "section" && `${componentName || "Section"} stopped working`}
+            {variant === "component" && `${componentName || "Component"} error`}
           </h2>
 
           <p className={cn("text-daintree-text/80", sizes.message)}>
             {import.meta.env.DEV
               ? error.message
-              : "Something went wrong. Please try again or contact support."}
+              : variant === "fullscreen"
+                ? "The window can't continue. Reloading usually fixes it."
+                : variant === "section"
+                  ? "This pane crashed but the rest of Daintree is still running."
+                  : `Couldn't render ${componentName || "this component"}. Try again, or reload the pane.`}
           </p>
 
-          {variant === "fullscreen" && (
-            <p className={cn("text-daintree-text/60", sizes.message)}>
-              The application encountered an unexpected error. You can try restarting or check the
-              logs for more details.
-            </p>
-          )}
-
           {!import.meta.env.DEV && incidentId && variant !== "component" && (
-            <p className={cn("text-daintree-text/50 font-mono", sizes.message)}>
-              Error ID: {incidentId.slice(-7)}
+            <p className={cn("text-daintree-text/50 font-mono break-all", sizes.message)}>
+              Error ID: {incidentId}
             </p>
           )}
         </div>
@@ -104,7 +101,11 @@ export function ErrorFallback({
               sizes.button
             )}
           >
-            {variant === "fullscreen" ? "Restart Application" : "Try Again"}
+            {variant === "fullscreen"
+              ? "Reload window"
+              : variant === "section"
+                ? "Reload pane"
+                : "Try again"}
           </button>
 
           {variant !== "component" && onReport && (

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -51,7 +51,7 @@ describe("ErrorBoundary", () => {
         <ThrowingChild shouldThrow={true} />
       </ErrorBoundary>
     );
-    expect(screen.getByText("Section Error")).toBeTruthy();
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
   });
 
   it("captures incidentId from addError and passes to fallback", () => {
@@ -65,13 +65,11 @@ describe("ErrorBoundary", () => {
     expect(errors.length).toBe(1);
 
     const storeId = errors[0]!.id;
-    const shortId = storeId.slice(-7);
     // In dev mode, incident ID is not displayed (only in prod)
     // but we can verify the error was added to the store
     expect(storeId).toMatch(
       /^error-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
-    expect(shortId).toHaveLength(7);
   });
 
   it("passes incidentId to logError context", async () => {
@@ -106,13 +104,13 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
-    expect(screen.getByText("Section Error")).toBeTruthy();
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
 
     shouldThrow = false;
-    fireEvent.click(screen.getByText("Try Again"));
+    fireEvent.click(screen.getByText("Reload pane"));
 
     expect(screen.getByText("Recovered")).toBeTruthy();
-    expect(screen.queryByText("Section Error")).toBeNull();
+    expect(screen.queryByText("Section stopped working")).toBeNull();
   });
 
   it("provides onReport to section variant", () => {
@@ -155,12 +153,12 @@ describe("ErrorBoundary", () => {
     );
 
     const errors = useErrorStore.getState().errors;
-    const shortId = errors[0]!.id.slice(-7);
+    const storeId = errors[0]!.id;
 
-    expect(screen.getByText(`Error ID: ${shortId}`)).toBeTruthy();
+    expect(screen.getByText(`Error ID: ${storeId}`)).toBeTruthy();
     expect(screen.queryByText("Test render error")).toBeNull();
     expect(
-      screen.getByText("Something went wrong. Please try again or contact support.")
+      screen.getByText("This pane crashed but the rest of Daintree is still running.")
     ).toBeTruthy();
   });
 

--- a/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
@@ -46,13 +46,13 @@ describe("ErrorFallback", () => {
     it("shows friendly message instead of raw error", () => {
       render(<ErrorFallback {...baseProps} variant="section" />);
       expect(
-        screen.getByText("Something went wrong. Please try again or contact support.")
+        screen.getByText("This pane crashed but the rest of Daintree is still running.")
       ).toBeTruthy();
     });
 
-    it("displays short incident ID", () => {
+    it("displays full incident ID", () => {
       render(<ErrorFallback {...baseProps} variant="section" />);
-      expect(screen.getByText("Error ID: a3f7b2x")).toBeTruthy();
+      expect(screen.getByText("Error ID: error-1710000000000-a3f7b2x")).toBeTruthy();
     });
 
     it("does not render technical details", () => {
@@ -107,10 +107,10 @@ describe("ErrorFallback", () => {
   });
 
   describe("buttons", () => {
-    it("calls resetError when Try Again is clicked", () => {
+    it("calls resetError when Reload pane is clicked", () => {
       vi.stubEnv("DEV", true);
       render(<ErrorFallback {...baseProps} variant="section" />);
-      fireEvent.click(screen.getByText("Try Again"));
+      fireEvent.click(screen.getByText("Reload pane"));
       expect(baseProps.resetError).toHaveBeenCalledOnce();
     });
 
@@ -130,10 +130,10 @@ describe("ErrorFallback", () => {
       expect(screen.queryByText("Report Issue")).toBeNull();
     });
 
-    it("shows Restart Application text for fullscreen variant", () => {
+    it("shows Reload window text for fullscreen variant", () => {
       vi.stubEnv("DEV", false);
       render(<ErrorFallback {...baseProps} variant="fullscreen" />);
-      expect(screen.getByText("Restart Application")).toBeTruthy();
+      expect(screen.getByText("Reload window")).toBeTruthy();
     });
   });
 

--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -64,7 +64,7 @@ export function CloudSyncBanner() {
         onClick={handleDismiss}
         className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
       >
-        Got it
+        Don&rsquo;t warn for this project
       </button>
     </div>
   );

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -151,7 +151,7 @@ export function CrashRecoveryDialog({
     >
       <AppDialog.Header>
         <AppDialog.Title icon={<AlertTriangle className="h-5 w-5 text-status-warning" />}>
-          Daintree crashed
+          Daintree closed unexpectedly
         </AppDialog.Title>
       </AppDialog.Header>
 
@@ -371,8 +371,9 @@ export function CrashRecoveryDialog({
                   className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
                   data-testid="privacy-warning"
                 >
-                  Crash info may include file paths. Click again to copy to clipboard and open
-                  GitHub Issues. You'll need to paste the info into the form.
+                  Crash info may include panel titles, panel kinds, file paths, and stack traces.
+                  Click again to copy to clipboard and open GitHub Issues. You'll need to paste the
+                  info into the form.
                 </p>
               )}
             </div>
@@ -388,7 +389,7 @@ export function CrashRecoveryDialog({
             data-testid="auto-restore-checkbox"
           />
           <span className="text-xs text-daintree-text/60">
-            Don't show this again — always restore automatically
+            Always restore sessions automatically
           </span>
         </label>
       </AppDialog.Body>

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -50,14 +50,14 @@ describe("CloudSyncBanner", () => {
     expect(region.getAttribute("aria-live")).toBe("polite");
     expect(screen.getByText("Cloud sync detected")).toBeTruthy();
     expect(screen.getByText(/Dropbox-synced folder/i)).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Got it" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Don.*t warn for this project/i })).toBeTruthy();
   });
 
   it("persists dismiss preference and clears the banner", async () => {
     useCloudSyncBannerStore.setState({ service: "iCloud Drive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    fireEvent.click(screen.getByRole("button", { name: /Don.*t warn for this project/i }));
 
     await waitFor(() => {
       expect(saveSettingsMock).toHaveBeenCalledWith(
@@ -81,7 +81,7 @@ describe("CloudSyncBanner", () => {
     useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    fireEvent.click(screen.getByRole("button", { name: /Don.*t warn for this project/i }));
 
     await waitFor(() => {
       expect(saveSettingsMock).toHaveBeenCalledOnce();
@@ -101,7 +101,7 @@ describe("CloudSyncBanner", () => {
     // Simulate the race: live project flips to p2 before the click handler runs.
     setProject("p2");
 
-    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    fireEvent.click(screen.getByRole("button", { name: /Don.*t warn for this project/i }));
 
     await waitFor(() => {
       expect(useCloudSyncBannerStore.getState().service).toBeNull();
@@ -114,7 +114,7 @@ describe("CloudSyncBanner", () => {
     useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
     render(<CloudSyncBanner />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Got it" }));
+    fireEvent.click(screen.getByRole("button", { name: /Don.*t warn for this project/i }));
 
     await waitFor(() => {
       expect(notifyMock).toHaveBeenCalled();

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -149,7 +149,7 @@ describe("CrashRecoveryDialog", () => {
   it("renders the dialog", () => {
     setup();
     expect(screen.getByTestId("crash-recovery-dialog")).toBeTruthy();
-    expect(screen.getByText("Daintree crashed")).toBeTruthy();
+    expect(screen.getByText("Daintree closed unexpectedly")).toBeTruthy();
   });
 
   describe("with panels (selective restore)", () => {

--- a/src/registry/__tests__/panelWrapperErrorBoundary.test.tsx
+++ b/src/registry/__tests__/panelWrapperErrorBoundary.test.tsx
@@ -44,8 +44,8 @@ describe("Panel wrapper ErrorBoundary + Suspense nesting", () => {
       </ErrorBoundary>
     );
 
-    expect(screen.getByText("BrowserPane Error")).toBeTruthy();
-    expect(screen.getByText("Try Again")).toBeTruthy();
+    expect(screen.getByText("BrowserPane error")).toBeTruthy();
+    expect(screen.getByText("Try again")).toBeTruthy();
     expect(screen.queryByText("Loading...")).toBeNull();
   });
 


### PR DESCRIPTION
## Summary
- Microcopy refresh across crash recovery, error fallback, and cloud sync banner dialogs to match Daintree style rules (sentence case, no periods on titles, verb-noun buttons, dropped "we").
- Pure copy changes — no logic, state, or behavior was touched.

Resolves #6174

## Changes
- **CrashRecoveryDialog:** sentence-case title ("Daintree closed unexpectedly"), active-framed body copy, accurate privacy note listing what crash bundles include.
- **ErrorFallback:** variant-specific copy for fullscreen/section/component scopes, full incident ID instead of truncated last-7-char suffix.
- **CloudSyncBanner:** "Don't warn for this project" replaces the less precise "Don't show this again."
- Tests updated in lockstep for all three components + the error boundaries E2E spec.

## Testing
- `CrashRecoveryDialog.test.tsx` — copy assertions updated.
- `ErrorFallback.test.tsx` + `ErrorBoundary.test.tsx` — copy assertions updated.
- `CloudSyncBanner.test.tsx` — button label assertion updated.
- `core-error-boundaries.spec.ts` — E2E selectors and assertions updated.
- Typecheck, lint, and format all pass.