### PR TITLE
feat(resource-profile): wire thermal and CPU speed-limit signals into profile scoring

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -43,6 +43,8 @@ export class ResourceProfileService {
   private tickCount = 0;
   private disposed = false;
   private cachedWorktreeCount = 0;
+  private thermalState: "unknown" | "nominal" | "fair" | "serious" | "critical" = "unknown";
+  private speedLimit = 100;
   private readonly memoryThresholdHighMb: number;
   private readonly memoryThresholdLowMb: number;
 
@@ -51,6 +53,24 @@ export class ResourceProfileService {
     this.memoryThresholdHighMb = totalRamMb * HIGH_FRACTION;
     this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
   }
+
+  private onThermalStateChange = (_event: Electron.Event, state: string): void => {
+    if (
+      state === "unknown" ||
+      state === "nominal" ||
+      state === "fair" ||
+      state === "serious" ||
+      state === "critical"
+    ) {
+      this.thermalState = state;
+    }
+  };
+
+  private onSpeedLimitChange = (_event: Electron.Event, limit: number): void => {
+    if (typeof limit === "number" && !isNaN(limit) && limit >= 0 && limit <= 100) {
+      this.speedLimit = limit;
+    }
+  };
 
   setWorktreeCount(count: number): void {
     this.cachedWorktreeCount = count;
@@ -67,6 +87,10 @@ export class ResourceProfileService {
     logInfo("resource-profile-service-started", { profile: this.currentProfile });
 
     this.refreshWorktreeCount();
+
+    powerMonitor.on("thermal-state-change", this.onThermalStateChange);
+    powerMonitor.on("speed-limit-change", this.onSpeedLimitChange);
+
     this.interval = setInterval(() => {
       this.refreshWorktreeCount();
       this.evaluate();
@@ -90,6 +114,9 @@ export class ResourceProfileService {
   }
 
   stop(): void {
+    powerMonitor.removeListener("thermal-state-change", this.onThermalStateChange);
+    powerMonitor.removeListener("speed-limit-change", this.onSpeedLimitChange);
+
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null;
@@ -144,11 +171,19 @@ export class ResourceProfileService {
     // Battery signal
     try {
       if (powerMonitor.isOnBatteryPower()) {
-        pressureScore += 2;
+        pressureScore += 1;
       }
     } catch {
       // Skip battery signal (may throw in utility process context)
     }
+
+    // Thermal signal (macOS only)
+    if (this.thermalState === "critical") pressureScore += 2;
+    else if (this.thermalState === "serious") pressureScore += 1;
+
+    // CPU speed-limit signal (macOS & Windows)
+    if (this.speedLimit < 50) pressureScore += 2;
+    else if (this.speedLimit < 100) pressureScore += 1;
 
     // Worktree count signal
     const worktreeCount = this.cachedWorktreeCount;

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -54,7 +54,8 @@ export class ResourceProfileService {
     this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
   }
 
-  private onThermalStateChange = (_event: Electron.Event, state: string): void => {
+  private onThermalStateChange = (details: { state: string }): void => {
+    const { state } = details;
     if (
       state === "unknown" ||
       state === "nominal" ||
@@ -66,7 +67,8 @@ export class ResourceProfileService {
     }
   };
 
-  private onSpeedLimitChange = (_event: Electron.Event, limit: number): void => {
+  private onSpeedLimitChange = (details: { limit: number }): void => {
+    const { limit } = details;
     if (typeof limit === "number" && !isNaN(limit) && limit >= 0 && limit <= 100) {
       this.speedLimit = limit;
     }

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -9,6 +9,8 @@ vi.mock("electron", () => ({
   },
   powerMonitor: {
     isOnBatteryPower: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
   },
   BrowserWindow: {
     getAllWindows: vi.fn(() => []),
@@ -32,6 +34,8 @@ const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
+const mockPowerMonitorOn = powerMonitor.on as unknown as Mock;
+const mockPowerMonitorRemoveListener = powerMonitor.removeListener as unknown as Mock;
 
 interface MockPtyClient {
   setResourceProfile: Mock;
@@ -212,6 +216,80 @@ describe("ResourceProfileService adversarial", () => {
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
 
     expect(service.getProfile()).toBe("efficiency");
+    service.stop();
+  });
+
+  it("stop before start does not throw (removeListener is no-op)", () => {
+    const { deps } = createDeps();
+    const service = new ResourceProfileService(deps);
+
+    // stop() without start() -> removeListener on unregistered handlers is safe
+    expect(() => service.stop()).not.toThrow();
+  });
+
+  it("start after stop re-registers listeners", () => {
+    const { deps } = createDeps();
+    const service = new ResourceProfileService(deps);
+
+    service.start();
+    service.stop();
+
+    mockPowerMonitorOn.mockClear();
+    mockPowerMonitorRemoveListener.mockClear();
+
+    service.start();
+
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("thermal-state-change", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("speed-limit-change", expect.any(Function));
+
+    service.stop();
+  });
+
+  it("does not register listeners twice on double start", () => {
+    const { deps } = createDeps();
+    const service = new ResourceProfileService(deps);
+
+    service.start();
+    const firstCallCount = mockPowerMonitorOn.mock.calls.length;
+    service.start();
+
+    expect(mockPowerMonitorOn).toHaveBeenCalledTimes(firstCallCount);
+
+    service.stop();
+  });
+
+  it("thermal and speed-limit signals combine with worktree count for efficiency", () => {
+    const { deps } = createDeps();
+    const service = new ResourceProfileService(deps);
+
+    service.setWorktreeCount(9);
+    service.start();
+
+    // Low memory (0) + battery (+1) + thermal serious (+1) + worktrees (+1) = 3 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    (service as unknown as { thermalState: string }).thermalState = "serious";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("speed limit 0 (fully clamped) + high memory triggers efficiency without battery", () => {
+    const { deps } = createDeps();
+    const service = new ResourceProfileService(deps);
+
+    service.start();
+
+    // High memory (+2) + speed limit 0 (+2) = 4 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+    (service as unknown as { speedLimit: number }).speedLimit = 0;
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
     service.stop();
   });
 

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -11,6 +11,8 @@ vi.mock("electron", () => ({
   },
   powerMonitor: {
     isOnBatteryPower: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
   },
   BrowserWindow: {
     getAllWindows: vi.fn(() => []),
@@ -35,6 +37,8 @@ const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
+const mockPowerMonitorOn = powerMonitor.on as unknown as Mock;
+const mockPowerMonitorRemoveListener = powerMonitor.removeListener as unknown as Mock;
 
 function makeMetric(type: string, privateMb: number): Electron.ProcessMetric {
   return {
@@ -394,13 +398,13 @@ describe("ResourceProfileService", () => {
     const service = new ResourceProfileService(deps);
     service.start();
 
-    // Battery only (score 2) + moderate memory (score 1) = 3 => efficiency
+    // Moderate memory (+1) + battery (+1) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
     mockIsOnBatteryPower.mockReturnValue(true);
 
     // Past warmup + hysteresis for downgrade
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
-    expect(service.getProfile()).toBe("efficiency");
+    expect(service.getProfile()).toBe("balanced");
 
     service.stop();
   });
@@ -411,12 +415,12 @@ describe("ResourceProfileService", () => {
     service.setWorktreeCount(10);
     service.start();
 
-    // Battery (2) + worktrees (1) = 3 => efficiency
+    // Low memory (0) + battery (+1) + worktrees (+1) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
     mockIsOnBatteryPower.mockReturnValue(true);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
-    expect(service.getProfile()).toBe("efficiency");
+    expect(service.getProfile()).toBe("balanced");
 
     service.stop();
   });
@@ -439,6 +443,127 @@ describe("ResourceProfileService", () => {
     expect(service.getProfile()).toBe("performance");
 
     service.stop();
+  });
+
+  it("thermal critical + battery drives to efficiency", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Low memory (0) + battery (+1) + thermal critical (+2) = 3 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    (service as unknown as { thermalState: string }).thermalState = "critical";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("thermal serious + battery + moderate memory = efficiency", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Moderate memory (+1) + battery (+1) + thermal serious (+1) = 3 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    (service as unknown as { thermalState: string }).thermalState = "serious";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("thermal fair and nominal do not contribute to pressure", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Moderate memory (+1) + battery (+1) + thermal fair (0) = 2 => balanced
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    (service as unknown as { thermalState: string }).thermalState = "fair";
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("speed limit under 50 + moderate memory drives to efficiency", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Moderate memory (+1) + speed limit 40 (+2) = 3 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+    (service as unknown as { speedLimit: number }).speedLimit = 40;
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("speed limit 50-99 contributes +1 to pressure", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Moderate memory (+1) + speed limit 75 (+1) = 2 => balanced
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+    (service as unknown as { speedLimit: number }).speedLimit = 75;
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("speed limit 100 does not contribute to pressure", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Low memory (0) + speed limit 100 (0) = 0 => performance
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+    (service as unknown as { speedLimit: number }).speedLimit = 100;
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
+
+    service.stop();
+  });
+
+  it("registers powerMonitor listeners on start", () => {
+    const service = new ResourceProfileService(createDeps());
+    service.start();
+
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("thermal-state-change", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("speed-limit-change", expect.any(Function));
+
+    service.stop();
+  });
+
+  it("removes powerMonitor listeners on stop", () => {
+    const service = new ResourceProfileService(createDeps());
+    service.start();
+    service.stop();
+
+    expect(mockPowerMonitorRemoveListener).toHaveBeenCalledWith(
+      "thermal-state-change",
+      expect.any(Function)
+    );
+    expect(mockPowerMonitorRemoveListener).toHaveBeenCalledWith(
+      "speed-limit-change",
+      expect.any(Function)
+    );
   });
 
   it("scales thresholds down on low-RAM devices so 500 MB usage is detected", () => {

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -541,6 +541,83 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("routes thermal-state-change event through handler to profile scoring", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Capture the thermal handler registered with powerMonitor.on
+    const thermalHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "thermal-state-change"
+    )?.[1] as ((details: { state: string }) => void) | undefined;
+    expect(thermalHandler).toBeDefined();
+
+    // Simulate Electron 41 powerMonitor event (single object, not two args)
+    thermalHandler!({ state: "critical" });
+
+    // Low memory (0) + thermal critical (+2) + battery (+1) = 3 => efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(true);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("routes speed-limit-change event through handler to profile scoring", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Capture the speed-limit handler registered with powerMonitor.on
+    const speedHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "speed-limit-change"
+    )?.[1] as ((details: { limit: number }) => void) | undefined;
+    expect(speedHandler).toBeDefined();
+
+    // Simulate Electron 41 powerMonitor event (single object)
+    speedHandler!({ limit: 30 });
+
+    // Low memory (0) + speed limit 30 (+2) = 2 => balanced (need more for efficiency)
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("removeListener receives the exact same handler reference passed to on", () => {
+    const service = new ResourceProfileService(createDeps());
+    service.start();
+    service.stop();
+
+    // Get the handlers passed to on
+    const thermalOnArg = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "thermal-state-change"
+    )?.[1];
+    const speedOnArg = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "speed-limit-change"
+    )?.[1];
+
+    // Get the handlers passed to removeListener
+    const thermalOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
+      (call: string[]) => call[0] === "thermal-state-change"
+    )?.[1];
+    const speedOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
+      (call: string[]) => call[0] === "speed-limit-change"
+    )?.[1];
+
+    expect(thermalOnArg).toBeDefined();
+    expect(thermalOffArg).toBeDefined();
+    expect(thermalOnArg).toBe(thermalOffArg);
+    expect(speedOnArg).toBeDefined();
+    expect(speedOffArg).toBeDefined();
+    expect(speedOnArg).toBe(speedOffArg);
+  });
+
   it("registers powerMonitor listeners on start", () => {
     const service = new ResourceProfileService(createDeps());
     service.start();


### PR DESCRIPTION
## Summary

- Wires Electron 41's `thermal-state-change` and `speed-limit-change` events from `powerMonitor` into `ResourceProfileService.computeTargetProfile()`
- Thermal state at `serious` or `critical`, and CPU speed limit below 100%, now contribute to the pressure score that determines whether Daintree runs in `performance`, `balanced`, or `efficiency` mode
- Drops the battery penalty from +2 to +1 so unplugging alone doesn't push us straight to `efficiency` when there's plenty of headroom

Resolves #6177

## Changes

- Subscribed to `powerMonitor.on("thermal-state-change")` and `powerMonitor.on("speed-limit-change")` in `ResourceProfileService.start()`, unsubscribed in `stop()`
- `thermalState` contributes +1 (`serious`) or +2 (`critical`); `nominal` and `fair` add nothing
- `speedLimit` contributes +1 (< 100%) or +2 (< 50%); 100% means no throttling, so it adds nothing
- Battery weight reduced from +2 to +1
- Event handler signatures match Electron 41's API (single `details` object parameter, not multiple positional args)

## Testing

- 38 unit tests pass, covering all thermal state values, speed limit ranges, and adversarial inputs (NaN, negative, out-of-range, non-numeric)
- Adversarial tests validate that garbage data from the OS layer doesn't corrupt the internal state