### PR TITLE
fix(protocols): resolve symlinks before containment check in daintree-file/canopy-file handlers

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { pathToFileURL } from "url";
+import path from "path";
 
 type WebContentsCreatedListener = (event: unknown, contents: MockWebContents) => void;
 
@@ -839,5 +840,56 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(new Request(url.toString()) as GlobalRequest);
 
     expect(response.status).toBe(400);
+  });
+
+  it("permits files whose name starts with '..' but isn't parent traversal", async () => {
+    // Regression for the bare startsWith('..') guard — '..hidden/file.txt' is a
+    // legitimate in-root path and must not be misclassified as escape.
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => Promise.resolve(p as string));
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/..hidden/file.txt", "/project"));
+
+    expect(response.status).toBe(200);
+    const electron = await import("electron");
+    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a prefix-sibling escape (root=/tmp/project, target=/tmp/project-evil/...)", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => Promise.resolve(p as string));
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(
+      makeRequest("/tmp/project-evil/secret.env", "/tmp/project")
+    );
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks via the path.isAbsolute(rel) branch (Windows cross-drive simulation)", async () => {
+    // Force path.relative to return an absolute path, isolating the isAbsolute guard
+    // from the '..' branch. This is the shape of path.relative on Windows when root
+    // and target are on different drives (e.g. relative('D:\\proj','C:\\win')==='C:\\win').
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => Promise.resolve(p as string));
+    const relativeSpy = vi.spyOn(path, "relative").mockReturnValue("/absolute/elsewhere");
+
+    try {
+      const handler = await captureHandler("daintree-file");
+      const response = await handler(makeRequest("/project/file.txt", "/project"));
+
+      expect(response.status).toBe(404);
+      const electron = await import("electron");
+      expect(electron.net.fetch).not.toHaveBeenCalled();
+    } finally {
+      relativeSpy.mockRestore();
+    }
   });
 });

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -863,9 +863,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     realpath.mockImplementation((p) => Promise.resolve(p as string));
 
     const handler = await captureHandler("daintree-file");
-    const response = await handler(
-      makeRequest("/tmp/project-evil/secret.env", "/tmp/project")
-    );
+    const response = await handler(makeRequest("/tmp/project-evil/secret.env", "/tmp/project"));
 
     expect(response.status).toBe(404);
     const electron = await import("electron");

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { pathToFileURL } from "url";
 
 type WebContentsCreatedListener = (event: unknown, contents: MockWebContents) => void;
 
@@ -64,6 +65,10 @@ vi.mock("../../utils/appProtocol.js", () => ({
   resolveAppUrlToDistPath: vi.fn(),
   getMimeType: vi.fn(),
   buildHeaders: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  realpath: vi.fn(),
 }));
 
 const mockSend = vi.fn();
@@ -657,5 +662,182 @@ describe("protocol registration", () => {
 
     expect(protocol.handle).toHaveBeenCalledWith("daintree-file", expect.any(Function));
     expect(protocol.handle).toHaveBeenCalledWith("canopy-file", expect.any(Function));
+  });
+});
+
+describe("createDaintreeFileProtocolHandler — symlink containment", () => {
+  type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
+
+  async function captureHandler(scheme: "daintree-file" | "canopy-file"): Promise<ProtocolHandler> {
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+    const call = handle.mock.calls.find((c) => c[0] === scheme);
+    if (!call) throw new Error(`handler for ${scheme} not registered`);
+    return call[1] as ProtocolHandler;
+  }
+
+  function makeRequest(filePath: string, rootPath: string): GlobalRequest {
+    const url = new URL("daintree-file://serve");
+    url.searchParams.set("path", filePath);
+    url.searchParams.set("root", rootPath);
+    return new Request(url.toString()) as GlobalRequest;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const electron = await import("electron");
+    vi.mocked(electron.net.fetch).mockResolvedValue(
+      new Response(new ArrayBuffer(4), { status: 200 })
+    );
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("text/plain");
+  });
+
+  it("serves a normal file inside root using the realpath-resolved path", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => Promise.resolve(p as string));
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/src/index.ts", "/project"));
+
+    expect(response.status).toBe(200);
+    const electron = await import("electron");
+    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
+    const fetchUrl = vi.mocked(electron.net.fetch).mock.calls[0][0] as string;
+    expect(fetchUrl).toBe(pathToFileURL("/project/src/index.ts").toString());
+  });
+
+  it("blocks a symlink whose path is inside root but whose target is outside root", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      if (p === "/project/escape") return Promise.resolve("/etc/passwd");
+      return Promise.resolve(p as string);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/escape", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a dangling symlink (ENOENT)", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return Promise.reject(err);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/dangling", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for a symlink loop (ELOOP)", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      const err = Object.assign(new Error("ELOOP"), { code: "ELOOP" });
+      return Promise.reject(err);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/loop", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the root itself fails to resolve (EACCES)", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation(() => {
+      const err = Object.assign(new Error("EACCES"), { code: "EACCES" });
+      return Promise.reject(err);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/file.txt", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("blocks a Windows cross-drive escape where path.relative returns an absolute path", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      // Simulate a symlink resolving to a path with a leading slash that path.relative
+      // treats as absolute relative to the root — same shape as Windows cross-drive escape
+      // (path.relative('D:\\project', 'C:\\windows') === 'C:\\windows').
+      if (p === "/project/winlink") return Promise.resolve("/totally/elsewhere");
+      return Promise.resolve(p as string);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/winlink", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("permits a symlink whose resolved target stays inside root", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      if (p === "/project/link") return Promise.resolve("/project/real/file.txt");
+      return Promise.resolve(p as string);
+    });
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/link", "/project"));
+
+    expect(response.status).toBe(200);
+    const electron = await import("electron");
+    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
+    const fetchUrl = vi.mocked(electron.net.fetch).mock.calls[0][0] as string;
+    // The fetch URL should be the resolved real path, not the symlink path.
+    expect(fetchUrl).toBe(pathToFileURL("/project/real/file.txt").toString());
+  });
+
+  it("applies the same containment to canopy-file:// alias", async () => {
+    const fs = await import("fs/promises");
+    const realpath = vi.mocked(fs.realpath);
+    realpath.mockImplementation((p) => {
+      if (p === "/project") return Promise.resolve("/project");
+      if (p === "/project/escape") return Promise.resolve("/etc/passwd");
+      return Promise.resolve(p as string);
+    });
+
+    const handler = await captureHandler("canopy-file");
+    const response = await handler(makeRequest("/project/escape", "/project"));
+
+    expect(response.status).toBe(404);
+    const electron = await import("electron");
+    expect(electron.net.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 (not 404) for missing parameters — input validation precedes realpath", async () => {
+    const handler = await captureHandler("daintree-file");
+    const url = new URL("daintree-file://serve");
+    const response = await handler(new Request(url.toString()) as GlobalRequest);
+
+    expect(response.status).toBe(400);
   });
 });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -113,8 +113,8 @@ function createDaintreeFileProtocolHandler() {
       }
 
       const rel = path.relative(realRoot, realFile);
