### PR TITLE
perf(projectview): polish deactivation sequence

### DIFF
--- a/e2e/nightly/nightly-evicted-view-leak.spec.ts
+++ b/e2e/nightly/nightly-evicted-view-leak.spec.ts
@@ -94,10 +94,9 @@ test.describe.serial("Nightly: Evicted project view leak detection", () => {
       pvm?.setCachedViewLimit(1);
     });
 
-    // Poll until eviction completes. GC_DELAY_MS in ProjectViewManager is
-    // 100ms but webContents.close() can be slower on loaded CI runners — a
-    // fixed sleep races there. Re-read state until the evicted view is gone
-    // or we hit a meaningful timeout.
+    // Poll until eviction completes. webContents.close() can be slower on
+    // loaded CI runners — a fixed sleep races there. Re-read state until the
+    // evicted view is gone or we hit a meaningful timeout.
     const readEvictionState = () =>
       app.evaluate(({ webContents }, wcId) => {
         const g = globalThis as Record<string, unknown>;

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -362,9 +362,13 @@ export class ProjectViewManager {
       }
       current.view.webContents.setBackgroundThrottling(true);
 
-      // Flush pending DOMStorage writes (fire-and-forget — view stays alive in
+      // Flush pending DOMStorage writes (synchronous — view stays alive in
       // cache, so data loss is not a concern)
-      current.view.webContents.session.flushStorageData().catch(() => {});
+      try {
+        current.view.webContents.session.flushStorageData();
+      } catch {
+        // Renderer may have torn down between the isDestroyed check and this call
+      }
 
       // Release back-forward history entries to free associated DOM/JS state
       try {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -33,7 +33,6 @@ import {
 } from "./rendererConsoleCapture.js";
 import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 
-const GC_DELAY_MS = 100;
 const LOAD_TIMEOUT_MS = 10_000;
 const CRASH_LOOP_WINDOW_MS = 60_000;
 const CRASH_LOOP_THRESHOLD = 3;
@@ -363,25 +362,35 @@ export class ProjectViewManager {
       }
       current.view.webContents.setBackgroundThrottling(true);
 
-      // Trigger V8 GC after a short delay to reclaim orphaned heap from
-      // unmounted React components, stale closures, and detached DOM.
-      // The delay lets React's unmount microtasks flush before collection.
+      // Flush pending DOMStorage writes (fire-and-forget — view stays alive in
+      // cache, so data loss is not a concern)
+      current.view.webContents.session.flushStorageData().catch(() => {});
+
+      // Release back-forward history entries to free associated DOM/JS state
+      try {
+        current.view.webContents.navigationHistory.clear();
+      } catch {
+        // Renderer may have torn down between the isDestroyed check and this call
+      }
+
+      // Trigger V8 GC during idle callbacks so the call doesn't synchronously
+      // block the renderer. The timeout (1s) guarantees it runs even under
+      // background throttling.
       const capturedProjectId = current.projectId;
       const { view, webContents } = { view: current.view, webContents: current.view.webContents };
-      setTimeout(() => {
-        const liveEntry = this.views.get(capturedProjectId);
-        if (
-          liveEntry &&
-          liveEntry.view === view &&
-          liveEntry.state === "cached" &&
-          !webContents.isDestroyed()
-        ) {
-          webContents.executeJavaScript("window.gc && window.gc()").catch(() => {
-            // Intentional: V8 GC is best-effort — failure (no --js-flags=--expose-gc,
-            // destroyed context) is harmless and noisy if logged.
-          });
-        }
-      }, GC_DELAY_MS);
+      const liveEntry = this.views.get(capturedProjectId);
+      if (
+        liveEntry &&
+        liveEntry.view === view &&
+        liveEntry.state === "cached" &&
+        !webContents.isDestroyed()
+      ) {
+        webContents
+          .executeJavaScript(
+            "requestIdleCallback(() => { if (window.gc) window.gc(); }, { timeout: 1000 })"
+          )
+          .catch(() => {});
+      }
     }
   }
 

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -41,7 +41,7 @@ function createMockWebContents(options?: { autoFinishLoad?: boolean }): MockWebC
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
-    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    session: { flushStorageData: vi.fn() },
     navigationHistory: { clear: vi.fn() },
     on: vi.fn((_event: string, _handler: Handler) => undefined),
     once: vi.fn((event: string, handler: Handler) => {

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -14,6 +14,8 @@ interface MockWebContents {
   close: ReturnType<typeof vi.fn>;
   reload: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
+  session: { flushStorageData: ReturnType<typeof vi.fn> };
+  navigationHistory: { clear: ReturnType<typeof vi.fn> };
   on: ReturnType<typeof vi.fn>;
   once: ReturnType<typeof vi.fn>;
   removeListener: ReturnType<typeof vi.fn>;
@@ -39,6 +41,8 @@ function createMockWebContents(options?: { autoFinishLoad?: boolean }): MockWebC
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
+    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    navigationHistory: { clear: vi.fn() },
     on: vi.fn((_event: string, _handler: Handler) => undefined),
     once: vi.fn((event: string, handler: Handler) => {
       const list = handlers.get(event) ?? [];
@@ -148,13 +152,12 @@ function createMockWindow() {
 
 describe("ProjectViewManager adversarial", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
     nextWebContentsId = 300;
     wcQueue.length = 0;
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    wcQueue.length = 0;
   });
 
   it("serializes rapid A→B→A→B switches within one tick without duplicating views", async () => {
@@ -188,7 +191,7 @@ describe("ProjectViewManager adversarial", () => {
     ).toEqual(["proj-a", "proj-b"]);
   });
 
-  it("skips deferred GC when a cached view is evicted by a subsequent switch before the timer fires", async () => {
+  it("requests GC immediately on deactivation, even when the view is evicted by a later switch", async () => {
     const win = createMockWindow();
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -204,13 +207,19 @@ describe("ProjectViewManager adversarial", () => {
 
     wcQueue.push(createMockWebContents(), createMockWebContents());
 
+    // Switch to B — deactivates A, GC requested immediately
     await manager.switchTo("proj-b", "/b");
+    expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
+    expect(initialWc.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("requestIdleCallback")
+    );
+
+    // Switch to C — evicts A (LRU, cache limit 2)
     await manager.switchTo("proj-c", "/c");
 
-    vi.advanceTimersByTime(100);
-
     expect(initialWc.close).toHaveBeenCalledTimes(1);
-    expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
+    // executeJavaScript was already called during deactivation — not called again on eviction
+    expect(initialWc.executeJavaScript).toHaveBeenCalledTimes(1);
     expect(manager.getActiveProjectId()).toBe("proj-c");
   });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -20,7 +20,7 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
-    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    session: { flushStorageData: vi.fn() },
     navigationHistory: { clear: vi.fn() },
     getOSProcessId: vi.fn(() => osPid),
     on: vi.fn((event: string, handler: Handler) => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -20,6 +20,8 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
+    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    navigationHistory: { clear: vi.fn() },
     getOSProcessId: vi.fn(() => osPid),
     on: vi.fn((event: string, handler: Handler) => {
       const list = handlers.get(event) ?? [];

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 let nextWebContentsId = 100;
 
@@ -14,7 +14,7 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
-    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    session: { flushStorageData: vi.fn() },
     navigationHistory: { clear: vi.fn() },
     on: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => {}),
     once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -169,12 +169,14 @@ describe("ProjectViewManager — GC on deactivate", () => {
     expect(initialWc.session.flushStorageData).toHaveBeenCalledOnce();
   });
 
-  it("does not throw when flushStorageData rejects", async () => {
-    initialWc.session.flushStorageData.mockRejectedValue(new Error("session gone"));
+  it("does not throw when flushStorageData throws", async () => {
+    initialWc.session.flushStorageData.mockImplementation(() => {
+      throw new Error("session gone");
+    });
 
     await expect(manager.switchTo("proj-b", "/path/b")).resolves.toBeDefined();
     expect(initialWc.session.flushStorageData).toHaveBeenCalledOnce();
-    // navigationHistory.clear should still fire despite flushStorageData rejection
+    // navigationHistory.clear should still fire despite flushStorageData throwing
     expect(initialWc.navigationHistory.clear).toHaveBeenCalledOnce();
   });
 

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -14,6 +14,8 @@ function createMockWebContents() {
     close: vi.fn(),
     reload: vi.fn(),
     send: vi.fn(),
+    session: { flushStorageData: vi.fn(() => Promise.resolve()) },
+    navigationHistory: { clear: vi.fn() },
     on: vi.fn((_event: string, _handler: (...args: unknown[]) => void) => {}),
     once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       if (event === "did-finish-load") {
@@ -107,7 +109,6 @@ describe("ProjectViewManager — GC on deactivate", () => {
   let initialWc: ReturnType<typeof createMockWebContents>;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     nextWebContentsId = 100;
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, { dirname: "/test", cachedProjectViews: 2 });
@@ -118,51 +119,39 @@ describe("ProjectViewManager — GC on deactivate", () => {
     manager.registerInitialView(initialView as never, "proj-a", "/path/a");
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("does not trigger GC before 100ms, triggers exactly at 100ms", async () => {
+  it("triggers GC via requestIdleCallback immediately on deactivation", async () => {
     await manager.switchTo("proj-b", "/path/b");
 
-    vi.advanceTimersByTime(99);
-    expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(1);
     expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
-    expect(initialWc.executeJavaScript).toHaveBeenCalledWith("window.gc && window.gc()");
+    expect(initialWc.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("requestIdleCallback")
+    );
+    expect(initialWc.executeJavaScript).toHaveBeenCalledWith(expect.stringContaining("window.gc"));
+    expect(initialWc.executeJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("timeout: 1000")
+    );
   });
 
-  it("skips GC if webContents is destroyed when timer fires", async () => {
-    await manager.switchTo("proj-b", "/path/b");
-
+  it("skips GC when webContents is destroyed at the outer guard", async () => {
     initialWc.isDestroyed.mockReturnValue(true);
-    vi.advanceTimersByTime(100);
+    await manager.switchTo("proj-b", "/path/b");
 
     expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
   });
 
-  it("skips GC if view was reactivated (state no longer cached)", async () => {
-    // Deactivate proj-a by switching to proj-b
+  it("requests GC, flushStorageData, and navigationHistory.clear in order on deactivation", async () => {
     await manager.switchTo("proj-b", "/path/b");
 
-    // Reactivate proj-a before the 100ms GC delay
-    await manager.switchTo("proj-a", "/path/a");
+    expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
+    expect(initialWc.session.flushStorageData).toHaveBeenCalledOnce();
+    expect(initialWc.navigationHistory.clear).toHaveBeenCalledOnce();
 
-    vi.advanceTimersByTime(100);
+    const flushOrder = initialWc.session.flushStorageData.mock.invocationCallOrder[0];
+    const clearOrder = initialWc.navigationHistory.clear.mock.invocationCallOrder[0];
+    const gcOrder = initialWc.executeJavaScript.mock.invocationCallOrder[0];
 
-    // GC should NOT have fired — view was reactivated (state is "active", not "cached")
-    expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
-  });
-
-  it("skips GC if view entry was evicted from the map", async () => {
-    await manager.switchTo("proj-b", "/path/b");
-
-    manager.destroyView("proj-a");
-
-    vi.advanceTimersByTime(100);
-
-    expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
+    expect(flushOrder).toBeLessThan(gcOrder);
+    expect(clearOrder).toBeLessThan(gcOrder);
   });
 
   it("suppresses executeJavaScript rejection without unhandled promise", async () => {
@@ -170,10 +159,48 @@ describe("ProjectViewManager — GC on deactivate", () => {
 
     await manager.switchTo("proj-b", "/path/b");
 
-    vi.advanceTimersByTime(100);
-    await vi.runAllTimersAsync();
-
     // Should have been called (and rejected silently)
     expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
+  });
+
+  it("calls session.flushStorageData on deactivation", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(initialWc.session.flushStorageData).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw when flushStorageData rejects", async () => {
+    initialWc.session.flushStorageData.mockRejectedValue(new Error("session gone"));
+
+    await expect(manager.switchTo("proj-b", "/path/b")).resolves.toBeDefined();
+    expect(initialWc.session.flushStorageData).toHaveBeenCalledOnce();
+    // navigationHistory.clear should still fire despite flushStorageData rejection
+    expect(initialWc.navigationHistory.clear).toHaveBeenCalledOnce();
+  });
+
+  it("calls navigationHistory.clear on deactivation", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(initialWc.navigationHistory.clear).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw when navigationHistory.clear throws (TOCTOU renderer crash)", async () => {
+    initialWc.navigationHistory.clear.mockImplementation(() => {
+      throw new Error("renderer gone");
+    });
+
+    await expect(manager.switchTo("proj-b", "/path/b")).resolves.toBeDefined();
+    expect(initialWc.navigationHistory.clear).toHaveBeenCalledOnce();
+    // executeJavaScript should still fire despite clear() throwing
+    expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
+  });
+
+  it("skips flushStorageData, clearHistory, and GC when webContents is destroyed at outer guard", async () => {
+    initialWc.isDestroyed.mockReturnValue(true);
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(initialWc.session.flushStorageData).not.toHaveBeenCalled();
+    expect(initialWc.navigationHistory.clear).not.toHaveBeenCalled();
+    expect(initialWc.executeJavaScript).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Replaced fixed `setTimeout` GC delay with `requestIdleCallback` so the call doesn't synchronously block the renderer.
- Added `flushStorageData` and `navigationHistory.clear` before the GC call to release DOM/JS state tied to in-view back-forward history and pending storage writes.
- Updated all ProjectViewManager tests to drop fake timers and cover the new ordering, error-swallowing, and TOCTOU guarantees.

Resolves #6297

## Changes
- `electron/window/ProjectViewManager.ts` -- deactivation now runs `flushStorageData`, `navigationHistory.clear`, and `requestIdleCallback`-wrapped GC in sequence, each in its own try/catch
- `e2e/nightly/nightly-evicted-view-leak.spec.ts` -- updated comment to reflect removal of fixed `GC_DELAY_MS`
- `electron/window/__tests__/ProjectViewManager.adversarial.test.ts` -- removed fake timers, updated adversarial GC test to expect immediate `requestIdleCallback` call, added mocks for `session.flushStorageData` and `navigationHistory.clear`
- `electron/window/__tests__/ProjectViewManager.eviction.test.ts` -- added mock stubs for new webContents methods
- `electron/window/__tests__/ProjectViewManager.gc.test.ts` -- full rewrite: dropped all fake timers, added 9 new test cases covering the new deactivation ordering, error swallowing, TOCTOU guard, and per-method coverage

## Testing
All unit tests pass. The `ProjectViewManager.gc.test.ts` suite now covers the full deactivation path including error paths where `flushStorageData` or `navigationHistory.clear` throws.