### PR TITLE
fix(workspace-host): scrub secrets from recipe stdout before agent context injection

### DIFF
--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -3,6 +3,7 @@ import { readFile, access, cp } from "fs/promises";
 import { join as pathJoin, basename, dirname } from "path";
 import os from "os";
 import { z } from "zod/v4";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 const OUTPUT_TAIL_BYTES = 8192;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -529,8 +530,9 @@ function buildSpawnEnv(customEnv: Record<string, string>): Record<string, string
 
 function tailOutput(chunks: string[]): string {
   const full = chunks.join("");
-  if (full.length <= OUTPUT_TAIL_BYTES) {
-    return full;
-  }
-  return "...(truncated)\n" + full.slice(full.length - OUTPUT_TAIL_BYTES);
+  const tail =
+    full.length <= OUTPUT_TAIL_BYTES
+      ? full
+      : "...(truncated)\n" + full.slice(full.length - OUTPUT_TAIL_BYTES);
+  return scrubSecrets(tail);
 }

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -248,6 +248,44 @@ describe("WorktreeLifecycleService", () => {
       return child;
     }
 
+    function makeFakeProcessWithOutput(stdoutData: string, exitCode: number = 0) {
+      const stdoutListeners: ((chunk: Buffer) => void)[] = [];
+      const stderrListeners: ((chunk: Buffer) => void)[] = [];
+      const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+      const stdout = {
+        on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+          if (event === "data") stdoutListeners.push(cb);
+        }),
+      };
+      const stderr = {
+        on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+          if (event === "data") stderrListeners.push(cb);
+        }),
+      };
+
+      const child = {
+        pid: 12345,
+        stdout,
+        stderr,
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+          listeners[event] ??= [];
+          listeners[event].push(cb);
+        }),
+        kill: vi.fn(),
+        emit: (event: string, ...args: unknown[]) => {
+          listeners[event]?.forEach((cb) => cb(...args));
+        },
+      };
+
+      setTimeout(() => {
+        stdoutListeners.forEach((cb) => cb(Buffer.from(stdoutData)));
+        child.emit("close", exitCode);
+      }, 0);
+
+      return child;
+    }
+
     it("returns success when command exits with code 0", async () => {
       mockSpawn.mockReturnValue(makeFakeProcess(0));
 
@@ -358,6 +396,43 @@ describe("WorktreeLifecycleService", () => {
           }),
         })
       );
+    });
+
+    it("scrubs secrets from captured stdout before returning", async () => {
+      const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+      const stdoutText = `Setup complete. token=${token} remaining work to do.`;
+      mockSpawn.mockReturnValue(makeFakeProcessWithOutput(stdoutText, 0));
+
+      const result = await service.runCommands(["./setup.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).not.toContain(token);
+      expect(result.output).toContain("[REDACTED]");
+      expect(result.output).toContain("Setup complete.");
+      expect(result.output).toContain("remaining work to do.");
+    });
+
+    it("preserves valid JSON structure when scrubbing a secret inside a string value", async () => {
+      const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+      const json = JSON.stringify({ status: "ok", endpoint: "https://api.example.com", token });
+      mockSpawn.mockReturnValue(makeFakeProcessWithOutput(json, 0));
+
+      const result = await service.runCommands(["./status.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).not.toContain(token);
+      const parsed = JSON.parse(result.output) as Record<string, string>;
+      expect(parsed.status).toBe("ok");
+      expect(parsed.endpoint).toBe("https://api.example.com");
+      expect(parsed.token).toBe("[REDACTED]");
     });
 
     it("uses detached conditionally based on platform", async () => {

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts
@@ -248,7 +248,11 @@ describe("WorktreeLifecycleService", () => {
       return child;
     }
 
-    function makeFakeProcessWithOutput(stdoutData: string, exitCode: number = 0) {
+    function makeFakeProcessWithOutput(
+      stdoutData: string | string[],
+      exitCode: number = 0,
+      stderrData?: string
+    ) {
       const stdoutListeners: ((chunk: Buffer) => void)[] = [];
       const stderrListeners: ((chunk: Buffer) => void)[] = [];
       const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
@@ -278,8 +282,15 @@ describe("WorktreeLifecycleService", () => {
         },
       };
 
+      const stdoutChunks = Array.isArray(stdoutData) ? stdoutData : [stdoutData];
+
       setTimeout(() => {
-        stdoutListeners.forEach((cb) => cb(Buffer.from(stdoutData)));
+        for (const chunk of stdoutChunks) {
+          stdoutListeners.forEach((cb) => cb(Buffer.from(chunk)));
+        }
+        if (stderrData !== undefined) {
+          stderrListeners.forEach((cb) => cb(Buffer.from(stderrData)));
+        }
         child.emit("close", exitCode);
       }, 0);
 
@@ -414,6 +425,42 @@ describe("WorktreeLifecycleService", () => {
       expect(result.output).toContain("[REDACTED]");
       expect(result.output).toContain("Setup complete.");
       expect(result.output).toContain("remaining work to do.");
+    });
+
+    it("scrubs secrets emitted to stderr on command failure", async () => {
+      const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+      const stderrText = `error: authentication failed using ${token}`;
+      mockSpawn.mockReturnValue(makeFakeProcessWithOutput("", 1, stderrText));
+
+      const result = await service.runCommands(["./setup.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.output).not.toContain(token);
+      expect(result.output).toContain("[REDACTED]");
+      expect(result.output).toContain("authentication failed");
+    });
+
+    it("scrubs secrets when split across multiple stdout chunks (post-join scrubbing)", async () => {
+      const token = "ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD";
+      const halfA = `before token=ghp_abcdefghijklmnop`;
+      const halfB = `qrstuvwxyz0123456789ABCD after`;
+      mockSpawn.mockReturnValue(makeFakeProcessWithOutput([halfA, halfB], 0));
+
+      const result = await service.runCommands(["./setup.sh"], {
+        cwd: "/test",
+        env: {},
+        onProgress: vi.fn(),
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).not.toContain(token);
+      expect(result.output).toContain("[REDACTED]");
+      expect(result.output).toContain("before");
+      expect(result.output).toContain("after");
     });
 
     it("preserves valid JSON structure when scrubbing a secret inside a string value", async () => {


### PR DESCRIPTION
## Summary

- `tailOutput` result is now passed through `scrubSecrets` before flowing into lifecycle IPC, resource-status persistence, and the `DAINTREE_RESOURCE_STATUS` env var injected into agent terminals — all three sinks covered from a single point.
- The agent context injection path is the highest-risk one: a recipe running `gh auth status`, `aws configure list`, or `cat .env` could hand raw credentials to an external LLM. This closes that gap.
- Uses the existing `scrubSecrets` utility from `electron/utils/secretScrubber.ts` — no new scrubbing logic needed.

Resolves #6246

## Changes

- `electron/workspace-host/WorktreeLifecycleService.ts` — import `scrubSecrets`, wrap the composed `tailOutput` string before it's returned.
- `electron/workspace-host/__tests__/WorktreeLifecycleService.test.ts` — four new test cases:
  1. Token redacted from stdout.
  2. JSON structure preserved when the secret appears inside a string value.
  3. Stderr scrubbed on command failure (the highest-risk credential path).
  4. Secret split across multiple output chunks is still caught after the join.

## Testing

All four cases pass. Typecheck, lint baseline, and prettier format all clean.