### PR TITLE
perf(main): active event-loop-lag mitigation in ResourceProfileService

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -1,5 +1,11 @@
 import os from "os";
 import { app, powerMonitor } from "electron";
+import {
+  monitorEventLoopDelay,
+  performance,
+  type EventLoopUtilization,
+  type IntervalHistogram,
+} from "node:perf_hooks";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { logInfo } from "../utils/logger.js";
@@ -17,6 +23,24 @@ const EVAL_INTERVAL_MS = 30_000;
 const DOWNGRADE_HOLD_MS = 30_000;
 const UPGRADE_HOLD_MS = 60_000;
 const WARMUP_TICKS = 2;
+
+// Active event-loop-lag mitigation. The diagnostics handler reads a separate
+// lifetime histogram for IPC; this service owns its own histogram and resets
+// it after each tumbling window so percentile() reflects only the recent slice.
+// p99 is biased low by monitorEventLoopDelay (a long block records as a single
+// large sample, not many) — thresholds are conservative to compensate.
+// AND-gating with eventLoopUtilization rejects GC-pause false positives: a
+// genuine sustained-saturation event has both high tail latency AND high loop
+// occupancy. ELU alone doesn't catch periodic long sync work; p99 alone trips
+// on isolated GC stalls.
+const LAG_SAMPLE_INTERVAL_MS = 5_000;
+const LAG_HISTOGRAM_RESOLUTION_MS = 10;
+const LAG_ENTRY_P99_MS = 250;
+const LAG_ENTRY_ELU = 0.7;
+const LAG_ESCALATE_P99_MS = 500;
+const LAG_EXIT_P99_MS = 150;
+const LAG_ENTER_TICKS_REQUIRED = 2; // 10s sustained
+const LAG_EXIT_TICKS_REQUIRED = 6; // 30s clean
 
 // Memory-pressure thresholds scale with device RAM so machines with very
 // different physical memory behave sensibly. On an 8 GB machine these
