### PR TITLE
perf(github-stats): tick rate-limit countdown only on label changes

### DIFF
--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -116,7 +116,11 @@ export const GitHubStatsToolbarButton = memo(
     const prevLastUpdatedRef = useRef<number | null>(null);
 
     useEffect(() => {
-      if (rateLimitResetAt === null || rateLimitResetAt <= Date.now()) {
+      if (
+        rateLimitResetAt === null ||
+        !Number.isFinite(rateLimitResetAt) ||
+        rateLimitResetAt <= Date.now()
+      ) {
         setRateLimitCountdown(null);
         return;
       }

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -41,6 +41,24 @@ function formatRateLimitCountdown(remainingMs: number): string {
   return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
 }
 
+// Returns the milliseconds until `formatRateLimitCountdown` next produces a
+// different string. Used to schedule the countdown's next tick exactly at the
+// label-change boundary instead of polling every second.
+//
+// In the hours range the label only includes minutes (e.g. "1h 5m"), so the
+// next change happens when `Math.ceil(remainingMs / 1000)` drops below the
+// current minute boundary. In the seconds and minutes ranges the seconds
+// component is part of the label, so cadence stays at 1Hz.
+export function msUntilNextLabelChange(remainingMs: number): number {
+  if (remainingMs <= 0) return 0;
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  if (totalSeconds < 3600) {
+    return remainingMs % 1000 || 1000;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  return remainingMs - (60_000 * minutes - 1000);
+}
+
 const LazyGitHubResourceList = lazy(() =>
   import("@/components/GitHub/GitHubResourceList").then((m) => ({
     default: m.GitHubResourceList,
@@ -102,27 +120,40 @@ export const GitHubStatsToolbarButton = memo(
         setRateLimitCountdown(null);
         return;
       }
-      let intervalId: number | null = null;
+      let timeoutId: number | null = null;
+
       const tick = () => {
+        timeoutId = null;
         const remainingMs = rateLimitResetAt - Date.now();
         if (remainingMs <= 0) {
           setRateLimitCountdown(null);
-          // Stop ticking once we've hit zero — otherwise the 1Hz interval
-          // keeps running uselessly until the component unmounts.
-          if (intervalId !== null) {
-            window.clearInterval(intervalId);
-            intervalId = null;
-          }
           return;
         }
         setRateLimitCountdown(formatRateLimitCountdown(remainingMs));
-      };
-      tick();
-      intervalId = window.setInterval(tick, 1000);
-      return () => {
-        if (intervalId !== null) {
-          window.clearInterval(intervalId);
+        if (!document.hidden) {
+          timeoutId = window.setTimeout(tick, msUntilNextLabelChange(remainingMs));
         }
+      };
+
+      const onVisibility = () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        if (!document.hidden) {
+          tick();
+        }
+      };
+
+      tick();
+      document.addEventListener("visibilitychange", onVisibility);
+
+      return () => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        document.removeEventListener("visibilitychange", onVisibility);
       };
     }, [rateLimitResetAt]);
 

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.rateLimitHelper.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.rateLimitHelper.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { msUntilNextLabelChange } from "../GitHubStatsToolbarButton";
+
+describe("msUntilNextLabelChange", () => {
+  it("returns 0 when no time remains", () => {
+    expect(msUntilNextLabelChange(0)).toBe(0);
+    expect(msUntilNextLabelChange(-1)).toBe(0);
+    expect(msUntilNextLabelChange(-1_000)).toBe(0);
+  });
+
+  it("aligns to the next whole-second boundary in the seconds range", () => {
+    expect(msUntilNextLabelChange(1)).toBe(1);
+    expect(msUntilNextLabelChange(500)).toBe(500);
+    expect(msUntilNextLabelChange(999)).toBe(999);
+    expect(msUntilNextLabelChange(1_000)).toBe(1_000);
+    expect(msUntilNextLabelChange(1_001)).toBe(1);
+    expect(msUntilNextLabelChange(59_999)).toBe(999);
+  });
+
+  it("aligns to the next whole-second boundary in the minutes range", () => {
+    expect(msUntilNextLabelChange(60_000)).toBe(1_000);
+    expect(msUntilNextLabelChange(60_001)).toBe(1);
+    expect(msUntilNextLabelChange(120_500)).toBe(500);
+    expect(msUntilNextLabelChange(3_599_000)).toBe(1_000);
+    expect(msUntilNextLabelChange(3_599_999)).toBe(999);
+  });
+
+  it("aligns to the next minute-boundary crossing in the hours range", () => {
+    // remainingMs=3_600_000 → totalSeconds=3600 → label "1h"
+    // Next change is "1h" → "59m 59s" at remainingMs=3_599_000 (1s away)
+    expect(msUntilNextLabelChange(3_600_000)).toBe(1_000);
+
+    // remainingMs=3_660_000 → totalSeconds=3660 → label "1h 1m"
+    // Next change is "1h 1m" → "1h" at remainingMs=3_659_000 (1s away)
+    expect(msUntilNextLabelChange(3_660_000)).toBe(1_000);
+
+    // remainingMs=3_659_000 → totalSeconds=3659 → label "1h"
+    // Next change is "1h" → "59m 59s" at remainingMs=3_599_000 (60s away)
+    expect(msUntilNextLabelChange(3_659_000)).toBe(60_000);
+
+    // Mid-minute-window in hours range: from totalSeconds=3700 down to 3659
+    expect(msUntilNextLabelChange(3_700_000)).toBe(41_000);
+
+    // Two-hour mark behaves like the one-hour mark
+    expect(msUntilNextLabelChange(7_200_000)).toBe(1_000);
+    expect(msUntilNextLabelChange(7_199_000)).toBe(60_000);
+  });
+
+  it("never returns 0 for positive remaining time (no busy loop)", () => {
+    const cases = [1, 500, 1_000, 60_000, 120_000, 3_599_000, 3_600_000, 3_660_000, 7_200_000];
+    for (const remainingMs of cases) {
+      expect(msUntilNextLabelChange(remainingMs)).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
This replaces the 1Hz `setInterval` in `GitHubStatsToolbarButton` with a self-rescheduling `setTimeout` that sleeps until the label string would actually change. So in the hours range it schedules at the next minute-boundary (up to 60s between renders). In the minutes/seconds range it keeps 1Hz cadence because the seconds component is still changing.

It also adds `visibilitychange` gating so the timer pauses when `document.hidden` and does an immediate tick on resume.

There's also a `Number.isFinite` guard on `rateLimitResetAt` to avoid `setTimeout(_, NaN)` collapsing to 0 and spinning.

Unit tests cover the boundary cases for the `msUntilNextLabelChange` helper.

Resolves #6207

## Changes

- `GitHubStatsToolbarButton.tsx` — replace `setInterval` with self-rescheduling `setTimeout`, add visibility gating, add `isFinite` guard
- `GitHubStatsToolbarButton.rateLimitHelper.test.ts` — unit tests for `msUntilNextLabelChange`

## Testing

Unit tests pass. Manually verified the countdown label ticks at the expected cadence across the hours, minutes, and seconds ranges.