### PR TITLE
fix(portal): gate in-page navigations to non-http(s) schemes

### DIFF
--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, Menu, WebContentsView, app, clipboard } from "electron";
 import type { PortalBounds, PortalNavEvent } from "../../shared/types/portal.js";
+import { isSafeNavigationUrl } from "../../shared/utils/urlUtils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getAppWebContents } from "../window/webContentsRegistry.js";
@@ -267,6 +268,20 @@ export class PortalManager {
 
         const menu = Menu.buildFromTemplate(template);
         menu.popup({ window: win });
+      });
+
+      view.webContents.on("will-navigate", (event, navigationUrl) => {
+        if (!isSafeNavigationUrl(navigationUrl)) {
+          console.warn(`[PortalManager] Blocked portal navigation to unsafe URL: ${navigationUrl}`);
+          event.preventDefault();
+        }
+      });
+
+      view.webContents.on("will-redirect", (event, redirectUrl) => {
+        if (!isSafeNavigationUrl(redirectUrl)) {
+          console.warn(`[PortalManager] Blocked portal redirect to unsafe URL: ${redirectUrl}`);
+          event.preventDefault();
+        }
       });
 
       view.webContents.loadURL(url).catch((err) => {

--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -284,6 +284,17 @@ export class PortalManager {
         }
       });
 
+      // Subframe coverage: will-navigate is main-frame only, so iframes inside
+      // a portal page can otherwise navigate to file:/data:/etc. unblocked.
+      view.webContents.on("will-frame-navigate", (details) => {
+        if (!isSafeNavigationUrl(details.url)) {
+          console.warn(
+            `[PortalManager] Blocked portal frame navigation to unsafe URL: ${details.url}`
+          );
+          details.preventDefault();
+        }
+      });
+
       view.webContents.loadURL(url).catch((err) => {
         console.error(`[PortalManager] Failed to load URL ${url} in tab ${tabId}:`, err);
       });

--- a/electron/services/__tests__/PortalManager.adversarial.test.ts
+++ b/electron/services/__tests__/PortalManager.adversarial.test.ts
@@ -147,4 +147,88 @@ describe("PortalManager adversarial", () => {
     expect(manager.hasTab("tab-1")).toBe(false);
     expect(evictedWebContents.close).toHaveBeenCalledTimes(1);
   });