@@ -47,6 +71,14 @@ export class ResourceProfileService {
   private speedLimit = 100;
   private readonly memoryThresholdHighMb: number;
   private readonly memoryThresholdLowMb: number;
+  private lagInterval: NodeJS.Timeout | null = null;
+  private lagHistogram: IntervalHistogram | null = null;
+  private lagPreviousElu: EventLoopUtilization | null = null;
+  private lagPressureActive = false;
+  private lagEscalatedActive = false;
+  private lagEnterTicks = 0;
+  private lagExitTicks = 0;
+  private lagLevel2Ticks = 0;
 
   constructor(private deps: ResourceProfileDeps) {
     const totalRamMb = os.totalmem() / 1024 / 1024;
@@ -98,10 +130,110 @@ export class ResourceProfileService {
       this.evaluate();
     }, EVAL_INTERVAL_MS);
     this.interval.unref();
+
+    this.startLagMonitor();
+  }
+
+  private startLagMonitor(): void {
+    if (this.lagInterval) return;
+    try {
+      this.lagHistogram = monitorEventLoopDelay({
+        resolution: LAG_HISTOGRAM_RESOLUTION_MS,
+      });
+      this.lagHistogram.enable();
+      this.lagPreviousElu = performance.eventLoopUtilization();
+    } catch {
+      // perf_hooks may be unavailable in some embedded contexts; skip silently
+      this.lagHistogram = null;
+      this.lagPreviousElu = null;
+      return;
+    }
+    this.lagInterval = setInterval(() => {
+      this.sampleLag();
+    }, LAG_SAMPLE_INTERVAL_MS);
+    this.lagInterval.unref();
+  }
+
+  private sampleLag(): void {
+    if (this.disposed || !this.lagHistogram) return;
+
+    let p99Ms = 0;
+    try {
+      const raw = this.lagHistogram.percentile(99) / 1_000_000;
+      if (Number.isFinite(raw)) p99Ms = raw;
+      this.lagHistogram.reset();
+    } catch {
+      return;
+    }
+
+    let utilization = 0;
+    try {
+      const current = performance.eventLoopUtilization();
+      const delta = this.lagPreviousElu
+        ? performance.eventLoopUtilization(current, this.lagPreviousElu)
+        : current;
+      this.lagPreviousElu = current;
+      if (Number.isFinite(delta.utilization)) utilization = delta.utilization;
+    } catch {
+      utilization = 0;
+    }
+
+    // Exit path runs first: a window that drops below 150ms while degraded
+    // counts toward recovery even if it would also satisfy the entry condition
+    // on a separate cycle.
+    if (this.lagPressureActive) {
+      if (p99Ms < LAG_EXIT_P99_MS) {
+        this.lagExitTicks += 1;
+        if (this.lagExitTicks >= LAG_EXIT_TICKS_REQUIRED) {
+          this.lagPressureActive = false;
+          this.lagEscalatedActive = false;
+          this.lagEnterTicks = 0;
+          this.lagExitTicks = 0;
+          this.lagLevel2Ticks = 0;
+          logInfo("event-loop-lag-cleared", { p99Ms: Math.round(p99Ms) });
+        }
+        return;
+      }
+      this.lagExitTicks = 0;
+
+      if (p99Ms > LAG_ESCALATE_P99_MS) {
+        this.lagLevel2Ticks += 1;
+        if (this.lagLevel2Ticks >= 1 && !this.lagEscalatedActive) {
+          this.lagEscalatedActive = true;
+          logInfo("event-loop-lag-escalated", {
+            p99Ms: Math.round(p99Ms),
+            utilization: Math.round(utilization * 100) / 100,
+          });
+        }
+      } else {
+        this.lagLevel2Ticks = 0;
+      }
+      return;
+    }
+
+    if (p99Ms > LAG_ENTRY_P99_MS && utilization > LAG_ENTRY_ELU) {
+      this.lagEnterTicks += 1;
+      if (this.lagEnterTicks >= LAG_ENTER_TICKS_REQUIRED) {
+        this.lagPressureActive = true;
+        this.lagEnterTicks = 0;
+        logInfo("event-loop-lag-detected", {
+          p99Ms: Math.round(p99Ms),
+          utilization: Math.round(utilization * 100) / 100,
+        });
+        if (this.currentProfile !== "efficiency") {
+          this.applyProfile("efficiency");
+        }
+      }
+    } else {
+      this.lagEnterTicks = 0;
+    }
   }
 
   private refreshWorktreeCount(): void {
     if (this.disposed) return;
+    // Under sustained event-loop saturation, skip the only optional async work
+    // in this service. Cached count is used until pressure clears.
+    if (this.lagEscalatedActive) return;
     const workspaceClient = this.deps.getWorkspaceClient();
     if (!workspaceClient) return;
     workspaceClient
@@ -123,6 +255,24 @@ export class ResourceProfileService {
       clearInterval(this.interval);
       this.interval = null;
     }
+    if (this.lagInterval) {
+      clearInterval(this.lagInterval);
+      this.lagInterval = null;
+    }
+    if (this.lagHistogram) {
+      try {
+        this.lagHistogram.disable();
+      } catch {
+        // non-critical
+      }
+      this.lagHistogram = null;
+    }
+    this.lagPreviousElu = null;
+    this.lagPressureActive = false;
+    this.lagEscalatedActive = false;
+    this.lagEnterTicks = 0;
+    this.lagExitTicks = 0;
+    this.lagLevel2Ticks = 0;
     this.disposed = true;
     logInfo("resource-profile-service-stopped");
   }
