### PR TITLE
fix(agent): add waiting watchdog to recover from silently-dead subprocesses

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -75,6 +75,8 @@ export interface ActivityMonitorOptions {
   pollingMaxBootMs?: number;
   maxWorkingSilenceMs?: number;
   maxCpuHighEscapeMs?: number;
+  maxWaitingSilenceMs?: number;
+  onWaitingTimeout?: (id: string, spawnedAt: number) => void;
 }
 
 export interface ActivityStateMetadata {
@@ -99,11 +101,14 @@ export class ActivityMonitor {
   private readonly COMPLETION_HOLD_MS = 500;
   private readonly WORKING_INDICATOR_TTL_MS = 5000;
   private readonly MAX_WORKING_SILENCE_MS: number;
+  private readonly MAX_WAITING_SILENCE_MS: number;
   private readonly MAX_CPU_HIGH_ESCAPE_MS: number;
   private readonly CPU_HIGH_THRESHOLD = 10;
   private readonly CPU_LOW_THRESHOLD = 3;
   private isCpuHigh = false;
   private cpuHighSince = 0;
+  private idleSince = 0;
+  private waitingWatchdogFired = false;
   private lastPatternResultAt = 0;
   private workingHoldUntil = 0;
 
@@ -120,6 +125,7 @@ export class ActivityMonitor {
   // Resize suppression
   private resizeSuppressUntil = 0;
 
+  private readonly onWaitingTimeout?: (id: string, spawnedAt: number) => void;
   private readonly processStateValidator?: ProcessStateValidator;
   private lastActivityTimestamp = Date.now();
   private lastDataTimestamp = Date.now();
@@ -135,6 +141,7 @@ export class ActivityMonitor {
   private readonly getVisibleLines?: (n: number) => string[];
   private readonly getCursorLine?: () => string | null;
   private pollingInterval?: ReturnType<typeof setInterval>;
+  private watchdogInterval?: ReturnType<typeof setInterval>;
 
   // Polling config
   private readonly POLLING_MAX_BOOT_MS: number;
@@ -166,8 +173,12 @@ export class ActivityMonitor {
     this.POLLING_MAX_BOOT_MS = options?.pollingMaxBootMs ?? 15000;
     this.MAX_WORKING_SILENCE_MS = options?.maxWorkingSilenceMs ?? 180000;
     this.MAX_CPU_HIGH_ESCAPE_MS = options?.maxCpuHighEscapeMs ?? 60000;
+    this.MAX_WAITING_SILENCE_MS = options?.maxWaitingSilenceMs ?? 600000;
+
+    this.idleSince = Date.now();
 
     this.processStateValidator = options?.processStateValidator;
+    this.onWaitingTimeout = options?.onWaitingTimeout;
 
     // Initialize subsystems
     this.inputTracker = new InputTracker({
@@ -220,6 +231,11 @@ export class ActivityMonitor {
 
     // Polling interval
     this.POLLING_INTERVAL_MS = options?.pollingIntervalMs ?? 50;
+
+    // Lightweight watchdog interval: runs the waiting watchdog check periodically
+    // even when there's no output/activity. 5s keeps overhead negligible while
+    // ensuring hung waiting states are caught within a reasonable window.
+    this.watchdogInterval = setInterval(() => this.checkWaitingWatchdog(Date.now()), 5000);
   }
 
   onInput(data: string): void {
@@ -395,6 +411,12 @@ export class ActivityMonitor {
         // Callback failure must not prevent cleanup
       }
     }
+    this.waitingWatchdogFired = false;
+    this.idleSince = 0;
+    if (this.watchdogInterval) {
+      clearInterval(this.watchdogInterval);
+      this.watchdogInterval = undefined;
+    }
     this.stopPolling();
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
@@ -551,10 +573,14 @@ export class ActivityMonitor {
     // Safety timeout: if no PTY output for MAX_WORKING_SILENCE_MS, force idle
     if (this.isWorkingSilenceTimeout(now)) {
       this.state = "idle";
+      this.idleSince = now;
       this.patternBuf.clear();
       this.onStateChange(this.terminalId, this.spawnedAt, "idle", { trigger: "timeout" });
       return;
     }
+
+    // Waiting watchdog: if idle (waiting) > MAX_WAITING_SILENCE_MS and agent process is dead
+    this.checkWaitingWatchdog(now);
 
     const hasRecentOutputActivity =
       this.lastOutputActivityAt > 0 &&
@@ -691,6 +717,7 @@ export class ActivityMonitor {
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
+      this.idleSince = now;
       this.patternBuf.clear();
       const waitingReason = classifyWaitingReason(lines, true);
       this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
@@ -727,6 +754,7 @@ export class ActivityMonitor {
       const lexemeResult = detectPromptLexeme(candidateLine);
       if (lexemeResult.isPrompt) {
         this.state = "idle";
+        this.idleSince = now;
         this.patternBuf.clear();
         this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
           trigger: "pattern",
@@ -746,6 +774,7 @@ export class ActivityMonitor {
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
+      this.idleSince = now;
       this.patternBuf.clear();
       const waitingReason = classifyWaitingReason(lines, isPrompt);
       this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
@@ -795,6 +824,7 @@ export class ActivityMonitor {
       }
       this.completionTimer.emitted = false;
       this.state = "idle";
+      this.idleSince = Date.now();
       this.patternBuf.clear();
       this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
         trigger: "pattern",
@@ -839,6 +869,7 @@ export class ActivityMonitor {
         this.debounceTimer = null;
       }
       this.state = "idle";
+      this.idleSince = Date.now();
       this.patternBuf.clear();
       this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
         trigger: "timeout",
@@ -856,12 +887,14 @@ export class ActivityMonitor {
     this.lastDataTimestamp = now;
     this.recordWorkingSignal(now);
     this.resetDebounceTimer();
+    this.waitingWatchdogFired = false;
 
     // Reset completion state for the new work cycle
     this.completionTimer.reset();
 
     if (this.state !== "busy") {
       this.state = "busy";
+      this.idleSince = now;
       this.onStateChange(this.terminalId, this.spawnedAt, "busy", metadata);
     }
   }
@@ -905,6 +938,7 @@ export class ActivityMonitor {
       // Safety timeout: if no PTY output for MAX_WORKING_SILENCE_MS, force idle
       if (this.isWorkingSilenceTimeout(Date.now())) {
         this.state = "idle";
+        this.idleSince = Date.now();
         this.patternBuf.clear();
         this.onStateChange(this.terminalId, this.spawnedAt, "idle", { trigger: "timeout" });
         this.debounceTimer = null;
@@ -916,6 +950,7 @@ export class ActivityMonitor {
       const actuallyBusy = this.hasActiveChildrenSafe();
       if (actuallyBusy === false) {
         this.state = "idle";
+        this.idleSince = Date.now();
         this.patternBuf.clear();
         this.onStateChange(this.terminalId, this.spawnedAt, "idle");
         this.debounceTimer = null;
@@ -958,6 +993,7 @@ export class ActivityMonitor {
       }
 
       this.state = "idle";
+      this.idleSince = Date.now();
       this.patternBuf.clear();
       this.onStateChange(this.terminalId, this.spawnedAt, "idle");
       this.debounceTimer = null;
@@ -972,6 +1008,19 @@ export class ActivityMonitor {
     // High CPU prevents premature silence timeout — but only up to the escape deadline
     if (this.isCpuHighAndNotDeadlined(now)) return false;
     return true;
+  }
+
+  private checkWaitingWatchdog(now: number): void {
+    if (this.state !== "idle") return;
+    if (this.waitingWatchdogFired) return;
+    if (now - this.idleSince < this.MAX_WAITING_SILENCE_MS) return;
+    if (!this.onWaitingTimeout) return;
+
+    const hasChildren = this.hasActiveChildrenSafe();
+    if (hasChildren !== false) return;
+
+    this.waitingWatchdogFired = true;
+    this.onWaitingTimeout(this.terminalId, this.spawnedAt);
   }
 
   private hasActiveChildrenSafe(): boolean | null {

--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -10,12 +10,13 @@ export type AgentEvent =
   | { type: "exit"; code: number; signal?: number }
   | { type: "error"; error: string }
   | { type: "kill" } // Intentional kill by user
-  | { type: "respawn" }; // New agent session detected in same PTY after a prior exit
+  | { type: "respawn" } // New agent session detected in same PTY after a prior exit
+  | { type: "watchdog-timeout" }; // Watchdog: waiting state timed out with dead children
 
 const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   idle: ["working", "exited"],
   working: ["waiting", "completed", "exited"],
-  waiting: ["working", "completed", "exited"],
+  waiting: ["working", "completed", "exited", "idle"],
   directing: [], // Renderer-only state, never produced by main process
   completed: ["working", "waiting", "exited"],
   exited: ["idle"], // Terminal per agent lifecycle; `respawn` allows a fresh agent session in the same PTY
@@ -88,6 +89,12 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
 
     case "respawn":
       if (current === "exited") {
+        return "idle";
+      }
+      break;
+
+    case "watchdog-timeout":
+      if (current === "waiting") {
         return "idle";
       }
       break;

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3896,4 +3896,205 @@ describe("ActivityMonitor", () => {
       expect(onStateChange).not.toHaveBeenCalled();
     });
   });
+
+  describe("Waiting watchdog", () => {
+    it("should fire onWaitingTimeout after MAX_WAITING_SILENCE_MS when idle with dead children", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-1", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      // Advance past the 5s watchdog interval + 1s silence threshold
+      vi.advanceTimersByTime(5100);
+
+      expect(onWaitingTimeout).toHaveBeenCalledWith("test-wd-1", 100);
+
+      monitor.dispose();
+    });
+
+    it("should not fire before MAX_WAITING_SILENCE_MS elapses", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-2", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 60000,
+      });
+
+      // Advance past watchdog interval but not past silence threshold
+      vi.advanceTimersByTime(10000);
+
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should not fire when hasActiveChildren returns true", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(true),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-3", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      vi.advanceTimersByTime(5100);
+
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should not fire when hasActiveChildren returns null (no validator)", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      // No processStateValidator at all
+      const monitor = new ActivityMonitor("test-wd-4", 100, onStateChange, {
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      vi.advanceTimersByTime(5100);
+
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should not fire when state is busy", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-5", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+        idleDebounceMs: 30000, // Keep busy long enough to test watchdog gate
+      });
+
+      // Enter busy state
+      monitor.onInput("\r");
+      expect(onStateChange).toHaveBeenCalledWith("test-wd-5", 100, "busy", { trigger: "input" });
+
+      // Advance past watchdog interval but not past idle debounce — still busy
+      vi.advanceTimersByTime(5100);
+      expect(monitor.getState()).toBe("busy");
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should fire only once per idle episode", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-6", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      // Advance well past multiple watchdog intervals
+      vi.advanceTimersByTime(15000);
+
+      expect(onWaitingTimeout).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+
+    it("should reset after becomeBusy and fire again next idle cycle", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-7", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      // Fire first watchdog
+      vi.advanceTimersByTime(5100);
+      expect(onWaitingTimeout).toHaveBeenCalledTimes(1);
+
+      // Transition to busy
+      monitor.onInput("\r");
+      onWaitingTimeout.mockClear();
+
+      // Still busy, watchdog shouldn't fire
+      vi.advanceTimersByTime(5100);
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should not fire after dispose", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const monitor = new ActivityMonitor("test-wd-8", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 1000,
+      });
+
+      monitor.dispose();
+
+      vi.advanceTimersByTime(1100);
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+    });
+
+    it("should fire for polling monitors after becoming idle", () => {
+      const onStateChange = vi.fn();
+      const onWaitingTimeout = vi.fn();
+      const processStateValidator = {
+        hasActiveChildren: vi.fn().mockReturnValue(false),
+        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
+      };
+      const getVisibleLines = vi.fn(() => ["$ "]);
+      // Stub detectPrompt to avoid importing the full module
+      const monitor = new ActivityMonitor("test-wd-9", 100, onStateChange, {
+        processStateValidator,
+        onWaitingTimeout,
+        maxWaitingSilenceMs: 100,
+        getVisibleLines,
+        pollingIntervalMs: 20,
+        idleDebounceMs: 50,
+      });
+
+      monitor.startPolling();
+
+      // Polling starts in busy boot phase — watchdog won't fire yet
+      vi.advanceTimersByTime(200);
+      expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/__tests__/AgentStateMachine.test.ts
+++ b/electron/services/__tests__/AgentStateMachine.test.ts
@@ -41,6 +41,10 @@ describe("AgentStateMachine", () => {
       expect(isValidTransition("completed", "working")).toBe(true);
     });
 
+    it("should allow waiting → idle (watchdog timeout)", () => {
+      expect(isValidTransition("waiting", "idle")).toBe(true);
+    });
+
     it("should allow completed → exited (exit from completed)", () => {
       expect(isValidTransition("completed", "exited")).toBe(true);
     });
@@ -262,6 +266,44 @@ describe("AgentStateMachine", () => {
         for (const state of states) {
           expect(nextAgentState(state, event)).toBe("idle");
         }
+      });
+    });
+
+    describe("watchdog-timeout event", () => {
+      it("should transition waiting → idle on watchdog-timeout", () => {
+        const event: AgentEvent = { type: "watchdog-timeout" };
+        expect(nextAgentState("waiting", event)).toBe("idle");
+      });
+
+      it("should not transition from completed on watchdog-timeout", () => {
+        const event: AgentEvent = { type: "watchdog-timeout" };
+        expect(nextAgentState("completed", event)).toBe("completed");
+      });
+
+      it("should not transition from working on watchdog-timeout", () => {
+        const event: AgentEvent = { type: "watchdog-timeout" };
+        expect(nextAgentState("working", event)).toBe("working");
+      });
+
+      it("should not transition from idle on watchdog-timeout", () => {
+        const event: AgentEvent = { type: "watchdog-timeout" };
+        expect(nextAgentState("idle", event)).toBe("idle");
+      });
+
+      it("should not transition from exited on watchdog-timeout", () => {
+        const event: AgentEvent = { type: "watchdog-timeout" };
+        expect(nextAgentState("exited", event)).toBe("exited");
+      });
+
+      it("should allow late exit: waiting→idle (watchdog) then idle→exited (exit)", () => {
+        const watchdogEvent: AgentEvent = { type: "watchdog-timeout" };
+        const exitEvent: AgentEvent = { type: "exit", code: 0 };
+
+        const afterWatchdog = nextAgentState("waiting", watchdogEvent);
+        expect(afterWatchdog).toBe("idle");
+
+        const afterExit = nextAgentState(afterWatchdog, exitEvent);
+        expect(afterExit).toBe("exited");
       });
     });
 

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -57,6 +57,8 @@ export class AgentStateService {
         return "activity";
       case "respawn":
         return "activity";
+      case "watchdog-timeout":
+        return "timeout";
       default:
         return "output";
     }

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -410,6 +410,14 @@ export class TerminalProcess {
             getCursorLine: () => this.getCursorLine(),
           }),
           processStateValidator,
+          onWaitingTimeout: (_id, _spawnedAt) => {
+            deps.agentStateService.updateAgentState(
+              this.terminalInfo,
+              { type: "watchdog-timeout" },
+              "timeout",
+              0.6
+            );
+          },
         }
       );
       this.activityMonitor.startPolling();
@@ -1447,6 +1455,14 @@ export class TerminalProcess {
           processStateValidator,
           initialState,
           skipInitialStateEmit: preserveState,
+          onWaitingTimeout: (_id, _spawnedAt) => {
+            this.deps.agentStateService.updateAgentState(
+              this.terminalInfo,
+              { type: "watchdog-timeout" },
+              "timeout",
+              0.6
+            );
+          },
         }
       );
       this.activityMonitor.startPolling();

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -207,5 +207,6 @@ export function buildActivityMonitorOptions(
     promptConfidence: detection?.promptConfidence,
     idleDebounceMs: effectiveAgentId ? (detection?.debounceMs ?? 4000) : undefined,
     promptFastPathMinQuietMs: detection?.promptFastPathMinQuietMs,
+    maxWaitingSilenceMs: 600_000,
   };
 }


### PR DESCRIPTION
## Summary

When an agent subprocess dies silently (no PTY exit event), the terminal stays in `waiting` forever. This happens when the OS kills the process or the exit never reaches the PTY, and there's no automatic recovery path.

This PR adds a watchdog that periodically checks `hasActiveChildren()` while the agent is waiting. If the process tree is dead and no activity arrives for a configurable silence period (defaulting to 10 minutes), it forces a `waiting` to `idle` transition. The watchdog only fires when `hasActiveChildren()` definitively returns `false`, and only in the `waiting` state specifically -- it won't walk back from `completed`.

Resolves #6208.

## Changes

- New `watchdog-timeout` AgentEvent and `waiting -> idle` transition in `AgentStateMachine`
- `idleSince` timestamp tracking and `checkWaitingWatchdog()` in `ActivityMonitor`, polled every 5s
- `onWaitingTimeout` callback added to `ActivityMonitorOptions`, wired through `TerminalProcess` to `AgentStateService`
- `maxWaitingSilenceMs` config (default 600s) in `terminalActivityPatterns`
- `inferTrigger` mapping for `watchdog-timeout -> timeout` in `AgentStateService`

## Testing

- 14 new tests across `AgentStateMachine.test.ts` and `ActivityMonitor.test.ts`
- All 247 tests pass, typecheck/lint/format green