### PR TITLE
fix(telemetry): disable @sentry/electron native minidump uploads

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -188,6 +188,11 @@ export async function initializeTelemetry(): Promise<void> {
         dsn,
         release: app.getVersion(),
         environment: app.isPackaged ? "production" : "development",
+        // Drop the default minidump integration. Native .dmp payloads contain
+        // stack/register memory that may include env vars (API keys, tokens) at
+        // crash time, and JS-level beforeSend cannot scrub binary data. JS
+        // crashes remain captured via globalErrorHandlers.ts / main-crash.log.
+        integrations: (defaults) => defaults.filter((i) => i.name !== "SentryMinidump"),
         // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
         // performance tracing is ever added, use `tracesSampleRate` instead.
         // The local `SentryEvent` interface is a narrower projection of the

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -626,6 +626,30 @@ describe("initializeTelemetry", () => {
     expect(options).not.toHaveProperty("sampleRate");
     process.env.SENTRY_DSN = original;
   });
+
+  // #6250 — sentryMinidumpIntegration is filtered out of the default integrations
+  // because native .dmp payloads can leak env-var secrets that beforeSend can't
+  // reach. Other defaults (e.g. ElectronMinidump alternative, breadcrumbs) stay.
+  it("filters SentryMinidump from default integrations, preserving others", async () => {
+    vi.resetModules();
+    const mod = await import("../TelemetryService.js");
+    setPrivacy({ telemetryLevel: "errors" });
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    await mod.initializeTelemetry();
+    const options = sentryInitMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(typeof options.integrations).toBe("function");
+    const fn = options.integrations as (
+      defaults: Array<{ name: string }>
+    ) => Array<{ name: string }>;
+    const result = fn([
+      { name: "SentryMinidump" },
+      { name: "Other" },
+      { name: "ElectronMinidump" },
+    ]);
+    expect(result.map((i) => i.name)).toEqual(["Other", "ElectronMinidump"]);
+    process.env.SENTRY_DSN = original;
+  });
 });
 
 describe("trackEvent", () => {


### PR DESCRIPTION
## Summary

- `@sentry/electron` enables `sentryMinidumpIntegration` by default, which can capture `process.env` at crash time — including `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, and similar secrets baked into the environment.
- The JS-level `beforeSend` hook in `TelemetryService.ts` can't reach the binary minidump payload, so it can't scrub secrets — it can only drop the event entirely.
- Filtering out the `SentryMinidump` integration at init time is the correct fix. Integration name verified in `node_modules/@sentry/electron`.

Resolves #6250

## Changes

- `electron/services/TelemetryService.ts` — adds `integrations: (defaults) => defaults.filter((i) => i.name !== "SentryMinidump")` to `sentry.init()`. A code comment documents the trade-off: native crashes still surface as process-exit signals handled by `globalErrorHandlers.ts`, but without native stack traces or register state. Acceptable for now; the long-term fix is moving secrets out of `process.env` into Electron's `safeStorage`.
- `electron/services/__tests__/TelemetryService.test.ts` — asserts the `SentryMinidump` integration is excluded from the init call.

## Testing

- Unit test added and passing.
- Verified `enableNative: false` is not a valid option in `@sentry/electron` (it's a Capacitor SDK flag) and that `Electron.crashReporter.start({ uploadToServer: false })` is silently overridden when `sentryMinidumpIntegration` is active — this filter is the right lever.