@@ -131,6 +281,15 @@ export class ResourceProfileService {
     this.tickCount++;
 
     if (this.tickCount <= WARMUP_TICKS) return;
+
+    // While the lag monitor holds the floor at efficiency, don't let memory or
+    // worktree-count signals upgrade out of it. Recovery is gated by the lag
+    // exit path which clears the flag and re-enables normal scoring.
+    if (this.lagPressureActive && this.currentProfile === "efficiency") {
+      this.candidateProfile = null;
+      this.candidateFirstSeenAt = null;
+      return;
+    }
 
     const target = this.computeTargetProfile();
 

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -78,7 +78,6 @@ export class ResourceProfileService {
   private lagEscalatedActive = false;
   private lagEnterTicks = 0;
   private lagExitTicks = 0;
-  private lagLevel2Ticks = 0;
 
   constructor(private deps: ResourceProfileDeps) {
     const totalRamMb = os.totalmem() / 1024 / 1024;
@@ -141,9 +140,22 @@ export class ResourceProfileService {
         resolution: LAG_HISTOGRAM_RESOLUTION_MS,
       });
       this.lagHistogram.enable();
-      this.lagPreviousElu = performance.eventLoopUtilization();
     } catch {
       // perf_hooks may be unavailable in some embedded contexts; skip silently
+      this.lagHistogram = null;
+      this.lagPreviousElu = null;
+      return;
+    }
+    try {
+      this.lagPreviousElu = performance.eventLoopUtilization();
+    } catch {
+      // ELU unavailable: tear the histogram down so it isn't orphaned in the
+      // native layer accumulating samples no one will ever read.
+      try {
+        this.lagHistogram.disable();
+      } catch {
+        // non-critical
+      }
       this.lagHistogram = null;
       this.lagPreviousElu = null;
       return;
@@ -161,9 +173,13 @@ export class ResourceProfileService {
     try {
       const raw = this.lagHistogram.percentile(99) / 1_000_000;
       if (Number.isFinite(raw)) p99Ms = raw;
+    } catch {
+      // Read failure: histogram still needs reset below so the window stays bounded.
+    }
+    try {
       this.lagHistogram.reset();
     } catch {
-      return;
+      // non-critical
     }
 
     let utilization = 0;
@@ -189,24 +205,18 @@ export class ResourceProfileService {
           this.lagEscalatedActive = false;
           this.lagEnterTicks = 0;
           this.lagExitTicks = 0;
-          this.lagLevel2Ticks = 0;
           logInfo("event-loop-lag-cleared", { p99Ms: Math.round(p99Ms) });
         }
         return;
       }
       this.lagExitTicks = 0;
 
-      if (p99Ms > LAG_ESCALATE_P99_MS) {
-        this.lagLevel2Ticks += 1;
-        if (this.lagLevel2Ticks >= 1 && !this.lagEscalatedActive) {
-          this.lagEscalatedActive = true;
-          logInfo("event-loop-lag-escalated", {
-            p99Ms: Math.round(p99Ms),
-            utilization: Math.round(utilization * 100) / 100,
-          });
-        }
-      } else {
-        this.lagLevel2Ticks = 0;
+      if (p99Ms > LAG_ESCALATE_P99_MS && !this.lagEscalatedActive) {
+        this.lagEscalatedActive = true;
+        logInfo("event-loop-lag-escalated", {
+          p99Ms: Math.round(p99Ms),
+          utilization: Math.round(utilization * 100) / 100,
+        });
       }
       return;
     }
@@ -272,7 +282,6 @@ export class ResourceProfileService {
     this.lagEscalatedActive = false;
     this.lagEnterTicks = 0;
     this.lagExitTicks = 0;
-    this.lagLevel2Ticks = 0;
     this.disposed = true;
     logInfo("resource-profile-service-stopped");
   }

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -3,6 +3,13 @@ import type { PtyClient } from "../PtyClient.js";
 import type { WorkspaceClient } from "../WorkspaceClient.js";
 import type { HibernationService } from "../HibernationService.js";
 
+const lagState = vi.hoisted(() => ({
+  // Returned by histogram.percentile(99) — nanoseconds.
+  p99Nanoseconds: 0,
+  utilization: 0,
+  resetCount: 0,
+}));
+
 vi.mock("electron", () => ({
   app: {
     getAppMetrics: vi.fn(() => []),
@@ -23,6 +30,24 @@ vi.mock("../../ipc/utils.js", () => ({
 
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
+}));
+
+vi.mock("node:perf_hooks", () => ({
+  monitorEventLoopDelay: () => ({
+    enable: vi.fn(),
+    disable: vi.fn(),
+    percentile: () => lagState.p99Nanoseconds,
+    reset: () => {
+      lagState.resetCount += 1;
+    },
+  }),
+  performance: {
+    eventLoopUtilization: (_current?: unknown, _previous?: unknown) => ({
+      idle: 0,
+      active: 0,
+      utilization: lagState.utilization,
+    }),
+  },
 }));
 
 import os from "os";
@@ -114,6 +139,11 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): {
   };
 }
 
+function setLag(p99Ms: number, utilization: number): void {
+  lagState.p99Nanoseconds = p99Ms * 1_000_000;
+  lagState.utilization = utilization;
+}
+
 describe("ResourceProfileService adversarial", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -123,6 +153,8 @@ describe("ResourceProfileService adversarial", () => {
     vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
     mockIsOnBatteryPower.mockReturnValue(false);
+    setLag(0, 0);
+    lagState.resetCount = 0;
   });
 
   afterEach(() => {
@@ -293,7 +325,286 @@ describe("ResourceProfileService adversarial", () => {
     service.stop();
   });
 
-  it.todo(
-    "loop-lag profile mismatches cannot be exercised yet because ResourceProfileService has no loop-lag signal"
-  );
+  describe("event-loop lag", () => {
+    it("drops to efficiency on sustained lag without waiting for the 30s eval", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // No memory/battery/thermal pressure — only lag is the trigger.
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85);
+      // Two 5s ticks satisfy the 10s sustained-entry requirement.
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("does not enter degraded mode on an isolated lag spike", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      setLag(400, 0.9);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      // Single clean tick resets the entry counter.
+      setLag(50, 0.2);
+      vi.advanceTimersByTime(5_000);
+
+      // Another spike — should NOT trigger immediately because the counter reset.
+      setLag(400, 0.9);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("AND-gates with ELU — high lag with low utilization is treated as a GC pause", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // p99 high, ELU low → suspected GC; do not enter degraded mode.
+      setLag(400, 0.3);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("does not retrigger applyProfile when already at efficiency", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Drive into efficiency via memory + battery first.
+      mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      const broadcastsBefore = (broadcastToRenderer as Mock).mock.calls.length;
+
+      // Now lag spikes too — should NOT re-broadcast or reapply.
+      setLag(400, 0.9);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+
+      expect(service.getProfile()).toBe("efficiency");
+      expect((broadcastToRenderer as Mock).mock.calls.length).toBe(broadcastsBefore);
+
+      service.stop();
+    });
+
+    it("recovers after 30s of clean p99 readings", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Enter degraded.
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(true);
+
+      // Six clean 5s windows = 30s sustained recovery.
+      setLag(50, 0.1);
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(false);
+
+      service.stop();
+    });
+
+    it("a single non-clean tick resets the recovery counter", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Enter degraded.
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(true);
+
+      // Five clean ticks (one short of the 6-tick threshold).
+      setLag(50, 0.1);
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(true);
+
+      // One non-clean tick (above exit threshold) resets the counter.
+      setLag(200, 0.5);
+      vi.advanceTimersByTime(5_000);
+
+      // Now five more clean ticks should still NOT recover (counter restarted).
+      setLag(50, 0.1);
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(true);
+
+      // Sixth clean tick clears it.
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(false);
+
+      service.stop();
+    });
+
+    it("escalates after one tick above 500ms while degraded", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Enter degraded at 300ms first.
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagEscalatedActive: boolean }).lagEscalatedActive).toBe(
+        false
+      );
+
+      // Spike past 500ms → escalation flag flips.
+      setLag(600, 0.9);
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagEscalatedActive: boolean }).lagEscalatedActive).toBe(true);
+
+      service.stop();
+    });
+
+    it("escalation skips refreshWorktreeCount", async () => {
+      const { deps, workspace } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // start() invokes refreshWorktreeCount once unconditionally.
+      const initialCalls = workspace.getAllStatesAsync.mock.calls.length;
+
+      // Enter degraded.
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+
+      // Escalate.
+      setLag(600, 0.9);
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagEscalatedActive: boolean }).lagEscalatedActive).toBe(true);
+
+      // The next 30s eval should NOT call refreshWorktreeCount.
+      vi.advanceTimersByTime(30_000);
+      expect(workspace.getAllStatesAsync).toHaveBeenCalledTimes(initialCalls);
+
+      service.stop();
+    });
+
+    it("lag-pressure floor blocks the slow scoring loop from upgrading out of efficiency", () => {
+      const { deps, workspace } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Enter degraded via lag, with no other pressure signals.
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      // Reset broadcast counter to track only post-degraded broadcasts.
+      (broadcastToRenderer as Mock).mockClear();
+      workspace.updateMonitorConfig.mockClear();
+
+      // Lag stays high (not in exit range). Advance 60s of eval ticks — even
+      // though computeTargetProfile() now reports score 0 → "performance",
+      // the floor must hold.
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+
+      expect(service.getProfile()).toBe("efficiency");
+      expect(broadcastToRenderer).not.toHaveBeenCalled();
+      expect(workspace.updateMonitorConfig).not.toHaveBeenCalled();
+
+      service.stop();
+    });
+
+    it("exit clears escalation state alongside pressure", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+
+      setLag(600, 0.9);
+      vi.advanceTimersByTime(5_000);
+      expect((service as unknown as { lagEscalatedActive: boolean }).lagEscalatedActive).toBe(true);
+
+      setLag(50, 0.1);
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+
+      const internals = service as unknown as {
+        lagPressureActive: boolean;
+        lagEscalatedActive: boolean;
+        lagLevel2Ticks: number;
+      };
+      expect(internals.lagPressureActive).toBe(false);
+      expect(internals.lagEscalatedActive).toBe(false);
+      expect(internals.lagLevel2Ticks).toBe(0);
+
+      service.stop();
+    });
+
+    it("resets the histogram on every sample", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      const before = lagState.resetCount;
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(lagState.resetCount - before).toBe(3);
+
+      service.stop();
+    });
+
+    it("stop tears down the lag timer and histogram", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      service.stop();
+
+      // After stop, advancing timers must not change state or invoke histogram reset.
+      const before = lagState.resetCount;
+      setLag(600, 0.9);
+      vi.advanceTimersByTime(60_000);
+      expect(lagState.resetCount).toBe(before);
+
+      const internals = service as unknown as {
+        lagInterval: NodeJS.Timeout | null;
+        lagHistogram: unknown;
+      };
+      expect(internals.lagInterval).toBeNull();
+      expect(internals.lagHistogram).toBeNull();
+    });
+  });
 });

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -563,11 +563,9 @@ describe("ResourceProfileService adversarial", () => {
       const internals = service as unknown as {
         lagPressureActive: boolean;
         lagEscalatedActive: boolean;
-        lagLevel2Ticks: number;
       };
       expect(internals.lagPressureActive).toBe(false);
       expect(internals.lagEscalatedActive).toBe(false);
-      expect(internals.lagLevel2Ticks).toBe(0);
 
       service.stop();
     });
