### PR TITLE
perf(terminal): shared visibility-aware minute ticker; gate reflow heartbeat

### DIFF
--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useCallback } from "react";
 import { Pause, Lock } from "lucide-react";
 import type { AgentState, PanelKind, AgentStateChangeTrigger } from "@/types";
 import { cn } from "@/lib/utils";
@@ -16,17 +16,11 @@ import { formatTokenCount } from "@/utils/formatTokenCount";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { useResourceMonitoringStore } from "@/store/resourceMonitoringStore";
 import { useErrorStore } from "@/store/errorStore";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { TerminalResourceSparkline } from "./TerminalResourceSparkline";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
-function ElapsedTime({ startedAt }: { startedAt: number }) {
-  const [now, setNow] = useState(() => Date.now());
-
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 30_000);
-    return () => clearInterval(id);
-  }, []);
-
+function ElapsedTime({ startedAt, now }: { startedAt: number; now: number }) {
   return <> · {formatElapsedDuration(now - startedAt)}</>;
 }
 
@@ -115,17 +109,17 @@ function TerminalHeaderContentComponent({
     )
   );
 
-  const [tick, setTick] = useState(() => Date.now());
-  useEffect(() => {
-    const interval = setInterval(() => setTick(Date.now()), 30_000);
-    return () => clearInterval(interval);
-  }, []);
+  // Shared visibility-aware ticker — drives the elapsed-duration displays
+  // that update at minute granularity. The tick value itself is unused;
+  // its identity changes ~every 30 s, which is what re-derives `now`.
+  useGlobalMinuteTicker();
+  const now = Date.now();
 
   const showStateDuration =
     (agentState === "working" || agentState === "waiting" || agentState === "directing") &&
     lastStateChange != null &&
     lastStateChange > 0 &&
-    tick - lastStateChange > 10_000;
+    now - lastStateChange > 10_000;
 
   // Show command pill only for plain terminals (not agent terminals)
   const isPlainTerminal = kind == null || kind === "terminal";
