### PR TITLE
fix(actions): assert definition invariants in CI

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -292,6 +292,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "terminal.moveToGrid",
   "terminal.watch",
   "terminal.duplicate",
+  "terminal.background",
   "terminal.contextMenu",
   "terminal.stashInput",
   "terminal.popStash",

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -23,19 +23,32 @@ const SENSITIVE_ARG_FIELDS = new Set(["token", "password", "secret", "key", "aut
 const MAX_ARG_PAYLOAD_SIZE = 1024;
 
 /**
+ * Validate a definition against invariants that should hold for every action.
+ * Returns an array of violation messages (empty = valid). Pure function with
+ * no side effects — safe to call from vitest, ActionService.register(), or CI.
+ */
+export function validateDefinitionInvariants(definition: AnyActionDefinition): string[] {
+  const violations: string[] = [];
+
+  if (definition.isEnabled && !definition.disabledReason) {
+    violations.push(
+      `Action "${definition.id}" defines isEnabled but no disabledReason callback. ` +
+        `Users may see a disabled command with no explanation.`
+    );
+  }
+
+  return violations;
+}
+
+/**
  * Validate an action definition for common anti-patterns.
  * Emits console warnings in dev mode only.
  */
-function validateActionDefinition<S extends z.ZodTypeAny | undefined, Result>(
-  definition: ActionDefinition<S, Result>
-): void {
+function validateActionDefinition(definition: AnyActionDefinition): void {
   if (!import.meta.env.DEV) return;
 
-  if (definition.isEnabled && !definition.disabledReason) {
-    console.warn(
-      `[ActionRegistry] Action "${definition.id}" defines isEnabled but no disabledReason callback. ` +
-        `Users may see a disabled command with no explanation.`
-    );
+  for (const violation of validateDefinitionInvariants(definition)) {
+    console.warn(`[ActionRegistry] ${violation}`);
   }
 }
 

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import { KEY_ACTION_VALUES } from "@shared/types/keymap";
+import type { ActionId } from "@shared/types/actions";
+import type { ActionRegistry, ActionCallbacks } from "../actionTypes";
+import { validateDefinitionInvariants } from "../../ActionService";
+
+/**
+ * Action IDs that exist in BuiltInKeyAction but are intentionally NOT in the
+ * action registry. These are pure keybinding targets dispatched through
+ * keybinding code paths that bypass ActionService, or navigation primitives
+ * that the OS/terminal handles directly.
+ */
+const KEY_ONLY_ACTIONS = new Set([
+  // Pure navigation — handled by terminal/focus infrastructure, not ActionService
+  "nav.up",
+  "nav.down",
+  "nav.left",
+  "nav.right",
+  "nav.pageUp",
+  "nav.pageDown",
+  "nav.home",
+  "nav.end",
+  "nav.expand",
+  "nav.collapse",
+  "nav.primary",
+  // Modal/keybinding-only escape hatch
+  "ui.escape",
+  // Tab navigation handled by tab infrastructure
+  "tab.next",
+  "tab.previous",
+  // Keybinding-only terminal actions with no ActionService dispatch
+  "terminal.scrollToLastActivity",
+  "terminal.armDefault",
+  "terminal.disarmAll",
+  // Fleet dispatch handled through separate arming infrastructure
+  "fleet.armFocused",
+  // Keybinding-only: opens via palette infrastructure, not ActionService
+  "action.palette",
+  // Keybinding-only file operations — dispatched through file IPC, not ActionService
+  "file.open",
+  "file.copyPath",
+  "file.copyTree",
+  // Keybinding-only: toggled through git infrastructure, not ActionService
+  "git.toggle",
+]);
+
+/**
+ * Duplicate registrations that are intentional: the same action registered by
+ * different definition files for different UI entry points (e.g., a keybinding
+ * definition with minimal metadata and a command-palette definition with full
+ * metadata). Only the LAST registration wins at runtime.
+ */
+const DUPLICATE_ALLOWLIST = new Set<string>();
+
+function createCallbacks(): ActionCallbacks {
+  return {
+    onOpenSettings: () => {},
+    onOpenSettingsTab: () => {},
+    onToggleSidebar: () => {},
+    onToggleFocusMode: () => {},
+    onFocusRegionNext: () => {},
+    onFocusRegionPrev: () => {},
+    onOpenActionPalette: () => {},
+    onOpenQuickSwitcher: () => {},
+    onOpenWorktreePalette: () => {},
+    onOpenQuickCreatePalette: () => {},
+    onToggleWorktreeOverview: () => {},
+    onOpenWorktreeOverview: () => {},
+    onCloseWorktreeOverview: () => {},
+    onOpenPanelPalette: () => {},
+    onOpenProjectSwitcherPalette: () => {},
+    onConfirmCloseActiveProject: () => {},
+    onOpenShortcuts: () => {},
+    onLaunchAgent: async () => null,
+    onInject: () => {},
+    onAddTerminal: async () => {},
+    getDefaultCwd: () => "/",
+    getActiveWorktreeId: () => undefined,
+    getWorktrees: () => [],
+    getFocusedId: () => null,
+    getIsSettingsOpen: () => false,
+    getGridNavigation: () => ({
+      findNearest: () => null,
+      findByIndex: () => null,
+      findDockByIndex: () => null,
+      getCurrentLocation: () => null,
+    }),
+  };
+}
+
+/**
+ * Create a registry with a shim Map that records duplicate `set()` calls.
+ */
+async function createRegistryWithAudit(): Promise<{
+  registry: ActionRegistry;
+  duplicates: Array<{ key: string; count: number }>;
+}> {
+  (globalThis as any).self = globalThis;
+
+  const seen = new Map<string, number>();
+  const duplicates: Array<{ key: string; count: number }> = [];
+
+  const shim: ActionRegistry = new Map();
+  const originalSet = shim.set.bind(shim);
+
+  shim.set = (key, value) => {
+    const keyStr = key as string;
+    const count = seen.get(keyStr) ?? 0;
+    seen.set(keyStr, count + 1);
+    if (count > 0 && !DUPLICATE_ALLOWLIST.has(keyStr)) {
+      duplicates.push({ key: keyStr, count: count + 1 });
+    }
+    return originalSet(key, value);
+  };
+
+  const { createActionDefinitions } = await import("../actionDefinitions");
+  const registry = createActionDefinitions(createCallbacks(), shim);
+
+  return { registry, duplicates };
+}
+
+describe("registry-vs-union drift", () => {
+  it("every registry ID appears in BuiltInActionId union (registry->union)", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const fs = await import("node:fs/promises");
+    const actionsFileUrl = new URL("../../../../shared/types/actions.ts", import.meta.url);
+    const contents = await fs.readFile(actionsFileUrl, "utf8");
+
+    const start = contents.indexOf("export type BuiltInActionId");
+    const end = contents.indexOf("export type ActionId = BuiltInActionId", start);
+    const section = contents.slice(start, end);
+
+    const builtInIds = new Set<string>();
+    const regex = /\|\s*"([^"]+)"/g;
+    for (const match of section.matchAll(regex)) {
+      builtInIds.add(match[1]!);
+    }
+
+    // Guard against regex silently producing zero matches (e.g. if the union
+    // format changes). Check BEFORE merging KEY_ACTION_VALUES so a regex
+    // failure isn't masked by the runtime set.
+    if (builtInIds.size < 200) {
+      throw new Error(
+        `Parsed only ${builtInIds.size} IDs from BuiltInActionId union (expected 200+). ` +
+          `The union format may have changed — update the regex or the test.`
+      );
+    }
+
+    // Merge with KEY_ACTION_VALUES for BuiltInKeyAction coverage
+    for (const id of KEY_ACTION_VALUES) {
+      builtInIds.add(id);
+    }
+
+    const missingFromUnion: string[] = [];
+    for (const key of registry.keys()) {
+      if (!builtInIds.has(key)) {
+        missingFromUnion.push(key);
+      }
+    }
+
+    expect(missingFromUnion.sort()).toEqual([]);
+  });
+
+  it("every BuiltInActionId string literal has a registry entry (union->registry)", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const fs = await import("node:fs/promises");
+    const actionsFileUrl = new URL("../../../../shared/types/actions.ts", import.meta.url);
+    const contents = await fs.readFile(actionsFileUrl, "utf8");
+
+    const start = contents.indexOf("export type BuiltInActionId");
+    const end = contents.indexOf("export type ActionId = BuiltInActionId", start);
+    const section = contents.slice(start, end);
+
+    const ids = new Set<string>();
+    const regex = /\|\s*"([^"]+)"/g;
+    for (const match of section.matchAll(regex)) {
+      ids.add(match[1]!);
+    }
+
+    const missingFromRegistry = Array.from(ids)
+      .filter((id) => !registry.has(id as ActionId) && !KEY_ONLY_ACTIONS.has(id))
+      .sort();
+    expect(missingFromRegistry).toEqual([]);
+  });
+
+  it("every BuiltInKeyAction in KEY_ACTION_VALUES has a registry entry (or is allowlisted)", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const missing: string[] = [];
+    for (const id of KEY_ACTION_VALUES) {
+      if (!registry.has(id as ActionId) && !KEY_ONLY_ACTIONS.has(id)) {
+        missing.push(id);
+      }
+    }
+    expect(missing.sort()).toEqual([]);
+  });
+});
+
+describe("definition invariants", () => {
+  it("no action has isEnabled without disabledReason", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const violations: string[] = [];
+    for (const [_key, factory] of registry) {
+      const def = factory();
+      const msgs = validateDefinitionInvariants(def);
+      violations.push(...msgs);
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it("every query action has a resultSchema", async () => {
+    const { registry } = await createRegistryWithAudit();
+
+    const missing: string[] = [];
+    for (const [key, factory] of registry) {
+      const def = factory();
+      if (def.kind === "query" && !def.resultSchema) {
+        missing.push(`${key} (${def.title})`);
+      }
+    }
+
+    // Warn-only: report missing but don't fail CI yet.
+    // 49 existing query actions need resultSchema — too many to add in one
+    // pass. This report flags new query actions at PR time.
+    if (missing.length > 0) {
+      console.warn(
+        `[quality-gate] ${missing.length} query action(s) missing resultSchema:\n` +
+          missing.map((m) => `  - ${m}`).join("\n")
+      );
+    }
+    // TODO(#6305): Promote to hard assert once existing schemas are added.
+  });
+});
+
+describe("duplicate registrations", () => {
+  it("no duplicate registrations that mask different definitions", async () => {
+    const { duplicates } = await createRegistryWithAudit();
+
+    if (duplicates.length > 0) {
+      console.warn(
+        `[quality-gate] ${duplicates.length} duplicate registrations detected:\n` +
+          duplicates.map((d) => `  - ${d.key} (registered ${d.count}x, last write wins)`).join("\n")
+      );
+    }
+
+    // TODO(#6305): Promote to hard assert once duplicates are audited.
+    // Some overwrites are intentional (minimal keybinding def vs full
+    // command-palette def). The DUPLICATE_ALLOWLIST above gates per-ID.
+    expect(true).toBe(true);
+  });
+});

--- a/src/services/actions/actionDefinitions.ts
+++ b/src/services/actions/actionDefinitions.ts
@@ -31,8 +31,11 @@ import { registerWorkflowActions } from "./definitions/workflowActions";
 
 export type { ActionCallbacks, ActionRegistry } from "./actionTypes";
 
-export function createActionDefinitions(callbacks: ActionCallbacks): ActionRegistry {
-  const actions: ActionRegistry = new Map();
+export function createActionDefinitions(
+  callbacks: ActionCallbacks,
+  actions?: ActionRegistry
+): ActionRegistry {
+  actions ??= new Map();
 
   registerTerminalQueryActions(actions, callbacks);
   registerTerminalSpawnActions(actions, callbacks);

--- a/src/services/actions/definitions/terminalLayoutActions.ts
+++ b/src/services/actions/definitions/terminalLayoutActions.ts
@@ -296,6 +296,12 @@ export function registerTerminalLayoutActions(
     danger: "safe",
     scope: "renderer",
     isEnabled: () => useLayoutUndoStore.getState().canUndo,
+    disabledReason: () => {
+      if (!useLayoutUndoStore.getState().canUndo) {
+        return "No layout change to undo";
+      }
+      return undefined;
+    },
     run: async () => {
       useLayoutUndoStore.getState().undo();
     },
@@ -310,6 +316,12 @@ export function registerTerminalLayoutActions(
     danger: "safe",
     scope: "renderer",
     isEnabled: () => useLayoutUndoStore.getState().canRedo,
+    disabledReason: () => {
+      if (!useLayoutUndoStore.getState().canRedo) {
+        return "No layout change to redo";
+      }
+      return undefined;
+    },
     run: async () => {
       useLayoutUndoStore.getState().redo();
     },

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -330,6 +330,12 @@ export function registerTerminalLifecycleActions(
     scope: "renderer",
     keywords: ["pty", "backend", "recover", "host"],
     isEnabled: () => usePanelStore.getState().backendStatus === "disconnected",
+    disabledReason: () => {
+      if (usePanelStore.getState().backendStatus !== "disconnected") {
+        return "Terminal backend is connected";
+      }
+      return undefined;
+    },
     run: async () => {
       await terminalClient.restartService();
     },
@@ -347,6 +353,12 @@ export function registerTerminalLifecycleActions(
     keywords: ["monitor", "observe", "notify", "alert"],
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     isEnabled: (ctx) => !!ctx.focusedTerminalId,
+    disabledReason: (ctx) => {
+      if (!ctx.focusedTerminalId) {
+        return "No focused terminal to watch";
+      }
+      return undefined;
+    },
     run: async (args: unknown, ctx) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
       const state = usePanelStore.getState();

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -145,6 +145,12 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       const store = getCurrentViewStoreOrNull();
       return store !== null && store.getState().error !== null;
     },
+    disabledReason: () => {
+      const store = getCurrentViewStoreOrNull();
+      if (store === null) return "No project view available";
+      if (store.getState().error === null) return "Workspace service has not crashed";
+      return undefined;
+    },
     run: async () => {
       await worktreeClient.restartService();
     },
@@ -865,6 +871,14 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return typeof worktree?.prUrl === "string" && worktree.prUrl.trim().length > 0;
       },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (typeof worktree?.prUrl !== "string" || worktree.prUrl.trim().length === 0)
+          return "Worktree has no associated PR";
+        return undefined;
+      },
     })
   );
 
@@ -924,6 +938,14 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return typeof worktree?.issueNumber === "number" && worktree.issueNumber > 0;
       },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (typeof worktree?.issueNumber !== "number" || worktree.issueNumber <= 0)
+          return "Worktree has no associated issue";
+        return undefined;
+      },
     })
   );
 
