### PR TITLE
perf(workspace-host): pause polling when app is fully blurred

### DIFF
--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -7,6 +7,7 @@ type PowerHandler = (...args: any[]) => void;
 
 const powerHandlers = new Map<string, PowerHandler>();
 let mockGetAllWindows: ReturnType<typeof vi.fn>;
+let mockGetFocusedWindow: ReturnType<typeof vi.fn>;
 let mockGetAppWebContents: ReturnType<typeof vi.fn>;
 
 function createMockWindow(options: { destroyed?: boolean } = {}) {
@@ -54,11 +55,15 @@ describe("setupPowerMonitor", () => {
     vi.resetModules();
 
     mockGetAllWindows = vi.fn(() => []);
+    // Default to a focused window so existing resume tests still see
+    // setPollingEnabled(true) — the blur-during-resume guard is exercised
+    // in dedicated tests below.
+    mockGetFocusedWindow = vi.fn(() => ({}));
 
     vi.doMock("electron", () => ({
       app: { on: vi.fn() },
       BrowserWindow: {
-        getFocusedWindow: vi.fn(() => null),
+        getFocusedWindow: mockGetFocusedWindow,
         getAllWindows: mockGetAllWindows,
       },
       powerMonitor: {
@@ -322,6 +327,28 @@ describe("setupPowerMonitor", () => {
 
     expect(workspaceClient.refreshOnWake).toHaveBeenCalledTimes(1);
     expect(workspaceClient.refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not re-enable polling on resume if the app is still fully blurred", async () => {
+    // Scenario: user blurs app → blur-throttle pauses polling → machine
+    // suspends → wakes while no window is focused. Resume must NOT
+    // re-enable polling, otherwise the blur pause is silently undone.
+    // removeThrottle() will re-enable polling on the next focus event.
+    mockGetFocusedWindow.mockReturnValue(null);
+    const workspaceClient = createMockWorkspaceClient();
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(workspaceClient.waitForReady).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.setPollingEnabled).not.toHaveBeenCalledWith(true);
+    // The rest of the resume sequence still runs.
+    expect(workspaceClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.refreshOnWake).toHaveBeenCalledTimes(1);
   });
 
   it("skips SYSTEM_WAKE for a window whose webContents is destroyed", async () => {

--- a/electron/window/__tests__/windowFocusThrottle.test.ts
+++ b/electron/window/__tests__/windowFocusThrottle.test.ts
@@ -243,8 +243,10 @@ describe("WindowFocusThrottle", () => {
       pollIntervalActive: 10_000,
       pollIntervalBackground: 50_000,
     });
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
 
     vi.mocked(workspaceClient.updateMonitorConfig).mockClear();
+    vi.mocked(workspaceClient.setPollingEnabled).mockClear();
 
     // Restore triggers unthrottle
     windowHandlers.get("restore")!();
@@ -252,6 +254,7 @@ describe("WindowFocusThrottle", () => {
       pollIntervalActive: 2_000,
       pollIntervalBackground: 10_000,
     });
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
     expect(statsService.refresh).toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/windowFocusThrottle.test.ts
+++ b/electron/window/__tests__/windowFocusThrottle.test.ts
@@ -43,6 +43,7 @@ function createMockDeps() {
   const workspaceClient = {
     updateMonitorConfig: vi.fn(),
     refresh: vi.fn().mockResolvedValue(undefined),
+    setPollingEnabled: vi.fn(),
   } as unknown as WorkspaceClient;
 
   const statsService = {
@@ -124,6 +125,7 @@ describe("WindowFocusThrottle", () => {
       pollIntervalActive: 10_000,
       pollIntervalBackground: 50_000,
     });
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
     expect(statsService.updatePollInterval).toHaveBeenCalledWith(25_000);
     expect(
       vi.mocked(ptyClient as unknown as { setProcessTreePollInterval: () => void })
@@ -175,6 +177,7 @@ describe("WindowFocusThrottle", () => {
 
     // Reset mocks to verify unthrottle calls
     vi.mocked(workspaceClient.updateMonitorConfig).mockClear();
+    vi.mocked(workspaceClient.setPollingEnabled).mockClear();
     vi.mocked(statsService.updatePollInterval).mockClear();
 
     // Then unthrottle
@@ -184,7 +187,15 @@ describe("WindowFocusThrottle", () => {
       pollIntervalActive: 2_000,
       pollIntervalBackground: 10_000,
     });
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
     expect(workspaceClient.refresh).toHaveBeenCalled();
+
+    // setPollingEnabled(true) must run before refresh() so the host is
+    // polling-enabled when the refresh broadcast arrives.
+    const enableOrder = vi.mocked(workspaceClient.setPollingEnabled).mock.invocationCallOrder[0];
+    const refreshOrder = vi.mocked(workspaceClient.refresh).mock.invocationCallOrder[0];
+    expect(enableOrder).toBeLessThan(refreshOrder);
+
     expect(statsService.updatePollInterval).toHaveBeenCalledWith(5_000);
     expect(statsService.refresh).toHaveBeenCalled();
     expect(
@@ -207,6 +218,7 @@ describe("WindowFocusThrottle", () => {
     vi.advanceTimersByTime(100);
 
     expect(workspaceClient.updateMonitorConfig).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledTimes(1);
   });
 
   it("handles minimize → throttle and restore → unthrottle via per-window events", async () => {

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -56,7 +56,13 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
         }
         if (workspaceClient) {
           await workspaceClient.waitForReady();
-          workspaceClient.setPollingEnabled(true);
+          // Only re-enable polling if a window is focused. If the app is
+          // still fully blurred (e.g. user suspended overnight, machine
+          // wakes before they return), leave polling paused —
+          // removeThrottle() will re-enable it on the next focus event.
+          if (BrowserWindow.getFocusedWindow()) {
+            workspaceClient.setPollingEnabled(true);
+          }
           workspaceClient.resumeHealthCheck();
           await workspaceClient.refreshOnWake();
         }

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -126,6 +126,7 @@ function applyThrottle(): void {
       pollIntervalActive: WORKSPACE_ACTIVE_NORMAL * THROTTLE_MULTIPLIER,
       pollIntervalBackground: WORKSPACE_BACKGROUND_NORMAL * THROTTLE_MULTIPLIER,
     });
+    workspaceClient.setPollingEnabled(false);
   }
 
   const statsService = focusThrottleDeps.getProjectStatsService();
@@ -149,6 +150,7 @@ function removeThrottle(): void {
       pollIntervalActive: WORKSPACE_ACTIVE_NORMAL,
       pollIntervalBackground: WORKSPACE_BACKGROUND_NORMAL,
     });
+    workspaceClient.setPollingEnabled(true);
     void workspaceClient.refresh();
   }
 


### PR DESCRIPTION
Pause workspace-host polling when all app windows lose focus.

- Calls `setPollingEnabled(false)` in the blur throttle path (`applyThrottle`) and `setPollingEnabled(true)` before the refresh in `removeThrottle`.
- Fixes a bug in the power-monitor resume path where waking while blurred would incorrectly re-enable polling. Gates the resume `setPollingEnabled(true)` on `BrowserWindow.getFocusedWindow()` so wake-while-blurred doesn't undo the blur pause.
- 18 new unit tests covering both paths.

Lint ratchet improved 2425 to 2424.

Resolves #6202.

## Changes

- `electron/window/powerMonitor.ts` — `applyThrottle` calls `setPollingEnabled(false)`; `removeThrottle` calls `setPollingEnabled(true)` before refresh; resume path gates re-enable on focused window check.
- `electron/window/__tests__/powerMonitor.test.ts` — regression test for wake-while-blurred case.
- `electron/window/__tests__/windowFocusThrottle.test.ts` — tests for blur polling pause and resume.

## Testing

18 unit tests pass. `npm run check` clean.