@@ -209,14 +203,14 @@ function TerminalHeaderContentComponent({
           <div className="flex flex-col gap-0.5">
             <span className="font-medium">
               {headline}
-              {startedAt != null && <ElapsedTime startedAt={startedAt} />}
+              {startedAt != null && <ElapsedTime startedAt={startedAt} now={now} />}
             </span>
             {isExited && exitCode != null && (
               <span className="text-status-error tabular-nums">Exit code: {exitCode}</span>
             )}
             <span>
               State: {stateLabel}
-              {showStateDuration && <> · {formatElapsedDuration(tick - lastStateChange!)}</>}
+              {showStateDuration && <> · {formatElapsedDuration(now - lastStateChange!)}</>}
               {stateChangeTrigger && <> · {TRIGGER_LABELS[stateChangeTrigger]}</>}
               {showConfidence && <> ({Math.round(stateChangeConfidence * 100)}%)</>}
             </span>

--- a/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
+++ b/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
@@ -63,10 +63,10 @@ describe("useGlobalMinuteTicker", () => {
     const { result } = renderHook(() => useGlobalMinuteTicker());
     const initial = result.current;
 
-    act(() => vi.advanceTimersByTime(30_000));
+    void act(() => vi.advanceTimersByTime(30_000));
     expect(result.current).toBe(initial + 1);
 
-    act(() => vi.advanceTimersByTime(30_000));
+    void act(() => vi.advanceTimersByTime(30_000));
     expect(result.current).toBe(initial + 2);
   });
 
@@ -74,10 +74,10 @@ describe("useGlobalMinuteTicker", () => {
     const { result } = renderHook(() => useGlobalMinuteTicker());
     const initial = result.current;
 
-    act(() => vi.advanceTimersByTime(29_999));
+    void act(() => vi.advanceTimersByTime(29_999));
     expect(result.current).toBe(initial);
 
-    act(() => vi.advanceTimersByTime(1));
+    void act(() => vi.advanceTimersByTime(1));
     expect(result.current).toBe(initial + 1);
   });
 
@@ -85,16 +85,16 @@ describe("useGlobalMinuteTicker", () => {
     const { result } = renderHook(() => useGlobalMinuteTicker());
     const initial = result.current;
 
-    act(() => vi.advanceTimersByTime(30_000));
+    void act(() => vi.advanceTimersByTime(30_000));
     expect(result.current).toBe(initial + 1);
 
-    act(() => fireVisibilityChange("hidden"));
+    void act(() => fireVisibilityChange("hidden"));
     const tickAfterHide = result.current;
 
-    act(() => vi.advanceTimersByTime(150_000));
+    void act(() => vi.advanceTimersByTime(150_000));
     expect(result.current).toBe(tickAfterHide);
 
-    act(() => fireVisibilityChange("visible"));
+    void act(() => fireVisibilityChange("visible"));
     // Immediate catch-up tick on restore
     expect(result.current).toBe(tickAfterHide + 1);
   });
@@ -104,13 +104,13 @@ describe("useGlobalMinuteTicker", () => {
     const { result } = renderHook(() => useGlobalMinuteTicker());
     const initial = result.current;
 
-    act(() => vi.advanceTimersByTime(150_000));
+    void act(() => vi.advanceTimersByTime(150_000));
     expect(result.current).toBe(initial);
 
-    act(() => fireVisibilityChange("visible"));
+    void act(() => fireVisibilityChange("visible"));
     expect(result.current).toBe(initial + 1);
 
-    act(() => vi.advanceTimersByTime(30_000));
+    void act(() => vi.advanceTimersByTime(30_000));
     expect(result.current).toBe(initial + 2);
   });
 
@@ -125,7 +125,7 @@ describe("useGlobalMinuteTicker", () => {
     ).length;
     expect(minuteTickerCalls).toBe(1);
 
-    act(() => vi.advanceTimersByTime(30_000));
+    void act(() => vi.advanceTimersByTime(30_000));
     expect(a.result.current).toBe(b.result.current);
   });
 

--- a/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
+++ b/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
@@ -47,6 +47,11 @@ describe("useGlobalMinuteTicker", () => {
       configurable: true,
       writable: true,
     });
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+      writable: true,
+    });
   });
 
   function fireVisibilityChange(state: DocumentVisibilityState) {

--- a/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
+++ b/src/hooks/__tests__/useGlobalMinuteTicker.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useGlobalMinuteTicker } from "../useGlobalMinuteTicker";
+
+describe("useGlobalMinuteTicker", () => {
+  let originalHidden: boolean;
+  let visibilityState: DocumentVisibilityState;
+  let visibilityListeners: Array<() => void>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visibilityListeners = [];
+    originalHidden = document.hidden;
+    visibilityState = "visible";
+
+    Object.defineProperty(document, "hidden", {
+      get: () => visibilityState === "hidden",
+      configurable: true,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      get: () => visibilityState,
+      configurable: true,
+    });
+
+    const origAdd = document.addEventListener.bind(document);
+    const origRemove = document.removeEventListener.bind(document);
+    vi.spyOn(document, "addEventListener").mockImplementation((type, handler, options) => {
+      if (type === "visibilitychange") {
+        visibilityListeners.push(handler as () => void);
+      }
+      return origAdd(type, handler, options);
+    });
+    vi.spyOn(document, "removeEventListener").mockImplementation((type, handler, options) => {
+      if (type === "visibilitychange") {
+        visibilityListeners = visibilityListeners.filter((l) => l !== handler);
+      }
+      return origRemove(type, handler, options);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(document, "hidden", {
+      value: originalHidden,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  function fireVisibilityChange(state: DocumentVisibilityState) {
+    visibilityState = state;
+    visibilityListeners.forEach((l) => l());
+  }
+
+  it("ticks every 30 seconds while visible", () => {
+    const { result } = renderHook(() => useGlobalMinuteTicker());
+    const initial = result.current;
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(initial + 1);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(initial + 2);
+  });
+
+  it("does not tick before the 30-second boundary", () => {
+    const { result } = renderHook(() => useGlobalMinuteTicker());
+    const initial = result.current;
+
+    act(() => vi.advanceTimersByTime(29_999));
+    expect(result.current).toBe(initial);
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(initial + 1);
+  });
+
+  it("stops ticking when hidden and resumes on visible", () => {
+    const { result } = renderHook(() => useGlobalMinuteTicker());
+    const initial = result.current;
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(initial + 1);
+
+    act(() => fireVisibilityChange("hidden"));
+    const tickAfterHide = result.current;
+
+    act(() => vi.advanceTimersByTime(150_000));
+    expect(result.current).toBe(tickAfterHide);
+
+    act(() => fireVisibilityChange("visible"));
+    // Immediate catch-up tick on restore
+    expect(result.current).toBe(tickAfterHide + 1);
+  });
+
+  it("does not start interval when mounted while hidden", () => {
+    visibilityState = "hidden";
+    const { result } = renderHook(() => useGlobalMinuteTicker());
+    const initial = result.current;
+
+    act(() => vi.advanceTimersByTime(150_000));
+    expect(result.current).toBe(initial);
+
+    act(() => fireVisibilityChange("visible"));
+    expect(result.current).toBe(initial + 1);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current).toBe(initial + 2);
+  });
+
+  it("shares a single interval across multiple subscribers", () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    const a = renderHook(() => useGlobalMinuteTicker());
+    const b = renderHook(() => useGlobalMinuteTicker());
+
+    const minuteTickerCalls = setIntervalSpy.mock.calls.filter(
+      ([, delay]) => delay === 30_000
+    ).length;
+    expect(minuteTickerCalls).toBe(1);
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(a.result.current).toBe(b.result.current);
+  });
+
+  it("cleans up interval and listener on last unmount", () => {
+    const { unmount } = renderHook(() => useGlobalMinuteTicker());
+    expect(visibilityListeners.length).toBeGreaterThan(0);
+
+    unmount();
+    expect(visibilityListeners.length).toBe(0);
+  });
+});

--- a/src/hooks/useGlobalMinuteTicker.ts
+++ b/src/hooks/useGlobalMinuteTicker.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+// 30-second cadence keeps minute-boundary refreshes within at most 30 s of
+// the actual transition while only firing twice per minute.
+const INTERVAL_MS = 30_000;
+
+let globalTick = 0;
+const listeners = new Set<(tick: number) => void>();
+let intervalId: number | null = null;
+
+function emitTick() {
+  globalTick++;
+  listeners.forEach((listener) => listener(globalTick));
+}
+
+function startGlobalTicker() {
+  if (intervalId !== null) return;
+  intervalId = window.setInterval(emitTick, INTERVAL_MS);
+}
+
+function stopGlobalTicker() {
+  if (intervalId === null) return;
+  clearInterval(intervalId);
+  intervalId = null;
+}
+
+function handleVisibility() {
+  if (document.hidden) {
+    stopGlobalTicker();
+  } else {
+    emitTick();
+    startGlobalTicker();
+  }
+}
+
+export function useGlobalMinuteTicker(): number {
+  const [tick, setTick] = useState(globalTick);
+
+  useEffect(() => {
+    listeners.add(setTick);
+    if (listeners.size === 1) {
+      document.addEventListener("visibilitychange", handleVisibility);
+      if (!document.hidden) {
+        startGlobalTicker();
+      }
+    }
+
+    return () => {
+      listeners.delete(setTick);
+      if (listeners.size === 0) {
+        stopGlobalTicker();
+        document.removeEventListener("visibilitychange", handleVisibility);
+      }
+    };
+  }, []);
+
+  return tick;
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -157,9 +157,11 @@ class TerminalInstanceService {
 
     // Periodic heartbeat: recovers a DOM-renderer terminal whose
     // IntersectionObserver has paused rendering, even while no new writes are
-    // arriving. Cheap (~1–5ms per visible non-agent terminal).
+    // arriving. Cheap (~1–5ms per visible non-agent terminal). Skipped while
+    // the document is hidden — _onVisibilityChange triggers a sweep on regain.
     if (typeof setInterval === "function") {
       this.reflowHeartbeatTimer = setInterval(() => {
+        if (typeof document !== "undefined" && document.visibilityState !== "visible") return;
         for (const managed of this.instances.values()) {
           this.maybeReflowTerminal(managed);
         }

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -289,12 +289,10 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
   let service: ReflowTestService;
   let visibilityState: DocumentVisibilityState;
-  let originalDescriptor: PropertyDescriptor | undefined;
 
   beforeEach(async () => {
     vi.useFakeTimers();
     visibilityState = "visible";
-    originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
     Object.defineProperty(document, "visibilityState", {
       get: () => visibilityState,
       configurable: true,
@@ -312,15 +310,13 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
     vi.useRealTimers();
     service.instances.clear();
     document.body.innerHTML = "";
-    if (originalDescriptor) {
-      Object.defineProperty(Document.prototype, "visibilityState", originalDescriptor);
-    } else {
-      // Fallback: leave the document in a sensible state for later tests
-      Object.defineProperty(document, "visibilityState", {
-        value: "visible",
-        configurable: true,
-      });
-    }
+    // Replace the live getter with a plain "visible" value so the document is
+    // back to a clean state for any subsequent tests.
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+      writable: true,
+    });
   });
 
   it("skips reflows while document is hidden", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -285,3 +285,73 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBe(0);
   });
 });
+
+describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
+  let service: ReflowTestService;
+  let visibilityState: DocumentVisibilityState;
+  let originalDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    visibilityState = "visible";
+    originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+    Object.defineProperty(document, "visibilityState", {
+      get: () => visibilityState,
+      configurable: true,
+    });
+
+    vi.resetModules();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: ReflowTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    service.instances.clear();
+    document.body.innerHTML = "";
+    if (originalDescriptor) {
+      Object.defineProperty(Document.prototype, "visibilityState", originalDescriptor);
+    } else {
+      // Fallback: leave the document in a sensible state for later tests
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+    }
+  });
+
+  it("skips reflows while document is hidden", () => {
+    visibilityState = "hidden";
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    vi.advanceTimersByTime(3000);
+    expect(paddingHistory(managed).length).toBe(0);
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("performs reflows on heartbeat when visible", () => {
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    vi.advanceTimersByTime(3000);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
+  it("resumes reflows when visibility transitions hidden → visible", () => {
+    visibilityState = "hidden";
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    vi.advanceTimersByTime(3000);
+    expect(paddingHistory(managed).length).toBe(0);
+
+    visibilityState = "visible";
+    vi.advanceTimersByTime(3000);
+    expect(paddingHistory(managed)).toContain("0.01px");
+  });
+});


### PR DESCRIPTION
## Summary

- Two independent 30-second `setInterval` timers per terminal header collapse into a single shared `useGlobalMinuteTicker` hook that pauses automatically when `document.visibilityState` is `hidden`
- `TerminalInstanceService` reflow heartbeat now early-returns when the document is hidden — the existing `visibilitychange` handler already triggers an immediate reflow on visibility-regain, so no recovery path is lost
- With 10–20 terminals across cached project views, this eliminates dozens of wasted timer fires per minute

Resolves #6205

## Changes

- `src/hooks/useGlobalMinuteTicker.ts` — new shared singleton ticker, mirrors `useGlobalSecondTicker` pattern, pauses on `visibilitychange`
- `src/components/Terminal/TerminalHeaderContent.tsx` — both `ElapsedTime` and the agent state chip now consume `useGlobalMinuteTicker` instead of their own intervals
- `src/services/terminal/TerminalInstanceService.ts` — `reflowHeartbeatTimer` skips when `document.visibilityState !== "visible"`
- `src/hooks/__tests__/useGlobalMinuteTicker.test.tsx` — full test coverage for the new hook
- `src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts` — visibility-gating test added to reflow suite

## Testing

All 39 targeted tests pass. Typecheck clean, no lint errors introduced.