### PR TITLE
fix(worktree): migrate navigation handler to modern Event<T> signature

### DIFF
--- a/electron/services/WorktreePortBroker.ts
+++ b/electron/services/WorktreePortBroker.ts
@@ -67,8 +67,7 @@ export class WorktreePortBroker {
       this.closePortsForView(wcId);
     };
     const onNavigation = (
-      _event: Electron.Event,
-      details: Electron.WebContentsDidStartNavigationEventParams
+      details: Electron.Event<Electron.WebContentsDidStartNavigationEventParams>
     ) => {
       if (details.isMainFrame && !details.isSameDocument && !webContents.isDestroyed()) {
         this.closePortsForView(wcId);

--- a/electron/services/WorktreePortBroker.ts
+++ b/electron/services/WorktreePortBroker.ts
@@ -68,13 +68,9 @@ export class WorktreePortBroker {
     };
     const onNavigation = (
       _event: Electron.Event,
-      _url: string,
-      isInPlace: boolean,
-      isMainFrame: boolean
+      details: Electron.WebContentsDidStartNavigationEventParams
     ) => {
-      // Only handle top-level navigations, not in-place (hash) changes
-      if (isMainFrame && !isInPlace && !webContents.isDestroyed()) {
-        // Close old port — the new page load will trigger a re-broker via onViewReady
+      if (details.isMainFrame && !details.isSameDocument && !webContents.isDestroyed()) {
         this.closePortsForView(wcId);
       }
     };

--- a/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
+++ b/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
@@ -153,6 +153,129 @@ describe("WorktreePortBroker adversarial", () => {
     expect(broker.hasPort(secondView.id)).toBe(false);
   });
 
+  it("closes the port on cross-document main-frame navigation", () => {
+    const broker = new WorktreePortBroker();
+    const host = createHost();
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
+    const channel = createdChannels[0];
+
+    webContents.emit(
+      "did-start-navigation",
+      {},
+      {
+        url: "https://example.com/new-page",
+        isSameDocument: false,
+        isMainFrame: true,
+        frame: null,
+      }
+    );
+
+    expect(channel.port1.close).toHaveBeenCalledTimes(1);
+    expect(broker.hasPort(webContents.id)).toBe(false);
+  });
+
+  it("does not close the port on same-document main-frame navigation", () => {
+    const broker = new WorktreePortBroker();
+    const host = createHost();
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
+    const channel = createdChannels[0];
+
+    webContents.emit(
+      "did-start-navigation",
+      {},
+      {
+        url: "https://example.com/#section",
+        isSameDocument: true,
+        isMainFrame: true,
+        frame: null,
+      }
+    );
+
+    expect(channel.port1.close).not.toHaveBeenCalled();
+    expect(broker.hasPort(webContents.id)).toBe(true);
+  });
+
+  it("does not close the port on sub-frame navigation", () => {
+    const broker = new WorktreePortBroker();
+    const host = createHost();
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
+    const channel = createdChannels[0];
+
+    webContents.emit(
+      "did-start-navigation",
+      {},
+      {
+        url: "https://example.com/iframe-content",
+        isSameDocument: false,
+        isMainFrame: false,
+        frame: null,
+      }
+    );
+
+    expect(channel.port1.close).not.toHaveBeenCalled();
+    expect(broker.hasPort(webContents.id)).toBe(true);
+  });
+
+  it("handles navigation after webContents is destroyed without throwing", () => {
+    const broker = new WorktreePortBroker();
+    const host = createHost();
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
+
+    webContents.setDestroyed(true);
+    webContents.emit("destroyed");
+
+    expect(() => {
+      webContents.emit(
+        "did-start-navigation",
+        {},
+        {
+          url: "https://example.com/late-navigation",
+          isSameDocument: false,
+          isMainFrame: true,
+          frame: null,
+        }
+      );
+    }).not.toThrow();
+  });
+
+  it("does not close view B port when view A navigates cross-document", () => {
+    const broker = new WorktreePortBroker();
+    const host = createHost("/tmp/shared-project");
+    const viewA = createWebContents();
+    const viewB = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(viewA))).toBe(true);
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(viewB))).toBe(true);
+
+    const channelA = createdChannels[0];
+    const channelB = createdChannels[1];
+
+    viewA.emit(
+      "did-start-navigation",
+      {},
+      {
+        url: "https://example.com/new-page",
+        isSameDocument: false,
+        isMainFrame: true,
+        frame: null,
+      }
+    );
+
+    expect(channelA.port1.close).toHaveBeenCalledTimes(1);
+    expect(broker.hasPort(viewA.id)).toBe(false);
+
+    expect(channelB.port1.close).not.toHaveBeenCalled();
+    expect(broker.hasPort(viewB.id)).toBe(true);
+  });
+
   it("cleans up the active port when a renderer crashes after brokering", () => {
     const broker = new WorktreePortBroker();
     const host = createHost();

--- a/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
+++ b/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
@@ -161,16 +161,14 @@ describe("WorktreePortBroker adversarial", () => {
     expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
     const channel = createdChannels[0];
 
-    webContents.emit(
-      "did-start-navigation",
-      {},
-      {
-        url: "https://example.com/new-page",
-        isSameDocument: false,
-        isMainFrame: true,
-        frame: null,
-      }
-    );
+    webContents.emit("did-start-navigation", {
+      url: "https://example.com/new-page",
+      isSameDocument: false,
+      isMainFrame: true,
+      frame: null,
+      preventDefault: () => {},
+      defaultPrevented: false,
+    });
 
     expect(channel.port1.close).toHaveBeenCalledTimes(1);
     expect(broker.hasPort(webContents.id)).toBe(false);
@@ -184,16 +182,14 @@ describe("WorktreePortBroker adversarial", () => {
     expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
     const channel = createdChannels[0];
 
-    webContents.emit(
-      "did-start-navigation",
-      {},
-      {
-        url: "https://example.com/#section",
-        isSameDocument: true,
-        isMainFrame: true,
-        frame: null,
-      }
-    );
+    webContents.emit("did-start-navigation", {
+      url: "https://example.com/#section",
+      isSameDocument: true,
+      isMainFrame: true,
+      frame: null,
+      preventDefault: () => {},
+      defaultPrevented: false,
+    });
 
     expect(channel.port1.close).not.toHaveBeenCalled();
     expect(broker.hasPort(webContents.id)).toBe(true);
@@ -207,16 +203,14 @@ describe("WorktreePortBroker adversarial", () => {
     expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
     const channel = createdChannels[0];
 
-    webContents.emit(
-      "did-start-navigation",
-      {},
-      {
-        url: "https://example.com/iframe-content",
-        isSameDocument: false,
-        isMainFrame: false,
-        frame: null,
-      }
-    );
+    webContents.emit("did-start-navigation", {
+      url: "https://example.com/iframe-content",
+      isSameDocument: false,
+      isMainFrame: false,
+      frame: null,
+      preventDefault: () => {},
+      defaultPrevented: false,
+    });
 
     expect(channel.port1.close).not.toHaveBeenCalled();
     expect(broker.hasPort(webContents.id)).toBe(true);
@@ -233,16 +227,14 @@ describe("WorktreePortBroker adversarial", () => {
     webContents.emit("destroyed");
 
     expect(() => {
-      webContents.emit(
-        "did-start-navigation",
-        {},
-        {
-          url: "https://example.com/late-navigation",
-          isSameDocument: false,
-          isMainFrame: true,
-          frame: null,
-        }
-      );
+      webContents.emit("did-start-navigation", {
+        url: "https://example.com/late-navigation",
+        isSameDocument: false,
+        isMainFrame: true,
+        frame: null,
+        preventDefault: () => {},
+        defaultPrevented: false,
+      });
     }).not.toThrow();
   });
 
@@ -258,16 +250,14 @@ describe("WorktreePortBroker adversarial", () => {
     const channelA = createdChannels[0];
     const channelB = createdChannels[1];
 
-    viewA.emit(
-      "did-start-navigation",
-      {},
-      {
-        url: "https://example.com/new-page",
-        isSameDocument: false,
-        isMainFrame: true,
-        frame: null,
-      }
-    );
+    viewA.emit("did-start-navigation", {
+      url: "https://example.com/new-page",
+      isSameDocument: false,
+      isMainFrame: true,
+      frame: null,
+      preventDefault: () => {},
+      defaultPrevented: false,
+    });
 
     expect(channelA.port1.close).toHaveBeenCalledTimes(1);
     expect(broker.hasPort(viewA.id)).toBe(false);


### PR DESCRIPTION
## Summary
- Migrated the `did-start-navigation` listener in `WorktreePortBroker` from Electron's older positional callback signature to the single-arg `Event<T>` shape, matching the documented Electron 41 API.
- Added adversarial tests covering cross-document navigation, same-document navigation, sub-frame navigation, destroyed-state safety, and per-view isolation.

Resolves #6300

## Changes
- `electron/services/WorktreePortBroker.ts` -- switched `onNavigation` from `(_event, _url, isInPlace, isMainFrame)` to `(details)` using `Electron.WebContentsDidStartNavigationEventParams`, and updated the filter to `details.isMainFrame && !details.isSameDocument`.
- `electron/services/__tests__/WorktreePortBroker.adversarial.test.ts` -- added 5 test cases: port closes on cross-document main-frame navigation, port stays open on same-document and sub-frame navigation, no throw when navigation fires after destroy, and navigation on one view doesn't affect another.

## Testing
- All 10 adversarial tests pass.
- Typecheck, ESLint, Prettier all clean.