### PR TITLE
feat(terminal-layout): add breakpoint hysteresis to auto grid column count

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -670,6 +670,13 @@ export function ContentGrid({
     }
   }, [layoutConfig, clearPreMaximizeLayout]);
 
+  // Hysteresis input for the automatic-strategy column count: holds the prior
+  // committed value so a brief drop in panel count doesn't ricochet the grid
+  // back through a re-flow. Read by the useMemo below; updated in the
+  // existing prevGridColsRef effect (~line 858) to mirror the codebase's
+  // established "previous value via ref" pattern.
+  const hysteresisGridColsRef = useRef<number | undefined>(undefined);
+
   const gridCols = useMemo(() => {
     if (
       !maximizedId &&
@@ -683,7 +690,13 @@ export function ContentGrid({
       return preMaximizeLayout.gridCols;
     }
     const { strategy, value } = layoutConfig;
-    return computeGridColumns(gridItemCount, gridWidth, strategy, value);
+    return computeGridColumns(
+      gridItemCount,
+      gridWidth,
+      strategy,
+      value,
+      hysteresisGridColsRef.current
+    );
   }, [gridItemCount, layoutConfig, gridWidth, maximizedId, preMaximizeLayout, activeWorktreeId]);
 
   // FLIP transition shared across every panel in this grid. During project
@@ -764,10 +777,21 @@ export function ContentGrid({
     return fleetPanels.some((t) => (t.worktreeId ?? null) !== firstWorktreeId);
   }, [fleetPanels]);
 
+  // Independent hysteresis state for the fleet grid — must not share with the
+  // main grid because fleet spans different worktrees with its own panel
+  // count history.
+  const hysteresisFleetColsRef = useRef<number | undefined>(undefined);
+
   const fleetGridCols = useMemo(() => {
     if (!isFleetScopeRender) return 1;
     const { strategy, value } = layoutConfig;
-    return computeGridColumns(Math.max(fleetPanels.length, 1), gridWidth, strategy, value);
+    return computeGridColumns(
+      Math.max(fleetPanels.length, 1),
+      gridWidth,
+      strategy,
+      value,
+      hysteresisFleetColsRef.current
+    );
   }, [isFleetScopeRender, fleetPanels, layoutConfig, gridWidth]);
 
   // Dedicated fleet batch-fit: the main startBatchFit closure reads
@@ -782,6 +806,7 @@ export function ContentGrid({
   useEffect(() => {
     if (!isFleetScopeRender) {
       prevFleetGridColsRef.current = fleetGridCols;
+      hysteresisFleetColsRef.current = fleetGridCols;
       return;
     }
     const ids = fleetPanels.map((t) => t.id);
@@ -792,6 +817,7 @@ export function ContentGrid({
     // count changes so motion.div translations don't trigger spurious SIGWINCH.
     const fleetColsChanged = prevFleetGridColsRef.current !== fleetGridCols;
     prevFleetGridColsRef.current = fleetGridCols;
+    hysteresisFleetColsRef.current = fleetGridCols;
     if (fleetColsChanged && !isDraggingRef.current && ids.length > 0) {
       terminalInstanceService.suppressResizesDuringLayoutTransition(
         ids,
@@ -861,6 +887,7 @@ export function ContentGrid({
 
     const colsChanged = prevGridColsRef.current !== gridCols;
     prevGridColsRef.current = gridCols;
+    hysteresisGridColsRef.current = gridCols;
 
     if (colsChanged && !isProjectSwitching && !isDraggingRef.current) {
       const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -804,9 +804,15 @@ export function ContentGrid({
   // otherwise demote them to BACKGROUND (showing stale frames).
   const prevFleetGridColsRef = useRef(fleetGridCols);
   useEffect(() => {
+    // Hysteresis ref is only meaningful for the automatic strategy — fixed
+    // strategies produce user-chosen counts that must not bias a future auto
+    // computation. Cleared whenever strategy isn't automatic or fleet scope
+    // isn't actively rendering.
+    const writeFleetHysteresis =
+      isFleetScopeRender && layoutConfig.strategy === "automatic" ? fleetGridCols : undefined;
     if (!isFleetScopeRender) {
       prevFleetGridColsRef.current = fleetGridCols;
-      hysteresisFleetColsRef.current = fleetGridCols;
+      hysteresisFleetColsRef.current = writeFleetHysteresis;
       return;
     }
     const ids = fleetPanels.map((t) => t.id);
@@ -817,7 +823,7 @@ export function ContentGrid({
     // count changes so motion.div translations don't trigger spurious SIGWINCH.
     const fleetColsChanged = prevFleetGridColsRef.current !== fleetGridCols;
     prevFleetGridColsRef.current = fleetGridCols;
-    hysteresisFleetColsRef.current = fleetGridCols;
+    hysteresisFleetColsRef.current = writeFleetHysteresis;
     if (fleetColsChanged && !isDraggingRef.current && ids.length > 0) {
       terminalInstanceService.suppressResizesDuringLayoutTransition(
         ids,
@@ -844,7 +850,7 @@ export function ContentGrid({
       cancelRef.cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [isFleetScopeRender, fleetPanels, fleetGridCols]);
+  }, [isFleetScopeRender, fleetPanels, fleetGridCols, layoutConfig.strategy]);
 
   // Batch-fit grid terminals when layout (gridCols/count) changes.
   // gridTerminals is read via useEffectEvent so the effect doesn't re-run on
@@ -887,7 +893,14 @@ export function ContentGrid({
 
     const colsChanged = prevGridColsRef.current !== gridCols;
     prevGridColsRef.current = gridCols;
-    hysteresisGridColsRef.current = gridCols;
+    // Only retain hysteresis state for the automatic strategy. Fixed strategies
+    // produce user-chosen column counts that must not bias a future automatic
+    // computation (e.g. fixed-columns=4 leaving the auto path stuck at 4).
+    // Skip the write while a drag placeholder is active so a phantom +1 in
+    // gridItemCount can't permanently sticky-widen the grid after a cancelled
+    // drop.
+    hysteresisGridColsRef.current =
+      layoutConfig.strategy === "automatic" && !showPlaceholder ? gridCols : undefined;
 
     if (colsChanged && !isProjectSwitching && !isDraggingRef.current) {
       const realPanelIds = panelIds.filter((id) => id !== GRID_PLACEHOLDER_ID);
@@ -906,7 +919,7 @@ export function ContentGrid({
       cancelRef.cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [gridCols, panelIds, isProjectSwitching]);
+  }, [gridCols, panelIds, isProjectSwitching, layoutConfig.strategy, showPlaceholder]);
 
   // Show "grid full" overlay when trying to drag from dock to a full grid
   const showGridFullOverlay = sourceContainer === "dock" && isGridFull;

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -126,13 +126,22 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     return getTabGroups("grid", activeWorktreeId ?? undefined);
   }, [getTabGroups, activeWorktreeId, tabGroups, panelIds, panelsById]);
 
+  // Hysteresis input mirroring ContentGrid: keyboard-nav column count must
+  // track the visual grid through the same sticky boundaries, otherwise arrow
+  // navigation maps to wrong cells when count drops into the buffer zone.
+  const hysteresisNavColsRef = useRef<number | undefined>(undefined);
+
   // Compute gridCols using visual group count, matching ContentGrid's gridItemCount.
   // In fleet scope render, count is fleet panels (matches ContentGrid.fleetGridCols).
   const gridCols = useMemo(() => {
     const { strategy, value } = layoutConfig;
     const count = isFleetScopeRender ? Math.max(fleetPanels.length, 1) : gridGroups.length;
-    return computeGridColumns(count, gridWidth, strategy, value);
+    return computeGridColumns(count, gridWidth, strategy, value, hysteresisNavColsRef.current);
   }, [isFleetScopeRender, fleetPanels.length, gridGroups.length, layoutConfig, gridWidth]);
+
+  useEffect(() => {
+    hysteresisNavColsRef.current = gridCols;
+  }, [gridCols]);
 
   // Compute grid layout from visual groups (no DOM measurement). Fleet branch
   // treats each armed panel as its own single-cell position, mirroring how

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -129,19 +129,32 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   // Hysteresis input mirroring ContentGrid: keyboard-nav column count must
   // track the visual grid through the same sticky boundaries, otherwise arrow
   // navigation maps to wrong cells when count drops into the buffer zone.
-  const hysteresisNavColsRef = useRef<number | undefined>(undefined);
+  // Two refs (normal vs fleet) mirror ContentGrid's split so a normal-grid
+  // history doesn't bleed into a fleet-scope render.
+  const hysteresisNavGridColsRef = useRef<number | undefined>(undefined);
+  const hysteresisNavFleetColsRef = useRef<number | undefined>(undefined);
 
   // Compute gridCols using visual group count, matching ContentGrid's gridItemCount.
   // In fleet scope render, count is fleet panels (matches ContentGrid.fleetGridCols).
   const gridCols = useMemo(() => {
     const { strategy, value } = layoutConfig;
     const count = isFleetScopeRender ? Math.max(fleetPanels.length, 1) : gridGroups.length;
-    return computeGridColumns(count, gridWidth, strategy, value, hysteresisNavColsRef.current);
+    const previousCols = isFleetScopeRender
+      ? hysteresisNavFleetColsRef.current
+      : hysteresisNavGridColsRef.current;
+    return computeGridColumns(count, gridWidth, strategy, value, previousCols);
   }, [isFleetScopeRender, fleetPanels.length, gridGroups.length, layoutConfig, gridWidth]);
 
   useEffect(() => {
-    hysteresisNavColsRef.current = gridCols;
-  }, [gridCols]);
+    // Only retain hysteresis state for the automatic strategy. Fixed strategies
+    // produce user-chosen counts that must not bias a later auto computation.
+    const value = layoutConfig.strategy === "automatic" ? gridCols : undefined;
+    if (isFleetScopeRender) {
+      hysteresisNavFleetColsRef.current = value;
+    } else {
+      hysteresisNavGridColsRef.current = value;
+    }
+  }, [gridCols, isFleetScopeRender, layoutConfig.strategy]);
 
   // Compute grid layout from visual groups (no DOM measurement). Fleet branch
   // treats each armed panel as its own single-cell position, mirroring how

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -147,6 +147,55 @@ describe("getAutoGridCols", () => {
       expect(getAutoGridCols(12, wideWidth)).toBe(4);
     });
   });
+
+  describe("breakpoint hysteresis", () => {
+    const wideWidth = MIN_TERMINAL_WIDTH_PX * 5; // Room for 5 columns
+
+    it("holds 3 columns at count=5 once widened (sticky narrow boundary)", () => {
+      // Was at 3 cols (count had reached ≥6), now back at 5 — must stay at 3.
+      expect(getAutoGridCols(5, wideWidth, 3)).toBe(3);
+    });
+
+    it("narrows to 2 columns at count=4 (drops at narrowAt)", () => {
+      expect(getAutoGridCols(4, wideWidth, 3)).toBe(2);
+    });
+
+    it("holds 4 columns at count=11 once widened (3→4 sticky)", () => {
+      expect(getAutoGridCols(11, wideWidth, 4)).toBe(4);
+    });
+
+    it("narrows to 3 columns at count=10 (3→4 narrowAt)", () => {
+      expect(getAutoGridCols(10, wideWidth, 4)).toBe(3);
+    });
+
+    it("maxFeasibleCols overrides sticky hysteresis", () => {
+      // Even with previousCols=3, a 1.5×min-width viewport only fits 1 column.
+      const narrowWidth = MIN_TERMINAL_WIDTH_PX * 1.5;
+      expect(getAutoGridCols(5, narrowWidth, 3)).toBe(1);
+    });
+
+    it("preserves backward-compatible behavior when previousCols is undefined", () => {
+      // Cold start (no prior state): pure count-based, symmetric.
+      expect(getAutoGridCols(5, wideWidth, undefined)).toBe(2);
+      expect(getAutoGridCols(11, wideWidth, undefined)).toBe(3);
+    });
+
+    it("does not widen past the natural target when previousCols is smaller", () => {
+      // previousCols=2 must not bias an upward widen — count drives that.
+      expect(getAutoGridCols(6, wideWidth, 2)).toBe(3);
+      expect(getAutoGridCols(12, wideWidth, 3)).toBe(4);
+    });
+
+    it("ignores stale previousCols beyond the natural target", () => {
+      // count=2 naturally caps at 2 cols even if a stale previousCols=4 leaks in.
+      expect(getAutoGridCols(2, wideWidth, 4)).toBe(2);
+    });
+
+    it("respects no-empty-columns rule under hysteresis", () => {
+      // count=2 wants ≤2 cols regardless of any sticky prior.
+      expect(getAutoGridCols(2, wideWidth, 3)).toBe(2);
+    });
+  });
 });
 
 describe("getMaxGridCapacity", () => {

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -195,6 +195,33 @@ describe("getAutoGridCols", () => {
       // count=2 wants ≤2 cols regardless of any sticky prior.
       expect(getAutoGridCols(2, wideWidth, 3)).toBe(2);
     });
+
+    it("cascades through intermediate bands on multi-tier drops", () => {
+      // From 4 cols, dropping straight to count=5 should pass through 3 cols
+      // (the 2→3 band is still sticky at count=5), not skip to 2.
+      expect(getAutoGridCols(5, wideWidth, 4)).toBe(3);
+      // count=4 clears both bands' narrowAt thresholds → drops to 2.
+      expect(getAutoGridCols(4, wideWidth, 4)).toBe(2);
+    });
+
+    it("holds chained sequence through staged decrements (6→5→4)", () => {
+      // Simulate the per-render previousCols handoff for a 6→5→4 sequence.
+      const at6 = getAutoGridCols(6, wideWidth, 2);
+      const at5 = getAutoGridCols(5, wideWidth, at6);
+      const at4 = getAutoGridCols(4, wideWidth, at5);
+      expect(at6).toBe(3); // widens
+      expect(at5).toBe(3); // sticky
+      expect(at4).toBe(2); // drops at narrowAt
+    });
+
+    it("holds chained sequence at the 3→4 band (12→11→10)", () => {
+      const at12 = getAutoGridCols(12, wideWidth, 3);
+      const at11 = getAutoGridCols(11, wideWidth, at12);
+      const at10 = getAutoGridCols(10, wideWidth, at11);
+      expect(at12).toBe(4);
+      expect(at11).toBe(4); // sticky at 3→4 band
+      expect(at10).toBe(3); // drops to 3, still sticky there (10>4) until count<=4
+    });
   });
 });
 

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -66,6 +66,22 @@ export function getMaxGridCapacity(width: number | null, height: number | null):
 }
 
 /**
+ * Schmitt-trigger boundaries for breakpoint hysteresis. Each entry promotes
+ * `from`→`to` columns once `count` reaches `widenAt`, and only relaxes back
+ * to `from` once `count` drops to `narrowAt`. The buffer between the two
+ * thresholds prevents single-panel toggles from re-flowing the grid.
+ */
+const HYSTERESIS_BANDS: ReadonlyArray<{
+  from: number;
+  to: number;
+  widenAt: number;
+  narrowAt: number;
+}> = [
+  { from: 2, to: 3, widenAt: 6, narrowAt: 4 },
+  { from: 3, to: 4, widenAt: 12, narrowAt: 10 },
+];
+
+/**
  * Pure function to calculate optimal grid columns for automatic layout.
  *
  * Design principles:
@@ -80,8 +96,19 @@ export function getMaxGridCapacity(width: number | null, height: number | null):
  * - 2-5 terminals: 2 columns (stable for common use, max 3 rows)
  * - 6-11 terminals: 3 columns (prevents pancakes, max 4 rows)
  * - 12+ terminals: 4 columns (high density fleet, max 4 rows)
+ *
+ * Breakpoint hysteresis: when `previousCols` is supplied (the column count from
+ * the prior render), the function holds the wider count through a buffer zone
+ * — e.g. once at 3 cols (count≥6), it stays at 3 down to count=5 and only
+ * narrows back to 2 at count≤4. `maxFeasibleCols` still caps the result so a
+ * narrowing viewport always overrides a sticky widen. Calling without
+ * `previousCols` preserves the original symmetric behavior.
  */
-export function getAutoGridCols(count: number, width: number | null): number {
+export function getAutoGridCols(
+  count: number,
+  width: number | null,
+  previousCols?: number
+): number {
   if (count <= 1) return 1;
 
   // Calculate max feasible columns based on minimum terminal width
@@ -103,10 +130,23 @@ export function getAutoGridCols(count: number, width: number | null): number {
     targetCols = 4;
   }
 
+  // Apply hysteresis: hold the prior wider count through the buffer zone
+  // between widenAt and narrowAt for any band whose `to` matches it.
+  if (previousCols !== undefined && previousCols > targetCols) {
+    for (const band of HYSTERESIS_BANDS) {
+      if (previousCols === band.to && count > band.narrowAt) {
+        targetCols = band.to;
+        break;
+      }
+    }
+  }
+
   // Don't use more columns than we have terminals (no empty columns)
   targetCols = Math.min(targetCols, count);
 
-  // Respect width constraints - never exceed what the viewport can fit
+  // Respect width constraints - never exceed what the viewport can fit.
+  // This is an unconditional override: a viewport that can't fit the sticky
+  // count must narrow regardless of hysteresis.
   return Math.min(maxFeasibleCols, targetCols);
 }
 
@@ -121,7 +161,8 @@ export function computeGridColumns(
   count: number,
   gridWidth: number | null,
   strategy: TerminalLayoutStrategy,
-  value?: number
+  value?: number,
+  previousCols?: number
 ): number {
   if (count === 0) return 1;
 
@@ -133,7 +174,7 @@ export function computeGridColumns(
 
   switch (strategy) {
     case "automatic":
-      return getAutoGridCols(count, gridWidth);
+      return getAutoGridCols(count, gridWidth, previousCols);
     case "fixed-rows": {
       const rows = Math.max(1, Math.min(value ?? 3, 10));
       return Math.ceil(count / rows);
@@ -141,6 +182,6 @@ export function computeGridColumns(
     case "fixed-columns":
       return Math.max(1, Math.min(value ?? 2, 10));
     default:
-      return getAutoGridCols(count, gridWidth);
+      return getAutoGridCols(count, gridWidth, previousCols);
   }
 }

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -130,15 +130,18 @@ export function getAutoGridCols(
     targetCols = 4;
   }
 
-  // Apply hysteresis: hold the prior wider count through the buffer zone
-  // between widenAt and narrowAt for any band whose `to` matches it.
-  if (previousCols !== undefined && previousCols > targetCols) {
+  // Apply hysteresis: walk every band whose `to` is at or below `previousCols`,
+  // hold the highest one whose narrowAt has not yet been reached. Cascading
+  // through intermediate bands matters when count drops several tiers at once
+  // (e.g. previousCols=4 → count=5 should pass through 3 cols, not jump to 2).
+  if (previousCols !== undefined) {
+    let stickyCols = targetCols;
     for (const band of HYSTERESIS_BANDS) {
-      if (previousCols === band.to && count > band.narrowAt) {
-        targetCols = band.to;
-        break;
+      if (previousCols >= band.to && count > band.narrowAt && band.to > stickyCols) {
+        stickyCols = band.to;
       }
     }
+    targetCols = stickyCols;
   }
 
   // Don't use more columns than we have terminals (no empty columns)


### PR DESCRIPTION
## Summary

- Adds Schmitt-trigger style hysteresis to `getAutoGridCols` so the auto grid resists immediate column reflow at breakpoint boundaries — a 5→6 add widens to 3 columns, but 6→5 doesn't immediately re-narrow
- `HYSTERESIS_BANDS` defines widen/narrow thresholds for each band (2→3: widen at count ≥ 6, narrow at ≤ 4; 3→4: widen at ≥ 12, narrow at ≤ 10); the cascade loop holds the highest sticky band still in its buffer zone; `maxFeasibleCols` overrides unconditionally
- `ContentGrid` and `useGridNavigation` track per-scope hysteresis refs, gated to automatic strategy only, so fixed-rows/fixed-columns paths are unaffected

Resolves #6166

## Changes

- `src/lib/terminalLayout.ts` — `HYSTERESIS_BANDS` constant, optional `previousCols` param on `getAutoGridCols` and `computeGridColumns`, cascade band loop
- `src/components/Terminal/ContentGrid.tsx` — `hysteresisGridColsRef` / `hysteresisFleetColsRef` tracked in existing prev-cols effects, gated to automatic strategy and no active drag placeholder
- `src/hooks/useGridNavigation.ts` — split into `hysteresisNavGridColsRef` / `hysteresisNavFleetColsRef`, selected by `isFleetScopeRender`, gated to automatic strategy only

## Testing

- 11 new unit test cases under "breakpoint hysteresis": sticky widen, narrow boundary, 3→4 band, `maxFeasibleCols` override, cold-start backward compat, no upward bias, stale-prev defences, multi-tier cascade, chained 6→5→4 and 12→11→10 sequences
- Vitest 56 tests pass, tsc clean, lint/format clean