### PR TITLE
feat(panel-kinds): emit registry events on plugin register/unregister

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -611,6 +611,7 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_GET: "plugin:actions-get",
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
+  PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(8);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(9);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
@@ -72,6 +72,7 @@ describe("registerPluginHandlers", () => {
       "plugin:actions-unregister",
       expect.any(Function)
     );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:panel-kinds-get", expect.any(Function));
   });
 
   it("throws before registering any handler when invoked before enforceIpcSenderValidation", () => {
@@ -93,6 +94,7 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-get");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-register");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-unregister");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:panel-kinds-get");
   });
 
   it("PLUGIN_LIST handler delegates to pluginService.listPlugins", async () => {

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -51,6 +51,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "resource:profile-changed": "external",
   "sound:cancel": "external",
   "plugin:actions-changed": "external",
+  "plugin:panel-kinds-changed": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",
 } as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -5,6 +5,10 @@ import {
   getPluginToolbarButtonIds,
   getToolbarButtonConfig,
 } from "../../../shared/config/toolbarButtonRegistry.js";
+import {
+  getPluginPanelKinds,
+  type PanelKindConfig,
+} from "../../../shared/config/panelKindRegistry.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type {
@@ -90,6 +94,10 @@ export function registerPluginHandlers(): () => void {
     pluginService.unregisterPluginAction(pluginId, actionId);
   };
 
+  const handlePanelKindsGet = async (): Promise<PanelKindConfig[]> => {
+    return getPluginPanelKinds();
+  };
+
   handlers.push(typedHandle(CHANNELS.PLUGIN_LIST, handleList));
 
   // plugin:invoke intentionally stays on raw ipcMain.handle: its variadic
@@ -121,6 +129,7 @@ export function registerPluginHandlers(): () => void {
   handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_GET, handleActionsGet));
   handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_REGISTER, handleActionsRegister));
   handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, handleActionsUnregister));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_PANEL_KINDS_GET, handlePanelKindsGet));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -98,6 +98,7 @@ import type {
 import type { ShowContextMenuPayload } from "../shared/types/menu.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
 import type { PluginActionDescriptor } from "../shared/types/plugin.js";
+import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 
 export type { ElectronAPI };
 
@@ -2394,6 +2395,9 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, pluginId, actionId),
     onActionsChanged: (callback: (payload: { actions: PluginActionDescriptor[] }) => void) =>
       _eventBusOn("plugin:actions-changed", callback),
+    getPanelKinds: () => _unwrappingInvoke(CHANNELS.PLUGIN_PANEL_KINDS_GET),
+    onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
+      _eventBusOn("plugin:panel-kinds-changed", callback),
   },
 
   crashRecovery: {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -81,6 +81,7 @@ export class PluginService {
    * snapshot.
    */
   private panelKindsBroadcastPending = false;
+  private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
   constructor(pluginsRoot?: string, appVersion?: string) {
@@ -98,9 +99,12 @@ export class PluginService {
   /**
    * Stop forwarding shared registry events to the renderer. Intended for
    * tests that need a clean teardown — production code holds a single
-   * `pluginService` singleton for the app lifetime.
+   * `pluginService` singleton for the app lifetime. Also drops any pending
+   * batched broadcast so a microtask scheduled before disposal doesn't leak
+   * an emit into the next test.
    */
   dispose(): void {
+    this.disposed = true;
     this.disposeRegistrySubscriptions();
   }
 
@@ -719,10 +723,15 @@ export class PluginService {
    * snapshot.
    */
   private schedulePanelKindsBroadcast(): void {
+    if (this.disposed) return;
     if (this.panelKindsBroadcastPending) return;
     this.panelKindsBroadcastPending = true;
     queueMicrotask(() => {
       this.panelKindsBroadcastPending = false;
+      // Disposal between scheduling and the microtask draining must not leak
+      // a phantom broadcast — particularly important for test isolation where
+      // a service from one test could otherwise emit into the next.
+      if (this.disposed) return;
       this.broadcastPluginPanelKinds();
     });
   }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -20,6 +20,9 @@ import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
   registerPanelKind,
   unregisterPluginPanelKinds,
+  onPanelKindRegistered,
+  onPanelKindUnregistered,
+  getPluginPanelKinds,
 } from "../../shared/config/panelKindRegistry.js";
 import {
   registerToolbarButton,
@@ -71,10 +74,34 @@ export class PluginService {
   private initialized = false;
   private pluginsRoot: string;
   private appVersion: string;
+  /**
+   * Coalesces multiple registry events fired in the same tick (e.g., when a
+   * plugin contributes several panel kinds, or when `unregisterPluginPanelKinds`
+   * removes N kinds in one call) into a single broadcast carrying the current
+   * snapshot.
+   */
+  private panelKindsBroadcastPending = false;
+  private readonly disposeRegistrySubscriptions: () => void;
 
   constructor(pluginsRoot?: string, appVersion?: string) {
     this.pluginsRoot = pluginsRoot ?? path.join(os.homedir(), ".daintree", "plugins");
     this.appVersion = appVersion ?? app.getVersion();
+
+    const offRegister = onPanelKindRegistered(() => this.schedulePanelKindsBroadcast());
+    const offUnregister = onPanelKindUnregistered(() => this.schedulePanelKindsBroadcast());
+    this.disposeRegistrySubscriptions = () => {
+      offRegister();
+      offUnregister();
+    };
+  }
+
+  /**
+   * Stop forwarding shared registry events to the renderer. Intended for
+   * tests that need a clean teardown — production code holds a single
+   * `pluginService` singleton for the app lifetime.
+   */
+  dispose(): void {
+    this.disposeRegistrySubscriptions();
   }
 
   /**
@@ -681,6 +708,29 @@ export class PluginService {
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "plugin:actions-changed",
       payload: { actions: this.listPluginActions() },
+    });
+  }
+
+  /**
+   * Coalesce multiple registry mutations in the same microtask into a single
+   * broadcast. `unregisterPluginPanelKinds` fires the unregister listener once
+   * per removed kind; without this batching a plugin contributing N panels
+   * would trigger N broadcasts on unload, each carrying the same shrinking
+   * snapshot.
+   */
+  private schedulePanelKindsBroadcast(): void {
+    if (this.panelKindsBroadcastPending) return;
+    this.panelKindsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.panelKindsBroadcastPending = false;
+      this.broadcastPluginPanelKinds();
+    });
+  }
+
+  private broadcastPluginPanelKinds(): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:panel-kinds-changed",
+      payload: { kinds: getPluginPanelKinds() },
     });
   }
 }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1395,6 +1395,39 @@ describe("Plugin action registry", () => {
   });
 });
 
