### PR TITLE
perf(worktree): negative-cache 'no upstream' to skip failing git rev-list spawns

### DIFF
--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -20,9 +20,12 @@ import { ensureSerializable } from "../../shared/utils/serialization.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitFileWatcher } from "../utils/gitFileWatcher.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
+import { Cache } from "../utils/cache.js";
 
 const GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS = 1000;
 const WATCHER_FALLBACK_POLL_INTERVAL_MS = 30_000;
+const NO_UPSTREAM_CACHE_TTL_MS = 5 * 60 * 1000;
+const UPSTREAM_NOT_FOUND_CACHE_TTL_MS = 2 * 60 * 1000;
 const WATCHER_RETRY_INTERVAL_MS = 30_000;
 const WATCHER_MAX_RETRIES = 5;
 const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 150;
@@ -82,6 +85,7 @@ export class WorktreeMonitor {
   // Upstream tracking state
   private aheadCount: number | undefined;
   private behindCount: number | undefined;
+  private upstreamFailureCache = new Cache<string, string>();
 
   // Issue/PR state
   private _issueNumber: number | undefined;
@@ -998,7 +1002,11 @@ export class WorktreeMonitor {
       const currentBranch = await this.readCurrentBranch();
       const branchChanged = currentBranch !== undefined && currentBranch !== this._branch;
       if (branchChanged) {
+        const oldCacheKey = this._branch ? `${this.path}:${this._branch}` : undefined;
         this._branch = currentBranch;
+        const newCacheKey = `${this.path}:${this._branch}`;
+        if (oldCacheKey) this.upstreamFailureCache.invalidate(oldCacheKey);
+        this.upstreamFailureCache.invalidate(newCacheKey);
         const hadPendingRefresh = this.gitWatchRefreshPending;
         this.updateWatcher();
         if (hadPendingRefresh) {
@@ -1168,6 +1176,11 @@ export class WorktreeMonitor {
       return { ahead: undefined, behind: undefined };
     }
 
+    const cacheKey = `${this.path}:${this._branch}`;
+    if (this.upstreamFailureCache.get(cacheKey)) {
+      return { ahead: undefined, behind: undefined };
+    }
+
     try {
       const wsl = this.wslInvocation;
       const git = wsl
@@ -1175,13 +1188,36 @@ export class WorktreeMonitor {
         : createHardenedGit(this.path, this._pollAbortController.signal);
       const output = await git.raw(["rev-list", "--left-right", "--count", "HEAD...@{u}"]);
       const [aheadStr, behindStr] = output.trim().split(/\s+/);
+
+      this.upstreamFailureCache.invalidate(cacheKey);
+
       return {
         ahead: parseInt(aheadStr, 10) || 0,
         behind: parseInt(behindStr, 10) || 0,
       };
-    } catch {
+    } catch (error) {
+      const classification = this.classifyUpstreamError(error);
+      if (classification) {
+        const ttl =
+          classification === "no-upstream"
+            ? NO_UPSTREAM_CACHE_TTL_MS
+            : UPSTREAM_NOT_FOUND_CACHE_TTL_MS;
+        this.upstreamFailureCache.set(cacheKey, classification, ttl);
+      }
       return { ahead: undefined, behind: undefined };
     }
+  }
+
+  private classifyUpstreamError(error: unknown): string | undefined {
+    if (!(error instanceof Error)) return undefined;
+    const msg = error.message;
+    if (msg.includes("no upstream configured") || msg.includes("bad revision '@{u}'")) {
+      return "no-upstream";
+    }
+    if (msg.includes("upstream branch") && msg.includes("not found")) {
+      return "upstream-not-found";
+    }
+    return undefined;
   }
 
   private calculateStateHash(changes: WorktreeChanges): string {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -245,6 +245,9 @@ export class WorktreeMonitor {
   }
 
   set branch(value: string | undefined) {
+    if (value !== this._branch && this._branch) {
+      this.upstreamFailureCache.invalidate(`${this.path}:${this._branch}`);
+    }
     this._branch = value;
   }
 
@@ -1025,7 +1028,7 @@ export class WorktreeMonitor {
 
       const noteData = await this.noteReader.read();
 
-      const upstreamCounts = await this.fetchUpstreamCounts();
+      const upstreamCounts = await this.fetchUpstreamCounts(forceRefresh);
 
       const detectedPlanFile = PLAN_FILE_CANDIDATES.find((candidate) =>
         existsSync(pathJoin(this.path, candidate))
@@ -1168,7 +1171,7 @@ export class WorktreeMonitor {
     }
   }
 
-  private async fetchUpstreamCounts(): Promise<{
+  private async fetchUpstreamCounts(force: boolean = false): Promise<{
     ahead: number | undefined;
     behind: number | undefined;
   }> {
@@ -1177,7 +1180,7 @@ export class WorktreeMonitor {
     }
 
     const cacheKey = `${this.path}:${this._branch}`;
-    if (this.upstreamFailureCache.get(cacheKey)) {
+    if (!force && this.upstreamFailureCache.get(cacheKey)) {
       return { ahead: undefined, behind: undefined };
     }
 
@@ -1211,7 +1214,11 @@ export class WorktreeMonitor {
   private classifyUpstreamError(error: unknown): string | undefined {
     if (!(error instanceof Error)) return undefined;
     const msg = error.message;
-    if (msg.includes("no upstream configured") || msg.includes("bad revision '@{u}'")) {
+    if (
+      msg.includes("no upstream configured") ||
+      msg.includes("bad revision '@{u}'") ||
+      msg.includes("ambiguous argument '@{u}'")
+    ) {
       return "no-upstream";
     }
     if (msg.includes("upstream branch") && msg.includes("not found")) {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -362,6 +362,172 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("caches 'no upstream' verdict and skips repeat git spawns", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(
+        new Error("fatal: no upstream configured for branch 'test-branch'")
+      );
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+      expect(mockGitRaw).toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
+
+      const snapshot1 = monitor.getSnapshot();
+      expect(snapshot1.aheadCount).toBeUndefined();
+      expect(snapshot1.behindCount).toBeUndefined();
+
+      // Second poll within TTL — should hit the cache, no new git spawn
+      await monitor.refresh();
+
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+
+      const snapshot2 = monitor.getSnapshot();
+      expect(snapshot2.aheadCount).toBeUndefined();
+      expect(snapshot2.behindCount).toBeUndefined();
+
+      monitor.stop();
+    });
+
+    it("retries rev-list after 'no upstream' cache TTL expires", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(
+        new Error("fatal: no upstream configured for branch 'test-branch'")
+      );
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const callsAfterStart = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterStart).toBe(1);
+
+      // Pause polling so scheduled polls don't interfere with time advance
+      monitor.pausePolling();
+
+      // Advance just under TTL — cache still valid
+      await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+      await monitor.refresh();
+      const callsWithinTTL = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsWithinTTL).toBe(1);
+
+      // Advance past TTL
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      await monitor.refresh();
+      const callsAfterTTL = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterTTL).toBe(2);
+
+      monitor.stop();
+    });
+
+    it("uses shorter TTL for 'upstream branch not found'", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(
+        new Error("fatal: upstream branch 'origin/test-branch' not found")
+      );
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const callsAfterStart = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterStart).toBe(1);
+
+      monitor.pausePolling();
+
+      // Within short TTL — cached
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      await monitor.refresh();
+      const callsWithinShortTTL = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsWithinShortTTL).toBe(1);
+
+      // Past 2-min TTL — retries
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      await monitor.refresh();
+      const callsAfterTTL = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterTTL).toBe(2);
+
+      monitor.stop();
+    });
+
+    it("invalidates failure cache when upstream becomes available", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+
+      // First call: no upstream
+      mockGitRaw.mockRejectedValueOnce(
+        new Error("fatal: no upstream configured for branch 'test-branch'")
+      );
+      // Second call (after TTL): upstream is now configured
+      mockGitRaw.mockResolvedValueOnce("2\t1\n");
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const revListCallsAfterStart = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(revListCallsAfterStart).toBe(1);
+      expect(monitor.getSnapshot().aheadCount).toBeUndefined();
+
+      // Pause polling so scheduled polls don't fire during time advance
+      monitor.pausePolling();
+      await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+      // Cache expired — refresh should call git and succeed
+      await monitor.refresh();
+
+      const revListCallsAfterRefresh = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(revListCallsAfterRefresh).toBe(2);
+      expect(monitor.getSnapshot().aheadCount).toBe(2);
+      expect(monitor.getSnapshot().behindCount).toBe(1);
+
+      // Success should have invalidated cache — next call also hits git
+      mockGitRaw.mockResolvedValueOnce("3\t2\n");
+      await monitor.refresh();
+
+      const revListCallsFinal = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(revListCallsFinal).toBe(3);
+      expect(monitor.getSnapshot().aheadCount).toBe(3);
+
+      monitor.stop();
+    });
+
+    it("does not cache unclassified git failures", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(new Error("fatal: ambiguous argument 'HEAD'"));
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(mockGitRaw).toHaveBeenCalledTimes(1);
+
+      await monitor.refresh();
+      // Unclassified errors should retry every poll
+      expect(mockGitRaw).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
   });
 
   describe("watcher retry", () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -380,8 +380,8 @@ describe("WorktreeMonitor", () => {
       expect(snapshot1.aheadCount).toBeUndefined();
       expect(snapshot1.behindCount).toBeUndefined();
 
-      // Second poll within TTL — should hit the cache, no new git spawn
-      await monitor.refresh();
+      // Second poll without forceRefresh — should hit the cache, no new git spawn
+      await monitor.updateGitStatus(false);
 
       expect(mockGitRaw).toHaveBeenCalledTimes(1);
 
@@ -412,15 +412,15 @@ describe("WorktreeMonitor", () => {
 
       // Advance just under TTL — cache still valid
       await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
-      await monitor.refresh();
+      await monitor.updateGitStatus(false);
       const callsWithinTTL = mockGitRaw.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
       ).length;
       expect(callsWithinTTL).toBe(1);
 
-      // Advance past TTL
+      // Advance past TTL — cache expired
       await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
-      await monitor.refresh();
+      await monitor.updateGitStatus(false);
       const callsAfterTTL = mockGitRaw.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
       ).length;
@@ -448,7 +448,7 @@ describe("WorktreeMonitor", () => {
 
       // Within short TTL — cached
       await vi.advanceTimersByTimeAsync(60 * 1000);
-      await monitor.refresh();
+      await monitor.updateGitStatus(false);
       const callsWithinShortTTL = mockGitRaw.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
       ).length;
@@ -456,7 +456,7 @@ describe("WorktreeMonitor", () => {
 
       // Past 2-min TTL — retries
       await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
-      await monitor.refresh();
+      await monitor.updateGitStatus(false);
       const callsAfterTTL = mockGitRaw.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
       ).length;
@@ -525,6 +525,68 @@ describe("WorktreeMonitor", () => {
       await monitor.refresh();
       // Unclassified errors should retry every poll
       expect(mockGitRaw).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
+
+    it("force-refresh bypasses the negative cache", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(
+        new Error("fatal: no upstream configured for branch 'test-branch'")
+      );
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      // Cache should be populated — first call from start
+      const callsAfterStart = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterStart).toBe(1);
+
+      monitor.pausePolling();
+
+      // Non-force call within TTL — cache hit
+      await monitor.updateGitStatus(false);
+      const callsAfterNonForce = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterNonForce).toBe(1);
+
+      // Force-refresh bypasses cache
+      await monitor.refresh();
+      const callsAfterForce = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(callsAfterForce).toBe(2);
+
+      monitor.stop();
+    });
+
+    it("classifies ambiguous argument @{u} as no-upstream", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockRejectedValue(
+        new Error(
+          "fatal: ambiguous argument '@{u}': unknown revision or path not in the working tree."
+        )
+      );
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.aheadCount).toBeUndefined();
+      expect(snapshot.behindCount).toBeUndefined();
+
+      // Should be cached, so second call doesn't spawn git
+      monitor.pausePolling();
+      await monitor.updateGitStatus(false);
+      const revListCalls = mockGitRaw.mock.calls.filter(
+        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
+      ).length;
+      expect(revListCalls).toBe(1);
 
       monitor.stop();
     });


### PR DESCRIPTION
## Summary
- Adds a negative cache to `WorktreeMonitor` so we stop spawning `git rev-list --left-right --count HEAD...@{u}` for worktrees without a configured or reachable upstream branch. These spawns always fail with exit code 128, and for a project with several detached or no-upstream worktrees, that's a steady stream of failing child processes on every poll cycle that will never succeed.
- The cache uses a short TTL and busts when the branch changes, on force-refresh, or when a rev-list call succeeds. It only blocks retries that have no chance of succeeding.

Resolves #6164

## Changes
- `WorktreeMonitor.ts`: Added `Cache<string, string>` for negative upstream verdicts, a `classifyUpstreamError` helper to distinguish "no upstream configured" from "ambiguous revision" failures, cache invalidation on branch change and successful rev-list calls, and a `forceRefresh` passthrough.
- `WorktreeMonitor.test.ts`: Added 7 tests covering cache hit/miss behavior, TTL expiry, branch-change invalidation, force-refresh bypass, and ambiguous argument classification.

## Testing
- 49 tests passing (7 new) covering the negative cache lifecycle, cache busting on branch change, force-refresh passthrough, and error classification.