### PR TITLE
fix(pty-host): clear queuedBytes in safety timeout, tear down port on active-view crash

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -207,6 +207,14 @@ if (!gotTheLock) {
         getWorkspaceClientRef()?.removeDirectPort(wcId);
         getWorktreePortBrokerRef()?.closePortsForView(wcId);
       },
+      onViewCrashed: () => {
+        // Tear down the per-window PTY MessagePort on renderer crash so the
+        // pty-host's PortQueueManager can drop stale queue accounting before
+        // reload re-issues a fresh port. Without this, a stale port keeps the
+        // safety-timeout pause loop wedged for the entire reload window (#6244).
+        if (win.isDestroyed()) return;
+        getPtyClient()?.disconnectMessagePort(win.id);
+      },
       onViewReady: (wc) => {
         // Re-distribute PTY MessagePort on every view load/reload.
         // This ensures terminals work after view creation, crash recovery, or DevTools refresh.

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -158,6 +158,37 @@ describe("PortQueueManager", () => {
     expect(coordinator!.resume).toHaveBeenCalledWith("port-queue");
   });
 
+  it("safety timeout clears stale queuedBytes so next byte does not re-pause (#6244)", () => {
+    // When the renderer crashes and stops draining the port, the safety
+    // timeout fires after IPC_MAX_PAUSE_MS. It must drop the stale byte
+    // accounting along with the pause maps, otherwise the very next
+    // PTY byte re-triggers applyBackpressure and the pause loop wedges
+    // for the entire reload window.
+    const deps = createMockDeps();
+    const mgr = new PortQueueManager(deps);
+
+    const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+    mgr.addBytes("t1", highWatermark + 1);
+    mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+    vi.advanceTimersByTime(5000);
+
+    expect(mgr.getQueuedBytes("t1")).toBe(0);
+
+    const coordinator = deps.getPauseCoordinator("t1");
+    const pauseCallsAfterTimeout = (coordinator!.pause as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+
+    mgr.addBytes("t1", 1);
+    const result = mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+    expect(result).toBe(false);
+    expect(mgr.isPaused("t1")).toBe(false);
+    expect((coordinator!.pause as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      pauseCallsAfterTimeout
+    );
+  });
+
   it("clearQueue clears all state for a terminal", () => {
     const deps = createMockDeps();
     const mgr = new PortQueueManager(deps);

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -107,12 +107,17 @@ export class PortQueueManager {
       });
 
       const safetyTimeout = setTimeout(() => {
-        this.pausedTerminals.delete(id);
-        this.pauseStartTimes.delete(id);
-        this.queuedBytes.delete(id);
-
+        // Capture utilization BEFORE clearing queuedBytes so the reliability
+        // metric reports the at-resume queue depth, not the post-clear 0%.
         const currentUtilization = this.getUtilization(id);
         const pauseDuration = Date.now() - pauseStartTime;
+
+        this.pausedTerminals.delete(id);
+        this.pauseStartTimes.delete(id);
+        // Drop stale byte accounting alongside the pause maps. Without this,
+        // the next addBytes call immediately re-triggers applyBackpressure
+        // and the pause loop wedges across the entire renderer reload (#6244).
+        this.queuedBytes.delete(id);
 
         const coordinator = this.deps.getPauseCoordinator(id);
         if (coordinator) {

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -109,6 +109,7 @@ export class PortQueueManager {
       const safetyTimeout = setTimeout(() => {
         this.pausedTerminals.delete(id);
         this.pauseStartTimes.delete(id);
+        this.queuedBytes.delete(id);
 
         const currentUtilization = this.getUtilization(id);
         const pauseDuration = Date.now() - pauseStartTime;

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -587,7 +587,12 @@ export class ProjectViewManager {
       // MessagePorts can be torn down before reload re-issues fresh ones.
       // Without this, a stale port can keep PortQueueManager wedged in a
       // backpressure-pause loop for the entire reload window (#6244).
-      this.onViewCrashed?.(wc);
+      // Scoped to the active project: only the active view ever owns the
+      // per-window port (handleDidFinishLoad gates onViewReady on
+      // activeProjectId), so a cached-view crash must not tear it down.
+      if (projectId && projectId === this.activeProjectId) {
+        this.onViewCrashed?.(wc);
+      }
 
       const crashTimestamps = crashEntry?.crashTimestamps ?? [];
       const now = Date.now();

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -59,6 +59,8 @@ export interface ProjectViewManagerOptions {
   onViewEvicted?: (webContentsId: number) => void;
   /** Called on every did-finish-load for any managed view (initial load and reloads) */
   onViewReady?: (webContents: Electron.WebContents) => void;
+  /** Called synchronously when a view's renderer process is gone (non-clean), before reload */
+  onViewCrashed?: (webContents: Electron.WebContents) => void;
   /** Number of project views to keep cached in memory (1–5, default: 1) */
   cachedProjectViews?: number;
 }
@@ -73,6 +75,7 @@ export class ProjectViewManager {
   private onRecreateWindow?: () => Promise<void>;
   private onViewEvicted?: (webContentsId: number) => void;
   private onViewReady?: (webContents: Electron.WebContents) => void;
+  private onViewCrashed?: (webContents: Electron.WebContents) => void;
   private windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
@@ -84,6 +87,7 @@ export class ProjectViewManager {
     this.onRecreateWindow = opts.onRecreateWindow;
     this.onViewEvicted = opts.onViewEvicted;
     this.onViewReady = opts.onViewReady;
+    this.onViewCrashed = opts.onViewCrashed;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {
       this.maxCachedViews = opts.cachedProjectViews;
@@ -578,6 +582,13 @@ export class ProjectViewManager {
       // If the view is still loading, loadView's one-shot handler will handle
       // the failure and trigger rollback — skip crash recovery here.
       if (crashEntry?.state === "loading") return;
+
+      // Synchronously notify subscribers (e.g. PtyClient) so per-window
+      // MessagePorts can be torn down before reload re-issues fresh ones.
+      // Without this, a stale port can keep PortQueueManager wedged in a
+      // backpressure-pause loop for the entire reload window (#6244).
+      this.onViewCrashed?.(wc);
+
       const crashTimestamps = crashEntry?.crashTimestamps ?? [];
       const now = Date.now();
       while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {

--- a/electron/window/__tests__/ProjectViewManager.recovery.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.recovery.test.ts
@@ -43,6 +43,8 @@ interface SetupOptions {
   entry?: ViewEntryLike | null;
   backupTimestamp?: number | null;
   onViewCrashed?: (wc: ReturnType<typeof createMockWebContents>) => void;
+  /** Mirrors `projectId === activeProjectId` in the real PVM. Defaults to true. */
+  isActiveProject?: boolean;
 }
 
 /**
@@ -55,7 +57,12 @@ function setupCrashRecovery(
   wc: ReturnType<typeof createMockWebContents>,
   options: SetupOptions = {}
 ) {
-  const { entry = null, backupTimestamp = null, onViewCrashed } = options;
+  const {
+    entry = null,
+    backupTimestamp = null,
+    onViewCrashed,
+    isActiveProject = true,
+  } = options;
   const crashTimestamps: number[] = entry?.crashTimestamps ?? [];
 
   wc.on("render-process-gone", (_event, ...args) => {
@@ -64,7 +71,9 @@ function setupCrashRecovery(
     if (win.isDestroyed()) return;
     if (entry?.state === "loading") return;
 
-    onViewCrashed?.(wc);
+    if (isActiveProject) {
+      onViewCrashed?.(wc);
+    }
 
     const now = Date.now();
     while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {
@@ -290,5 +299,25 @@ describe("ProjectViewManager — onViewCrashed callback (#6244)", () => {
     crashThrice(wc);
 
     expect(onViewCrashed).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not fire when a cached (non-active) project view crashes", () => {
+    // The per-window PTY MessagePort is only ever held by the active view
+    // (handleDidFinishLoad gates onViewReady on activeProjectId). Tearing
+    // it down on a cached-view crash would leave the active terminals with
+    // no port and no recovery path — worse than the bug being fixed.
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-cached",
+      crashTimestamps: [],
+      state: "cached",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed, isActiveProject: false });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+
+    expect(onViewCrashed).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.recovery.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.recovery.test.ts
@@ -57,12 +57,7 @@ function setupCrashRecovery(
   wc: ReturnType<typeof createMockWebContents>,
   options: SetupOptions = {}
 ) {
-  const {
-    entry = null,
-    backupTimestamp = null,
-    onViewCrashed,
-    isActiveProject = true,
-  } = options;
+  const { entry = null, backupTimestamp = null, onViewCrashed, isActiveProject = true } = options;
   const crashTimestamps: number[] = entry?.crashTimestamps ?? [];
 
   wc.on("render-process-gone", (_event, ...args) => {

--- a/electron/window/__tests__/ProjectViewManager.recovery.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.recovery.test.ts
@@ -42,6 +42,7 @@ interface ViewEntryLike {
 interface SetupOptions {
   entry?: ViewEntryLike | null;
   backupTimestamp?: number | null;
+  onViewCrashed?: (wc: ReturnType<typeof createMockWebContents>) => void;
 }
 
 /**
@@ -54,7 +55,7 @@ function setupCrashRecovery(
   wc: ReturnType<typeof createMockWebContents>,
   options: SetupOptions = {}
 ) {
-  const { entry = null, backupTimestamp = null } = options;
+  const { entry = null, backupTimestamp = null, onViewCrashed } = options;
   const crashTimestamps: number[] = entry?.crashTimestamps ?? [];
 
   wc.on("render-process-gone", (_event, ...args) => {
@@ -62,6 +63,8 @@ function setupCrashRecovery(
     if (details.reason === "clean-exit") return;
     if (win.isDestroyed()) return;
     if (entry?.state === "loading") return;
+
+    onViewCrashed?.(wc);
 
     const now = Date.now();
     while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {
@@ -195,5 +198,97 @@ describe("ProjectViewManager — crash recovery URL", () => {
 
     const url = wc.loadURL.mock.calls[0][0] as string;
     expect(url).toContain("project=My+Project");
+  });
+});
+
+describe("ProjectViewManager — onViewCrashed callback (#6244)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires synchronously on non-clean render-process-gone", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+
+    expect(onViewCrashed).toHaveBeenCalledTimes(1);
+    expect(onViewCrashed).toHaveBeenCalledWith(wc);
+  });
+
+  it("does not fire on clean-exit", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed });
+
+    wc._emit("render-process-gone", { reason: "clean-exit", exitCode: 0 });
+
+    expect(onViewCrashed).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when view is in loading state (loadView handles rollback)", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "loading",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+
+    expect(onViewCrashed).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when window is destroyed", () => {
+    const win = createMockWindow();
+    win.isDestroyed.mockReturnValue(true);
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+
+    expect(onViewCrashed).not.toHaveBeenCalled();
+  });
+
+  it("fires on every non-clean crash including the loop threshold", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const onViewCrashed = vi.fn();
+    setupCrashRecovery(win, wc, { entry, onViewCrashed });
+
+    crashThrice(wc);
+
+    expect(onViewCrashed).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary

- The port-queue safety timeout was clearing the pause state but leaving `queuedBytes` populated, so the next PTY byte immediately re-triggered backpressure on a stale count — causing the timer to loop without actually unsticking anything
- The `ProjectViewManager` crash handler wasn't tearing down the per-window port, so `PortBatcher` kept posting to a dead frame until `did-finish-load` eventually replaced it
- Both fixes are scoped correctly: `portQueue.ts` deletes `queuedBytes` entries in the safety timeout alongside clearing the pause; `ProjectViewManager` calls the PTY host to disconnect the window port on crash, but only for the active project (inactive views reloading in the background should not trigger this)

Resolves #6244

## Changes

- `electron/pty-host/portQueue.ts` — safety timeout now deletes `queuedBytes` entries; also captures per-terminal utilization before clearing so the log line stays accurate
- `electron/window/ProjectViewManager.ts` — `onViewCrashed` callback added; fires `disconnectWindow` for the active project view only
- `electron/main.ts` — wires up the `onViewCrashed` hook from `ProjectViewManager` into the PTY host
- `electron/pty-host/__tests__/portQueue.test.ts` — regression test for the `queuedBytes` wedge (safety timeout must fully clear byte accounting)
- `electron/window/__tests__/ProjectViewManager.recovery.test.ts` — callback-firing semantics for crash recovery, including a case confirming cached (inactive) views do not fire the disconnect

## Testing

Unit tests cover both failure modes directly. The `portQueue` test verifies that after a safety timeout fires, a subsequent byte does not re-apply backpressure. The `ProjectViewManager` recovery tests confirm the crash callback fires for the active view and is suppressed for cached views.