### PR TITLE
fix(ui): accent restraint for drag handles, drop placeholders, and resize feedback

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -144,7 +144,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 "bg-overlay-medium text-daintree-text border-border-strong aria-selected:bg-overlay-medium aria-selected:text-daintree-text";
 ```
 
-**Usage:** Combine with `transition-colors` for smooth toggle transitions. The active segment gets a neutral background fill and text emphasis; the border distinguishes it from inactive peers. Accent must NOT appear on any toggle segment. Current implementation in `FleetArmingDialog.tsx` ChipButton (lines 370-390) uses `bg-overlay-subtle`; this recipe prescribes the canonical target (`overlay-medium`).
+**Usage:** Combine with `transition-colors` for smooth toggle transitions. The active segment gets a neutral background fill and text emphasis; the border distinguishes it from inactive peers. Accent must NOT appear on any toggle segment. Current implementation in `FleetArmingDialog.tsx` ChipButton (lines 538-558) uses `bg-overlay-subtle`; this recipe prescribes the canonical target (`overlay-medium`).
 
 ---
 
@@ -227,7 +227,7 @@ Each recipe is a class fragment to apply to a suitable base component, not a sta
 | Worktree Card         | `WorktreeCard.tsx`                       | Card hover with accent-tinged border + elevation |
 | GitHub Settings Tab   | `GitHubSettingsTab.tsx` (line 213)       | Input focus with border-shift (no outline)       |
 | Notification Settings | `NotificationSettingsTab.tsx` (line 217) | Input focus with border-shift (no outline)       |
-| Segmented Toggle      | `FleetArmingDialog.tsx` (line 370)       | Active segment with neutral overlay lift         |
+| Segmented Toggle      | `FleetArmingDialog.tsx` (line 538)       | Active segment with neutral overlay lift         |
 | Settings Switch Row   | `SettingsSwitchCard.tsx`                 | Neutral row, accent only on switch track         |
 | Portal Drag Handle    | `PortalToolbar.tsx` (line 107)           | Drag state with elevation + scale, no accent     |
 | Inline Rename Input   | `TabButton.tsx` (line 274)               | Neutral border with accent focus outline only    |

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -191,7 +191,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
         className={cn(
           "group h-3 cursor-ns-resize transition-colors flex items-center justify-center",
           "hover:bg-overlay-soft focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",
-          isResizing && "bg-daintree-accent/20"
+          isResizing && "bg-overlay-medium"
         )}
         onMouseDown={handleResizeStart}
         onKeyDown={handleKeyDown}
@@ -208,7 +208,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
             "w-10 h-px rounded-full transition-[height] duration-150 delay-100 group-hover:h-0.5",
             "bg-daintree-text/15",
             "group-hover:bg-daintree-text/30 group-focus-visible:bg-daintree-accent",
-            isResizing && "bg-daintree-accent"
+            isResizing && "bg-daintree-text/50"
           )}
         />
       </div>

--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -27,7 +27,7 @@ export function DockPlaceholder({ className }: DockPlaceholderProps) {
     <div
       className={cn(
         "flex flex-col gap-1 px-3 py-2 min-w-[120px] h-full",
-        "rounded border border-daintree-accent/30 bg-daintree-accent/5",
+        "rounded border border-border-strong bg-overlay-subtle",
         className
       )}
       aria-hidden="true"

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -28,7 +28,7 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
     <div
       className={cn(
         "h-full w-full rounded flex flex-col overflow-hidden",
-        "border border-daintree-accent/40 bg-daintree-accent/5",
+        "border border-border-strong bg-overlay-subtle",
         "animate-in fade-in duration-200",
         className
       )}
@@ -38,13 +38,13 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
       <div
         className={cn(
           "flex items-center gap-2 px-3 h-7 shrink-0 font-mono text-xs",
-          "bg-daintree-accent/10 border-b border-daintree-accent/10"
+          "bg-overlay-subtle border-b border-border-strong/30"
         )}
       >
-        <span className="shrink-0 flex items-center justify-center text-daintree-accent/80">
+        <span className="shrink-0 flex items-center justify-center text-daintree-text/50">
           <TerminalIcon kind={kind} chrome={chrome} className="w-3.5 h-3.5" />
         </span>
-        <span className="font-medium text-daintree-accent/80 truncate opacity-80">{title}</span>
+        <span className="font-medium text-daintree-text/60 truncate">{title}</span>
       </div>
 
       {/* Panel-specific placeholder body */}

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -38,7 +38,7 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
       <div
         className={cn(
           "flex items-center gap-2 px-3 h-7 shrink-0 font-mono text-xs",
-          "bg-overlay-subtle border-b border-border-strong/30"
+          "bg-overlay-medium border-b border-border-strong/30"
         )}
       >
         <span className="shrink-0 flex items-center justify-center text-daintree-text/50">

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -88,7 +88,7 @@ export function SortableTerminal({
         style={sortableStyle}
         className={cn(
           "h-full min-w-0 contain-layout contain-style",
-          isDragging && "opacity-40 ring-2 ring-daintree-accent/50 rounded"
+          isDragging && "opacity-40 ring-2 ring-daintree-text/20 rounded"
         )}
       >
         <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -38,7 +38,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
             position: "absolute",
             top: -8,
             right: -8,
-            backgroundColor: "var(--color-daintree-accent)",
+            backgroundColor: "var(--color-daintree-text)",
             color: "var(--color-daintree-bg)",
             borderRadius: "9999px",
             padding: "2px 6px",

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1228,7 +1228,7 @@ export function BulkCreateWorktreeDialog({
                     className="w-8 h-8 rounded-full shrink-0"
                   />
                 ) : (
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-daintree-accent/10 text-daintree-accent">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-overlay-medium text-daintree-text/60">
                     <UserPlus className="w-4 h-4" />
                   </div>
                 )}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -244,8 +244,8 @@ export function HelpPanel() {
         tabIndex={0}
         className={cn(
           "absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10",
-          "hover:bg-daintree-accent/20 active:bg-daintree-accent/30 transition-colors",
-          isResizing && "bg-daintree-accent/30"
+          "hover:bg-overlay-soft active:bg-overlay-medium transition-colors",
+          isResizing && "bg-overlay-medium"
         )}
         onMouseDown={handleResizeStart}
         onKeyDown={handleResizeKeyDown}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -137,7 +137,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             className={cn(
               "group absolute top-0 -right-1.5 w-3 h-full cursor-col-resize flex items-center justify-center z-50",
               "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",
-              isResizing && "bg-daintree-accent/20"
+              isResizing && "bg-overlay-medium"
             )}
             onMouseDown={startResizing}
             onKeyDown={handleKeyDown}
@@ -149,7 +149,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
                 "w-px h-8 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
                 "bg-daintree-text/20",
                 "group-hover:bg-daintree-text/35 group-focus-visible:bg-daintree-accent",
-                isResizing && "bg-daintree-accent"
+                isResizing && "bg-daintree-text/50"
               )}
             />
           </div>

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -403,7 +403,7 @@ export function PortalDock() {
             className={cn(
               "group absolute -left-1.5 top-0 bottom-0 w-3 cursor-col-resize flex items-center justify-center z-50",
               "hover:bg-overlay-soft transition-colors focus:outline-hidden focus:bg-tint/[0.04] focus:ring-1 focus:ring-daintree-accent/50",
-              isResizing && "bg-daintree-accent/20"
+              isResizing && "bg-overlay-medium"
             )}
             onMouseDown={handleResizeStart}
             onKeyDown={handleKeyDown}
@@ -413,7 +413,7 @@ export function PortalDock() {
                 "w-px h-8 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
                 "bg-daintree-text/20",
                 "group-hover:bg-daintree-text/35 group-focus:bg-daintree-accent",
-                isResizing && "bg-daintree-accent"
+                isResizing && "bg-daintree-text/50"
               )}
             />
           </div>

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -235,8 +235,8 @@ export function CrashRecoveryDialog({
               className="cursor-pointer flex items-start gap-3 p-3 rounded-lg border border-daintree-border hover:border-daintree-accent hover:bg-overlay-soft text-left transition-colors disabled:opacity-50 disabled:pointer-events-none"
               data-testid="restore-button"
             >
-              <div className="mt-0.5 h-5 w-5 rounded-full bg-daintree-accent/20 flex items-center justify-center shrink-0">
-                <div className="h-2 w-2 rounded-full bg-daintree-accent" />
+              <div className="mt-0.5 h-5 w-5 rounded-full bg-overlay-medium flex items-center justify-center shrink-0">
+                <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
               </div>
               <div>
                 <div className="text-sm font-medium text-daintree-text">

--- a/src/components/Terminal/TwoPaneSplitDivider.tsx
+++ b/src/components/Terminal/TwoPaneSplitDivider.tsx
@@ -179,7 +179,7 @@ export function TwoPaneSplitDivider({
       className={cn(
         "group cursor-col-resize flex items-center justify-center z-10 shrink-0",
         "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",
-        isDragging && "bg-daintree-accent/20"
+        isDragging && "bg-overlay-medium"
       )}
       style={{ width: DIVIDER_WIDTH_PX }}
       onMouseDown={handleMouseDown}
@@ -191,7 +191,7 @@ export function TwoPaneSplitDivider({
           "w-px h-16 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
           "bg-daintree-text/20",
           "group-hover:bg-daintree-text/35 group-focus-visible:bg-daintree-accent",
-          isDragging && "bg-daintree-accent"
+          isDragging && "bg-daintree-text/50"
         )}
       />
     </div>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -870,8 +870,8 @@ export function NewWorktreeDialog({
         ) : (
           <div className="space-y-4">
             {initialPR ? (
-              <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-daintree-accent/5 border border-daintree-accent/20 text-sm min-w-0">
-                <FolderGit2 className="w-4 h-4 text-daintree-accent shrink-0" aria-hidden="true" />
+              <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-strong text-sm min-w-0">
+                <FolderGit2 className="w-4 h-4 text-daintree-text/60 shrink-0" aria-hidden="true" />
                 <TruncatedTooltip content={`PR #${initialPR.number} — ${initialPR.title}`}>
                   <span className="text-daintree-text/80 min-w-0 truncate">
                     PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
