### PR TITLE
fix(error-boundary): add boundaries around ContentGrid, palettes, and sidebar dialogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ Central orchestration layer for all UI operations. Provides a unified, typed API
 
 Discriminated union types for type safety:
 
-- `PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData | DevPreviewPanelData` (`shared/types/panel.ts`)
-- Built-in panel kinds: `"terminal"` | `"agent"` | `"browser"` | `"notes"` | `"dev-preview"`
+- `PanelInstance = PtyPanelData | BrowserPanelData | DevPreviewPanelData` (`shared/types/panel.ts`)
+- Built-in panel kinds: `"terminal"` | `"browser"` | `"dev-preview"`
 - `panelKindHasPty(kind)` — Check if panel requires PTY process
 - Panel Kind Registry (`shared/config/panelKindRegistry.ts`) — config/metadata shared between processes
 - Panel Kind Modules (`src/panels/<kind>/`) — per-kind serializer, defaults factory, and component. Unified registry in `src/panels/registry.tsx`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -501,35 +501,47 @@ function App() {
                   isHydrated={isStateLoaded}
                   projectSwitcherPalette={projectSwitcherPalette}
                 >
-                  <Profiler id="content-grid" onRender={onContentGridRender}>
-                    <ContentGrid
-                      className="h-full w-full"
-                      agentAvailability={availability}
-                      defaultCwd={defaultTerminalCwd}
-                      emptyContent={
-                        currentProject === null ? (
-                          <WelcomeScreen gettingStarted={gettingStarted} />
-                        ) : undefined
-                      }
-                    />
-                  </Profiler>
+                  <ErrorBoundary
+                    variant="section"
+                    componentName="ContentGrid"
+                    resetKeys={[currentProject?.id].filter((k): k is string => k != null)}
+                  >
+                    <Profiler id="content-grid" onRender={onContentGridRender}>
+                      <ContentGrid
+                        className="h-full w-full"
+                        agentAvailability={availability}
+                        defaultCwd={defaultTerminalCwd}
+                        emptyContent={
+                          currentProject === null ? (
+                            <WelcomeScreen gettingStarted={gettingStarted} />
+                          ) : undefined
+                        }
+                      />
+                    </Profiler>
+                  </ErrorBoundary>
                 </AppLayout>
               </Profiler>
             </DndProvider>
 
-            <QuickSwitcher
-              isOpen={quickSwitcher.isOpen}
-              query={quickSwitcher.query}
-              results={quickSwitcher.results}
-              totalResults={quickSwitcher.totalResults}
-              selectedIndex={quickSwitcher.selectedIndex}
-              close={quickSwitcher.close}
-              setQuery={quickSwitcher.setQuery}
-              selectPrevious={quickSwitcher.selectPrevious}
-              selectNext={quickSwitcher.selectNext}
-              selectItem={quickSwitcher.selectItem}
-              confirmSelection={quickSwitcher.confirmSelection}
-            />
+            <ErrorBoundary
+              variant="component"
+              componentName="QuickSwitcher"
+              resetKeys={[Number(quickSwitcher.isOpen)]}
+            >
+              <QuickSwitcher
+                isOpen={quickSwitcher.isOpen}
+                query={quickSwitcher.query}
+                results={quickSwitcher.results}
+                totalResults={quickSwitcher.totalResults}
+                selectedIndex={quickSwitcher.selectedIndex}
+                close={quickSwitcher.close}
+                setQuery={quickSwitcher.setQuery}
+                selectPrevious={quickSwitcher.selectPrevious}
+                selectNext={quickSwitcher.selectNext}
+                selectItem={quickSwitcher.selectItem}
+                confirmSelection={quickSwitcher.confirmSelection}
+              />
+            </ErrorBoundary>
             <SendToAgentPalette
               isOpen={sendToAgentPalette.isOpen}
               query={sendToAgentPalette.query}
@@ -571,91 +583,97 @@ function App() {
               onClose={worktreePalette.close}
             />
             <QuickCreatePalette palette={quickCreatePalette} />
-            <PanelPalette
-              isOpen={panelPalette.isOpen}
-              query={panelPalette.query}
-              results={panelPalette.results}
-              totalResults={panelPalette.totalResults}
-              selectedIndex={panelPalette.selectedIndex}
-              matchesById={panelPalette.matchesById}
-              onQueryChange={panelPalette.setQuery}
-              onSelectPrevious={panelPalette.selectPrevious}
-              onSelectNext={panelPalette.selectNext}
-              onSelect={(kind) => {
-                const result = panelPalette.handleSelect(kind);
-                if (!result) return;
-                if (result.resumeSession) {
-                  const session = result.resumeSession;
-                  const agentConfig = getEffectiveAgentConfig(session.agentId);
-                  const command = buildResumeCommand(
-                    session.agentId,
-                    session.sessionId,
-                    session.agentLaunchFlags
-                  );
-                  if (command && agentConfig) {
+            <ErrorBoundary
+              variant="component"
+              componentName="PanelPalette"
+              resetKeys={[Number(panelPalette.isOpen)]}
+            >
+              <PanelPalette
+                isOpen={panelPalette.isOpen}
+                query={panelPalette.query}
+                results={panelPalette.results}
+                totalResults={panelPalette.totalResults}
+                selectedIndex={panelPalette.selectedIndex}
+                matchesById={panelPalette.matchesById}
+                onQueryChange={panelPalette.setQuery}
+                onSelectPrevious={panelPalette.selectPrevious}
+                onSelectNext={panelPalette.selectNext}
+                onSelect={(kind) => {
+                  const result = panelPalette.handleSelect(kind);
+                  if (!result) return;
+                  if (result.resumeSession) {
+                    const session = result.resumeSession;
+                    const agentConfig = getEffectiveAgentConfig(session.agentId);
+                    const command = buildResumeCommand(
+                      session.agentId,
+                      session.sessionId,
+                      session.agentLaunchFlags
+                    );
+                    if (command && agentConfig) {
+                      addPanel({
+                        kind: "terminal",
+                        launchAgentId: session.agentId,
+                        title: agentConfig.name,
+                        cwd: defaultTerminalCwd,
+                        worktreeId: activeWorktreeId ?? undefined,
+                        command,
+                        location: "grid",
+                      });
+                    }
+                  } else if (result.id.startsWith("agent:")) {
+                    const agentId = result.id.slice("agent:".length);
+                    if (agentId) {
+                      launchAgent(agentId);
+                    }
+                  } else {
                     addPanel({
-                      kind: "terminal",
-                      launchAgentId: session.agentId,
-                      title: agentConfig.name,
+                      kind: result.id as BuiltInPanelKind,
                       cwd: defaultTerminalCwd,
                       worktreeId: activeWorktreeId ?? undefined,
-                      command,
                       location: "grid",
                     });
                   }
-                } else if (result.id.startsWith("agent:")) {
-                  const agentId = result.id.slice("agent:".length);
-                  if (agentId) {
-                    launchAgent(agentId);
-                  }
-                } else {
-                  addPanel({
-                    kind: result.id as BuiltInPanelKind,
-                    cwd: defaultTerminalCwd,
-                    worktreeId: activeWorktreeId ?? undefined,
-                    location: "grid",
-                  });
-                }
-              }}
-              onConfirm={() => {
-                const selected = panelPalette.confirmSelection();
-                if (!selected) return;
-                if (selected.id === MORE_AGENTS_PANEL_ID) return;
-                if (selected.resumeSession) {
-                  const session = selected.resumeSession;
-                  const agentConfig = getEffectiveAgentConfig(session.agentId);
-                  const command = buildResumeCommand(
-                    session.agentId,
-                    session.sessionId,
-                    session.agentLaunchFlags
-                  );
-                  if (command && agentConfig) {
+                }}
+                onConfirm={() => {
+                  const selected = panelPalette.confirmSelection();
+                  if (!selected) return;
+                  if (selected.id === MORE_AGENTS_PANEL_ID) return;
+                  if (selected.resumeSession) {
+                    const session = selected.resumeSession;
+                    const agentConfig = getEffectiveAgentConfig(session.agentId);
+                    const command = buildResumeCommand(
+                      session.agentId,
+                      session.sessionId,
+                      session.agentLaunchFlags
+                    );
+                    if (command && agentConfig) {
+                      addPanel({
+                        kind: "terminal",
+                        launchAgentId: session.agentId,
+                        title: agentConfig.name,
+                        cwd: defaultTerminalCwd,
+                        worktreeId: activeWorktreeId ?? undefined,
+                        command,
+                        location: "grid",
+                      });
+                    }
+                  } else if (selected.id.startsWith("agent:")) {
+                    const agentId = selected.id.slice("agent:".length);
+                    if (agentId) {
+                      launchAgent(agentId);
+                    }
+                  } else {
                     addPanel({
-                      kind: "terminal",
-                      launchAgentId: session.agentId,
-                      title: agentConfig.name,
+                      kind: selected.id as BuiltInPanelKind,
                       cwd: defaultTerminalCwd,
                       worktreeId: activeWorktreeId ?? undefined,
-                      command,
                       location: "grid",
                     });
                   }
-                } else if (selected.id.startsWith("agent:")) {
-                  const agentId = selected.id.slice("agent:".length);
-                  if (agentId) {
-                    launchAgent(agentId);
-                  }
-                } else {
-                  addPanel({
-                    kind: selected.id as BuiltInPanelKind,
-                    cwd: defaultTerminalCwd,
-                    worktreeId: activeWorktreeId ?? undefined,
-                    location: "grid",
-                  });
-                }
-              }}
-              onClose={panelPalette.close}
-            />
+                }}
+                onClose={panelPalette.close}
+              />
+            </ErrorBoundary>
             <ProjectMruSwitcherOverlay
               isVisible={mruSwitcher.isVisible}
               projects={mruSwitcher.projects}
@@ -705,19 +723,25 @@ function App() {
 
             <LogLevelPalette isOpen={isLogLevelPaletteOpen} onClose={closeLogLevelPalette} />
 
-            <ActionPalette
-              isOpen={actionPalette.isOpen}
-              query={actionPalette.query}
-              results={actionPalette.results}
-              totalResults={actionPalette.totalResults}
-              selectedIndex={actionPalette.selectedIndex}
-              close={actionPalette.close}
-              setQuery={actionPalette.setQuery}
-              selectPrevious={actionPalette.selectPrevious}
-              selectNext={actionPalette.selectNext}
-              executeAction={actionPalette.executeAction}
-              confirmSelection={actionPalette.confirmSelection}
-            />
+            <ErrorBoundary
+              variant="component"
+              componentName="ActionPalette"
+              resetKeys={[Number(actionPalette.isOpen)]}
+            >
+              <ActionPalette
+                isOpen={actionPalette.isOpen}
+                query={actionPalette.query}
+                results={actionPalette.results}
+                totalResults={actionPalette.totalResults}
+                selectedIndex={actionPalette.selectedIndex}
+                close={actionPalette.close}
+                setQuery={actionPalette.setQuery}
+                selectPrevious={actionPalette.selectPrevious}
+                selectNext={actionPalette.selectNext}
+                executeAction={actionPalette.executeAction}
+                confirmSelection={actionPalette.confirmSelection}
+              />
+            </ErrorBoundary>
 
             <WorktreeOverviewModal
               isOpen={isWorktreeOverviewOpen}

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -184,4 +184,42 @@ describe("ErrorBoundary", () => {
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({}));
   });
+
+  it("resets error state when numeric resetKeys change", () => {
+    let key = 0;
+    let shouldThrow = true;
+
+    function ConditionalNumericThrow({ resetKey }: { resetKey: number }) {
+      if (shouldThrow) throw new Error(`Test error at key ${resetKey}`);
+      return <div>Recovered at key {resetKey}</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary variant="component" resetKeys={[key]}>
+        <ConditionalNumericThrow resetKey={key} />
+      </ErrorBoundary>
+    );
+
+    // DEV mode shows the actual error message for component variant
+    expect(screen.getByText("Test error at key 0")).toBeTruthy();
+
+    // Same key, still throwing — boundary stays in error state
+    rerender(
+      <ErrorBoundary variant="component" resetKeys={[key]}>
+        <ConditionalNumericThrow resetKey={key} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Test error at key 0")).toBeTruthy();
+
+    // Change key (simulating dialog close → reopen) and stop throwing
+    key = 1;
+    shouldThrow = false;
+    rerender(
+      <ErrorBoundary variant="component" resetKeys={[key]}>
+        <ConditionalNumericThrow resetKey={key} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Recovered at key 1")).toBeTruthy();
+  });
 });

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1115,49 +1115,79 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
       </div>
 
-      <RecipeEditor
-        recipe={recipeManagerEdit}
-        worktreeId={recipeEditorWorktreeId}
-        initialTerminals={recipeEditorInitialTerminals}
-        defaultScope={recipeEditorDefaultScope}
-        isOpen={isRecipeEditorOpen}
-        onClose={handleCloseRecipeEditor}
-      />
+      <ErrorBoundary
+        variant="component"
+        componentName="RecipeEditor"
+        resetKeys={[Number(isRecipeEditorOpen)]}
+      >
+        <RecipeEditor
+          recipe={recipeManagerEdit}
+          worktreeId={recipeEditorWorktreeId}
+          initialTerminals={recipeEditorInitialTerminals}
+          defaultScope={recipeEditorDefaultScope}
+          isOpen={isRecipeEditorOpen}
+          onClose={handleCloseRecipeEditor}
+        />
+      </ErrorBoundary>
 
-      <RecipeManager
-        isOpen={isRecipeManagerOpen}
-        onClose={handleCloseRecipeManager}
-        onEditRecipe={handleRecipeManagerEdit}
-        onCreateRecipe={handleRecipeManagerCreate}
-      />
+      <ErrorBoundary
+        variant="component"
+        componentName="RecipeManager"
+        resetKeys={[Number(isRecipeManagerOpen)]}
+      >
+        <RecipeManager
+          isOpen={isRecipeManagerOpen}
+          onClose={handleCloseRecipeManager}
+          onEditRecipe={handleRecipeManagerEdit}
+          onCreateRecipe={handleRecipeManagerCreate}
+        />
+      </ErrorBoundary>
 
       {rootPath && (createDialog.isOpen || hasOpenedNewWorktree) && (
-        <Suspense fallback={null}>
-          <LazyNewWorktreeDialog
-            isOpen={createDialog.isOpen}
-            onClose={closeCreateDialog}
-            rootPath={rootPath}
-            onWorktreeCreated={(worktreeId) => {
-              refresh();
-              createDialog.onCreated?.(worktreeId);
-            }}
-            initialIssue={createDialog.initialIssue}
-            initialPR={createDialog.initialPR}
-            initialRecipeId={createDialog.initialRecipeId}
-          />
-        </Suspense>
+        <ErrorBoundary
+          variant="component"
+          componentName="NewWorktreeDialog"
+          resetKeys={[Number(createDialog.isOpen)]}
+        >
+          <Suspense fallback={null}>
+            <LazyNewWorktreeDialog
+              isOpen={createDialog.isOpen}
+              onClose={closeCreateDialog}
+              rootPath={rootPath}
+              onWorktreeCreated={(worktreeId) => {
+                refresh();
+                createDialog.onCreated?.(worktreeId);
+              }}
+              initialIssue={createDialog.initialIssue}
+              initialPR={createDialog.initialPR}
+              initialRecipeId={createDialog.initialRecipeId}
+            />
+          </Suspense>
+        </ErrorBoundary>
       )}
 
-      <BulkCreateWorktreeDialog
-        isOpen={bulkCreateDialog.isOpen}
-        onClose={closeBulkCreateDialog}
-        mode={bulkCreateDialog.mode}
-        selectedIssues={bulkCreateDialog.selectedIssues}
-        selectedPRs={bulkCreateDialog.selectedPRs}
-        onComplete={closeBulkCreateDialog}
-      />
+      <ErrorBoundary
+        variant="component"
+        componentName="BulkCreateWorktreeDialog"
+        resetKeys={[Number(bulkCreateDialog.isOpen)]}
+      >
+        <BulkCreateWorktreeDialog
+          isOpen={bulkCreateDialog.isOpen}
+          onClose={closeBulkCreateDialog}
+          mode={bulkCreateDialog.mode}
+          selectedIssues={bulkCreateDialog.selectedIssues}
+          selectedPRs={bulkCreateDialog.selectedPRs}
+          onComplete={closeBulkCreateDialog}
+        />
+      </ErrorBoundary>
 
-      <FleetArmingDialog isOpen={isFleetArmingDialogOpen} onClose={closeFleetArmingDialog} />
+      <ErrorBoundary
+        variant="component"
+        componentName="FleetArmingDialog"
+        resetKeys={[Number(isFleetArmingDialogOpen)]}
+      >
+        <FleetArmingDialog isOpen={isFleetArmingDialogOpen} onClose={closeFleetArmingDialog} />
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -49,6 +49,10 @@ const LazyDevPreviewPane = lazy(() =>
   import("@/components/DevPreview/DevPreviewPane").then((m) => ({ default: m.DevPreviewPane }))
 );
 
+// Wrapper providing Suspense fallback for the lazy dynamic import and
+// correct componentName attribution on chunk-load failures. The per-panel
+// boundary in GridPanel catches render errors; this wrapper catches import
+// failures with proper attribution — the two boundaries serve different roles.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function BrowserPaneWrapper(props: any) {
   return (


### PR DESCRIPTION
## Summary
- Wraps ContentGrid, three high-risk command palettes, and five sidebar dialogs in ErrorBoundary so a render crash in any one of them does not take down the whole App-level boundary
- resetKeys use `isOpen` for palettes and dialogs, and the project ID for ContentGrid, so recovery is possible on the next open or project switch
- Fixes a stale panel-kinds list in CLAUDE.md (it claimed five but only three are registered) and adds a comment in registry.tsx clarifying that the lazy wrappers serve a different purpose than the GridPanel per-panel boundaries

Resolves #6201

## Changes
- **ContentGrid:** section boundary with project ID as resetKey -- a project switch is a reliable recovery path for state-corruption crashes
- **QuickSwitcher, PanelPalette, ActionPalette:** component boundaries with `isOpen` as resetKey -- closing and reopening the palette resets the error state
- **RecipeEditor, RecipeManager, NewWorktreeDialog, BulkCreateWorktreeDialog, FleetArmingDialog:** component boundaries with `isOpen` as resetKey -- same recovery model
- **CLAUDE.md:** corrected panel-kinds list from five ("terminal", "agent", "browser", "notes", "dev-preview") to the three that are actually registered in `panelKindRegistry.ts`
- **registry.tsx:** added a comment explaining that the lazy wrappers provide Suspense fallbacks for dynamic imports and correct `componentName` attribution on chunk-load failures, distinct from the per-panel render-error boundaries in GridPanel
- **Test:** verifies that numeric resetKeys (as used for `isOpen`) correctly reset the error state when the key changes

## Testing
- Existing ErrorBoundary test suite passes, including the new numeric resetKeys test
- Manual verification that all wrapped components render without regression