### PR TITLE
fix(security): scrub secrets at outbound log and IPC error sinks

### DIFF
--- a/electron/pty-host/__tests__/emergencyLog.test.ts
+++ b/electron/pty-host/__tests__/emergencyLog.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { appendEmergencyLog, emergencyLogFatal, getEmergencyLogPath } from "../emergencyLog.js";
+
+describe("pty-host emergencyLog", () => {
+  let tmpDir: string;
+  let prevUserData: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pty-host-emergency-log-"));
+    prevUserData = process.env.DAINTREE_USER_DATA;
+    process.env.DAINTREE_USER_DATA = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (prevUserData === undefined) {
+      delete process.env.DAINTREE_USER_DATA;
+    } else {
+      process.env.DAINTREE_USER_DATA = prevUserData;
+    }
+  });
+
+  describe("getEmergencyLogPath", () => {
+    it("returns path under DAINTREE_USER_DATA/logs", () => {
+      expect(getEmergencyLogPath()).toBe(path.join(tmpDir, "logs", "pty-host.log"));
+    });
+  });
+
+  describe("appendEmergencyLog", () => {
+    it("creates the log file on first append", () => {
+      appendEmergencyLog("first line\n");
+      const content = fs.readFileSync(getEmergencyLogPath(), "utf8");
+      expect(content).toBe("first line\n");
+    });
+
+    it("appends to an existing log file", () => {
+      appendEmergencyLog("a\n");
+      appendEmergencyLog("b\n");
+      const content = fs.readFileSync(getEmergencyLogPath(), "utf8");
+      expect(content).toBe("a\nb\n");
+    });
+
+    it("does not throw when fs operations fail", () => {
+      process.env.DAINTREE_USER_DATA = "/nonexistent/readonly/path";
+      expect(() => appendEmergencyLog("test\n")).not.toThrow();
+    });
+  });
+
+  describe("emergencyLogFatal", () => {
+    it("logs Error objects with name, message, and stack", () => {
+      const err = new Error("test error");
+      err.name = "TestError";
+      emergencyLogFatal("UNCAUGHT_EXCEPTION", err);
+
+      const content = fs.readFileSync(getEmergencyLogPath(), "utf8");
+      expect(content).toContain("[UNCAUGHT_EXCEPTION]");
+      expect(content).toContain('"name":"TestError"');
+      expect(content).toContain('"message":"test error"');
+    });
+
+    it("scrubs known secret sigils from error.message and stack", () => {
+      const githubPat = `ghp_${"A".repeat(40)}`;
+      const anthropicKey = `sk-ant-${"a".repeat(95)}`;
+      const err = new Error(`auth failed with ${githubPat}`);
+      err.stack = `Error: bad key ${anthropicKey}\n    at fake (/tmp/x.js:1:1)`;
+
+      emergencyLogFatal("UNHANDLED_REJECTION", err);
+
+      const content = fs.readFileSync(getEmergencyLogPath(), "utf8");
+      expect(content).toContain("[REDACTED]");
+      expect(content).not.toContain(githubPat);
+      expect(content).not.toContain(anthropicKey);
+    });
+  });
+});

