### PR TITLE
fix(crash-guard): use resilientAtomicWriteFileSync for state writes

### DIFF
--- a/electron/services/CrashLoopGuardService.ts
+++ b/electron/services/CrashLoopGuardService.ts
@@ -1,6 +1,7 @@
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 
 const STATE_FILENAME = "crash-loop-state.json";
 const CRASH_THRESHOLD = 3;
@@ -191,26 +192,14 @@ export class CrashLoopGuardService {
   private writeState(state: CrashLoopState): void {
     const data = JSON.stringify(state);
 
-    // Ensure the parent directory exists (e.g. first launch of dev userData)
+    // Ensure the parent directory exists (e.g. first launch of dev userData).
+    // resilientAtomicWriteFileSync does not create parent directories.
     const dir = path.dirname(this.statePath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
 
-    // Try atomic write (tmp + rename), fall back to direct write
-    const tmpPath = `${this.statePath}.${Date.now()}.tmp`;
-    try {
-      fs.writeFileSync(tmpPath, data, "utf8");
-      fs.renameSync(tmpPath, this.statePath);
-    } catch {
-      try {
-        fs.unlinkSync(tmpPath);
-      } catch {
-        // ignore
-      }
-      // Fallback: direct write (non-atomic but functional)
-      fs.writeFileSync(this.statePath, data, "utf8");
-    }
+    resilientAtomicWriteFileSync(this.statePath, data, "utf-8");
   }
 }
 

--- a/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.adversarial.test.ts
@@ -7,9 +7,15 @@ const appMock = vi.hoisted(() => ({
   getPath: vi.fn(() => ""),
 }));
 
+const utilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFileSync: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
   app: appMock,
 }));
+
+vi.mock("../../utils/fs.js", () => utilsMock);
 
 import { CrashLoopGuardService } from "../CrashLoopGuardService.js";
 
