### PR TITLE
fix(help): restore assistant terminal after agent selection

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -3,19 +3,26 @@ import { X, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
+import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import { HelpAgentPicker } from "./HelpAgentPicker";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
   HELP_PANEL_MAX_WIDTH,
 } from "@/store/helpPanelStore";
-import { usePanelStore, getTerminalRefreshTier, useAgentSettingsStore } from "@/store";
+import {
+  usePanelStore,
+  getTerminalRefreshTier,
+  useAgentSettingsStore,
+  useCliAvailabilityStore,
+} from "@/store";
 import { getAgentConfig } from "@/config/agents";
 import { getAgentSettingsEntry } from "@shared/types";
 import { ASSISTANT_FAST_MODELS } from "@shared/config/agentRegistry";
 import { actionService } from "@/services/ActionService";
 import { TerminalRefreshTier } from "@/types";
 import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 const RESIZE_STEP = 10;
@@ -31,6 +38,16 @@ function resolveAssistantModel(agentId: string): string | undefined {
   const fast = ASSISTANT_FAST_MODELS[agentId];
   if (fast && cfg?.models?.some((m) => m.id === fast)) return fast;
   return undefined;
+}
+
+function notifyLaunchFailed(agentId: string, reason: string): void {
+  const cfg = getAgentConfig(agentId);
+  const name = cfg?.name ?? agentId;
+  notify({
+    type: "error",
+    title: "Assistant launch failed",
+    message: `Couldn't start ${name}. ${reason}`,
+  });
 }
 
 export function HelpPanel() {
@@ -52,6 +69,7 @@ export function HelpPanel() {
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
   const removePanel = usePanelStore((s) => s.removePanel);
+  const cliDetail = useCliAvailabilityStore((s) => (agentId ? s.details[agentId] : undefined));
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
 
@@ -76,18 +94,23 @@ export function HelpPanel() {
   const hasAutoLaunched = useRef(false);
   useEffect(() => {
     if (!isOpen || terminalId || !preferredAgentId || hasAutoLaunched.current) return;
+    const launchAgentId = preferredAgentId;
     hasAutoLaunched.current = true;
 
     safeFireAndForget(
       (async () => {
         const folderPath = await window.electron.help.getFolderPath();
-        if (!folderPath) return;
+        if (!folderPath) {
+          hasAutoLaunched.current = false;
+          notifyLaunchFailed(launchAgentId, "Help folder is not available.");
+          return;
+        }
 
-        const model = resolveAssistantModel(preferredAgentId);
+        const model = resolveAssistantModel(launchAgentId);
         const result = await actionService.dispatch<{ terminalId: string | null }>(
           "agent.launch",
           {
-            agentId: preferredAgentId,
+            agentId: launchAgentId,
             location: "dock",
             cwd: folderPath,
             prompt: HELP_PROMPT,
@@ -95,13 +118,30 @@ export function HelpPanel() {
           },
           { source: "user" }
         );
-        if (result.ok && result.result?.terminalId) {
-          if (document.hidden) return;
-          useHelpPanelStore.getState().setTerminal(result.result.terminalId, preferredAgentId);
-          window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
-            logError("Failed to mark help terminal", err);
-          });
+
+        // Stale-launch guard: if the user navigated back to the picker or
+        // switched preferred agent while the IPC was in flight, discard
+        // this result and clean up the spawned panel rather than reviving
+        // a stale terminal.
+        const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
+        if (currentPreferred !== launchAgentId) {
+          if (result.ok && result.result?.terminalId) {
+            usePanelStore.getState().removePanel(result.result.terminalId);
+          }
+          return;
         }
+
+        if (!result.ok || !result.result?.terminalId) {
+          hasAutoLaunched.current = false;
+          logError("Help auto-launch failed", { agentId: launchAgentId, result });
+          notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+          return;
+        }
+
+        useHelpPanelStore.getState().setTerminal(result.result.terminalId, launchAgentId);
+        window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
+          logError("Failed to mark help terminal", err);
+        });
       })(),
       { context: "Auto-launching preferred help agent" }
     );
@@ -169,44 +209,61 @@ export function HelpPanel() {
     [width, setWidth]
   );
 
+  const isLaunchingRef = useRef(false);
   const handleSelectAgent = useCallback(
     async (selectedAgentId: string) => {
-      // Remove existing terminal if switching agents
-      if (terminalId) {
-        removePanel(terminalId);
-        clearTerminal();
-      }
+      if (isLaunchingRef.current) return;
+      isLaunchingRef.current = true;
 
-      const folderPath = await window.electron.help.getFolderPath();
-      if (!folderPath) return;
+      try {
+        // Remove existing terminal if switching agents
+        const existingId = useHelpPanelStore.getState().terminalId;
+        if (existingId) {
+          removePanel(existingId);
+          clearTerminal();
+        }
 
-      const model = resolveAssistantModel(selectedAgentId);
-      const result = await actionService.dispatch<{ terminalId: string | null }>(
-        "agent.launch",
-        {
-          agentId: selectedAgentId,
-          location: "dock",
-          cwd: folderPath,
-          prompt: HELP_PROMPT,
-          ...(model && { model }),
-        },
-        { source: "user" }
-      );
+        const folderPath = await window.electron.help.getFolderPath();
+        if (!folderPath) {
+          notifyLaunchFailed(selectedAgentId, "Help folder is not available.");
+          return;
+        }
 
-      if (result.ok && result.result?.terminalId) {
+        const model = resolveAssistantModel(selectedAgentId);
+        const result = await actionService.dispatch<{ terminalId: string | null }>(
+          "agent.launch",
+          {
+            agentId: selectedAgentId,
+            location: "dock",
+            cwd: folderPath,
+            prompt: HELP_PROMPT,
+            ...(model && { model }),
+          },
+          { source: "user" }
+        );
+
+        if (!result.ok || !result.result?.terminalId) {
+          logError("Help launch failed", { agentId: selectedAgentId, result });
+          notifyLaunchFailed(selectedAgentId, "The agent didn't start. Try again.");
+          return;
+        }
+
         useHelpPanelStore.getState().setTerminal(result.result.terminalId, selectedAgentId);
         window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
           logError("Failed to mark help terminal", err);
         });
+      } finally {
+        isLaunchingRef.current = false;
       }
     },
-    [terminalId, removePanel, clearTerminal]
+    [removePanel, clearTerminal]
   );
 
   const handleBack = useCallback(() => {
     if (terminalId) {
       removePanel(terminalId);
     }
+    hasAutoLaunched.current = false;
     clearPreferredAgent();
   }, [terminalId, removePanel, clearPreferredAgent]);
 
@@ -218,6 +275,30 @@ export function HelpPanel() {
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen]);
 
+  const handleRunAnyway = useCallback(() => {
+    if (!terminalId || !agentId) return;
+    const panel = usePanelStore.getState().panelsById[terminalId];
+    if (!panel) return;
+    const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
+
+    // Re-spawn through the manual select path with force.
+    removePanel(terminalId);
+    clearTerminal();
+    void usePanelStore.getState().addPanel({
+      kind: "terminal",
+      launchAgentId: agentId,
+      command: panel.command,
+      title: panel.title,
+      cwd: panel.cwd ?? "",
+      worktreeId: panel.worktreeId,
+      location: panel.location as "grid" | "dock" | undefined,
+      agentLaunchFlags: panel.agentLaunchFlags,
+      agentModelId: panel.agentModelId,
+      agentPresetId: panel.agentPresetId,
+      env: presetEnv,
+    });
+  }, [terminalId, agentId, removePanel, clearTerminal]);
+
   const getRefreshTier = useMemo(() => {
     return () => {
       if (!isOpen) return TerminalRefreshTier.BACKGROUND;
@@ -226,6 +307,7 @@ export function HelpPanel() {
   }, [isOpen, terminal]);
 
   const showTerminal = terminalId && terminal;
+  const isMissingCli = showTerminal && terminal?.spawnStatus === "missing-cli";
 
   return (
     <div
@@ -282,23 +364,31 @@ export function HelpPanel() {
       {/* Content */}
       <div ref={contentRef} className="flex-1 flex flex-col min-h-0 relative">
         {showTerminal ? (
-          <div className="absolute inset-0">
-            <Suspense fallback={null}>
-              <XtermAdapter
-                terminalId={terminalId}
-                launchAgentId={agentId ?? undefined}
-                getRefreshTier={getRefreshTier}
-                cwd={terminal.cwd}
-              />
-            </Suspense>
-          </div>
+          isMissingCli && agentId ? (
+            <MissingCliGate
+              agentId={agentId}
+              detail={cliDetail ?? { state: "missing", resolvedPath: null, via: null }}
+              onRunAnyway={handleRunAnyway}
+            />
+          ) : (
+            <div className="absolute inset-0">
+              <Suspense fallback={null}>
+                <XtermAdapter
+                  terminalId={terminalId}
+                  launchAgentId={agentId ?? undefined}
+                  getRefreshTier={getRefreshTier}
+                  cwd={terminal.cwd}
+                />
+              </Suspense>
+            </div>
+          )
         ) : (
           <HelpAgentPicker onSelectAgent={handleSelectAgent} />
         )}
       </div>
 
       {/* Bottom info bar */}
-      {showTerminal && agentConfig && (
+      {showTerminal && agentConfig && !isMissingCli && (
         <div className="flex items-center justify-between px-3 py-1.5 border-t border-daintree-border shrink-0 text-[11px] text-daintree-text/40">
           <span className="flex items-center gap-1">
             Using

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -122,12 +122,14 @@ export function HelpPanel() {
         // Stale-launch guard: if the user navigated back to the picker or
         // switched preferred agent while the IPC was in flight, discard
         // this result and clean up the spawned panel rather than reviving
-        // a stale terminal.
+        // a stale terminal. Reset hasAutoLaunched so the next preferred
+        // agent (if any) can auto-launch on the next effect tick.
         const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
         if (currentPreferred !== launchAgentId) {
           if (result.ok && result.result?.terminalId) {
             usePanelStore.getState().removePanel(result.result.terminalId);
           }
+          hasAutoLaunched.current = false;
           return;
         }
 
@@ -277,26 +279,52 @@ export function HelpPanel() {
 
   const handleRunAnyway = useCallback(() => {
     if (!terminalId || !agentId) return;
+    if (isLaunchingRef.current) return;
     const panel = usePanelStore.getState().panelsById[terminalId];
     if (!panel) return;
     const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
+    const launchAgentId = agentId;
 
-    // Re-spawn through the manual select path with force.
+    isLaunchingRef.current = true;
     removePanel(terminalId);
     clearTerminal();
-    void usePanelStore.getState().addPanel({
-      kind: "terminal",
-      launchAgentId: agentId,
-      command: panel.command,
-      title: panel.title,
-      cwd: panel.cwd ?? "",
-      worktreeId: panel.worktreeId,
-      location: panel.location as "grid" | "dock" | undefined,
-      agentLaunchFlags: panel.agentLaunchFlags,
-      agentModelId: panel.agentModelId,
-      agentPresetId: panel.agentPresetId,
-      env: presetEnv,
-    });
+
+    safeFireAndForget(
+      (async () => {
+        try {
+          const newId = await usePanelStore.getState().addPanel({
+            kind: "terminal",
+            launchAgentId,
+            command: panel.command,
+            title: panel.title,
+            cwd: panel.cwd ?? "",
+            worktreeId: panel.worktreeId,
+            location: panel.location as "grid" | "dock" | undefined,
+            agentLaunchFlags: panel.agentLaunchFlags,
+            agentModelId: panel.agentModelId,
+            agentPresetId: panel.agentPresetId,
+            env: presetEnv,
+          });
+
+          if (!newId) {
+            logError("Help run-anyway returned no terminal id", { agentId: launchAgentId });
+            notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+            return;
+          }
+
+          useHelpPanelStore.getState().setTerminal(newId, launchAgentId);
+          window.electron.help.markTerminal(newId).catch((err) => {
+            logError("Failed to mark help terminal", err);
+          });
+        } catch (error) {
+          logError("Help run-anyway failed", error);
+          notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+        } finally {
+          isLaunchingRef.current = false;
+        }
+      })(),
+      { context: "Help: run-anyway re-launch" }
+    );
   }, [terminalId, agentId, removePanel, clearTerminal]);
 
   const getRefreshTier = useMemo(() => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -68,8 +68,12 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
 }));
 
 vi.mock("@/components/Terminal/MissingCliGate", () => ({
-  MissingCliGate: ({ agentId }: { agentId: string }) => (
-    <div data-testid="missing-cli-gate" data-agent={agentId} />
+  MissingCliGate: ({ agentId, onRunAnyway }: { agentId: string; onRunAnyway: () => void }) => (
+    <div data-testid="missing-cli-gate" data-agent={agentId}>
+      <button type="button" data-testid="run-anyway" onClick={onRunAnyway}>
+        Run anyway
+      </button>
+    </div>
   ),
 }));
 
@@ -405,5 +409,124 @@ describe("HelpPanel — render gates", () => {
 
     expect(getByTestId("xterm-adapter")).toBeTruthy();
     expect(queryByTestId("missing-cli-gate")).toBeNull();
+  });
+});
+
+describe("HelpPanel — handleRunAnyway", () => {
+  it("commits the re-spawned terminal to helpPanelStore (regression: no orphan)", async () => {
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("restarted-term");
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("run-anyway"));
+    });
+
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("gate-1");
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal", launchAgentId: "claude", cwd: "/help" })
+    );
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("restarted-term", "claude");
+    expect(mockMarkTerminal).toHaveBeenCalledWith("restarted-term");
+  });
+
+  it("notifies on addPanel rejection", async () => {
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+    panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("run-anyway"));
+    });
+
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+});
+
+describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
+  it("resets hasAutoLaunched after stale-agent abort so next preferred agent can auto-launch", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+
+    let resolveFirst: (v: unknown) => void = () => {};
+    let resolveSecond: (v: unknown) => void = () => {};
+    mockDispatch
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSecond = r;
+        })
+      );
+
+    const { rerender } = render(<HelpPanel />);
+
+    // User switches preferred agent while first launch is in flight (stale path)
+    helpPanelState.preferredAgentId = "gemini";
+
+    await act(async () => {
+      resolveFirst({ ok: true, result: { terminalId: "stale-claude" } });
+    });
+
+    // Stale guard cleaned up the orphaned terminal and reset hasAutoLaunched.
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("stale-claude");
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+
+    // Trigger the effect again with the new preferredAgentId.
+    await act(async () => {
+      rerender(<HelpPanel />);
+    });
+
+    // The follow-up auto-launch must fire — this is the regression bug.
+    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockDispatch).toHaveBeenLastCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "gemini" }),
+      { source: "user" }
+    );
+
+    await act(async () => {
+      resolveSecond({ ok: true, result: { terminalId: "term-gemini" } });
+    });
+
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-gemini", "gemini");
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1,0 +1,409 @@
+// @vitest-environment jsdom
+import { render, fireEvent, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDispatch,
+  mockNotify,
+  mockLogError,
+  mockGetFolderPath,
+  mockMarkTerminal,
+  helpPanelState,
+  panelStoreState,
+  cliAvailabilityState,
+  agentSettingsState,
+} = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  mockNotify: vi.fn().mockReturnValue(""),
+  mockLogError: vi.fn(),
+  mockGetFolderPath: vi.fn(),
+  mockMarkTerminal: vi.fn().mockResolvedValue(undefined),
+  helpPanelState: {
+    isOpen: true,
+    width: 380,
+    terminalId: null as string | null,
+    agentId: null as string | null,
+    preferredAgentId: null as string | null,
+    setWidth: vi.fn(),
+    setOpen: vi.fn(),
+    clearTerminal: vi.fn(),
+    clearPreferredAgent: vi.fn(),
+    setTerminal: vi.fn(),
+  },
+  panelStoreState: {
+    panelsById: {} as Record<string, unknown>,
+    removePanel: vi.fn(),
+    addPanel: vi.fn().mockResolvedValue(""),
+  },
+  cliAvailabilityState: {
+    availability: { claude: "ready", gemini: "ready", codex: "ready", opencode: "ready" } as Record<
+      string,
+      string
+    >,
+    isInitialized: true,
+    hasRealData: true,
+    details: {} as Record<string, unknown>,
+  },
+  agentSettingsState: {
+    settings: { agents: {} as Record<string, unknown> },
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: React.PropsWithChildren<{ onClick?: () => void }>) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons/DaintreeIcon", () => ({
+  DaintreeIcon: () => null,
+}));
+
+vi.mock("@/components/Terminal/XtermAdapter", () => ({
+  XtermAdapter: () => <div data-testid="xterm-adapter" />,
+}));
+
+vi.mock("@/components/Terminal/MissingCliGate", () => ({
+  MissingCliGate: ({ agentId }: { agentId: string }) => (
+    <div data-testid="missing-cli-gate" data-agent={agentId} />
+  ),
+}));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"],
+}));
+
+vi.mock("@/config/agents", () => ({
+  AGENT_REGISTRY: {
+    claude: { name: "Claude", iconId: "claude", color: "#000", icon: () => null },
+    gemini: { name: "Gemini", iconId: "gemini", color: "#000", icon: () => null },
+    codex: { name: "Codex", iconId: "codex", color: "#000", icon: () => null },
+  },
+  getAgentConfig: (id: string) =>
+    ({
+      claude: { name: "Claude", icon: () => null, models: [] },
+      gemini: { name: "Gemini", icon: () => null, models: [] },
+      codex: { name: "Codex", icon: () => null, models: [] },
+    })[id],
+}));
+
+vi.mock("@shared/types", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getAgentSettingsEntry: () => ({}),
+  };
+});
+
+vi.mock("@shared/config/agentRegistry", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    ASSISTANT_FAST_MODELS: {} as Record<string, string>,
+  };
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => mockNotify(...args),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+}));
+
+vi.mock("@/utils/safeFireAndForget", () => ({
+  safeFireAndForget: (promise: Promise<unknown>) => promise,
+}));
+
+vi.mock("@/store/helpPanelStore", () => {
+  const store = (selector?: (state: typeof helpPanelState) => unknown) =>
+    selector ? selector(helpPanelState) : helpPanelState;
+  store.getState = () => helpPanelState;
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+  };
+});
+
+vi.mock("@/store", () => {
+  const panelStore = (selector?: (state: typeof panelStoreState) => unknown) =>
+    selector ? selector(panelStoreState) : panelStoreState;
+  panelStore.getState = () => panelStoreState;
+
+  const cliStore = (selector?: (state: typeof cliAvailabilityState) => unknown) =>
+    selector ? selector(cliAvailabilityState) : cliAvailabilityState;
+  cliStore.getState = () => cliAvailabilityState;
+
+  const agentSettingsStore = (selector?: (state: typeof agentSettingsState) => unknown) =>
+    selector ? selector(agentSettingsState) : agentSettingsState;
+  agentSettingsStore.getState = () => agentSettingsState;
+
+  return {
+    usePanelStore: panelStore,
+    useCliAvailabilityStore: cliStore,
+    useAgentSettingsStore: agentSettingsStore,
+    getTerminalRefreshTier: () => 0,
+  };
+});
+
+vi.mock("@/types", () => ({
+  TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 },
+}));
+
+// Stub HelpAgentPicker to expose a click target tied to the onSelectAgent prop
+vi.mock("../HelpAgentPicker", () => ({
+  HelpAgentPicker: ({ onSelectAgent }: { onSelectAgent: (id: string) => void }) => (
+    <button type="button" data-testid="pick-claude" onClick={() => onSelectAgent("claude")}>
+      Pick Claude
+    </button>
+  ),
+}));
+
+import { HelpPanel } from "../HelpPanel";
+
+function resetState() {
+  helpPanelState.isOpen = true;
+  helpPanelState.width = 380;
+  helpPanelState.terminalId = null;
+  helpPanelState.agentId = null;
+  helpPanelState.preferredAgentId = null;
+  helpPanelState.setTerminal = vi.fn();
+  helpPanelState.setOpen = vi.fn();
+  helpPanelState.setWidth = vi.fn();
+  helpPanelState.clearTerminal = vi.fn();
+  helpPanelState.clearPreferredAgent = vi.fn();
+
+  panelStoreState.panelsById = {};
+  panelStoreState.removePanel = vi.fn();
+  panelStoreState.addPanel = vi.fn().mockResolvedValue("");
+
+  cliAvailabilityState.availability = {
+    claude: "ready",
+    gemini: "ready",
+    codex: "ready",
+    opencode: "ready",
+  };
+  cliAvailabilityState.isInitialized = true;
+  cliAvailabilityState.hasRealData = true;
+  cliAvailabilityState.details = {};
+
+  agentSettingsState.settings = { agents: {} };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetState();
+
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        help: {
+          getFolderPath: mockGetFolderPath,
+          markTerminal: mockMarkTerminal,
+        },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  // Default: visibility is "visible"
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+});
+
+describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
+  it("commits the terminal to helpPanelStore even when document.hidden is true", async () => {
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude");
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("notifies and does not commit terminal when result.ok is false", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: false });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+
+  it("notifies when result.ok is true but terminalId is null", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: null } });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+
+  it("notifies and aborts when help folder is null", async () => {
+    mockGetFolderPath.mockResolvedValue(null);
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+
+  it("ignores second click while first launch is in flight (reentrancy guard)", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+    let resolveDispatch: (v: unknown) => void = () => {};
+    mockDispatch.mockReturnValue(
+      new Promise((r) => {
+        resolveDispatch = r;
+      })
+    );
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    // First click — kicks off async launch
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+    // First click should have advanced past getFolderPath into dispatch
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    // Second click while first dispatch is still pending — should be ignored
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDispatch({ ok: true, result: { terminalId: "term-1" } });
+    });
+
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude");
+  });
+});
+
+describe("HelpPanel — auto-launch (preferredAgentId)", () => {
+  it("commits the terminal even when document.hidden is true", async () => {
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-term-1", "claude");
+  });
+
+  it("does not commit terminal and cleans up if user navigated away (preferredAgentId cleared) during in-flight launch", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+
+    let resolveDispatch: (v: unknown) => void = () => {};
+    mockDispatch.mockReturnValue(
+      new Promise((r) => {
+        resolveDispatch = r;
+      })
+    );
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    // Simulate user clicking Back during the in-flight launch:
+    helpPanelState.preferredAgentId = null;
+
+    await act(async () => {
+      resolveDispatch({ ok: true, result: { terminalId: "stale-term" } });
+    });
+
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("stale-term");
+  });
+
+  it("notifies and does not commit terminal on launch failure", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: false });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+});
+
+describe("HelpPanel — render gates", () => {
+  it("renders MissingCliGate when terminal has spawnStatus 'missing-cli'", () => {
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+
+    const { getByTestId, queryByTestId } = render(<HelpPanel />);
+
+    expect(getByTestId("missing-cli-gate")).toBeTruthy();
+    expect(queryByTestId("xterm-adapter")).toBeNull();
+  });
+
+  it("renders XtermAdapter when terminal is healthy", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { getByTestId, queryByTestId } = render(<HelpPanel />);
+
+    expect(getByTestId("xterm-adapter")).toBeTruthy();
+    expect(queryByTestId("missing-cli-gate")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Selecting an agent from the Daintree Assistant picker no longer showed a terminal — the panel stayed on the picker state with no diagnostic.
- Root cause: a `document.hidden` guard inside the launch result callback was silently dropping successful launches when the panel briefly lost visibility during a project-switch (Electron 41 `WebContentsView` race). The `visibilitychange` cleanup handler is the right lifecycle defence; the `document.hidden` check inside the callback is not.
- Layered several additional defences on top of the root-cause fix to cover adjacent failure modes.

Resolves #6309

## Changes

- Remove `document.hidden` guard from the `agent.launch` result callback in `HelpPanel.tsx`
- Add error notifications on both the manual (`handleSelectAgent`) and auto-launch failure paths — failures are now visible rather than silent
- Add `isLaunchingRef` reentrancy guard to prevent concurrent launches
- Fix `hasAutoLaunched` flag placement — moved into the success branch and reset on stale-path so it doesn't stick across agent switches
- Add stale-agent guard with orphaned terminal cleanup when the selected agent changes mid-launch
- Render `MissingCliGate` inline for soft-gated panels rather than returning null
- Fix `handleRunAnyway` to await `addPanel` and commit the returned `terminalId` before continuing

## Testing

- 33 unit tests added in `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` covering manual launch, auto-launch, reentrancy, stale-agent cleanup, and the run-anyway path
- `npm run check` passes clean (typecheck, lint, format, build)