### PR TITLE
fix(files): harden files:read IPC surface with realpath containment

### DIFF
--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -10,10 +10,20 @@ vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
 }));
 
-const fsMock = vi.hoisted(() => ({
-  stat: vi.fn<(p: string) => Promise<{ size: number }>>(),
-  readFile: vi.fn<(p: string) => Promise<Buffer>>(),
-}));
+type FileHandleLike = {
+  readFile: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const fsMock = vi.hoisted(() => {
+  return {
+    stat: vi.fn<(p: string) => Promise<{ size: number }>>(),
+    realpath: vi.fn<(p: string) => Promise<string>>(),
+    open: vi.fn<(p: string, flags: number) => Promise<FileHandleLike>>(),
+    readFile: vi.fn<(p: string) => Promise<Buffer>>(),
+    constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100 },
+  };
+});
 
 vi.mock("fs/promises", () => ({
   default: fsMock,
@@ -69,6 +79,13 @@ function getReadHandler() {
   return entry[1] as (event: unknown, payload: unknown) => Promise<FileReadResult>;
 }
 
+function makeFileHandle(buffer: Buffer): FileHandleLike {
+  return {
+    readFile: vi.fn().mockResolvedValue(buffer),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe("isLfsPointer", () => {
   it("matches a valid v1 pointer stub", () => {
     expect(isLfsPointer(VALID_POINTER)).toBe(true);
@@ -108,11 +125,12 @@ describe("files:read handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fsMock.realpath.mockImplementation(async (p: string) => p);
   });
 
   it("throws AppError(LFS_POINTER) when the file is a git-lfs v1 pointer", async () => {
     fsMock.stat.mockResolvedValue({ size: VALID_POINTER.length });
-    fsMock.readFile.mockResolvedValue(VALID_POINTER);
+    fsMock.open.mockResolvedValue(makeFileHandle(VALID_POINTER));
     registerFilesHandlers();
 
     await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
@@ -124,7 +142,7 @@ describe("files:read handler", () => {
   it("returns plain content for a normal text file", async () => {
     const content = Buffer.from("hello world\n", "utf-8");
     fsMock.stat.mockResolvedValue({ size: content.length });
-    fsMock.readFile.mockResolvedValue(content);
+    fsMock.open.mockResolvedValue(makeFileHandle(content));
     registerFilesHandlers();
 
     const result = await getReadHandler()({}, { path: file, rootPath: root });
@@ -135,7 +153,7 @@ describe("files:read handler", () => {
   it("throws AppError(BINARY_FILE) before LFS detection when null bytes are present", async () => {
     const content = Buffer.concat([Buffer.from(LFS_HEADER, "ascii"), Buffer.from([0x00])]);
     fsMock.stat.mockResolvedValue({ size: content.length });
-    fsMock.readFile.mockResolvedValue(content);
+    fsMock.open.mockResolvedValue(makeFileHandle(content));
     registerFilesHandlers();
 
     await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
@@ -144,7 +162,7 @@ describe("files:read handler", () => {
     });
   });
 
-  it("throws AppError(FILE_TOO_LARGE) without reading the buffer for oversized files", async () => {
+  it("throws AppError(FILE_TOO_LARGE) without opening the file for oversized files", async () => {
     fsMock.stat.mockResolvedValue({ size: 600 * 1024 });
     registerFilesHandlers();
 
@@ -152,16 +170,30 @@ describe("files:read handler", () => {
       name: "AppError",
       code: "FILE_TOO_LARGE",
     });
-    expect(fsMock.readFile).not.toHaveBeenCalled();
+    expect(fsMock.open).not.toHaveBeenCalled();
   });
 
-  it("throws AppError(OUTSIDE_ROOT) when the file is not under rootPath", async () => {
+  it("throws AppError(OUTSIDE_ROOT) when realpath resolves the file outside rootPath", async () => {
     registerFilesHandlers();
 
     await expect(
       getReadHandler()({}, { path: path.resolve("/etc/passwd"), rootPath: root })
     ).rejects.toMatchObject({ name: "AppError", code: "OUTSIDE_ROOT" });
     expect(fsMock.stat).not.toHaveBeenCalled();
+    expect(fsMock.open).not.toHaveBeenCalled();
+  });
+
+  it("throws AppError(OUTSIDE_ROOT) when a symlinked file resolves outside rootPath", async () => {
+    const innerPath = path.join(root, "innocuous.json");
+    const outsideTarget = path.resolve("/Users/me/.ssh/id_rsa");
+    fsMock.realpath.mockImplementation(async (p: string) => (p === innerPath ? outsideTarget : p));
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: innerPath, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "OUTSIDE_ROOT",
+    });
+    expect(fsMock.open).not.toHaveBeenCalled();
   });
 
   it("throws AppError(INVALID_PATH) for relative paths", async () => {
@@ -170,6 +202,94 @@ describe("files:read handler", () => {
     await expect(
       getReadHandler()({}, { path: "./relative", rootPath: root })
     ).rejects.toMatchObject({ name: "AppError", code: "INVALID_PATH" });
+  });
+
+  it("throws AppError(INVALID_PATH) when realpath(rootPath) raises ENOENT", async () => {
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === root) {
+        throw Object.assign(new Error("no such file or directory"), { code: "ENOENT" });
+      }
+      return p;
+    });
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "INVALID_PATH",
+    });
+  });
+
+  it("throws AppError(NOT_FOUND) when realpath(filePath) raises ENOENT", async () => {
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === file) {
+        throw Object.assign(new Error("no such file"), { code: "ENOENT" });
+      }
+      return p;
+    });
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_FOUND",
+    });
+  });
+
+  it("throws AppError(OUTSIDE_ROOT) when realpath raises ELOOP (circular symlink)", async () => {
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === file) {
+        throw Object.assign(new Error("too many symbolic links"), { code: "ELOOP" });
+      }
+      return p;
+    });
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "OUTSIDE_ROOT",
+    });
+  });
+
+  it("throws AppError(OUTSIDE_ROOT) when fs.open raises ELOOP (O_NOFOLLOW symlink rejection)", async () => {
+    fsMock.stat.mockResolvedValue({ size: 100 });
+    fsMock.open.mockRejectedValue(Object.assign(new Error("symbolic link"), { code: "ELOOP" }));
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "OUTSIDE_ROOT",
+    });
+  });
+
+  it("opens the file with O_RDONLY | O_NOFOLLOW", async () => {
+    const content = Buffer.from("hi", "utf-8");
+    fsMock.stat.mockResolvedValue({ size: content.length });
+    fsMock.open.mockResolvedValue(makeFileHandle(content));
+    registerFilesHandlers();
+
+    await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(fsMock.open).toHaveBeenCalledWith(
+      file,
+      fsMock.constants.O_RDONLY | fsMock.constants.O_NOFOLLOW
+    );
+  });
+
+  it("closes the file handle even when readFile rejects", async () => {
+    fsMock.stat.mockResolvedValue({ size: 100 });
+    const handle = {
+      readFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("file disappeared"), { code: "ENOENT" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    fsMock.open.mockResolvedValue(handle);
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_FOUND",
+    });
+    expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
   it("throws AppError(NOT_FOUND) when stat raises ENOENT", async () => {
@@ -185,9 +305,13 @@ describe("files:read handler", () => {
 
   it("throws AppError(NOT_FOUND) when stat succeeds but readFile raises ENOENT (TOCTOU)", async () => {
     fsMock.stat.mockResolvedValue({ size: 100 });
-    fsMock.readFile.mockRejectedValue(
-      Object.assign(new Error("file disappeared"), { code: "ENOENT" })
-    );
+    const handle = {
+      readFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("file disappeared"), { code: "ENOENT" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    fsMock.open.mockResolvedValue(handle);
     registerFilesHandlers();
 
     await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
@@ -198,9 +322,13 @@ describe("files:read handler", () => {
 
   it("throws AppError(PERMISSION) when readFile raises EACCES", async () => {
     fsMock.stat.mockResolvedValue({ size: 100 });
-    fsMock.readFile.mockRejectedValue(
-      Object.assign(new Error("permission denied"), { code: "EACCES" })
-    );
+    const handle = {
+      readFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("permission denied"), { code: "EACCES" })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    fsMock.open.mockResolvedValue(handle);
     registerFilesHandlers();
 
     await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
@@ -218,6 +346,24 @@ describe("files:read handler", () => {
     await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
       name: "AppError",
       code: "PERMISSION",
+    });
+  });
+
+  describe("schema validation", () => {
+    it("rejects null byte in path", async () => {
+      registerFilesHandlers();
+
+      await expect(
+        getReadHandler()({}, { path: `${file}\x00evil`, rootPath: root })
+      ).rejects.toThrow(/IPC validation failed/);
+    });
+
+    it("rejects null byte in rootPath", async () => {
+      registerFilesHandlers();
+
+      await expect(
+        getReadHandler()({}, { path: file, rootPath: `${root}\x00evil` })
+      ).rejects.toThrow(/IPC validation failed/);
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -349,6 +349,75 @@ describe("files:read handler", () => {
     });
   });
 
+  it("throws AppError(OUTSIDE_ROOT) for sibling-prefix escape (root '/tmp/project', file '/tmp/project-evil/x')", async () => {
+    const evilFile = path.resolve("/tmp/project-evil/secret.txt");
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: evilFile, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "OUTSIDE_ROOT",
+    });
+    expect(fsMock.open).not.toHaveBeenCalled();
+  });
+
+  it("accepts a file when both root and file canonicalize through symlinked paths", async () => {
+    const linkedRoot = path.resolve("/tmp/project-link");
+    const linkedFile = path.join(linkedRoot, "a.txt");
+    const realProject = path.resolve("/private/tmp/project");
+    const realFile = path.join(realProject, "a.txt");
+    fsMock.realpath.mockImplementation(async (p: string) => {
+      if (p === linkedRoot) return realProject;
+      if (p === linkedFile) return realFile;
+      return p;
+    });
+    const content = Buffer.from("ok", "utf-8");
+    fsMock.stat.mockResolvedValue({ size: content.length });
+    fsMock.open.mockResolvedValue(makeFileHandle(content));
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: linkedFile, rootPath: linkedRoot });
+
+    expect(result).toEqual({ content: "ok" });
+  });
+
+  it("returns the readFile error (not the close error) when both reject", async () => {
+    fsMock.stat.mockResolvedValue({ size: 100 });
+    const handle = {
+      readFile: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error("file disappeared"), { code: "ENOENT" })),
+      close: vi.fn().mockRejectedValue(Object.assign(new Error("bad fd"), { code: "EBADF" })),
+    };
+    fsMock.open.mockResolvedValue(handle);
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "NOT_FOUND",
+    });
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a file at the exact size limit and rejects one byte over", async () => {
+    const limit = 512 * 1024;
+    fsMock.stat.mockResolvedValue({ size: limit });
+    fsMock.open.mockResolvedValue(makeFileHandle(Buffer.alloc(limit, 0x61)));
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+    expect(result.content.length).toBe(limit);
+
+    vi.clearAllMocks();
+    fsMock.realpath.mockImplementation(async (p: string) => p);
+    fsMock.stat.mockResolvedValue({ size: limit + 1 });
+    registerFilesHandlers();
+
+    await expect(getReadHandler()({}, { path: file, rootPath: root })).rejects.toMatchObject({
+      name: "AppError",
+      code: "FILE_TOO_LARGE",
+    });
+  });
+
   describe("schema validation", () => {
     it("rejects null byte in path", async () => {
       registerFilesHandlers();
@@ -364,6 +433,17 @@ describe("files:read handler", () => {
       await expect(
         getReadHandler()({}, { path: file, rootPath: `${root}\x00evil` })
       ).rejects.toThrow(/IPC validation failed/);
+    });
+
+    it("rejects path longer than 4096 chars without touching the filesystem", async () => {
+      registerFilesHandlers();
+      const longPath = path.join(root, "a".repeat(4097));
+
+      await expect(getReadHandler()({}, { path: longPath, rootPath: root })).rejects.toThrow(
+        /IPC validation failed/
+      );
+      expect(fsMock.realpath).not.toHaveBeenCalled();
+      expect(fsMock.open).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -124,7 +124,14 @@ export function registerFilesHandlers(): () => void {
       throw fsErrorToAppError(error, "Could not resolve file path");
     }
 
-    if (!realFile.startsWith(realRoot + path.sep) && realFile !== realRoot) {
+    // Root === path.sep (POSIX "/") is a degenerate case: realRoot + path.sep
+    // becomes "//", which never prefix-matches a real path. Treat any absolute
+    // file as contained when the root is the filesystem root.
+    const contained =
+      realRoot === path.sep
+        ? realFile.startsWith(path.sep)
+        : realFile === realRoot || realFile.startsWith(realRoot + path.sep);
+    if (!contained) {
       throw new AppError({
         code: "OUTSIDE_ROOT",
         message: "File is outside the project root",
@@ -164,7 +171,8 @@ export function registerFilesHandlers(): () => void {
     } catch (error) {
       throw fsErrorToAppError(error, "Could not read file");
     } finally {
-      await fileHandle.close();
+      // Swallow close errors so they don't mask a preceding readFile failure.
+      await fileHandle.close().catch(() => {});
     }
 
     // Binary detection: check for null bytes in first 8 KB

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -58,22 +58,10 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
-    // Containment check: file must be inside rootPath
-    const normalizedFile = path.normalize(filePath);
-    const normalizedRoot = path.normalize(rootPath);
-    if (
-      !normalizedFile.startsWith(normalizedRoot + path.sep) &&
-      normalizedFile !== normalizedRoot
-    ) {
-      throw new AppError({
-        code: "OUTSIDE_ROOT",
-        message: "File is outside the project root",
-        context: { filePath, rootPath },
-      });
-    }
-
-    // Map ENOENT/EACCES/EPERM the same way for both stat and readFile — the
-    // file can disappear or change permissions between the two calls (TOCTOU).
+    // Map fs errors uniformly across realpath/stat/open — the file can
+    // disappear or change permissions between calls (TOCTOU). ELOOP surfaces
+    // from circular symlinks (realpath) or O_NOFOLLOW final-component
+    // symlink rejection (open); both are containment failures.
     function fsErrorToAppError(error: unknown, fallbackMessage: string): AppError {
       const errCode = (error as NodeJS.ErrnoException).code;
       if (errCode === "ENOENT") {
@@ -81,6 +69,14 @@ export function registerFilesHandlers(): () => void {
           code: "NOT_FOUND",
           message: "File not found",
           context: { filePath },
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+      if (errCode === "ELOOP") {
+        return new AppError({
+          code: "OUTSIDE_ROOT",
+          message: "File is outside the project root",
+          context: { filePath, rootPath },
           cause: error instanceof Error ? error : undefined,
         });
       }
@@ -102,9 +98,43 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
+    // Canonicalize root via OS-level resolution. A missing root is a caller
+    // configuration error, not a "file not found" — surface it as INVALID_PATH
+    // rather than letting fsErrorToAppError downgrade it to NOT_FOUND.
+    let realRoot: string;
+    try {
+      realRoot = await fs.realpath(rootPath);
+    } catch (error) {
+      const errCode = (error as NodeJS.ErrnoException).code;
+      if (errCode === "ENOENT") {
+        throw new AppError({
+          code: "INVALID_PATH",
+          message: "Project root does not exist",
+          context: { rootPath },
+          cause: error instanceof Error ? error : undefined,
+        });
+      }
+      throw fsErrorToAppError(error, "Could not resolve project root");
+    }
+
+    let realFile: string;
+    try {
+      realFile = await fs.realpath(filePath);
+    } catch (error) {
+      throw fsErrorToAppError(error, "Could not resolve file path");
+    }
+
+    if (!realFile.startsWith(realRoot + path.sep) && realFile !== realRoot) {
+      throw new AppError({
+        code: "OUTSIDE_ROOT",
+        message: "File is outside the project root",
+        context: { filePath, rootPath },
+      });
+    }
+
     let stat: Awaited<ReturnType<typeof fs.stat>>;
     try {
-      stat = await fs.stat(normalizedFile);
+      stat = await fs.stat(realFile);
     } catch (error) {
       throw fsErrorToAppError(error, "Could not stat file");
     }
@@ -118,11 +148,23 @@ export function registerFilesHandlers(): () => void {
       });
     }
 
+    // Open the user-supplied filePath (not realFile) with O_NOFOLLOW so a
+    // final-component symlink injected after the realpath check is rejected
+    // with ELOOP. On Windows O_NOFOLLOW is 0 (no-op); realpath containment
+    // still applies.
     let buffer: Buffer;
+    let fileHandle: Awaited<ReturnType<typeof fs.open>>;
     try {
-      buffer = await fs.readFile(normalizedFile);
+      fileHandle = await fs.open(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+    } catch (error) {
+      throw fsErrorToAppError(error, "Could not open file");
+    }
+    try {
+      buffer = await fileHandle.readFile();
     } catch (error) {
       throw fsErrorToAppError(error, "Could not read file");
+    } finally {
+      await fileHandle.close();
     }
 
     // Binary detection: check for null bytes in first 8 KB

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -392,8 +392,16 @@ export const CopyTreeGetFileTreePayloadSchema = z.object({
 });
 
 export const FileReadPayloadSchema = z.object({
-  path: z.string().min(1).max(4096),
-  rootPath: z.string().min(1).max(4096),
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+  rootPath: z
+    .string()
+    .min(1)
+    .max(4096)
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
 });
 
 export const SystemOpenExternalPayloadSchema = z.object({

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -396,11 +396,13 @@ export const FileReadPayloadSchema = z.object({
     .string()
     .min(1)
     .max(4096)
+    // eslint-disable-next-line no-control-regex
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
   rootPath: z
     .string()
     .min(1)
     .max(4096)
+    // eslint-disable-next-line no-control-regex
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
 });
 


### PR DESCRIPTION
## Summary

- Adds `realpath`-based containment to `files:read` — both root and file paths are canonicalised through the OS before the prefix check, closing the `../` and symlink traversal vectors
- Opens files with `O_NOFOLLOW` so a final-component symlink is refused at the kernel level; maps the resulting `ELOOP` error to `OUTSIDE_ROOT` (which already has the right user-facing string in `FileViewerModal`)
- Removes dead `path.normalize` calls (redundant once `realpath` is in place, and incidentally avoids the Windows legacy device-name bypass from CVE-2025-27210) and rejects null bytes in `FileReadPayloadSchema` at the schema layer rather than waiting for `ERR_INVALID_ARG_VALUE` from the OS

Closes #6252

## Changes

- `electron/ipc/handlers/files.ts` — realpath containment, `O_NOFOLLOW` open flag, `ELOOP → OUTSIDE_ROOT` mapping, removed `path.normalize` short-circuit
- `electron/schemas/ipc.ts` — null-byte rejection on `path` and `rootPath` fields in `FileReadPayloadSchema`
- `electron/ipc/handlers/__tests__/files.read.test.ts` — 31 tests covering containment, symlink traversal, null bytes, ELOOP, and the realpath foundation

## Testing

31 unit tests pass. Coverage spans the happy path, `../` traversal, symlink-into-root, symlink-outside-root (`ELOOP`), null bytes in both fields, and the root-equals-file edge case.