### PR TITLE
perf(memory): tighten memory observability and per-view eviction

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -117,6 +117,7 @@ export const CHANNELS = {
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",
   DIAGNOSTICS_GET_HEAP_STATS: "diagnostics:get-heap-stats",
   DIAGNOSTICS_GET_INFO: "diagnostics:get-info",
+  SYSTEM_REPORT_BLINK_MEMORY: "system:report-blink-memory",
 
   PR_DETECTED: "pr:detected",
   PR_CLEARED: "pr:cleared",

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -18,6 +18,7 @@ import type {
   DiagnosticsBundleSavePayload,
 } from "../../../shared/types/ipc/system.js";
 import type * as DiagnosticsCollectorModule from "../../services/DiagnosticsCollector.js";
+import { recordBlinkSample } from "../../services/ProcessMemoryMonitor.js";
 
 let cachedDiagnosticsCollector: typeof DiagnosticsCollectorModule | null = null;
 async function getDiagnosticsCollector(): Promise<typeof DiagnosticsCollectorModule> {
@@ -33,7 +34,7 @@ import {
   applyReplacements,
   type ReplacementRule,
 } from "../../../shared/utils/diagnosticsTransform.js";
-import { typedHandle } from "../utils.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 let eventLoopHistogram: IntervalHistogram | null = null;
 
@@ -159,6 +160,21 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
     }
   };
   handlers.push(typedHandle(CHANNELS.DIAGNOSTICS_GET_INFO, handleGetDiagnosticsInfo));
