### PR TITLE
fix(disk-pressure): honor writesSuppressed in non-critical main-process writers

### DIFF
--- a/electron/services/DiskSpaceMonitor.ts
+++ b/electron/services/DiskSpaceMonitor.ts
@@ -64,13 +64,15 @@ export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => v
 
     const writesSuppressed = status === "critical";
 
+    // Publish the flag before any logger call so the very next log line that
+    // would hit disk under critical pressure is also dropped.
+    currentStatus = { status, availableMb, writesSuppressed };
+    setWritesSuppressed(writesSuppressed);
+
     logDebug("disk-space-check", {
       availableMb: Math.round(availableMb),
       status,
     });
-
-    currentStatus = { status, availableMb, writesSuppressed };
-    setWritesSuppressed(writesSuppressed);
 
     if (status !== lastStatus) {
       logInfo("disk-space-status-changed", {

--- a/electron/services/DiskSpaceMonitor.ts
+++ b/electron/services/DiskSpaceMonitor.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import { app } from "electron";
 import { logDebug, logInfo, logWarn } from "../utils/logger.js";
+import { setWritesSuppressed } from "./diskPressureState.js";
 
 export type DiskSpaceStatus = "normal" | "warning" | "critical";
 
@@ -69,6 +70,7 @@ export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => v
     });
 
     currentStatus = { status, availableMb, writesSuppressed };
+    setWritesSuppressed(writesSuppressed);
 
     if (status !== lastStatus) {
       logInfo("disk-space-status-changed", {

--- a/electron/services/GitHubStatsCache.ts
+++ b/electron/services/GitHubStatsCache.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, mkdirSync } from "fs";
 import { resilientAtomicWriteFileSync } from "../utils/fs.js";
+import { getWritesSuppressed } from "./diskPressureState.js";
 import path from "path";
 import os from "os";
 
@@ -180,6 +181,12 @@ export class GitHubStatsCache {
   }
 
   private save(cache: CacheFile): void {
+    // Keep the in-memory cache fresh regardless of disk pressure so in-process
+    // reads stay consistent. Skip the atomic write to disk when suppressed.
+    this.memoryCache = cache;
+
+    if (getWritesSuppressed()) return;
+
     try {
       const dir = path.dirname(this.cacheFilePath);
       if (!existsSync(dir)) {
@@ -187,7 +194,6 @@ export class GitHubStatsCache {
       }
 
       resilientAtomicWriteFileSync(this.cacheFilePath, JSON.stringify(cache, null, 2), "utf8");
-      this.memoryCache = cache;
     } catch (error) {
       console.error("[GitHubStatsCache] Failed to save cache:", error);
     }

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -33,6 +33,7 @@ import { cleanupQuarantinedProjectFiles } from "./projectQuarantineCleanup.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 
 import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
+import { getWritesSuppressed } from "./diskPressureState.js";
 
 export const DEFAULT_PROJECT_EMOJI = "🌲";
 
@@ -164,6 +165,12 @@ export class ProjectStore {
     const existing = await this.getProjectByPath(normalizedPath);
     if (existing) {
       const now = Date.now();
+      // Skip frecency churn under disk pressure — these are non-critical
+      // ranking-signal writes. `lastOpened` is also non-critical here (the
+      // existing project row is unchanged for the user's purposes).
+      if (getWritesSuppressed()) {
+        return existing;
+      }
       const newScore = computeFrecencyScore(
         existing.frecencyScore ?? FRECENCY_COLD_START,
         existing.lastAccessedAt ?? 0,
@@ -504,11 +511,17 @@ export class ProjectStore {
     const db = getSharedDb();
 
     const now = Date.now();
-    const newScore = computeFrecencyScore(
-      project.frecencyScore ?? FRECENCY_COLD_START,
-      project.lastAccessedAt ?? 0,
-      now
-    );
+    // Suppress frecency-signal columns under disk pressure but keep the
+    // critical state updates (currentProjectId pointer + active/background
+    // status) unconditional — those are session state the user depends on.
+    const writesSuppressed = getWritesSuppressed();
+    const newScore = writesSuppressed
+      ? null
+      : computeFrecencyScore(
+          project.frecencyScore ?? FRECENCY_COLD_START,
+          project.lastAccessedAt ?? 0,
+          now
+        );
 
     db.transaction((tx) => {
       if (previousProjectId && previousProjectId !== projectId) {
@@ -522,15 +535,18 @@ export class ProjectStore {
         .values({ key: "currentProjectId", value: projectId })
         .onConflictDoUpdate({ target: appStateTable.key, set: { value: projectId } })
         .run();
-      tx.update(projectsTable)
-        .set({
-          lastOpened: now,
-          status: "active",
-          frecencyScore: newScore,
-          lastAccessedAt: now,
-        })
-        .where(eq(projectsTable.id, projectId))
-        .run();
+      const activeUpdate: {
+        status: "active";
+        lastOpened?: number;
+        frecencyScore?: number;
+        lastAccessedAt?: number;
+      } = { status: "active" };
+      if (!writesSuppressed && newScore !== null) {
+        activeUpdate.lastOpened = now;
+        activeUpdate.frecencyScore = newScore;
+        activeUpdate.lastAccessedAt = now;
+      }
+      tx.update(projectsTable).set(activeUpdate).where(eq(projectsTable.id, projectId)).run();
     });
 
     if (process.env.DAINTREE_VERBOSE) {

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -6,6 +6,7 @@ import type { ActionBreadcrumb } from "../../shared/types/ipc/crashRecovery.js";
 import type { SanitizedTelemetryEvent } from "../../shared/types/ipc/telemetryPreview.js";
 import { scrubSecrets } from "../utils/secretScrubber.js";
 import { emitTelemetryPreview, isTelemetryPreviewActive } from "./TelemetryPreviewBroadcaster.js";
+import { getWritesSuppressed } from "./diskPressureState.js";
 
 export interface SentryBreadcrumb {
   message?: string;
@@ -201,6 +202,9 @@ export async function initializeTelemetry(): Promise<void> {
         beforeSend: (event) => {
           const sanitized = sanitizeEvent(event as unknown as SentryEvent);
           if (sanitized) capturePreviewFromSanitizedEvent(sanitized);
+          // Drop the SDK send under disk pressure but still mirror to the
+          // preview stream above — preview is in-memory only.
+          if (getWritesSuppressed()) return null;
           return sanitized as unknown as typeof event;
         },
         initialScope: {
@@ -332,9 +336,13 @@ export function trackEvent(event: string, properties: Record<string, unknown> = 
 
   // Only send analytics events at "full" level; "errors" only permits crash reports via Sentry
   if (level === "full" && captureEventFn) {
-    // `beforeSend` will fire the preview tap as part of the capture path.
-    captureEventFn(buildAnalyticsSentryEvent(event, properties, Date.now()));
-    return;
+    // Skip the SDK submission under disk pressure but still mirror to the
+    // preview stream below if a subscriber is active.
+    if (!getWritesSuppressed()) {
+      // `beforeSend` will fire the preview tap as part of the capture path.
+      captureEventFn(buildAnalyticsSentryEvent(event, properties, Date.now()));
+      return;
+    }
   }
 
   // Preview should mirror what *would* be sent even when consent is off or

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -324,6 +324,13 @@ function deriveTelemetryPreviewLabel(event: Record<string, unknown>): string {
 
 function flushPreConsentBuffer(): void {
   if (!captureEventFn) return;
+  // Under disk pressure `beforeSend` would drop each event, but invoking the
+  // SDK still spins through serialisation and queueing — drop the buffer
+  // contents up front so the flush is genuinely a no-op.
+  if (getWritesSuppressed()) {
+    preConsentBuffer.length = 0;
+    return;
+  }
   const events = preConsentBuffer.splice(0);
   for (const { event, properties, timestamp } of events) {
     captureEventFn(buildAnalyticsSentryEvent(event, properties, timestamp));

--- a/electron/services/__tests__/DiskSpaceMonitor.test.ts
+++ b/electron/services/__tests__/DiskSpaceMonitor.test.ts
@@ -211,4 +211,36 @@ describe("DiskSpaceMonitor", () => {
     expect(status.availableMb).toBeCloseTo(1500, 0);
     expect(status.writesSuppressed).toBe(false);
   });
+
+  it("publishes writesSuppressed=true to the shared diskPressureState shim on critical", async () => {
+    statfsMock.mockResolvedValue(makeStatfs(50));
+    const actions = createActions();
+    await importAndStart(actions);
+
+    const { getWritesSuppressed } = await import("../diskPressureState.js");
+    expect(getWritesSuppressed()).toBe(true);
+  });
+
+  it("publishes writesSuppressed=false to the shim once disk recovers", async () => {
+    statfsMock.mockResolvedValue(makeStatfs(50));
+    const actions = createActions();
+    await importAndStart(actions);
+
+    const { getWritesSuppressed } = await import("../diskPressureState.js");
+    expect(getWritesSuppressed()).toBe(true);
+
+    statfsMock.mockResolvedValue(makeStatfs(3000));
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(getWritesSuppressed()).toBe(false);
+  });
+
+  it("does not suppress writes at warning level", async () => {
+    statfsMock.mockResolvedValue(makeStatfs(1500));
+    const actions = createActions();
+    await importAndStart(actions);
+
+    const { getWritesSuppressed } = await import("../diskPressureState.js");
+    expect(getWritesSuppressed()).toBe(false);
+  });
 });

--- a/electron/services/__tests__/GitHubStatsCache.test.ts
+++ b/electron/services/__tests__/GitHubStatsCache.test.ts
@@ -20,6 +20,8 @@ describe("GitHubStatsCache", () => {
   afterEach(async () => {
     const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
     GitHubStatsCache.resetInstance();
+    const { resetWritesSuppressedForTesting } = await import("../diskPressureState.js");
+    resetWritesSuppressedForTesting();
     delete process.env.DAINTREE_USER_DATA;
     vi.useRealTimers();
     vi.resetModules();
@@ -168,6 +170,48 @@ describe("GitHubStatsCache", () => {
       projects: Record<string, unknown>;
     };
     expect(Object.keys(disk.projects)).toHaveLength(10);
+  });
+
+  it("does not write to disk when disk pressure suppresses writes", async () => {
+    const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+    const { setWritesSuppressed } = await import("../diskPressureState.js");
+    GitHubStatsCache.resetInstance();
+    const cache = GitHubStatsCache.getInstance();
+
+    setWritesSuppressed(true);
+    cache.set("octocat/under-pressure", { issueCount: 5, prCount: 2 }, "/repo/under-pressure");
+
+    expect(fs.existsSync(cacheFilePath)).toBe(false);
+    // Memory cache stays consistent so in-process reads still work.
+    expect(cache.get("octocat/under-pressure")).toEqual({
+      issueCount: 5,
+      prCount: 2,
+      lastUpdated: Date.now(),
+      projectPath: "/repo/under-pressure",
+    });
+  });
+
+  it("resumes writing to disk after pressure clears", async () => {
+    const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+    const { setWritesSuppressed } = await import("../diskPressureState.js");
+    GitHubStatsCache.resetInstance();
+    const cache = GitHubStatsCache.getInstance();
+
+    setWritesSuppressed(true);
+    cache.set("octocat/dropped", { issueCount: 1, prCount: 1 }, "/repo/dropped");
+    expect(fs.existsSync(cacheFilePath)).toBe(false);
+
+    setWritesSuppressed(false);
+    cache.set("octocat/persisted", { issueCount: 2, prCount: 3 }, "/repo/persisted");
+
+    expect(fs.existsSync(cacheFilePath)).toBe(true);
+    const disk = JSON.parse(fs.readFileSync(cacheFilePath, "utf8")) as {
+      projects: Record<string, unknown>;
+    };
+    expect(disk.projects).toHaveProperty("octocat/persisted");
+    // The earlier set's data was retained in memory, so the post-recovery write
+    // includes it as well.
+    expect(disk.projects).toHaveProperty("octocat/dropped");
   });
 
   it("clear removes cached data from memory and disk", async () => {

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-disk-pressure-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return p;
+    }
+  },
+}));
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject() {}
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({
+  ProjectFileStore: class {},
+}));
+
+vi.mock("../GlobalFileStore.js", () => ({
+  GlobalFileStore: class {},
+}));
+
+vi.mock("../ProjectIdentityFiles.js", () => ({
+  ProjectIdentityFiles: class {
+    async readInRepoProjectIdentity() {
+      return { found: false };
+    }
+  },
+}));
+
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore } from "../ProjectStore.js";
+import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
+
+describe("ProjectStore disk pressure suppression", () => {
+  let store: ProjectStore;
+  let alphaDir: string;
+  let betaDir: string;
+  let projectId: string;
+  let otherProjectId: string;
+  const seededFrecencyScore = 7.5;
+  // Use a recent timestamp so the half-life decay during the test doesn't
+  // drag the new score below the seeded value when frecency is recomputed.
+  let seededLastAccessedAt: number;
+  let seededLastOpened: number;
+
+  beforeEach(async () => {
+    alphaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-alpha-"));
+    betaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-beta-"));
+    // generateProjectId uses path.normalize on the canonical realpath
+    const { generateProjectId } = await import("../projectStorePaths.js");
+    const alphaCanonical = await fs.promises.realpath(alphaDir);
+    const betaCanonical = await fs.promises.realpath(betaDir);
+    projectId = generateProjectId(alphaCanonical);
+    otherProjectId = generateProjectId(betaCanonical);
+
+    seededLastAccessedAt = Date.now() - 60_000;
+    seededLastOpened = seededLastAccessedAt;
+
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    db.insert(schema.projects)
+      .values({
+        id: projectId,
+        path: alphaCanonical,
+        name: "Alpha",
+        emoji: "🌲",
+        lastOpened: seededLastOpened,
+        status: "closed",
+        frecencyScore: seededFrecencyScore,
+        lastAccessedAt: seededLastAccessedAt,
+      })
+      .run();
+
+    db.insert(schema.projects)
+      .values({
+        id: otherProjectId,
+        path: betaCanonical,
+        name: "Beta",
+        emoji: "🌲",
+        lastOpened: seededLastOpened,
+        status: "active",
+        frecencyScore: 1.0,
+        lastAccessedAt: seededLastAccessedAt,
+      })
+      .run();
+
+    db.insert(schema.appState).values({ key: "currentProjectId", value: otherProjectId }).run();
+
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    resetWritesSuppressedForTesting();
+    sqlite.close();
+    fs.rmSync(alphaDir, { recursive: true, force: true });
+    fs.rmSync(betaDir, { recursive: true, force: true });
+  });
+
+  it("setCurrentProject still updates currentProjectId and active status under suppression", async () => {
+    setWritesSuppressed(true);
+
+    await store.setCurrentProject(projectId);
+
+    const ptr = db
+      .select()
+      .from(schema.appState)
+      .where(eq(schema.appState.key, "currentProjectId"))
+      .get();
+    expect(ptr?.value).toBe(projectId);
+
+    const newActive = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, projectId))
+      .get();
+    expect(newActive?.status).toBe("active");
+
+    const previous = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, otherProjectId))
+      .get();
+    expect(previous?.status).toBe("background");
+  });
+
+  it("setCurrentProject does NOT update frecency columns under suppression", async () => {
+    setWritesSuppressed(true);
+
+    await store.setCurrentProject(projectId);
+
+    const row = db.select().from(schema.projects).where(eq(schema.projects.id, projectId)).get();
+    expect(row?.frecencyScore).toBe(seededFrecencyScore);
+    expect(row?.lastAccessedAt).toBe(seededLastAccessedAt);
+    expect(row?.lastOpened).toBe(seededLastOpened);
+  });
+
+  it("setCurrentProject DOES update frecency columns when not suppressed", async () => {
+    setWritesSuppressed(false);
+
+    await store.setCurrentProject(projectId);
+
+    const row = db.select().from(schema.projects).where(eq(schema.projects.id, projectId)).get();
+    // Frecency score increases on access (boost added before decay).
+    expect(row?.frecencyScore).toBeGreaterThan(seededFrecencyScore);
+    expect(row?.lastAccessedAt).toBeGreaterThan(seededLastAccessedAt);
+    expect(row?.lastOpened).toBeGreaterThan(seededLastOpened);
+  });
+
+  it("addProject for existing project skips frecency refresh under suppression", async () => {
+    setWritesSuppressed(true);
+
+    const result = await store.addProject(alphaDir);
+
+    expect(result.id).toBe(projectId);
+    expect(result.frecencyScore).toBe(seededFrecencyScore);
+    expect(result.lastAccessedAt).toBe(seededLastAccessedAt);
+
+    // DB row unchanged
+    const row = db.select().from(schema.projects).where(eq(schema.projects.id, projectId)).get();
+    expect(row?.frecencyScore).toBe(seededFrecencyScore);
+    expect(row?.lastAccessedAt).toBe(seededLastAccessedAt);
+    expect(row?.lastOpened).toBe(seededLastOpened);
+  });
+
+  it("addProject for existing project DOES refresh frecency when not suppressed", async () => {
+    setWritesSuppressed(false);
+
+    const result = await store.addProject(alphaDir);
+
+    expect(result.id).toBe(projectId);
+    expect(result.frecencyScore ?? 0).toBeGreaterThan(seededFrecencyScore);
+    expect(result.lastAccessedAt ?? 0).toBeGreaterThanOrEqual(seededLastAccessedAt);
+  });
+});

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -80,6 +80,7 @@ import {
   _getPreConsentBufferLength,
   type SentryEvent,
 } from "../TelemetryService.js";
+import { setWritesSuppressed, resetWritesSuppressedForTesting } from "../diskPressureState.js";
 
 function setPrivacy(patch: {
   telemetryLevel?: "off" | "errors" | "full";
@@ -701,6 +702,36 @@ describe("trackEvent", () => {
     for (const call of storeMock.set.mock.calls) {
       expect(call[0]).not.toContain("buffer");
     }
+  });
+});
+
+describe("trackEvent under disk pressure", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    captureEventMock.mockClear();
+    resetWritesSuppressedForTesting();
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    await setTelemetryEnabled(false);
+  });
+
+  it("does not call Sentry.captureEvent when writes are suppressed at 'full' level", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
+    await initializeTelemetry();
+    captureEventMock.mockClear();
+
+    setWritesSuppressed(true);
+    trackEvent("onboarding_completed", { totalSteps: 3 });
+
+    expect(captureEventMock).not.toHaveBeenCalled();
+
+    setWritesSuppressed(false);
+    trackEvent("onboarding_completed", { totalSteps: 3 });
+    expect(captureEventMock).toHaveBeenCalledTimes(1);
+
+    resetWritesSuppressedForTesting();
+    process.env.SENTRY_DSN = original;
   });
 });
 

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -733,6 +733,27 @@ describe("trackEvent under disk pressure", () => {
     resetWritesSuppressedForTesting();
     process.env.SENTRY_DSN = original;
   });
+
+  it("setTelemetryLevel('full') drops the pre-consent buffer when writes are suppressed", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    trackEvent("onboarding_step_viewed", { step: "telemetry" });
+    trackEvent("onboarding_step_viewed", { step: "agentSelection" });
+    expect(_getPreConsentBufferLength()).toBeGreaterThan(0);
+
+    setWritesSuppressed(true);
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
+    captureEventMock.mockClear();
+    await setTelemetryLevel("full");
+
+    expect(captureEventMock).not.toHaveBeenCalled();
+    expect(_getPreConsentBufferLength()).toBe(0);
+
+    resetWritesSuppressedForTesting();
+    process.env.SENTRY_DSN = original;
+  });
 });
 
 describe("setTelemetryLevel with buffer", () => {

--- a/electron/services/__tests__/diskPressureState.test.ts
+++ b/electron/services/__tests__/diskPressureState.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getWritesSuppressed,
+  setWritesSuppressed,
+  resetWritesSuppressedForTesting,
+} from "../diskPressureState.js";
+
+describe("diskPressureState", () => {
+  afterEach(() => {
+    resetWritesSuppressedForTesting();
+  });
+
+  it("defaults to writes allowed", () => {
+    expect(getWritesSuppressed()).toBe(false);
+  });
+
+  it("round-trips set/get", () => {
+    setWritesSuppressed(true);
+    expect(getWritesSuppressed()).toBe(true);
+    setWritesSuppressed(false);
+    expect(getWritesSuppressed()).toBe(false);
+  });
+
+  it("resetWritesSuppressedForTesting returns flag to false", () => {
+    setWritesSuppressed(true);
+    expect(getWritesSuppressed()).toBe(true);
+    resetWritesSuppressedForTesting();
+    expect(getWritesSuppressed()).toBe(false);
+  });
+});

--- a/electron/services/diskPressureState.ts
+++ b/electron/services/diskPressureState.ts
@@ -1,0 +1,22 @@
+/**
+ * Dependency-free disk-pressure flag shared between `DiskSpaceMonitor` (writer)
+ * and non-critical Tier 2 writers (logger, telemetry, frecency, caches) that
+ * need to drop writes when free space is below the critical threshold.
+ *
+ * Kept in its own module so writers can read the flag without importing
+ * `DiskSpaceMonitor` (which itself imports `logger.ts`, creating a cycle).
+ */
+
+let writesSuppressed = false;
+
+export function getWritesSuppressed(): boolean {
+  return writesSuppressed;
+}
+
+export function setWritesSuppressed(value: boolean): void {
+  writesSuppressed = value;
+}
+
+export function resetWritesSuppressedForTesting(): void {
+  writesSuppressed = false;
+}

--- a/electron/services/diskPressureState.ts
+++ b/electron/services/diskPressureState.ts
@@ -5,6 +5,12 @@
  *
  * Kept in its own module so writers can read the flag without importing
  * `DiskSpaceMonitor` (which itself imports `logger.ts`, creating a cycle).
+ *
+ * Scope: this module is per-process. `DiskSpaceMonitor` only runs in the main
+ * process, so utility processes (pty-host, workspace-host) keep their copy of
+ * `writesSuppressed` at `false` and continue writing. Forwarding the flag to
+ * those processes is a follow-up — issue #6271 only covers main-process
+ * writers.
  */
 
 let writesSuppressed = false;

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -20,6 +20,10 @@ import {
   setVerboseLogging,
 } from "../logger.js";
 import { logBuffer } from "../../services/LogBuffer.js";
+import {
+  setWritesSuppressed,
+  resetWritesSuppressedForTesting,
+} from "../../services/diskPressureState.js";
 
 const TEST_LOG_DIR = join(process.cwd(), "test-logs");
 
@@ -42,6 +46,7 @@ beforeEach(() => {
 
 afterEach(() => {
   resetLoggerStateForTesting();
+  resetWritesSuppressedForTesting();
   delete process.env.DAINTREE_USER_DATA;
   cleanupTestLogs();
 });
@@ -220,6 +225,42 @@ describe("logger", () => {
       logError("Error log", new Error("Test error"));
 
       expect(getLogFilePath()).toBeTruthy();
+    });
+  });
+
+  describe("disk pressure suppression", () => {
+    it("does not append to the log file when writes are suppressed", () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      logInfo("baseline write before suppression");
+      const beforeSize = existsSync(logFile) ? readFileSync(logFile, "utf8").length : 0;
+      expect(beforeSize).toBeGreaterThan(0);
+
+      setWritesSuppressed(true);
+      logInfo("suppressed entry should not reach disk");
+      logWarn("another suppressed entry");
+
+      const afterSize = readFileSync(logFile, "utf8").length;
+      expect(afterSize).toBe(beforeSize);
+      const content = readFileSync(logFile, "utf8");
+      expect(content).not.toContain("suppressed entry should not reach disk");
+      expect(content).not.toContain("another suppressed entry");
+    });
+
+    it("resumes writing once disk pressure clears", () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      setWritesSuppressed(true);
+      logInfo("dropped during suppression");
+
+      setWritesSuppressed(false);
+      logInfo("written after recovery");
+
+      const content = readFileSync(logFile, "utf8");
+      expect(content).not.toContain("dropped during suppression");
+      expect(content).toContain("written after recovery");
     });
   });
 

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -16,6 +16,7 @@ import { logBuffer, type LogEntry } from "../services/LogBuffer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { resilientRenameSync } from "./fs.js";
 import { scrubSecrets } from "./secretScrubber.js";
+import { getWritesSuppressed } from "../services/diskPressureState.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -511,6 +512,7 @@ function safeStringify(value: unknown): string {
 
 function writeToLogFile(level: string, message: string, context?: LogContext): void {
   if (!ENABLE_FILE_LOGGING) return;
+  if (getWritesSuppressed()) return;
 
   try {
     const logFile = getLogFilePath();


### PR DESCRIPTION
## Summary

- `writesSuppressed` was already being broadcast when disk space hits critical, but nothing in the main process was actually checking it — telemetry, log writes, the GitHub stats cache, and frecency updates in `ProjectStore` kept writing regardless
- Introduces `diskPressureState` as a thin shared module so any writer can check the current status without threading the monitor instance around
- Each non-critical writer now checks before flushing and skips writes when critical; tier-1 session/config writes are left untouched

Resolves #6271

## Changes

- `electron/services/diskPressureState.ts` — new shared module exposing `getCurrentDiskPressureStatus()` and `setCurrentDiskPressureStatus()`, updated by `DiskSpaceMonitor` on each poll
- `electron/services/DiskSpaceMonitor.ts` — calls `setCurrentDiskPressureStatus()` to keep the shared state current
- `electron/services/TelemetryService.ts` — skips flush when critical
- `electron/utils/logger.ts` — skips file writes when critical
- `electron/services/GitHubStatsCache.ts` — skips cache persistence when critical
- `electron/services/ProjectStore.ts` — skips frecency and related non-critical writes when critical
- Tests added for all modified services and the new `diskPressureState` module

## Testing

- Unit tests cover: `diskPressureState` get/set, `DiskSpaceMonitor` status propagation, `TelemetryService` suppression under critical, `logger` write suppression, `GitHubStatsCache` persistence suppression, and `ProjectStore` frecency suppression
- All existing tests pass after rebase onto develop