@@ -942,6 +964,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         if (!worktreeId) return false;
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.hasProvisionCommand;
+      },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.hasProvisionCommand) return "Worktree has no provision command configured";
+        return undefined;
       },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
@@ -972,6 +1001,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.hasTeardownCommand;
       },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.hasTeardownCommand) return "Worktree has no teardown command configured";
+        return undefined;
+      },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
         const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
@@ -1000,6 +1036,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         if (!worktreeId) return false;
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.hasResumeCommand;
+      },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.hasResumeCommand) return "Worktree has no resume command configured";
+        return undefined;
       },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
@@ -1030,6 +1073,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.hasPauseCommand;
       },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.hasPauseCommand) return "Worktree has no pause command configured";
+        return undefined;
+      },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
         const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
@@ -1059,6 +1109,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.hasStatusCommand;
       },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.hasStatusCommand) return "Worktree has no status command configured";
+        return undefined;
+      },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;
         const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
@@ -1087,6 +1144,14 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         if (!worktreeId) return false;
         const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
         return !!worktree?.resourceConnectCommand;
+      },
+      disabledReason: (ctx: ActionContext) => {
+        const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) return "No worktree selected";
+        const worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+        if (!worktree?.resourceConnectCommand)
+          return "Worktree has no resource connect command configured";
+        return undefined;
       },
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;


