### PR TITLE
feat(scrubber): extend secret catalog with 2026 vendor sigils

### DIFF
--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -33,9 +33,7 @@ function redactDeep(value: unknown): unknown {
   if (value === null || value === undefined) return value;
 
   if (typeof value === "string") {
-    let result = sanitizeString(value);
-    result = result.replace(/https?:\/\/[^@\s]+@/g, "https://<redacted>@");
-    return result;
+    return sanitizeString(value);
   }
 
   if (Array.isArray(value)) {
@@ -304,9 +302,7 @@ async function collectGit() {
     result.remotes = remoteOutput
       .split("\n")
       .filter(Boolean)
-      .map((line) => {
-        return sanitizePath(line.replace(/https?:\/\/[^@\s]+@/g, "https://<redacted>@"));
-      });
+      .map((line) => sanitizeString(line));
   }
 
   const versionOutput = await runCommand("git", ["--version"]);

--- a/electron/services/__tests__/DiagnosticsCollector.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { scrubSecrets } from "../../utils/secretScrubber.js";
 
 // We test the module-level helpers by importing them indirectly.
 // Since redactDeep and withTimeout are not exported, we test them
 // through collectDiagnostics or by extracting testable behavior.
 
-// For now, test the redaction regex and timeout logic via isolated reproductions.
+// URL basic-auth stripping now lives in scrubSecrets — see secretScrubber.test.ts
+// for the canonical coverage. The blocks below mirror DiagnosticsCollector's
+// internal pipeline so the file documents the contract end-to-end.
 
 describe("DiagnosticsCollector helpers", () => {
   const SENSITIVE_KEY_PATTERN =
@@ -51,24 +54,27 @@ describe("DiagnosticsCollector helpers", () => {
     });
   });
 
-  describe("URL credential stripping", () => {
-    const stripCredentials = (str: string) =>
-      str.replace(/https?:\/\/[^@\s]+@/g, "https://<redacted>@");
-
+  describe("URL credential stripping (via scrubSecrets)", () => {
     it("strips basic auth from HTTPS URLs", () => {
-      expect(stripCredentials("https://user:pass@github.com/repo.git")).toBe(
-        "https://<redacted>@github.com/repo.git"
+      expect(scrubSecrets("https://user:pass@github.com/repo.git")).toBe(
+        "https://<credentials-redacted>@github.com/repo.git"
       );
     });
 
     it("strips token-style auth from URLs", () => {
-      expect(stripCredentials("https://x-access-token:ghp_abc123@github.com/repo.git")).toBe(
-        "https://<redacted>@github.com/repo.git"
+      expect(scrubSecrets("https://x-access-token:ghp_abc123@github.com/repo.git")).toBe(
+        "https://<credentials-redacted>@github.com/repo.git"
+      );
+    });
+
+    it("preserves the protocol scheme on http URLs", () => {
+      expect(scrubSecrets("http://user:pass@internal.example/path")).toBe(
+        "http://<credentials-redacted>@internal.example/path"
       );
     });
 
     it("leaves URLs without credentials unchanged", () => {
-      expect(stripCredentials("https://github.com/repo.git")).toBe("https://github.com/repo.git");
+      expect(scrubSecrets("https://github.com/repo.git")).toBe("https://github.com/repo.git");
     });
   });
 
@@ -102,7 +108,7 @@ describe("DiagnosticsCollector helpers", () => {
     function redactDeep(value: unknown): unknown {
       if (value === null || value === undefined) return value;
       if (typeof value === "string") {
-        return value.replace(/https?:\/\/[^@\s]+@/g, "https://<redacted>@");
+        return scrubSecrets(value);
       }
       if (Array.isArray(value)) return value.map(redactDeep);
       if (typeof value === "object") {
@@ -151,7 +157,7 @@ describe("DiagnosticsCollector helpers", () => {
 
     it("strips credentials from URLs in string values", () => {
       const result = redactDeep("https://user:pass@host.com/path");
-      expect(result).toBe("https://<redacted>@host.com/path");
+      expect(result).toBe("https://<credentials-redacted>@host.com/path");
     });
   });
 });

--- a/electron/services/__tests__/DiagnosticsCollector.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.test.ts
@@ -57,19 +57,19 @@ describe("DiagnosticsCollector helpers", () => {
   describe("URL credential stripping (via scrubSecrets)", () => {
     it("strips basic auth from HTTPS URLs", () => {
       expect(scrubSecrets("https://user:pass@github.com/repo.git")).toBe(
-        "https://<credentials-redacted>@github.com/repo.git"
+        "https://<redacted>@github.com/repo.git"
       );
     });
 
     it("strips token-style auth from URLs", () => {
       expect(scrubSecrets("https://x-access-token:ghp_abc123@github.com/repo.git")).toBe(
-        "https://<credentials-redacted>@github.com/repo.git"
+        "https://<redacted>@github.com/repo.git"
       );
     });
 
     it("preserves the protocol scheme on http URLs", () => {
       expect(scrubSecrets("http://user:pass@internal.example/path")).toBe(
-        "http://<credentials-redacted>@internal.example/path"
+        "http://<redacted>@internal.example/path"
       );
     });
 
@@ -157,7 +157,7 @@ describe("DiagnosticsCollector helpers", () => {
 
     it("strips credentials from URLs in string values", () => {
       const result = redactDeep("https://user:pass@host.com/path");
-      expect(result).toBe("https://<credentials-redacted>@host.com/path");
+      expect(result).toBe("https://<redacted>@host.com/path");
     });
   });
 });

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -42,9 +42,36 @@ describe("secretScrubber", () => {
         expected: `token=${REDACTED}`,
       },
       {
+        name: "gitlab-personal-token",
+        input: `glpat-${"A".repeat(20)} trailing`,
+        expected: `${REDACTED} trailing`,
+      },
+      {
+        name: "gitlab-deploy-token",
+        input: `gldt-${"x".repeat(20)}`,
+        expected: REDACTED,
+      },
+      {
         name: "anthropic-api-key",
         input: `key=sk-ant-${"a".repeat(95)}`,
         expected: `key=${REDACTED}`,
+      },
+      {
+        name: "anthropic-oauth-setup-token",
+        // `sk-ant-oat01-` should be covered by the existing anthropic-api-key
+        // pattern. Body length here is 95 (includes the `oat01-` infix).
+        input: `key=sk-ant-oat01-${"b".repeat(89)}`,
+        expected: `key=${REDACTED}`,
+      },
+      {
+        name: "openai-project-key",
+        input: `OPENAI_API_KEY=sk-proj-${"A".repeat(120)} next`,
+        expected: `OPENAI_API_KEY=${REDACTED} next`,
+      },
+      {
+        name: "openai-svcacct-key",
+        input: `OPENAI_API_KEY=sk-svcacct-${"z".repeat(150)}`,
+        expected: `OPENAI_API_KEY=${REDACTED}`,
       },
       {
         name: "openai-api-key",
@@ -60,6 +87,16 @@ describe("secretScrubber", () => {
         name: "stripe-test",
         input: `stripe=sk_test_${"z".repeat(40)}`,
         expected: `stripe=${REDACTED}`,
+      },
+      {
+        name: "stripe-restricted-live",
+        input: `stripe=rk_live_${"a".repeat(32)}`,
+        expected: `stripe=${REDACTED}`,
+      },
+      {
+        name: "stripe-restricted-test",
+        input: `stripe=rk_test_${"z".repeat(40)} end`,
+        expected: `stripe=${REDACTED} end`,
       },
       {
         name: "slack-token",
@@ -97,6 +134,56 @@ describe("secretScrubber", () => {
         expected: `registry=${REDACTED}`,
       },
       {
+        name: "digitalocean-personal-token",
+        input: `DO_TOKEN=dop_v1_${"a".repeat(64)} next`,
+        expected: `DO_TOKEN=${REDACTED} next`,
+      },
+      {
+        name: "digitalocean-oauth-token",
+        input: `tok=doo_v1_${"B".repeat(64)}`,
+        expected: `tok=${REDACTED}`,
+      },
+      {
+        name: "digitalocean-refresh-token",
+        input: `tok=dor_v1_${"9".repeat(64)}`,
+        expected: `tok=${REDACTED}`,
+      },
+      {
+        name: "atlassian-api-token",
+        input: `auth=ATATT3xFfGF0${"A".repeat(180)}=`,
+        expected: `auth=${REDACTED}`,
+      },
+      {
+        name: "atlassian-connect-token",
+        input: `auth=ATCTT3xFfGN0${"a".repeat(150)}`,
+        expected: `auth=${REDACTED}`,
+      },
+      {
+        name: "cloudflare-account-token",
+        input: `CF_TOKEN=cfat_${"A".repeat(40)}${"0a1b2c3d"} end`,
+        expected: `CF_TOKEN=${REDACTED} end`,
+      },
+      {
+        name: "cloudflare-user-token",
+        input: `tok=cfut_${"z".repeat(40)}deadbeef`,
+        expected: `tok=${REDACTED}`,
+      },
+      {
+        name: "cloudflare-key",
+        input: `tok=cfk_${"x".repeat(40)}cafebabe`,
+        expected: `tok=${REDACTED}`,
+      },
+      {
+        name: "supabase-publishable",
+        input: `SUPABASE_KEY=sb_publishable_${"A".repeat(48)}`,
+        expected: `SUPABASE_KEY=${REDACTED}`,
+      },
+      {
+        name: "supabase-secret",
+        input: `SUPABASE_KEY=sb_secret_${"z".repeat(48)} next`,
+        expected: `SUPABASE_KEY=${REDACTED} next`,
+      },
+      {
         name: "azure-connection-string",
         input: `conn=DefaultEndpointsProtocol=https;AccountName=myacct;AccountKey=${"A".repeat(86)}== end`,
         expected: `conn=${REDACTED} end`,
@@ -131,6 +218,26 @@ describe("secretScrubber", () => {
         name: "oauth-code-in-url",
         input: "https://example.com/callback?code=abcd1234xyz&state=zz",
         expected: `https://example.com/callback?code=${REDACTED}&state=zz`,
+      },
+      {
+        name: "url-basic-auth-https",
+        input: "git remote set-url origin https://user:pass@example.com/x/y.git",
+        expected: "git remote set-url origin https://<credentials-redacted>@example.com/x/y.git",
+      },
+      {
+        name: "url-basic-auth-http",
+        input: "fetch http://admin:hunter2@internal.example.com/path",
+        expected: "fetch http://<credentials-redacted>@internal.example.com/path",
+      },
+      {
+        name: "generic-api-key-fallback",
+        input: `API_KEY=${"A".repeat(32)} trailing`,
+        expected: `${REDACTED} trailing`,
+      },
+      {
+        name: "generic-client-secret-fallback",
+        input: `client_secret = ${"x".repeat(40)}`,
+        expected: REDACTED,
       },
     ];
 
@@ -187,6 +294,36 @@ describe("secretScrubber", () => {
       const hashish = "sha256=" + "A".repeat(40);
       expect(scrubSecrets(hashish)).toBe(hashish);
     });
+
+    it("does not flag a too-short GitLab token", () => {
+      const tooShort = `glpat-${"A".repeat(19)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag MAX_TOKENS as a generic API key", () => {
+      const config = "MAX_TOKENS=8192 next";
+      expect(scrubSecrets(config)).toBe(config);
+    });
+
+    it("does not flag TOTAL_TOKENS as a generic API key", () => {
+      const config = "TOTAL_TOKENS=4096";
+      expect(scrubSecrets(config)).toBe(config);
+    });
+
+    it("does not flag short API_KEY values below the 16-char floor", () => {
+      const tooShort = "API_KEY=12345";
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag a request-id-shaped value without a key prefix", () => {
+      const reqId = "req_01HXABCDEFGHJKMNPQRSTVWXYZ trace=ok";
+      expect(scrubSecrets(reqId)).toBe(reqId);
+    });
+
+    it("does not flag a URL without basic-auth credentials", () => {
+      const url = "https://example.com/path?foo=bar";
+      expect(scrubSecrets(url)).toBe(url);
+    });
   });
 
   describe("idempotence", () => {
@@ -195,12 +332,25 @@ describe("secretScrubber", () => {
         "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456",
         "Bearer abcdefghij.klmnop-qr_st=",
         `sk-${"A".repeat(48)}`,
+        `sk-proj-${"A".repeat(120)}`,
+        `glpat-${"A".repeat(20)}`,
+        `dop_v1_${"a".repeat(64)}`,
+        `cfat_${"A".repeat(40)}deadbeef`,
+        `sb_secret_${"x".repeat(48)}`,
+        "https://user:pass@example.com/path",
         "AKIAIOSFODNN7EXAMPLE",
         "plain text with no secrets",
       ].join(" | ");
 
       const once = scrubSecrets(mixed);
       expect(scrubSecrets(once)).toBe(once);
+    });
+
+    it("URL basic-auth replacement is itself non-matching (no infinite loop)", () => {
+      const input = "clone https://user:pass@example.com/x/y.git";
+      const out = scrubSecrets(input);
+      expect(out).toBe("clone https://<credentials-redacted>@example.com/x/y.git");
+      expect(scrubSecrets(out)).toBe(out);
     });
   });
 

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -230,6 +230,11 @@ describe("secretScrubber", () => {
         expected: "fetch http://<credentials-redacted>@internal.example.com/path",
       },
       {
+        name: "url-basic-auth-percent-encoded",
+        input: "clone https://oauth2:%24token%2Fvalue@gitlab.com/a/b.git",
+        expected: "clone https://<credentials-redacted>@gitlab.com/a/b.git",
+      },
+      {
         name: "generic-api-key-fallback",
         input: `API_KEY=${"A".repeat(32)} trailing`,
         expected: `${REDACTED} trailing`,
@@ -323,6 +328,15 @@ describe("secretScrubber", () => {
     it("does not flag a URL without basic-auth credentials", () => {
       const url = "https://example.com/path?foo=bar";
       expect(scrubSecrets(url)).toBe(url);
+    });
+
+    it("redacts realistically-sized Atlassian token bodies fully", () => {
+      // Real Atlassian tokens are ~170-200 chars. The {120,512} upper bound
+      // must cover that range plus generous headroom. A 400-char body is well
+      // past typical and must still be fully consumed by the pattern.
+      const realistic = `auth=ATATT3x${"A".repeat(400)}`;
+      const out = scrubSecrets(realistic);
+      expect(out).toBe(`auth=${REDACTED}`);
     });
   });
 

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -222,17 +222,17 @@ describe("secretScrubber", () => {
       {
         name: "url-basic-auth-https",
         input: "git remote set-url origin https://user:pass@example.com/x/y.git",
-        expected: "git remote set-url origin https://<credentials-redacted>@example.com/x/y.git",
+        expected: "git remote set-url origin https://<redacted>@example.com/x/y.git",
       },
       {
         name: "url-basic-auth-http",
         input: "fetch http://admin:hunter2@internal.example.com/path",
-        expected: "fetch http://<credentials-redacted>@internal.example.com/path",
+        expected: "fetch http://<redacted>@internal.example.com/path",
       },
       {
         name: "url-basic-auth-percent-encoded",
         input: "clone https://oauth2:%24token%2Fvalue@gitlab.com/a/b.git",
-        expected: "clone https://<credentials-redacted>@gitlab.com/a/b.git",
+        expected: "clone https://<redacted>@gitlab.com/a/b.git",
       },
       {
         name: "generic-api-key-fallback",
@@ -363,7 +363,7 @@ describe("secretScrubber", () => {
     it("URL basic-auth replacement is itself non-matching (no infinite loop)", () => {
       const input = "clone https://user:pass@example.com/x/y.git";
       const out = scrubSecrets(input);
-      expect(out).toBe("clone https://<credentials-redacted>@example.com/x/y.git");
+      expect(out).toBe("clone https://<redacted>@example.com/x/y.git");
       expect(scrubSecrets(out)).toBe(out);
     });
   });

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -195,9 +195,11 @@ export const PATTERNS: readonly SecretPattern[] = [
     // `https://user:pass@host/path` — promoted from DiagnosticsCollector so
     // every sink that calls scrubSecrets benefits. Capture group preserves
     // protocol; the replacement contains `<` / `>` (not in the credential
-    // charset), so a second pass cannot re-match.
+    // charset), so a second pass cannot re-match. The `<redacted>` placeholder
+    // matches the convention DiagnosticsCollector previously used inline so
+    // downstream consumers see no behavioral change.
     regex: /((https?):\/\/)[A-Za-z0-9%!$&'()*+,;=:._~-]{1,512}@/g,
-    replacement: "$1<credentials-redacted>@",
+    replacement: "$1<redacted>@",
   },
   {
     name: "generic-key-fallback",

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -126,8 +126,9 @@ export const PATTERNS: readonly SecretPattern[] = [
     name: "atlassian-token",
     // `ATATT3x` (API tokens) and `ATCTT3x` (Connect/access tokens). Body is
     // base64url-ish and frequently ends with `=` padding, so no trailing `\b`
-    // (it would fail to match after a non-word `=` char).
-    regex: /\bAT[AC]TT3x[A-Za-z0-9+/=_-]{120,256}/g,
+    // (it would fail to match after a non-word `=` char). Upper bound 512 so
+    // unusually long tokens don't leave a tail visible.
+    regex: /\bAT[AC]TT3x[A-Za-z0-9+/=_-]{120,512}/g,
     replacement: REDACTED,
   },
   {

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -47,8 +47,27 @@ export const PATTERNS: readonly SecretPattern[] = [
     replacement: REDACTED,
   },
   {
+    name: "gitlab-personal-token",
+    regex: /\bglpat-[0-9a-zA-Z_-]{20}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "gitlab-deploy-token",
+    regex: /\bgldt-[0-9a-zA-Z_-]{20}\b/g,
+    replacement: REDACTED,
+  },
+  {
     name: "anthropic-api-key",
+    // Also covers `sk-ant-oat01-` OAuth setup tokens — the `oat01-` infix is
+    // within the `[A-Za-z0-9\-_]` charset and the body length falls inside {90,255}.
     regex: /\bsk-ant-[A-Za-z0-9\-_]{90,255}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "openai-project-key",
+    // MUST precede `openai-api-key` so the shorter `sk-` prefix doesn't
+    // greedily consume `sk-proj-`/`sk-svcacct-` and leave the body unredacted.
+    regex: /\bsk-(?:proj|svcacct)-[A-Za-z0-9_-]{100,256}\b/g,
     replacement: REDACTED,
   },
   {
@@ -59,6 +78,11 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "stripe-secret-key",
     regex: /\bsk_(?:live|test)_[0-9a-zA-Z]{24,48}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "stripe-restricted-key",
+    regex: /\brk_(?:live|test)_[0-9a-zA-Z]{24,48}\b/g,
     replacement: REDACTED,
   },
   {
@@ -90,6 +114,32 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "npm-token",
     regex: /\bnpm_[A-Za-z0-9]{36}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "digitalocean-token",
+    // Covers `dop_v1_` (personal), `doo_v1_` (OAuth), `dor_v1_` (refresh).
+    regex: /\bdo[por]_v1_[A-Za-z0-9]{64}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "atlassian-token",
+    // `ATATT3x` (API tokens) and `ATCTT3x` (Connect/access tokens). Body is
+    // base64url-ish and frequently ends with `=` padding, so no trailing `\b`
+    // (it would fail to match after a non-word `=` char).
+    regex: /\bAT[AC]TT3x[A-Za-z0-9+/=_-]{120,256}/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "cloudflare-token",
+    // `cfat_` (account), `cfut_` (user), `cfk_` (global key). 40-char body
+    // followed by an 8-char hex checksum.
+    regex: /\bcf(?:at|ut|k)_[A-Za-z0-9]{40}[0-9a-f]{8}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "supabase-key",
+    regex: /\bsb_(?:publishable|secret)_[A-Za-z0-9_]{32,64}\b/g,
     replacement: REDACTED,
   },
   {
@@ -138,6 +188,25 @@ export const PATTERNS: readonly SecretPattern[] = [
     // `code=42 not found`.
     regex: /([?&])code=[^&\s]{1,1000}/g,
     replacement: `$1code=${REDACTED}`,
+  },
+  {
+    name: "url-basic-auth",
+    // `https://user:pass@host/path` — promoted from DiagnosticsCollector so
+    // every sink that calls scrubSecrets benefits. Capture group preserves
+    // protocol; the replacement contains `<` / `>` (not in the credential
+    // charset), so a second pass cannot re-match.
+    regex: /((https?):\/\/)[A-Za-z0-9%!$&'()*+,;=:._~-]{1,512}@/g,
+    replacement: "$1<credentials-redacted>@",
+  },
+  {
+    name: "generic-key-fallback",
+    // Last-resort fallback for `.env`-shaped lines using common API key names.
+    // The 16-char minimum body excludes short numeric values like `MAX_TOKENS=8192`,
+    // and the listed key names exclude `MAX_TOKENS` / `TOTAL_TOKENS` / request-id
+    // shapes by construction.
+    regex:
+      /\b(?:api_key|api_secret|access_key|secret_key|private_key|auth_token|auth_secret|client_secret|app_secret|app_key)[ \t]{0,4}=[ \t]{0,4}[A-Za-z0-9/+_-]{16,512}/gi,
+    replacement: REDACTED,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Extended the `PATTERNS` array in `electron/utils/secretScrubber.ts` with 10 new vendor token formats covering gaps that show up regularly in IDE and agent CLI output in 2026
- Cleaned up duplicate inline URL-credential redaction in `DiagnosticsCollector` — the local replaces in `redactDeep` and `collectGit` are now gone; `sanitizeString` (which calls `scrubSecrets`) handles it centrally
- Pattern ordering: `openai-project-key` inserted before the existing `openai-api-key` so the shorter `sk-` prefix doesn't greedily consume `sk-proj-` and `sk-svcacct-` tokens

Resolves #6242

## Changes

- `electron/utils/secretScrubber.ts` — 10 new patterns: `gitlab-personal-token` (`glpat-`), `gitlab-deploy-token` (`gldt-`), `openai-project-key` (`sk-proj-`/`sk-svcacct-`), `stripe-restricted-key` (`rk_live_`/`rk_test_`), `digitalocean-token` (`dop_v1_`/`doo_v1_`/`dor_v1_`), `atlassian-token` (`ATATT3x`/`ATCTT3x`, cap widened to 512 for headroom), `cloudflare-token` (`cfat_`/`cfut_`/`cfk_`), `supabase-key` (`sb_publishable_`/`sb_secret_`), `url-basic-auth` (promoted from `DiagnosticsCollector` with protocol-preserving capture group), `generic-key-fallback` (last-resort `.env`-shaped pattern)
- `electron/services/DiagnosticsCollector.ts` — removed two redundant inline `https?://[^@\s]+@` replaces; `collectGit` line 308 switched from `sanitizePath(line.replace(...))` to `sanitizeString(line)` so `scrubSecrets` is actually invoked
- `electron/utils/__tests__/secretScrubber.test.ts` — positive and negative cases for every new pattern, idempotency check for URL basic-auth, `safe-regex2` enforcement on all patterns. 114 tests total
- `electron/services/__tests__/DiagnosticsCollector.test.ts` — refreshed to call `scrubSecrets` directly rather than holding local copies of the old inline redaction logic

## Testing

114 unit tests, all passing. Negative cases cover: tokens below minimum length, `MAX_TOKENS`/`TOTAL_TOKENS` env vars, short `API_KEY` values, request-ID-shaped strings, plain URLs without credentials, and overlong Atlassian tokens. `safe-regex2` enforced on every pattern in the catalog.