### PR TITLE
perf(ci): cache fontconfig on Ubuntu runners to reduce cold-start variance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
           key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
 
       - name: Warm fontconfig cache
-        if: steps.cache-fontconfig.outputs.cache-hit != 'true'
         run: fc-cache -fv
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
+      - name: Fontconfig cache key
+        id: fontconfig-cache-key
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/fontconfig
+          source /etc/os-release
+          echo "ubuntu=${ID}-${VERSION_ID}-${VERSION_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "fc_version=$(fc-cache --version 2>&1 | head -1)" >> "$GITHUB_OUTPUT"
+          echo "font_pkg_hash=$(dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null | grep -E '^fonts-|^fontconfig' | LC_ALL=C sort | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache fontconfig
+        id: cache-fontconfig
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fontconfig
+          key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
+
+      - name: Warm fontconfig cache
+        if: steps.cache-fontconfig.outputs.cache-hit != 'true'
+        run: fc-cache -fv
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -156,7 +156,7 @@ jobs:
           key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
 
       - name: Warm fontconfig cache
-        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        if: runner.os == 'Linux'
         run: fc-cache -fv
 
       - name: Install dependencies

--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -136,6 +136,29 @@ jobs:
             libnotify4 \
             xvfb
 
+      - name: Fontconfig cache key
+        id: fontconfig-cache-key
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/fontconfig
+          source /etc/os-release
+          echo "ubuntu=${ID}-${VERSION_ID}-${VERSION_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "fc_version=$(fc-cache --version 2>&1 | head -1)" >> "$GITHUB_OUTPUT"
+          echo "font_pkg_hash=$(dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null | grep -E '^fonts-|^fontconfig' | LC_ALL=C sort | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache fontconfig
+        id: cache-fontconfig
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fontconfig
+          key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
+
+      - name: Warm fontconfig cache
+        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        run: fc-cache -fv
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -119,7 +119,7 @@ jobs:
           key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
 
       - name: Warm fontconfig cache
-        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        if: runner.os == 'Linux'
         run: fc-cache -fv
 
       - name: Install dependencies (Windows)

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -99,6 +99,29 @@ jobs:
             libnotify4 \
             xvfb
 
+      - name: Fontconfig cache key
+        id: fontconfig-cache-key
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/fontconfig
+          source /etc/os-release
+          echo "ubuntu=${ID}-${VERSION_ID}-${VERSION_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "fc_version=$(fc-cache --version 2>&1 | head -1)" >> "$GITHUB_OUTPUT"
+          echo "font_pkg_hash=$(dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null | grep -E '^fonts-|^fontconfig' | LC_ALL=C sort | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache fontconfig
+        id: cache-fontconfig
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fontconfig
+          key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
+
+      - name: Warm fontconfig cache
+        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        run: fc-cache -fv
+
       - name: Install dependencies (Windows)
         if: runner.os == 'Windows'
         run: npm ci

--- a/.github/workflows/e2e-online.yml
+++ b/.github/workflows/e2e-online.yml
@@ -128,7 +128,7 @@ jobs:
           key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
 
       - name: Warm fontconfig cache
-        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        if: runner.os == 'Linux'
         run: fc-cache -fv
 
       - name: Install dependencies

--- a/.github/workflows/e2e-online.yml
+++ b/.github/workflows/e2e-online.yml
@@ -108,6 +108,29 @@ jobs:
             libnotify4 \
             xvfb
 
+      - name: Fontconfig cache key
+        id: fontconfig-cache-key
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/fontconfig
+          source /etc/os-release
+          echo "ubuntu=${ID}-${VERSION_ID}-${VERSION_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "fc_version=$(fc-cache --version 2>&1 | head -1)" >> "$GITHUB_OUTPUT"
+          echo "font_pkg_hash=$(dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null | grep -E '^fonts-|^fontconfig' | LC_ALL=C sort | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache fontconfig
+        id: cache-fontconfig
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fontconfig
+          key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
+
+      - name: Warm fontconfig cache
+        if: runner.os == 'Linux' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        run: fc-cache -fv
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,7 +175,7 @@ jobs:
           key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
 
       - name: Warm fontconfig cache
-        if: matrix.os == 'ubuntu-22.04' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        if: matrix.os == 'ubuntu-22.04'
         run: fc-cache -fv
 
       - name: Install dependencies (Windows)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,6 +155,29 @@ jobs:
             libnotify-dev \
             libxkbfile-dev
 
+      - name: Fontconfig cache key
+        id: fontconfig-cache-key
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/fontconfig
+          source /etc/os-release
+          echo "ubuntu=${ID}-${VERSION_ID}-${VERSION_CODENAME}" >> "$GITHUB_OUTPUT"
+          echo "fc_version=$(fc-cache --version 2>&1 | head -1)" >> "$GITHUB_OUTPUT"
+          echo "font_pkg_hash=$(dpkg-query -W -f='${Package} ${Version}\n' 2>/dev/null | grep -E '^fonts-|^fontconfig' | LC_ALL=C sort | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache fontconfig
+        id: cache-fontconfig
+        if: matrix.os == 'ubuntu-22.04'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/fontconfig
+          key: fontconfig-${{ runner.os }}-${{ runner.arch }}-${{ steps.fontconfig-cache-key.outputs.ubuntu }}-${{ steps.fontconfig-cache-key.outputs.fc_version }}-${{ steps.fontconfig-cache-key.outputs.font_pkg_hash }}
+
+      - name: Warm fontconfig cache
+        if: matrix.os == 'ubuntu-22.04' && steps.cache-fontconfig.outputs.cache-hit != 'true'
+        run: fc-cache -fv
+
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: npm ci


### PR DESCRIPTION
## Summary

This adds fontconfig caching to five Ubuntu CI jobs across four workflow files. Fresh runners pay a 200--500ms fontconfig scan on first render, and a corrupt or partial cache has triggered flaky Skia SIGILL/SIGTRAP crashes in recent Electron builds. Persisting the cache removes both failure modes.

Resolves #6175.

## Changes

- Added `actions/cache@v4` fontconfig cache to `ci.yml`, `e2e-core.yml`, `e2e-nightly.yml`, `e2e-online.yml`, and `nightly.yml`
- Cache key is composite: OS, arch, Ubuntu release, fontconfig version, and a hash of installed font packages -- so it rotates when the runner image or font set changes
- `fc-cache -fv` runs unconditionally after cache restore to validate the cache and catch any corruption
- Linux-only: gated behind `runner.os == 'Linux'` or `matrix.os == 'ubuntu-22.04'` where applicable

## Testing

The cache hit should be visible in the workflow log on the second run. Two back-to-back runs of the same workflow should show a meaningful speedup on the renderer-startup phase, and the fontconfig cache step should report a hit.