### PR TITLE
test(terminal): drop vestigial @xterm/addon-canvas mocks

### DIFF
--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -29,12 +29,6 @@ vi.mock("@/clients", () => ({
   },
 }));
 
-vi.mock("@xterm/addon-canvas", () => ({
-  CanvasAddon: class {
-    dispose() {}
-  },
-}));
-
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(() => ({
     dispose: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -2,12 +2,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
-vi.mock("@xterm/addon-canvas", () => ({
-  CanvasAddon: class {
-    dispose() {}
-  },
-}));
-
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(() => ({
     dispose: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -2,12 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { terminalInstanceService } from "../TerminalInstanceService";
 import { INCREMENTAL_RESTORE_CONFIG } from "../types";
 
-vi.mock("@xterm/addon-canvas", () => ({
-  CanvasAddon: class {
-    dispose() {}
-  },
-}));
-
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(() => ({
     dispose: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -25,12 +25,6 @@ vi.mock("@/clients", () => ({
   },
 }));
 
-vi.mock("@xterm/addon-canvas", () => ({
-  CanvasAddon: class {
-    dispose() {}
-  },
-}));
-
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(() => ({
     dispose: vi.fn(),


### PR DESCRIPTION
## Summary

- `@xterm/addon-canvas` was removed in xterm.js 6.0 and isn't installed — the mocks in four test files were dead code
- They gave the false impression a canvas renderer fallback still existed, which was misleading for anyone reading the tests
- The neighboring `@xterm/addon-webgl` mocks are load-bearing and were left untouched

Resolves #6291

## Changes

- Removed identical `vi.mock("@xterm/addon-canvas", ...)` blocks from four files in `src/services/terminal/__tests__/`: `TerminalInstanceService.hibernation.test.ts`, `TerminalInstanceService.options.test.ts`, `TerminalInstanceService.restore.test.ts`, `TerminalInstanceService.tier.test.ts`

## Testing

All four test files still pass with the mocks removed. The `@xterm/addon-webgl` mocks remain in place.