@@ -31,47 +37,62 @@ describe("CrashLoopGuardService adversarial", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-guard-adv-"));
     appMock.getPath.mockReturnValue(tmpDir);
     statePath = path.join(tmpDir, "crash-loop-state.json");
+    utilsMock.resilientAtomicWriteFileSync.mockImplementation(
+      (fp: string, data: string, enc?: BufferEncoding) => {
+        fs.writeFileSync(fp, data, enc ?? "utf-8");
+      }
+    );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    vi.clearAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("keeps the persisted file valid across back-to-back initialize calls sharing one userData dir", () => {
-    const renameSpy = vi.spyOn(fs, "renameSync");
-    renameSpy.mockImplementationOnce(() => {
+  it("recovers a valid state file on the next boot when a prior atomic write transient-fails", () => {
+    utilsMock.resilientAtomicWriteFileSync.mockImplementationOnce(() => {
       throw Object.assign(new Error("rename race"), { code: "EPERM" });
     });
 
     const first = new CrashLoopGuardService();
     const second = new CrashLoopGuardService();
 
+    // First boot's write fails and is swallowed by initialize's try/catch
+    // (non-fatal). No state file is written. Second boot starts fresh and
+    // produces a valid persisted state.
     first.initialize();
+    expect(fs.existsSync(statePath)).toBe(false);
+
     second.initialize();
 
     const parsed = readStateFile(statePath);
     expect(parsed.version).toBe(1);
     expect(parsed.cleanExit).toBe(false);
     expect(Array.isArray(parsed.launches)).toBe(true);
-    expect(parsed.launches).toHaveLength(2);
+    expect(parsed.launches).toHaveLength(1);
   });
 
-  it("falls back to a direct write when tmp cleanup loses a delete race", () => {
-    vi.spyOn(fs, "renameSync").mockImplementation(() => {
+  it("preserves the prior on-disk state when the next atomic write fails (no silent fallback)", () => {
+    // Seed a known-good state via a successful initialize.
+    const seed = new CrashLoopGuardService();
+    seed.initialize();
+    const stateBeforeFailure = readStateFile(statePath);
+
+    // Next write fails — historically this fell back to a direct
+    // (non-atomic) writeFileSync that could truncate the file. The fix
+    // propagates the error and leaves the prior state intact.
+    utilsMock.resilientAtomicWriteFileSync.mockImplementationOnce(() => {
       throw Object.assign(new Error("cross-device"), { code: "EXDEV" });
-    });
-    vi.spyOn(fs, "unlinkSync").mockImplementation(() => {
-      throw Object.assign(new Error("missing tmp"), { code: "ENOENT" });
     });
 
     const guard = new CrashLoopGuardService();
     guard.initialize();
 
-    const parsed = readStateFile(statePath);
-    expect(parsed.version).toBe(1);
-    expect(parsed.cleanExit).toBe(false);
+    // The on-disk state is unchanged — no truncation, no partial write.
+    const stateAfterFailure = readStateFile(statePath);
+    expect(stateAfterFailure).toEqual(stateBeforeFailure);
   });
 
   it("counts only launches strictly inside the rapid-crash window boundary", () => {

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -7,9 +7,15 @@ const appMock = vi.hoisted(() => ({
   getPath: vi.fn(() => ""),
 }));
 
+const utilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFileSync: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
   app: appMock,
 }));
+
+vi.mock("../../utils/fs.js", () => utilsMock);
 
 import { CrashLoopGuardService, isSafeModeActive } from "../CrashLoopGuardService.js";
 
@@ -126,11 +132,17 @@ describe("CrashLoopGuardService", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-guard-test-"));
     appMock.getPath.mockReturnValue(tmpDir);
     statePath = path.join(tmpDir, "crash-loop-state.json");
+    utilsMock.resilientAtomicWriteFileSync.mockImplementation(
+      (fp: string, data: string, enc?: BufferEncoding) => {
+        fs.writeFileSync(fp, data, enc ?? "utf-8");
+      }
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.clearAllMocks();
   });
 
   function writeState(state: Record<string, unknown>): void {
@@ -405,18 +417,21 @@ describe("CrashLoopGuardService", () => {
       guard.initialize();
       expect(guard.isSafeMode()).toBe(true);
 
-      // Force the underlying disk write to throw so the user-initiated reset
-      // surfaces the failure to the IPC layer instead of silently leaving
-      // the unclean sentinel on disk.
-      const writeSpy = vi.spyOn(fs, "writeFileSync").mockImplementation(() => {
+      // Force the underlying atomic write to throw so the user-initiated reset
+      // surfaces the failure to the IPC layer instead of silently leaving the
+      // unclean sentinel on disk via a non-atomic fallback write.
+      utilsMock.resilientAtomicWriteFileSync.mockImplementationOnce(() => {
         throw new Error("EROFS: read-only filesystem");
       });
 
       expect(() => guard.resetForNormalBoot()).toThrow(/read-only/);
       expect(guard.isSafeMode()).toBe(true);
       expect(guard.getCrashCount()).toBe(3);
-
-      writeSpy.mockRestore();
+      expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+        statePath,
+        expect.any(String),
+        "utf-8"
+      );
     });
 
     it("rejects state files with non-numeric launch entries", () => {

--- a/electron/services/__tests__/CrashLoopGuardService.test.ts
+++ b/electron/services/__tests__/CrashLoopGuardService.test.ts
@@ -417,6 +417,11 @@ describe("CrashLoopGuardService", () => {
       guard.initialize();
       expect(guard.isSafeMode()).toBe(true);
 
+      // Capture the on-disk unclean sentinel — the reset failure must leave
+      // it intact rather than silently truncating it via a fallback write.
+      const stateBeforeReset = readState();
+      expect(stateBeforeReset.cleanExit).toBe(false);
+
       // Force the underlying atomic write to throw so the user-initiated reset
       // surfaces the failure to the IPC layer instead of silently leaving the
       // unclean sentinel on disk via a non-atomic fallback write.
@@ -432,6 +437,9 @@ describe("CrashLoopGuardService", () => {
         expect.any(String),
         "utf-8"
       );
+
+      // The on-disk state is unchanged — no truncation, no partial write.
+      expect(readState()).toEqual(stateBeforeReset);
     });
 
     it("rejects state files with non-numeric launch entries", () => {


### PR DESCRIPTION
## Summary

- `CrashLoopGuardService.writeState` was using a hand-rolled tmp+rename pattern with a silent fallback to `fs.writeFileSync` on rename failure. That fallback could produce truncated `crash-loop-state.json` files if the process died mid-write, pinning users into (or out of) safe mode with no recoverable error surfaced.
- Replaced with `resilientAtomicWriteFileSync` — the same helper every other durable JSON write path in the codebase uses. Errors now propagate to callers instead of being swallowed.
- Parent-dir `mkdirSync` guard kept in place (the helper doesn't create parent directories).

Resolves #6241

## Changes

- `CrashLoopGuardService.writeState`: drop hand-rolled tmp+rename+fallback; call `resilientAtomicWriteFileSync` directly.
- Tests updated to mock the helper module via `vi.hoisted` + `vi.mock`, matching the `GlobalFileStore.adversarial.test.ts` pattern (prior `fs.renameSync` spies never intercepted because `stubborn-fs` captures the reference at module load).
- EROFS reset-failure test strengthened: reads the state file before and after the failure to assert the unclean sentinel is untouched on disk.
- Adversarial "falls back to direct write" test replaced with one asserting the prior on-disk state is preserved when an atomic write throws.

## Testing

36 tests passing. Clean typecheck, lint, and format. No new dependencies.