-      // isAbsolute catches Windows cross-drive escapes where path.relative returns an absolute path instead of "..".
-      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      // Match exact ".." and "../*" — bare startsWith("..") would reject legitimate files like "..hidden/x". isAbsolute catches Windows cross-drive escapes.
+      if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
         return new Response("Not Found", { status: 404 });
       }
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -1,6 +1,7 @@
 import { app, protocol, net, session } from "electron";
 import { getWindowForWebContents, getAppWebContents } from "../window/webContentsRegistry.js";
 import path from "path";
+import { realpath } from "fs/promises";
 import { pathToFileURL } from "url";
 import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../utils/appProtocol.js";
 import {
@@ -101,15 +102,24 @@ function createDaintreeFileProtocolHandler() {
       const normalizedFile = path.normalize(filePath);
       const normalizedRoot = path.normalize(rootPath);
 
-      if (
-        !normalizedFile.startsWith(normalizedRoot + path.sep) &&
-        normalizedFile !== normalizedRoot
-      ) {
-        return new Response("Forbidden — path outside root", { status: 403 });
+      // Resolve symlinks before containment to block in-root symlinks pointing outside root (CVE-2025-53109 / CVE-2025-54794 class).
+      let realRoot: string;
+      let realFile: string;
+      try {
+        realRoot = await realpath(normalizedRoot);
+        realFile = await realpath(normalizedFile);
+      } catch {
+        return new Response("Not Found", { status: 404 });
       }
 
-      const mimeType = getMimeType(normalizedFile);
-      const fileUrl = pathToFileURL(normalizedFile).toString();
+      const rel = path.relative(realRoot, realFile);
+      // isAbsolute catches Windows cross-drive escapes where path.relative returns an absolute path instead of "..".
+      if (rel.startsWith("..") || path.isAbsolute(rel)) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      const mimeType = getMimeType(realFile);
+      const fileUrl = pathToFileURL(realFile).toString();
       const response = await net.fetch(fileUrl);
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary

- `createDaintreeFileProtocolHandler` was using lexical `path.normalize` plus a string prefix check to confine requests to the workspace root, but never resolved symlinks. A tracked symlink pointing outside the workspace passed the prefix check and `net.fetch` followed it — same bug class as CVE-2025-53109 and CVE-2025-54794.
- Fix replaces `path.normalize` with `fs.realpath` on both the root and target paths, uses `path.relative` plus an exact separator-prefix guard for containment, and passes the realpath-resolved path to `net.fetch` to close the TOCTOU window. All `realpath` errors (`ENOENT`, `ELOOP`, `EACCES`) return 404 to avoid existence leaks.
- Also corrects a guard bug where bare `startsWith('..')` would have blocked legitimate files whose names start with `..` (e.g. `..hidden/file.txt`).

Resolves #6248

## Changes

- `electron/setup/protocols.ts` — replace lexical normalization with `fs.realpath`-based containment in `createDaintreeFileProtocolHandler`; fix `..`-prefix guard; pass resolved path to `net.fetch`
- `electron/setup/__tests__/protocols.test.ts` — 11 new regression tests: in-root file, symlink escape, dangling symlink, symlink loop, root resolve failure, Windows cross-drive, in-root symlink, `canopy-file://` alias, missing params, `..name` false-positive, prefix-sibling escape, and `isAbsolute` branch via `path.relative` spy

## Testing

All 11 new regression tests pass. Existing protocol test suite passes. Typecheck and lint clean.