### PR TITLE
feat(security): add CSP to the persist:daintree session

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -715,6 +715,46 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
 
     expect(onHeadersReceivedRegistrations).toEqual(["persist:browser", "persist:daintree"]);
   });
+
+  it("invokes the callback with the daintree CSP string for the persist:daintree session", async () => {
+    const { session } = await import("electron");
+    const fromPartition = vi.mocked(session.fromPartition);
+    const callbacksByPartition = new Map<
+      string,
+      (details: unknown, callback: (response: unknown) => void) => void
+    >();
+    fromPartition.mockImplementation((partition: string) => {
+      const onHeadersReceived = vi.fn((listener) => {
+        callbacksByPartition.set(partition, listener);
+      });
+      return {
+        webRequest: { onHeadersReceived },
+      } as unknown as Electron.Session;
+    });
+
+    setupWebviewCSP();
+
+    const daintreeListener = callbacksByPartition.get("persist:daintree");
+    const browserListener = callbacksByPartition.get("persist:browser");
+    expect(daintreeListener).toBeDefined();
+    expect(browserListener).toBeDefined();
+
+    let daintreeResponse: { responseHeaders?: Record<string, string[]> } | undefined;
+    daintreeListener!({ responseHeaders: {} }, (response: unknown) => {
+      daintreeResponse = response as typeof daintreeResponse;
+    });
+    let browserResponse: { responseHeaders?: Record<string, string[]> } | undefined;
+    browserListener!({ responseHeaders: {} }, (response: unknown) => {
+      browserResponse = response as typeof browserResponse;
+    });
+
+    expect(daintreeResponse?.responseHeaders?.["Content-Security-Policy"]?.[0]).toContain(
+      "/* daintree */"
+    );
+    expect(browserResponse?.responseHeaders?.["Content-Security-Policy"]?.[0]).toContain(
+      "/* browser */"
+    );
+  });
 });
 
 describe("protocol registration", () => {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -42,8 +42,11 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("../../utils/webviewCsp.js", () => ({
-  classifyPartition: vi.fn(() => "browser"),
-  getLocalhostDevCSP: vi.fn(() => "default-src 'self'"),
+  classifyPartition: vi.fn((partition: string) =>
+    partition === "persist:daintree" ? "project" : "browser"
+  ),
+  getDaintreeAppCSP: vi.fn(() => "default-src 'self' /* daintree */"),
+  getLocalhostDevCSP: vi.fn(() => "default-src 'self' /* browser */"),
   mergeCspHeaders: vi.fn((_details: unknown, csp: string) => ({
     "Content-Security-Policy": [csp],
   })),
@@ -636,6 +639,81 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       expect(event.preventDefault).toHaveBeenCalledTimes(1);
       expect(mockSend).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("setupWebviewCSP — partition CSP wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webContentsCreatedListeners.length = 0;
+  });
+
+  it("registers CSP on persist:browser and persist:daintree", async () => {
+    const { session } = await import("electron");
+    const fromPartition = vi.mocked(session.fromPartition);
+
+    setupWebviewCSP();
+
+    const partitions = fromPartition.mock.calls.map((call) => call[0]);
+    expect(partitions).toContain("persist:browser");
+    expect(partitions).toContain("persist:daintree");
+  });
+
+  it("uses the daintree app CSP for persist:daintree (not the localhost dev CSP)", async () => {
+    const { getDaintreeAppCSP, getLocalhostDevCSP } = await import("../../utils/webviewCsp.js");
+    const daintreeCspMock = vi.mocked(getDaintreeAppCSP);
+    const localhostCspMock = vi.mocked(getLocalhostDevCSP);
+
+    setupWebviewCSP();
+
+    expect(daintreeCspMock).toHaveBeenCalledTimes(1);
+    expect(localhostCspMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes isDev=false to getDaintreeAppCSP when NODE_ENV is not 'development'", async () => {
+    const { getDaintreeAppCSP } = await import("../../utils/webviewCsp.js");
+    const daintreeCspMock = vi.mocked(getDaintreeAppCSP);
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    try {
+      setupWebviewCSP();
+      expect(daintreeCspMock).toHaveBeenCalledWith(false);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it("passes isDev=true to getDaintreeAppCSP when NODE_ENV is 'development'", async () => {
+    const { getDaintreeAppCSP } = await import("../../utils/webviewCsp.js");
+    const daintreeCspMock = vi.mocked(getDaintreeAppCSP);
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    try {
+      setupWebviewCSP();
+      expect(daintreeCspMock).toHaveBeenCalledWith(true);
+    } finally {
+      process.env.NODE_ENV = original;
+    }
+  });
+
+  it("attaches an onHeadersReceived listener for both static partitions", async () => {
+    const { session } = await import("electron");
+    const fromPartition = vi.mocked(session.fromPartition);
+    const onHeadersReceivedRegistrations: string[] = [];
+    fromPartition.mockImplementation((partition: string) => {
+      const onHeadersReceived = vi.fn(() => {
+        onHeadersReceivedRegistrations.push(partition);
+      });
+      return {
+        webRequest: { onHeadersReceived },
+      } as unknown as Electron.Session;
+    });
+
+    setupWebviewCSP();
+
+    expect(onHeadersReceivedRegistrations).toEqual(["persist:browser", "persist:daintree"]);
   });
 });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "url";
 import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../utils/appProtocol.js";
 import {
   classifyPartition,
+  getDaintreeAppCSP,
   getLocalhostDevCSP,
   mergeCspHeaders,
   isDevPreviewPartition,
@@ -194,7 +195,10 @@ export function setupWebviewCSP(): void {
     }
 
     const ses = session.fromPartition(partition);
-    const cspPolicy = getLocalhostDevCSP();
+    const cspPolicy =
+      partitionType === "project"
+        ? getDaintreeAppCSP(process.env.NODE_ENV === "development")
+        : getLocalhostDevCSP();
 
     ses.webRequest.onHeadersReceived((details, callback) => {
       callback({
@@ -205,9 +209,12 @@ export function setupWebviewCSP(): void {
     configuredPartitions.add(partition);
   };
 
-  // No static partitions get a CSP overlay — browser hosts arbitrary remote
-  // sites (handled above), portal/unknown are excluded, and dev-preview
-  // partitions are wired dynamically via will-attach-webview below.
+  // Configure static partitions:
+  // - persist:daintree: trusted Daintree renderer shell (strict app CSP)
+  // Browser hosts arbitrary remote sites (skipped by classifyPartition guard above
+  // to avoid intersecting with site CSPs), portal/unknown are excluded, and
+  // dev-preview partitions are wired dynamically via will-attach-webview below.
+  applyCSP("persist:daintree");
 
   // Singleton for the browser partition session — used for identity comparison in navigation handlers.
   const browserSession = session.fromPartition("persist:browser");

--- a/electron/utils/__tests__/webviewCsp.test.ts
+++ b/electron/utils/__tests__/webviewCsp.test.ts
@@ -248,16 +248,12 @@ describe("webviewCsp", () => {
         expect(directives["script-src"]).not.toContain("'unsafe-inline'");
       });
 
-      it("locks script-src to 'self' only", () => {
-        expect(directives["script-src"]).toBe("'self'");
+      it("retains 'wasm-unsafe-eval' in script-src for WASM compilation", () => {
+        expect(directives["script-src"]).toContain("'wasm-unsafe-eval'");
       });
 
       it("keeps 'unsafe-inline' in style-src for Vite inline style injection", () => {
         expect(directives["style-src"]).toContain("'unsafe-inline'");
-      });
-
-      it("denies all frames", () => {
-        expect(directives["frame-src"]).toBe("'none'");
       });
 
       it("denies plugins via object-src 'none'", () => {
@@ -268,15 +264,24 @@ describe("webviewCsp", () => {
         expect(directives["base-uri"]).toBe("'self'");
       });
 
-      it("locks form-action to 'self' (explicit, not inherited from default-src)", () => {
-        expect(directives["form-action"]).toBe("'self'");
+      it("denies all form submissions via form-action 'none'", () => {
+        expect(directives["form-action"]).toBe("'none'");
       });
 
-      it("allows blob: workers (xterm/parsers)", () => {
+      it("allows blob: workers", () => {
         expect(directives["worker-src"]).toContain("blob:");
       });
 
-      it("allows data: and blob: images", () => {
+      it("allows daintree-file: in connect-src for Web Audio fetches", () => {
+        expect(directives["connect-src"]).toContain("daintree-file:");
+        expect(directives["connect-src"]).toContain("canopy-file:");
+      });
+
+      it("allows daintree-file: + GitHub avatar host + data:/blob: in img-src", () => {
+        expect(directives["img-src"]).toContain("'self'");
+        expect(directives["img-src"]).toContain("daintree-file:");
+        expect(directives["img-src"]).toContain("canopy-file:");
+        expect(directives["img-src"]).toContain("https://avatars.githubusercontent.com");
         expect(directives["img-src"]).toContain("data:");
         expect(directives["img-src"]).toContain("blob:");
       });
@@ -285,18 +290,26 @@ describe("webviewCsp", () => {
         expect(directives["font-src"]).toContain("data:");
       });
 
-      it("does not include any localhost or dev server origins", () => {
-        expect(csp).not.toContain("localhost");
-        expect(csp).not.toContain("127.0.0.1");
-        expect(csp).not.toContain("[::1]");
-        expect(csp).not.toMatch(/\bws:/);
-        expect(csp).not.toMatch(/\bwss:/);
+      it("allows localhost frames so embedded <webview> guests can mount", () => {
+        expect(directives["frame-src"]).toContain("'self'");
+        expect(directives["frame-src"]).toContain("http://localhost:*");
+        expect(directives["frame-src"]).toContain("http://127.0.0.1:*");
+        expect(directives["frame-src"]).toContain("https://localhost:*");
+        expect(directives["frame-src"]).toContain("https://127.0.0.1:*");
       });
 
-      it("does not allow external HTTP(S) wildcard origins", () => {
-        expect(directives["default-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
+      it("does not include any dev server origins", () => {
+        expect(directives["default-src"]).not.toContain("http://localhost");
+        expect(directives["default-src"]).not.toContain("http://127.0.0.1");
+        expect(directives["script-src"]).not.toContain("http://localhost");
+        expect(directives["script-src"]).not.toContain("http://127.0.0.1");
+        expect(directives["script-src"]).not.toContain("ws:");
+        expect(directives["connect-src"]).not.toContain("ws:");
+      });
+
+      it("does not allow external HTTP(S) wildcard origins in script-src", () => {
         expect(directives["script-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
-        expect(directives["connect-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
+        expect(directives["default-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
       });
     });
 
@@ -306,10 +319,6 @@ describe("webviewCsp", () => {
 
       it("includes 'unsafe-eval' in script-src for Vite HMR", () => {
         expect(directives["script-src"]).toContain("'unsafe-eval'");
-      });
-
-      it("includes 'unsafe-inline' in script-src for Vite module bootstrap", () => {
-        expect(directives["script-src"]).toContain("'unsafe-inline'");
       });
 
       it("adds the dev server HTTP origin to script-src", () => {
@@ -327,6 +336,11 @@ describe("webviewCsp", () => {
         expect(directives["connect-src"]).toMatch(/ws:\/\/localhost:\d+/);
       });
 
+      it("retains daintree-file: in connect-src and img-src", () => {
+        expect(directives["connect-src"]).toContain("daintree-file:");
+        expect(directives["img-src"]).toContain("daintree-file:");
+      });
+
       it("adds the dev server HTTP origin to style-src, img-src, font-src", () => {
         expect(directives["style-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
         expect(directives["img-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
@@ -334,10 +348,9 @@ describe("webviewCsp", () => {
       });
 
       it("retains the strict directives that don't depend on the dev server", () => {
-        expect(directives["frame-src"]).toBe("'none'");
         expect(directives["object-src"]).toBe("'none'");
         expect(directives["base-uri"]).toBe("'self'");
-        expect(directives["form-action"]).toBe("'self'");
+        expect(directives["form-action"]).toBe("'none'");
       });
     });
   });

--- a/electron/utils/__tests__/webviewCsp.test.ts
+++ b/electron/utils/__tests__/webviewCsp.test.ts
@@ -1,11 +1,21 @@
 import { describe, it, expect } from "vitest";
 import {
   classifyPartition,
+  getDaintreeAppCSP,
   getLocalhostDevCSP,
   mergeCspHeaders,
   isDevPreviewPartition,
 } from "../webviewCsp.js";
 import type { OnHeadersReceivedListenerDetails } from "electron";
+
+function parseDirectives(csp: string): Record<string, string> {
+  return Object.fromEntries(
+    csp.split("; ").map((d) => {
+      const [name, ...rest] = d.split(" ");
+      return [name, rest.join(" ")];
+    })
+  );
+}
 
 describe("webviewCsp", () => {
   describe("isDevPreviewPartition", () => {
@@ -207,6 +217,128 @@ describe("webviewCsp", () => {
       expect(directives["form-action"]).not.toMatch(/(?:^|\s)http:(?:\s|$)/);
       expect(directives["form-action"]).not.toMatch(/(?:^|\s)\*(?:\s|$)/);
       expect(directives["form-action"]).not.toContain("http://example.com");
+    });
+  });
+
+  describe("getDaintreeAppCSP", () => {
+    describe("production policy (isDev=false)", () => {
+      const csp = getDaintreeAppCSP(false);
+      const directives = parseDirectives(csp);
+
+      it("includes all required directives", () => {
+        expect(directives["default-src"]).toBeDefined();
+        expect(directives["script-src"]).toBeDefined();
+        expect(directives["style-src"]).toBeDefined();
+        expect(directives["connect-src"]).toBeDefined();
+        expect(directives["img-src"]).toBeDefined();
+        expect(directives["font-src"]).toBeDefined();
+        expect(directives["media-src"]).toBeDefined();
+        expect(directives["worker-src"]).toBeDefined();
+        expect(directives["frame-src"]).toBeDefined();
+        expect(directives["object-src"]).toBeDefined();
+        expect(directives["base-uri"]).toBeDefined();
+        expect(directives["form-action"]).toBeDefined();
+      });
+
+      it("omits 'unsafe-eval' in script-src", () => {
+        expect(directives["script-src"]).not.toContain("'unsafe-eval'");
+      });
+
+      it("omits 'unsafe-inline' in script-src", () => {
+        expect(directives["script-src"]).not.toContain("'unsafe-inline'");
+      });
+
+      it("locks script-src to 'self' only", () => {
+        expect(directives["script-src"]).toBe("'self'");
+      });
+
+      it("keeps 'unsafe-inline' in style-src for Vite inline style injection", () => {
+        expect(directives["style-src"]).toContain("'unsafe-inline'");
+      });
+
+      it("denies all frames", () => {
+        expect(directives["frame-src"]).toBe("'none'");
+      });
+
+      it("denies plugins via object-src 'none'", () => {
+        expect(directives["object-src"]).toBe("'none'");
+      });
+
+      it("locks base-uri to 'self'", () => {
+        expect(directives["base-uri"]).toBe("'self'");
+      });
+
+      it("locks form-action to 'self' (explicit, not inherited from default-src)", () => {
+        expect(directives["form-action"]).toBe("'self'");
+      });
+
+      it("allows blob: workers (xterm/parsers)", () => {
+        expect(directives["worker-src"]).toContain("blob:");
+      });
+
+      it("allows data: and blob: images", () => {
+        expect(directives["img-src"]).toContain("data:");
+        expect(directives["img-src"]).toContain("blob:");
+      });
+
+      it("allows data: fonts (Vite inlines small fonts)", () => {
+        expect(directives["font-src"]).toContain("data:");
+      });
+
+      it("does not include any localhost or dev server origins", () => {
+        expect(csp).not.toContain("localhost");
+        expect(csp).not.toContain("127.0.0.1");
+        expect(csp).not.toContain("[::1]");
+        expect(csp).not.toMatch(/\bws:/);
+        expect(csp).not.toMatch(/\bwss:/);
+      });
+
+      it("does not allow external HTTP(S) wildcard origins", () => {
+        expect(directives["default-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
+        expect(directives["script-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
+        expect(directives["connect-src"]).not.toMatch(/(?:^|\s)https?:(?:\s|$)/);
+      });
+    });
+
+    describe("development policy (isDev=true)", () => {
+      const csp = getDaintreeAppCSP(true);
+      const directives = parseDirectives(csp);
+
+      it("includes 'unsafe-eval' in script-src for Vite HMR", () => {
+        expect(directives["script-src"]).toContain("'unsafe-eval'");
+      });
+
+      it("includes 'unsafe-inline' in script-src for Vite module bootstrap", () => {
+        expect(directives["script-src"]).toContain("'unsafe-inline'");
+      });
+
+      it("adds the dev server HTTP origin to script-src", () => {
+        expect(directives["script-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+        expect(directives["script-src"]).toMatch(/http:\/\/localhost:\d+/);
+      });
+
+      it("adds the dev server HTTP origin to connect-src", () => {
+        expect(directives["connect-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+        expect(directives["connect-src"]).toMatch(/http:\/\/localhost:\d+/);
+      });
+
+      it("adds the WebSocket dev server origin to connect-src for HMR", () => {
+        expect(directives["connect-src"]).toMatch(/ws:\/\/127\.0\.0\.1:\d+/);
+        expect(directives["connect-src"]).toMatch(/ws:\/\/localhost:\d+/);
+      });
+
+      it("adds the dev server HTTP origin to style-src, img-src, font-src", () => {
+        expect(directives["style-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+        expect(directives["img-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+        expect(directives["font-src"]).toMatch(/http:\/\/127\.0\.0\.1:\d+/);
+      });
+
+      it("retains the strict directives that don't depend on the dev server", () => {
+        expect(directives["frame-src"]).toBe("'none'");
+        expect(directives["object-src"]).toBe("'none'");
+        expect(directives["base-uri"]).toBe("'self'");
+        expect(directives["form-action"]).toBe("'self'");
+      });
     });
   });
 

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -1,4 +1,8 @@
 import type { OnHeadersReceivedListenerDetails } from "electron";
+import {
+  getDevServerOrigins,
+  getDevServerWebSocketOrigins,
+} from "../../shared/config/devServer.js";
 
 export type WebviewPartitionType = "browser" | "dev-preview" | "portal" | "project" | "unknown";
 
@@ -55,6 +59,58 @@ export function getLocalhostDevCSP(): string {
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
+  ].join("; ");
+}
+
+/**
+ * Returns the CSP policy for the trusted Daintree app renderer (`persist:daintree`).
+ *
+ * Defense-in-depth hardening: this CSP applies to the React shell loaded from
+ * `app://daintree` (production) or the Vite dev server (development). It does not
+ * replace existing security boundaries (preload contextIsolation, navigation guards,
+ * IPC sender validation) — it limits the blast radius if any of those fail.
+ *
+ * Production: strict policy with no `'unsafe-eval'`. `'unsafe-inline'` is kept in
+ * `style-src` because Vite still injects inline `<style>` tags for CSS chunk loading.
+ *
+ * Development: appends Vite dev-server HTTP origins to script/style/connect/img/font,
+ * adds WebSocket origins to connect-src for HMR, and re-enables `'unsafe-eval'` +
+ * `'unsafe-inline'` in script-src for Vite's HMR runtime + module bootstrap.
+ */
+export function getDaintreeAppCSP(isDev: boolean): string {
+  if (!isDev) {
+    return [
+      "default-src 'self'",
+      "script-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "connect-src 'self'",
+      "img-src 'self' data: blob:",
+      "font-src 'self' data:",
+      "media-src 'self'",
+      "worker-src 'self' blob:",
+      "frame-src 'none'",
+      "object-src 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join("; ");
+  }
+
+  const httpOrigins = getDevServerOrigins().join(" ");
+  const wsOrigins = getDevServerWebSocketOrigins().join(" ");
+
+  return [
+    `default-src 'self' ${httpOrigins}`,
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${httpOrigins}`,
+    `style-src 'self' 'unsafe-inline' ${httpOrigins}`,
+    `connect-src 'self' ${httpOrigins} ${wsOrigins}`,
+    `img-src 'self' data: blob: ${httpOrigins}`,
+    `font-src 'self' data: ${httpOrigins}`,
+    "media-src 'self'",
+    "worker-src 'self' blob:",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
   ].join("; ");
 }
 

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -1,8 +1,7 @@
 import type { OnHeadersReceivedListenerDetails } from "electron";
-import {
-  getDevServerOrigins,
-  getDevServerWebSocketOrigins,
-} from "../../shared/config/devServer.js";
+import { getDaintreeAppCSP } from "../../shared/config/csp.js";
+
+export { getDaintreeAppCSP };
 
 export type WebviewPartitionType = "browser" | "dev-preview" | "portal" | "project" | "unknown";
 
@@ -59,58 +58,6 @@ export function getLocalhostDevCSP(): string {
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self' http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:* https://[::1]:*",
-  ].join("; ");
-}
-
-/**
- * Returns the CSP policy for the trusted Daintree app renderer (`persist:daintree`).
- *
- * Defense-in-depth hardening: this CSP applies to the React shell loaded from
- * `app://daintree` (production) or the Vite dev server (development). It does not
- * replace existing security boundaries (preload contextIsolation, navigation guards,
- * IPC sender validation) — it limits the blast radius if any of those fail.
- *
- * Production: strict policy with no `'unsafe-eval'`. `'unsafe-inline'` is kept in
- * `style-src` because Vite still injects inline `<style>` tags for CSS chunk loading.
- *
- * Development: appends Vite dev-server HTTP origins to script/style/connect/img/font,
- * adds WebSocket origins to connect-src for HMR, and re-enables `'unsafe-eval'` +
- * `'unsafe-inline'` in script-src for Vite's HMR runtime + module bootstrap.
- */
-export function getDaintreeAppCSP(isDev: boolean): string {
-  if (!isDev) {
-    return [
-      "default-src 'self'",
-      "script-src 'self'",
-      "style-src 'self' 'unsafe-inline'",
-      "connect-src 'self'",
-      "img-src 'self' data: blob:",
-      "font-src 'self' data:",
-      "media-src 'self'",
-      "worker-src 'self' blob:",
-      "frame-src 'none'",
-      "object-src 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-    ].join("; ");
-  }
-
-  const httpOrigins = getDevServerOrigins().join(" ");
-  const wsOrigins = getDevServerWebSocketOrigins().join(" ");
-
-  return [
-    `default-src 'self' ${httpOrigins}`,
-    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${httpOrigins}`,
-    `style-src 'self' 'unsafe-inline' ${httpOrigins}`,
-    `connect-src 'self' ${httpOrigins} ${wsOrigins}`,
-    `img-src 'self' data: blob: ${httpOrigins}`,
-    `font-src 'self' data: ${httpOrigins}`,
-    "media-src 'self'",
-    "worker-src 'self' blob:",
-    "frame-src 'none'",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
   ].join("; ");
 }
 

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -1,0 +1,82 @@
+import { getDevServerOrigins, getDevServerWebSocketOrigins } from "./devServer.js";
+
+// Custom protocol schemes the renderer fetches/loads from. Both stay whitelisted
+// through the 0.8 migration window so the app can still load persisted
+// canopy-file:// URLs after a manual reinstall from Canopy.
+const FILE_SCHEMES = "daintree-file: canopy-file:";
+
+// Localhost origins allowed for embedded <webview> guests in BrowserPane and
+// DevPreviewPane. Without these in frame-src the host page cannot mount its
+// webview elements at all.
+const FRAME_LOCALHOST =
+  "http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*";
+
+const GITHUB_AVATARS = "https://avatars.githubusercontent.com";
+
+/**
+ * Production CSP for the trusted Daintree renderer (`persist:daintree`).
+ *
+ * Loaded from `app://daintree` in production. Defense-in-depth — limits the
+ * blast radius of a hypothetical XSS by forbidding `unsafe-inline` scripts
+ * and external script sources. `'wasm-unsafe-eval'` stays for any future
+ * library that compiles WASM at runtime.
+ *
+ * Applied at two layers (must stay aligned to avoid the browser intersecting
+ * them into a stricter effective policy that breaks the app):
+ *   1. `<meta http-equiv="Content-Security-Policy">` injected into index.html
+ *      at build time by the Vite plugin in vite.config.ts.
+ *   2. `Content-Security-Policy` HTTP response header set by the main process
+ *      via `webRequest.onHeadersReceived` on the persist:daintree session.
+ */
+export function getDaintreeAppProdCSP(): string {
+  return [
+    "default-src 'self'",
+    "script-src 'self' 'wasm-unsafe-eval'",
+    "style-src 'self' 'unsafe-inline'",
+    `connect-src 'self' ${FILE_SCHEMES}`,
+    `img-src 'self' ${GITHUB_AVATARS} ${FILE_SCHEMES} data: blob:`,
+    "font-src 'self' data:",
+    "media-src 'self'",
+    "worker-src 'self' blob:",
+    `frame-src 'self' ${FRAME_LOCALHOST}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'none'",
+  ].join("; ");
+}
+
+/**
+ * Development CSP for the trusted Daintree renderer.
+ *
+ * Loaded from the Vite dev server in development. Loosens script-src with
+ * `'unsafe-eval'` for HMR + React Refresh, and adds dev-server HTTP/WebSocket
+ * origins. The strict floor (object-src 'none', base-uri 'self', form-action
+ * 'none') still applies.
+ */
+export function getDaintreeAppDevCSP(): string {
+  const origins = getDevServerOrigins().join(" ");
+  const wsOrigins = getDevServerWebSocketOrigins().join(" ");
+
+  return [
+    `default-src 'self' ${origins} ${wsOrigins}`,
+    `script-src 'self' ${origins} 'unsafe-eval'`,
+    `style-src 'self' ${origins} 'unsafe-inline'`,
+    `connect-src 'self' ${origins} ${wsOrigins} ${FILE_SCHEMES}`,
+    `img-src 'self' ${origins} ${GITHUB_AVATARS} ${FILE_SCHEMES} data: blob:`,
+    `font-src 'self' ${origins} data:`,
+    "media-src 'self'",
+    "worker-src 'self' blob:",
+    `frame-src 'self' ${FRAME_LOCALHOST}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'none'",
+  ].join("; ");
+}
+
+/**
+ * Returns the appropriate CSP for the trusted Daintree renderer based on
+ * whether the process is running in development mode.
+ */
+export function getDaintreeAppCSP(isDev: boolean): string {
+  return isDev ? getDaintreeAppDevCSP() : getDaintreeAppProdCSP();
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,46 +5,19 @@ import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
-import {
-  getDevServerConfig,
-  getDevServerOrigins,
-  getDevServerWebSocketOrigins,
-} from "./shared/config/devServer";
+import { getDevServerConfig } from "./shared/config/devServer";
+import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp";
 
 const devServerConfig = getDevServerConfig();
-const devServerOrigins = getDevServerOrigins();
-const devServerWebSocketOrigins = getDevServerWebSocketOrigins();
 
 const IS_LEGACY_BUILD = process.env.BUILD_VARIANT === "canopy";
-// Custom protocol schemes used by the app's file handlers. Both schemes stay
-// whitelisted through the 0.8 migration window so Daintree can still load
-// persisted canopy-file:// URLs after a manual reinstall from Canopy.
-const FILE_SCHEMES = "daintree-file: canopy-file:";
 
-// CSP definitions for development and production
-const DEV_CSP = [
-  `default-src 'self' ${devServerOrigins.join(" ")} ${devServerWebSocketOrigins.join(" ")}`,
-  `script-src 'self' ${devServerOrigins.join(" ")} 'unsafe-eval'`,
-  `style-src 'self' ${devServerOrigins.join(" ")} 'unsafe-inline'`,
-  "font-src 'self' data:",
-  `connect-src 'self' ${devServerOrigins.join(" ")} ${devServerWebSocketOrigins.join(" ")} ${FILE_SCHEMES}`,
-  `img-src 'self' ${devServerOrigins.join(" ")} https://avatars.githubusercontent.com ${FILE_SCHEMES} data:`,
-  "frame-src 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
-].join("; ");
-
-const PROD_CSP = [
-  "default-src 'self'",
-  "script-src 'self' 'wasm-unsafe-eval'",
-  "style-src 'self' 'unsafe-inline'",
-  "font-src 'self' data:",
-  `connect-src 'self' ${FILE_SCHEMES}`,
-  `img-src 'self' https://avatars.githubusercontent.com ${FILE_SCHEMES} data: blob:`,
-  "frame-src 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
-  "worker-src 'self' blob:",
-  "object-src 'none'",
-  "base-uri 'self'",
-  "form-action 'none'",
-].join("; ");
+// CSP definitions for development and production. Single source of truth lives
+// in shared/config/csp.ts so the meta tag injected here and the HTTP header set
+// by the main process stay in sync — the browser intersects header + meta, so
+// any divergence silently tightens the effective policy and breaks the app.
+const DEV_CSP = getDaintreeAppDevCSP();
+const PROD_CSP = getDaintreeAppProdCSP();
 
 // Per-file accumulator written to dist/compiler-bailout-report.json after the
 // build completes. Counts come from babel-plugin-react-compiler's logger:


### PR DESCRIPTION
## Summary

- `persist:daintree` is the session backing the trusted React renderer, but `applyCSP` was silently skipping it — `classifyPartition` returns `"project"` for this partition and the function only acted on `"browser"` and `"dev-preview"`. No CSP at all, even though `app://daintree` responses already set `COOP`, `COEP`, `X-Content-Type-Options`, and `CORP`.
- This adds a proper `Content-Security-Policy` header via `session.fromHeadersReceived`, using a policy derived from the existing `<meta>` tag so the two layers are consistent and the browser intersects them correctly.
- Defense-in-depth — there's no known XSS vector today, but without a header CSP a future bug in the trusted renderer would have full IPC access with no browser-level constraint on what runs.

Resolves #6253

## Changes

- `shared/config/csp.ts` — single source of truth for the Daintree renderer CSP; exports `PROD_CSP`, `DEV_CSP`, and `getDaintreeAppCSP(isDev)`.
- `vite.config.ts` — imports `DEV_CSP`/`PROD_CSP` from the shared module instead of maintaining its own inline string (eliminates drift between meta tag and header).
- `electron/utils/webviewCsp.ts` — re-exports `getDaintreeAppCSP` from the shared module; keeps the existing API intact.
- `electron/setup/protocols.ts` — wires `applyCSP("persist:daintree")` using partition-type-aware policy selection so the session now gets a CSP header on every response.
- `electron/utils/__tests__/webviewCsp.test.ts` — comprehensive unit tests covering prod vs dev policy, all required directives, and the operationally-required allowances (`daintree-file:`, GitHub avatars, localhost frames for webviews, `wasm-unsafe-eval`).
- `electron/setup/__tests__/protocols.test.ts` — wiring tests that invoke `onHeadersReceived` and assert the correct CSP string is delivered per session type.

## Testing

Unit tests cover both the policy content and the wiring. Typecheck, lint, format, and build all pass.