### PR TITLE
test(pty): verify EnvironmentFilter denylist covers SDK auth tokens

### DIFF
--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -250,6 +250,13 @@ describe("filterEnvironment + injectDaintreeMetadata integration", () => {
       AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG",
       DATABASE_URL: "postgres://localhost/dev",
       MY_CUSTOM_TOKEN: "tok_abc123",
+      AWS_BEARER_TOKEN_BEDROCK: "bedrock-bearer",
+      ANTHROPIC_AUTH_TOKEN: "ant-auth",
+      OPENAI_WEBHOOK_SECRET: "whsec_xyz",
+      COPILOT_CLI_TOKEN: "copilot-tok",
+      SRC_ACCESS_TOKEN: "sgp_abc",
+      GH_ENTERPRISE_TOKEN: "ghe-tok",
+      GITHUB_ENTERPRISE_TOKEN: "github-ent-tok",
       // Pre-existing DAINTREE_ vars should be stripped
       DAINTREE_PANE_ID: "old-id",
     };
@@ -274,6 +281,13 @@ describe("filterEnvironment + injectDaintreeMetadata integration", () => {
     expect(final.AWS_SECRET_ACCESS_KEY).toBeUndefined();
     expect(final.DATABASE_URL).toBeUndefined();
     expect(final.MY_CUSTOM_TOKEN).toBeUndefined();
+    expect(final.AWS_BEARER_TOKEN_BEDROCK).toBeUndefined();
+    expect(final.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(final.OPENAI_WEBHOOK_SECRET).toBeUndefined();
+    expect(final.COPILOT_CLI_TOKEN).toBeUndefined();
+    expect(final.SRC_ACCESS_TOKEN).toBeUndefined();
+    expect(final.GH_ENTERPRISE_TOKEN).toBeUndefined();
+    expect(final.GITHUB_ENTERPRISE_TOKEN).toBeUndefined();
 
     // DAINTREE_* freshly injected (not spoofed)
     expect(final.DAINTREE_PANE_ID).toBe("new-pane-id");

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -37,6 +37,21 @@ describe("isSensitiveVar", () => {
     it("blocks JWT_SECRET", () => expect(isSensitiveVar("JWT_SECRET")).toBe(true));
   });
 
+  describe("pattern blocklist — SDK auth vars", () => {
+    it("blocks AWS_BEARER_TOKEN_BEDROCK", () =>
+      expect(isSensitiveVar("AWS_BEARER_TOKEN_BEDROCK")).toBe(true));
+    it("blocks ANTHROPIC_AUTH_TOKEN", () =>
+      expect(isSensitiveVar("ANTHROPIC_AUTH_TOKEN")).toBe(true));
+    it("blocks OPENAI_WEBHOOK_SECRET", () =>
+      expect(isSensitiveVar("OPENAI_WEBHOOK_SECRET")).toBe(true));
+    it("blocks COPILOT_CLI_TOKEN", () => expect(isSensitiveVar("COPILOT_CLI_TOKEN")).toBe(true));
+    it("blocks SRC_ACCESS_TOKEN", () => expect(isSensitiveVar("SRC_ACCESS_TOKEN")).toBe(true));
+    it("blocks GH_ENTERPRISE_TOKEN", () =>
+      expect(isSensitiveVar("GH_ENTERPRISE_TOKEN")).toBe(true));
+    it("blocks GITHUB_ENTERPRISE_TOKEN", () =>
+      expect(isSensitiveVar("GITHUB_ENTERPRISE_TOKEN")).toBe(true));
+  });
+
   describe("safe vars — must NOT be blocked", () => {
     it("allows PATH", () => expect(isSensitiveVar("PATH")).toBe(false));
     it("allows HOME", () => expect(isSensitiveVar("HOME")).toBe(false));


### PR DESCRIPTION
## Summary

- Adds explicit unit tests to `EnvironmentFilter.test.ts` for 7 SDK auth env vars that surfaced in a recent audit but had no direct test coverage
- Extends the existing `filterEnvironment` integration fixture to confirm all 7 are stripped end-to-end
- No source changes needed — `SENSITIVE_PATTERN` already catches all 7 via the `_TOKEN_` / `_KEY_` boundary match; the tests make that guarantee explicit so future regex tweaks can't silently drop coverage

Resolves #6251

## Changes

The 7 vars now directly tested:

- `AWS_BEARER_TOKEN_BEDROCK` — Bedrock relay token
- `ANTHROPIC_AUTH_TOKEN` — Anthropic SDK bearer alternative
- `OPENAI_WEBHOOK_SECRET` — documented in `openai-node`
- `COPILOT_CLI_TOKEN` — GitHub Copilot CLI dedicated token
- `SRC_ACCESS_TOKEN` — Sourcegraph Cody auth
- `GH_ENTERPRISE_TOKEN` / `GITHUB_ENTERPRISE_TOKEN` — `gh` CLI enterprise auth

## Testing

71 unit tests pass (`EnvironmentFilter.test.ts`). All 7 vars confirmed blocked by `isSensitiveVar` and absent from the output of `filterEnvironment`.