### PR TITLE
fix(ui): demote decorative accent on code spans, secondary links, and icon hovers

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -1079,7 +1079,7 @@ export function BrowserPane({
                     onClick={handleRetryFromError}
                     variant="ghost"
                     size="sm"
-                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                    className="gap-1.5 px-2.5 py-1.5 group"
                   >
                     <RotateCw className="h-3.5 w-3.5" />
                     <span className="text-xs">Retry</span>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1108,7 +1108,7 @@ export function DevPreviewPane({
                   onClick={handleRetry}
                   variant="ghost"
                   size="sm"
-                  className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                  className="gap-1.5 px-2.5 py-1.5 group"
                 >
                   <RotateCw className="h-3.5 w-3.5" />
                   <span className="text-xs">Retry</span>
@@ -1154,7 +1154,7 @@ export function DevPreviewPane({
                           disabled={isAutoDetecting || isSettingsLoading}
                           variant="ghost"
                           size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                          className="gap-1.5 px-2.5 py-1.5 group"
                         >
                           <WandSparkles className="h-3.5 w-3.5" />
                           <span className="text-xs">
@@ -1241,7 +1241,7 @@ export function DevPreviewPane({
                           }
                           variant="ghost"
                           size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                          className="gap-1.5 px-2.5 py-1.5 group"
                         >
                           <RotateCw className="h-3.5 w-3.5" />
                           <span className="text-xs">

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -401,7 +401,7 @@ export function AutomationTab({
         {branchPrefixMode !== "none" && (
           <div className="mt-3 p-3 rounded-[var(--radius-md)] bg-daintree-bg/50 border border-daintree-border">
             <span className="block text-xs font-medium text-daintree-text/70 mb-1">Preview:</span>
-            <code className="text-xs text-daintree-accent">
+            <code className="text-xs text-daintree-text">
               {branchPrefixMode === "username"
                 ? "alice/fix-bug"
                 : branchPrefixCustom.trim()
@@ -448,7 +448,7 @@ export function AutomationTab({
                 <span className="block text-xs font-medium text-daintree-text/70 mb-1">
                   Preview:
                 </span>
-                <code className="text-xs text-daintree-accent break-all">{preview}</code>
+                <code className="text-xs text-daintree-text break-all">{preview}</code>
               </div>
             );
           })()}
@@ -464,7 +464,7 @@ export function AutomationTab({
               key={v}
               className="text-xs p-2 rounded-[var(--radius-md)] bg-daintree-bg/30 border border-daintree-border"
             >
-              <code className="text-daintree-accent">{v}</code>
+              <code className="text-text-secondary">{v}</code>
               <span className="text-daintree-text/50 ml-1">{desc}</span>
             </div>
           ))}

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -282,7 +282,7 @@ export function AutomationTab({
                   No global recipes available.{" "}
                   <button
                     onClick={onNavigateToRecipes}
-                    className="text-daintree-accent hover:underline"
+                    className="text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
                   >
                     Create a recipe
                   </button>

--- a/src/components/Project/ProjectNotificationsTab.tsx
+++ b/src/components/Project/ProjectNotificationsTab.tsx
@@ -90,7 +90,7 @@ export function ProjectNotificationsTab({ overrides, onChange }: ProjectNotifica
                 setGlobalError("Failed to load global settings");
               });
           }}
-          className="text-daintree-accent underline hover:text-daintree-accent/80"
+          className="text-text-secondary hover:text-daintree-text underline-offset-2 underline hover:underline"
         >
           Retry
         </button>

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -582,7 +582,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                                 className="ml-2 shrink-0 rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-overlay-soft"
                                 aria-label="Pin this command"
                               >
-                                <Pin className="h-3 w-3 text-text-muted hover:text-daintree-accent" />
+                                <Pin className="h-3 w-3 text-text-muted hover:text-daintree-text" />
                               </button>
                             )}
                           </div>

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -168,7 +168,7 @@ export function CrashRecoveryDialog({
                 <button
                   type="button"
                   onClick={toggleAll}
-                  className="cursor-pointer text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+                  className="cursor-pointer text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
                   data-testid="toggle-all-button"
                 >
                   {allSelected ? "Deselect all" : "Select all"}

--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -177,7 +177,7 @@ function RadioOption({
         className="mt-0.5 shrink-0 accent-daintree-accent"
       />
       <div>
-        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-accent transition-colors">
+        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-text transition-colors">
           {label}
         </span>
         <p className="text-xs text-daintree-text/40 select-text">{description}</p>

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -217,7 +217,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
               size="sm"
               variant="ghost"
               onClick={() => window.electron.system.openExternal(usageUrl)}
-              className="text-daintree-accent hover:text-daintree-accent/80 mt-2"
+              className="mt-2"
             >
               Install Instructions
             </Button>

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -677,7 +677,6 @@ export function AgentSettings({
                         size="sm"
                         variant="ghost"
                         data-testid="preset-add-button"
-                        className="text-daintree-accent hover:text-daintree-accent/80"
                         onClick={openAddDialog}
                       >
                         <Plus size={14} />
@@ -784,7 +783,7 @@ export function AgentSettings({
                           />
                         ) : (
                           <button
-                            className="flex items-center gap-1.5 text-sm font-medium text-daintree-text hover:text-daintree-accent transition-colors text-left"
+                            className="flex items-center gap-1.5 text-sm font-medium text-daintree-text hover:text-daintree-text/80 hover:underline underline-offset-2 transition-colors text-left"
                             onClick={() => handleStartEdit(selectedPreset)}
                             aria-label={`Edit ${selectedPreset.name}`}
                             title="Click to rename"
@@ -892,7 +891,7 @@ export function AgentSettings({
                                 <button
                                   type="button"
                                   aria-label={`Reset custom arguments override for ${scopeLabel}`}
-                                  className="p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-accent invisible group-hover/args:visible group-focus-within/args:visible focus-visible:visible focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent transition-colors"
+                                  className="p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text invisible group-hover/args:visible group-focus-within/args:visible focus-visible:visible focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent transition-colors"
                                   onClick={handleCustomFlagsOverrideReset}
                                   data-testid="preset-custom-flags-reset"
                                 >

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -351,7 +351,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
             <button
               type="button"
               onClick={handleChangeTheme}
-              className="text-xs font-medium text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+              className="text-xs font-medium text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
             >
               Change theme…
             </button>
@@ -397,7 +397,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
             type="button"
             onClick={handleAccentReset}
             data-testid="accent-color-override-reset"
-            className="text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors shrink-0"
+            className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors shrink-0"
           >
             Reset to theme default
           </button>
@@ -407,13 +407,13 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
       <div className="flex items-center gap-3">
         <button
           onClick={handleExport}
-          className="text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
         >
           Export app theme...
         </button>
         <button
           onClick={handleImport}
-          className="text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
         >
           Import app theme...
         </button>
@@ -421,7 +421,7 @@ export function AppThemePicker({ onClose }: AppThemePickerProps = {}) {
           <button
             type="button"
             onClick={handleShuffle}
-            className="ml-auto flex items-center gap-1.5 text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+            className="ml-auto flex items-center gap-1.5 text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
           >
             <Shuffle className="h-3 w-3" />
             Random theme

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -274,7 +274,7 @@ export function ColorSchemePicker() {
 
       <button
         onClick={handleImport}
-        className="text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors"
+        className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors"
       >
         Import color scheme...
       </button>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -546,7 +546,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
         <p className="text-xs text-daintree-text/60 mb-2 select-text">
           Define a custom prompt to send to the agent instead of executing the default command
           behavior. Use template variables like{" "}
-          <code className="text-daintree-accent">
+          <code className="text-text-secondary">
             {"{"}variableName{"}"}
           </code>{" "}
           to include argument values.

--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -659,7 +659,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={handleAdd}
-            className="w-full flex items-center justify-center gap-1.5 py-4 text-[12px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 rounded-[var(--radius-sm)]"
+            className="w-full flex items-center justify-center gap-1.5 py-4 text-[12px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors border border-dashed border-daintree-border/60 rounded-[var(--radius-sm)]"
             data-testid="env-editor-add"
           >
             <Plus size={12} aria-hidden="true" />
@@ -668,7 +668,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={() => setIsImportOpen(true)}
-            className="w-full flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors rounded-[var(--radius-sm)]"
+            className="w-full flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors rounded-[var(--radius-sm)]"
             data-testid="env-editor-import"
           >
             <Upload size={12} aria-hidden="true" />
@@ -802,7 +802,7 @@ export function EnvVarEditor({
                   {row.isInherited ? (
                     <button
                       type="button"
-                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-accent hover:bg-daintree-bg/60 transition-colors"
+                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-bg/60 transition-colors"
                       aria-label={`Override ${trimmedKey} in this preset`}
                       onClick={() => handleOverride(row.rowId)}
                       data-testid="env-editor-override"
@@ -813,7 +813,7 @@ export function EnvVarEditor({
                   ) : isOverride ? (
                     <button
                       type="button"
-                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-accent hover:bg-daintree-bg/60 transition-colors"
+                      className="p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-bg/60 transition-colors"
                       aria-label={`Revert ${trimmedKey} to inherited value`}
                       onClick={() => handleRevert(row.rowId)}
                       data-testid="env-editor-revert"
@@ -844,7 +844,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={handleAdd}
-            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors"
+            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
             data-testid="env-editor-add"
           >
             <Plus size={12} aria-hidden="true" />
@@ -853,7 +853,7 @@ export function EnvVarEditor({
           <button
             type="button"
             onClick={() => setIsImportOpen(true)}
-            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-accent hover:bg-daintree-bg/50 transition-colors"
+            className="flex items-center justify-center gap-1.5 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text hover:bg-daintree-bg/50 transition-colors"
             data-testid="env-editor-import"
           >
             <Upload size={12} aria-hidden="true" />

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -436,7 +436,7 @@ export function GeneralTab({
                     { source: "user" }
                   )
                 }
-                className="flex items-center gap-1.5 text-xs text-text-muted hover:text-daintree-accent transition-colors pt-1"
+                className="flex items-center gap-1.5 text-xs text-text-muted hover:text-daintree-text transition-colors pt-1"
               >
                 <ExternalLink className="w-3 h-3" />
                 daintree.org
@@ -469,7 +469,7 @@ export function GeneralTab({
                       <div className="flex items-center gap-3">
                         <button
                           type="button"
-                          className="text-xs text-daintree-accent hover:underline"
+                          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
                           onClick={() =>
                             window.dispatchEvent(
                               new CustomEvent("daintree:open-agent-setup-wizard")
@@ -481,7 +481,7 @@ export function GeneralTab({
                         {onNavigateToAgents && (
                           <button
                             type="button"
-                            className="text-xs text-daintree-accent hover:underline"
+                            className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
                             onClick={() => onNavigateToAgents?.()}
                           >
                             Browse available agents
@@ -540,7 +540,7 @@ export function GeneralTab({
                       <button
                         type="button"
                         onClick={() => onNavigateToAgents?.()}
-                        className="text-xs text-daintree-accent hover:underline"
+                        className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
                       >
                         {`Daintree supports ${hiddenCount} more ${hiddenCount === 1 ? "agent" : "agents"} →`}
                       </button>

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -265,7 +265,7 @@ function ConflictOption({
         data-testid={testId}
       />
       <div>
-        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-accent transition-colors">
+        <span className="text-sm font-medium text-daintree-text group-hover:text-daintree-text transition-colors">
           {label}
         </span>
         <p className="text-xs text-daintree-text/40">{description}</p>

--- a/src/components/Settings/KeybindingProfileActions.tsx
+++ b/src/components/Settings/KeybindingProfileActions.tsx
@@ -81,7 +81,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
           "flex items-center gap-1.5 px-3 py-2 text-sm border border-daintree-border rounded transition-colors",
           isLoading
             ? "opacity-50 cursor-not-allowed text-daintree-text/40"
-            : "text-daintree-text/60 hover:text-daintree-text hover:border-daintree-accent"
+            : "text-daintree-text/60 hover:text-daintree-text hover:border-daintree-border"
         )}
       >
         <Download className="w-3.5 h-3.5" />
@@ -94,7 +94,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
           "flex items-center gap-1.5 px-3 py-2 text-sm border border-daintree-border rounded transition-colors",
           isLoading
             ? "opacity-50 cursor-not-allowed text-daintree-text/40"
-            : "text-daintree-text/60 hover:text-daintree-text hover:border-daintree-accent"
+            : "text-daintree-text/60 hover:text-daintree-text hover:border-daintree-border"
         )}
       >
         <Upload className="w-3.5 h-3.5" />

--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -171,7 +171,7 @@ export function PresetColorPicker({
           </button>
           <button
             type="button"
-            className="text-[11px] font-medium text-daintree-accent hover:text-daintree-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="text-[11px] font-medium text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={handleDone}
             disabled={!isValidHex(draftColor)}
             data-testid="preset-color-done"

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -436,35 +436,35 @@ export function ResourceEnvironmentsSection({
         </div>
         <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
           <div>
-            <code className="text-daintree-accent/80">{"{branch}"}</code>
+            <code className="text-text-secondary">{"{branch}"}</code>
             <span className="text-daintree-text/40"> — branch name</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{branch-slug}"}</code>
+            <code className="text-text-secondary">{"{branch-slug}"}</code>
             <span className="text-daintree-text/40"> — sanitized branch</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{repo-name}"}</code>
+            <code className="text-text-secondary">{"{repo-name}"}</code>
             <span className="text-daintree-text/40"> — repository folder</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{base-folder}"}</code>
+            <code className="text-text-secondary">{"{base-folder}"}</code>
             <span className="text-daintree-text/40"> — alias for repo-name</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{parent-dir}"}</code>
+            <code className="text-text-secondary">{"{parent-dir}"}</code>
             <span className="text-daintree-text/40"> — parent directory</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{worktree_name}"}</code>
+            <code className="text-text-secondary">{"{worktree_name}"}</code>
             <span className="text-daintree-text/40"> — worktree name</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{worktree_path}"}</code>
+            <code className="text-text-secondary">{"{worktree_path}"}</code>
             <span className="text-daintree-text/40"> — full worktree path</span>
           </div>
           <div>
-            <code className="text-daintree-accent/80">{"{project_root}"}</code>
+            <code className="text-text-secondary">{"{project_root}"}</code>
             <span className="text-daintree-text/40"> — project root path</span>
           </div>
         </div>

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -135,7 +135,7 @@ export function SettingsChoicebox<T extends string = string>({
               type="button"
               aria-label={resetAriaLabel ?? `Reset ${label} to default`}
               className={cn(
-                "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-accent",
+                "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
                 "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
                 "transition-colors"
@@ -153,7 +153,7 @@ export function SettingsChoicebox<T extends string = string>({
             type="button"
             aria-label="Reset to default"
             className={cn(
-              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-accent",
+              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -69,7 +69,7 @@ export function SettingsInput({
             type="button"
             aria-label={resetAriaLabel ?? `Reset ${label} to default`}
             className={cn(
-              "p-0.5 rounded-sm text-text-muted hover:text-daintree-accent",
+              "p-0.5 rounded-sm text-text-muted hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -89,7 +89,7 @@ export function SettingsSelect({
             type="button"
             aria-label={resetAriaLabel ?? `Reset ${label} to default`}
             className={cn(
-              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-accent",
+              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -134,7 +134,7 @@ export function SettingsSwitchCard({
           aria-label={resetAriaLabel ?? `Reset ${title} to default`}
           className={cn(
             "absolute top-1/2 -translate-y-1/2 z-10 p-1 rounded-sm",
-            "text-daintree-text/40 hover:text-daintree-accent",
+            "text-daintree-text/40 hover:text-daintree-text",
             "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
             "transition-colors",

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -52,7 +52,7 @@ export function SettingsTextarea({
             type="button"
             aria-label={resetAriaLabel ?? `Reset ${label} to default`}
             className={cn(
-              "p-0.5 rounded-sm text-text-muted hover:text-daintree-accent",
+              "p-0.5 rounded-sm text-text-muted hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -425,7 +425,7 @@ function ApiKeyRow({
           ) : (
             <button
               onClick={() => window.electron?.system?.openExternal(helpUrl)}
-              className="text-xs text-daintree-accent hover:underline flex items-center gap-1"
+              className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline flex items-center gap-1"
             >
               {helpLabel}
               <ExternalLink className="w-3 h-3" />
@@ -555,7 +555,7 @@ function MicPermissionRow({
             <div className="flex gap-2">
               <button
                 onClick={onOpenSettings}
-                className="text-xs text-daintree-accent hover:underline flex items-center gap-1"
+                className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline flex items-center gap-1"
               >
                 Open {settingsLabel}
                 <ExternalLink className="w-3 h-3" />

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -215,19 +215,19 @@ export function WorktreeSettingsTab() {
             </span>
             <div className="grid grid-cols-2 gap-2 text-xs">
               <div className="flex items-center gap-2 p-2 bg-daintree-bg/50 rounded-[var(--radius-md)] border border-daintree-border">
-                <code className="text-daintree-accent">{"{base-folder}"}</code>
+                <code className="text-text-secondary">{"{base-folder}"}</code>
                 <span className="text-daintree-text/50">Repository folder name</span>
               </div>
               <div className="flex items-center gap-2 p-2 bg-daintree-bg/50 rounded-[var(--radius-md)] border border-daintree-border">
-                <code className="text-daintree-accent">{"{branch-slug}"}</code>
+                <code className="text-text-secondary">{"{branch-slug}"}</code>
                 <span className="text-daintree-text/50">Sanitized branch name</span>
               </div>
               <div className="flex items-center gap-2 p-2 bg-daintree-bg/50 rounded-[var(--radius-md)] border border-daintree-border">
-                <code className="text-daintree-accent">{"{repo-name}"}</code>
+                <code className="text-text-secondary">{"{repo-name}"}</code>
                 <span className="text-daintree-text/50">Repository name</span>
               </div>
               <div className="flex items-center gap-2 p-2 bg-daintree-bg/50 rounded-[var(--radius-md)] border border-daintree-border">
-                <code className="text-daintree-accent">{"{parent-dir}"}</code>
+                <code className="text-text-secondary">{"{parent-dir}"}</code>
                 <span className="text-daintree-text/50">Parent directory path</span>
               </div>
             </div>
@@ -271,7 +271,7 @@ export function WorktreeSettingsTab() {
                 </div>
                 <div className="flex items-center gap-2 pt-1 border-t border-daintree-border mt-1">
                   <span className="text-daintree-text/50">Result:</span>
-                  <code className="text-daintree-accent break-all">{preview}</code>
+                  <code className="text-daintree-text break-all">{preview}</code>
                 </div>
               </div>
             </div>

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -246,7 +246,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                     <span
                       role="link"
                       tabIndex={0}
-                      className="text-daintree-text/30 hover:text-daintree-accent transition-colors p-0.5 cursor-pointer"
+                      className="text-daintree-text/30 hover:text-daintree-text transition-colors p-0.5 cursor-pointer"
                       onClick={() => systemClient.openExternal(config.install!.docsUrl!)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter" || e.key === " ")

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -855,7 +855,7 @@ function SelectionStep({
             </p>
             <button
               type="button"
-              className="text-xs text-daintree-accent hover:underline focus-visible:outline-hidden focus-visible:underline"
+              className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:underline"
               onClick={() =>
                 void actionService.dispatch(
                   "telemetry.togglePreview",

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -57,7 +57,7 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
               <button
                 type="button"
                 onClick={() => setExpanded((v) => !v)}
-                className="inline-flex items-center gap-1 text-[11px] text-daintree-accent hover:underline"
+                className="inline-flex items-center gap-1 text-[11px] text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
               >
                 {expanded ? (
                   <ChevronDown className="w-3 h-3" />

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -999,7 +999,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     { source: "user" }
                   )
                 }
-                className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
+                className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-text-secondary hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                 aria-label={`Arm ${filteredWorktrees.length} matching worktrees`}
               >
                 <Zap className="w-3 h-3" />

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -236,7 +236,7 @@ function RotatingTip() {
         <button
           type="button"
           onClick={() => void actionService.dispatch(tip.actionId!, undefined, { source: "user" })}
-          className="text-xs text-daintree-accent hover:text-daintree-accent/80 transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent/50 rounded px-1"
+          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
         >
           {tip.actionLabel}
         </button>

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx
@@ -16,7 +16,7 @@ export function RecipeRunnerEmpty({ onCreate }: RecipeRunnerEmptyProps) {
         className="group flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
       >
         <Plus
-          className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-accent transition-colors shrink-0"
+          className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
           aria-hidden
         />
         <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx
@@ -64,7 +64,7 @@ export function RecipeRunnerGrid({
           className="group col-span-full flex items-center justify-center gap-2 px-3 py-2 mt-1 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
         >
           <Plus
-            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-accent transition-colors shrink-0"
+            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
             aria-hidden
           />
           <span className="text-sm text-text-muted group-hover:text-daintree-text transition-colors">

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -177,7 +177,7 @@ export function RecipeRunnerList({
           className="group w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] hover:bg-overlay-medium transition-colors text-left focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent aria-selected:ring-2 aria-selected:ring-daintree-accent/60"
         >
           <Plus
-            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-accent transition-colors shrink-0"
+            className="h-3.5 w-3.5 text-text-muted group-hover:text-daintree-text transition-colors shrink-0"
             aria-hidden
           />
           <span className="flex-1 text-sm text-text-muted group-hover:text-daintree-text transition-colors">

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -345,7 +345,6 @@ export function AgentInstallSection({
                 });
               }
             }}
-            className="text-daintree-accent hover:text-daintree-accent/80"
           >
             <ExternalLink size={14} />
             Open Install Docs


### PR DESCRIPTION
## Summary

- The accent color was being applied decoratively across 35 component files in three broad patterns: template variable `<code>` spans, secondary text-link buttons, and icon button hover states. None of these are load-bearing signals.
- Demoted all three categories to neutral (`text-text-secondary`) with `text-daintree-text` as the hover/focal target. Secondary links also pick up `underline-offset-2 hover:underline` for affordance. Fixed `KeybindingProfileActions` border hover and replaced `ContentGrid`'s non-canonical focus ring with the prescribed outline pattern.
- All genuinely load-bearing accent uses are preserved throughout: `focus-visible:outline-daintree-accent`, badge chips, status indicators, dialog title icons, the HybridInputBar shell prompt, voice recording state, and primary CTAs.

Resolves #6218

## Changes

- `<code>` template variable spans: `text-text-secondary` across the board; single focal preview values (e.g. `WorktreeSettingsTab` branch preview) promoted to `text-daintree-text`
- Secondary text-link buttons: `text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline` replacing the old `text-daintree-accent hover:text-daintree-accent/80` pattern
- Icon button hovers: `hover:text-daintree-text` replacing `hover:text-daintree-accent` across env editors, recipe rows, browser/dev-preview toolbars, settings reset icons, and similar
- `KeybindingProfileActions`: `hover:border-daintree-border` replacing accent border hover
- `ContentGrid`: canonical `focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent` replacing `focus-visible:ring-1 focus-visible:ring-daintree-accent/50`
- 35 files across Settings, Setup, Project, Terminal/RecipeRunner, Browser, DevPreview, Sidebar, Recovery, and agents

## Testing

- Ran `npm run check` (tsc + lint:ratchet + format:check + check:channels) — passes clean
- Visually verified settings panels, recipe runner, browser/dev-preview toolbars, env var editor, and setup wizard to confirm accent restraint is correct and no affordances regressed