### PR TITLE
fix(security): sandbox env-var inheritance for agent CLI probes

### DIFF
--- a/electron/services/AgentHelpService.ts
+++ b/electron/services/AgentHelpService.ts
@@ -2,6 +2,8 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { getEffectiveAgentConfig } from "../../shared/config/agentRegistry.js";
 import type { AgentHelpResult } from "../../shared/types/ipc/agent.js";
+import { buildProbeEnv } from "../utils/spawnEnv.js";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -68,6 +70,7 @@ export class AgentHelpService {
         maxBuffer: this.MAX_BUFFER,
         shell: false,
         windowsHide: true,
+        env: buildProbeEnv(),
       });
 
       stdout = out || "";
@@ -108,8 +111,8 @@ export class AgentHelpService {
     }
 
     return {
-      stdout,
-      stderr,
+      stdout: scrubSecrets(stdout),
+      stderr: scrubSecrets(stderr),
       exitCode,
       timedOut,
       truncated,

--- a/electron/services/AgentInstallService.ts
+++ b/electron/services/AgentInstallService.ts
@@ -5,6 +5,8 @@ import type {
   AgentInstallResult,
   AgentInstallProgressEvent,
 } from "../../shared/types/ipc/system.js";
+import { buildInstallEnv } from "../utils/spawnEnv.js";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 function isManualOnlyCommand(command: string): boolean {
   return /\|\s*(bash|sh|zsh)\b/.test(command) || /\|\s*iex\b/.test(command);
@@ -53,7 +55,7 @@ function runSingleCommand(
     let finalized = false;
 
     const env = {
-      ...process.env,
+      ...buildInstallEnv(),
       CI: "1",
       NO_UPDATE_NOTIFIER: "1",
     };
@@ -65,11 +67,11 @@ function runSingleCommand(
     });
 
     child.stdout?.on("data", (chunk: Buffer) => {
-      onProgress({ jobId, chunk: chunk.toString(), stream: "stdout" });
+      onProgress({ jobId, chunk: scrubSecrets(chunk.toString()), stream: "stdout" });
     });
 
     child.stderr?.on("data", (chunk: Buffer) => {
-      onProgress({ jobId, chunk: chunk.toString(), stream: "stderr" });
+      onProgress({ jobId, chunk: scrubSecrets(chunk.toString()), stream: "stderr" });
     });
 
     const finalize = (exitCode: number | null) => {

--- a/electron/services/AgentInstallService.ts
+++ b/electron/services/AgentInstallService.ts
@@ -82,7 +82,7 @@ function runSingleCommand(
 
     child.on("close", (code) => finalize(code));
     child.on("error", (err) => {
-      onProgress({ jobId, chunk: err.message + "\n", stream: "stderr" });
+      onProgress({ jobId, chunk: scrubSecrets(err.message) + "\n", stream: "stderr" });
       finalize(1);
     });
   });

--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -9,6 +9,8 @@ import type { AgentVersionInfo } from "../../shared/types/ipc/system.js";
 import type { AgentId } from "../../shared/types/agent.js";
 import { CliAvailabilityService } from "./CliAvailabilityService.js";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability.js";
+import { buildProbeEnv } from "../utils/spawnEnv.js";
+import { scrubSecrets } from "../utils/secretScrubber.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -186,6 +188,7 @@ export class AgentVersionService {
         maxBuffer: this.MAX_BUFFER,
         shell: false,
         windowsHide: true,
+        env: buildProbeEnv(),
       });
       stdout = result.stdout || result.stderr || "";
     } catch (error: any) {
@@ -200,7 +203,7 @@ export class AgentVersionService {
       }
       stdout = error.stdout?.toString() || error.stderr?.toString() || "";
       if (!stdout) {
-        throw new Error(`Command failed: ${error.message}`);
+        throw new Error(`Command failed: ${scrubSecrets(error.message ?? "")}`);
       }
     }
 

--- a/electron/services/__tests__/AgentHelpService.test.ts
+++ b/electron/services/__tests__/AgentHelpService.test.ts
@@ -183,6 +183,54 @@ describe("AgentHelpService", () => {
     });
   });
 