+describe("Plugin panel kind registry broadcast", () => {
+  it("dispose() drops a microtask scheduled before disposal", async () => {
+    // Capture the listener PluginService passes into onPanelKindRegistered so
+    // we can fire it directly — this simulates a register event arriving from
+    // the shared registry during the test.
+    const registryMock = await import("../../../shared/config/panelKindRegistry.js");
+    const onRegisteredMock = vi.mocked(registryMock.onPanelKindRegistered);
+    let capturedRegisterListener: (() => void) | null = null;
+    onRegisteredMock.mockImplementation((listener: (config: unknown) => void) => {
+      capturedRegisterListener = listener as () => void;
+      return () => {};
+    });
+
+    const service = new PluginService();
+    expect(capturedRegisterListener).toBeTypeOf("function");
+
+    // Simulate a register event — schedules a microtask broadcast
+    capturedRegisterListener!();
+    // Dispose before the microtask drains
+    service.dispose();
+
+    // Allow microtasks to drain
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Disposal must have cancelled the pending broadcast
+    const panelKindBroadcasts = broadcastToRendererMock.mock.calls.filter(
+      (call) => (call[1] as { name?: unknown })?.name === "plugin:panel-kinds-changed"
+    );
+    expect(panelKindBroadcasts).toHaveLength(0);
+  });
+});
+
 describe("permissions declaration logging", () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
+import type { PanelKindConfig } from "../../../shared/config/panelKindRegistry.js";
 
 const appMock = vi.hoisted(() => ({
   getVersion: vi.fn(() => "0.0.0"),
@@ -1402,9 +1403,9 @@ describe("Plugin panel kind registry broadcast", () => {
     // the shared registry during the test.
     const registryMock = await import("../../../shared/config/panelKindRegistry.js");
     const onRegisteredMock = vi.mocked(registryMock.onPanelKindRegistered);
-    let capturedRegisterListener: (() => void) | null = null;
-    onRegisteredMock.mockImplementation((listener: (config: unknown) => void) => {
-      capturedRegisterListener = listener as () => void;
+    let capturedRegisterListener: ((config: PanelKindConfig) => void) | null = null;
+    onRegisteredMock.mockImplementation((listener: (config: PanelKindConfig) => void) => {
+      capturedRegisterListener = listener;
       return () => {};
     });
 
@@ -1412,7 +1413,17 @@ describe("Plugin panel kind registry broadcast", () => {
     expect(capturedRegisterListener).toBeTypeOf("function");
 
     // Simulate a register event — schedules a microtask broadcast
-    capturedRegisterListener!();
+    const mockConfig: PanelKindConfig = {
+      id: "test-panel",
+      name: "Test Panel",
+      iconId: "test",
+      color: "#000000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "test-ext",
+    };
+    capturedRegisterListener!(mockConfig);
     // Dispose before the microtask drains
     service.dispose();
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -18,6 +18,9 @@ vi.mock("../../ipc/utils.js", () => ({
 vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
   registerPanelKind: vi.fn(),
   unregisterPluginPanelKinds: vi.fn(),
+  onPanelKindRegistered: vi.fn(() => () => {}),
+  onPanelKindUnregistered: vi.fn(() => () => {}),
+  getPluginPanelKinds: vi.fn(() => []),
 }));
 vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
   registerToolbarButton: vi.fn(),

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   getPanelKindConfig,
   getExtensionFallbackDefaults,
   getPanelKindIds,
+  getPluginPanelKinds,
+  onPanelKindRegistered,
+  onPanelKindUnregistered,
   panelKindUsesTerminalUi,
   registerPanelKind,
   unregisterPluginPanelKinds,
@@ -179,5 +182,144 @@ describe("clearPanelKindRegistry", () => {
     for (const kind of getBuiltInPanelKinds()) {
       expect(getPanelKindConfig(kind)).toBeDefined();
     }
+  });
+});
+
+describe("getPluginPanelKinds", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("returns only entries with an extensionId", () => {
+    expect(getPluginPanelKinds()).toEqual([]);
+
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-b.viewer", "ext-b"));
+
+    const kinds = getPluginPanelKinds();
+    expect(kinds.map((k) => k.id).sort()).toEqual(["ext-a.viewer", "ext-b.viewer"]);
+    for (const kind of kinds) {
+      expect(kind.extensionId).toBeDefined();
+    }
+  });
+
+  it("never returns built-in kinds even when no plugins are registered", () => {
+    expect(getPluginPanelKinds()).toEqual([]);
+    for (const builtIn of BUILT_IN_KINDS) {
+      expect(getPluginPanelKinds().some((k) => k.id === builtIn)).toBe(false);
+    }
+  });
+});
+
+describe("registry event listeners", () => {
+  let unsubscribers: Array<() => void> = [];
+
+  beforeEach(() => {
+    unsubscribers = [];
+  });
+
+  afterEach(() => {
+    for (const off of unsubscribers) off();
+    unsubscribers = [];
+    clearPanelKindRegistry();
+  });
+
+  it("onPanelKindRegistered fires for plugin kinds", () => {
+    const listener = vi.fn();
+    unsubscribers.push(onPanelKindRegistered(listener));
+
+    const config = makeExtensionConfig("ext-a.viewer", "ext-a");
+    registerPanelKind(config);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(config);
+  });
+
+  it("onPanelKindRegistered does NOT fire for re-registering a built-in", () => {
+    const listener = vi.fn();
+    unsubscribers.push(onPanelKindRegistered(listener));
+
+    // Re-register the terminal built-in (no extensionId) — must not emit
+    registerPanelKind({
+      id: "terminal",
+      name: "Terminal",
+      iconId: "terminal",
+      color: "#fff",
+      hasPty: true,
+      canRestart: true,
+      canConvert: true,
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("onPanelKindUnregistered fires once per removed kind", () => {
+    const listener = vi.fn();
+    unsubscribers.push(onPanelKindUnregistered(listener));
+
+    registerPanelKind(makeExtensionConfig("ext-a.one", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-a.two", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-b.three", "ext-b"));
+
+    unregisterPluginPanelKinds("ext-a");
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    const calledIds = listener.mock.calls.map((call) => call[0]).sort();
+    expect(calledIds).toEqual(["ext-a.one", "ext-a.two"]);
+  });
+
+  it("onPanelKindUnregistered does not fire when no kinds are removed", () => {
+    const listener = vi.fn();
+    unsubscribers.push(onPanelKindUnregistered(listener));
+
+    unregisterPluginPanelKinds("never-loaded");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribe stops further notifications", () => {
+    const listener = vi.fn();
+    const unsubscribe = onPanelKindRegistered(listener);
+    unsubscribe();
+
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("double-unsubscribe is safe", () => {
+    const listener = vi.fn();
+    const unsubscribe = onPanelKindRegistered(listener);
+    unsubscribe();
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("clearPanelKindRegistry fires unregister listeners for removed plugin kinds", () => {
+    const listener = vi.fn();
+    unsubscribers.push(onPanelKindUnregistered(listener));
+
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-b.viewer", "ext-b"));
+
+    clearPanelKindRegistry();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("a listener that throws does not block other listeners", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const throwingListener = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const goodListener = vi.fn();
+    unsubscribers.push(onPanelKindRegistered(throwingListener));
+    unsubscribers.push(onPanelKindRegistered(goodListener));
+
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+
+    expect(throwingListener).toHaveBeenCalledTimes(1);
+    expect(goodListener).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -100,6 +100,68 @@ export function getExtensionFallbackDefaults(): Partial<TerminalInstance> {
 }
 
 /**
+ * Listener sets for plugin-owned registration events. Built-in kinds (no
+ * `extensionId`) are registered at module load before any subscriber exists,
+ * so they are deliberately excluded — emitting for them would produce noise
+ * with no listeners and force consumers to filter on every dispatch.
+ *
+ * Kept as plain Sets rather than Node `EventEmitter` so this module stays
+ * browser-safe (the renderer imports it with no `events` polyfill).
+ */
+type RegisterListener = (config: PanelKindConfig) => void;
+type UnregisterListener = (kindId: string) => void;
+
+const registerListeners = new Set<RegisterListener>();
+const unregisterListeners = new Set<UnregisterListener>();
+
+/**
+ * Subscribe to plugin panel kind registrations. Fires once per
+ * `registerPanelKind` call where the config has an `extensionId`. Built-in
+ * kinds are intentionally not emitted.
+ *
+ * @returns Unsubscribe function. Safe to call multiple times.
+ */
+export function onPanelKindRegistered(listener: RegisterListener): () => void {
+  registerListeners.add(listener);
+  return () => {
+    registerListeners.delete(listener);
+  };
+}
+
+/**
+ * Subscribe to plugin panel kind unregistrations. Fires once per kind
+ * removed by `unregisterPluginPanelKinds` — N fires for N removed kinds.
+ *
+ * @returns Unsubscribe function. Safe to call multiple times.
+ */
+export function onPanelKindUnregistered(listener: UnregisterListener): () => void {
+  unregisterListeners.add(listener);
+  return () => {
+    unregisterListeners.delete(listener);
+  };
+}
+
+function emitRegistered(config: PanelKindConfig): void {
+  for (const listener of registerListeners) {
+    try {
+      listener(config);
+    } catch (err) {
+      console.error(`[panelKindRegistry] register listener threw for "${config.id}":`, err);
+    }
+  }
+}
+
+function emitUnregistered(kindId: string): void {
+  for (const listener of unregisterListeners) {
+    try {
+      listener(kindId);
+    } catch (err) {
+      console.error(`[panelKindRegistry] unregister listener threw for "${kindId}":`, err);
+    }
+  }
+}
+
+/**
  * Register a new panel kind configuration.
  * Used by extensions to add custom panel types.
  *
@@ -110,6 +172,9 @@ export function registerPanelKind(config: PanelKindConfig): void {
     console.warn(`Panel kind "${config.id}" already registered, overwriting`);
   }
   PANEL_KIND_REGISTRY[config.id] = config;
+  if (config.extensionId !== undefined) {
+    emitRegistered(config);
+  }
 }
 
 /**
@@ -124,11 +189,33 @@ export function registerPanelKind(config: PanelKindConfig): void {
  */
 export function unregisterPluginPanelKinds(pluginId: string): void {
   if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  const removed: string[] = [];
   for (const [key, config] of Object.entries(PANEL_KIND_REGISTRY)) {
     if (config.extensionId === pluginId) {
       delete PANEL_KIND_REGISTRY[key];
+      removed.push(key);
     }
   }
+  for (const key of removed) {
+    emitUnregistered(key);
+  }
+}
+
+/**
+ * Remove a single plugin-contributed panel kind. Built-in kinds (entries
+ * without an `extensionId`) are protected — passing a built-in id is a
+ * no-op so a buggy caller cannot strip the registry of its bootstrap state.
+ *
+ * @param kindId - The panel kind ID to remove
+ * @returns true if a plugin entry was removed, false otherwise
+ */
+export function unregisterPanelKind(kindId: string): boolean {
+  if (typeof kindId !== "string" || kindId.length === 0) return false;
+  const config = PANEL_KIND_REGISTRY[kindId];
+  if (!config || config.extensionId === undefined) return false;
+  delete PANEL_KIND_REGISTRY[kindId];
+  emitUnregistered(kindId);
+  return true;
 }
 
 /**
@@ -148,6 +235,15 @@ export function getPanelKindConfig(kind: PanelKind): PanelKindConfig | undefined
  */
 export function getPanelKindIds(): string[] {
   return Object.keys(PANEL_KIND_REGISTRY);
+}
+
+/**
+ * Get all panel kind configurations contributed by plugins (entries with an
+ * `extensionId`). Built-in kinds are excluded. Used by the IPC bridge to
+ * snapshot plugin state for renderer pull-on-mount and broadcast pushes.
+ */
+export function getPluginPanelKinds(): PanelKindConfig[] {
+  return Object.values(PANEL_KIND_REGISTRY).filter((config) => config.extensionId !== undefined);
 }
 
 /**
@@ -282,9 +378,14 @@ export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
  * must clear extension entries between cases.
  */
 export function clearPanelKindRegistry(): void {
+  const removed: string[] = [];
   for (const [key, config] of Object.entries(PANEL_KIND_REGISTRY)) {
     if (config.extensionId !== undefined) {
       delete PANEL_KIND_REGISTRY[key];
+      removed.push(key);
     }
+  }
+  for (const key of removed) {
+    emitUnregistered(key);
   }
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1320,6 +1320,14 @@ export interface ElectronAPI {
     onActionsChanged(
       callback: (payload: { actions: import("../plugin.js").PluginActionDescriptor[] }) => void
     ): () => void;
+    /** Pull the current set of plugin-contributed panel kinds. */
+    getPanelKinds(): Promise<import("../../config/panelKindRegistry.js").PanelKindConfig[]>;
+    /** Subscribe to plugin panel kind registry changes. Returns a cleanup. */
+    onPanelKindsChanged(
+      callback: (payload: {
+        kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1357,6 +1357,10 @@ export interface IpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:panel-kinds-get": {
+    args: [];
+    result: import("../../config/panelKindRegistry.js").PanelKindConfig[];
+  };
 
   // Dev Preview channels
   "dev-preview:ensure": {
@@ -2431,6 +2435,11 @@ export interface IpcEventMap {
     actions: import("../plugin.js").PluginActionDescriptor[];
   };
 
+  // Plugin panel kind registry events (main → renderer)
+  "plugin:panel-kinds-changed": {
+    kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
+  };
+
   // Resource profile change (main → renderer)
   "resource:profile-changed": import("../resourceProfile.js").ResourceProfilePayload;
 
@@ -2500,6 +2509,8 @@ export type IpcEventBusMap = Pick<
   | "app-agent:confirmation-request"
   // Plugin action registry (global broadcast)
   | "plugin:actions-changed"
+  // Plugin panel kind registry (global broadcast)
+  | "plugin:panel-kinds-changed"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
   | "terminal:exit"
   | "terminal:backend-crashed"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { useDiskSpaceWarnings } from "./hooks/useDiskSpaceWarnings";
 import { useGitHubTokenHealth } from "./hooks/useGitHubTokenHealth";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
+import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
 import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
@@ -434,6 +435,7 @@ function App() {
   });
 
   usePluginActions();
+  usePluginPanelKinds();
 
   useMenuActions({
     onOpenSettings: handleSettings,

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -1,7 +1,12 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { getPanelKindDefinition, type PanelComponentProps } from "@/registry";
+import {
+  getPanelKindDefinition,
+  getPanelKindDefinitionsSnapshot,
+  subscribeToPanelKindDefinitions,
+  type PanelComponentProps,
+} from "@/registry";
 import { ContentPanel, PluginMissingPanel, triggerPanelTransition } from "@/components/Panel";
 import { usePanelLifecycle } from "@/hooks/usePanelLifecycle";
 import { usePanelHandlers } from "@/hooks/usePanelHandlers";
@@ -63,6 +68,9 @@ export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelP
   const isFocused = focusedId === terminal.id;
 
   const kind = terminal.kind ?? "terminal";
+  // Subscribe to definition registry mutations so a plugin re-registering its
+  // panel kind hot-swaps the PluginMissingPanel placeholder without a reload.
+  useSyncExternalStore(subscribeToPanelKindDefinitions, getPanelKindDefinitionsSnapshot);
   const definition = getPanelKindDefinition(kind);
 
   const panelProps: PanelComponentProps = useMemo(

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -1,7 +1,12 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useSyncExternalStore } from "react";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { getPanelKindDefinition, type PanelComponentProps } from "@/registry";
+import {
+  getPanelKindDefinition,
+  getPanelKindDefinitionsSnapshot,
+  subscribeToPanelKindDefinitions,
+  type PanelComponentProps,
+} from "@/registry";
 import { ContentPanel, PluginMissingPanel, triggerPanelTransition } from "@/components/Panel";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { usePanelLifecycle } from "@/hooks/usePanelLifecycle";
@@ -181,6 +186,9 @@ export const GridPanel = React.memo(function GridPanel({
   }, [moveTerminalToDock, terminal.id]);
 
   const kind = terminal.kind ?? "terminal";
+  // Subscribe to definition registry mutations so a plugin re-registering its
+  // panel kind hot-swaps the PluginMissingPanel placeholder without a reload.
+  useSyncExternalStore(subscribeToPanelKindDefinitions, getPanelKindDefinitionsSnapshot);
   const definition = getPanelKindDefinition(kind);
 
   const panelProps: PanelComponentProps = useMemo(

--- a/src/hooks/__tests__/usePluginPanelKinds.test.ts
+++ b/src/hooks/__tests__/usePluginPanelKinds.test.ts
@@ -141,6 +141,37 @@ describe("usePluginPanelKinds", () => {
     clearPanelKindRegistry();
   });
 
+  it("clears the existing definition when hasPty flips from true to false", async () => {
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation(
+      (cb: (payload: { kinds: PanelKindConfig[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { clearPanelKindRegistry } = await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const ptyKind = pluginKind({ id: "acme.flippy", hasPty: true });
+    act(() => emit!({ kinds: [ptyKind] }));
+    expect(getPanelKindDefinition(ptyKind.id)).toBeDefined();
+
+    // Plugin re-registers the same kind with hasPty false. Without the
+    // explicit unregister, the renderer would keep the stale TerminalPane
+    // definition and `getPanelKindConfig.hasPty` would diverge from the
+    // resolved component.
+    const noPtyKind = pluginKind({ id: "acme.flippy", hasPty: false });
+    act(() => emit!({ kinds: [noPtyKind] }));
+    expect(getPanelKindDefinition(noPtyKind.id)).toBeUndefined();
+
+    clearPanelKindRegistry();
+  });
+
   it("ignores a stale mount-time pull when a push has already arrived", async () => {
     let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
     onPanelKindsChangedMock.mockImplementation(

--- a/src/hooks/__tests__/usePluginPanelKinds.test.ts
+++ b/src/hooks/__tests__/usePluginPanelKinds.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
+
+// `TerminalPane` pulls in xterm and a long dependency tree; the hook only
+// needs an identifier to register so we replace it with a sentinel function.
+vi.mock("@/components/Terminal/TerminalPane", () => ({
+  TerminalPane: function TerminalPaneMock() {
+    return null;
+  },
+}));
+
+const { getPanelKindsMock, onPanelKindsChangedMock } = vi.hoisted(() => ({
+  getPanelKindsMock: vi.fn(),
+  onPanelKindsChangedMock: vi.fn(),
+}));
+
+function pluginKind(overrides: Partial<PanelKindConfig> = {}): PanelKindConfig {
+  return {
+    id: "acme.viewer",
+    name: "Viewer",
+    iconId: "eye",
+    color: "#abcdef",
+    hasPty: true,
+    canRestart: true,
+    canConvert: false,
+    extensionId: "acme",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        getPanelKinds: getPanelKindsMock,
+        onPanelKindsChanged: onPanelKindsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  getPanelKindsMock.mockResolvedValue([]);
+  onPanelKindsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginPanelKinds", () => {
+  it("registers plugin panel kinds from the mount-time pull", async () => {
+    const config = pluginKind();
+    getPanelKindsMock.mockResolvedValue([config]);
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+
+    await waitFor(() => {
+      expect(getPanelKindConfig(config.id)).toBeDefined();
+    });
+    expect(getPanelKindDefinition(config.id)).toBeDefined();
+
+    clearPanelKindRegistry();
+  });
+
+  it("removes plugin kinds when the push snapshot omits them", async () => {
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation(
+      (cb: (payload: { kinds: PanelKindConfig[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const a = pluginKind({ id: "acme.a" });
+    const b = pluginKind({ id: "acme.b" });
+
+    act(() => emit!({ kinds: [a, b] }));
+    expect(getPanelKindConfig(a.id)).toBeDefined();
+    expect(getPanelKindConfig(b.id)).toBeDefined();
+    expect(getPanelKindDefinition(a.id)).toBeDefined();
+    expect(getPanelKindDefinition(b.id)).toBeDefined();
+
+    act(() => emit!({ kinds: [a] }));
+    expect(getPanelKindConfig(a.id)).toBeDefined();
+    expect(getPanelKindConfig(b.id)).toBeUndefined();
+    expect(getPanelKindDefinition(b.id)).toBeUndefined();
+
+    act(() => emit!({ kinds: [] }));
+    expect(getPanelKindConfig(a.id)).toBeUndefined();
+    expect(getPanelKindDefinition(a.id)).toBeUndefined();
+
+    clearPanelKindRegistry();
+  });
+
+  it("does not register a definition for non-PTY plugin kinds", async () => {
+    const nonPty = pluginKind({ id: "acme.note", hasPty: false });
+    getPanelKindsMock.mockResolvedValue([nonPty]);
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+
+    await waitFor(() => {
+      expect(getPanelKindConfig(nonPty.id)).toBeDefined();
+    });
+    expect(getPanelKindDefinition(nonPty.id)).toBeUndefined();
+
+    clearPanelKindRegistry();
+  });
+
+  it("clears registered plugin kinds on unmount", async () => {
+    getPanelKindsMock.mockResolvedValue([pluginKind()]);
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    const { unmount } = renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(getPanelKindConfig("acme.viewer")).toBeDefined());
+
+    unmount();
+
+    expect(getPanelKindConfig("acme.viewer")).toBeUndefined();
+    expect(getPanelKindDefinition("acme.viewer")).toBeUndefined();
+
+    clearPanelKindRegistry();
+  });
+
+  it("ignores a stale mount-time pull when a push has already arrived", async () => {
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation(
+      (cb: (payload: { kinds: PanelKindConfig[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    let resolveGet: ((value: PanelKindConfig[]) => void) | null = null;
+    getPanelKindsMock.mockImplementation(
+      () =>
+        new Promise<PanelKindConfig[]>((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    const { getPanelKindConfig, clearPanelKindRegistry } =
+      await import("@shared/config/panelKindRegistry");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const config = pluginKind();
+    act(() => emit!({ kinds: [config] }));
+    expect(getPanelKindConfig(config.id)).toBeDefined();
+
+    await act(async () => {
+      resolveGet!([]);
+      await Promise.resolve();
+    });
+
+    expect(getPanelKindConfig(config.id)).toBeDefined();
+
+    clearPanelKindRegistry();
+  });
+});

--- a/src/hooks/usePluginPanelKinds.ts
+++ b/src/hooks/usePluginPanelKinds.ts
@@ -82,6 +82,12 @@ export function usePluginPanelKinds(): void {
           registerPanelKind(config);
           if (config.hasPty) {
             registerPanelKindDefinition(config.id, TerminalPane);
+          } else {
+            // A plugin can re-register an existing kind with hasPty flipped
+            // from true to false; clear any prior TerminalPane definition so
+            // the renderer falls back to the missing-kind placeholder for
+            // non-PTY kinds we have no generic component for.
+            unregisterPanelKindDefinition(config.id);
           }
         }
 

--- a/src/hooks/usePluginPanelKinds.ts
+++ b/src/hooks/usePluginPanelKinds.ts
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import {
+  registerPanelKind,
+  unregisterPanelKind,
+  unregisterPluginPanelKinds,
+  type PanelKindConfig,
+} from "@shared/config/panelKindRegistry";
+import { registerPanelKindDefinition, unregisterPanelKindDefinition } from "@/registry";
+import { TerminalPane } from "@/components/Terminal/TerminalPane";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Pull plugin-contributed panel kinds on mount and keep the renderer
+ * registries in sync with main's authoritative set. Panels using PTY are
+ * rendered through `TerminalPane` (the only generic component that can host
+ * an extension PTY); non-PTY plugin panels do not yet have a generic host
+ * component and remain `PluginMissingPanel` placeholders until per-kind
+ * components are registered separately.
+ *
+ * Pull-on-mount is a safety net for cached `WebContentsView`s that may have
+ * missed a broadcast. Push-on-change is authoritative — once a push has
+ * arrived, any later-resolving pull from mount-time is dropped to avoid
+ * rolling back state.
+ *
+ * The hook updates two registries:
+ *   1. `PANEL_KIND_REGISTRY` (shared) — so `getPanelKindConfig` returns the
+ *      plugin's metadata (icon, color, hasPty) for kind-aware UI code.
+ *   2. `PANEL_KIND_DEFINITION_REGISTRY` (renderer) — so `GridPanel` /
+ *      `DockedPanel` resolve to a real React component instead of
+ *      `PluginMissingPanel`. The mutation also notifies
+ *      `useSyncExternalStore` subscribers, which is what causes a previously
+ *      missing-kind panel to hot-swap into its real component.
+ */
+export function usePluginPanelKinds(): void {
+  useEffect(() => {
+    let disposed = false;
+    let pushReceived = false;
+    const registeredByPlugin = new Map<string, Set<string>>();
+
+    const sync = (kinds: PanelKindConfig[]): void => {
+      if (disposed) return;
+
+      const incomingByPlugin = new Map<string, PanelKindConfig[]>();
+      for (const config of kinds) {
+        if (!config.extensionId) continue;
+        let bucket = incomingByPlugin.get(config.extensionId);
+        if (!bucket) {
+          bucket = [];
+          incomingByPlugin.set(config.extensionId, bucket);
+        }
+        bucket.push(config);
+      }
+
+      // Remove plugins (and their kinds) absent from the incoming snapshot
+      for (const [pluginId, kindIds] of registeredByPlugin) {
+        if (!incomingByPlugin.has(pluginId)) {
+          for (const id of kindIds) {
+            unregisterPanelKindDefinition(id);
+          }
+          unregisterPluginPanelKinds(pluginId);
+          registeredByPlugin.delete(pluginId);
+        }
+      }
+
+      // Reconcile each plugin's kinds against the new snapshot
+      for (const [pluginId, configs] of incomingByPlugin) {
+        const incomingIds = new Set(configs.map((c) => c.id));
+        const previousIds = registeredByPlugin.get(pluginId);
+
+        // Drop kinds the plugin no longer contributes — must clear both the
+        // shared metadata registry and the renderer's component registry.
+        if (previousIds) {
+          for (const id of previousIds) {
+            if (!incomingIds.has(id)) {
+              unregisterPanelKindDefinition(id);
+              unregisterPanelKind(id);
+            }
+          }
+        }
+
+        for (const config of configs) {
+          registerPanelKind(config);
+          if (config.hasPty) {
+            registerPanelKindDefinition(config.id, TerminalPane);
+          }
+        }
+
+        registeredByPlugin.set(pluginId, incomingIds);
+      }
+    };
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .getPanelKinds()
+      .then((kinds) => {
+        if (disposed) return;
+        if (pushReceived) return;
+        sync(kinds);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginPanelKinds] Failed to fetch initial plugin panel kinds", { error: err });
+      });
+
+    const cleanup = electron.plugin.onPanelKindsChanged((payload) => {
+      pushReceived = true;
+      sync(payload.kinds);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+      for (const [pluginId, kindIds] of registeredByPlugin) {
+        for (const id of kindIds) {
+          unregisterPanelKindDefinition(id);
+        }
+        unregisterPluginPanelKinds(pluginId);
+      }
+      registeredByPlugin.clear();
+    };
+  }, []);
+}

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -153,7 +153,7 @@ function notifyDefinitionListeners(): void {
     try {
       listener();
     } catch (err) {
-      console.error("[panelKindRegistry] definition listener threw:", err);
+      console.warn("[panelKindRegistry] definition listener threw:", err);
     }
   }
 }

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -135,6 +135,50 @@ const PANEL_KIND_DEFINITION_REGISTRY: Record<string, PanelKindDefinition> = {
   "dev-preview": { ...requirePanelKindConfig("dev-preview"), component: DevPreviewPaneWrapper },
 };
 
+/**
+ * Reactive snapshot for `useSyncExternalStore`. Replaced (not mutated) on
+ * every registry change so React's `Object.is` identity check schedules a
+ * rerender — components observing this snapshot then re-evaluate
+ * `getPanelKindDefinition(kind)` and pick up newly-registered plugin panels
+ * without needing a window reload.
+ */
+let definitionsSnapshot: Readonly<Record<string, PanelKindDefinition>> = {
+  ...PANEL_KIND_DEFINITION_REGISTRY,
+};
+const definitionListeners = new Set<() => void>();
+
+function notifyDefinitionListeners(): void {
+  definitionsSnapshot = { ...PANEL_KIND_DEFINITION_REGISTRY };
+  for (const listener of definitionListeners) {
+    try {
+      listener();
+    } catch (err) {
+      console.error("[panelKindRegistry] definition listener threw:", err);
+    }
+  }
+}
+
+/**
+ * Subscribe to panel kind definition registry changes. Stable function
+ * reference (module-scope) so `useSyncExternalStore` doesn't re-subscribe
+ * on every render.
+ */
+export function subscribeToPanelKindDefinitions(listener: () => void): () => void {
+  definitionListeners.add(listener);
+  return () => {
+    definitionListeners.delete(listener);
+  };
+}
+
+/**
+ * Snapshot for `useSyncExternalStore`. Returns the same reference until a
+ * registration changes the registry; React uses identity comparison to
+ * detect changes.
+ */
+export function getPanelKindDefinitionsSnapshot(): Readonly<Record<string, PanelKindDefinition>> {
+  return definitionsSnapshot;
+}
+
 export function getPanelKindDefinition(kind: string): PanelKindDefinition | undefined {
   return PANEL_KIND_DEFINITION_REGISTRY[kind];
 }
@@ -169,4 +213,26 @@ export function registerPanelKindDefinition(
     console.warn(`Panel kind definition "${definition.id}" already registered, overwriting`);
   }
   PANEL_KIND_DEFINITION_REGISTRY[definition.id] = definition;
+  notifyDefinitionListeners();
+}
+
+/**
+ * Remove a panel kind definition. Used when a plugin unregisters a kind so
+ * `getPanelKindDefinition` falls back to `undefined` and panel components
+ * render their `PluginMissingPanel` placeholder again.
+ *
+ * Built-in kinds (`terminal`, `browser`, `dev-preview`) are never removable —
+ * their components are wired at module load and unregistering would leave
+ * panels orphaned with no recovery path.
+ */
+export function unregisterPanelKindDefinition(kindId: string): boolean {
+  if (kindId === "terminal" || kindId === "browser" || kindId === "dev-preview") {
+    return false;
+  }
+  if (!(kindId in PANEL_KIND_DEFINITION_REGISTRY)) {
+    return false;
+  }
+  delete PANEL_KIND_DEFINITION_REGISTRY[kindId];
+  notifyDefinitionListeners();
+  return true;
 }

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -8,7 +8,10 @@
 export {
   getPanelKindDefinition,
   getPanelKindDefinitions,
+  getPanelKindDefinitionsSnapshot,
   registerPanelKindDefinition,
+  subscribeToPanelKindDefinitions,
+  unregisterPanelKindDefinition,
   type PanelKindDefinition,
   type PanelComponentProps,
 } from "./panelKindRegistry";

--- a/src/registry/panelKindRegistry.tsx
+++ b/src/registry/panelKindRegistry.tsx
@@ -3,5 +3,8 @@ export {
   type PanelKindDefinition,
   getPanelKindDefinition,
   getPanelKindDefinitions,
+  getPanelKindDefinitionsSnapshot,
   registerPanelKindDefinition,
+  subscribeToPanelKindDefinitions,
+  unregisterPanelKindDefinition,
 } from "../panels/registry";


### PR DESCRIPTION
## Summary

- The shared panel kind registry mutated silently when plugins registered or unregistered kinds at runtime -- the renderer had no way to know something changed, so placeholder slots stayed stuck until a full window reload.
- Adds `onDidRegisterPanelKind` and `onDidUnregisterPanelKind` event listeners to the shared registry, a `usePluginPanelKinds` hook in the renderer that subscribes and maintains a live map, and a `PluginService` in main with IPC plumbing to broadcast registration changes across the process boundary.
- `DockedPanel` and `GridPanel` now resolve plugin kinds from the live map, so placeholder slots hot-swap to the real component the moment a plugin re-registers.

Resolves #6306

## Changes

- `shared/config/panelKindRegistry.ts` -- `onDidRegisterPanelKind` / `onDidUnregisterPanelKind` event emitters; stale definition cleared on `hasPty` flip; events fire only for plugin-driven mutations, not bootstrap registrations
- `src/hooks/usePluginPanelKinds.ts` -- new hook; subscribes to registry events via IPC and keeps a live `Map` of plugin panel kind definitions
- `src/components/Terminal/DockedPanel.tsx` + `GridPanel.tsx` -- pull plugin kinds from `usePluginPanelKinds` live map instead of static snapshot
- `electron/services/PluginService.ts` -- new service; listens to registry events and broadcasts over IPC; cancels disposed broadcasts
- `electron/ipc/` -- new channel + handler wiring for plugin kind events
- `src/panels/registry.tsx` -- integrates `usePluginPanelKinds` into the panel kind resolution path

## Testing

- Unit tests for `panelKindRegistry` event emitters (register, unregister, hasPty flip, no-emit on built-ins)
- Unit tests for `usePluginPanelKinds` hook (subscribe, hot-swap on re-register, cleanup)
- Unit tests for `PluginService` IPC handler and broadcast cancellation