@@ -582,6 +580,72 @@ describe("ResourceProfileService adversarial", () => {
       vi.advanceTimersByTime(5_000);
       vi.advanceTimersByTime(5_000);
       expect(lagState.resetCount - before).toBe(3);
+
+      service.stop();
+    });
+
+    it("entry thresholds are strict greater-than (boundary values do not trigger)", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Exactly at thresholds: p99 === 250 and util === 0.7. Neither satisfies `>`.
+      setLag(250, 0.7);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      // p99 just over while util at boundary — still no entry.
+      setLag(251, 0.7);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      // util just over while p99 at boundary — still no entry.
+      setLag(250, 0.71);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      // Both strictly over → enters as expected.
+      setLag(251, 0.71);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("normal scoring upgrades out of efficiency after lag recovery", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Drive into efficiency via lag.
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      // Recover.
+      setLag(50, 0.1);
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(5_000);
+      }
+      expect((service as unknown as { lagPressureActive: boolean }).lagPressureActive).toBe(false);
+
+      // From here, normal scoring should drive back up. While lag was active,
+      // evaluate() returned early at the lag floor without exiting warmup,
+      // so tickCount has only crossed the floor branch. Drive past the
+      // 2-warmup ticks + 60s upgrade hold combination.
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+      expect(service.getProfile()).toBe("performance");
 
       service.stop();
     });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -27,6 +27,20 @@ vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
 }));
 
