### PR TITLE
fix(drag-drop): use theme shadow tokens for drag previews

### DIFF
--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -24,7 +24,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
         backgroundColor: "var(--color-daintree-sidebar)",
         border: "1px solid var(--color-daintree-border)",
         borderRadius: "var(--radius-lg)",
-        boxShadow: "0 8px 24px rgba(0, 0, 0, 0.6)",
+        boxShadow: "var(--theme-shadow-floating)",
         overflow: "visible",
         display: "flex",
         flexDirection: "column",
@@ -47,7 +47,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
             display: "flex",
             alignItems: "center",
             gap: 3,
-            boxShadow: "0 2px 8px rgba(0, 0, 0, 0.4)",
+            boxShadow: "var(--theme-shadow-ambient)",
             fontVariantNumeric: "tabular-nums",
             zIndex: 10,
           }}

--- a/src/components/DragDrop/WorktreeDragPreview.tsx
+++ b/src/components/DragDrop/WorktreeDragPreview.tsx
@@ -17,7 +17,7 @@ export function WorktreeDragPreview({ worktree }: WorktreeDragPreviewProps) {
         backgroundColor: "var(--color-daintree-sidebar)",
         border: "1px solid var(--color-daintree-border)",
         borderRadius: "var(--radius-lg)",
-        boxShadow: "0 8px 24px rgba(0, 0, 0, 0.6)",
+        boxShadow: "var(--theme-shadow-floating)",
         overflow: "hidden",
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
## Summary
- Drag preview drop-shadows were hardcoded to black rgba values, bypassing the theme shadow system entirely
- Replaced hardcoded `boxShadow` in `WorktreeDragPreview.tsx` and `TerminalDragPreview.tsx` with `var(--theme-shadow-floating)` and `var(--theme-shadow-ambient)`
- The theme layer already defines these tokens via shadowStyle profiles (crisp, soft, atmospheric, none) in `shared/theme/semantic.ts`

Resolves #6213

## Changes
- `WorktreeDragPreview.tsx`: outer card shadow uses `var(--theme-shadow-floating)`
- `TerminalDragPreview.tsx`: outer card shadow uses `var(--theme-shadow-floating)`, badge shadow uses `var(--theme-shadow-ambient)`

## Testing
- Verified shadows render correctly across all built-in themes (light and dark)
- Confirmed shadowStyle profiles produce appropriate preview shadows per theme