### PR TITLE
feat(actions): backfill keyword synonyms for top palette commands

### DIFF
--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -137,6 +137,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["appearance", "colors", "scheme", "palette"],
     nonRepeatable: true,
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:open-theme-palette"));
@@ -151,6 +152,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["appearance", "colors", "scheme", "preview"],
     nonRepeatable: true,
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:open-theme-browser"));
@@ -165,6 +167,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["appearance", "mode", "dark", "light"],
     run: async () => {
       const {
         selectedSchemeId,

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -70,6 +70,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["preferences", "options", "config", "prefs"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onOpenSettings();
@@ -152,7 +153,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["appearance", "colors", "scheme", "preview"],
+    keywords: ["appearance", "colors", "scheme", "browse"],
     nonRepeatable: true,
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:open-theme-browser"));

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -104,6 +104,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["create", "add", "launcher", "picker"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onOpenPanelPalette();
@@ -162,6 +163,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["debug", "problems", "lint", "events"],
     run: async () => {
       useDiagnosticsStore.getState().toggleDock();
     },
@@ -175,6 +177,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["debug", "output", "trace", "console"],
     run: async () => {
       useDiagnosticsStore.getState().openDock("logs");
     },
@@ -188,6 +191,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["debug", "timeline", "activity", "trace"],
     run: async () => {
       useDiagnosticsStore.getState().openDock("events");
     },
@@ -201,6 +205,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["errors", "warnings", "issues", "lint"],
     run: async () => {
       useDiagnosticsStore.getState().openDock("problems");
     },
@@ -214,6 +219,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["web", "embed", "browser", "dock"],
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:toggle-portal"));
     },
@@ -227,6 +233,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["web", "embed", "browser", "dock"],
     run: async () => {
       usePortalStore.getState().toggle();
     },
@@ -397,6 +404,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["cycle", "forward", "switch", "tab"],
     run: async () => {
       const state = usePortalStore.getState();
       if (state.tabs.length <= 1) return;
@@ -416,6 +424,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["cycle", "back", "switch", "tab"],
     run: async () => {
       const state = usePortalStore.getState();
       if (state.tabs.length <= 1) return;
@@ -435,6 +444,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["create", "add", "blank", "tab"],
     run: async () => {
       const state = usePortalStore.getState();
 
@@ -464,6 +474,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["home", "blank", "start", "tab"],
     run: async () => {
       usePortalStore.getState().createBlankTab();
       await window.electron.portal.hide().catch(() => {});
@@ -478,6 +489,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["remove", "clear", "cleanup", "tabs"],
     run: async () => {
       usePortalStore.getState().closeAllTabs();
       await window.electron.portal.hide().catch(() => {});
@@ -821,6 +833,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["size", "default", "resize", "layout"],
     run: async () => {
       usePortalStore.getState().setWidth(PORTAL_DEFAULT_WIDTH);
     },

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -404,7 +404,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["cycle", "forward", "switch", "tab"],
+    keywords: ["cycle", "forward", "advance", "switch"],
     run: async () => {
       const state = usePortalStore.getState();
       if (state.tabs.length <= 1) return;
@@ -424,7 +424,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["cycle", "back", "switch", "tab"],
+    keywords: ["cycle", "back", "switch", "last"],
     run: async () => {
       const state = usePortalStore.getState();
       if (state.tabs.length <= 1) return;
@@ -444,7 +444,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["create", "add", "blank", "tab"],
+    keywords: ["create", "add", "blank", "open"],
     run: async () => {
       const state = usePortalStore.getState();
 

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -117,6 +117,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["maximize", "presentation", "immersive", "expand"],
     run: async () => {
       await window.electron.window.toggleFullscreen();
     },
@@ -130,6 +131,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["refresh", "restart", "renderer", "soft"],
     run: async () => {
       await window.electron.window.reload();
     },
@@ -143,6 +145,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["refresh", "cache", "hard", "renderer"],
     run: async () => {
       await window.electron.window.forceReload();
     },
@@ -156,6 +159,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["developer", "inspect", "console", "debug"],
     run: async () => {
       await window.electron.window.toggleDevTools();
     },
@@ -169,6 +173,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["larger", "increase", "scale", "magnify"],
     run: async () => {
       await window.electron.window.zoomIn();
     },
@@ -182,6 +187,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["smaller", "decrease", "scale", "shrink"],
     run: async () => {
       await window.electron.window.zoomOut();
     },
@@ -195,6 +201,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["default", "normal", "scale", "restore"],
     run: async () => {
       await window.electron.window.zoomReset();
     },
@@ -208,6 +215,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["dismiss", "shut", "exit", "hide"],
     run: async () => {
       await window.electron.window.close();
     },
@@ -325,6 +333,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["defaults", "restore", "clear", "agents"],
     argsSchema: z
       .object({
         agentId: z.string().optional(),
@@ -397,6 +406,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["shortcuts", "hotkeys", "defaults", "restore"],
     run: async () => {
       await keybindingService.resetAllOverrides();
       return keybindingService.getOverridesSnapshot();
@@ -644,6 +654,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["hotkeys", "keys", "reference", "bindings"],
     run: async () => {
       callbacks.onOpenShortcuts();
     },
@@ -657,6 +668,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["hotkeys", "keys", "reference", "bindings"],
     run: async () => {
       callbacks.onOpenShortcuts();
     },
@@ -670,6 +682,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["assistant", "support", "docs", "guide"],
     argsSchema: z.object({ agentId: AgentIdSchema.optional() }).optional(),
     run: async (args?: unknown) => {
       const folderPath = await window.electron.help.getFolderPath();
@@ -734,6 +747,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["docs", "support", "guide", "assistant"],
     run: async () => {
       useHelpPanelStore.getState().toggle();
     },
@@ -747,6 +761,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["dismiss", "escape", "dialog", "overlay"],
     nonRepeatable: true,
     run: async () => {
       dispatchEscape();
@@ -761,6 +776,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["exit", "close", "shutdown", "leave"],
     run: async () => {
       await appClient.quit();
     },
@@ -774,6 +790,7 @@ export function registerPreferencesActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["exit", "kill", "shutdown", "terminate"],
     run: async () => {
       await appClient.forceQuit();
     },

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -17,6 +17,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["trash", "hide", "dismiss", "remove"],
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     run: async (args: unknown) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
@@ -58,6 +59,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["hide", "minimize", "stash", "park"],
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     run: async (args: unknown) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
@@ -82,6 +84,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["terminate", "stop", "remove", "delete"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -101,6 +104,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["relaunch", "reset", "rerun", "process"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -120,6 +124,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["refresh", "render", "repair", "display"],
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     run: async (args: unknown) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
@@ -140,6 +145,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["title", "label", "name", "edit"],
     argsSchema: z.object({
       terminalId: z.string().optional(),
       name: z
@@ -170,6 +176,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["details", "metadata", "inspect", "status"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -190,6 +197,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["details", "metadata", "inspect", "status"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -229,6 +237,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["readonly", "typing", "disable", "keyboard"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -248,6 +257,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["wake", "unstick", "unpause", "stuck"],
     argsSchema: z.object({ terminalId: z.string().optional() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId?: string };
@@ -266,6 +276,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["trash", "hide", "clear", "cleanup"],
     run: async () => {
       const state = usePanelStore.getState();
       const activeWorktreeId = callbacks.getActiveWorktreeId();
@@ -289,6 +300,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "confirm",
     scope: "renderer",
+    keywords: ["terminate", "stop", "remove", "delete"],
     run: async () => {
       usePanelStore.getState().bulkCloseAll();
     },
@@ -302,6 +314,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["relaunch", "reset", "rerun", "processes"],
     run: async () => {
       usePanelStore.getState().bulkRestartAll();
     },
@@ -315,6 +328,7 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["pty", "backend", "recover", "host"],
     isEnabled: () => usePanelStore.getState().backendStatus === "disconnected",
     run: async () => {
       await terminalClient.restartService();

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -107,6 +107,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["sync", "reload", "update", "sidebar"],
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
       await Promise.allSettled([
@@ -124,6 +125,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["pr", "github", "fetch", "sync"],
     run: async () => {
       await worktreeClient.refreshPullRequests();
     },
@@ -138,6 +140,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["workspace", "backend", "recover", "host"],
     isEnabled: () => {
       const store = getCurrentViewStoreOrNull();
       return store !== null && store.getState().error !== null;
@@ -171,6 +174,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["new", "branch", "checkout", "recipe"],
     run: async () => {
       useWorktreeSelectionStore.getState().openQuickCreate();
     },
@@ -184,6 +188,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["create", "branch", "checkout", "add"],
     run: async () => {
       useWorktreeSelectionStore.getState().openCreateDialog();
     },
@@ -310,6 +315,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      keywords: ["choose", "activate", "focus", "switch"],
       argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
       nonRepeatable: true,
       run: async (args, ctx: ActionContext) => {
@@ -331,6 +337,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["cycle", "forward", "advance", "switch"],
     nonRepeatable: true,
     run: async () => {
       const activeWorktreeId = callbacks.getActiveWorktreeId();
@@ -352,6 +359,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["cycle", "back", "switch", "last"],
     nonRepeatable: true,
     run: async () => {
       const activeWorktreeId = callbacks.getActiveWorktreeId();
@@ -546,6 +554,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["switcher", "chooser", "list", "picker"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onOpenWorktreePalette();
@@ -560,6 +569,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["dashboard", "grid", "summary", "modal"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onToggleWorktreeOverview();
@@ -574,6 +584,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["dashboard", "grid", "summary", "modal"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onOpenWorktreeOverview();
@@ -588,6 +599,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["dismiss", "hide", "exit", "escape"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onCloseWorktreeOverview();
@@ -602,6 +614,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    keywords: ["sidebar", "switcher", "chooser", "picker"],
     nonRepeatable: true,
     run: async () => {
       callbacks.onOpenWorktreePalette();


### PR DESCRIPTION
## Summary

- Backfilled `keywords` arrays across 5 action definition files: `worktreeActions.ts`, `panelActions.ts`, `preferencesActions.ts`, `terminalLifecycleActions.ts`, `appActions.ts`
- 60 actions now have synonym coverage for the mental models users actually search by — things like "maximize" for Toggle Fullscreen, "appearance" for Pick Theme, "pty" for Restart Terminal Service
- The ranking pipeline already weighted `keywords` correctly; this is purely content

Resolves #6307

## Changes

- `worktreeActions.ts` — 13 actions backfilled
- `panelActions.ts` — 13 actions backfilled
- `preferencesActions.ts` — 17 actions backfilled
- `terminalLifecycleActions.ts` — 14 actions backfilled
- `appActions.ts` — 4 actions backfilled

## Testing

- Typecheck clean
- 24/24 unit tests pass (`actionPaletteSearch`, `actionMetadata`)
- Lint at 0 errors (ratchet count decreased by 2)