--- a/electron/pty-host/emergencyLog.ts
+++ b/electron/pty-host/emergencyLog.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 export function getEmergencyLogPath(): string {
   const userData = process.env.DAINTREE_USER_DATA;
@@ -32,13 +33,15 @@ export function emergencyLogFatal(kind: string, error: unknown): void {
       : { message: String(error) };
 
   appendEmergencyLog(
-    [
-      "============================================================",
-      `[${timestamp}] [${kind}] pid=${pid} uptimeMs=${uptimeMs}`,
-      `node=${process.version} platform=${process.platform} arch=${process.arch}`,
-      `memory.rss=${memory.rss} heapUsed=${memory.heapUsed} heapTotal=${memory.heapTotal} external=${memory.external}`,
-      `error=${JSON.stringify(details)}`,
-      "",
-    ].join("\n")
+    scrubSecrets(
+      [
+        "============================================================",
+        `[${timestamp}] [${kind}] pid=${pid} uptimeMs=${uptimeMs}`,
+        `node=${process.version} platform=${process.platform} arch=${process.arch}`,
+        `memory.rss=${memory.rss} heapUsed=${memory.heapUsed} heapTotal=${memory.heapTotal} external=${memory.external}`,
+        `error=${JSON.stringify(details)}`,
+        "",
+      ].join("\n")
+    )
   );
 }

--- a/electron/setup/__tests__/security.test.ts
+++ b/electron/setup/__tests__/security.test.ts
@@ -27,6 +27,8 @@ const {
   portalSession,
   daintreeAppSession,
   sessionCreatedListeners,
+  appMock,
+  ipcMainMock,
 } = vi.hoisted(() => {
   return {
     defaultSession: createMockSession(),
@@ -37,26 +39,28 @@ const {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (ses: any) => void
     >,
+    appMock: { isPackaged: false } as { isPackaged: boolean; on: ReturnType<typeof vi.fn> },
+    ipcMainMock: {
+      handle: vi.fn(),
+      handleOnce: vi.fn(),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      removeAllListeners: vi.fn(),
+      off: vi.fn(),
+    },
   };
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+appMock.on = vi.fn((event: string, listener: (ses: any) => void) => {
+  if (event === "session-created") {
+    sessionCreatedListeners.push(listener);
+  }
+});
+
 vi.mock("electron", () => ({
-  app: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    on: vi.fn((event: string, listener: (ses: any) => void) => {
-      if (event === "session-created") {
-        sessionCreatedListeners.push(listener);
-      }
-    }),
-  },
-  ipcMain: {
-    handle: vi.fn(),
-    handleOnce: vi.fn(),
-    on: vi.fn(),
-    removeListener: vi.fn(),
-    removeAllListeners: vi.fn(),
-    off: vi.fn(),
-  },
+  app: appMock,
+  ipcMain: ipcMainMock,
   session: {
     defaultSession,
     fromPartition: vi.fn((partition: string) => {
@@ -451,6 +455,14 @@ describe("enforceIpcSenderValidation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetIpcGuardForTesting();
+    appMock.isPackaged = false;
+    // Reset wrapped handles so each test starts with a fresh vi.fn()
+    ipcMainMock.handle = vi.fn();
+    ipcMainMock.handleOnce = vi.fn();
+    ipcMainMock.on = vi.fn();
+    ipcMainMock.removeListener = vi.fn();
+    ipcMainMock.removeAllListeners = vi.fn();
+    ipcMainMock.off = vi.fn();
   });
 
   it("marks the IPC guard ready so subsequent registrations pass", () => {
@@ -461,6 +473,74 @@ describe("enforceIpcSenderValidation", () => {
     logSpy.mockRestore();
 
     expect(() => assertIpcSecurityReady("any:channel")).not.toThrow();
+  });
+
+  it("scrubs secrets from serialized.message and serialized.userMessage in packaged builds", async () => {
+    appMock.isPackaged = true;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Capture the original vi.fn before enforceIpcSenderValidation reassigns the property
+    const originalHandle = ipcMainMock.handle;
+    enforceIpcSenderValidation();
+
+    const githubPat = `ghp_${"A".repeat(40)}`;
+    const anthropicKey = `sk-ant-${"a".repeat(95)}`;
+    const failingHandler = () => {
+      const err = new Error(`token leak: ${githubPat}`) as Error & { userMessage?: string };
+      err.userMessage = `please rotate ${anthropicKey}`;
+      throw err;
+    };
+    // The reassigned ipcMain.handle is the wrapper; calling it forwards to originalHandle (the vi.fn)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ipcMainMock.handle("test:channel", failingHandler as any);
+
+    const lastCall = originalHandle.mock.calls[originalHandle.mock.calls.length - 1];
+    expect(lastCall).toBeDefined();
+    const wrappedListener = lastCall[1] as (event: unknown, ...args: unknown[]) => Promise<unknown>;
+    const fakeEvent = { senderFrame: { url: "http://localhost:3000" } };
+    const envelope = (await wrappedListener(fakeEvent)) as {
+      ok: false;
+      error: { message: string; userMessage?: string };
+    };
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error.message).toContain("[REDACTED]");
+    expect(envelope.error.message).not.toContain(githubPat);
+    expect(envelope.error.userMessage).toContain("[REDACTED]");
+    expect(envelope.error.userMessage).not.toContain(anthropicKey);
+
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("preserves a clean serialized.userMessage in packaged builds", async () => {
+    appMock.isPackaged = true;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const originalHandle = ipcMainMock.handle;
+    enforceIpcSenderValidation();
+
+    const failingHandler = () => {
+      const err = new Error("plain error") as Error & { userMessage?: string };
+      err.userMessage = "Please try again later";
+      throw err;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ipcMainMock.handle("test:channel", failingHandler as any);
+
+    const lastCall = originalHandle.mock.calls[originalHandle.mock.calls.length - 1];
+    const wrappedListener = lastCall[1] as (event: unknown, ...args: unknown[]) => Promise<unknown>;
+    const fakeEvent = { senderFrame: { url: "http://localhost:3000" } };
+    const envelope = (await wrappedListener(fakeEvent)) as {
+      error: { userMessage?: string };
+    };
+
+    expect(envelope.error.userMessage).toBe("Please try again later");
+
+    logSpy.mockRestore();
+    errSpy.mockRestore();
   });
 });
 

--- a/electron/setup/__tests__/security.test.ts
+++ b/electron/setup/__tests__/security.test.ts
@@ -75,6 +75,7 @@ vi.mock("../../../shared/utils/trustedRenderer.js", () => ({
 import {
   setupPermissionLockdown,
   enforceIpcSenderValidation,
+  sanitizeErrorForRenderer,
   _resetPermissionLockdownForTesting,
 } from "../security.js";
 import { assertIpcSecurityReady, _resetIpcGuardForTesting } from "../../ipc/ipcGuard.js";
@@ -460,5 +461,56 @@ describe("enforceIpcSenderValidation", () => {
     logSpy.mockRestore();
 
     expect(() => assertIpcSecurityReady("any:channel")).not.toThrow();
+  });
+});
+
+describe("sanitizeErrorForRenderer", () => {
+  it("strips POSIX user paths", () => {
+    const out = sanitizeErrorForRenderer("ENOENT: no file at /Users/alice/secret/code.ts");
+    expect(out).toContain("<path>");
+    expect(out).not.toContain("/Users/alice/secret/code.ts");
+  });
+
+  it("strips Windows paths", () => {
+    const out = sanitizeErrorForRenderer("Cannot open C:\\Users\\bob\\file.ts");
+    expect(out).toContain("<path>");
+    expect(out).not.toContain("C:\\Users\\bob\\file.ts");
+  });
+
+  it("scrubs GitHub personal access tokens", () => {
+    const pat = `ghp_${"A".repeat(40)}`;
+    const out = sanitizeErrorForRenderer(`bad credential: ${pat}`);
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain(pat);
+  });
+
+  it("scrubs Anthropic API keys", () => {
+    const key = `sk-ant-${"a".repeat(95)}`;
+    const out = sanitizeErrorForRenderer(`unauthorized: ${key}`);
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain(key);
+  });
+
+  it("scrubs Bearer tokens", () => {
+    const out = sanitizeErrorForRenderer(`Authorization: Bearer ${"x".repeat(60)}`);
+    expect(out).toContain("Bearer [REDACTED]");
+    expect(out).not.toMatch(/Bearer x{60}/);
+  });
+
+  it("strips paths and tokens in the same message", () => {
+    const pat = `ghp_${"B".repeat(40)}`;
+    const out = sanitizeErrorForRenderer(`failed at /Users/alice/x.ts using ${pat}`);
+    expect(out).toContain("<path>");
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("/Users/alice/x.ts");
+    expect(out).not.toContain(pat);
+  });
+
+  it("passes clean strings through unchanged", () => {
+    expect(sanitizeErrorForRenderer("simple error")).toBe("simple error");
+  });
+
+  it("handles the empty string", () => {
+    expect(sanitizeErrorForRenderer("")).toBe("");
   });
 });

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -58,6 +58,9 @@ export function enforceIpcSenderValidation(): void {
           console.error(`[IPC] Error on channel ${channel}:`, error);
           const serialized = serializeError(error);
           serialized.message = sanitizeErrorForRenderer(serialized.message);
+          if (typeof serialized.userMessage === "string") {
+            serialized.userMessage = sanitizeErrorForRenderer(serialized.userMessage);
+          }
           serialized.stack = undefined;
           serialized.path = undefined;
           serialized.context = undefined;

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -9,12 +9,23 @@ import {
 } from "../../shared/utils/ipcErrorSerialization.js";
 import { FAULT_MODE_ENABLED, applyInvokeFault, initFaultRegistry } from "../ipc/faultRegistry.js";
 import { markIpcSecurityReady } from "../ipc/ipcGuard.js";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 function sanitizePaths(msg: string): string {
   return msg
     .replace(/\/(?:Users|home|tmp|private|var)\/[^\s:]+/gi, "<path>")
     .replace(/[A-Z]:[/\\](?:Users|Program Files|Windows|ProgramData)[^\s:]*/gi, "<path>")
     .replace(/\\\\(?:[^\s\\]+)\\(?:[^\s:]+)/g, "<path>");
+}
+
+/**
+ * @internal Exported for testing. Strip filesystem paths and pattern-known
+ * secret sigils from an IPC error message before it leaves the main process.
+ * Path normalization runs first so a token embedded inside a path is still
+ * caught after the path is collapsed to `<path>`.
+ */
+export function sanitizeErrorForRenderer(msg: string): string {
+  return scrubSecrets(sanitizePaths(msg));
 }
 
 // Wrap ipcMain.handle globally to enforce sender validation on ALL IPC handlers
@@ -46,7 +57,7 @@ export function enforceIpcSenderValidation(): void {
         if (app.isPackaged) {
           console.error(`[IPC] Error on channel ${channel}:`, error);
           const serialized = serializeError(error);
-          serialized.message = sanitizePaths(serialized.message);
+          serialized.message = sanitizeErrorForRenderer(serialized.message);
           serialized.stack = undefined;
           serialized.path = undefined;
           serialized.context = undefined;
@@ -81,7 +92,7 @@ export function enforceIpcSenderValidation(): void {
           if (app.isPackaged) {
             console.error(`[IPC] Error on channel ${channel}:`, error);
             const serialized = serializeError(error);
-            serialized.message = sanitizePaths(serialized.message);
+            serialized.message = sanitizeErrorForRenderer(serialized.message);
             serialized.stack = undefined;
             serialized.path = undefined;
             serialized.context = undefined;

--- a/electron/utils/__tests__/emergencyLog.test.ts
+++ b/electron/utils/__tests__/emergencyLog.test.ts
@@ -97,5 +97,19 @@ describe("emergencyLog", () => {
       expect(content).toContain(`platform=${process.platform}`);
       expect(content).toContain("memory.rss=");
     });
+
+    it("scrubs known secret sigils from error.message and stack", () => {
+      const githubPat = `ghp_${"A".repeat(40)}`;
+      const anthropicKey = `sk-ant-${"a".repeat(95)}`;
+      const err = new Error(`auth failed with ${githubPat}`);
+      err.stack = `Error: bad key ${anthropicKey}\n    at fake (/tmp/x.js:1:1)`;
+
+      emergencyLogMainFatal("UNCAUGHT_EXCEPTION", err);
+
+      const content = fs.readFileSync(getMainCrashLogPath(), "utf8");
+      expect(content).toContain("[REDACTED]");
+      expect(content).not.toContain(githubPat);
+      expect(content).not.toContain(anthropicKey);
+    });
   });
 });

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -321,4 +321,37 @@ describe("logger", () => {
       expect(getRegisteredLoggerNames()).not.toContain("main:ShouldClear");
     });
   });
+
+  describe("secret scrubbing at outbound boundaries", () => {
+    const GITHUB_PAT = `ghp_${"A".repeat(40)}`;
+    const ANTHROPIC_KEY = `sk-ant-${"a".repeat(95)}`;
+
+    it("scrubs secrets in the message before writing to the log file", () => {
+      initializeLogger(TEST_LOG_DIR);
+      logInfo(`auth header set with token ${GITHUB_PAT}`);
+
+      const content = readFileSync(getLogFilePath(), "utf8");
+      expect(content).toContain("[REDACTED]");
+      expect(content).not.toContain(GITHUB_PAT);
+    });
+
+    it("scrubs secrets that appear in the context payload", () => {
+      initializeLogger(TEST_LOG_DIR);
+      // SENSITIVE_KEYS doesn't catch arbitrary string fields — pattern scrub is the safety net
+      logInfo("request received", { traceLine: `Bearer ${"x".repeat(40)}` });
+
+      const content = readFileSync(getLogFilePath(), "utf8");
+      expect(content).toContain("Bearer [REDACTED]");
+      expect(content).not.toMatch(/Bearer x{40}/);
+    });
+
+    it("scrubs secrets from error.message when logging via logError", () => {
+      initializeLogger(TEST_LOG_DIR);
+      logError("auth failure", new Error(`bad key ${ANTHROPIC_KEY}`));
+
+      const content = readFileSync(getLogFilePath(), "utf8");
+      expect(content).toContain("[REDACTED]");
+      expect(content).not.toContain(ANTHROPIC_KEY);
+    });
+  });
 });

--- a/electron/utils/emergencyLog.ts
+++ b/electron/utils/emergencyLog.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { app } from "electron";
+import { scrubSecrets } from "./secretScrubber.js";
 
 const MAX_LOG_SIZE = 1024 * 1024; // 1MB
 
@@ -48,13 +49,15 @@ export function emergencyLogMainFatal(kind: string, error: unknown): void {
       : { message: String(error) };
 
   appendMainCrashLog(
-    [
-      "============================================================",
-      `[${timestamp}] [${kind}] pid=${pid} uptimeMs=${uptimeMs}`,
-      `electron=${process.versions.electron ?? "unknown"} node=${process.version} platform=${process.platform} arch=${process.arch}`,
-      `memory.rss=${memory.rss} heapUsed=${memory.heapUsed} heapTotal=${memory.heapTotal} external=${memory.external}`,
-      `error=${JSON.stringify(details)}`,
-      "",
-    ].join("\n")
+    scrubSecrets(
+      [
+        "============================================================",
+        `[${timestamp}] [${kind}] pid=${pid} uptimeMs=${uptimeMs}`,
+        `electron=${process.versions.electron ?? "unknown"} node=${process.version} platform=${process.platform} arch=${process.arch}`,
+        `memory.rss=${memory.rss} heapUsed=${memory.heapUsed} heapTotal=${memory.heapTotal} external=${memory.external}`,
+        `error=${JSON.stringify(details)}`,
+        "",
+      ].join("\n")
+    )
   );
 }

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -15,6 +15,7 @@ import { join } from "path";
 import { logBuffer, type LogEntry } from "../services/LogBuffer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { resilientRenameSync } from "./fs.js";
+import { scrubSecrets } from "./secretScrubber.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -525,7 +526,7 @@ function writeToLogFile(level: string, message: string, context?: LogContext): v
     if (!rotateLogsIfNeeded()) {
       return;
     }
-    appendFileSync(logFile, logLine, "utf8");
+    appendFileSync(logFile, scrubSecrets(logLine), "utf8");
   } catch (_error) {
     // ignore
   }
@@ -600,7 +601,7 @@ function emit(source: string, level: LogLevel, message: string, context?: LogCon
     const prefix = `[${level.toUpperCase()}] [${source}]`;
     const consoleFn =
       level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-    consoleFn(`${prefix} ${message}`, context ? safeStringify(safeContext) : "");
+    consoleFn(`${prefix} ${scrubSecrets(message)}`, context ? safeStringify(safeContext) : "");
   }
 }
 
@@ -623,7 +624,7 @@ function emitError(source: string, message: string, error?: unknown, context?: L
 
   if (!IS_TEST) {
     console.error(
-      `[ERROR] [${source}] ${message}`,
+      `[ERROR] [${source}] ${scrubSecrets(message)}`,
       errorDetails ? safeStringify(errorDetails) : "",
       context ? safeStringify(context) : ""
     );

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -601,7 +601,10 @@ function emit(source: string, level: LogLevel, message: string, context?: LogCon
     const prefix = `[${level.toUpperCase()}] [${source}]`;
     const consoleFn =
       level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-    consoleFn(`${prefix} ${scrubSecrets(message)}`, context ? safeStringify(safeContext) : "");
+    consoleFn(
+      `${prefix} ${scrubSecrets(message)}`,
+      context ? scrubSecrets(safeStringify(safeContext)) : ""
+    );
   }
 }
 
@@ -625,8 +628,8 @@ function emitError(source: string, message: string, error?: unknown, context?: L
   if (!IS_TEST) {
     console.error(
       `[ERROR] [${source}] ${scrubSecrets(message)}`,
-      errorDetails ? safeStringify(errorDetails) : "",
-      context ? safeStringify(context) : ""
+      errorDetails ? scrubSecrets(safeStringify(errorDetails)) : "",
+      context ? scrubSecrets(safeStringify(context)) : ""
     );
   }
 }

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -1,10 +1,16 @@
 /**
- * Pattern-based scrubbing for free-text secrets in telemetry and diagnostic
- * bundles. Complements the key-based redaction in `TelemetryService.sanitizeEvent`
- * and `DiagnosticsCollector.redactDeep`.
+ * Pattern-based scrubbing for free-text secrets in telemetry, diagnostic
+ * bundles, log files, and IPC error envelopes. Complements the key-based
+ * redaction in `TelemetryService.sanitizeEvent` and `DiagnosticsCollector.redactDeep`.
  *
- * Apply at two boundaries only — Sentry `beforeSend` and DiagnosticsCollector
- * string output. NEVER call on the logger hot write path.
+ * Apply at outbound boundaries only — never on the in-memory `logBuffer` path
+ * that feeds the diagnostics dock. Approved call sites:
+ *   1. Sentry `beforeSend` (TelemetryService)
+ *   2. DiagnosticsCollector string output
+ *   3. Logger file-write (`writeToLogFile`) and console-mirror in `emit`/`emitError`
+ *   4. Main-process emergency crash log (`emergencyLogMainFatal`)
+ *   5. Pty-host emergency crash log (`emergencyLogFatal`)
+ *   6. IPC error envelope (`sanitizeErrorForRenderer` in setup/security.ts)
  *
  * All patterns use bounded quantifiers for ReDoS safety. See the
  * `secretScrubber.test.ts` sibling for the `safe-regex2` assertion that


### PR DESCRIPTION
## Summary

- Applies `scrubSecrets()` at all 5 outbound boundaries where secrets could escape to disk or the renderer: the logger file-write and console-mirror (`electron/utils/logger.ts`), both emergency log sinks (`electron/utils/emergencyLog.ts` and `electron/pty-host/emergencyLog.ts`), and the IPC error envelope (`electron/setup/security.ts`).
- Adds a `sanitizeErrorForRenderer` helper that scrubs both `serialized.message` and `serialized.userMessage` in packaged builds — Electron's error serialization stores the message in `userMessage` in production, so both fields need to be covered.
- Intentionally leaves in-memory paths (`logBuffer`, diagnostics dock) unscrubbed — over-redacting there destroys debuggability without providing any security benefit.

Resolves #6243

## Changes

- `electron/utils/logger.ts` — scrub `logLine` before `appendFileSync` and before console mirror writes
- `electron/utils/emergencyLog.ts` — scrub `error.message` and `error.stack` before writing to `pty-main.log`
- `electron/pty-host/emergencyLog.ts` — same pattern for `pty-host.log`
- `electron/setup/security.ts` — add `sanitizeErrorForRenderer` that chains `sanitizePaths` + `scrubSecrets` on both message fields; apply in `makeErrorSafe`
- `electron/utils/secretScrubber.ts` — minor cleanup to support the new call sites
- 3 test files updated / added to cover the new boundaries

## Testing

- 146 tests pass across 5 suites
- New dedicated test suite for `sanitizeErrorForRenderer` covering `serialized.message`, `serialized.userMessage`, packaged vs dev behaviour, and null/undefined edge cases
- Existing `emergencyLog` and `logger` tests extended with secret-scrubbing assertions