### PR TITLE
fix(crash-recovery): widen crash-loop window, raise disk thresholds, clear snapshot cache

### DIFF
--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -6,7 +6,7 @@ const STATE_FILENAME = "crash-loop-state.json";
 const CRASH_THRESHOLD = 3;
 const HARD_STOP_THRESHOLD = 5;
 const STABILITY_TIMEOUT_MS = 5 * 60 * 1000;
-const RAPID_CRASH_WINDOW_MS = 60_000;
+const RAPID_CRASH_WINDOW_MS = 300_000;
 
 interface CrashLoopState {
   version: 1;

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -191,6 +191,7 @@ export class CrashRecoveryService {
         hasSeenWelcome: true,
         panelGridConfig: { strategy: "automatic" as const, value: 3 },
       });
+      this.cachedBackupSnapshot = null;
       console.log("[CrashRecovery] Reset to fresh state");
     } catch (err) {
       console.error("[CrashRecovery] Failed to reset to fresh:", err);
@@ -204,6 +205,7 @@ export class CrashRecoveryService {
       this.deleteMarker();
       console.log("[CrashRecovery] Clean exit — marker removed");
     }
+    this.cachedBackupSnapshot = null;
   }
 
   private consumeMarker(): PendingCrash | null {

--- a/electron/services/DiskSpaceMonitor.ts
+++ b/electron/services/DiskSpaceMonitor.ts
@@ -17,8 +17,8 @@ export interface DiskSpaceMonitorActions {
   isWindowFocused: () => boolean;
 }
 
-const WARNING_MB = 500;
-const CRITICAL_MB = 100;
+const WARNING_MB = 2000;
+const CRITICAL_MB = 500;
 const POLL_INTERVAL_MS = 5 * 60 * 1000;
 const NOTIFICATION_COOLDOWN_MS = 30 * 60 * 1000;
 

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -79,7 +79,7 @@ describe("CrashLoopGuardService adversarial", () => {
     writeStateFile(statePath, {
       version: 1,
       crashes: 9,
-      launches: [now - 60_000, now - 59_999],
+      launches: [now - 300_000, now - 299_999],
       cleanExit: false,
       lastReset: now - 5_000,
     });
@@ -134,7 +134,14 @@ describe("CrashLoopGuardService adversarial", () => {
     writeStateFile(statePath, {
       version: 1,
       crashes: 5,
-      launches: [now - 120_000, now - 110_000, now - 100_000, now - 90_000, now - 1_000, now - 500],
+      launches: [
+        now - 320_000,
+        now - 310_000,
+        now - 305_000,
+        now - 301_000,
+        now - 1_000,
+        now - 500,
+      ],
       cleanExit: false,
       lastReset: now - 120_000,
     });

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -91,7 +91,7 @@ describe("isSafeModeActive", () => {
       JSON.stringify({
         version: 1,
         crashes: 3,
-        launches: [now - 120000, now - 90000, now - 70000],
+        launches: [now - 400000, now - 370000, now - 340000],
         cleanExit: false,
         lastReset: now - 300000,
       }),
@@ -261,11 +261,11 @@ describe("CrashLoopGuardService", () => {
   it("only counts crashes within the rapid crash window", () => {
     const now = Date.now();
 
-    // Write state with old launches (outside 60s window)
+    // Write state with old launches (outside 300s window)
     writeState({
       version: 1,
       crashes: 3,
-      launches: [now - 120000, now - 90000, now - 70000],
+      launches: [now - 400000, now - 370000, now - 340000],
       cleanExit: false,
       lastReset: now - 300000,
     });
@@ -273,7 +273,7 @@ describe("CrashLoopGuardService", () => {
     const guard = new CrashLoopGuardService();
     guard.initialize();
 
-    // Old launches are outside the 60s window, so crashes should be 0
+    // Old launches are outside the 300s window, so crashes should be 0
     expect(guard.isSafeMode()).toBe(false);
   });
 

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -900,6 +900,39 @@ describe("CrashRecoveryService", () => {
       expect(storeMock.set).toHaveBeenCalledTimes(1);
       expect(storeMock.set.mock.calls[0][0]).toBe("appState");
     });
+
+    it("clears cached backup snapshot so restoreBackup has no stale reference", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: Date.now(),
+          appState: { sidebarWidth: 999, terminals: [] },
+        })
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+      const svc = makeService();
+      svc.initialize();
+
+      // Delete backup file so restoreBackup can only succeed via cache
+      fs.unlinkSync(path.join(backupDir, "session-state.json"));
+
+      storeMock.set.mockClear();
+      svc.resetToFresh();
+
+      expect(svc.restoreBackup()).toBe(false);
+    });
   });
 
   describe("cleanupOnExit", () => {
@@ -927,6 +960,41 @@ describe("CrashRecoveryService", () => {
       // Actually in our impl, recordCrash writes a new lock with crash info, so it still exists
       // cleanupOnExit skips deletion when crashRecorded=true
       expect(fs.existsSync(markerPath)).toBe(true);
+    });
+
+    it("clears cached backup snapshot even when crashRecorded prevents backup/marker cleanup", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(backupDir, "session-state.json"),
+        JSON.stringify({
+          capturedAt: Date.now(),
+          appState: { sidebarWidth: 999, terminals: [] },
+        })
+      );
+
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+      const svc = makeService();
+      svc.initialize();
+
+      // Record crash so cleanupOnExit skips takeBackup/deleteMarker
+      svc.recordCrash(new Error("test crash"));
+
+      // Delete backup file so restoreBackup can only succeed via cache
+      fs.unlinkSync(path.join(backupDir, "session-state.json"));
+
+      svc.cleanupOnExit();
+
+      expect(svc.restoreBackup()).toBe(false);
     });
   });
 });

--- a/electron/services/__tests__/DiskSpaceMonitor.test.ts
+++ b/electron/services/__tests__/DiskSpaceMonitor.test.ts
@@ -75,18 +75,18 @@ describe("DiskSpaceMonitor", () => {
   }
 
   it("runs startup poll immediately and reports normal status", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(1000));
+    statfsMock.mockResolvedValue(makeStatfs(3000));
     const actions = createActions();
     const mod = await importAndStart(actions);
 
     // Normal status: no sendStatus call (status didn't change from initial "normal")
     expect(actions.calls.sendStatus).toHaveLength(0);
     expect(mod.getCurrentDiskSpaceStatus().status).toBe("normal");
-    expect(mod.getCurrentDiskSpaceStatus().availableMb).toBeCloseTo(1000, 0);
+    expect(mod.getCurrentDiskSpaceStatus().availableMb).toBeCloseTo(3000, 0);
   });
 
-  it("transitions to warning when disk space drops below 500MB", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(400));
+  it("transitions to warning when disk space drops below 2000MB", async () => {
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     await importAndStart(actions);
 
@@ -96,7 +96,7 @@ describe("DiskSpaceMonitor", () => {
     expect(actions.calls.onCriticalChange).toHaveLength(0);
   });
 
-  it("transitions to critical when disk space drops below 100MB", async () => {
+  it("transitions to critical when disk space drops below 500MB", async () => {
     statfsMock.mockResolvedValue(makeStatfs(50));
     const actions = createActions();
     await importAndStart(actions);
@@ -108,7 +108,7 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("sends native notification when not focused", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(300));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     await importAndStart(actions);
 
@@ -117,7 +117,7 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("does not send native notification when focused", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(300));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     actions.isWindowFocused = () => true;
     await importAndStart(actions);
@@ -133,7 +133,7 @@ describe("DiskSpaceMonitor", () => {
     expect(actions.calls.onCriticalChange).toEqual([true]);
 
     // Recover
-    statfsMock.mockResolvedValue(makeStatfs(1000));
+    statfsMock.mockResolvedValue(makeStatfs(3000));
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 
     expect(actions.calls.onCriticalChange).toEqual([true, false]);
@@ -150,7 +150,7 @@ describe("DiskSpaceMonitor", () => {
     expect(actions.calls.sendStatus).toHaveLength(0);
 
     // Next poll works
-    statfsMock.mockResolvedValue(makeStatfs(300));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 
     expect(actions.calls.sendStatus).toHaveLength(1);
@@ -158,14 +158,14 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("respects notification cooldown", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(400));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     await importAndStart(actions);
 
     expect(actions.calls.notifications).toHaveLength(1);
 
     // Still warning after 5 minutes - same status, no new sendStatus call
-    statfsMock.mockResolvedValue(makeStatfs(350));
+    statfsMock.mockResolvedValue(makeStatfs(1400));
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 
     // No new notification (same status, cooldown not expired)
@@ -173,7 +173,7 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("bypasses cooldown when escalating to critical", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(400));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     await importAndStart(actions);
 
@@ -188,7 +188,7 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("does not call callbacks after disposal", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(1000));
+    statfsMock.mockResolvedValue(makeStatfs(3000));
     const actions = createActions();
     await importAndStart(actions);
 
@@ -202,13 +202,13 @@ describe("DiskSpaceMonitor", () => {
   });
 
   it("getCurrentDiskSpaceStatus returns cached value", async () => {
-    statfsMock.mockResolvedValue(makeStatfs(300));
+    statfsMock.mockResolvedValue(makeStatfs(1500));
     const actions = createActions();
     const mod = await importAndStart(actions);
 
     const status = mod.getCurrentDiskSpaceStatus();
     expect(status.status).toBe("warning");
-    expect(status.availableMb).toBeCloseTo(300, 0);
+    expect(status.availableMb).toBeCloseTo(1500, 0);
     expect(status.writesSuppressed).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Widens the crash-loop detection window from 60s to 5 minutes, matching VS Code's extension-host hard-stop threshold. A slow-failing agent or extension that crashes sporadically across a few minutes now trips the guard instead of slipping through.
- Raises disk-space warning from 500 MB to 2 GB and critical from 100 MB to 500 MB. The old thresholds were below where the OS can reliably write a crash dump, so a crash near those floors also lost diagnostics.
- Clears the cached backup snapshot on `resetToFresh()` and `cleanupOnExit()` so the snapshot doesn't leak in memory when the user dismisses the recovery dialog without choosing to restore.

Resolves #6170

## Changes
- `CrashLoopGuardService`: `RAPID_CRASH_WINDOW_MS` 60s to 300s
- `DiskSpaceMonitor`: `WARNING_MB` 500 to 2000, `CRITICAL_MB` 100 to 500
- `CrashRecoveryService`: clear `cachedBackupSnapshot` in `resetToFresh()` and `cleanupOnExit()`
- Test fixtures recalibrated for the new thresholds, plus two new tests for cache clearing

## Testing
- All 79 existing tests pass.
- 2 new tests verify snapshot cache clearing on reset and cleanup.
- eslint, prettier, and tsc all clean.