### PR TITLE
fix(theme): replace hard-coded chromatic utilities with semantic status tokens

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -702,7 +702,7 @@ export function FleetArmingRibbon(): ReactElement | null {
                 disabled={isSendingBroadcast}
                 onClick={() => void confirmPendingBroadcast()}
                 data-testid="fleet-paste-confirm-send"
-                className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-0.5 text-category-amber-text transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
+                className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-0.5 text-category-amber-text transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
               >
                 Send anyway
               </button>

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -702,7 +702,7 @@ export function FleetArmingRibbon(): ReactElement | null {
                 disabled={isSendingBroadcast}
                 onClick={() => void confirmPendingBroadcast()}
                 data-testid="fleet-paste-confirm-send"
-                className="rounded bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
+                className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-0.5 text-category-amber-text transition-colors hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
               >
                 Send anyway
               </button>
@@ -720,7 +720,7 @@ export function FleetArmingRibbon(): ReactElement | null {
                 )}
               >
                 <span>Exit</span>
-                <kbd className="rounded border border-category-amber-border bg-amber-500/5 px-1 font-mono text-[10px] leading-tight text-category-amber-text">
+                <kbd className="rounded border border-category-amber-border bg-category-amber-subtle px-1 font-mono text-[10px] leading-tight text-category-amber-text">
                   {exitChordLabel}
                 </kbd>
               </button>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -416,7 +416,7 @@ function AgentWelcomeCard() {
               <p
                 role="alert"
                 data-testid="welcome-card-pin-error"
-                className="mt-2 text-xs text-red-400"
+                className="mt-2 text-xs text-status-error"
               >
                 Couldn&apos;t pin all agents. Please try again.
               </p>

--- a/src/components/Settings/EnvVarEditor.tsx
+++ b/src/components/Settings/EnvVarEditor.tsx
@@ -252,7 +252,7 @@ function EnvVarKeyCell({
                 : isEmptyKey
                   ? "text-status-error"
                   : isDuplicate
-                    ? "text-amber-500"
+                    ? "text-status-warning"
                     : "text-daintree-text/80"
             )}
             value={value}
@@ -367,7 +367,7 @@ function EnvVarKeyCell({
         <p
           className={cn(
             "absolute left-2.5 bottom-0.5 text-[9px] leading-none pointer-events-none",
-            isEmptyKey ? "text-status-error" : "text-amber-500"
+            isEmptyKey ? "text-status-error" : "text-status-warning"
           )}
           data-testid={isEmptyKey ? "env-editor-error-empty" : "env-editor-error-duplicate"}
         >
@@ -692,7 +692,7 @@ export function EnvVarEditor({
             const stripeClass = isEmptyKey
               ? "before:bg-status-error"
               : isDuplicate || hasSecretWarning
-                ? "before:bg-amber-500/70"
+                ? "before:bg-status-warning/70"
                 : isOverride
                   ? "before:bg-daintree-accent"
                   : "before:bg-transparent";
@@ -743,7 +743,7 @@ export function EnvVarEditor({
                       row.isInherited
                         ? "text-daintree-text/40"
                         : hasSecretWarning
-                          ? "text-amber-500"
+                          ? "text-status-warning"
                           : "text-daintree-accent/90"
                     )}
                     value={row.value}
@@ -789,7 +789,7 @@ export function EnvVarEditor({
                   )}
                   {hasSecretWarning && (
                     <p
-                      className="absolute left-2.5 bottom-0.5 text-[9px] leading-none text-amber-500 pointer-events-none"
+                      className="absolute left-2.5 bottom-0.5 text-[9px] leading-none text-status-warning pointer-events-none"
                       data-testid="env-editor-warning-secret"
                       title="Looks like a secret. Prefer a ${ENV_VAR} reference to your shell environment."
                     >

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -147,7 +147,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
             />
             {hasErrors && (
               <div
-                className="rounded-[var(--radius-md)] border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-500"
+                className="rounded-[var(--radius-md)] border border-status-warning/40 bg-status-warning/10 px-3 py-2 text-[12px] text-status-warning"
                 data-testid="import-env-errors"
               >
                 <div className="flex items-center gap-1.5 font-medium mb-1">
@@ -160,7 +160,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
                 <ul className="space-y-0.5 font-mono text-[11px]">
                   {parsed.errors.map((e) => (
                     <li key={`${e.line}-${e.raw}`}>
-                      <span className="text-amber-500/70">Line {e.line}:</span> {e.reason}
+                      <span className="text-status-warning/70">Line {e.line}:</span> {e.reason}
                       {e.raw.trim() !== "" && (
                         <span className="text-daintree-text/50"> — {e.raw}</span>
                       )}

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -40,7 +40,7 @@ export function SettingsCheckbox({
         scope === "project"
           ? "bg-daintree-accent/10 text-daintree-accent dark:bg-daintree-accent/20"
           : scope === "global"
-            ? "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20"
+            ? "bg-status-info/10 text-status-info"
             : "bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20"
       }`}
     >

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -46,7 +46,7 @@ export function SettingsInput({
         scope === "project"
           ? "bg-daintree-accent/10 text-daintree-accent dark:bg-daintree-accent/20"
           : scope === "global"
-            ? "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20"
+            ? "bg-status-info/10 text-status-info"
             : "bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20"
       }`}
     >

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -66,7 +66,7 @@ export function SettingsSelect({
         scope === "project"
           ? "bg-daintree-accent/10 text-daintree-accent dark:bg-daintree-accent/20"
           : scope === "global"
-            ? "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20"
+            ? "bg-status-info/10 text-status-info"
             : "bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20"
       }`}
     >

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -62,7 +62,7 @@ export function SettingsSwitchCard({
         scope === "project"
           ? "bg-daintree-accent/10 text-daintree-accent dark:bg-daintree-accent/20"
           : scope === "global"
-            ? "bg-blue-500/10 text-blue-500 dark:bg-blue-500/20"
+            ? "bg-status-info/10 text-status-info"
             : "bg-text-secondary/10 text-text-secondary dark:bg-text-secondary/20"
       }`}
     >

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -23,7 +23,7 @@ function StateBanner({ state, detail }: { state: AgentAvailabilityState; detail:
   if (state === "ready") {
     return (
       <div className="flex items-start gap-3 px-4 py-3 rounded-[var(--radius-md)] border border-status-success/20 bg-status-success/5">
-        <Check className="w-5 h-5 text-green-500 shrink-0 mt-px" />
+        <Check className="w-5 h-5 text-status-success shrink-0 mt-px" />
         <div>
           <p className="text-sm font-medium">CLI is now available</p>
           <p className="text-xs text-daintree-text/60 mt-1">
@@ -152,7 +152,7 @@ function CopyableCommand({ command }: { command: string }) {
         aria-label={copied ? "Copied" : "Copy command"}
       >
         {copied ? (
-          <Check className="w-3.5 h-3.5 text-green-500" />
+          <Check className="w-3.5 h-3.5 text-status-success" />
         ) : (
           <Clipboard className="w-3.5 h-3.5" />
         )}


### PR DESCRIPTION
## Summary
9 components were using raw Tailwind chromatic utilities (`text-amber-500`, `text-blue-500`, `bg-blue-500/10`, `text-green-500`, `text-red-400`) where they semantically meant a status color. The theme system already has `status-warning`, `status-error`, `status-success`, and `status-info` tokens wired through `src/index.css` and used by 19+ other components. The hard-coded colors don't change with theme, breaking contrast tuning on the six light themes and any custom theme.

Resolves #6209.

## Changes
- **EnvVarEditor** — replaced `text-amber-500` and `text-amber-500/70` / `before:bg-amber-500/70` with `text-status-warning` and `text-status-warning/70` / `before:bg-status-warning/70` (duplicate-key warnings, secret-warning labels, stripe indicators)
- **ImportEnvDialog** — replaced `border-amber-500/40 bg-amber-500/10 text-amber-500` and `text-amber-500/70` with `border-status-warning/40 bg-status-warning/10 text-status-warning` and `text-status-warning/70`
- **MissingCliGate** — replaced `text-green-500` on CLI-ready check icons with `text-status-success`
- **WelcomeScreen** — replaced `text-red-400` on pin error with `text-status-error`
- **SettingsCheckbox, SettingsSwitchCard, SettingsInput, SettingsSelect** — replaced `bg-blue-500/10 text-blue-500 dark:bg-blue-500/20` Global scope badge with `bg-status-info/10 text-status-info`
- **FleetArmingRibbon** — replaced `bg-amber-500/20 text-amber-100 hover:bg-amber-500/30` on confirm-pending broadcast button and `bg-amber-500/5` on Exit kbd with existing `bg-category-amber-subtle` / `text-category-amber-text` tokens already used elsewhere in the file. Changed `transition-colors` to `transition` per the accent-color-restraint rule.

## Testing
- Verified all 9 files compile with `npm run check` (typecheck + lint)
- Manually confirmed token references match existing conventions (`text-status-error` over `text-status-danger` for consistency with 19+ existing sites)