+  describe("env sandboxing and secret scrubbing (issue #6247)", () => {
+    const originalEnv = process.env;
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it("does not pass ANTHROPIC_API_KEY or GITHUB_TOKEN to the child process", async () => {
+      process.env = {
+        ...originalEnv,
+        ANTHROPIC_API_KEY: "sk-ant-secretvalue",
+        GITHUB_TOKEN: "ghp_secrettoken",
+        OPENAI_API_KEY: "sk-secret",
+      } as NodeJS.ProcessEnv;
+
+      mockedExecFile.mockImplementation((_cmd, _args, _opts, callback: any) => {
+        callback(null, { stdout: "Help", stderr: "" });
+        return {} as any;
+      });
+
+      await service.getHelp("claude");
+
+      const opts = mockedExecFile.mock.calls[0][2] as { env?: Record<string, string> };
+      expect(opts.env).toBeDefined();
+      expect(opts.env!.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(opts.env!.GITHUB_TOKEN).toBeUndefined();
+      expect(opts.env!.OPENAI_API_KEY).toBeUndefined();
+    });
+
+    it("scrubs secrets from stdout and stderr before returning to caller (cache boundary)", async () => {
+      const leakingKey = "sk-ant-" + "A".repeat(95);
+      mockedExecFile.mockImplementation((_cmd, _args, _opts, callback: any) => {
+        callback(null, {
+          stdout: `usage: claude\nDEBUG: key=${leakingKey}`,
+          stderr: `warn: token ghp_${"B".repeat(40)} expired`,
+        });
+        return {} as any;
+      });
+
+      const result = await service.getHelp("claude");
+
+      expect(result.stdout).not.toContain(leakingKey);
+      expect(result.stdout).toContain("[REDACTED]");
+      expect(result.stderr).not.toMatch(/ghp_[A-Z]{40}/);
+      expect(result.stderr).toContain("[REDACTED]");
+    });
+  });
+
   describe("command validation", () => {
     it("rejects empty command", async () => {
       vi.doUnmock("../../../shared/config/agentRegistry.js");

--- a/electron/services/__tests__/AgentInstallService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentInstallService.adversarial.test.ts
@@ -254,6 +254,100 @@ describe("AgentInstallService adversarial", () => {
       expect(result.error).toContain("No install blocks");
     });
 
+    describe("env sandboxing and secret scrubbing (issue #6247)", () => {
+      const originalEnv = process.env;
+
+      afterEach(() => {
+        process.env = originalEnv;
+      });
+
+      it("does not pass ANTHROPIC_API_KEY or GITHUB_TOKEN into the spawned child env", async () => {
+        process.env = {
+          ...originalEnv,
+          ANTHROPIC_API_KEY: "sk-ant-x",
+          GITHUB_TOKEN: "ghp_x",
+          OPENAI_API_KEY: "sk-x",
+          PATH: process.env.PATH ?? "/usr/bin",
+          HOME: process.env.HOME ?? "/home/u",
+        } as NodeJS.ProcessEnv;
+
+        getAgentConfigMock.mockReturnValue({
+          install: { byOs: { linux: [{ commands: ["npm install -g foo"] }] } },
+        });
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+
+        const pending = runAgentInstall({ agentId: "a", jobId: "j1" }, vi.fn());
+        child.emitClose(0);
+        await pending;
+
+        const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+        expect(opts.env.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(opts.env.GITHUB_TOKEN).toBeUndefined();
+        expect(opts.env.OPENAI_API_KEY).toBeUndefined();
+        expect(opts.env.CI).toBe("1");
+        expect(opts.env.NO_UPDATE_NOTIFIER).toBe("1");
+      });
+
+      it("preserves proxy and version-manager vars needed for installs", async () => {
+        process.env = {
+          ...originalEnv,
+          PATH: process.env.PATH ?? "/usr/bin",
+          HOME: process.env.HOME ?? "/home/u",
+          HTTPS_PROXY: "http://proxy:8080",
+          NODE_EXTRA_CA_CERTS: "/etc/ssl/corp-ca.pem",
+          NVM_DIR: "/home/u/.nvm",
+        } as NodeJS.ProcessEnv;
+
+        getAgentConfigMock.mockReturnValue({
+          install: { byOs: { linux: [{ commands: ["npm install -g foo"] }] } },
+        });
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+
+        const pending = runAgentInstall({ agentId: "a", jobId: "j1" }, vi.fn());
+        child.emitClose(0);
+        await pending;
+
+        const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+        expect(opts.env.HTTPS_PROXY).toBe("http://proxy:8080");
+        expect(opts.env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/corp-ca.pem");
+        expect(opts.env.NVM_DIR).toBe("/home/u/.nvm");
+      });
+
+      it("scrubs secrets from streamed stdout chunks at the emit boundary", async () => {
+        getAgentConfigMock.mockReturnValue({
+          install: { byOs: { linux: [{ commands: ["npm install -g foo"] }] } },
+        });
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+        const onProgress = vi.fn();
+
+        const pending = runAgentInstall({ agentId: "a", jobId: "j1" }, onProgress);
+        const leakingKey = "sk-ant-" + "A".repeat(95);
+        child.emitStdout(`npm warn deprecated\nleak ${leakingKey} trailing\n`);
+        child.emitStderr(`auth failure ghp_${"B".repeat(40)}\n`);
+        child.emitClose(0);
+        await pending;
+
+        const stdoutEvents = onProgress.mock.calls
+          .map(([e]) => e as { stream: string; chunk: string })
+          .filter((e) => e.stream === "stdout");
+        const stderrEvents = onProgress.mock.calls
+          .map(([e]) => e as { stream: string; chunk: string })
+          .filter((e) => e.stream === "stderr");
+
+        for (const ev of stdoutEvents) {
+          expect(ev.chunk).not.toContain(leakingKey);
+        }
+        expect(stdoutEvents.some((e) => e.chunk.includes("[REDACTED]"))).toBe(true);
+        for (const ev of stderrEvents) {
+          expect(ev.chunk).not.toMatch(/ghp_[A-Z]{40}/);
+        }
+        expect(stderrEvents.some((e) => e.chunk.includes("[REDACTED]"))).toBe(true);
+      });
+    });
+
     it("finalize is idempotent — close after error does not emit a second result", async () => {
       getAgentConfigMock.mockReturnValue({
         install: { byOs: { linux: [{ commands: ["cmd1"] }] } },

--- a/electron/services/__tests__/AgentInstallService.adversarial.test.ts
+++ b/electron/services/__tests__/AgentInstallService.adversarial.test.ts
@@ -315,6 +315,27 @@ describe("AgentInstallService adversarial", () => {
         expect(opts.env.NVM_DIR).toBe("/home/u/.nvm");
       });
 
+      it("scrubs secrets from spawn-error messages emitted via the 'error' event", async () => {
+        getAgentConfigMock.mockReturnValue({
+          install: { byOs: { linux: [{ commands: ["nope"] }] } },
+        });
+        const child = makeFakeChild();
+        spawnMock.mockReturnValue(child);
+        const onProgress = vi.fn();
+
+        const pending = runAgentInstall({ agentId: "a", jobId: "j1" }, onProgress);
+        const leakingKey = "sk-ant-" + "A".repeat(95);
+        child.emitError(new Error(`spawn failed for env=${leakingKey}`));
+        await pending;
+
+        const errorEvent = onProgress.mock.calls
+          .map(([e]) => e as { stream: string; chunk: string })
+          .find((e) => e.stream === "stderr" && e.chunk.includes("spawn failed"));
+        expect(errorEvent).toBeDefined();
+        expect(errorEvent!.chunk).not.toContain(leakingKey);
+        expect(errorEvent!.chunk).toContain("[REDACTED]");
+      });
+
       it("scrubs secrets from streamed stdout chunks at the emit boundary", async () => {
         getAgentConfigMock.mockReturnValue({
           install: { byOs: { linux: [{ commands: ["npm install -g foo"] }] } },

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -122,7 +122,9 @@ describe("AgentVersionService resilience", () => {
       process.env = originalEnv;
     });
 
-    function setExecFileImpl(impl: (...args: unknown[]) => void): void {
+    function setExecFileImpl(
+      impl: (cmd: string, args: string[], opts: unknown, cb: (...cbArgs: unknown[]) => void) => void
+    ): void {
       execFileMock.mockImplementation(impl as never);
     }
 
@@ -144,7 +146,7 @@ describe("AgentVersionService resilience", () => {
       setExecFileImpl(
         (
           _cmd: string,
-          _args: readonly string[],
+          _args: string[],
           _opts: unknown,
           cb: (err: unknown, stdout: string, stderr: string) => void
         ) => {
@@ -173,7 +175,7 @@ describe("AgentVersionService resilience", () => {
       });
 
       setExecFileImpl(
-        (_cmd: string, _args: readonly string[], _opts: unknown, cb: (err: unknown) => void) => {
+        (_cmd: string, _args: string[], _opts: unknown, cb: (err: unknown) => void) => {
           const err = new Error(leakingMessage) as NodeJS.ErrnoException & {
             stdout?: string;
             stderr?: string;

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { AgentId } from "../../../shared/types/agent.js";
 
 const registryMock = vi.hoisted(() => ({
@@ -113,6 +113,84 @@ describe("AgentVersionService resilience", () => {
         error: expect.stringContaining("bad config payload"),
       })
     );
+  });
+
+  describe("env sandboxing and secret scrubbing (issue #6247)", () => {
+    const originalEnv = process.env;
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    function setExecFileImpl(impl: (...args: unknown[]) => void): void {
+      execFileMock.mockImplementation(impl as never);
+    }
+
+    it("passes a sandboxed env to execFile (excludes ANTHROPIC_API_KEY, GITHUB_TOKEN)", async () => {
+      process.env = {
+        ...originalEnv,
+        ANTHROPIC_API_KEY: "sk-ant-x",
+        GITHUB_TOKEN: "ghp_x",
+        PATH: process.env.PATH ?? "/usr/bin",
+      } as NodeJS.ProcessEnv;
+
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      setExecFileImpl(
+        (
+          _cmd: string,
+          _args: readonly string[],
+          _opts: unknown,
+          cb: (err: unknown, stdout: string, stderr: string) => void
+        ) => {
+          cb(null, "1.0.0\n", "");
+        }
+      );
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+      await service.getVersion("claude" as AgentId);
+
+      const opts = execFileMock.mock.calls[0][2] as { env?: Record<string, string> };
+      expect(opts.env).toBeDefined();
+      expect(opts.env!.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(opts.env!.GITHUB_TOKEN).toBeUndefined();
+      expect(opts.env!.PATH).toBeTruthy();
+    });
+
+    it("scrubs secrets from error.message before they flow into AgentVersionInfo.error", async () => {
+      const leakingMessage = `spawn failed for ANTHROPIC_API_KEY=sk-ant-${"A".repeat(95)}`;
+
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      setExecFileImpl(
+        (_cmd: string, _args: readonly string[], _opts: unknown, cb: (err: unknown) => void) => {
+          const err = new Error(leakingMessage) as NodeJS.ErrnoException & {
+            stdout?: string;
+            stderr?: string;
+          };
+          err.code = "EUNKNOWN";
+          err.stdout = "";
+          err.stderr = "";
+          cb(err);
+        }
+      );
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+      const result = await service.getVersion("claude" as AgentId);
+
+      expect(result.error ?? "").not.toContain("sk-ant-");
+      expect(result.error ?? "").toContain("[REDACTED]");
+    });
   });
 
   describe("PyPI version feed", () => {

--- a/electron/utils/__tests__/spawnEnv.test.ts
+++ b/electron/utils/__tests__/spawnEnv.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildInstallEnv, buildProbeEnv } from "../spawnEnv.js";
+
+const originalEnv = process.env;
+const originalPlatform = process.platform;
+
+function setPlatform(p: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: p });
+}
+
+function setEnv(env: Record<string, string | undefined>): void {
+  process.env = { ...env } as NodeJS.ProcessEnv;
+}
+
+describe("spawnEnv", () => {
+  beforeEach(() => {
+    setEnv({});
+    setPlatform("linux");
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    setPlatform(originalPlatform);
+  });
+
+  describe("buildProbeEnv", () => {
+    it("forces TERM=dumb so CLIs do not emit ANSI escapes into captured stdout", () => {
+      setEnv({ TERM: "xterm-256color" });
+      expect(buildProbeEnv().TERM).toBe("dumb");
+    });
+
+    it("passes PATH through from process.env", () => {
+      setEnv({ PATH: "/custom/bin:/usr/bin" });
+      expect(buildProbeEnv().PATH).toBe("/custom/bin:/usr/bin");
+    });
+
+    it("supplies a sane default PATH when process.env.PATH is unset", () => {
+      setEnv({});
+      const env = buildProbeEnv();
+      expect(env.PATH).toBeTruthy();
+      expect(env.PATH).toContain("/usr/bin");
+    });
+
+    it("includes HOME on POSIX so CLIs can locate user config", () => {
+      setEnv({ HOME: "/home/alice" });
+      expect(buildProbeEnv().HOME).toBe("/home/alice");
+    });
+
+    it("excludes ANTHROPIC_API_KEY", () => {
+      setEnv({ ANTHROPIC_API_KEY: "sk-ant-secret" });
+      expect(buildProbeEnv().ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it("excludes OPENAI_API_KEY, GITHUB_TOKEN, AWS_SECRET_ACCESS_KEY, NPM_TOKEN", () => {
+      setEnv({
+        OPENAI_API_KEY: "sk-x",
+        GITHUB_TOKEN: "ghp_x",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        NPM_TOKEN: "npm_x",
+      });
+      const env = buildProbeEnv();
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+      expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(env.NPM_TOKEN).toBeUndefined();
+    });
+
+    it("excludes loader/injection vars (LD_PRELOAD, DYLD_INSERT_LIBRARIES, NODE_OPTIONS, ELECTRON_RUN_AS_NODE)", () => {
+      setEnv({
+        LD_PRELOAD: "/evil.so",
+        DYLD_INSERT_LIBRARIES: "/evil.dylib",
+        NODE_OPTIONS: "--require /evil.js",
+        ELECTRON_RUN_AS_NODE: "1",
+        LD_LIBRARY_PATH: "/evil",
+        DYLD_LIBRARY_PATH: "/evil",
+      });
+      const env = buildProbeEnv();
+      expect(env.LD_PRELOAD).toBeUndefined();
+      expect(env.DYLD_INSERT_LIBRARIES).toBeUndefined();
+      expect(env.NODE_OPTIONS).toBeUndefined();
+      expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(env.LD_LIBRARY_PATH).toBeUndefined();
+      expect(env.DYLD_LIBRARY_PATH).toBeUndefined();
+    });
+
+    it("excludes proxy and version-manager vars (those are install-only)", () => {
+      setEnv({
+        HTTPS_PROXY: "http://proxy",
+        NVM_DIR: "/home/u/.nvm",
+        VOLTA_HOME: "/home/u/.volta",
+        XDG_CONFIG_HOME: "/home/u/.config",
+      });
+      const env = buildProbeEnv();
+      expect(env.HTTPS_PROXY).toBeUndefined();
+      expect(env.NVM_DIR).toBeUndefined();
+      expect(env.VOLTA_HOME).toBeUndefined();
+      expect(env.XDG_CONFIG_HOME).toBeUndefined();
+    });
+
+    it("preserves LC_* prefix vars for locale-correct help output", () => {
+      setEnv({ LC_ALL: "en_US.UTF-8", LC_MESSAGES: "en_US.UTF-8", LANG: "en_US.UTF-8" });
+      const env = buildProbeEnv();
+      expect(env.LC_ALL).toBe("en_US.UTF-8");
+      expect(env.LC_MESSAGES).toBe("en_US.UTF-8");
+      expect(env.LANG).toBe("en_US.UTF-8");
+    });
+
+    it("preserves DAINTREE_* prefix vars", () => {
+      setEnv({ DAINTREE_PROJECT_ID: "abc", DAINTREE_RECIPE_ID: "xyz" });
+      const env = buildProbeEnv();
+      expect(env.DAINTREE_PROJECT_ID).toBe("abc");
+      expect(env.DAINTREE_RECIPE_ID).toBe("xyz");
+    });
+
+    it("on Windows, includes SystemRoot, USERPROFILE, TEMP, TMP, PATHEXT", () => {
+      setPlatform("win32");
+      setEnv({
+        SystemRoot: "C:\\Windows",
+        USERPROFILE: "C:\\Users\\alice",
+        TEMP: "C:\\Temp",
+        TMP: "C:\\Tmp",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        Path: "C:\\Windows\\System32",
+      });
+      const env = buildProbeEnv();
+      expect(env.SystemRoot).toBe("C:\\Windows");
+      expect(env.USERPROFILE).toBe("C:\\Users\\alice");
+      expect(env.TEMP).toBe("C:\\Temp");
+      expect(env.TMP).toBe("C:\\Tmp");
+      expect(env.PATHEXT).toBe(".COM;.EXE;.BAT;.CMD");
+      // Original casing is preserved (Windows uses `Path`, not `PATH`)
+      expect(env.Path).toBe("C:\\Windows\\System32");
+    });
+
+    it("on Windows, supplies defaults for missing SystemRoot/PATHEXT", () => {
+      setPlatform("win32");
+      setEnv({});
+      const env = buildProbeEnv();
+      expect(env.SystemRoot).toBeTruthy();
+      expect(env.PATHEXT).toContain(".EXE");
+    });
+
+    it("skips undefined values without inserting empty strings", () => {
+      setEnv({ PATH: undefined, HOME: "/h" });
+      const env = buildProbeEnv();
+      // PATH was undefined, so we fall back to default
+      expect(env.PATH).toBeTruthy();
+      expect(env.HOME).toBe("/h");
+    });
+  });
+
+  describe("buildInstallEnv", () => {
+    it("includes everything in the probe env plus install-only keys", () => {
+      setEnv({
+        PATH: "/usr/bin",
+        HOME: "/home/u",
+        HTTPS_PROXY: "http://proxy:8080",
+        NVM_DIR: "/home/u/.nvm",
+        XDG_CONFIG_HOME: "/home/u/.config",
+        PIPX_HOME: "/home/u/.local/pipx",
+      });
+      const env = buildInstallEnv();
+      expect(env.PATH).toBe("/usr/bin");
+      expect(env.HOME).toBe("/home/u");
+      expect(env.HTTPS_PROXY).toBe("http://proxy:8080");
+      expect(env.NVM_DIR).toBe("/home/u/.nvm");
+      expect(env.XDG_CONFIG_HOME).toBe("/home/u/.config");
+      expect(env.PIPX_HOME).toBe("/home/u/.local/pipx");
+    });
+
+    it("still excludes credential-shaped keys", () => {
+      setEnv({ HOME: "/h", ANTHROPIC_API_KEY: "sk-ant-x", AWS_ACCESS_KEY_ID: "AKIA..." });
+      const env = buildInstallEnv();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(env.AWS_ACCESS_KEY_ID).toBeUndefined();
+    });
+
+    it("preserves NODE_EXTRA_CA_CERTS and SSL_CERT_FILE for corporate TLS interception", () => {
+      setEnv({
+        HOME: "/h",
+        NODE_EXTRA_CA_CERTS: "/etc/ssl/corp-ca.pem",
+        SSL_CERT_FILE: "/etc/ssl/cert.pem",
+      });
+      const env = buildInstallEnv();
+      expect(env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/corp-ca.pem");
+      expect(env.SSL_CERT_FILE).toBe("/etc/ssl/cert.pem");
+    });
+
+    it("preserves lowercase http_proxy via case-insensitive matching", () => {
+      setEnv({ HOME: "/h", http_proxy: "http://proxy", https_proxy: "http://proxy" });
+      const env = buildInstallEnv();
+      // Case-insensitive lookup: lowercase keys also pass the allowlist;
+      // original casing is preserved on output.
+      expect(env.http_proxy).toBe("http://proxy");
+      expect(env.https_proxy).toBe("http://proxy");
+    });
+
+    it("on Windows includes APPDATA and LOCALAPPDATA for npm global install paths", () => {
+      setPlatform("win32");
+      setEnv({
+        SystemRoot: "C:\\Windows",
+        APPDATA: "C:\\Users\\u\\AppData\\Roaming",
+        LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local",
+        Path: "C:\\Windows",
+      });
+      const env = buildInstallEnv();
+      expect(env.APPDATA).toBe("C:\\Users\\u\\AppData\\Roaming");
+      expect(env.LOCALAPPDATA).toBe("C:\\Users\\u\\AppData\\Local");
+    });
+
+    it("forces TERM=dumb (install runners stream output verbatim to renderer)", () => {
+      setEnv({ HOME: "/h", TERM: "xterm" });
+      expect(buildInstallEnv().TERM).toBe("dumb");
+    });
+
+    it("HOME is always present on POSIX so npm/.npmrc lookup succeeds", () => {
+      setEnv({});
+      const env = buildInstallEnv();
+      expect(env.HOME).toBeTruthy();
+    });
+  });
+});

--- a/electron/utils/spawnEnv.ts
+++ b/electron/utils/spawnEnv.ts
@@ -1,0 +1,140 @@
+/**
+ * Allowlist-based environment construction for child processes that capture
+ * stdout/stderr surfaced into the renderer (agent help/version/install probes
+ * and recipe runners).
+ *
+ * Allowlist (not denylist) is the security boundary: the universe of secret
+ * env-var names is unbounded (`MY_SERVICE_TOKEN`, `APP_DB_PASS`, ...), so
+ * blocking known-bad keys is structurally insufficient. Only well-known
+ * non-credential keys pass through. Dangerous loader/injection vars
+ * (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`,
+ * `ELECTRON_RUN_AS_NODE`, ...) are excluded by virtue of not being on the
+ * allowlist; no explicit strip step is required.
+ *
+ * Two variants:
+ *   - `buildProbeEnv()`  — minimum needed to resolve and run a CLI binary
+ *                          for `--help` / `--version`. No network keys.
+ *   - `buildInstallEnv()` — adds proxy, CA, version-manager, and OS config
+ *                          dirs needed by `npm install -g`, `pipx install`,
+ *                          `brew install`, etc.
+ *
+ * The install variant must include `HOME` on macOS/Linux and `APPDATA`/
+ * `USERPROFILE` on Windows — `npm` and `pipx` resolve user-level config
+ * (`.npmrc`, `~/.config/pipx`) from these. Omitting them silently breaks
+ * private-registry auth for users behind corporate proxies.
+ *
+ * Callers must invoke after `app.ready` and after any startup `fixPath()`
+ * has completed, since these functions read `process.env.PATH` directly.
+ * IPC-handled service methods are safe by construction.
+ */
+
+import os from "os";
+
+const PROBE_KEYS_POSIX = new Set(["PATH", "HOME", "LANG", "LANGUAGE"]);
+const PROBE_KEYS_WIN32 = new Set([
+  "PATH",
+  "SYSTEMROOT",
+  "USERPROFILE",
+  "TEMP",
+  "TMP",
+  "PATHEXT",
+  "LANG",
+  "LANGUAGE",
+]);
+
+const INSTALL_EXTRA_KEYS = new Set([
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "NO_PROXY",
+  "ALL_PROXY",
+  "NODE_EXTRA_CA_CERTS",
+  "SSL_CERT_FILE",
+  "SSL_CERT_DIR",
+  "NVM_DIR",
+  "FNM_DIR",
+  "VOLTA_HOME",
+  "PYENV_ROOT",
+  "ASDF_DATA_DIR",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_CACHE_HOME",
+  "PIPX_HOME",
+  "PIPX_BIN_DIR",
+]);
+
+const ALLOWED_PREFIXES = ["LC_", "DAINTREE_"];
+
+function defaultPath(): string {
+  if (process.platform === "win32") {
+    const sysRoot = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
+    return `${sysRoot}\\System32;${sysRoot};${sysRoot}\\System32\\Wbem`;
+  }
+  return "/usr/local/bin:/usr/bin:/bin";
+}
+
+function buildAllowlistEnv(allowed: Set<string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  const source = process.env;
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    const upper = key.toUpperCase();
+    if (allowed.has(upper) || ALLOWED_PREFIXES.some((p) => upper.startsWith(p))) {
+      out[key] = value;
+    }
+  }
+
+  if (!Object.keys(out).some((k) => k.toUpperCase() === "PATH")) {
+    out.PATH = defaultPath();
+  }
+
+  if (process.platform === "win32") {
+    if (!Object.keys(out).some((k) => k.toUpperCase() === "SYSTEMROOT")) {
+      out.SystemRoot = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
+    }
+    if (!Object.keys(out).some((k) => k.toUpperCase() === "USERPROFILE")) {
+      out.USERPROFILE = os.homedir();
+    }
+    if (!Object.keys(out).some((k) => k.toUpperCase() === "TEMP")) {
+      out.TEMP = os.tmpdir();
+    }
+    if (!Object.keys(out).some((k) => k.toUpperCase() === "TMP")) {
+      out.TMP = os.tmpdir();
+    }
+    if (!Object.keys(out).some((k) => k.toUpperCase() === "PATHEXT")) {
+      out.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    }
+  } else if (!Object.keys(out).some((k) => k.toUpperCase() === "HOME")) {
+    out.HOME = os.homedir();
+  }
+
+  out.TERM = "dumb";
+  return out;
+}
+
+function probeKeys(): Set<string> {
+  return process.platform === "win32" ? PROBE_KEYS_WIN32 : PROBE_KEYS_POSIX;
+}
+
+/**
+ * Tight allowlist for `--help` / `--version` probes. Includes only what's
+ * required to resolve and execute a CLI binary, plus locale (for non-ASCII
+ * help output) and DAINTREE_* prefix vars. No proxy, no version-manager
+ * dirs, no XDG dirs, no credential-shaped keys.
+ */
+export function buildProbeEnv(): Record<string, string> {
+  return buildAllowlistEnv(probeKeys());
+}
+
+/**
+ * Broader allowlist for install runners (`npm install -g`, `pipx install`,
+ * `brew install`, ...). Adds proxy, CA, version-manager, XDG, and pipx
+ * config keys to the probe set. `HOME` (or `APPDATA`/`USERPROFILE` on
+ * Windows) is always present so package managers can locate user config.
+ */
+export function buildInstallEnv(): Record<string, string> {
+  const allowed = new Set([...probeKeys(), ...INSTALL_EXTRA_KEYS]);
+  return buildAllowlistEnv(allowed);
+}

--- a/electron/utils/spawnEnv.ts
+++ b/electron/utils/spawnEnv.ts
@@ -64,6 +64,10 @@ const INSTALL_EXTRA_KEYS = new Set([
   "PIPX_BIN_DIR",
 ]);
 
+// `DAINTREE_*` is the application namespace — vars like `DAINTREE_WORKTREE_PATH`
+// and `DAINTREE_RECIPE_ID` are injected by recipe runners and read by spawned
+// CLIs. Accepted risk: a user who mirrors a credential into a `DAINTREE_*` var
+// (e.g., `DAINTREE_GITHUB_TOKEN` in CI) gets it forwarded to children.
 const ALLOWED_PREFIXES = ["LC_", "DAINTREE_"];
 
 function defaultPath(): string {

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -4,6 +4,7 @@ import { join as pathJoin, basename, dirname } from "path";
 import os from "os";
 import { z } from "zod/v4";
 import { scrubSecrets } from "../utils/secretScrubber.js";
+import { buildProbeEnv } from "../utils/spawnEnv.js";
 
 const OUTPUT_TAIL_BYTES = 8192;
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -507,25 +508,7 @@ function shellEscapeValue(value: string): string {
 }
 
 function buildSpawnEnv(customEnv: Record<string, string>): Record<string, string> {
-  if (process.platform === "win32") {
-    const sysRoot = process.env.SystemRoot ?? process.env.windir ?? "C:\\Windows";
-    return {
-      PATH: process.env.PATH ?? `${sysRoot}\\System32;${sysRoot};${sysRoot}\\System32\\Wbem`,
-      PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
-      SystemRoot: sysRoot,
-      USERPROFILE: process.env.USERPROFILE ?? os.homedir(),
-      TEMP: process.env.TEMP ?? os.tmpdir(),
-      TMP: process.env.TMP ?? os.tmpdir(),
-      TERM: "dumb",
-      ...customEnv,
-    };
-  }
-  return {
-    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-    HOME: process.env.HOME ?? os.homedir(),
-    TERM: "dumb",
-    ...customEnv,
-  };
+  return { ...buildProbeEnv(), ...customEnv };
 }
 
 function tailOutput(chunks: string[]): string {


### PR DESCRIPTION
## Summary

- Three call sites were passing `process.env` wholesale to spawned agent CLIs (`AgentHelpService`, `AgentVersionService`, `AgentInstallService`) — none of these probes authenticate, so there's no reason for them to inherit `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `AWS_*`, `GITHUB_TOKEN`, or similar.
- New `electron/utils/spawnEnv.ts` introduces `buildProbeEnv()` (tight allowlist for `--help`/`--version`) and `buildInstallEnv()` (broader allowlist adding proxy, CA, version-manager, and XDG vars that install commands actually need). Both strip dangerous loader vars (`LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, `NODE_OPTIONS`, `ELECTRON_RUN_AS_NODE`).
- `scrubSecrets()` now runs at cache-store and chunk-stream boundaries in all three services, covering the output leak surface that the input sandbox alone can't close.

Resolves #6247

## Changes

- `electron/utils/spawnEnv.ts` — `buildProbeEnv()` and `buildInstallEnv()` factories; `WorktreeLifecycleService.buildSpawnEnv()` refactored to delegate to `buildProbeEnv()` so recipe-runner env stays consistent
- `AgentHelpService`, `AgentVersionService`, `AgentInstallService` — pass sandboxed env to `execFile`/`spawn`; `scrubSecrets()` applied at cache and chunk-emit boundaries including spawn-error messages
- 20 new unit tests in `electron/utils/__tests__/spawnEnv.test.ts` covering allowlist and denylist behavior; extended help/version/install service tests with sandbox + scrub assertions and a spawn-error scrub regression case

## Testing

141+ unit tests pass. Typecheck, lint, and format clean. Allowlist coverage verified against the real call sites for npm-based (Claude Code) and PyPI-based (Aider via pipx) install paths to confirm no install regressions from the tighter env.