### PR TITLE
fix(fs): consolidate two write paths onto resilientAtomicWriteFile

### DIFF
--- a/electron/services/TrashedPidTracker.ts
+++ b/electron/services/TrashedPidTracker.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 
 const TRASHED_PIDS_FILENAME = "trashed-pids.json";
 
@@ -187,19 +188,9 @@ export class TrashedPidTracker {
   }
 
   private writeEntries(entries: TrashedPidEntry[]): void {
-    const tmpPath = `${this.filePath}.${Date.now()}.tmp`;
     try {
-      fs.writeFileSync(tmpPath, JSON.stringify(entries), {
-        encoding: "utf8",
-        flush: true,
-      } as Parameters<typeof fs.writeFileSync>[2]);
-      fs.renameSync(tmpPath, this.filePath);
+      resilientAtomicWriteFileSync(this.filePath, JSON.stringify(entries), "utf8");
     } catch (err) {
-      try {
-        fs.unlinkSync(tmpPath);
-      } catch {
-        // ignore
-      }
       console.warn("[TrashedPidTracker] Failed to write trashed PIDs:", err);
     }
   }

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -73,6 +73,27 @@ describe("terminalSessionPersistence", () => {
     expect(fs.existsSync(asyncPath)).toBe(false);
   });
 
+  it("persists and restores snapshots via the atomic write helpers", async () => {
+    persistSessionSnapshotSync("term-rt-sync", "sync payload");
+    await persistSessionSnapshotAsync("term-rt-async", "async payload");
+
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    const syncPath = path.join(sessionDir, "term-rt-sync.restore");
+    const asyncPath = path.join(sessionDir, "term-rt-async.restore");
+
+    expect(fs.readFileSync(syncPath, "utf8")).toBe("sync payload");
+    expect(fs.readFileSync(asyncPath, "utf8")).toBe("async payload");
+
+    // The atomic helpers must not leave temp files behind
+    const stragglers = fs.readdirSync(sessionDir).filter((name) => name.endsWith(".tmp"));
+    expect(stragglers).toEqual([]);
+
+    const headless = createMockHeadless();
+    const result = restoreSessionFromFile(headless as never, "term-rt-sync");
+    expect(result.restored).toBe(true);
+    expect(headless.write).toHaveBeenCalledWith("sync payload");
+  });
+
   it("restores valid snapshot and injects separator banner", async () => {
     const sessionDir = path.join(userDataDir, "terminal-sessions");
     await fsp.mkdir(sessionDir, { recursive: true });

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, statSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
-import { mkdir, readdir, stat, writeFile, unlink } from "node:fs/promises";
-import { resilientRename, resilientRenameSync } from "../../utils/fs.js";
+import { mkdir, readdir, stat, unlink } from "node:fs/promises";
+import { resilientAtomicWriteFile, resilientAtomicWriteFileSync } from "../../utils/fs.js";
 import path from "node:path";
 import type { Terminal as HeadlessTerminalType, IMarker } from "@xterm/headless";
 
@@ -133,19 +133,7 @@ export function persistSessionSnapshotSync(terminalId: string, state: string): v
   if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
 
   mkdirSync(dir, { recursive: true });
-
-  const tmpPath = `${sessionPath}.tmp`;
-  try {
-    writeFileSync(tmpPath, state, "utf8");
-    resilientRenameSync(tmpPath, sessionPath);
-  } catch (error) {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      /* best-effort cleanup */
-    }
-    throw error;
-  }
+  resilientAtomicWriteFileSync(sessionPath, state, "utf8");
 }
 
 export async function persistSessionSnapshotAsync(
@@ -158,17 +146,7 @@ export async function persistSessionSnapshotAsync(
   if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
 
   await mkdir(dir, { recursive: true });
-
-  const tmpPath = `${sessionPath}.tmp`;
-  try {
-    await writeFile(tmpPath, state, "utf8");
-    await resilientRename(tmpPath, sessionPath);
-  } catch (error) {
-    unlink(tmpPath).catch(() => {
-      /* best-effort cleanup */
-    });
-    throw error;
-  }
+  await resilientAtomicWriteFile(sessionPath, state, "utf8");
 }
 
 export async function deleteSessionFile(terminalId: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Two places in `electron/services/` perform durable JSON writes using a bespoke `tmp + rename` approach instead of the project-wide `resilientAtomicWriteFile` helper
- `terminalSessionPersistence.persistSessionSnapshot` uses a fixed temp filename, so two overlapping snapshot writes for the same terminal race and clobber each other's temp file
- `TrashedPidTracker.writeEntries` has no rename retry, so transient antivirus locks on Windows surface as logged write failures instead of recovering

Resolves #6254

## Changes

- `terminalSessionPersistence.persistSessionSnapshot{Sync,Async}` — switched to `resilientAtomicWriteFile` / `resilientAtomicWriteFileSync`; inherits timestamp+random temp naming and `stubborn-fs` retry loop
- `TrashedPidTracker.writeEntries` — same promotion; picks up the retry path for Windows AV lock scenarios
- `terminalSessionPersistence.test.ts` — round-trip coverage for both sync and async snapshot persist helpers

## Testing

49 unit tests pass. Typecheck, lint, format, and build all clean. The codebase invariant now holds: `grep` for `writeFile.*\.tmp` in `electron/services/` returns zero hits.