### PR TITLE
fix(views): close producer ports on cache to prevent freeze/OOM

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -51,6 +51,12 @@ vi.mock("electron", () => ({
     isPackaged: false,
     getVersion: vi.fn(() => "1.0.0"),
     setAboutPanelOptions: vi.fn(),
+    setPath: vi.fn(),
+    getPath: vi.fn(() => "/mock/path"),
+    commandLine: {
+      appendSwitch: vi.fn(),
+      appendArgument: vi.fn(),
+    },
   },
   webContents: {
     getFocusedWebContents: vi.fn(() => mockFocusedWebContents),
@@ -69,11 +75,17 @@ vi.mock("../ipc/channels.js", () => ({
 }));
 
 vi.mock("../../shared/config/agentRegistry.js", () => ({
+  AGENT_REGISTRY: {},
   getEffectiveRegistry: vi.fn(() => ({})),
 }));
 
 vi.mock("../services/CliAvailabilityService.js", () => ({}));
 vi.mock("../services/CliInstallService.js", () => ({}));
+vi.mock("../window/windowServices.js", () => ({
+  getPtyClient: vi.fn(),
+  getWorkspaceClientRef: vi.fn(),
+  getWorktreePortBrokerRef: vi.fn(),
+}));
 
 vi.mock("../window/windowRef.js", () => ({
   getWindowRegistry: vi.fn(() => null),

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -207,6 +207,15 @@ if (!gotTheLock) {
         getWorkspaceClientRef()?.removeDirectPort(wcId);
         getWorktreePortBrokerRef()?.closePortsForView(wcId);
       },
+      onViewCached: (wcId) => {
+        // Same producer cleanup as eviction: a cached view becomes
+        // freeze-eligible once setBackgroundThrottling(true) is applied.
+        // Live worktree/workspace ports would otherwise queue messages
+        // into a frozen renderer (#6273). Reactivation re-brokers a fresh
+        // port via activateProjectView in projectCrud/switch.ts.
+        getWorkspaceClientRef()?.removeDirectPort(wcId);
+        getWorktreePortBrokerRef()?.closePortsForView(wcId);
+      },
       onViewReady: (wc) => {
         // Re-distribute PTY MessagePort on every view load/reload.
         // This ensures terminals work after view creation, crash recovery, or DevTools refresh.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -204,8 +204,19 @@ if (!gotTheLock) {
         store.get("terminalConfig")?.cachedProjectViews
       ),
       onViewEvicted: (wcId) => {
-        getWorkspaceClientRef()?.removeDirectPort(wcId);
-        getWorktreePortBrokerRef()?.closePortsForView(wcId);
+        // Each cleanup is isolated: if removeDirectPort throws, the worktree
+        // port must still close. Partial cleanup leaves a live producer
+        // posting into a soon-to-be-destroyed renderer.
+        try {
+          getWorkspaceClientRef()?.removeDirectPort(wcId);
+        } catch (err) {
+          console.error("[main] removeDirectPort failed during eviction:", err);
+        }
+        try {
+          getWorktreePortBrokerRef()?.closePortsForView(wcId);
+        } catch (err) {
+          console.error("[main] closePortsForView failed during eviction:", err);
+        }
       },
       onViewCached: (wcId) => {
         // Same producer cleanup as eviction: a cached view becomes
@@ -213,8 +224,19 @@ if (!gotTheLock) {
         // Live worktree/workspace ports would otherwise queue messages
         // into a frozen renderer (#6273). Reactivation re-brokers a fresh
         // port via activateProjectView in projectCrud/switch.ts.
-        getWorkspaceClientRef()?.removeDirectPort(wcId);
-        getWorktreePortBrokerRef()?.closePortsForView(wcId);
+        // Each cleanup is isolated so a throw in one path can't leave the
+        // other producer alive — that's the exact failure mode this PR
+        // exists to prevent.
+        try {
+          getWorkspaceClientRef()?.removeDirectPort(wcId);
+        } catch (err) {
+          console.error("[main] removeDirectPort failed during cache:", err);
+        }
+        try {
+          getWorktreePortBrokerRef()?.closePortsForView(wcId);
+        } catch (err) {
+          console.error("[main] closePortsForView failed during cache:", err);
+        }
       },
       onViewReady: (wc) => {
         // Re-distribute PTY MessagePort on every view load/reload.

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -6,6 +6,12 @@ import type { CliAvailabilityService } from "./services/CliAvailabilityService.j
 import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
 import * as CliInstallService from "./services/CliInstallService.js";
 import { getWindowRegistry, getProjectViewManager } from "./window/windowRef.js";
+import {
+  getPtyClient,
+  getWorkspaceClientRef,
+  getWorktreePortBrokerRef,
+} from "./window/windowServices.js";
+import { distributePortsToView } from "./window/portDistribution.js";
 // Auto-updater is dynamically imported on click to keep it out of the eager
 // graph — the menu is built at startup but "Check for Updates" only fires on
 // user action.
@@ -508,8 +514,41 @@ export async function handleDirectoryOpen(
     // Use ProjectViewManager for multi-view switching when available
     const pvm = getProjectViewManager();
     if (pvm) {
-      await pvm.switchTo(project.id, project.path);
+      const { view } = await pvm.switchTo(project.id, project.path);
       await projectStore.setCurrentProject(project.id);
+
+      // Re-attach producer ports for cached-view reactivation. The IPC switch
+      // handler (projectCrud/switch.ts:activateProjectView) does this in the
+      // primary path; the menu path must mirror it because cached views have
+      // their worktree port + workspace direct port closed on cache to avoid
+      // freeze accumulation (#6273), and the PTY MessagePort is per-window
+      // and was replaced when the user last switched away.
+      if (!view.webContents.isDestroyed()) {
+        const wsClient = getWorkspaceClientRef();
+        const broker = getWorktreePortBrokerRef();
+        if (wsClient) {
+          try {
+            await wsClient.loadProject(project.path, targetWindow.id);
+            wsClient.attachDirectPort(targetWindow.id, view.webContents);
+            const host = wsClient.getHostForProject(project.path);
+            if (host && broker) {
+              broker.brokerPort(host, view.webContents);
+            }
+          } catch (err) {
+            console.error("[menu] Failed to restore worktree ports:", err);
+          }
+        }
+
+        // Distribute fresh PTY MessagePort + notify pty-host of project switch
+        const ptyClient = getPtyClient();
+        if (ptyClient) {
+          ptyClient.onProjectSwitch(targetWindow.id, project.id, project.path);
+        }
+        const ctx = getWindowRegistry()?.getByWindowId(targetWindow.id);
+        if (ctx) {
+          distributePortsToView(targetWindow, ctx, view.webContents, ptyClient ?? null);
+        }
+      }
     } else {
       // Fallback: legacy single-view switch
       const registry = getWindowRegistry();

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -57,6 +57,13 @@ export interface ProjectViewManagerOptions {
   windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   /** Called when a view is evicted (destroyed) with its webContents.id, for port cleanup */
   onViewEvicted?: (webContentsId: number) => void;
+  /**
+   * Called when a view transitions from active to cached with its webContents.id.
+   * Mirrors onViewEvicted: live producer ports (worktree, workspace direct) must
+   * be closed so messages don't accumulate in a renderer that Chromium may freeze
+   * after backgroundThrottling is enabled. Reactivation re-brokers a fresh port.
+   */
+  onViewCached?: (webContentsId: number) => void;
   /** Called on every did-finish-load for any managed view (initial load and reloads) */
   onViewReady?: (webContents: Electron.WebContents) => void;
   /** Number of project views to keep cached in memory (1–5, default: 1) */
@@ -72,6 +79,7 @@ export class ProjectViewManager {
   private dirname: string;
   private onRecreateWindow?: () => Promise<void>;
   private onViewEvicted?: (webContentsId: number) => void;
+  private onViewCached?: (webContentsId: number) => void;
   private onViewReady?: (webContents: Electron.WebContents) => void;
   private windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
@@ -83,6 +91,7 @@ export class ProjectViewManager {
     this.dirname = opts.dirname;
     this.onRecreateWindow = opts.onRecreateWindow;
     this.onViewEvicted = opts.onViewEvicted;
+    this.onViewCached = opts.onViewCached;
     this.onViewReady = opts.onViewReady;
     this.windowRegistry = opts.windowRegistry;
     if (opts.cachedProjectViews != null) {
@@ -336,6 +345,17 @@ export class ProjectViewManager {
 
     // Throttle background view to reduce CPU and allow Chromium to reclaim memory
     if (!current.view.webContents.isDestroyed()) {
+      const cachedWcId = current.view.webContents.id;
+      // Close live producer ports BEFORE enabling background throttling. Once
+      // throttled, Chromium can freeze the renderer after ~5 min hidden or
+      // under memory pressure; any messages still posted by main/utility
+      // processes accumulate in the frozen renderer's task queue (no native
+      // backpressure). Reactivation re-brokers a fresh port via activateView.
+      try {
+        this.onViewCached?.(cachedWcId);
+      } catch (error) {
+        console.error("[ProjectViewManager] onViewCached threw during deactivate:", error);
+      }
       current.view.webContents.setBackgroundThrottling(true);
 
       // Trigger V8 GC after a short delay to reclaim orphaned heap from

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -546,7 +546,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     expect(onViewCached).toHaveBeenCalledWith(wcA.id);
     // Newly-activated view's wcId must NOT have been passed to onViewCached
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
-    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
     expect(onViewCached).not.toHaveBeenCalledWith(wcB.id);
   });
 
@@ -586,11 +586,11 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
 
     await manager.switchTo("proj-b", "/path/b");
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
-    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     await manager.switchTo("proj-c", "/path/c");
     const cEntry = manager.getAllViews().find((v) => v.projectId === "proj-c");
-    const wcC = cEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcC = cEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     const calls = onViewCached.mock.calls.map(([id]) => id);
     expect(calls).toEqual([wcA.id, wcB.id]);

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -515,6 +515,180 @@ describe("ProjectViewManager — telemetry", () => {
   });
 });
 
+describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
+  let win: ReturnType<typeof createMockWindow>;
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
+    win = createMockWindow();
+  });
+
+  it("invokes onViewCached with the previous view's webContentsId on switch (not the newly active view)", async () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    expect(onViewCached).not.toHaveBeenCalled();
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(onViewCached).toHaveBeenCalledTimes(1);
+    expect(onViewCached).toHaveBeenCalledWith(wcA.id);
+    // Newly-activated view's wcId must NOT have been passed to onViewCached
+    const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+    expect(onViewCached).not.toHaveBeenCalledWith(wcB.id);
+  });
+
+  it("fires onViewCached BEFORE setBackgroundThrottling(true) so ports close before freeze becomes possible", async () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    const cachedOrder = onViewCached.mock.invocationCallOrder[0];
+    const throttleOrder = wcA.setBackgroundThrottling.mock.invocationCallOrder[0];
+    expect(cachedOrder).toBeDefined();
+    expect(throttleOrder).toBeDefined();
+    expect(cachedOrder!).toBeLessThan(throttleOrder);
+    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+  });
+
+  it("invokes onViewCached for each cached view across rapid switches A→B→C (never for the active C)", async () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = bEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+
+    await manager.switchTo("proj-c", "/path/c");
+    const cEntry = manager.getAllViews().find((v) => v.projectId === "proj-c");
+    const wcC = cEntry!.view.webContents as ReturnType<typeof createMockWebContents>;
+
+    const calls = onViewCached.mock.calls.map(([id]) => id);
+    expect(calls).toEqual([wcA.id, wcB.id]);
+    expect(calls).not.toContain(wcC.id);
+  });
+
+  it("does not invoke onViewCached when there is no prior active view", () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    // registerInitialView only — no prior active view to deactivate
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    expect(onViewCached).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onViewCached when switching to the already-active project", async () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-a", "/path/a");
+
+    expect(onViewCached).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onViewCached when the previous view's webContents is destroyed", async () => {
+    const onViewCached = vi.fn();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    // Simulate the active view's renderer dying before the switch lands —
+    // deactivateCurrentView reaches the destroyed branch and must skip the
+    // producer-cleanup callback (no live ports to close, no freeze risk).
+    wcA.isDestroyed.mockReturnValue(true);
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(onViewCached).not.toHaveBeenCalled();
+  });
+
+  it("a throwing onViewCached does not break the switch — switching still works and reaches the new view", async () => {
+    const onViewCached = vi.fn(() => {
+      throw new Error("simulated downstream cleanup failure");
+    });
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      onViewCached,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    expect(onViewCached).toHaveBeenCalledWith(wcA.id);
+    // Throttling must still happen even if the callback throws — the catch
+    // is around onViewCached only, not the surrounding deactivate flow.
+    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+  });
+
+  it("manager works without onViewCached configured (option is optional)", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
+    expect(wcA.setBackgroundThrottling).toHaveBeenCalledWith(true);
+  });
+});
+
 describe("ProjectViewManager — listener cleanup", () => {
   const PERSISTENT_EVENTS = [
     "will-navigate",


### PR DESCRIPTION
## Summary

When a project view is cached, `ProjectViewManager` enables background throttling, making the renderer eligible for Chromium's Page Lifecycle freeze state. The problem: `MessagePort` and IPC producers had no idea the renderer was frozen and kept pushing events into its task queue, where they'd accumulate without bound until OOM.

The fix is to close producer ports at cache time, before `setBackgroundThrottling(true)` is called, so there's a hard upstream limit on what can queue. Reactivation re-brokers the ports on the way back in.

Resolves #6273

## Changes

- **`ProjectViewManager`** — adds `onViewCached(webContentsId)` callback, fired before `setBackgroundThrottling` so ports are closed while the renderer is still responsive
- **`main.ts`** — wires `onViewCached` to close worktree `MessagePort` and workspace direct port (each in its own `try/catch`, matching the `onViewEvicted` pattern)
- **`menu.ts`** — adds port re-attachment after `pvm.switchTo` for the menu reactivation path (`worktree.loadProject` + `attachDirectPort` + `brokerPort` + PTY `distributePortsToView`); this path was previously only safe for cold-start projects and would have left cached views portless after the cache-time closure
- **`ProjectViewManager.eviction.test.ts`** — 7 new tests covering `onViewCached` invocation, ordering before throttle, rapid switches, no-prior-active edge case, no-op self-switch, destroyed webContents skip, and throwing callback; 229 total PVM tests pass

## Testing

- All 229 `ProjectViewManager` tests pass
- Covered: callback fires before `setBackgroundThrottling`, partial failure in one port closure doesn't block the other, rapid switch sequences, optional callback (no-op when not provided)