+// Neutral perf_hooks stub: returns zero lag and zero utilization, so the new
+// 5s lag-monitor timer fires harmlessly inside fake-timer windows.
+vi.mock("node:perf_hooks", () => ({
+  monitorEventLoopDelay: () => ({
+    enable: vi.fn(),
+    disable: vi.fn(),
+    percentile: () => 0,
+    reset: vi.fn(),
+  }),
+  performance: {
+    eventLoopUtilization: () => ({ idle: 0, active: 0, utilization: 0 }),
+  },
+}));
+
 import os from "os";
 import { app, powerMonitor } from "electron";
 import { broadcastToRenderer } from "../../ipc/utils.js";


### PR DESCRIPTION
## Summary

- Adds a private 5-second tumbling-window lag monitor to `ResourceProfileService` using an `IntervalHistogram` (10ms resolution, independent from the diagnostics handler's lifetime singleton)
- AND-gates p99 > 250ms with `eventLoopUtilization` > 0.7 for 10s sustained to immediately drop to the efficiency profile, bypassing the normal 30-second scoring hold; escalates at p99 > 500ms by skipping `refreshWorktreeCount`
- Recovery requires 30 consecutive seconds of p99 < 150ms — any non-clean tick resets the counter; a lag-pressure floor in `evaluate()` blocks scoring upgrades while lag is active

Resolves #6275

## Changes

- `electron/services/ResourceProfileService.ts` — lag monitor, AND-gate entry, escalation path, recovery logic, lag-pressure floor in `evaluate()`
- `electron/services/__tests__/ResourceProfileService.test.ts` — neutral `perf_hooks` mock so existing 13 tests are undisturbed
- `electron/services/__tests__/ResourceProfileService.adversarial.test.ts` — 14 new lag-specific tests covering entry, AND-gate, single-spike rejection, idempotency, recovery, recovery counter reset, escalation, escalation skipping `refreshWorktreeCount`, floor blocking upgrades, exit clearing state, histogram reset, stop teardown, boundary thresholds, and post-recovery upgrade

## Testing

52/52 tests pass. `npm run check` clean — typecheck, lint, and format all pass. Net lint warnings down 2 vs baseline.