+
+  describe("navigation gating", () => {
+    type WebContentsMock = ReturnType<typeof createMockWebContents>;
+    type EventCall = [string, (event: { preventDefault: () => void }, url: string) => void];
+
+    const findHandler = (wc: WebContentsMock, eventName: "will-navigate" | "will-redirect") => {
+      const call = (wc.on.mock.calls as EventCall[]).find(([name]) => name === eventName);
+      if (!call) throw new Error(`No ${eventName} handler registered`);
+      return call[1];
+    };
+
+    const blockedUrls = [
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "blob:https://example.com/abc-123",
+      "about:blank",
+      "vbscript:msgbox(1)",
+      "ftp://example.com/file",
+      "",
+      "   ",
+      "not a url",
+    ];
+
+    const allowedUrls = [
+      "http://example.com/",
+      "https://example.com/path?q=1",
+      "http://localhost:3001/",
+    ];
+
+    it("registers will-navigate and will-redirect handlers on createTab", () => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const wc = createdWebContents[0];
+      const eventNames = (wc.on.mock.calls as EventCall[]).map(([name]) => name);
+      expect(eventNames).toContain("will-navigate");
+      expect(eventNames).toContain("will-redirect");
+    });
+
+    it.each(blockedUrls)("blocks will-navigate to unsafe URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler(createdWebContents[0], "will-navigate");
+      const event = { preventDefault: vi.fn() };
+      handler(event, url);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(blockedUrls)("blocks will-redirect to unsafe URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler(createdWebContents[0], "will-redirect");
+      const event = { preventDefault: vi.fn() };
+      handler(event, url);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(allowedUrls)("allows will-navigate to safe http(s) URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler(createdWebContents[0], "will-navigate");
+      const event = { preventDefault: vi.fn() };
+      handler(event, url);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it.each(allowedUrls)("allows will-redirect to safe http(s) URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler(createdWebContents[0], "will-redirect");
+      const event = { preventDefault: vi.fn() };
+      handler(event, url);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/electron/services/__tests__/PortalManager.adversarial.test.ts
+++ b/electron/services/__tests__/PortalManager.adversarial.test.ts
@@ -150,12 +150,22 @@ describe("PortalManager adversarial", () => {
 
   describe("navigation gating", () => {
     type WebContentsMock = ReturnType<typeof createMockWebContents>;
-    type EventCall = [string, (event: { preventDefault: () => void }, url: string) => void];
+    type EventName = "will-navigate" | "will-redirect" | "will-frame-navigate";
+    type PositionalHandler = (event: { preventDefault: () => void }, url: string) => void;
+    type DetailsHandler = (details: {
+      url: string;
+      isMainFrame: boolean;
+      preventDefault: () => void;
+    }) => void;
+    type EventCall = [EventName, PositionalHandler | DetailsHandler];
 
-    const findHandler = (wc: WebContentsMock, eventName: "will-navigate" | "will-redirect") => {
+    const findHandler = <T extends PositionalHandler | DetailsHandler>(
+      wc: WebContentsMock,
+      eventName: EventName
+    ): T => {
       const call = (wc.on.mock.calls as EventCall[]).find(([name]) => name === eventName);
       if (!call) throw new Error(`No ${eventName} handler registered`);
-      return call[1];
+      return call[1] as T;
     };
 
     const blockedUrls = [
@@ -177,7 +187,7 @@ describe("PortalManager adversarial", () => {
       "http://localhost:3001/",
     ];
 
-    it("registers will-navigate and will-redirect handlers on createTab", () => {
+    it("registers will-navigate, will-redirect, and will-frame-navigate handlers on createTab", () => {
       const manager = new PortalManagerClass(mockWindow);
       manager.createTab("tab-1", "http://localhost:3001");
 
@@ -185,13 +195,14 @@ describe("PortalManager adversarial", () => {
       const eventNames = (wc.on.mock.calls as EventCall[]).map(([name]) => name);
       expect(eventNames).toContain("will-navigate");
       expect(eventNames).toContain("will-redirect");
+      expect(eventNames).toContain("will-frame-navigate");
     });
 
     it.each(blockedUrls)("blocks will-navigate to unsafe URL: %s", (url) => {
       const manager = new PortalManagerClass(mockWindow);
       manager.createTab("tab-1", "http://localhost:3001");
 
-      const handler = findHandler(createdWebContents[0], "will-navigate");
+      const handler = findHandler<PositionalHandler>(createdWebContents[0], "will-navigate");
       const event = { preventDefault: vi.fn() };
       handler(event, url);
 
@@ -202,7 +213,7 @@ describe("PortalManager adversarial", () => {
       const manager = new PortalManagerClass(mockWindow);
       manager.createTab("tab-1", "http://localhost:3001");
 
-      const handler = findHandler(createdWebContents[0], "will-redirect");
+      const handler = findHandler<PositionalHandler>(createdWebContents[0], "will-redirect");
       const event = { preventDefault: vi.fn() };
       handler(event, url);
 
@@ -213,7 +224,7 @@ describe("PortalManager adversarial", () => {
       const manager = new PortalManagerClass(mockWindow);
       manager.createTab("tab-1", "http://localhost:3001");
 
-      const handler = findHandler(createdWebContents[0], "will-navigate");
+      const handler = findHandler<PositionalHandler>(createdWebContents[0], "will-navigate");
       const event = { preventDefault: vi.fn() };
       handler(event, url);
 
@@ -224,11 +235,74 @@ describe("PortalManager adversarial", () => {
       const manager = new PortalManagerClass(mockWindow);
       manager.createTab("tab-1", "http://localhost:3001");
 
-      const handler = findHandler(createdWebContents[0], "will-redirect");
+      const handler = findHandler<PositionalHandler>(createdWebContents[0], "will-redirect");
       const event = { preventDefault: vi.fn() };
       handler(event, url);
 
       expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it.each(blockedUrls)("blocks will-frame-navigate (subframe) to unsafe URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler<DetailsHandler>(createdWebContents[0], "will-frame-navigate");
+      const details = { url, isMainFrame: false, preventDefault: vi.fn() };
+      handler(details);
+
+      expect(details.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(allowedUrls)("allows will-frame-navigate (subframe) to safe http(s) URL: %s", (url) => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler<DetailsHandler>(createdWebContents[0], "will-frame-navigate");
+      const details = { url, isMainFrame: false, preventDefault: vi.fn() };
+      handler(details);
+
+      expect(details.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("allows will-frame-navigate for safe main-frame navigation", () => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler<DetailsHandler>(createdWebContents[0], "will-frame-navigate");
+      const details = {
+        url: "https://example.com/path",
+        isMainFrame: true,
+        preventDefault: vi.fn(),
+      };
+      handler(details);
+
+      expect(details.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("blocks will-frame-navigate for unsafe main-frame navigation", () => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler<DetailsHandler>(createdWebContents[0], "will-frame-navigate");
+      const details = { url: "file:///etc/passwd", isMainFrame: true, preventDefault: vi.fn() };
+      handler(details);
+
+      expect(details.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it("evaluates will-redirect independently across multiple invocations", () => {
+      const manager = new PortalManagerClass(mockWindow);
+      manager.createTab("tab-1", "http://localhost:3001");
+
+      const handler = findHandler<PositionalHandler>(createdWebContents[0], "will-redirect");
+
+      const safeEvent = { preventDefault: vi.fn() };
+      handler(safeEvent, "https://example.com/safe");
+      expect(safeEvent.preventDefault).not.toHaveBeenCalled();
+
+      const unsafeEvent = { preventDefault: vi.fn() };
+      handler(unsafeEvent, "data:text/html,evil");
+      expect(unsafeEvent.preventDefault).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/electron/services/__tests__/PortalManager.test.ts
+++ b/electron/services/__tests__/PortalManager.test.ts
@@ -360,17 +360,22 @@ describe("PortalManager", () => {
       const manager = new PortalManagerClass(mockWindow);
 
       manager.createTab("tab-nav-invalid", "http://localhost:3000");
+      const wc = createdWebContents[createdWebContents.length - 1];
+      const initialLoadCount = wc.loadURL.mock.calls.length;
 
-      // Should not throw, just log error
       expect(() => manager.navigate("tab-nav-invalid", "file:///etc/passwd")).not.toThrow();
+      expect(wc.loadURL.mock.calls.length).toBe(initialLoadCount);
     });
 
     it("rejects navigation to javascript: URL", () => {
       const manager = new PortalManagerClass(mockWindow);
 
       manager.createTab("tab-nav-js", "http://localhost:3000");
+      const wc = createdWebContents[createdWebContents.length - 1];
+      const initialLoadCount = wc.loadURL.mock.calls.length;
 
       expect(() => manager.navigate("tab-nav-js", "javascript:alert(1)")).not.toThrow();
+      expect(wc.loadURL.mock.calls.length).toBe(initialLoadCount);
     });
 
     it("does nothing for non-existent tab", () => {


### PR DESCRIPTION
## Summary

- `PortalManager` validated URLs on initial load and explicit `navigate()` calls, but never registered navigation listeners on the resulting `WebContentsView` — a page inside the portal could escape to `file:`, `data:`, `javascript:`, or other unsafe schemes via `location.href`, meta-refresh, or iframe navigation with no application-level check
- Adds `will-navigate`, `will-redirect`, and `will-frame-navigate` listeners that run every navigation through the existing `isSafeNavigationUrl` allowlist and call `preventDefault()` on anything non-http(s)
- `will-frame-navigate` is separate from `will-navigate` because the latter is main-frame only — without it, iframes inside a portal page were completely ungated

Resolves #6245

## Changes

- `electron/services/PortalManager.ts` — registers `will-navigate`, `will-redirect`, and `will-frame-navigate` on each `WebContentsView`; listeners are cleaned up in `destroyTab`
- `electron/services/__tests__/PortalManager.adversarial.test.ts` — adversarial test suite covering blocked schemes (`javascript:`, `data:`, `file:`, `blob:`, `vbscript:`, `about:`), allowed http/https passthrough, subframe navigations, multi-tab listener isolation, and redirect chains
- `electron/services/__tests__/PortalManager.test.ts` — strengthened existing `navigate()` tests to assert `loadURL` was not called (not just no-throw) for invalid-protocol inputs

## Testing

Unit tests cover the full adversarial surface: blocked and allowed URLs on `will-navigate` and `will-redirect`, subframe vs main-frame behaviour on `will-frame-navigate`, and independence of listeners across multiple tabs.