+
+  // Renderer report → ProcessMemoryMonitor. webContents id is taken from
+  // event.sender.id (cannot be spoofed by the renderer payload).
+  handlers.push(
+    typedHandleWithContext(CHANNELS.SYSTEM_REPORT_BLINK_MEMORY, (ctx, payload) => {
+      if (!payload || typeof payload.allocated !== "number") return;
+      recordBlinkSample(ctx.webContentsId, {
+        allocated: payload.allocated,
+        marked: typeof payload.marked === "number" ? payload.marked : undefined,
+        total: typeof payload.total === "number" ? payload.total : undefined,
+        partitionAlloc:
+          typeof payload.partitionAlloc === "number" ? payload.partitionAlloc : undefined,
+      });
+    })
+  );
 
   const handleGetHardwareInfo = (): HardwareInfo => {
     try {

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -165,13 +165,19 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   // event.sender.id (cannot be spoofed by the renderer payload).
   handlers.push(
     typedHandleWithContext(CHANNELS.SYSTEM_REPORT_BLINK_MEMORY, (ctx, payload) => {
-      if (!payload || typeof payload.allocated !== "number") return;
+      // Number.isFinite filters NaN/Infinity that `typeof === "number"` would
+      // otherwise accept; observability data should not be silently corrupted.
+      if (!payload || !Number.isFinite(payload.allocated)) return;
+      // Late IPC reply against an evicted view: don't reinsert into the
+      // sample map (forgetBlinkSample already cleaned it up on cleanupEntry).
+      if (ctx.event.sender.isDestroyed()) return;
+      const optionalKb = (v: unknown): number | undefined =>
+        Number.isFinite(v) ? (v as number) : undefined;
       recordBlinkSample(ctx.webContentsId, {
         allocated: payload.allocated,
-        marked: typeof payload.marked === "number" ? payload.marked : undefined,
-        total: typeof payload.total === "number" ? payload.total : undefined,
-        partitionAlloc:
-          typeof payload.partitionAlloc === "number" ? payload.partitionAlloc : undefined,
+        marked: optionalKb(payload.marked),
+        total: optionalKb(payload.total),
+        partitionAlloc: optionalKb(payload.partitionAlloc),
       });
     })
   );

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -36,6 +36,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "window:reclaim-memory": "external",
   "window:destroy-hidden-webviews": "external",
   "window:disk-space-status": "external",
+  "window:sample-blink-memory": "external",
   "system:wake": "external",
   "app-agent:dispatch-action-request": "external",
   "app-agent:confirmation-request": "external",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,13 @@ import "./setup/environment.js";
 
 import nodeV8 from "node:v8";
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
+
+// Ask V8 to auto-dump a heap snapshot when the main process is genuinely close
+// to its heap limit. Complements the existing dev-only 600 MB RSS heuristic in
+// ProcessMemoryMonitor, but works in packaged builds too. Snapshot files land
+// in the process CWD (or wherever `--diagnostic-dir` points). count=2 caps
+// lifetime auto-dumps so a thrashing process can't fill the disk.
+nodeV8.setHeapSnapshotNearHeapLimit(2);
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
 import { startDevDiagnostics } from "./setup/devDiagnostics.js";
 import path from "path";

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2538,6 +2538,36 @@ _eventBusOn("window:reclaim-memory", () => {
   (globalThis as unknown as { gc?: () => void }).gc?.();
 });
 
+// Private listener: report Blink (DOM/CSS/cross-frame) memory back to
+// ProcessMemoryMonitor. Tracks the tier of memory that V8 heap stats miss.
+// `process.getBlinkMemoryInfo` is an Electron-specific addition on the
+// renderer's `process` global; it works under sandbox: true. Failures here
+// are silent — the sample is best-effort observability, not a recovery path.
+type BlinkMemoryInfo = {
+  allocated: number;
+  marked?: number;
+  total?: number;
+  partitionAlloc?: number;
+};
+_eventBusOn("window:sample-blink-memory", ({ requestId }) => {
+  try {
+    const fn = (process as unknown as { getBlinkMemoryInfo?: () => BlinkMemoryInfo })
+      .getBlinkMemoryInfo;
+    if (typeof fn !== "function") return;
+    const info = fn();
+    if (!info || typeof info.allocated !== "number") return;
+    void ipcRenderer.invoke(CHANNELS.SYSTEM_REPORT_BLINK_MEMORY, {
+      requestId,
+      allocated: info.allocated,
+      marked: info.marked,
+      total: info.total,
+      partitionAlloc: info.partitionAlloc,
+    });
+  } catch {
+    /* observability is best-effort */
+  }
+});
+
 // E2E test bridge: expose renderer-side IPC listener introspection in fault mode.
 // Gated by DAINTREE_E2E_FAULT_MODE to avoid production surface area.
 if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -24,6 +24,12 @@ for (const stream of [process.stdout, process.stderr]) {
   }
 }
 
+import nodeV8 from "node:v8";
+// Ask V8 to auto-dump up to two heap snapshots when this utility process is
+// genuinely close to its --max-old-space-size limit. Snapshot path is governed
+// by the parent's `--diagnostic-dir` execArgv (set in PtyClient).
+nodeV8.setHeapSnapshotNearHeapLimit(2);
+
 import { MessagePort } from "node:worker_threads";
 import os from "node:os";
 import { PtyManager } from "./services/PtyManager.js";

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -35,11 +35,62 @@ interface PidTrendState {
   emaHistory: number[];
 }
 
+export interface BlinkMemorySample {
+  /** process.getBlinkMemoryInfo().allocated — bytes currently in use by Blink. */
+  allocated: number;
+  /** Bytes pinned by GC mark phase, when reported. */
+  marked?: number;
+  /** Total reserved (allocated + free), when reported. */
+  total?: number;
+  /** PartitionAlloc-managed bytes, when reported. */
+  partitionAlloc?: number;
+  /** Wall-clock time the sample was recorded. */
+  timestamp: number;
+}
+
+const blinkSamples = new Map<number, BlinkMemorySample>();
+
+/**
+ * Called by the IPC handler when a renderer reports its Blink memory snapshot.
+ * Keyed by webContents id; cleared on view eviction via `forgetBlinkSample`.
+ * Logs at debug level — issue #6272 is about visibility, not alerting.
+ */
+export function recordBlinkSample(
+  webContentsId: number,
+  sample: Omit<BlinkMemorySample, "timestamp">
+): void {
+  const stored: BlinkMemorySample = { ...sample, timestamp: Date.now() };
+  blinkSamples.set(webContentsId, stored);
+  logDebug("blink-memory-sample", {
+    webContentsId,
+    allocatedMb: Math.round(sample.allocated / 1024 / 1024),
+    totalMb: typeof sample.total === "number" ? Math.round(sample.total / 1024 / 1024) : undefined,
+  });
+}
+
+/** Drop a renderer's last Blink sample (call from ProjectViewManager onViewEvicted). */
+export function forgetBlinkSample(webContentsId: number): void {
+  blinkSamples.delete(webContentsId);
+}
+
+/** Read-only view for diagnostics / tests. */
+export function getBlinkSamples(): ReadonlyMap<number, BlinkMemorySample> {
+  return blinkSamples;
+}
+
 export interface MemoryPressureActions {
   clearCaches: () => Promise<void>;
   destroyHiddenWebviews: (tier: 1 | 2) => Promise<void>;
   hibernateIdleProjects: () => Promise<void>;
   trimPtyHostState?: () => void;
+  /**
+   * Optional Blink memory sampler. If wired, called once per poll BEFORE
+   * pressure evaluation so renderer samples land alongside the metrics
+   * snapshot. Implementations should fan a `window:sample-blink-memory`
+   * push event out to live renderers; renderers reply via the
+   * `system:report-blink-memory` IPC channel which calls `recordBlinkSample`.
+   */
+  sampleBlinkMemory?: () => void;
 }
 
 function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
@@ -57,6 +108,14 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   const timer = setInterval(() => {
     try {
       pollCount++;
+      // Kick off a Blink-memory sample fan-out for this tick. Renderer replies
+      // arrive asynchronously via the SYSTEM_REPORT_BLINK_MEMORY handler and
+      // populate `blinkSamples` for the next poll's diagnostics.
+      try {
+        actions?.sampleBlinkMemory?.();
+      } catch {
+        /* non-critical */
+      }
       const metrics = app.getAppMetrics();
       const activePids = new Set<number>();
       let hasPressure = false;

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -36,13 +36,20 @@ interface PidTrendState {
 }
 
 export interface BlinkMemorySample {
-  /** process.getBlinkMemoryInfo().allocated — bytes currently in use by Blink. */
+  /**
+   * process.getBlinkMemoryInfo().allocated — kilobytes currently in use by
+   * Blink. Note: the Electron API reports KB, not bytes (electron.d.ts:
+   * BlinkMemoryInfo).
+   */
   allocated: number;
-  /** Bytes pinned by GC mark phase, when reported. */
+  /** Reserved for future Electron versions; not populated on Electron 41. */
   marked?: number;
-  /** Total reserved (allocated + free), when reported. */
+  /**
+   * process.getBlinkMemoryInfo().total — total reserved kilobytes (allocated
+   * + free) when the renderer reports it.
+   */
   total?: number;
-  /** PartitionAlloc-managed bytes, when reported. */
+  /** Reserved for future Electron versions; not populated on Electron 41. */
   partitionAlloc?: number;
   /** Wall-clock time the sample was recorded. */
   timestamp: number;
@@ -63,8 +70,9 @@ export function recordBlinkSample(
   blinkSamples.set(webContentsId, stored);
   logDebug("blink-memory-sample", {
     webContentsId,
-    allocatedMb: Math.round(sample.allocated / 1024 / 1024),
-    totalMb: typeof sample.total === "number" ? Math.round(sample.total / 1024 / 1024) : undefined,
+    // sample.allocated/total are in kilobytes per Electron's BlinkMemoryInfo.
+    allocatedMb: Math.round(sample.allocated / 1024),
+    totalMb: typeof sample.total === "number" ? Math.round(sample.total / 1024) : undefined,
   });
 }
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -459,7 +459,13 @@ export class PtyClient extends EventEmitter {
         serviceName: "daintree-pty-host",
         stdio: "pipe",
         cwd: os.homedir(),
-        execArgv: [`--max-old-space-size=${this.config.memoryLimitMb}`],
+        // `--diagnostic-dir` redirects v8.setHeapSnapshotNearHeapLimit dumps
+        // (set in pty-host.ts) into the app's logs directory instead of the
+        // utility process CWD (homedir).
+        execArgv: [
+          `--max-old-space-size=${this.config.memoryLimitMb}`,
+          `--diagnostic-dir=${app.getPath("logs")}`,
+        ],
         env: {
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -417,6 +417,9 @@ export class WorkspaceHostProcess extends EventEmitter {
         serviceName: this.serviceName,
         stdio: "pipe",
         cwd: os.homedir(),
+        // Redirect v8.setHeapSnapshotNearHeapLimit dumps (set in
+        // workspace-host.ts) into the app's logs directory.
+        execArgv: [`--diagnostic-dir=${app.getPath("logs")}`],
         env: {
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -597,24 +597,34 @@ describe("ProcessMemoryMonitor", () => {
       }
     });
 
-    it("recordBlinkSample stores per-webContentsId payload and emits debug log", () => {
+    it("recordBlinkSample stores per-webContentsId payload (values in KB) and emits debug log", () => {
+      // Electron's BlinkMemoryInfo reports kilobytes; 50 MB == 50*1024 KB.
       recordBlinkSample(42, {
-        allocated: 50 * 1024 * 1024,
-        marked: 10 * 1024 * 1024,
-        total: 60 * 1024 * 1024,
-        partitionAlloc: 8 * 1024 * 1024,
+        allocated: 50 * 1024,
+        marked: 10 * 1024,
+        total: 60 * 1024,
+        partitionAlloc: 8 * 1024,
       });
 
       const stored = getBlinkSamples().get(42);
-      expect(stored?.allocated).toBe(50 * 1024 * 1024);
-      expect(stored?.marked).toBe(10 * 1024 * 1024);
-      expect(stored?.total).toBe(60 * 1024 * 1024);
-      expect(stored?.partitionAlloc).toBe(8 * 1024 * 1024);
+      expect(stored?.allocated).toBe(50 * 1024);
+      expect(stored?.marked).toBe(10 * 1024);
+      expect(stored?.total).toBe(60 * 1024);
+      expect(stored?.partitionAlloc).toBe(8 * 1024);
       expect(typeof stored?.timestamp).toBe("number");
 
       expect(logDebug).toHaveBeenCalledWith(
         "blink-memory-sample",
         expect.objectContaining({ webContentsId: 42, allocatedMb: 50, totalMb: 60 })
+      );
+    });
+
+    it("recordBlinkSample log conversion is KB → MB (regression for unit bug)", () => {
+      // 512 MB worth of Blink memory == 512*1024 KB.
+      recordBlinkSample(99, { allocated: 512 * 1024 });
+      expect(logDebug).toHaveBeenCalledWith(
+        "blink-memory-sample",
+        expect.objectContaining({ webContentsId: 99, allocatedMb: 512 })
       );
     });
 

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -32,6 +32,9 @@ import {
   WARMUP_INTERVALS,
   PRESSURE_COUNT_TIER2,
   MITIGATION_COOLDOWN_MS,
+  recordBlinkSample,
+  forgetBlinkSample,
+  getBlinkSamples,
   type MemoryPressureActions,
 } from "../ProcessMemoryMonitor.js";
 
@@ -583,6 +586,107 @@ describe("ProcessMemoryMonitor", () => {
 
       expect(mockActions.clearCaches).not.toHaveBeenCalled();
       expect(mockActions.hibernateIdleProjects).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("blink memory sampling (issue #6272)", () => {
+    beforeEach(() => {
+      // Sample map is module-scoped; clear per-test so order doesn't matter.
+      for (const wcId of Array.from(getBlinkSamples().keys())) {
+        forgetBlinkSample(wcId);
+      }
+    });
+
+    it("recordBlinkSample stores per-webContentsId payload and emits debug log", () => {
+      recordBlinkSample(42, {
+        allocated: 50 * 1024 * 1024,
+        marked: 10 * 1024 * 1024,
+        total: 60 * 1024 * 1024,
+        partitionAlloc: 8 * 1024 * 1024,
+      });
+
+      const stored = getBlinkSamples().get(42);
+      expect(stored?.allocated).toBe(50 * 1024 * 1024);
+      expect(stored?.marked).toBe(10 * 1024 * 1024);
+      expect(stored?.total).toBe(60 * 1024 * 1024);
+      expect(stored?.partitionAlloc).toBe(8 * 1024 * 1024);
+      expect(typeof stored?.timestamp).toBe("number");
+
+      expect(logDebug).toHaveBeenCalledWith(
+        "blink-memory-sample",
+        expect.objectContaining({ webContentsId: 42, allocatedMb: 50, totalMb: 60 })
+      );
+    });
+
+    it("recordBlinkSample overwrites the previous value for the same webContentsId", () => {
+      recordBlinkSample(7, { allocated: 10 });
+      recordBlinkSample(7, { allocated: 99 });
+      expect(getBlinkSamples().get(7)?.allocated).toBe(99);
+    });
+
+    it("forgetBlinkSample removes the recorded sample (used by view eviction)", () => {
+      recordBlinkSample(11, { allocated: 5 });
+      expect(getBlinkSamples().has(11)).toBe(true);
+      forgetBlinkSample(11);
+      expect(getBlinkSamples().has(11)).toBe(false);
+    });
+
+    it("startAppMetricsMonitor invokes actions.sampleBlinkMemory once per poll", () => {
+      const sampleBlinkMemory = vi.fn();
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        sampleBlinkMemory,
+      };
+
+      stop = startAppMetricsMonitor(actions);
+
+      vi.advanceTimersByTime(30_000);
+      expect(sampleBlinkMemory).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(30_000);
+      expect(sampleBlinkMemory).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(30_000);
+      expect(sampleBlinkMemory).toHaveBeenCalledTimes(3);
+    });
+
+    it("sampleBlinkMemory throwing does not break the poll loop", () => {
+      const sampleBlinkMemory = vi.fn().mockImplementation(() => {
+        throw new Error("renderer port closed");
+      });
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        sampleBlinkMemory,
+      };
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);
+      stop = startAppMetricsMonitor(actions);
+
+      // Two consecutive polls — both should still log the debug sample even
+      // though sampleBlinkMemory throws every time.
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+
+      expect(sampleBlinkMemory).toHaveBeenCalledTimes(2);
+      expect(logDebug).toHaveBeenCalledWith("process-memory-sample", expect.any(Object));
+    });
+
+    it("works without sampleBlinkMemory (optional field, backwards compat)", () => {
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+      };
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);
+      stop = startAppMetricsMonitor(actions);
+
+      // Should not throw — sampleBlinkMemory is optional.
+      expect(() => vi.advanceTimersByTime(30_000)).not.toThrow();
     });
   });
 });

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -198,7 +198,7 @@ describe("PtyClient Handshake Protocol", () => {
         expect.any(String),
         [],
         expect.objectContaining({
-          execArgv: ["--max-old-space-size=512"],
+          execArgv: expect.arrayContaining(["--max-old-space-size=512"]),
         })
       );
     });
@@ -209,7 +209,18 @@ describe("PtyClient Handshake Protocol", () => {
         expect.any(String),
         [],
         expect.objectContaining({
-          execArgv: ["--max-old-space-size=1024"],
+          execArgv: expect.arrayContaining(["--max-old-space-size=1024"]),
+        })
+      );
+    });
+
+    it("should pass --diagnostic-dir pointing at the logs path", () => {
+      createClient();
+      expect(forkMock).toHaveBeenCalledWith(
+        expect.any(String),
+        [],
+        expect.objectContaining({
+          execArgv: expect.arrayContaining(["--diagnostic-dir=/mock/user/data"]),
         })
       );
     });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -5,7 +5,7 @@
  * Switching projects swaps the visible view (<16ms for cached views).
  */
 
-import { BrowserWindow, WebContentsView, session } from "electron";
+import { app, BrowserWindow, WebContentsView, session } from "electron";
 import path from "path";
 import { performance } from "node:perf_hooks";
 import {
@@ -21,6 +21,7 @@ import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+import { forgetBlinkSample } from "../services/ProcessMemoryMonitor.js";
 import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
@@ -721,6 +722,7 @@ export class ProjectViewManager {
 
     this.webContentsToProject.delete(wcId);
     unregisterProjectView(wcId);
+    forgetBlinkSample(wcId);
 
     // Notify listeners (e.g. WorkspaceClient) so they can clean up direct ports
     this.onViewEvicted?.(wcId);
@@ -747,9 +749,42 @@ export class ProjectViewManager {
     if (this.views.size <= this.maxCachedViews) return;
     if (this.activeProjectId === null) return;
 
+    // Build pid → privateBytes index from the synchronous app.getAppMetrics()
+    // snapshot. Joined per-view via `webContents.getOSProcessId()` so eviction
+    // can prefer the largest renderer first instead of pure LRU. Views without
+    // a measured pid (process not yet spawned, or metrics missing) sort below
+    // measured ones via the 0 fallback, preserving LRU as the final tiebreak.
+    const memoryByPid = new Map<number, number>();
+    try {
+      for (const proc of app.getAppMetrics()) {
+        const kb = proc.memory.privateBytes ?? proc.memory.workingSetSize;
+        if (typeof kb === "number" && kb > 0) {
+          memoryByPid.set(proc.pid, kb);
+        }
+      }
+    } catch {
+      // app.getAppMetrics() throwing is non-fatal — fall back to pure LRU below.
+    }
+    const memoryFor = (entry: ViewEntry): number => {
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed()) return 0;
+      const getPid = (wc as { getOSProcessId?: () => number }).getOSProcessId;
+      if (typeof getPid !== "function") return 0;
+      const pid = getPid.call(wc);
+      if (typeof pid !== "number" || pid <= 0) return 0;
+      return memoryByPid.get(pid) ?? 0;
+    };
+
     const evictable = Array.from(this.views.entries())
       .filter(([id]) => id !== this.activeProjectId)
-      .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
+      // Largest privateBytes first; LRU (oldest first) as tiebreaker so the
+      // existing limit-change/lru ordering still holds when memory data is
+      // unavailable for both candidates.
+      .sort(([, a], [, b]) => {
+        const memDelta = memoryFor(b) - memoryFor(a);
+        if (memDelta !== 0) return memDelta;
+        return a.lastUsed - b.lastUsed;
+      });
 
     // Partition: evict views without active agents first, only fall back to
     // active-agent views when safe candidates are exhausted. This keeps memory
@@ -771,7 +806,10 @@ export class ProjectViewManager {
     while (this.views.size > this.maxCachedViews && candidates.length > 0) {
       const [projectId, entry, activeAgent] = candidates.shift()!;
       const ageMs = Date.now() - entry.lastUsed;
-      logInfo("projectview.eviction", { projectId, reason, ageMs, activeAgent });
+      const memoryKb = memoryFor(entry);
+      const ctx: Record<string, unknown> = { projectId, reason, ageMs, activeAgent };
+      if (memoryKb > 0) ctx.memoryKb = memoryKb;
+      logInfo("projectview.eviction", ctx);
       this.evictionTimestamps.set(projectId, Date.now());
       this.cleanupEntry(projectId);
     }

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -357,7 +357,7 @@ describe("ProjectViewManager — eviction safety", () => {
     // proj-a (oldest LRU) is small; proj-b is the heaviest cached renderer.
     // Memory-sorted eviction should target proj-b even though proj-a is older.
     const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
-    const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents>;
+    const wcB = wcBEntry?.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
     mockGetAppMetrics.mockReturnValue([
       { pid: wcA.osPid, memory: { privateBytes: 50 * 1024 } },
       { pid: wcB.osPid, memory: { privateBytes: 800 * 1024 } },
@@ -443,7 +443,7 @@ describe("ProjectViewManager — eviction safety", () => {
       {
         pid: (
           managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
-            .webContents as ReturnType<typeof createMockWebContents>
+            .webContents as unknown as ReturnType<typeof createMockWebContents>
         ).osPid,
         memory: { privateBytes: 100 * 1024 },
       },
@@ -523,9 +523,9 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.switchTo("proj-d", "/path/d");
 
     const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
-      .webContents as ReturnType<typeof createMockWebContents>;
+      .webContents as unknown as ReturnType<typeof createMockWebContents>;
     const wcC = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-c")?.view
-      .webContents as ReturnType<typeof createMockWebContents>;
+      .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     // proj-d is active. Among the cached three (a, b, c), expect c (900) to
     // evict before a (800), with b (100) surviving once limit drops to 2.

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 let nextWebContentsId = 100;
+let nextOsProcessId = 1000;
 
 type Handler = (...args: unknown[]) => void;
 
 function createMockWebContents() {
   const id = nextWebContentsId++;
+  const osPid = nextOsProcessId++;
   const handlers = new Map<string, Handler[]>();
   const wc = {
     id,
+    osPid,
     isDestroyed: vi.fn(() => false),
     setBackgroundThrottling: vi.fn(),
     executeJavaScript: vi.fn(() => Promise.resolve()),
@@ -17,6 +20,7 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
+    getOSProcessId: vi.fn(() => osPid),
     on: vi.fn((event: string, handler: Handler) => {
       const list = handlers.get(event) ?? [];
       list.push(handler);
@@ -40,13 +44,19 @@ function createMockWebContents() {
   return wc;
 }
 
+const mockGetAppMetrics = vi.fn<() => Electron.ProcessMetric[]>(() => []);
+
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
     return { webContents: wc, setBounds: vi.fn() };
   }
   return {
-    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getAppMetrics: () => mockGetAppMetrics(),
+    },
     BrowserWindow: vi.fn(),
     WebContentsView: MockWebContentsView,
     session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },
@@ -54,6 +64,10 @@ vi.mock("electron", () => {
     nativeTheme: { shouldUseDarkColors: true },
   };
 });
+
+vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
+  forgetBlinkSample: vi.fn(),
+}));
 
 vi.mock("../webContentsRegistry.js", () => ({
   registerWebContents: vi.fn(),
@@ -143,9 +157,12 @@ describe("ProjectViewManager — eviction safety", () => {
 
   beforeEach(() => {
     nextWebContentsId = 100;
+    nextOsProcessId = 1000;
     vi.clearAllMocks();
     mockGetAll.mockReset();
     mockGetAll.mockReturnValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -321,6 +338,149 @@ describe("ProjectViewManager — eviction safety", () => {
       expect.objectContaining({ projectId: "proj-b", activeAgent: true })
     );
   });
+
+  // ── Memory-sorted eviction (issue #6272) ──
+
+  it("evicts the largest-privateBytes cached view first, not the LRU one", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // proj-a (oldest LRU) is small; proj-b is the heaviest cached renderer.
+    // Memory-sorted eviction should target proj-b even though proj-a is older.
+    const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents>;
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { privateBytes: 50 * 1024 } },
+      { pid: wcB.osPid, memory: { privateBytes: 800 * 1024 } },
+    ] as unknown as Electron.ProcessMetric[]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toContain("proj-a");
+    expect(remaining).toContain("proj-c");
+    expect(remaining).not.toContain("proj-b");
+    expect(wcA.close).not.toHaveBeenCalled();
+    expect(wcB.close).toHaveBeenCalled();
+  });
+
+  it("falls back to LRU when no candidate has measured memory", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // No metrics returned — LRU should still drive eviction (proj-a evicted).
+    mockGetAppMetrics.mockReturnValue([]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-c");
+    expect(wcA.close).toHaveBeenCalled();
+  });
+
+  it("missing-metric views sort below measured ones (LRU as the deeper fallback)", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // Only proj-a has a measured pid. proj-b is unmeasured and should sort
+    // *below* proj-a despite being newer; proj-a (the only measured candidate)
+    // wins eviction priority.
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { privateBytes: 600 * 1024 } },
+    ] as unknown as Electron.ProcessMetric[]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-c");
+  });
+
+  it("active-agent views are still evicted last regardless of memory rank", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // proj-a is huge but has an active agent — must not be evicted.
+    // proj-b is smaller but evictable.
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { privateBytes: 900 * 1024 } },
+      {
+        pid: (
+          managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
+            .webContents as ReturnType<typeof createMockWebContents>
+        ).osPid,
+        memory: { privateBytes: 100 * 1024 },
+      },
+    ] as unknown as Electron.ProcessMetric[]);
+    mockGetAll.mockReturnValue([{ projectId: "proj-a", agentState: "working" }]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toContain("proj-a");
+    expect(remaining).toContain("proj-c");
+    expect(remaining).not.toContain("proj-b");
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("logs memoryKb in projectview.eviction when measured", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
+    ] as unknown as Electron.ProcessMetric[]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-a", memoryKb: 250 * 1024 })
+    );
+  });
 });
 
 describe("ProjectViewManager — telemetry", () => {
@@ -328,9 +488,12 @@ describe("ProjectViewManager — telemetry", () => {
 
   beforeEach(() => {
     nextWebContentsId = 100;
+    nextOsProcessId = 1000;
     vi.clearAllMocks();
     mockGetAll.mockReset();
     mockGetAll.mockReturnValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
   });
 
@@ -703,9 +866,12 @@ describe("ProjectViewManager — listener cleanup", () => {
 
   beforeEach(() => {
     nextWebContentsId = 100;
+    nextOsProcessId = 1000;
     vi.clearAllMocks();
     mockGetAll.mockReset();
     mockGetAll.mockReturnValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
     win = createMockWindow();
   });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -134,6 +134,7 @@ vi.mock("../../services/PtyManager.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
+import { forgetBlinkSample } from "../../services/ProcessMemoryMonitor.js";
 import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
 
 function createMockWindow() {
@@ -480,6 +481,83 @@ describe("ProjectViewManager — eviction safety", () => {
       "projectview.eviction",
       expect.objectContaining({ projectId: "proj-a", memoryKb: 250 * 1024 })
     );
+  });
+
+  it("falls back to LRU when app.getAppMetrics() throws", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    mockGetAppMetrics.mockImplementation(() => {
+      throw new Error("metrics unavailable");
+    });
+
+    // Eviction must still complete without throwing — LRU drives the choice.
+    await expect(managerWithLimit.switchTo("proj-c", "/path/c")).resolves.toBeDefined();
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-c");
+  });
+
+  it("evicts in descending privateBytes order when limit shrinks past multiple views", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 4,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+    await managerWithLimit.switchTo("proj-d", "/path/d");
+
+    const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
+      .webContents as ReturnType<typeof createMockWebContents>;
+    const wcC = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-c")?.view
+      .webContents as ReturnType<typeof createMockWebContents>;
+
+    // proj-d is active. Among the cached three (a, b, c), expect c (900) to
+    // evict before a (800), with b (100) surviving once limit drops to 2.
+    mockGetAppMetrics.mockReturnValue([
+      { pid: wcA.osPid, memory: { privateBytes: 800 * 1024 } },
+      { pid: wcB.osPid, memory: { privateBytes: 100 * 1024 } },
+      { pid: wcC.osPid, memory: { privateBytes: 900 * 1024 } },
+    ] as unknown as Electron.ProcessMetric[]);
+
+    managerWithLimit.setCachedViewLimit(2);
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-d");
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).not.toContain("proj-c");
+  });
+
+  it("calls forgetBlinkSample with the evicted webContents id", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    expect(vi.mocked(forgetBlinkSample)).toHaveBeenCalledWith(wcA.id);
   });
 });
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -544,6 +544,32 @@ export async function setupWindowServices(
           trimPtyHostState: () => {
             ptyClient?.trimState(SCROLLBACK_BACKGROUND);
           },
+          sampleBlinkMemory: () => {
+            if (!windowRegistry) return;
+            const requestId = `blink-${Date.now().toString(36)}`;
+            for (const wCtx of windowRegistry.all()) {
+              const w = wCtx.browserWindow;
+              if (w.isDestroyed()) continue;
+              // Per-window PVM tracks every cached project renderer; falling
+              // back to the app webContents covers windows still on the
+              // bootstrap shell (no PVM yet).
+              const pvm = wCtx.services.projectViewManager;
+              const targets = pvm
+                ? pvm.getAllViews().map((v) => v.view.webContents)
+                : [getAppWebContents(w)];
+              for (const wc of targets) {
+                if (!wc || wc.isDestroyed()) continue;
+                try {
+                  wc.send(CHANNELS.EVENTS_PUSH, {
+                    name: "window:sample-blink-memory",
+                    payload: { requestId },
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
         });
       },
     });

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -13,6 +13,12 @@ for (const stream of [process.stdout, process.stderr]) {
   }
 }
 
+import nodeV8 from "node:v8";
+// Auto-dump up to two heap snapshots when this utility process is genuinely
+// close to V8's heap limit. Snapshot path follows the parent's `--diagnostic-dir`
+// execArgv (set in WorkspaceHostProcess).
+nodeV8.setHeapSnapshotNearHeapLimit(2);
+
 import { MessagePort } from "node:worker_threads";
 import { initializeLogger, setLogLevelOverrides } from "./utils/logger.js";
 import { copyTreeService } from "./services/CopyTreeService.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -570,7 +570,8 @@ export interface IpcInvokeMap {
   };
   // Renderer reports process.getBlinkMemoryInfo() to ProcessMemoryMonitor.
   // The webContents id is taken from event.sender on the handler side, so
-  // a renderer cannot claim to be a different view.
+  // a renderer cannot claim to be a different view. All numeric fields are
+  // kilobytes (Electron's BlinkMemoryInfo unit, not bytes).
   "system:report-blink-memory": {
     args: [
       payload: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -568,6 +568,21 @@ export interface IpcInvokeMap {
     args: [];
     result: DiagnosticsInfo;
   };
+  // Renderer reports process.getBlinkMemoryInfo() to ProcessMemoryMonitor.
+  // The webContents id is taken from event.sender on the handler side, so
+  // a renderer cannot claim to be a different view.
+  "system:report-blink-memory": {
+    args: [
+      payload: {
+        requestId: string;
+        allocated: number;
+        marked?: number;
+        total?: number;
+        partitionAlloc?: number;
+      },
+    ];
+    result: void;
+  };
 
   // App state channels
   "app:get-state": {
@@ -2286,6 +2301,10 @@ export interface IpcEventMap {
   "window:fullscreen-change": boolean;
   "window:reclaim-memory": { reason: string };
   "window:destroy-hidden-webviews": { tier: 1 | 2 };
+  // Main asks renderers to report process.getBlinkMemoryInfo() so
+  // ProcessMemoryMonitor can see the Blink (DOM/CSS/inter-frame) memory tier
+  // that V8 heap stats miss. Renderer replies via SYSTEM_REPORT_BLINK_MEMORY.
+  "window:sample-blink-memory": { requestId: string };
   "window:disk-space-status": {
     status: "normal" | "warning" | "critical";
     availableMb: number;
@@ -2457,6 +2476,7 @@ export type IpcEventBusMap = Pick<
   | "window:reclaim-memory"
   | "window:destroy-hidden-webviews"
   | "window:disk-space-status"
+  | "window:sample-blink-memory"
   // System wake (per-webContents)
   | "system:wake"
   // Resource profile (global broadcast)


### PR DESCRIPTION
## Summary

- Installs `v8.setHeapSnapshotNearHeapLimit(2)` in the main process, `pty-host`, and `workspace-host` so heap snapshots auto-dump when any process approaches its V8 limit — works in packaged builds, complementing the existing dev-only RSS heuristic
- `ProjectViewManager.evictStaleViews` now pulls `privateBytes` from `app.getAppMetrics()` and evicts the largest cached renderer first; LRU is the fallback when metrics are unavailable
- Adds periodic Blink memory sampling via `process.getBlinkMemoryInfo()` to capture DOM and CSS memory that V8 stats miss; samples are stored per-`webContents` in `ProcessMemoryMonitor` and cleared on view eviction

Closes #6272.

## Test plan
- [ ] Vitest: 11 new tests pass (`ProcessMemoryMonitor.test.ts`, `ProjectViewManager.eviction.test.ts`)
- [ ] `npm run check` clean (typecheck + lint + format)
- [ ] `npm run build` succeeds
- [ ] No new warnings against the eslint baseline
- [ ] Existing eviction and telemetry tests still pass