### PR TITLE
feat(mcp): shrink default tool surface to curated allowlist

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -590,7 +590,7 @@ export class McpServerService {
     if (entry.danger === "restricted") {
       return false;
     }
-    if (this.getConfig().fullToolSurface ?? false) {
+    if (this.getConfig().fullToolSurface === true) {
       return true;
     }
     return MCP_TOOL_ALLOWLIST.has(entry.id);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -32,6 +32,84 @@ const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "system",
 ]);
 
+// Curated set of action IDs advertised over MCP by default. Keeps the tool
+// surface small enough for `tool_choice: "auto"` reliability and bounded
+// token cost while still covering the agent-facing introspection,
+// query, and command actions. Power users opt into the full surface via
+// `mcpServer.fullToolSurface = true`. Dispatch is not gated by this list —
+// callers that already know an ID can still invoke it.
+const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
+  "actions.list",
+  "actions.getContext",
+
+  "agent.launch",
+  "agent.terminal",
+  "agent.focusNextWaiting",
+  "agent.focusNextWorking",
+
+  "git.getProjectPulse",
+  "git.getFileDiff",
+  "git.listCommits",
+  "git.getStagingStatus",
+  "git.stageFile",
+  "git.unstageFile",
+  "git.stageAll",
+  "git.unstageAll",
+  "git.commit",
+  "git.push",
+  "git.snapshotGet",
+  "git.snapshotList",
+
+  "github.checkCli",
+  "github.getRepoStats",
+  "github.listIssues",
+  "github.listPullRequests",
+  "github.openIssue",
+  "github.openPR",
+
+  "terminal.list",
+  "terminal.getOutput",
+  "terminal.sendCommand",
+  "terminal.bulkCommand",
+  "terminal.inject",
+  "terminal.new",
+
+  "worktree.list",
+  "worktree.getCurrent",
+  "worktree.refresh",
+  "worktree.create",
+  "worktree.createWithRecipe",
+  "worktree.listBranches",
+  "worktree.getDefaultPath",
+  "worktree.getAvailableBranch",
+  "worktree.delete",
+  "worktree.setActive",
+  "worktree.resource.status",
+
+  "files.search",
+  "file.view",
+  "file.openInEditor",
+
+  "copyTree.isAvailable",
+  "copyTree.generate",
+  "copyTree.generateAndCopyFile",
+  "copyTree.injectToTerminal",
+
+  "slashCommands.list",
+
+  "project.getAll",
+  "project.getCurrent",
+  "project.getSettings",
+  "project.getStats",
+  "project.detectRunners",
+
+  "recipe.list",
+  "recipe.run",
+
+  "system.checkCommand",
+  "system.checkDirectory",
+]);
+
 interface PendingRequest<T> {
   resolve: (value: T) => void;
   reject: (err: Error) => void;
@@ -434,7 +512,7 @@ export class McpServerService {
       const manifest = await this.requestManifest();
       return {
         tools: manifest
-          .filter((entry) => entry.danger !== "restricted")
+          .filter((entry) => this.shouldExposeTool(entry))
           .map((entry) => ({
             name: entry.id,
             description: this.buildToolDescription(entry),
@@ -506,6 +584,16 @@ export class McpServerService {
     if (!apiKey) return true;
     const auth = req.headers.authorization ?? "";
     return auth === `Bearer ${apiKey}`;
+  }
+
+  private shouldExposeTool(entry: ActionManifestEntry): boolean {
+    if (entry.danger === "restricted") {
+      return false;
+    }
+    if (this.getConfig().fullToolSurface ?? false) {
+      return true;
+    }
+    return MCP_TOOL_ALLOWLIST.has(entry.id);
   }
 
   private buildToolDescription(entry: ActionManifestEntry): string {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -639,6 +639,33 @@ describe("McpServerService", () => {
     expect(ids).not.toContain("internal.dangerous");
   });
 
+  it("treats non-true fullToolSurface values as curated (fail-closed)", async () => {
+    (storeState.mcpServer as { fullToolSurface: unknown }).fullToolSurface = "false";
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "panel.gridLayout.setStrategy" as ActionId,
+          title: "Set grid layout",
+          description: "UI plumbing",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const ids = (await client.listTools()).tools.map((tool) => tool.name);
+    expect(ids).toContain("actions.list");
+    expect(ids).not.toContain("panel.gridLayout.setStrategy");
+  });
+
   it("dispatches non-allowlisted actions even in curated mode", async () => {
     const dispatchMock = vi.fn(
       (payload: DispatchRequest): ActionDispatchResult => ({

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -65,6 +65,7 @@ const storeState = vi.hoisted(() => ({
     enabled: true,
     port: 0,
     apiKey: "",
+    fullToolSurface: false,
   },
 }));
 
@@ -283,6 +284,7 @@ describe("McpServerService", () => {
       enabled: true,
       port: 0,
       apiKey: "",
+      fullToolSurface: false,
     };
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
@@ -571,6 +573,111 @@ describe("McpServerService", () => {
       "MCP renderer bridge unavailable"
     );
     expect(webContents.send).not.toHaveBeenCalled();
+  });
+
+  it("hides non-allowlisted tools by default (curated MCP surface)", async () => {
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "panel.gridLayout.setStrategy" as ActionId,
+          title: "Set grid layout",
+          description: "UI plumbing — should not appear in curated surface",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = await client.listTools();
+    const ids = result.tools.map((tool) => tool.name);
+
+    expect(ids).toContain("actions.list");
+    expect(ids).not.toContain("panel.gridLayout.setStrategy");
+  });
+
+  it("exposes the full non-restricted surface when fullToolSurface is enabled", async () => {
+    storeState.mcpServer.fullToolSurface = true;
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "panel.gridLayout.setStrategy" as ActionId,
+          title: "Set grid layout",
+          description: "Power-user UI plumbing",
+        }),
+        createManifestEntry({
+          id: "internal.dangerous" as ActionId,
+          title: "Restricted",
+          description: "Should never be advertised",
+          danger: "restricted",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = await client.listTools();
+    const ids = result.tools.map((tool) => tool.name);
+
+    expect(ids).toContain("actions.list");
+    expect(ids).toContain("panel.gridLayout.setStrategy");
+    expect(ids).not.toContain("internal.dangerous");
+  });
+
+  it("dispatches non-allowlisted actions even in curated mode", async () => {
+    const dispatchMock = vi.fn(
+      (payload: DispatchRequest): ActionDispatchResult => ({
+        ok: true,
+        result: { dispatched: payload.actionId },
+      })
+    );
+
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const ids = (await client.listTools()).tools.map((tool) => tool.name);
+    expect(ids).not.toContain("panel.gridLayout.setStrategy");
+
+    const result = getTextResult(
+      await client.callTool({
+        name: "panel.gridLayout.setStrategy",
+        arguments: { strategy: "automatic" },
+      })
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0].text).toContain('"dispatched": "panel.gridLayout.setStrategy"');
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ actionId: "panel.gridLayout.setStrategy" })
+    );
   });
 
   it("returns safe text output for circular tool results", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -188,6 +188,7 @@ export interface StoreSchema {
     enabled: boolean;
     port: number | null;
     apiKey: string;
+    fullToolSurface: boolean;
   };
   pendingErrors: ErrorRecord[];
   gpu: {
@@ -325,6 +326,7 @@ const storeOptions = {
       enabled: false,
       port: 45454,
       apiKey: "",
+      fullToolSurface: false,
     },
     pendingErrors: [],
     gpu: {


### PR DESCRIPTION
## Summary

- The MCP server was advertising ~380 registered actions to LLM clients — well past the ~50-tool threshold where `tool_choice: "auto"` accuracy degrades and tool definitions alone consume 60-90k tokens of input context
- Adds `MCP_TOOL_ALLOWLIST` (~55 curated action IDs across introspection, agent, git, GitHub, terminal, worktree, files, project, recipes, and system) and a `shouldExposeTool()` method that gates the manifest assembly
- A `fullToolSurface` config flag lets power users opt back into the full registry; `restricted` actions are always hidden regardless of the flag

Resolves #6301

## Changes

- `electron/services/McpServerService.ts` — `MCP_TOOL_ALLOWLIST` constant and `shouldExposeTool()` replacing the previous `danger !== "restricted"` filter in the `ListToolsRequestSchema` handler
- `electron/store.ts` — `fullToolSurface: boolean` added to `StoreSchema.mcpServer` (defaults to `false`)
- `electron/services/__tests__/McpServerService.test.ts` — 4 new tests: curated mode, full mode (restricted still hidden), dispatch independence, and fail-closed on malformed config

## Testing

- 10/10 unit tests pass including the 4 new cases
- Typecheck, lint ratchet (-2 warnings net), format, and build all clean
- No UI changes; settings UI is a follow-up if requested