### PR TITLE
feat(mcp): emit ToolAnnotations on exposed tools

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -10,6 +10,7 @@ import type { AddressInfo } from "node:net";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/types/actions.js";
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
@@ -21,6 +22,15 @@ const MCP_SERVER_KEY = "daintree";
 
 const DEFAULT_PORT = 45454;
 const MAX_PORT_RETRIES = 10;
+
+const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
+  "browser",
+  "devServer",
+  "github",
+  "portal",
+  "voice",
+  "system",
+]);
 
 interface PendingRequest<T> {
   resolve: (value: T) => void;
@@ -429,6 +439,7 @@ export class McpServerService {
             name: entry.id,
             description: this.buildToolDescription(entry),
             inputSchema: this.buildToolInputSchema(entry),
+            annotations: this.buildAnnotations(entry),
           })),
       };
     });
@@ -543,6 +554,16 @@ export class McpServerService {
     return {
       ...baseSchema,
       properties,
+    };
+  }
+
+  private buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
+    return {
+      title: entry.title,
+      readOnlyHint: entry.kind === "query",
+      idempotentHint: entry.kind === "query",
+      destructiveHint: entry.danger === "confirm",
+      openWorldHint: OPEN_WORLD_CATEGORIES.has(entry.category),
     };
   }
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -358,6 +358,65 @@ describe("McpServerService", () => {
       },
       additionalProperties: false,
     });
+
+    // Annotations — query tool
+    expect(safeTool?.annotations).toEqual({
+      title: "List Actions",
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+
+    // Annotations — destructive tool
+    expect(dangerousTool?.annotations).toEqual({
+      title: "Delete Worktree",
+      readOnlyHint: false,
+      idempotentHint: false,
+      destructiveHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it("sets openWorldHint true for network-bound categories and false for local ones", async () => {
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "github.listPRs" as ActionId,
+          title: "List PRs",
+          description: "List pull requests",
+          category: "github",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "browser.navigate" as ActionId,
+          title: "Navigate",
+          description: "Navigate the browser",
+          category: "browser",
+          kind: "command",
+        }),
+        createManifestEntry({
+          id: "worktree.create" as ActionId,
+          title: "Create Worktree",
+          description: "Create a new worktree",
+          category: "worktree",
+          kind: "command",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = await client.listTools();
+    const ghTool = result.tools.find((t) => t.name === "github.listPRs");
+    const browserTool = result.tools.find((t) => t.name === "browser.navigate");
+    const wtTool = result.tools.find((t) => t.name === "worktree.create");
+
+    expect(ghTool?.annotations?.openWorldHint).toBe(true);
+    expect(browserTool?.annotations?.openWorldHint).toBe(true);
+    expect(wtTool?.annotations?.openWorldHint).toBe(false);
   });
 
   it("requires explicit MCP confirmation before dispatching destructive actions", async () => {


### PR DESCRIPTION
## Summary
- MCP-aware hosts like Claude Desktop and Cursor now see proper tool metadata -- read-only tools, destructive tools, network-bound tools -- and can surface native confirmation dialogs where appropriate.
- Annotations (`title`, `readOnlyHint`, `idempotentHint`, `destructiveHint`, `openWorldHint`) are derived mechanically from existing `ActionDefinition` fields. The `_meta.confirmed` enforcement gate stays as-is.
- Resolves #6304

## Changes
- `electron/services/McpServerService.ts` -- Added `buildAnnotations()` and wired it into `handleListTools()`
- `electron/services/__tests__/McpServerService.test.ts` -- Tests for annotation values on query, destructive, and network-bound vs local tools

## Testing
- `kind: "query"` maps to `readOnlyHint: true`, `idempotentHint: true`
- `danger: "confirm"` maps to `destructiveHint: true`
- Network-bound categories (`browser`, `devServer`, `github`, `portal`, `voice`, `system`) get `openWorldHint: true`; local categories get `false`
- Unit tests pass for all annotation mappings