### PR TITLE
fix(accent-restraint): neutralize multi-select rows, segmented toggles, and type chips

### DIFF
--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -219,7 +219,7 @@ export function CommandPicker({
               <div className="flex items-center justify-between">
                 <span className="font-mono text-sm text-daintree-text/90">/{cmd.id}</span>
                 {cmd.hasBuilder && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-daintree-accent/20 text-daintree-accent">
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-overlay-medium text-daintree-text/70">
                     Builder
                   </span>
                 )}

--- a/src/components/GitHub/GitHubDropdownSkeletons.tsx
+++ b/src/components/GitHub/GitHubDropdownSkeletons.tsx
@@ -80,9 +80,7 @@ export function GitHubResourceListSkeleton({
               key={tab.id}
               className={cn(
                 "flex-1 px-3 py-1 text-xs font-medium rounded text-center",
-                tab.id === "open"
-                  ? "bg-overlay-medium text-daintree-text"
-                  : "text-muted-foreground"
+                tab.id === "open" ? "bg-overlay-medium text-daintree-text" : "text-muted-foreground"
               )}
             >
               {tab.label}

--- a/src/components/GitHub/GitHubDropdownSkeletons.tsx
+++ b/src/components/GitHub/GitHubDropdownSkeletons.tsx
@@ -81,7 +81,7 @@ export function GitHubResourceListSkeleton({
               className={cn(
                 "flex-1 px-3 py-1 text-xs font-medium rounded text-center",
                 tab.id === "open"
-                  ? "bg-daintree-accent/10 text-daintree-accent"
+                  ? "bg-overlay-medium text-daintree-text"
                   : "text-muted-foreground"
               )}
             >

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -944,7 +944,7 @@ export function GitHubResourceList({
                     className={cn(
                       "flex items-center gap-2 px-2 py-1 text-xs rounded",
                       sortOrder === option.value
-                        ? "bg-daintree-accent/10 text-daintree-accent"
+                        ? "bg-overlay-soft text-daintree-text"
                         : "text-daintree-text/70 hover:bg-overlay-medium"
                     )}
                   >
@@ -952,7 +952,7 @@ export function GitHubResourceList({
                       className={cn(
                         "w-3 h-3 rounded-full border",
                         sortOrder === option.value
-                          ? "border-daintree-accent bg-daintree-accent"
+                          ? "border-daintree-text bg-daintree-text"
                           : "border-daintree-border"
                       )}
                     >
@@ -1029,7 +1029,7 @@ export function GitHubResourceList({
                 className={cn(
                   "flex-1 px-3 py-1 text-xs font-medium rounded transition-colors",
                   isActive
-                    ? "bg-daintree-accent/10 text-daintree-accent"
+                    ? "bg-overlay-medium text-daintree-text"
                     : "text-muted-foreground hover:text-daintree-text"
                 )}
               >

--- a/src/components/LogLevelPalette/LogLevelPalette.tsx
+++ b/src/components/LogLevelPalette/LogLevelPalette.tsx
@@ -160,7 +160,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
                 className={cn(
                   "text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded",
                   isSelected
-                    ? "bg-daintree-accent/20 text-daintree-accent"
+                    ? "bg-overlay-medium text-daintree-text/70"
                     : "bg-daintree-border/60 text-daintree-text/70"
                 )}
               >

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -50,7 +50,7 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
             className={cn(
               "shrink-0 px-1.5 py-0.5 text-xs rounded-[var(--radius-sm)] border",
               item.type === "terminal"
-                ? "bg-daintree-accent/10 text-daintree-accent border-daintree-accent/30"
+                ? "bg-overlay-medium text-daintree-text/70 border-border-strong"
                 : "bg-status-success/10 text-status-success border-status-success/30"
             )}
           >

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -59,7 +59,7 @@ function PreferredSchemePicker({
             className={cn(
               "flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] border text-xs transition-colors",
               selectedId === scheme.id
-                ? "border-daintree-accent/30 bg-daintree-accent/10 text-daintree-text"
+                ? "border-border-strong bg-overlay-medium text-daintree-text"
                 : "border-daintree-border text-daintree-text/70 hover:bg-surface-hover"
             )}
           >

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -285,10 +285,10 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
               key={mode}
               onClick={() => setFilterMode(mode)}
               className={cn(
-                "px-3 py-1.5 text-xs font-medium rounded transition-colors capitalize",
+                "px-3 py-1.5 text-xs font-medium rounded transition-colors capitalize border",
                 filterMode === mode
-                  ? "bg-daintree-accent text-daintree-bg"
-                  : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
+                  ? "border-border-strong bg-overlay-medium text-daintree-text"
+                  : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
               )}
             >
               {mode}
@@ -323,7 +323,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
               className={cn(
                 "rounded-[var(--radius-md)] border transition-colors",
                 hasOverride(command.id)
-                  ? "border-daintree-accent/30 bg-daintree-accent/5"
+                  ? "border-border-strong bg-overlay-subtle"
                   : "border-daintree-border bg-daintree-bg"
               )}
             >
@@ -356,7 +356,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                       {command.id}
                     </span>
                     {hasOverride(command.id) && (
-                      <span className="text-[11px] text-daintree-accent bg-daintree-accent/10 px-1.5 py-0.5 rounded font-medium">
+                      <span className="text-[11px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded font-medium">
                         {override?.prompt ? "Custom Prompt" : "Modified"}
                       </span>
                     )}
@@ -425,10 +425,10 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                         <button
                           onClick={() => setOverrideMode(command.id, "defaults")}
                           className={cn(
-                            "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                            "px-3 py-1.5 text-xs font-medium rounded-md transition-colors border",
                             currentMode === "defaults"
-                              ? "bg-daintree-accent text-daintree-bg"
-                              : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
+                              ? "border-border-strong bg-overlay-medium text-daintree-text"
+                              : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
                           )}
                         >
                           Default Values
@@ -437,10 +437,10 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                       <button
                         onClick={() => setOverrideMode(command.id, "prompt")}
                         className={cn(
-                          "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                          "px-3 py-1.5 text-xs font-medium rounded-md transition-colors border",
                           currentMode === "prompt"
-                            ? "bg-daintree-accent text-daintree-bg"
-                            : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
+                            ? "border-border-strong bg-overlay-medium text-daintree-text"
+                            : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
                         )}
                       >
                         Custom Prompt
@@ -472,7 +472,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                                   )}
                                 </label>
                                 {hasDefaultValue && (
-                                  <span className="text-[10px] text-daintree-accent bg-daintree-accent/10 px-1.5 py-0.5 rounded">
+                                  <span className="text-[10px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded">
                                     Custom
                                   </span>
                                 )}
@@ -564,7 +564,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
                       className={cn(
                         "text-[11px] px-2 py-0.5 rounded font-mono transition-colors",
                         usedVariables.includes(arg.name)
-                          ? "bg-daintree-accent/20 text-daintree-accent border border-daintree-accent/30"
+                          ? "bg-overlay-medium text-daintree-text/70 border border-border-strong"
                           : "bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border border border-daintree-border"
                       )}
                     >

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -366,7 +366,7 @@ export function NotificationSettingsTab() {
                           className={cn(
                             "px-2.5 py-1 text-xs rounded-[var(--radius-md)] border transition-colors",
                             active
-                              ? "border-daintree-accent bg-daintree-accent/10 text-daintree-text"
+                              ? "border-border-strong bg-overlay-medium text-daintree-text"
                               : "border-daintree-border bg-daintree-bg text-daintree-text/50 hover:text-daintree-text/80"
                           )}
                           aria-pressed={active}

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -191,7 +191,7 @@ function IconPickerButton({ currentIcon, onChange }: IconPickerButtonProps) {
                 className={cn(
                   "p-2 rounded flex items-center justify-center transition-colors",
                   isSelected
-                    ? "bg-daintree-accent/20 border border-daintree-accent"
+                    ? "bg-overlay-medium border border-border-strong"
                     : "hover:bg-surface-hover border border-transparent"
                 )}
                 title={label}

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -31,7 +31,7 @@ interface SettingsChoiceboxProps<T extends string = string> extends Omit<
 const CARD_BASE_CLASSES =
   "flex-1 px-3 py-2 rounded-[var(--radius-md)] border text-sm text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 
-const CARD_SELECTED_CLASSES = "border-daintree-accent bg-daintree-accent/10 text-daintree-text";
+const CARD_SELECTED_CLASSES = "border-border-strong bg-overlay-medium text-daintree-text";
 
 const CARD_UNSELECTED_CLASSES =
   "border-daintree-border bg-daintree-bg text-text-secondary hover:border-daintree-text/30 hover:text-daintree-text disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-daintree-border disabled:hover:text-text-secondary";

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -221,7 +221,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
               <div
                 className={`flex items-center gap-3 w-full px-3 py-2 rounded-[var(--radius-md)] border transition-colors ${
                   isInstalling
-                    ? "bg-daintree-accent/5 border-daintree-accent/30"
+                    ? "bg-overlay-soft border-border-strong"
                     : isInstalled
                       ? "bg-status-success/5 border-status-success/20"
                       : isError

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -68,7 +68,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
                     className={cn(
                       "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
                       idx === selectedIndex
-                        ? "bg-daintree-accent/20 text-daintree-text"
+                        ? "bg-overlay-soft text-daintree-text"
                         : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
                     )}
                     onMouseDown={(e) => e.preventDefault()}

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -67,7 +67,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
         className={cn(
           "flex items-center justify-between gap-2 px-3 py-2 rounded-[var(--radius-md)] cursor-pointer text-sm",
           isSelected
-            ? "bg-daintree-accent/15 text-daintree-text"
+            ? "bg-overlay-soft text-daintree-text"
             : "text-daintree-text/80 hover:bg-daintree-sidebar"
         )}
         onClick={() => selectEntry(item)}

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -266,7 +266,7 @@ function TerminalHeaderContentComponent({
         <Tooltip>
           <TooltipTrigger asChild>
             <div
-              className="inline-flex items-center gap-1 text-xs font-sans bg-daintree-accent/15 text-daintree-text px-1.5 py-0.5 rounded ml-1"
+              className="inline-flex items-center gap-1 text-xs font-sans bg-overlay-medium text-daintree-text px-1.5 py-0.5 rounded ml-1"
               role="status"
               aria-live="polite"
             >

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -37,9 +37,10 @@ function ThemeListItem({
       role="option"
       aria-selected={isSelected}
       className={cn(
-        "w-full text-left px-3 py-2 rounded-[var(--radius-md)] border flex items-center gap-3 transition-colors",
+        "relative w-full text-left px-3 py-2 rounded-[var(--radius-md)] border flex items-center gap-3 transition-colors",
         "border-daintree-border/40 hover:border-daintree-border/60 hover:bg-surface",
-        isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
+        isSelected &&
+          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
       )}
     >
       <PaletteStrip scheme={scheme} />

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -42,7 +42,7 @@ function IssueOptionRow({ issue, isSelected, isCurrentlyAttached, onClick }: Iss
         className={cn(
           "w-full text-left px-3 py-2.5 rounded-[var(--radius-md)] transition-colors flex items-start gap-3",
           isSelected
-            ? "bg-daintree-accent/10 border border-daintree-accent/30"
+            ? "bg-overlay-soft border border-border-strong"
             : "hover:bg-tint/5 border border-transparent",
           isCurrentlyAttached && "ring-1 ring-status-success/30"
         )}
@@ -205,8 +205,8 @@ export function IssuePickerDialog({
               className={cn(
                 "px-3 py-1 text-xs rounded-full transition-colors capitalize",
                 stateFilter === state
-                  ? "bg-daintree-accent/20 text-daintree-accent"
-                  : "text-daintree-text/50 hover:text-daintree-text/80 hover:bg-tint/5"
+                  ? "bg-overlay-medium text-daintree-text border border-border-strong"
+                  : "border border-transparent text-daintree-text/50 hover:text-daintree-text/80 hover:bg-tint/5"
               )}
             >
               {state}

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -36,10 +36,11 @@ function RecipeListItem({
         id={`quick-create-option-${item.id}`}
         onClick={onClick}
         className={cn(
-          "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex items-center gap-2",
+          "relative w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex items-center gap-2",
           "border-daintree-border/40 hover:border-daintree-border/60",
           "bg-daintree-bg hover:bg-surface transition-colors",
-          isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
+          isSelected &&
+            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
         )}
         aria-selected={isSelected}
         role="option"
@@ -62,10 +63,11 @@ function RecipeListItem({
       id={`quick-create-option-${recipe.id}`}
       onClick={onClick}
       className={cn(
-        "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
+        "relative w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
         "border-daintree-border/40 hover:border-daintree-border/60",
         "bg-daintree-bg hover:bg-surface transition-colors",
-        isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
+        isSelected &&
+          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
       )}
       aria-selected={isSelected}
       role="option"
@@ -76,7 +78,7 @@ function RecipeListItem({
           {uniqueTypes.map((type) => (
             <span
               key={type}
-              className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-daintree-accent/10 text-daintree-text/60 text-[11px]"
+              className="px-1.5 py-0.5 rounded-[var(--radius-md)] bg-overlay-medium text-daintree-text/70 text-[11px]"
             >
               {type}
             </span>

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -275,7 +275,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                     className={cn(
                       "flex items-center gap-2 px-2 py-1 text-xs rounded",
                       orderBy === option.value
-                        ? "bg-daintree-accent/10 text-daintree-accent"
+                        ? "bg-overlay-soft text-daintree-text"
                         : "text-daintree-text/70 hover:bg-overlay-medium"
                     )}
                   >
@@ -283,7 +283,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                       className={cn(
                         "w-3 h-3 rounded-full border",
                         orderBy === option.value
-                          ? "border-daintree-accent bg-daintree-accent"
+                          ? "border-daintree-text bg-daintree-text"
                           : "border-daintree-border"
                       )}
                     >

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -24,10 +24,11 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         id={`worktree-option-${worktree.id}`}
         onClick={onClick}
         className={cn(
-          "w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
+          "relative w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
           "border-daintree-border/40 hover:border-daintree-border/60",
           "bg-daintree-bg hover:bg-surface transition-colors",
-          isSelected && "border-daintree-accent/60 bg-daintree-accent/10"
+          isSelected &&
+            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
         )}
         aria-selected={isSelected}
         role="option"

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -98,7 +98,7 @@ function collectSourceFiles(dir: string): string[] {
 // Legitimate accent usage that will persist after all cleanup PRs land.
 // Each entry must carry a brief rationale.
 const DURABLE_ALLOWLIST = new Set([
-  // Theme picker swatch data (theme content, not app chrome)
+  // Text-link CTAs (Change theme, Reset, Export, Import, Random theme) — separate cleanup
   "src/components/Settings/AppThemePicker.tsx",
 
   // Theme browser accent display (theme content, not app chrome)
@@ -184,12 +184,10 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Fleet/FleetArmingDialog.tsx",
     "src/components/Fleet/FleetArmingRibbon.tsx",
     "src/components/GitHub/BulkActionBar.tsx",
-    "src/components/GitHub/GitHubDropdownSkeletons.tsx",
     "src/components/GitHub/GitHubListItem.tsx",
     "src/components/GitHub/GitHubResourceList.tsx",
     "src/components/HelpPanel/HelpPanel.tsx",
     "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx",
-    "src/components/LogLevelPalette/LogLevelPalette.tsx",
     "src/components/Notifications/NotificationCenterEntry.tsx",
     "src/components/PanelPalette/PanelPalette.tsx",
     "src/components/Portal/PortalDock.tsx",
@@ -221,7 +219,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Settings/ImportEnvDialog.tsx",
     "src/components/Settings/KeybindingProfileActions.tsx",
     "src/components/Settings/KeyboardShortcutsTab.tsx",
-    "src/components/Settings/NotificationSettingsTab.tsx",
     "src/components/Settings/PortalSettingsTab.tsx",
     "src/components/Settings/PresetSelector.tsx",
     "src/components/Settings/PrivacyDataTab.tsx",
@@ -240,18 +237,15 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Setup/AgentCliStep.tsx",
     "src/components/Setup/SystemToolsStep.tsx",
     "src/components/Sidebar/SidebarContent.tsx",
-    "src/components/Terminal/AutocompleteMenu.tsx",
     "src/components/Terminal/ContentGrid.tsx",
     "src/components/Terminal/GridNotificationBar.tsx",
     "src/components/Terminal/HybridInputBar.tsx",
     "src/components/Terminal/InlineStatusBanner.tsx",
-    "src/components/Terminal/PromptHistoryPalette.tsx",
     "src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx",
     "src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx",
     "src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx",
     "src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx",
     "src/components/Terminal/SendToAgentPalette.tsx",
-    "src/components/Terminal/TerminalHeaderContent.tsx",
     "src/components/Terminal/TerminalPane.tsx",
     "src/components/Terminal/TerminalRestartStatusBanner.tsx",
     "src/components/Terminal/TwoPaneSplitDivider.tsx",
@@ -261,7 +255,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/TerminalRecipe/RecipeEditor.tsx",
     "src/components/ui/ReEntrySummary.tsx",
     "src/components/ui/toaster.tsx",
-    "src/components/Worktree/IssuePickerDialog.tsx",
     "src/components/Worktree/QuickCreatePalette.tsx",
     "src/components/Worktree/QuickStateFilterBar.tsx",
     "src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx",


### PR DESCRIPTION
## Summary

- Replaced `bg-daintree-accent` fills on multi-select rows, segmented toggle active states, type chips, filter chips, and sort radios with neutral overlay/border tokens (`bg-overlay-soft`, `bg-overlay-medium`, `border-border-strong`), following `interaction-state-recipes.md`
- Pruned 7 files from the accentGuard contract allowlist that are now fully clean
- Updated AppThemePicker allowlist rationale (text-link CTAs are separate cleanup)

Resolves #6217

## Changes

- `WorktreePalette`, `QuickCreatePalette`, `IssuePickerDialog` — selected rows and filter chips use neutral overlay lift instead of accent fill
- `Settings/CommandOverridesTab` — segmented toggle active state, variable pills switched to overlay-medium
- `Settings/AppThemePicker`, `Settings/ResourceEnvironmentsSection`, `Settings/NotificationSettingsTab`, `Settings/SettingsChoicebox` — selected states use overlay/border tokens
- `QuickSwitcher/QuickSwitcherItem`, `Commands/CommandPicker`, `Terminal/TerminalHeaderContent` — type chips use `bg-overlay-medium text-daintree-text`
- `Terminal/AutocompleteMenu`, `Terminal/PromptHistoryPalette`, `LogLevelPalette`, `Setup/AgentCliStep`, `GitHub/GitHubResourceList`, `GitHub/GitHubDropdownSkeletons`, `WorktreeFilterPopover` — accent fills replaced with neutral tokens
- accentGuard contract test: 7 files removed from allowlist, all now fully clean

## Testing

- accentGuard contract: 57 tests pass
- Full vitest run: 1264 tests pass
- `tsc --noEmit`: clean
- ESLint: no errors
- Production build: successful