### PR TITLE
feat(persistence): cap WAL journal size and add SQLITE_FULL recovery

### DIFF
--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -68,6 +68,9 @@ describe("openDb (integration)", () => {
       const tempStore = sqlite.pragma("temp_store", { simple: true });
       // temp_store = MEMORY is enum value 2
       expect(Number(tempStore)).toBe(2);
+
+      const journalSizeLimit = sqlite.pragma("journal_size_limit", { simple: true });
+      expect(Number(journalSizeLimit)).toBe(5_242_880);
     } finally {
       sqlite.close();
     }

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -255,6 +255,52 @@ describe("withDiskRecovery", () => {
     expect(pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
   });
 
+  it("retries when disk status is warning (not just normal)", () => {
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "warning",
+      availableMb: 1024,
+      writesSuppressed: false,
+    });
+    const fn = vi
+      .fn<() => string>()
+      .mockImplementationOnce(() => {
+        throw makeError("SQLITE_FULL", "disk full");
+      })
+      .mockImplementationOnce(() => "recovered");
+
+    expect(withDiskRecovery(sqlite, fn)).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it.each([
+    "SQLITE_IOERR_READ",
+    "SQLITE_IOERR_LOCK",
+    "SQLITE_IOERR_ACCESS",
+    "SQLITE_IOERR_SHMOPEN",
+  ])("does not retry on non-write IOERR variant %s", (code) => {
+    const err = makeError(code);
+    const fn = vi.fn(() => {
+      throw err;
+    });
+
+    expect(() => withDiskRecovery(sqlite, fn)).toThrow(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(pragma).not.toHaveBeenCalled();
+    expect(mockGetCurrentDiskSpaceStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not crash and rethrows when error.code is not a string", () => {
+    const weirdError = { code: 5 };
+    const fn = vi.fn(() => {
+      throw weirdError;
+    });
+
+    expect(() => withDiskRecovery(sqlite, fn)).toThrow();
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(pragma).not.toHaveBeenCalled();
+  });
+
   it("re-throws original error and does not retry when disk is critical", () => {
     mockGetCurrentDiskSpaceStatus.mockReturnValue({
       status: "critical",

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -7,6 +7,12 @@ vi.mock("electron", () => ({
   app: { getPath: () => "/fake/userData" },
 }));
 
+const mockGetCurrentDiskSpaceStatus = vi.fn();
+
+vi.mock("../../DiskSpaceMonitor.js", () => ({
+  getCurrentDiskSpaceStatus: () => mockGetCurrentDiskSpaceStatus(),
+}));
+
 const mockPragma = vi.fn();
 const mockClose = vi.fn();
 const mockExec = vi.fn();
@@ -33,7 +39,7 @@ vi.mock("drizzle-orm/better-sqlite3", () => ({
   drizzle: vi.fn(() => ({})),
 }));
 
-import { probeDb, attemptRecovery, closeSharedDb } from "../db.js";
+import { probeDb, attemptRecovery, closeSharedDb, withDiskRecovery } from "../db.js";
 
 describe("probeDb", () => {
   let tmpDir: string;
@@ -184,5 +190,128 @@ describe("attemptRecovery", () => {
 describe("closeSharedDb", () => {
   it("does nothing when no shared instance exists", () => {
     expect(() => closeSharedDb({ checkpoint: true })).not.toThrow();
+  });
+});
+
+describe("withDiskRecovery", () => {
+  type SqliteHandle = Parameters<typeof withDiskRecovery>[0];
+  let pragma: ReturnType<typeof vi.fn>;
+  let sqlite: SqliteHandle;
+
+  function makeError(code: string, message = code): Error & { code: string } {
+    const err = new Error(message) as Error & { code: string };
+    err.code = code;
+    return err;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    pragma = vi.fn();
+    sqlite = { pragma } as unknown as SqliteHandle;
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "normal",
+      availableMb: 4096,
+      writesSuppressed: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the result without retrying when fn succeeds", () => {
+    const fn = vi.fn(() => "ok");
+
+    expect(withDiskRecovery(sqlite, fn)).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(pragma).not.toHaveBeenCalled();
+    expect(mockGetCurrentDiskSpaceStatus).not.toHaveBeenCalled();
+  });
+
+  it("checkpoints WAL and retries once on SQLITE_FULL when disk is not critical", () => {
+    const fn = vi
+      .fn<() => string>()
+      .mockImplementationOnce(() => {
+        throw makeError("SQLITE_FULL", "database or disk is full");
+      })
+      .mockImplementationOnce(() => "recovered");
+
+    expect(withDiskRecovery(sqlite, fn)).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it("retries on SQLITE_IOERR_WRITE (extended IOERR variant)", () => {
+    const fn = vi
+      .fn<() => string>()
+      .mockImplementationOnce(() => {
+        throw makeError("SQLITE_IOERR_WRITE", "io write failed");
+      })
+      .mockImplementationOnce(() => "recovered");
+
+    expect(withDiskRecovery(sqlite, fn)).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it("re-throws original error and does not retry when disk is critical", () => {
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "critical",
+      availableMb: 100,
+      writesSuppressed: true,
+    });
+    const fullErr = makeError("SQLITE_FULL", "no space left");
+    const fn = vi.fn(() => {
+      throw fullErr;
+    });
+
+    expect(() => withDiskRecovery(sqlite, fn)).toThrow(fullErr);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(pragma).not.toHaveBeenCalled();
+  });
+
+  it("does not retry on non-recoverable error (e.g. SQLITE_CORRUPT)", () => {
+    const corruptErr = makeError("SQLITE_CORRUPT", "image malformed");
+    const fn = vi.fn(() => {
+      throw corruptErr;
+    });
+
+    expect(() => withDiskRecovery(sqlite, fn)).toThrow(corruptErr);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(pragma).not.toHaveBeenCalled();
+    expect(mockGetCurrentDiskSpaceStatus).not.toHaveBeenCalled();
+  });
+
+  it("propagates the retry error if the second attempt also throws", () => {
+    const firstErr = makeError("SQLITE_FULL", "first");
+    const retryErr = makeError("SQLITE_FULL", "second");
+    const fn = vi
+      .fn<() => string>()
+      .mockImplementationOnce(() => {
+        throw firstErr;
+      })
+      .mockImplementationOnce(() => {
+        throw retryErr;
+      });
+
+    expect(() => withDiskRecovery(sqlite, fn)).toThrow(retryErr);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+  });
+
+  it("still attempts the retry when the recovery checkpoint itself throws", () => {
+    pragma.mockImplementationOnce(() => {
+      throw makeError("SQLITE_FULL", "checkpoint failed");
+    });
+    const fn = vi
+      .fn<() => string>()
+      .mockImplementationOnce(() => {
+        throw makeError("SQLITE_FULL", "first");
+      })
+      .mockImplementationOnce(() => "recovered");
+
+    expect(withDiskRecovery(sqlite, fn)).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -187,20 +187,30 @@ export function resetSharedInstance(): void {
   sharedInstance = null;
 }
 
+// Disk-pressure codes that a WAL truncate plus a single retry can plausibly
+// recover from. Other SQLITE_IOERR_* variants (lock, read, access, shmopen,
+// etc.) are not write-pressure failures, so we leave them to the caller.
+const RECOVERABLE_IOERR_CODES = new Set([
+  "SQLITE_IOERR_WRITE",
+  "SQLITE_IOERR_FSYNC",
+  "SQLITE_IOERR_TRUNCATE",
+  "SQLITE_IOERR_DIR_FSYNC",
+]);
+
 function isDiskFullError(error: unknown): boolean {
-  const code = (error as { code?: string } | null | undefined)?.code;
-  if (!code) return false;
-  return code === "SQLITE_FULL" || code.startsWith("SQLITE_IOERR");
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (typeof code !== "string") return false;
+  return code === "SQLITE_FULL" || RECOVERABLE_IOERR_CODES.has(code);
 }
 
-// Run `fn` against the SQLite handle; on SQLITE_FULL / SQLITE_IOERR* try to free
-// space by truncating the WAL and retry once. The retry is gated on disk-space
-// status — when the volume is critical, the WAL truncate would itself need to
-// write and is unlikely to recover, so we skip straight to re-throwing the
-// original error. The recovery checkpoint is wrapped in its own try/catch so a
-// failed checkpoint does not mask the caller's error or trigger a recursive
-// retry; we still attempt the retry afterwards in case the checkpoint freed
-// some pages before failing.
+// Run `fn` against the SQLite handle; on SQLITE_FULL or a write-side
+// SQLITE_IOERR_* code try to free space by truncating the WAL and retry once.
+// The retry is gated on disk-space status — when the volume is critical, the
+// WAL truncate would itself need to write and is unlikely to recover, so we
+// skip straight to re-throwing the original error. The recovery checkpoint is
+// wrapped in its own try/catch so a failed checkpoint does not mask the
+// caller's error or trigger a recursive retry; we still attempt the retry
+// afterwards in case the checkpoint freed some pages before failing.
 export function withDiskRecovery<T>(sqlite: Database.Database, fn: () => T): T {
   try {
     return fn();

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -4,6 +4,7 @@ import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
+import { getCurrentDiskSpaceStatus } from "../DiskSpaceMonitor.js";
 import * as schema from "./schema.js";
 
 export type AppDb = ReturnType<typeof drizzle<typeof schema>>;
@@ -80,6 +81,7 @@ export function openDb(
     sqlite.pragma("temp_store = MEMORY");
     sqlite.pragma("mmap_size = 10737418240");
     sqlite.pragma("cache_size = -65536");
+    sqlite.pragma("journal_size_limit = 5242880");
 
     adoptLegacyProjectColumns(sqlite);
 
@@ -183,4 +185,36 @@ export function closeSharedDb(options?: { checkpoint?: boolean }): void {
 
 export function resetSharedInstance(): void {
   sharedInstance = null;
+}
+
+function isDiskFullError(error: unknown): boolean {
+  const code = (error as { code?: string } | null | undefined)?.code;
+  if (!code) return false;
+  return code === "SQLITE_FULL" || code.startsWith("SQLITE_IOERR");
+}
+
+// Run `fn` against the SQLite handle; on SQLITE_FULL / SQLITE_IOERR* try to free
+// space by truncating the WAL and retry once. The retry is gated on disk-space
+// status — when the volume is critical, the WAL truncate would itself need to
+// write and is unlikely to recover, so we skip straight to re-throwing the
+// original error. The recovery checkpoint is wrapped in its own try/catch so a
+// failed checkpoint does not mask the caller's error or trigger a recursive
+// retry; we still attempt the retry afterwards in case the checkpoint freed
+// some pages before failing.
+export function withDiskRecovery<T>(sqlite: Database.Database, fn: () => T): T {
+  try {
+    return fn();
+  } catch (error) {
+    if (!isDiskFullError(error)) throw error;
+    if (getCurrentDiskSpaceStatus().status === "critical") throw error;
+
+    console.warn("[DB] Disk-full error, attempting WAL truncate and retry:", error);
+    try {
+      sqlite.pragma("wal_checkpoint(TRUNCATE)");
+    } catch (checkpointError) {
+      console.warn("[DB] Recovery WAL checkpoint failed:", checkpointError);
+    }
+
+    return fn();
+  }
 }


### PR DESCRIPTION
## Summary

- Sets `journal_size_limit` to `5242880` (5 MB) so the WAL file can't grow unbounded between checkpoints -- `DatabaseMaintenanceService` already runs `wal_checkpoint(PASSIVE)` on idle and `TRUNCATE` on dispose, so this just bounds growth between those ticks.
- Exports `withDiskRecovery<T>()`, a helper that catches `SQLITE_FULL` and a curated allowlist of `SQLITE_IOERR_*` variants, runs `wal_checkpoint(TRUNCATE)` to free space, and retries once. Retry only fires when `DiskSpaceMonitor` reports a non-critical status.
- Layered defense, not a redesign -- the existing `probeDb` + `attemptRecovery` corruption path still handles the worst case.

Resolves #6270

## Changes

- `electron/services/persistence/db.ts` -- adds `journal_size_limit` pragma to `openDb`, exports `withDiskRecovery<T>()`
- `electron/services/persistence/__tests__/db.openDb.test.ts` -- asserts the new pragma value
- `electron/services/persistence/__tests__/db.test.ts` -- 11 new cases covering recoverable errors, critical-disk no-retry, IOERR allowlist boundaries, non-string error codes, retry-throws, and checkpoint-throws

## Testing

All 30 tests in the persistence suite pass. Typecheck, lint, and format clean.