### PR TITLE
fix(github): fall back to raw CI rollup when no required checks exist

### DIFF
--- a/electron/services/github/__tests__/prRequiredCIStatus.test.ts
+++ b/electron/services/github/__tests__/prRequiredCIStatus.test.ts
@@ -124,6 +124,12 @@ describe("deriveRequiredCIStatus", () => {
     expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 0, requiredPending: 1 });
   });
 
+  it("falls back to raw rollup when contexts list is empty", () => {
+    const r = deriveRequiredCIStatus([], false, "PENDING");
+    expect(r.ciStatus).toBe("PENDING");
+    expect(r.ciSummary).toBeUndefined();
+  });
+
   it("falls back to raw FAILURE rollup when no required checks exist", () => {
     const r = deriveRequiredCIStatus(
       [

--- a/electron/services/github/__tests__/prRequiredCIStatus.test.ts
+++ b/electron/services/github/__tests__/prRequiredCIStatus.test.ts
@@ -124,7 +124,7 @@ describe("deriveRequiredCIStatus", () => {
     expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 0, requiredPending: 1 });
   });
 
-  it("returns SUCCESS with zeroed summary when no required checks exist", () => {
+  it("falls back to raw FAILURE rollup when no required checks exist", () => {
     const r = deriveRequiredCIStatus(
       [
         {
@@ -137,8 +137,42 @@ describe("deriveRequiredCIStatus", () => {
       false,
       "FAILURE"
     );
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toBeUndefined();
+  });
+
+  it("falls back to raw PENDING rollup when no required checks exist", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: null,
+          status: "IN_PROGRESS",
+          isRequired: false,
+        },
+      ],
+      false,
+      "PENDING"
+    );
+    expect(r.ciStatus).toBe("PENDING");
+    expect(r.ciSummary).toBeUndefined();
+  });
+
+  it("falls back to raw SUCCESS rollup when no required checks exist", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: "SUCCESS",
+          status: "COMPLETED",
+          isRequired: false,
+        },
+      ],
+      false,
+      "SUCCESS"
+    );
     expect(r.ciStatus).toBe("SUCCESS");
-    expect(r.ciSummary).toEqual({ requiredTotal: 0, requiredFailing: 0, requiredPending: 0 });
+    expect(r.ciSummary).toBeUndefined();
   });
 
   it("ignores non-required checks entirely", () => {

--- a/electron/services/github/prRequiredCIStatus.ts
+++ b/electron/services/github/prRequiredCIStatus.ts
@@ -66,8 +66,8 @@ function normalizeRawState(
  * Returns the raw rollup status and no summary when:
  * - contexts page is truncated (hasNextPage) — avoids false-greens from unseen required checks
  * - the contexts list is null/undefined — no data to enrich
- *
- * When no required contexts are present in a full page, falls back to the raw status.
+ * - no required contexts are present in a full page — repos without branch protection have
+ *   no "required" / "non-required" distinction, so the raw rollup is the right signal
  */
 export function deriveRequiredCIStatus(
   contexts: RollupContextNode[] | null | undefined,
@@ -122,11 +122,10 @@ export function deriveRequiredCIStatus(
   }
 
   if (requiredTotal === 0) {
-    // No required checks configured — non-required failures shouldn't turn the indicator red.
-    return {
-      ciStatus: "SUCCESS",
-      ciSummary: { requiredTotal: 0, requiredFailing: 0, requiredPending: 0 },
-    };
+    // No required checks configured — fall back to the raw rollup state so the indicator
+    // reflects actual CI health. A zeroed summary would mask real failures by forcing the
+    // tooltip down the "No required checks" path even when checks are red or in-flight.
+    return { ciStatus: rawCiStatus, ciSummary: undefined };
   }
 
   const summary: GitHubPRCISummary = { requiredTotal, requiredFailing, requiredPending };

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -88,7 +88,9 @@ export interface GitHubPR {
   commentCount?: number;
   /** CI status rollup from the latest commit (reflects required checks only when ciSummary is present) */
   ciStatus?: GitHubPRCIStatus;
-  /** Summary of required checks; only present when contexts were successfully enriched */
+  /** Summary of required checks. Absent when enrichment hasn't run, when the context page
+   *  was truncated, or when the repository has no required checks configured (in which case
+   *  ciStatus reflects the raw rollup). */
   ciSummary?: GitHubPRCISummary;
 }
 


### PR DESCRIPTION
## Summary

- `deriveRequiredCIStatus` was returning hard-coded `SUCCESS` when `requiredTotal === 0`, so repos with no branch protection rules always showed a green indicator regardless of actual check state
- When `requiredTotal === 0`, the function now returns `{ ciStatus: rawCiStatus, ciSummary: undefined }`, reflecting the real rollup state in the PR dropdown
- UI tooltip copy falls through to the existing raw-state paths via `getCIStatusInfo`, so pending stays amber and failures stay red

Resolves #6239

## Changes

- `electron/services/github/prRequiredCIStatus.ts` — removed hard-coded `SUCCESS` return in the `requiredTotal === 0` branch; returns raw rollup state and leaves `ciSummary` as `undefined` instead
- `shared/types/github.ts` — `ciSummary` on `PRRequiredCIStatus` is now `undefined` when there are no required checks (was previously always populated)
- `electron/services/github/__tests__/prRequiredCIStatus.test.ts` — flipped the broken-behavior assertion, added 3 new tests covering FAILURE/PENDING/SUCCESS raw fallback and the empty-contexts case

## Testing

13 unit tests pass. The `requiredTotal > 0` path is untouched, so the #5400 regression (non-required failures on protected branches flipping the indicator red) is not affected.