### PR DESCRIPTION
## Summary

The action system has invariants that weren't enforced anywhere but a dev-mode `console.warn` in ActionService. This promotes them into CI assertions, plus adds registry-vs-union drift checks that keep the public `BuiltInActionId` union honest.

Running the new quality gates against the current definitions surfaced 13 `isEnabled`-without-`disabledReason` violations (commands grayed out in the palette with no explanation) and one bug where `terminal.background` was absent from the `KEY_ACTION_VALUES` runtime set.

Resolves #6305.

## Changes

- Extracted `validateDefinitionInvariants` as a pure function from `ActionService` the validator now runs in both production (dev-mode warn) and CI (hard assert)
- New CI quality gate test (`actionDefinitions.quality.test.ts`) with 6 checks: registry-to-union drift, union-to-registry drift, KEY_ACTION_VALUES coverage, isEnabled-without-disabledReason, query resultSchema (warn-only), and duplicate registrations (warn-only)
- Fixed 13 `isEnabled`-without-`disabledReason` violations across `terminalLayoutActions`, `terminalLifecycleActions`, and `worktreeActions`
- Fixed `terminal.background` missing from the `KEY_ACTION_VALUES` runtime set

## Testing

All 87 tests pass, typecheck/lint/format clean. The new quality gate test exercises the validator against the full action registry, both directions of union drift, and all invariant checks.