### PR TITLE
docs(pty-host): document backpressure byte-unit rationale

### DIFF
--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -7,6 +7,12 @@ import type {
 import type { PtyPauseCoordinator } from "./PtyPauseCoordinator.js";
 
 export const MAX_PACKET_PAYLOAD = 65535;
+// Caps are in bytes, not chars: they bound the memory consumed by in-flight
+// Uint8Array payloads on the MessagePort between pty-host and renderer.
+// MessagePort transfers the underlying ArrayBuffer byte-for-byte, so byte
+// count is the exact memory footprint. VS Code uses char-based flow control
+// because its IPC routes through string-based JSON-RPC; copying that
+// approach here would misrepresent the actual resource being protected.
 export const MAX_PENDING_BYTES_PER_TERMINAL = 4 * 1024 * 1024;
 export const MAX_TOTAL_PENDING_BYTES = 16 * 1024 * 1024;
 export const BACKPRESSURE_SAFETY_TIMEOUT_MS = 10000;

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -8,11 +8,11 @@ import type { PtyPauseCoordinator } from "./PtyPauseCoordinator.js";
 
 export const MAX_PACKET_PAYLOAD = 65535;
 // Caps are in bytes, not chars: they bound the memory consumed by in-flight
-// Uint8Array payloads on the MessagePort between pty-host and renderer.
-// MessagePort transfers the underlying ArrayBuffer byte-for-byte, so byte
-// count is the exact memory footprint. VS Code uses char-based flow control
-// because its IPC routes through string-based JSON-RPC; copying that
-// approach here would misrepresent the actual resource being protected.
+// Uint8Array payloads queued for the SharedArrayBuffer ring buffer path.
+// The Uint8Array byte length closely approximates the actual memory footprint
+// of these payloads. VS Code uses char-based flow control because its IPC
+// routes through string-based JSON-RPC; copying that approach here would
+// misrepresent the resource being protected.
 export const MAX_PENDING_BYTES_PER_TERMINAL = 4 * 1024 * 1024;
 export const MAX_TOTAL_PENDING_BYTES = 16 * 1024 * 1024;
 export const BACKPRESSURE_SAFETY_TIMEOUT_MS = 10000;


### PR DESCRIPTION
## Summary
- Adds comments above `MAX_PENDING_BYTES_PER_TERMINAL` and `MAX_TOTAL_PENDING_BYTES` explaining why the caps use bytes rather than chars.
- The in-flight payloads are `Uint8Array` objects passed between the pty-host utility process and the renderer on `MessagePort`s -- byte length closely approximates the actual memory footprint.
- VS Code uses char-based flow control because its IPC routes through string-based JSON-RPC; copying that approach here would misrepresent the resource being protected.

Resolves #6298.

## Changes
- `electron/pty-host/backpressure.ts` -- added explanatory comment above the two backpressure constants.

## Testing
Docs-only change. All CI checks pass (format, lint, typecheck, backpressure adversarial tests).