@@ -920,7 +920,7 @@ export function NewWorktreeDialog({
                     className="w-8 h-8 rounded-full shrink-0"
                   />
                 ) : (
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-daintree-accent/10 text-daintree-accent">
+                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-overlay-medium text-daintree-text/60">
                     <UserPlus className="w-4 h-4" />
                   </div>
                 )}

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -448,7 +448,7 @@ export function WorktreeTerminalSection({
               {marqueeBox && (
                 <div
                   aria-hidden
-                  className="pointer-events-none absolute z-10 rounded border border-daintree-accent/60 bg-daintree-accent/10"
+                  className="pointer-events-none absolute z-10 rounded border border-border-strong bg-overlay-medium"
                   style={{
                     left: marqueeBox.x,
                     top: marqueeBox.y,

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -155,8 +155,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
   "#5984": [
     "src/components/GitHub/BulkCreateWorktreeDialog.tsx",
     "src/components/Worktree/NewWorktreeDialog.tsx",
-    "src/components/DragDrop/DockPlaceholder.tsx",
-    "src/components/DragDrop/GridPlaceholder.tsx",
   ],
 
   // #5985: [panels] Exit Focus badge competes with macro-focus ring
@@ -187,7 +185,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/GitHub/GitHubDropdownSkeletons.tsx",
     "src/components/GitHub/GitHubListItem.tsx",
     "src/components/GitHub/GitHubResourceList.tsx",
-    "src/components/HelpPanel/HelpPanel.tsx",
     "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx",
     "src/components/LogLevelPalette/LogLevelPalette.tsx",
     "src/components/Notifications/NotificationCenterEntry.tsx",
@@ -273,7 +270,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Worktree/WorktreePalette.tsx",
     "src/hooks/useUpdateListener.tsx",
     "src/components/agents/AgentCard.tsx",
-    "src/components/DragDrop/SortableTerminal.tsx",
     "src/components/GitHub/CommitList.tsx",
     "src/components/Layout/ContentDock.tsx",
     "src/components/Layout/DockedTabGroup.tsx",


### PR DESCRIPTION
## Summary

- Removes accent from all drag and resize feedback — drag handles, drop placeholders, resize dividers, multi-step dialog step circles, drag ghost ring, and group badge — replacing them with neutral overlay tokens (`bg-overlay-medium`, `bg-overlay-subtle`, `border-border-strong`, etc.)
- Keyboard-focus accent paths are left unchanged throughout; those are the one load-bearing signal they're supposed to be
- `accentGuard` contract test allowlist tightened to match; recipe doc line references updated

Resolves #6219

## Changes

- `Layout/Sidebar.tsx` — resize handle hover/active tint and active stripe now neutral
- `Terminal/TwoPaneSplitDivider.tsx` — drag-state feedback neutral; keyboard-focus accent preserved
- `Portal/PortalDock.tsx` — same pattern
- `Diagnostics/DiagnosticsDock.tsx` — same pattern
- `HelpPanel/HelpPanel.tsx` — resize handle neutral
- `DragDrop/DockPlaceholder.tsx` and `GridPlaceholder.tsx` — drop placeholder borders and backgrounds now neutral
- `Worktree/WorktreeCard/WorktreeTerminalSection.tsx` — drag-over highlight neutral
- `DragDrop/SortableTerminal.tsx` — drag ghost ring switched from accent to neutral
- `DragDrop/TerminalDragPreview.tsx` — group badge background switched to neutral
- `Worktree/NewWorktreeDialog.tsx` and `GitHub/BulkCreateWorktreeDialog.tsx` — step circles neutral
- `Recovery/CrashRecoveryDialog.tsx` — confirmation circle neutral
- `src/config/__tests__/accentGuard.contract.test.ts` — allowlist tightened
- `docs/themes/interaction-state-recipes.md` — line refs updated

## Testing

Ran `npm run check` (typecheck, lint, format) and `vitest` — all pass. Visually verified drag handles, drop zones, and resize dividers render with neutral tones; keyboard-focus ring stays accent throughout.