### PR TITLE
fix(build): prevent tsc typecheck from clobbering esbuild bundle output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 # Build outputs
 dist/
 dist-electron/
+dist-typecheck/
 out/
 release/
 *.asar

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # Build outputs
 dist/
 dist-electron/
+dist-typecheck/
 release/
 
 # Dependencies

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    "outDir": "../dist-electron/typecheck",
+    "outDir": "../dist-typecheck/electron",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    "outDir": "../dist-electron/electron",
+    "outDir": "../dist-electron/typecheck",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,

--- a/electron/tsconfig.preload.json
+++ b/electron/tsconfig.preload.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM"],
-    "outDir": "../dist-electron/typecheck",
+    "outDir": "../dist-typecheck/electron",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,

--- a/electron/tsconfig.preload.json
+++ b/electron/tsconfig.preload.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM"],
-    "outDir": "../dist-electron/electron",
+    "outDir": "../dist-electron/typecheck",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -316,6 +316,7 @@ export default tseslint.config(
     ignores: [
       "dist/**",
       "dist-electron/**",
+      "dist-typecheck/**",
       "release/**",
       "node_modules/**",
       "*.config.js",


### PR DESCRIPTION
## Summary

- `tsc -b electron/tsconfig.json` was emitting unbundled `.js` files to `dist-electron/electron/`, the same directory esbuild owns. Running `npm run check` after `npm run build` would overwrite `main.js` and `bootstrap.js` with tsc-emitted versions that lack esbuild's `IS_LEGACY_BUILD` define substitution, crashing the app on launch.
- Fixed by redirecting both `electron/tsconfig.json` and `electron/tsconfig.preload.json` to write to `dist-typecheck/electron/` instead — a separate directory that esbuild never touches.
- Added `dist-typecheck/` to `.gitignore`, `.prettierignore`, and eslint ignores so the isolated output stays out of tooling.

Resolves #6279

## Changes

- `electron/tsconfig.json` — `outDir` changed from `../dist-electron/electron` to `../dist-typecheck/electron`
- `electron/tsconfig.preload.json` — same redirect
- `.gitignore` — `dist-typecheck/` added
- `.prettierignore` — `dist-typecheck/` added
- `eslint.config.js` — `dist-typecheck/**` added to ignores

## Testing

Verified that the shasum of `dist-electron/electron/main.js` and `bootstrap.js` is identical before and after `npm run check`. Full file tree of `dist-electron/electron/` is unchanged after running check. `npm run check` and `npm run build` both exit 0. Lint ratchet baseline holds at 2425 warnings with no new entries.