### PR TITLE
perf(workspace): skip git status polling during active rebase/merge/cherry-pick

### DIFF
--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1023,6 +1023,40 @@ describe("GitFileWatcher", () => {
     Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
   });
 
+  it("fires onChange when an operation sentinel appears or disappears", async () => {
+    const gitDir = pathJoin("/repo", ".git");
+    const onChange = vi.fn();
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 100,
+      onChange,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    // The .git dir watcher is reused for sentinels — no extra fs.watch is opened.
+    const dotGitCalls = vi.mocked(watch).mock.calls.filter(([path]) => path === gitDir);
+    expect(dotGitCalls).toHaveLength(1);
+    const dotGitCallback = dotGitCalls[0][2] as
+      | ((eventType: string, filename: string | Buffer | null) => void)
+      | undefined;
+    expect(dotGitCallback).toBeDefined();
+
+    for (const sentinel of [
+      "MERGE_HEAD",
+      "rebase-merge",
+      "rebase-apply",
+      "CHERRY_PICK_HEAD",
+      "REVERT_HEAD",
+    ]) {
+      onChange.mockClear();
+      dotGitCallback?.("rename", sentinel);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    }
+  });
+
   it("detects commits via branch ref changes", async () => {
     const gitDir = pathJoin("/repo", ".git");
     const onChange = vi.fn();

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1036,7 +1036,11 @@ describe("GitFileWatcher", () => {
     expect(gitWatcher.start()).toBe(true);
 
     // The .git dir watcher is reused for sentinels — no extra fs.watch is opened.
-    const dotGitCalls = vi.mocked(watch).mock.calls.filter(([path]) => path === gitDir);
+    const dotGitCalls = vi
+      .mocked(watch)
+      .mock.calls.filter(([path]) => path === gitDir) as unknown as Array<
+      [unknown, unknown, unknown]
+    >;
     expect(dotGitCalls).toHaveLength(1);
     const dotGitCallback = dotGitCalls[0][2] as
       | ((eventType: string, filename: string | Buffer | null) => void)

--- a/electron/utils/__tests__/gitRepoOperationState.test.ts
+++ b/electron/utils/__tests__/gitRepoOperationState.test.ts
@@ -47,4 +47,16 @@ describe("gitRepoOperationState", () => {
     expect(isRepoOperationInProgress(gitDir)).toBe(true);
     expect(vi.mocked(existsSync)).toHaveBeenCalledTimes(1);
   });
+
+  it("fails open when existsSync throws — treats sentinel as absent", () => {
+    // EPERM or similar permission errors must not propagate; the caller
+    // would otherwise stall every poll cycle for the worktree.
+    vi.mocked(existsSync).mockImplementation(() => {
+      const err = new Error("EPERM") as NodeJS.ErrnoException;
+      err.code = "EPERM";
+      throw err;
+    });
+    expect(() => isRepoOperationInProgress(gitDir)).not.toThrow();
+    expect(isRepoOperationInProgress(gitDir)).toBe(false);
+  });
 });

--- a/electron/utils/__tests__/gitRepoOperationState.test.ts
+++ b/electron/utils/__tests__/gitRepoOperationState.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "fs";
+import { join as pathJoin } from "path";
+import { OPERATION_SENTINEL_NAMES, isRepoOperationInProgress } from "../gitRepoOperationState.js";
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+describe("gitRepoOperationState", () => {
+  const gitDir = pathJoin("/repo", ".git");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes the expected sentinel names", () => {
+    // index.lock and REBASE_HEAD must NOT be in the set — they're either too
+    // transient (index.lock) or redundant (REBASE_HEAD is replaced by the
+    // rebase-merge/rebase-apply directories).
+    expect([...OPERATION_SENTINEL_NAMES]).toEqual([
+      "MERGE_HEAD",
+      "rebase-merge",
+      "rebase-apply",
+      "CHERRY_PICK_HEAD",
+      "REVERT_HEAD",
+    ]);
+  });
+
+  it("returns false when no sentinel files exist", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(isRepoOperationInProgress(gitDir)).toBe(false);
+  });
+
+  for (const sentinel of OPERATION_SENTINEL_NAMES) {
+    it(`returns true when ${sentinel} exists`, () => {
+      const expected = pathJoin(gitDir, sentinel);
+      vi.mocked(existsSync).mockImplementation((p) => p === expected);
+      expect(isRepoOperationInProgress(gitDir)).toBe(true);
+    });
+  }
+
+  it("short-circuits on the first sentinel match", () => {
+    // MERGE_HEAD is checked first — once it returns true the function should
+    // not stat the remaining sentinel paths.
+    vi.mocked(existsSync).mockImplementation((p) => p === pathJoin(gitDir, "MERGE_HEAD"));
+    expect(isRepoOperationInProgress(gitDir)).toBe(true);
+    expect(vi.mocked(existsSync)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -8,6 +8,7 @@ import {
   normalize as pathNormalize,
 } from "path";
 import { getGitDir } from "./gitUtils.js";
+import { OPERATION_SENTINEL_NAMES } from "./gitRepoOperationState.js";
 import { logWarn } from "./logger.js";
 
 export interface GitFileWatcherOptions {
@@ -99,6 +100,13 @@ export class GitFileWatcher {
       if (this.currentBranch) {
         const branchRefPath = pathJoin(commonDir, "refs", "heads", this.currentBranch);
         this.watchFile(branchRefPath);
+      }
+
+      // Track rebase/merge/cherry-pick/revert sentinel files so the watcher
+      // wakes immediately when an operation starts or finishes. The sentinels
+      // live in gitDir alongside HEAD, so this reuses the existing dir watcher.
+      for (const sentinelName of OPERATION_SENTINEL_NAMES) {
+        this.watchFile(pathJoin(gitDir, sentinelName));
       }
 
       if (this.watchWorktree) {

--- a/electron/utils/gitRepoOperationState.ts
+++ b/electron/utils/gitRepoOperationState.ts
@@ -22,11 +22,19 @@ export const OPERATION_SENTINEL_NAMES = [
  * Returns true if any of the rebase/merge/cherry-pick/revert sentinel files
  * exist in `gitDir`. Synchronous so it's safe to call on hot paths (e.g.
  * before each git status poll) without adding an async round-trip.
+ *
+ * Fails open on filesystem errors (e.g. EPERM) — if we can't determine
+ * the state, let the regular polling/git invocations proceed. Surfacing a
+ * permission error here would stall every poll cycle for the worktree.
  */
 export function isRepoOperationInProgress(gitDir: string): boolean {
   for (const name of OPERATION_SENTINEL_NAMES) {
-    if (existsSync(pathJoin(gitDir, name))) {
-      return true;
+    try {
+      if (existsSync(pathJoin(gitDir, name))) {
+        return true;
+      }
+    } catch {
+      // Treat unreadable sentinel paths as absent and continue.
     }
   }
   return false;

--- a/electron/utils/gitRepoOperationState.ts
+++ b/electron/utils/gitRepoOperationState.ts
@@ -1,0 +1,33 @@
+import { existsSync } from "fs";
+import { join as pathJoin } from "path";
+
+/**
+ * Sentinel files/directories git creates while a multi-step operation is
+ * in progress. While any of these are present, running `git status` competes
+ * with the user's git client for `.git/index.lock`.
+ *
+ * `index.lock` is intentionally excluded — it's too transient to drive
+ * polling decisions and `WorktreeMonitor` already has a dedicated retry
+ * path for `index.lock` errors raised by `git status`.
+ */
+export const OPERATION_SENTINEL_NAMES = [
+  "MERGE_HEAD",
+  "rebase-merge",
+  "rebase-apply",
+  "CHERRY_PICK_HEAD",
+  "REVERT_HEAD",
+] as const;
+
+/**
+ * Returns true if any of the rebase/merge/cherry-pick/revert sentinel files
+ * exist in `gitDir`. Synchronous so it's safe to call on hot paths (e.g.
+ * before each git status poll) without adding an async round-trip.
+ */
+export function isRepoOperationInProgress(gitDir: string): boolean {
+  for (const name of OPERATION_SENTINEL_NAMES) {
+    if (existsSync(pathJoin(gitDir, name))) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1035,6 +1035,13 @@ export class WorktreeMonitor {
     // sentinels clear also picks up the change.
     const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
     if (gitDir && isRepoOperationInProgress(gitDir)) {
+      // If we're skipping the very first poll (e.g. app started mid-rebase),
+      // emit a default snapshot so the renderer can still display the worktree.
+      // Mirrors startWithoutGitStatus()'s contract.
+      if (!this._hasInitialStatus) {
+        this._hasInitialStatus = true;
+        this.emitUpdate();
+      }
       return;
     }
 

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -13,6 +13,7 @@ import type {
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
 import { getGitDir } from "../utils/gitUtils.js";
+import { isRepoOperationInProgress } from "../utils/gitRepoOperationState.js";
 import { WorktreeRemovedError } from "../utils/errorTypes.js";
 import { categorizeWorktree } from "../services/worktree/mood.js";
 import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
@@ -1023,6 +1024,17 @@ export class WorktreeMonitor {
 
   async updateGitStatus(forceRefresh: boolean = false): Promise<void> {
     if (this._isUpdating) {
+      return;
+    }
+
+    // Skip the git status invocation while a rebase/merge/cherry-pick/revert
+    // is in progress — running it would compete with the user's git client
+    // for .git/index.lock. The watcher tracks the same sentinel files, so
+    // it fires when the operation finishes and triggers a fresh refresh.
+    // Polling continues uninterrupted, so the next scheduled poll after
+    // sentinels clear also picks up the change.
+    const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
+    if (gitDir && isRepoOperationInProgress(gitDir)) {
       return;
     }
 

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1662,7 +1662,6 @@ describe("WorktreeMonitor", () => {
 
       expect(mockIsRepoOperationInProgress).toHaveBeenCalledWith("/test/worktree/.git");
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
-      expect(callbacks.onUpdate).not.toHaveBeenCalled();
 
       monitor.stop();
     });
@@ -1696,6 +1695,24 @@ describe("WorktreeMonitor", () => {
 
       expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
       expect(callbacks.onUpdate).toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
+    it("emits an initial snapshot when start() is skipped mid-operation", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      mockIsRepoOperationInProgress.mockReturnValue(true);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+
+      // The renderer must still receive a snapshot so the worktree is
+      // visible — otherwise it stays invisible until the operation ends.
+      expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
+      expect(monitor.hasInitialStatus).toBe(true);
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
 
       monitor.stop();
     });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -53,6 +53,18 @@ vi.mock("../../utils/gitUtils.js", () => ({
   clearGitDirCache: vi.fn(),
 }));
 
+const mockIsRepoOperationInProgress = vi.fn().mockReturnValue(false);
+vi.mock("../../utils/gitRepoOperationState.js", () => ({
+  isRepoOperationInProgress: (...args: unknown[]) => mockIsRepoOperationInProgress(...args),
+  OPERATION_SENTINEL_NAMES: [
+    "MERGE_HEAD",
+    "rebase-merge",
+    "rebase-apply",
+    "CHERRY_PICK_HEAD",
+    "REVERT_HEAD",
+  ],
+}));
+
 let mockWatcherStartResult = false;
 /** When true, the stub's `start()` synchronously invokes `onWatcherFailed`
  *  before returning — mirroring the real startup-ENOSPC catch path. */
@@ -114,6 +126,7 @@ vi.mock("../../services/worktree/index.js", () => ({
 
 import { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { WorktreeMonitorConfig, WorktreeMonitorCallbacks } from "../WorktreeMonitor.js";
+import { getGitDir } from "../../utils/gitUtils.js";
 
 const TEST_WORKTREE: Worktree = {
   id: "/test/worktree",
@@ -153,6 +166,8 @@ describe("WorktreeMonitor", () => {
     capturedOnInotifyLimitReached = undefined;
     capturedOnEmfileLimitReached = undefined;
     capturedWatcherOptions = undefined;
+    mockIsRepoOperationInProgress.mockReturnValue(false);
+    vi.mocked(getGitDir).mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -1631,6 +1646,83 @@ describe("WorktreeMonitor", () => {
       expect(moods[moods.length - 1]).toBe("dirty");
 
       mockCategorizeWorktree.mockReturnValue("stable");
+      monitor.stop();
+    });
+  });
+
+  describe("git operation skip (rebase / merge / cherry-pick)", () => {
+    it("skips getWorktreeChangesWithStats while a git operation is in progress", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      mockIsRepoOperationInProgress.mockReturnValue(true);
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+
+      expect(mockIsRepoOperationInProgress).toHaveBeenCalledWith("/test/worktree/.git");
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
+    it("runs git status normally once the operation finishes", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      mockIsRepoOperationInProgress.mockReturnValue(true);
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        totalInsertions: 0,
+        totalDeletions: 0,
+        insertions: 0,
+        deletions: 0,
+        latestFileMtime: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+
+      // Simulate the rebase/merge finishing — sentinels disappear, then a
+      // subsequent updateGitStatus call exercises the normal flow.
+      mockIsRepoOperationInProgress.mockReturnValue(false);
+      await monitor.updateGitStatus(true);
+
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+      expect(callbacks.onUpdate).toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
+    it("does not call isRepoOperationInProgress when getGitDir returns null", async () => {
+      vi.mocked(getGitDir).mockReturnValue(null);
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        totalInsertions: 0,
+        totalDeletions: 0,
+        insertions: 0,
+        deletions: 0,
+        latestFileMtime: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+
+      expect(mockIsRepoOperationInProgress).not.toHaveBeenCalled();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalled();
+
       monitor.stop();
     });
   });


### PR DESCRIPTION
## Summary

- Extracts `detectRepoOperationState` from its inline location in `git-write.ts` into a reusable `electron/utils/gitRepoOperationState.ts` utility
- `WorktreeMonitor` now calls that utility before each `git status` poll — if a sentinel file (`MERGE_HEAD`, `CHERRY_PICK_HEAD`, `rebase-merge/`, etc.) is present, the poll is skipped for that cycle
- On sentinel-file disappearance the watcher fires an immediate refresh, so the dashboard catches up as soon as the operation finishes rather than waiting for the next poll interval

The existing `.git/` file watcher already covers wake-on-change, so no new infrastructure was needed — this is mostly a skip guard on the hot path and a utility extraction so both call sites share the same detection logic.

Resolves #6168

## Changes

- `electron/utils/gitRepoOperationState.ts` — new shared utility (extracted + extended from `git-write.ts`)
- `electron/utils/gitFileWatcher.ts` — minor type tightening for the sentinel watcher path
- `electron/workspace-host/WorktreeMonitor.ts` — skip-guard added to the status poll loop; sentinel disappearance triggers an immediate snapshot
- Unit tests for both new utilities and the updated monitor behaviour

## Testing

- Unit tests cover the sentinel detection logic, the watcher callback contract, and the WorktreeMonitor skip/refresh behaviour
- Manually verified that polling resumes correctly after `git rebase --abort` and after a completed merge commit