### PR TITLE
fix(errors): replace silent .catch swallows with logging and selective notifications

### DIFF
--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -723,7 +723,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
                 logWarn("OAuth CDP non-token continueRequest failed", {
                   panelId,
                   url: p.request.url,
-                  error: err instanceof Error ? err.message : String(err),
+                  error: formatErrorMessage(err, "CDP continueRequest failed"),
                 });
               });
             return;

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../../shared/types/ipc/webviewConsole.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { AppError } from "../../utils/errorTypes.js";
+import { logError, logWarn } from "../../utils/logger.js";
 
 interface CdpSession {
   runtimeEnabled: boolean;
@@ -712,10 +713,18 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
             p.request.postData?.includes("grant_type=authorization_code");
 
           if (!isTokenExchange) {
-            // Not the token exchange — let it through
+            // Not the token exchange — let it through. Failure here is usually
+            // a teardown race (debugger detached, request superseded). Surface
+            // at warn so it's visible in logs without polluting error metrics.
             wc.debugger
               .sendCommand("Fetch.continueRequest", { requestId: p.requestId })
-              .catch(() => {});
+              .catch((err) => {
+                logWarn("OAuth CDP non-token continueRequest failed", {
+                  panelId,
+                  url: p.request.url,
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
             return;
           }
 
@@ -741,7 +750,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
               postData: Buffer.from(rewrittenBody).toString("base64"),
             })
             .catch((err) => {
-              console.error("[OAuthLoopback] CDP continueRequest failed:", err);
+              logError("OAuth CDP token-exchange continueRequest failed", err, { panelId });
             });
 
           clearTimeout(timeout);
@@ -754,7 +763,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         // The page will load, the app's JS will fire the token exchange fetch,
         // and our CDP listener will intercept and rewrite it.
         wc.loadURL(callbackUrl).catch((err) => {
-          console.error("[OAuthLoopback] Failed to navigate webview:", err);
+          logError("OAuth callback webview navigation failed", err, { panelId });
           clearTimeout(timeout);
           finishIntercept();
         });
@@ -763,7 +772,9 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       const msg = formatErrorMessage(err, "CDP setup failed");
       console.error("[OAuthLoopback] CDP setup failed:", msg);
       // Still try to navigate even without interception — might work for providers
-      // that don't enforce strict redirect_uri matching at token exchange
+      // that don't enforce strict redirect_uri matching at token exchange.
+      // Intentional: the primary CDP failure was already logged + rethrown above;
+      // this fallback navigation's failure adds no actionable signal.
       wc.loadURL(callbackUrl).catch(() => {});
       throw new AppError({
         code: "INTERNAL",
@@ -781,10 +792,15 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
           .sendCommand("Page.removeScriptToEvaluateOnNewDocument", {
             identifier: restoreScriptIdentifier,
           })
-          .catch(() => {});
+          .catch(() => {
+            // Intentional: post-flow CDP cleanup. Any primary failure was
+            // already surfaced; cleanup race conditions add no signal.
+          });
       }
       if (fetchEnabled && !wc.isDestroyed()) {
-        wc.debugger.sendCommand("Fetch.disable").catch(() => {});
+        wc.debugger.sendCommand("Fetch.disable").catch(() => {
+          // Intentional: post-flow CDP cleanup (see above).
+        });
       }
     }
 

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -638,6 +638,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     let interceptorListener:
       | ((event: Electron.Event, method: string, params: unknown) => void)
       | null = null;
+    let navigationError: Error | null = null;
 
     try {
       if (!wc.debugger.isAttached()) {
@@ -763,6 +764,10 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         // The page will load, the app's JS will fire the token exchange fetch,
         // and our CDP listener will intercept and rewrite it.
         wc.loadURL(callbackUrl).catch((err) => {
+          // Capture so the outer scope can throw after CDP cleanup runs;
+          // resolving the promise here lets the `finally` block tear down
+          // listeners and Fetch.disable cleanly before the error propagates.
+          navigationError = err instanceof Error ? err : new Error(String(err));
           logError("OAuth callback webview navigation failed", err, { panelId });
           clearTimeout(timeout);
           finishIntercept();
@@ -802,6 +807,15 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
           // Intentional: post-flow CDP cleanup (see above).
         });
       }
+    }
+
+    if (navigationError) {
+      throw new AppError({
+        code: "INTERNAL",
+        message: `OAuth callback navigation failed: ${navigationError.message}`,
+        context: { panelId },
+        cause: navigationError,
+      });
     }
 
     return { success: true };

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -812,7 +812,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     if (navigationError) {
       throw new AppError({
         code: "INTERNAL",
-        message: `OAuth callback navigation failed: ${navigationError.message}`,
+        message: `OAuth callback navigation failed: ${(navigationError as Error).message}`,
         context: { panelId },
         cause: navigationError,
       });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -24,6 +24,7 @@ import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { injectSkeletonCss } from "./skeletonCss.js";
 import {
   attachRendererConsoleCapture,
@@ -454,7 +455,7 @@ export class ProjectViewManager {
         logWarn("Project view loadURL rejected", {
           projectId,
           url,
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "loadURL failed"),
         });
       };
       if (process.env.NODE_ENV === "development") {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -23,7 +23,7 @@ import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
-import { logInfo } from "../utils/logger.js";
+import { logInfo, logWarn } from "../utils/logger.js";
 import { injectSkeletonCss } from "./skeletonCss.js";
 import {
   attachRendererConsoleCapture,
@@ -350,7 +350,10 @@ export class ProjectViewManager {
           liveEntry.state === "cached" &&
           !webContents.isDestroyed()
         ) {
-          webContents.executeJavaScript("window.gc && window.gc()").catch(() => {});
+          webContents.executeJavaScript("window.gc && window.gc()").catch(() => {
+            // Intentional: V8 GC is best-effort — failure (no --js-flags=--expose-gc,
+            // destroyed context) is harmless and noisy if logged.
+          });
         }
       }, GC_DELAY_MS);
     }
@@ -441,11 +444,26 @@ export class ProjectViewManager {
       injectSkeletonCss(wc);
 
       const encodedId = encodeURIComponent(projectId);
+      // Outer .catch surfaces any rejection from `wc.loadURL` itself; the inner
+      // did-fail-load / preload-error / timeout handlers already reject the
+      // outer Promise with a descriptive Error. ERR_ABORTED is the dominant
+      // normal case during rapid project switching and renderer teardown — drop
+      // it silently to avoid log noise.
+      const onLoadURLReject = (err: unknown, url: string) => {
+        if (err instanceof Error && err.message.includes("ERR_ABORTED")) return;
+        logWarn("Project view loadURL rejected", {
+          projectId,
+          url,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      };
       if (process.env.NODE_ENV === "development") {
         const devServerUrl = getDevServerUrl();
-        wc.loadURL(`${devServerUrl}?projectId=${encodedId}`).catch(() => {});
+        const url = `${devServerUrl}?projectId=${encodedId}`;
+        wc.loadURL(url).catch((err) => onLoadURLReject(err, url));
       } else {
-        wc.loadURL(`app://daintree/index.html?projectId=${encodedId}`).catch(() => {});
+        const url = `app://daintree/index.html?projectId=${encodedId}`;
+        wc.loadURL(url).catch((err) => onLoadURLReject(err, url));
       }
     });
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { useHeldShortcutReveal } from "./hooks/useHeldShortcutReveal";
 import { removeStartupSkeleton } from "./utils/removeStartupSkeleton";
 import { logWarn } from "./utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
 import { SafeModeBanner } from "./components/Recovery/SafeModeBanner";
@@ -362,7 +363,7 @@ function App() {
           logWarn("Default agent auto-launch failed", {
             primaryAgent,
             worktreeId: activeWorktreeId ?? null,
-            error: err instanceof Error ? err.message : String(err),
+            error: formatErrorMessage(err, "Auto-launch failed"),
           });
         });
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
 import { useHeldShortcutReveal } from "./hooks/useHeldShortcutReveal";
 import { removeStartupSkeleton } from "./utils/removeStartupSkeleton";
+import { logWarn } from "./utils/logger";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
 import { SafeModeBanner } from "./components/Recovery/SafeModeBanner";
@@ -354,7 +355,16 @@ function App() {
       if (primaryAgent && isAgentLaunchable(availability[primaryAgent])) {
         launchAgent(primaryAgent, {
           worktreeId: activeWorktreeId ?? undefined,
-        }).catch(() => {});
+        }).catch((err) => {
+          // Log only — auto-launch fires on every project switch; a toast
+          // would be too noisy. The user can see the agent failed to start
+          // from the panel itself.
+          logWarn("Default agent auto-launch failed", {
+            primaryAgent,
+            worktreeId: activeWorktreeId ?? null,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
       }
     },
     [launchAgent, activeWorktreeId, availability, switchProject, currentProject?.id]

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -7,6 +7,8 @@ import { SettingsSection } from "./SettingsSection";
 import { isSensitiveEnvKey } from "@shared/utils/envVars";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
 
 interface EnvVar {
   id: string;
@@ -52,6 +54,7 @@ export function EnvironmentSettingsTab() {
   const hasError = Object.keys(rowErrors).length > 0;
   useSettingsTabValidation("environment", hasError);
 
+  const [loadFailed, setLoadFailed] = useState(false);
   useEffect(() => {
     let cancelled = false;
     window.electron.globalEnv
@@ -62,8 +65,22 @@ export function EnvironmentSettingsTab() {
         setSavedSnapshot(vars);
         setIsLoading(false);
       })
-      .catch(() => {
-        if (!cancelled) setIsLoading(false);
+      .catch((err) => {
+        if (cancelled) return;
+        // Showing an empty form here would let the user "save" and silently
+        // overwrite their stored variables with nothing. Block save and tell
+        // them what happened.
+        setLoadFailed(true);
+        setIsLoading(false);
+        logError("Failed to load global env vars", err);
+        notify({
+          type: "error",
+          title: "Couldn't load environment variables",
+          message:
+            "The settings form couldn't load your saved variables. Saving now would overwrite them with an empty list.",
+          priority: "high",
+          duration: 0,
+        });
       });
     return () => {
       cancelled = true;
@@ -190,6 +207,22 @@ export function EnvironmentSettingsTab() {
       <div className="flex items-center justify-center py-16">
         <Spinner size="lg" />
       </div>
+    );
+  }
+
+  if (loadFailed) {
+    return (
+      <SettingsSection
+        icon={Key}
+        title="Environment Variables"
+        description="Global environment variables injected into all new terminals. Project-level variables override globals with the same name."
+        id="environment-variables"
+      >
+        <div className="text-sm text-status-error/90 py-8 px-4 border border-status-error/40 rounded-[var(--radius-md)] bg-status-error/5">
+          Couldn't load saved environment variables. Close and reopen settings to try again. Editing
+          isn't available right now to avoid overwriting your stored values.
+        </div>
+      </SettingsSection>
     );
   }
 

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Key, Eye, EyeOff, Trash2, Plus, Save } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Spinner } from "@/components/ui/Spinner";
@@ -50,11 +50,16 @@ export function EnvironmentSettingsTab() {
   const [isDirty, setIsDirty] = useState(false);
   const [savedSnapshot, setSavedSnapshot] = useState<Record<string, string>>({});
 
-  // Report validation state to sidebar
-  const hasError = Object.keys(rowErrors).length > 0;
-  useSettingsTabValidation("environment", hasError);
-
   const [loadFailed, setLoadFailed] = useState(false);
+
+  // Report validation state to sidebar — a failed load also marks the tab
+  // as in-error so the sidebar reflects the user-visible error block.
+  const hasError = Object.keys(rowErrors).length > 0;
+  useSettingsTabValidation("environment", hasError || loadFailed);
+
+  // Suppress duplicate toasts when the tab remounts (close/reopen Settings)
+  // while the IPC failure persists — notify() has no dedup-by-key.
+  const notifiedFailureRef = useRef(false);
   useEffect(() => {
     let cancelled = false;
     window.electron.globalEnv
@@ -73,14 +78,17 @@ export function EnvironmentSettingsTab() {
         setLoadFailed(true);
         setIsLoading(false);
         logError("Failed to load global env vars", err);
-        notify({
-          type: "error",
-          title: "Couldn't load environment variables",
-          message:
-            "The settings form couldn't load your saved variables. Saving now would overwrite them with an empty list.",
-          priority: "high",
-          duration: 0,
-        });
+        if (!notifiedFailureRef.current) {
+          notifiedFailureRef.current = true;
+          notify({
+            type: "error",
+            title: "Couldn't load environment variables",
+            message:
+              "The settings form couldn't load your saved variables. Saving now would overwrite them with an empty list.",
+            priority: "high",
+            duration: 0,
+          });
+        }
       });
     return () => {
       cancelled = true;

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -438,7 +438,11 @@ function SettingsDialogInner({
     window.electron.globalEnv
       .get()
       .then(setGlobalEnvVars)
-      .catch(() => {});
+      .catch((err) => {
+        // Log only — EnvironmentSettingsTab owns the user-visible failure path
+        // when the user opens that tab. Avoid double-toasting the same IPC fail.
+        logError("Failed to preload global env vars for agent settings", err);
+      });
   }, [isOpen]);
 
   const handleBeforeClose = useCallback(async () => {

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -27,6 +27,7 @@ import { SettingsNumberInput } from "@/components/Settings/SettingsNumberInput";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { logError, logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import {
   useLayoutConfigStore,
@@ -164,7 +165,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
       .catch((err) => {
         // Background probe — the UI gracefully renders without hardware info.
         logWarn("Failed to load hardware info", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Hardware info probe failed"),
         });
       });
   }, [initializeFromHardware]);

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -26,7 +26,7 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { SettingsNumberInput } from "@/components/Settings/SettingsNumberInput";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
-import { logError } from "@/utils/logger";
+import { logError, logWarn } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import {
   useLayoutConfigStore,
@@ -161,7 +161,12 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
     window.electron.system
       .getHardwareInfo()
       .then(setHardwareInfo)
-      .catch(() => {});
+      .catch((err) => {
+        // Background probe — the UI gracefully renders without hardware info.
+        logWarn("Failed to load hardware info", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
   }, [initializeFromHardware]);
 
   const [showMemoryDetails, setShowMemoryDetails] = useState(false);

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -25,6 +25,7 @@ import { SettingsSelect } from "./SettingsSelect";
 import { SettingsTextarea } from "./SettingsTextarea";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
 import { logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
   VoiceInputSettings,
@@ -134,7 +135,7 @@ export function VoiceInputSettingsTab() {
       .catch((err) => {
         // Background probe — UI shows fallback "unknown" state.
         logWarn("Failed to check microphone permission", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Mic permission probe failed"),
         });
       });
 

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -24,6 +24,7 @@ import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsTextarea } from "./SettingsTextarea";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
+import { logWarn } from "@/utils/logger";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
   VoiceInputSettings,
@@ -130,7 +131,12 @@ export function VoiceInputSettingsTab() {
       .then((status) => {
         if (status) setMicPermission(status);
       })
-      .catch(() => {});
+      .catch((err) => {
+        // Background probe — UI shows fallback "unknown" state.
+        logWarn("Failed to check microphone permission", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
 
     return () => clearTimeout(timer);
   }, []);

--- a/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
@@ -5,6 +5,20 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EnvironmentSettingsTab } from "../EnvironmentSettingsTab";
 import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+
 beforeEach(() => {
   vi.clearAllMocks();
   window.electron = {
@@ -88,7 +102,7 @@ describe("EnvironmentSettingsTab", () => {
     });
   });
 
-  it("handles globalEnv.get failure gracefully (shows empty state)", async () => {
+  it("blocks editing and notifies the user when globalEnv.get fails", async () => {
     window.electron = {
       globalEnv: {
         get: vi.fn().mockRejectedValue(new Error("IPC channel not found")),
@@ -99,10 +113,23 @@ describe("EnvironmentSettingsTab", () => {
     renderTab();
 
     await waitFor(() => {
-      expect(screen.getByText("No environment variables configured yet")).toBeTruthy();
+      expect(screen.getByText(/Couldn't load saved environment variables/)).toBeTruthy();
     });
 
+    // Save and editing affordances must be absent so a failed load can't
+    // overwrite the user's stored variables with an empty record.
     expect(screen.queryByRole("button", { name: /save/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add variable/i })).toBeNull();
+
+    expect(logError).toHaveBeenCalledWith("Failed to load global env vars", expect.any(Error));
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        title: "Couldn't load environment variables",
+        priority: "high",
+        duration: 0,
+      })
+    );
   });
 
   it("adds new variable row and saves via globalEnv.set", async () => {

--- a/src/hooks/__tests__/useWebviewDialog.test.tsx
+++ b/src/hooks/__tests__/useWebviewDialog.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+import { useWebviewDialog } from "../useWebviewDialog";
+
+interface DialogRequestPayload {
+  panelId: string;
+  dialogId: string;
+}
+
+let dialogListener: ((payload: DialogRequestPayload) => void) | null = null;
+let respondToDialog: ReturnType<typeof vi.fn>;
+let registerPanel: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dialogListener = null;
+  respondToDialog = vi.fn();
+  registerPanel = vi.fn().mockResolvedValue(undefined);
+
+  Object.defineProperty(window, "electron", {
+    value: {
+      webview: {
+        registerPanel,
+        respondToDialog,
+        onDialogRequest: (cb: (payload: DialogRequestPayload) => void) => {
+          dialogListener = cb;
+          return () => {
+            dialogListener = null;
+          };
+        },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+function emitDialog(panelId: string, dialogId: string): void {
+  if (!dialogListener) throw new Error("dialog listener not registered");
+  dialogListener({ panelId, dialogId });
+}
+
+describe("useWebviewDialog", () => {
+  it("notifies the user and advances the queue when respondToDialog rejects", async () => {
+    respondToDialog.mockRejectedValueOnce(new Error("IPC channel closed"));
+
+    const { result } = renderHook(() => useWebviewDialog("panel-1", null, false));
+
+    act(() => {
+      emitDialog("panel-1", "dialog-1");
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-1");
+    });
+
+    act(() => {
+      result.current.handleDialogRespond(true, "user-input");
+    });
+
+    expect(respondToDialog).toHaveBeenCalledWith("dialog-1", true, "user-input");
+
+    await waitFor(() => {
+      expect(logError).toHaveBeenCalledWith(
+        "Webview dialog response failed",
+        expect.any(Error),
+        expect.objectContaining({ panelId: "panel-1", dialogId: "dialog-1" })
+      );
+    });
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        title: "Dialog response failed",
+        priority: "high",
+        duration: 0,
+        context: { panelId: "panel-1" },
+      })
+    );
+
+    // Notify must NOT carry an action button — no panel-reload action exists
+    // in the registry, so users get the message without a misleading CTA.
+    const notifyCall = vi.mocked(notify).mock.calls[0]?.[0];
+    expect(notifyCall && "action" in notifyCall ? notifyCall.action : undefined).toBeUndefined();
+
+    // Queue must advance past the failed item so the next dialog can render.
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+  });
+
+  it("does not notify or log on a successful respondToDialog", async () => {
+    respondToDialog.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useWebviewDialog("panel-2", null, false));
+
+    act(() => {
+      emitDialog("panel-2", "dialog-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentDialog?.dialogId).toBe("dialog-2");
+    });
+
+    act(() => {
+      result.current.handleDialogRespond(false);
+    });
+
+    // Let the resolved promise flush.
+    await waitFor(() => {
+      expect(result.current.currentDialog).toBeNull();
+    });
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { logError, logWarn } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useTerminalFontStore, useScreenReaderStore } from "@/store";
 import { useTerminalColorSchemeStore } from "@/store/terminalColorSchemeStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
@@ -77,7 +78,7 @@ export function useTerminalConfig() {
         // Background probe — `onSupportChanged` will repopulate state when the
         // OS event fires. Falling through with the prior store value is fine.
         logWarn("Failed to read OS accessibility state", {
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Accessibility probe failed"),
         });
       });
 

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { logError } from "@/utils/logger";
+import { logError, logWarn } from "@/utils/logger";
 import { useTerminalFontStore, useScreenReaderStore } from "@/store";
 import { useTerminalColorSchemeStore } from "@/store/terminalColorSchemeStore";
 import { useAppThemeStore } from "@/store/appThemeStore";
@@ -73,7 +73,13 @@ export function useTerminalConfig() {
           useScreenReaderStore.getState().setOsAccessibilityEnabled(enabled);
         }
       })
-      .catch(() => {});
+      .catch((err) => {
+        // Background probe — `onSupportChanged` will repopulate state when the
+        // OS event fires. Falling through with the prior store value is fine.
+        logWarn("Failed to read OS accessibility state", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
 
     const cleanup = window.electron.accessibility.onSupportChanged(({ enabled }) => {
       if (!cancelled) {

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import type { WebviewDialogRequest } from "@/components/Browser/WebviewDialog";
 import { logError, logWarn } from "@/utils/logger";
 import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export function useWebviewDialog(
   panelId: string,
@@ -20,7 +21,7 @@ export function useWebviewDialog(
         // warn (not error) since native fallback is a working UX, not broken.
         logWarn("Webview dialog registration failed", {
           panelId,
-          error: err instanceof Error ? err.message : String(err),
+          error: formatErrorMessage(err, "Panel registration failed"),
         });
       });
     } catch {

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { WebviewDialogRequest } from "@/components/Browser/WebviewDialog";
+import { logError, logWarn } from "@/utils/logger";
+import { notify } from "@/lib/notify";
 
 export function useWebviewDialog(
   panelId: string,
@@ -13,11 +15,17 @@ export function useWebviewDialog(
     if (!webviewElement || !isWebviewReady) return;
     try {
       const webContentsId = webviewElement.getWebContentsId();
-      window.electron.webview.registerPanel(webContentsId, panelId).catch(() => {
-        // Registration failed — dialogs will fall back to native
+      window.electron.webview.registerPanel(webContentsId, panelId).catch((err) => {
+        // Registration failed — dialogs will fall back to native. Surface at
+        // warn (not error) since native fallback is a working UX, not broken.
+        logWarn("Webview dialog registration failed", {
+          panelId,
+          error: err instanceof Error ? err.message : String(err),
+        });
       });
     } catch {
-      // getWebContentsId() can throw if webview not attached
+      // Intentional: getWebContentsId() throws when the webview isn't attached
+      // yet — the next ready cycle re-runs this effect.
     }
   }, [panelId, webviewElement, isWebviewReady]);
 
@@ -38,7 +46,24 @@ export function useWebviewDialog(
 
       window.electron.webview
         .respondToDialog(current.dialogId, confirmed, response)
-        .catch(() => {});
+        .catch((err) => {
+          // The blocking JS dialog never gets answered if respondToDialog
+          // rejects — the page hangs. Surface to the user with a sticky
+          // error toast so they know the panel may need reloading.
+          logError("Webview dialog response failed", err, {
+            panelId,
+            dialogId: current.dialogId,
+          });
+          notify({
+            type: "error",
+            title: "Dialog response failed",
+            message:
+              "Couldn't send a response to the page dialog. The page may be unresponsive — try reloading the panel.",
+            priority: "high",
+            duration: 0,
+            context: { panelId },
+          });
+        });
 
       setDialogQueue((prev) => prev.slice(1));
     },

--- a/src/hooks/useWebviewDialog.ts
+++ b/src/hooks/useWebviewDialog.ts
@@ -68,7 +68,7 @@ export function useWebviewDialog(
 
       setDialogQueue((prev) => prev.slice(1));
     },
-    [dialogQueue]
+    [dialogQueue, panelId]
   );
 
   return {


### PR DESCRIPTION
Closes #6206

A sweep across `electron/ipc/handlers/`, `electron/window/`, and the renderer's hooks and Settings components found ~30 sites swallowing errors silently. This PR applies a consistent three-tier policy to the subset that actually hides information, and documents the rest so they don't get "fixed" by accident.

**Three-tier policy:**

- **Best-effort cleanup** (file unlinks, handle close in finally, GC) — stays silent. Short comment added at each site explaining why.
- **Background config/settings load** — `logError` with no toast. Failure is recorded but doesn't interrupt the user.
- **User-visible failures** — `logError` plus a sticky `notify()`. Reserved for cases where a silent failure leaves the UI in a misleading state.

**Highest-impact behavior changes:**

- **`useWebviewDialog`** — `respondToDialog` failure now surfaces a sticky error toast. Previously the underlying `<webview>` JS dialog (`alert`/`confirm`/`prompt`) never got a response and the page hung indefinitely with no indication why.
- **`EnvironmentSettingsTab`** — `globalEnv.get` failure now blocks editing entirely (Save and Add are disabled until the load succeeds). Previously the form showed empty, and a save would silently overwrite real stored vars with an empty record.

**Other notable fixes:**

- `webview.ts` OAuth flow now throws `AppError` on callback navigation failure instead of logging the error and returning `{ success: true }`. That was a correctness bug surfaced during review.
- `ProjectViewManager` `loadURL` drops `ERR_ABORTED` without logging (expected during rapid project switching) and warns on every other error code.

## Test plan

- [ ] Unit tests cover the two highest-impact paths: `useWebviewDialog` (respondToDialog rejection → sticky toast) and `EnvironmentSettingsTab` (globalEnv.get failure → editing blocked)
- [ ] Open Settings while offline / with IPC stubbed to reject — confirm env vars tab shows blocked state, not an empty editable form
- [ ] Trigger a blocking dialog in a Browser/DevPreview pane and simulate a respondToDialog failure — confirm sticky toast appears
- [ ] Walk through an OAuth flow in a webview — confirm a navigation failure surfaces as an error rather than a silent success