### PR TITLE
feat(watchdog): external main-process watchdog for deadlock recovery

### DIFF
--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -27,6 +27,13 @@ describe("parseMainPid", () => {
   it("returns null when the value is empty", () => {
     expect(parseMainPid(["--main-pid="])).toBeNull();
   });
+
+  it("rejects partial-numeric inputs (parseInt would silently truncate)", () => {
+    expect(parseMainPid(["--main-pid=123abc"])).toBeNull();
+    expect(parseMainPid(["--main-pid=1.9"])).toBeNull();
+    expect(parseMainPid(["--main-pid= 42"])).toBeNull();
+    expect(parseMainPid(["--main-pid=42 "])).toBeNull();
+  });
 });
 
 describe("createWatchdog", () => {

--- a/electron/__tests__/watchdog-host-core.test.ts
+++ b/electron/__tests__/watchdog-host-core.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createWatchdog,
+  parseMainPid,
+  HEARTBEAT_INTERVAL_MS,
+  MAX_MISSED,
+} from "../watchdog-host-core.js";
+
+describe("parseMainPid", () => {
+  it("extracts a valid pid from --main-pid=<pid>", () => {
+    expect(parseMainPid(["node", "watchdog", "--main-pid=12345"])).toBe(12345);
+  });
+
+  it("returns null when the flag is missing", () => {
+    expect(parseMainPid(["node", "watchdog"])).toBeNull();
+  });
+
+  it("returns null when the value is non-numeric", () => {
+    expect(parseMainPid(["--main-pid=abc"])).toBeNull();
+  });
+
+  it("returns null when the value is zero or negative", () => {
+    expect(parseMainPid(["--main-pid=0"])).toBeNull();
+    expect(parseMainPid(["--main-pid=-1"])).toBeNull();
+  });
+
+  it("returns null when the value is empty", () => {
+    expect(parseMainPid(["--main-pid="])).toBeNull();
+  });
+});
+
+describe("createWatchdog", () => {
+  it("does not fire kill before the first ping arms the watchdog (startup grace)", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+
+    // Simulate many ticks before any ping is received.
+    for (let i = 0; i < MAX_MISSED * 2; i++) wd.tick();
+
+    expect(killMain).not.toHaveBeenCalled();
+    expect(wd.state.isArmed).toBe(false);
+  });
+
+  it("arms on first ping and resets missedBeats", () => {
+    const wd = createWatchdog({ killMain: vi.fn(), logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+    expect(wd.state.isArmed).toBe(true);
+    expect(wd.state.missedBeats).toBe(0);
+  });
+
+  it("fires kill when missedBeats reaches MAX_MISSED after arm", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    for (let i = 0; i < MAX_MISSED - 1; i++) wd.tick();
+    expect(killMain).not.toHaveBeenCalled();
+    expect(wd.state.missedBeats).toBe(MAX_MISSED - 1);
+
+    wd.tick(); // crosses threshold
+    expect(killMain).toHaveBeenCalledTimes(1);
+  });
+
+  it("disarms after firing so a single deadlock doesn't loop SIGKILL", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+    expect(killMain).toHaveBeenCalledTimes(1);
+    expect(wd.state.isArmed).toBe(false);
+
+    // More ticks must NOT trigger another kill.
+    for (let i = 0; i < MAX_MISSED * 2; i++) wd.tick();
+    expect(killMain).toHaveBeenCalledTimes(1);
+  });
+
+  it("a fresh ping after a kill re-arms the watchdog", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+    expect(killMain).toHaveBeenCalledTimes(1);
+
+    // CrashRecoveryService relaunches main; first ping should re-arm.
+    wd.handleMessage({ type: "ping" });
+    expect(wd.state.isArmed).toBe(true);
+    expect(wd.state.missedBeats).toBe(0);
+
+    for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+    expect(killMain).toHaveBeenCalledTimes(2);
+  });
+
+  it("subsequent pings reset the missed counter (steady-state ping/pong)", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    for (let i = 0; i < 100; i++) {
+      wd.tick();
+      wd.handleMessage({ type: "ping" });
+    }
+
+    expect(killMain).not.toHaveBeenCalled();
+    expect(wd.state.missedBeats).toBe(0);
+  });
+
+  it("sleep suppresses kill across many ticks without losing arm state", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    wd.handleMessage({ type: "sleep" });
+    expect(wd.state.isPaused).toBe(true);
+
+    for (let i = 0; i < MAX_MISSED * 5; i++) wd.tick();
+    expect(killMain).not.toHaveBeenCalled();
+    expect(wd.state.missedBeats).toBe(0);
+  });
+
+  it("wake clears the missed counter and resumes counting", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    wd.handleMessage({ type: "sleep" });
+    for (let i = 0; i < MAX_MISSED * 5; i++) wd.tick();
+
+    wd.handleMessage({ type: "wake" });
+    expect(wd.state.isPaused).toBe(false);
+    expect(wd.state.missedBeats).toBe(0);
+
+    // After wake, normal counting resumes.
+    for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+    expect(killMain).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose disarms the watchdog so an in-flight tick can't fire", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    // Drive missedBeats up to MAX_MISSED - 1 (just below threshold).
+    for (let i = 0; i < MAX_MISSED - 1; i++) wd.tick();
+    expect(killMain).not.toHaveBeenCalled();
+
+    wd.handleMessage({ type: "dispose" });
+    expect(wd.state.isArmed).toBe(false);
+
+    // Any ticks after dispose must not fire.
+    for (let i = 0; i < MAX_MISSED * 2; i++) wd.tick();
+    expect(killMain).not.toHaveBeenCalled();
+  });
+
+  it("disarm() works as a direct teardown helper", () => {
+    const killMain = vi.fn();
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+    wd.disarm();
+    expect(wd.state.isArmed).toBe(false);
+    for (let i = 0; i < MAX_MISSED * 2; i++) wd.tick();
+    expect(killMain).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed messages", () => {
+    const wd = createWatchdog({ killMain: vi.fn(), logError: () => {} });
+    expect(wd.handleMessage(null)).toBe(false);
+    expect(wd.handleMessage(undefined)).toBe(false);
+    expect(wd.handleMessage({ type: "unknown" } as unknown as { type: "ping" })).toBe(false);
+    expect(wd.state.isArmed).toBe(false);
+  });
+
+  it("swallows errors from killMain so a throwing kill doesn't crash the watchdog", () => {
+    const killMain = vi.fn().mockImplementation(() => {
+      throw new Error("kill failed");
+    });
+    const wd = createWatchdog({ killMain, logError: () => {} });
+    wd.handleMessage({ type: "ping" });
+
+    expect(() => {
+      for (let i = 0; i < MAX_MISSED; i++) wd.tick();
+    }).not.toThrow();
+    expect(killMain).toHaveBeenCalledTimes(1);
+    // Even though kill threw, the watchdog disarms so the next tick is inert.
+    expect(wd.state.isArmed).toBe(false);
+  });
+
+  it("HEARTBEAT_INTERVAL_MS × MAX_MISSED gives the conservative ~15s threshold", () => {
+    expect(HEARTBEAT_INTERVAL_MS * MAX_MISSED).toBe(15000);
+  });
+});

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -13,6 +13,7 @@ import { disposeAgentRouter } from "../services/AgentRouter.js";
 import { disposeTaskOrchestrator } from "../services/TaskOrchestrator.js";
 import { disposePtyClient } from "../services/PtyClient.js";
 import { disposeWorkspaceClient } from "../services/WorkspaceClient.js";
+import { disposeMainProcessWatchdog } from "../services/MainProcessWatchdogClient.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
@@ -151,6 +152,7 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
             }
             disposePtyClient();
             disposeWorkspaceClient();
+            disposeMainProcessWatchdog();
             resolve();
           }),
         ])

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -57,6 +57,7 @@ import {
   setStopAppMetricsMonitor,
   getStopDiskSpaceMonitor,
   setStopDiskSpaceMonitor,
+  getMainProcessWatchdogClientRef,
 } from "./window/windowServices.js";
 import {
   setupPowerMonitor,
@@ -321,6 +322,7 @@ if (!gotTheLock) {
       setupPowerMonitor({
         getPtyClient,
         getWorkspaceClient: getWorkspaceClientRef,
+        getMainProcessWatchdogClient: getMainProcessWatchdogClientRef,
       });
       setupWindowFocusThrottle({
         getPtyClient,

--- a/electron/services/MainProcessWatchdogClient.ts
+++ b/electron/services/MainProcessWatchdogClient.ts
@@ -19,6 +19,13 @@ import path from "node:path";
 const PING_INTERVAL_MS = 5000;
 const SERVICE_NAME = "daintree-watchdog";
 
+// If the watchdog stays alive this long after a fork, treat it as stable and
+// reset the restart counter. Without this reset, three transient crashes
+// spread across a multi-hour session would permanently disable deadlock
+// detection. Any duration well above the cap of cumulative backoff
+// (≤30s for 3 attempts) is safe — we pick 30s for the symmetry.
+const RESTART_COUNTER_RESET_MS = 30_000;
+
 export interface MainProcessWatchdogClientConfig {
   /** Maximum restart attempts before giving up. After this, deadlock
    * detection is disabled until the next app launch. */
@@ -47,6 +54,7 @@ export class MainProcessWatchdogClient {
 
   private pingInterval: NodeJS.Timeout | null = null;
   private restartTimer: NodeJS.Timeout | null = null;
+  private stabilityTimer: NodeJS.Timeout | null = null;
   private restartAttempts = 0;
   private isDisposed = false;
   private isPaused = false;
@@ -114,6 +122,12 @@ export class MainProcessWatchdogClient {
       const wasDisposed = this.isDisposed;
       this.child = null;
       this.stopPingInterval();
+      // Cancel any pending stability timer — the new fork must accumulate
+      // its own grace period from scratch.
+      if (this.stabilityTimer) {
+        clearTimeout(this.stabilityTimer);
+        this.stabilityTimer = null;
+      }
 
       if (wasDisposed) return;
 
@@ -121,11 +135,32 @@ export class MainProcessWatchdogClient {
       this.scheduleRestart();
     });
 
+    // Reset the restart counter once this fork stays alive long enough to be
+    // considered stable. Cumulative restart backoff for 3 attempts is well
+    // under 30s, so 30s of uptime confirms we're past the recovery phase.
+    if (this.stabilityTimer) clearTimeout(this.stabilityTimer);
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      if (this.isDisposed) return;
+      this.restartAttempts = 0;
+    }, RESTART_COUNTER_RESET_MS);
+
     // Immediately send the first ping so the watchdog arms (it stays inert
     // until `isArmed = true` to prevent killing a slow-booting main).
     this.sendPing();
 
-    if (!this.isPaused) {
+    if (this.isPaused) {
+      // The watchdog crashed-and-restarted while we're suspended. Without
+      // this, the new subprocess would be armed (by the ping above) and
+      // its tick interval would accumulate missed beats during sleep,
+      // leading to a false-positive SIGKILL on wake. Send "sleep" right
+      // after the arming ping to suppress the kill path.
+      try {
+        this.child.postMessage({ type: "sleep" });
+      } catch {
+        // Channel down — exit handler will reschedule another restart.
+      }
+    } else {
       this.startPingInterval();
     }
   }
@@ -233,6 +268,10 @@ export class MainProcessWatchdogClient {
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
+    }
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
     }
 
     if (this.child) {

--- a/electron/services/MainProcessWatchdogClient.ts
+++ b/electron/services/MainProcessWatchdogClient.ts
@@ -1,0 +1,275 @@
+/**
+ * Main-side manager for the external watchdog UtilityProcess.
+ *
+ * Forks `watchdog-host-bootstrap.js` with this process's PID, sends a "ping"
+ * every PING_INTERVAL_MS, and restarts the watchdog with exponential backoff
+ * if it crashes. Sleep/wake handling routes "sleep"/"wake" messages through
+ * to the subprocess and stops/restarts the ping interval — both paths
+ * (interval-stop and explicit "sleep") so the watchdog can't fire during
+ * suspend even if a transient race delivers them out of order.
+ *
+ * This client never kills main itself. The kill authority lives entirely in
+ * the watchdog subprocess; if the watchdog crashes, deadlock detection is
+ * temporarily inactive but main is unharmed (fail-open).
+ */
+
+import { app, utilityProcess, type UtilityProcess } from "electron";
+import path from "node:path";
+
+const PING_INTERVAL_MS = 5000;
+const SERVICE_NAME = "daintree-watchdog";
+
+export interface MainProcessWatchdogClientConfig {
+  /** Maximum restart attempts before giving up. After this, deadlock
+   * detection is disabled until the next app launch. */
+  maxRestartAttempts?: number;
+  /** Test seam: override `process.pid` with a deterministic value. */
+  mainPid?: number;
+  /** Test seam: override the resolved bootstrap path. */
+  hostPathOverride?: string;
+  /** Test seam: skip the actual `utilityProcess.fork()`. Used by unit tests
+   * that want to assert configuration without spinning up a child. */
+  startImmediately?: boolean;
+}
+
+const DEFAULT_CONFIG: Required<
+  Omit<MainProcessWatchdogClientConfig, "mainPid" | "hostPathOverride">
+> = {
+  maxRestartAttempts: 3,
+  startImmediately: true,
+};
+
+export class MainProcessWatchdogClient {
+  private child: UtilityProcess | null = null;
+  private config: Required<Omit<MainProcessWatchdogClientConfig, "mainPid" | "hostPathOverride">>;
+  private mainPid: number;
+  private hostPathOverride: string | undefined;
+
+  private pingInterval: NodeJS.Timeout | null = null;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private restartAttempts = 0;
+  private isDisposed = false;
+  private isPaused = false;
+
+  constructor(config: MainProcessWatchdogClientConfig = {}) {
+    this.config = {
+      maxRestartAttempts: config.maxRestartAttempts ?? DEFAULT_CONFIG.maxRestartAttempts,
+      startImmediately: config.startImmediately ?? DEFAULT_CONFIG.startImmediately,
+    };
+    this.mainPid = config.mainPid ?? process.pid;
+    this.hostPathOverride = config.hostPathOverride;
+
+    if (this.config.startImmediately) {
+      this.startHost();
+    }
+  }
+
+  private resolveHostPath(): string {
+    if (this.hostPathOverride) return this.hostPathOverride;
+    // esbuild emits this file under dist-electron/electron/. When running
+    // from the chunked production bundle, __dirname is …/chunks; the host
+    // bootstrap sits one level up, so normalise both layouts.
+    const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+    return path.join(electronDir, "watchdog-host-bootstrap.js");
+  }
+
+  private startHost(): void {
+    if (this.isDisposed) return;
+    if (this.child) return;
+
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    const hostPath = this.resolveHostPath();
+    console.log(`[MainProcessWatchdogClient] Starting watchdog from: ${hostPath}`);
+
+    try {
+      this.child = utilityProcess.fork(hostPath, [`--main-pid=${this.mainPid}`], {
+        serviceName: SERVICE_NAME,
+        stdio: "pipe",
+        env: {
+          ...(process.env as Record<string, string>),
+          DAINTREE_USER_DATA: app.getPath("userData"),
+          DAINTREE_UTILITY_PROCESS_KIND: "watchdog-host",
+        },
+      });
+    } catch (error) {
+      console.error("[MainProcessWatchdogClient] Failed to fork watchdog:", error);
+      this.scheduleRestart();
+      return;
+    }
+
+    // Forward stdout/stderr for diagnosis — the watchdog logs are tiny so
+    // there's no concern about flooding the main process.
+    this.child.stdout?.on("data", (chunk: Buffer) => {
+      process.stdout.write(`[watchdog] ${chunk.toString()}`);
+    });
+    this.child.stderr?.on("data", (chunk: Buffer) => {
+      process.stderr.write(`[watchdog] ${chunk.toString()}`);
+    });
+
+    this.child.on("exit", (code) => {
+      const wasDisposed = this.isDisposed;
+      this.child = null;
+      this.stopPingInterval();
+
+      if (wasDisposed) return;
+
+      console.warn(`[MainProcessWatchdogClient] Watchdog exited (code=${code})`);
+      this.scheduleRestart();
+    });
+
+    // Immediately send the first ping so the watchdog arms (it stays inert
+    // until `isArmed = true` to prevent killing a slow-booting main).
+    this.sendPing();
+
+    if (!this.isPaused) {
+      this.startPingInterval();
+    }
+  }
+
+  private scheduleRestart(): void {
+    if (this.isDisposed) return;
+    if (this.restartAttempts >= this.config.maxRestartAttempts) {
+      console.error(
+        `[MainProcessWatchdogClient] Max restart attempts (${this.config.maxRestartAttempts}) reached. Deadlock detection disabled until next launch.`
+      );
+      return;
+    }
+
+    this.restartAttempts += 1;
+    // Full jitter with floor — same formula as PtyClient/WorkspaceClient:
+    // `cap = min(1000 * 2^n, 10000)`, floor `100ms`. Jitter breaks
+    // deterministic retry lockstep when paired with a sibling client that
+    // crashed at the same instant; the floor stops fork-storms when the
+    // watchdog binary itself is broken.
+    const cap = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
+    const floor = 100;
+    const delay = floor + Math.floor(Math.random() * Math.max(0, cap - floor));
+
+    console.log(
+      `[MainProcessWatchdogClient] Restarting watchdog in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+    );
+
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      if (this.isDisposed || this.child !== null) return;
+      this.startHost();
+    }, delay);
+  }
+
+  private startPingInterval(): void {
+    if (this.pingInterval) return;
+    this.pingInterval = setInterval(() => {
+      this.sendPing();
+    }, PING_INTERVAL_MS);
+  }
+
+  private stopPingInterval(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+  }
+
+  private sendPing(): void {
+    if (!this.child) return;
+    try {
+      this.child.postMessage({ type: "ping" });
+    } catch (err) {
+      // postMessage can throw if the child is between exit and our exit
+      // handler (the channel is already torn down). Drop silently — the
+      // exit handler will reschedule a restart.
+      console.warn("[MainProcessWatchdogClient] ping postMessage failed:", err);
+    }
+  }
+
+  /** Pause the watchdog during system sleep. Stops the ping interval and
+   * sends an explicit "sleep" message so the subprocess won't accumulate
+   * missed beats during suspend. Called from setupPowerMonitor. */
+  pause(): void {
+    if (this.isPaused) return;
+    this.isPaused = true;
+    this.stopPingInterval();
+    if (this.child) {
+      try {
+        this.child.postMessage({ type: "sleep" });
+      } catch {
+        // Channel down — the watchdog's interval is unref'd, so it'll
+        // exit naturally if main has already gone.
+      }
+    }
+  }
+
+  /** Resume the watchdog after system wake. Sends "wake" to clear the
+   * subprocess's missed counter, then restarts the ping interval. */
+  resume(): void {
+    if (!this.isPaused) return;
+    this.isPaused = false;
+    if (this.child) {
+      try {
+        this.child.postMessage({ type: "wake" });
+      } catch {
+        // Same justification as pause().
+      }
+      // Send an immediate ping so the subprocess resets `missedBeats=0` and
+      // re-arms before the first interval tick lands.
+      this.sendPing();
+      this.startPingInterval();
+    }
+    // If the child is null (crashed during sleep), scheduleRestart from the
+    // exit handler will resurrect it; we'll re-arm via the immediate ping
+    // in startHost().
+  }
+
+  /** Stop the watchdog cleanly. Idempotent. */
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+
+    this.stopPingInterval();
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    if (this.child) {
+      try {
+        this.child.postMessage({ type: "dispose" });
+      } catch {
+        // Channel may already be closed; falling through to kill().
+      }
+      try {
+        this.child.kill();
+      } catch {
+        // Child may have exited between postMessage and kill — that's fine.
+      }
+      this.child = null;
+    }
+  }
+
+  /** Test/diagnostic accessor. */
+  isRunning(): boolean {
+    return this.child !== null && !this.isDisposed;
+  }
+}
+
+let instance: MainProcessWatchdogClient | null = null;
+
+export function getMainProcessWatchdogClient(
+  config?: MainProcessWatchdogClientConfig
+): MainProcessWatchdogClient {
+  if (!instance) {
+    instance = new MainProcessWatchdogClient(config);
+  }
+  return instance;
+}
+
+export function disposeMainProcessWatchdog(): void {
+  if (instance) {
+    instance.dispose();
+    instance = null;
+  }
+}

--- a/electron/services/__tests__/MainProcessWatchdogClient.test.ts
+++ b/electron/services/__tests__/MainProcessWatchdogClient.test.ts
@@ -231,6 +231,84 @@ describe("MainProcessWatchdogClient", () => {
     expect(argv[0]).toBe(`--main-pid=${process.pid}`);
   });
 
+  it("a watchdog that crashes during sleep restarts in paused state (sleep sent after arming ping)", () => {
+    const client = new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 3 });
+    client.pause();
+
+    // Simulate the watchdog crashing during sleep.
+    const replacementChild = createMockChild();
+    shared.forkMock.mockReturnValue(replacementChild);
+    mockChild.emit("exit", 1);
+
+    // Drive the restart timer past the cap so the new fork happens.
+    vi.advanceTimersByTime(11_000);
+    expect(shared.forkMock).toHaveBeenCalledTimes(2);
+
+    // The replacement child must have received both an arming ping AND a
+    // "sleep" message — without "sleep", its tick interval would accumulate
+    // missed beats during sleep and SIGKILL main on wake.
+    const types = replacementChild.postMessage.mock.calls.map(
+      (c) => (c[0] as { type?: string })?.type
+    );
+    expect(types).toContain("ping");
+    expect(types).toContain("sleep");
+
+    // No ping interval should be running while paused — verify by advancing
+    // time and counting subsequent pings.
+    replacementChild.postMessage.mockClear();
+    vi.advanceTimersByTime(30_000);
+    const subsequentPings = replacementChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "ping"
+    );
+    expect(subsequentPings).toHaveLength(0);
+    client.dispose();
+  });
+
+  it("disposeMainProcessWatchdog() disposes the singleton instance", async () => {
+    const { getMainProcessWatchdogClient, disposeMainProcessWatchdog } =
+      await import("../MainProcessWatchdogClient.js");
+    const singleton = getMainProcessWatchdogClient({ mainPid: 4242 });
+    expect(singleton.isRunning()).toBe(true);
+
+    disposeMainProcessWatchdog();
+    expect(singleton.isRunning()).toBe(false);
+
+    // Subsequent calls return a fresh instance.
+    const next = getMainProcessWatchdogClient({ mainPid: 4242 });
+    expect(next).not.toBe(singleton);
+    next.dispose();
+  });
+
+  it("restartAttempts resets after the watchdog stays alive long enough to be considered stable", () => {
+    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 2 });
+
+    // Crash once → restart triggered, attempts=1.
+    let currentChild = mockChild;
+    let next = createMockChild();
+    shared.forkMock.mockReturnValueOnce(next);
+    currentChild.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    currentChild = next;
+    expect(shared.forkMock).toHaveBeenCalledTimes(2);
+
+    // Advance past the stability reset window so restartAttempts goes back to 0.
+    vi.advanceTimersByTime(31_000);
+
+    // Two more crashes should now be tolerated (counter has reset).
+    next = createMockChild();
+    shared.forkMock.mockReturnValueOnce(next);
+    currentChild.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    currentChild = next;
+    expect(shared.forkMock).toHaveBeenCalledTimes(3);
+
+    next = createMockChild();
+    shared.forkMock.mockReturnValueOnce(next);
+    currentChild.emit("exit", 1);
+    vi.advanceTimersByTime(11_000);
+    expect(shared.forkMock).toHaveBeenCalledTimes(4);
+  });
+
   it("pause() before resume() is a no-op when called on an already-paused client", () => {
     const client = new WatchdogClient({ mainPid: 4242 });
     client.pause();

--- a/electron/services/__tests__/MainProcessWatchdogClient.test.ts
+++ b/electron/services/__tests__/MainProcessWatchdogClient.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { EventEmitter } from "events";
+
+const shared = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  });
+  return {
+    forkMock: vi.fn(),
+    appMock,
+  };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: shared.forkMock,
+  },
+  UtilityProcess: EventEmitter,
+  app: shared.appMock,
+}));
+
+interface MockChild extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  pid?: number;
+}
+
+function createMockChild(): MockChild {
+  return Object.assign(new EventEmitter(), {
+    postMessage: vi.fn(),
+    kill: vi.fn(),
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    pid: 9999 as number | undefined,
+  });
+}
+
+describe("MainProcessWatchdogClient", () => {
+  let mockChild: MockChild;
+  let WatchdogClient: typeof import("../MainProcessWatchdogClient.js").MainProcessWatchdogClient;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockChild = createMockChild();
+    shared.forkMock.mockReturnValue(mockChild);
+    ({ MainProcessWatchdogClient: WatchdogClient } =
+      await import("../MainProcessWatchdogClient.js"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("forks the watchdog with serviceName and --main-pid argv", () => {
+    new WatchdogClient({ mainPid: 4242 });
+
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+    const [, argv, options] = shared.forkMock.mock.calls[0];
+    expect(argv).toEqual(["--main-pid=4242"]);
+    expect(options).toMatchObject({
+      serviceName: "daintree-watchdog",
+      stdio: "pipe",
+    });
+    expect(options.env).toMatchObject({
+      DAINTREE_USER_DATA: "/mock/user/data",
+      DAINTREE_UTILITY_PROCESS_KIND: "watchdog-host",
+    });
+  });
+
+  it("sends an immediate ping on fork so the watchdog arms before the first interval", () => {
+    new WatchdogClient({ mainPid: 4242 });
+    const pings = mockChild.postMessage.mock.calls.filter(
+      (call) => (call[0] as { type?: string })?.type === "ping"
+    );
+    expect(pings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("sends a ping every 5 seconds", () => {
+    new WatchdogClient({ mainPid: 4242 });
+    mockChild.postMessage.mockClear();
+
+    vi.advanceTimersByTime(5000);
+    let pings = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "ping"
+    );
+    expect(pings).toHaveLength(1);
+
+    vi.advanceTimersByTime(15000);
+    pings = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "ping"
+    );
+    expect(pings).toHaveLength(4);
+  });
+
+  it("pause() stops the ping interval and posts {type: 'sleep'}", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    mockChild.postMessage.mockClear();
+
+    client.pause();
+
+    const sleeps = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "sleep"
+    );
+    expect(sleeps).toHaveLength(1);
+
+    // Advance 30s — no further pings should fire while paused.
+    vi.advanceTimersByTime(30_000);
+    const pings = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "ping"
+    );
+    expect(pings).toHaveLength(0);
+  });
+
+  it("resume() posts {type: 'wake'}, an immediate ping, and restarts the interval", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    client.pause();
+    mockChild.postMessage.mockClear();
+
+    client.resume();
+
+    const calls = mockChild.postMessage.mock.calls.map((c) => (c[0] as { type?: string })?.type);
+    expect(calls.filter((t) => t === "wake")).toHaveLength(1);
+    expect(calls.filter((t) => t === "ping").length).toBeGreaterThanOrEqual(1);
+
+    // Interval restarts: a 5s tick produces another ping.
+    mockChild.postMessage.mockClear();
+    vi.advanceTimersByTime(5000);
+    const pingsAfter = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "ping"
+    );
+    expect(pingsAfter).toHaveLength(1);
+  });
+
+  it("dispose() posts 'dispose', kills the child, and stops the ping interval", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    mockChild.postMessage.mockClear();
+
+    client.dispose();
+
+    const disposeCalls = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "dispose"
+    );
+    expect(disposeCalls).toHaveLength(1);
+    expect(mockChild.kill).toHaveBeenCalledTimes(1);
+
+    // No further pings after dispose.
+    mockChild.postMessage.mockClear();
+    vi.advanceTimersByTime(60_000);
+    expect(mockChild.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("dispose() is idempotent", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    client.dispose();
+    expect(() => client.dispose()).not.toThrow();
+  });
+
+  it("schedules a restart with backoff when the watchdog exits unexpectedly", () => {
+    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 3 });
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+
+    // Simulate a crash.
+    mockChild.emit("exit", 1);
+
+    // Advance past the maximum cap (10s) so the timer always fires regardless
+    // of jitter — fork must be called again.
+    const nextChild = createMockChild();
+    shared.forkMock.mockReturnValue(nextChild);
+    vi.advanceTimersByTime(11_000);
+
+    expect(shared.forkMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops restarting after maxRestartAttempts (deadlock detection becomes inactive)", () => {
+    new WatchdogClient({ mainPid: 4242, maxRestartAttempts: 2 });
+
+    // Simulate repeated crashes — track when each new child appears so we
+    // can attach the next exit emission to it.
+    let currentChild = mockChild;
+    for (let i = 0; i < 3; i++) {
+      const next = createMockChild();
+      shared.forkMock.mockReturnValueOnce(next);
+      currentChild.emit("exit", 1);
+      vi.advanceTimersByTime(11_000);
+      currentChild = next;
+    }
+
+    // Initial fork + 2 restart attempts = 3 total. The 4th is suppressed.
+    expect(shared.forkMock.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it("does not throw if postMessage fails (channel torn down)", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    mockChild.postMessage.mockImplementation(() => {
+      throw new Error("channel closed");
+    });
+
+    expect(() => vi.advanceTimersByTime(5000)).not.toThrow();
+    expect(() => client.pause()).not.toThrow();
+    expect(() => client.resume()).not.toThrow();
+    expect(() => client.dispose()).not.toThrow();
+  });
+
+  it("isRunning() reflects child lifecycle", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    expect(client.isRunning()).toBe(true);
+
+    mockChild.emit("exit", 0);
+    expect(client.isRunning()).toBe(false);
+
+    client.dispose();
+    expect(client.isRunning()).toBe(false);
+  });
+
+  it("does not start the host when startImmediately is false", () => {
+    new WatchdogClient({ mainPid: 4242, startImmediately: false });
+    expect(shared.forkMock).not.toHaveBeenCalled();
+  });
+
+  it("uses process.pid when mainPid config is omitted", () => {
+    new WatchdogClient();
+    const argv = shared.forkMock.mock.calls[0][1] as string[];
+    expect(argv[0]).toBe(`--main-pid=${process.pid}`);
+  });
+
+  it("pause() before resume() is a no-op when called on an already-paused client", () => {
+    const client = new WatchdogClient({ mainPid: 4242 });
+    client.pause();
+    mockChild.postMessage.mockClear();
+    client.pause();
+    const sleeps = mockChild.postMessage.mock.calls.filter(
+      (c) => (c[0] as { type?: string })?.type === "sleep"
+    );
+    expect(sleeps).toHaveLength(0);
+  });
+});

--- a/electron/watchdog-host-bootstrap.ts
+++ b/electron/watchdog-host-bootstrap.ts
@@ -1,0 +1,18 @@
+import { enableCompileCache } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+
+const userData = process.env.DAINTREE_USER_DATA;
+if (userData) {
+  try {
+    const cacheDir = path.join(userData, "compile-cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    enableCompileCache(cacheDir);
+  } catch {
+    enableCompileCache();
+  }
+} else {
+  enableCompileCache();
+}
+
+await import("./watchdog-host.js");

--- a/electron/watchdog-host-core.ts
+++ b/electron/watchdog-host-core.ts
@@ -105,11 +105,15 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
 
 /** Parse the `--main-pid=<pid>` flag out of argv. Returns null if missing
  * or malformed — Chromium injects positional arguments into `process.argv`,
- * so the named flag is the only reliable transport. */
+ * so the named flag is the only reliable transport. Strict parsing: rejects
+ * partial-numeric strings like "123abc" (which `parseInt` would silently
+ * truncate to 123). The PID we send SIGKILL to must be exactly the PID main
+ * intended us to watch. */
 export function parseMainPid(argv: readonly string[]): number | null {
   const arg = argv.find((a) => a.startsWith("--main-pid="));
   if (!arg) return null;
   const raw = arg.slice("--main-pid=".length);
-  const pid = Number.parseInt(raw, 10);
-  return Number.isFinite(pid) && pid > 0 ? pid : null;
+  if (!/^\d+$/.test(raw)) return null;
+  const pid = Number(raw);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
 }

--- a/electron/watchdog-host-core.ts
+++ b/electron/watchdog-host-core.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure watchdog logic, extracted for testability. The runtime entry point
+ * (watchdog-host.ts) is a thin wrapper that injects the real ping/timer/
+ * kill primitives.
+ */
+
+export const HEARTBEAT_INTERVAL_MS = 5000;
+
+// 3 misses × 5s = ~15s of unresponsiveness before kill. Conservative floor:
+// V8 major GC and synchronous better-sqlite3 ops can pause main for several
+// seconds, so anything under ~10s risks false positives.
+export const MAX_MISSED = 3;
+
+export interface WatchdogDeps {
+  /** Send SIGKILL (or equivalent) to the main process. The watchdog never
+   * calls this directly — it's injected so tests can observe and so the
+   * runtime can layer in a PID-validity check before firing. */
+  killMain: () => void;
+  /** Optional log sink. Defaults to console.error in the runtime entry. */
+  logError?: (msg: string) => void;
+}
+
+export interface WatchdogMessage {
+  type: "ping" | "sleep" | "wake" | "dispose";
+}
+
+export interface WatchdogState {
+  isArmed: boolean;
+  isPaused: boolean;
+  missedBeats: number;
+}
+
+export interface Watchdog {
+  readonly state: Readonly<WatchdogState>;
+  /** Advance one heartbeat interval. Increments the missed counter and
+   * fires kill when the threshold is crossed. No-op if not armed or paused. */
+  tick(): void;
+  /** Apply an inbound message from main. Returns true if the message was
+   * recognised and applied, false otherwise. */
+  handleMessage(msg: WatchdogMessage | null | undefined): boolean;
+  /** Force-disarm the watchdog. Used during dispose so an in-flight tick
+   * can't fire after the interval has been cleared. */
+  disarm(): void;
+}
+
+export function createWatchdog(deps: WatchdogDeps): Watchdog {
+  const log = deps.logError ?? ((msg) => console.error(msg));
+  const state: WatchdogState = {
+    isArmed: false,
+    isPaused: false,
+    missedBeats: 0,
+  };
+
+  function tick(): void {
+    if (!state.isArmed || state.isPaused) return;
+
+    state.missedBeats += 1;
+
+    if (state.missedBeats >= MAX_MISSED) {
+      log(
+        `[WatchdogHost] Main process unresponsive for ${state.missedBeats * HEARTBEAT_INTERVAL_MS}ms (${state.missedBeats} missed beats). Firing kill.`
+      );
+      try {
+        deps.killMain();
+      } catch (err) {
+        log(`[WatchdogHost] killMain threw: ${String(err)}`);
+      }
+      // Disarm so the next tick can't re-fire before main's relaunch sends
+      // its first ping. CrashRecoveryService will respawn main; it must
+      // explicitly re-arm us by sending a ping.
+      state.missedBeats = 0;
+      state.isArmed = false;
+    }
+  }
+
+  function handleMessage(msg: WatchdogMessage | null | undefined): boolean {
+    if (!msg || typeof msg.type !== "string") return false;
+    switch (msg.type) {
+      case "ping":
+        state.isArmed = true;
+        state.missedBeats = 0;
+        return true;
+      case "sleep":
+        state.isPaused = true;
+        state.missedBeats = 0;
+        return true;
+      case "wake":
+        state.isPaused = false;
+        state.missedBeats = 0;
+        return true;
+      case "dispose":
+        state.isArmed = false;
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function disarm(): void {
+    state.isArmed = false;
+  }
+
+  return { state, tick, handleMessage, disarm };
+}
+
+/** Parse the `--main-pid=<pid>` flag out of argv. Returns null if missing
+ * or malformed — Chromium injects positional arguments into `process.argv`,
+ * so the named flag is the only reliable transport. */
+export function parseMainPid(argv: readonly string[]): number | null {
+  const arg = argv.find((a) => a.startsWith("--main-pid="));
+  if (!arg) return null;
+  const raw = arg.slice("--main-pid=".length);
+  const pid = Number.parseInt(raw, 10);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}

--- a/electron/watchdog-host.ts
+++ b/electron/watchdog-host.ts
@@ -1,0 +1,112 @@
+/**
+ * External Main-Process Watchdog (UtilityProcess entry point).
+ *
+ * Lives outside the main event loop so a fully-deadlocked main process can
+ * still be force-killed. Receives the main PID via `--main-pid=<pid>` argv,
+ * expects a "ping" message every HEARTBEAT_INTERVAL_MS, and SIGKILLs main
+ * after MAX_MISSED missed beats. CrashRecoveryService and CrashLoopGuard
+ * handle the relaunch + safe-mode path.
+ *
+ * Fail-open: if anything is malformed (no PID, no parentPort, watchdog
+ * itself crashes), we exit without killing main. False positives are far
+ * worse than missing a deadlock — every kill path is gated.
+ */
+
+import { MessagePort } from "node:worker_threads";
+import {
+  createWatchdog,
+  parseMainPid,
+  HEARTBEAT_INTERVAL_MS,
+  MAX_MISSED,
+  type WatchdogMessage,
+} from "./watchdog-host-core.js";
+
+const STDIO_DEAD_CODES = new Set(["EPIPE", "EIO", "EBADF", "ECONNRESET"]);
+for (const stream of [process.stdout, process.stderr]) {
+  if (stream && typeof stream.on === "function") {
+    stream.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code && STDIO_DEAD_CODES.has(err.code)) return;
+      throw err;
+    });
+  }
+}
+
+if (!process.parentPort) {
+  console.error("[WatchdogHost] Must run in UtilityProcess context");
+  process.exit(1);
+}
+
+const port = process.parentPort as unknown as MessagePort;
+
+const mainPid = parseMainPid(process.argv);
+
+// Without a valid PID we cannot safely fire SIGKILL. Stay alive so main can
+// log the misconfiguration; the kill path is permanently disarmed.
+if (mainPid === null) {
+  console.error("[WatchdogHost] Missing or invalid --main-pid argv; kill path disabled");
+}
+
+function isMainAlive(pid: number): boolean {
+  // signal 0 is the POSIX existence-check probe. On Windows, Node maps it to
+  // OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION). Wrapping in try/catch
+  // handles both EPERM (permission) and ESRCH (not found) defensively —
+  // only "definitely-alive" returns true.
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const watchdog = createWatchdog({
+  killMain: () => {
+    if (mainPid === null) return;
+    if (!isMainAlive(mainPid)) {
+      console.error(
+        `[WatchdogHost] Main PID ${mainPid} is not alive; skipping SIGKILL (likely already exited)`
+      );
+      return;
+    }
+    console.error(`[WatchdogHost] Sending SIGKILL to main PID ${mainPid}`);
+    try {
+      process.kill(mainPid, "SIGKILL");
+    } catch (err) {
+      console.error("[WatchdogHost] SIGKILL failed:", err);
+    }
+  },
+});
+
+const intervalHandle: NodeJS.Timeout = setInterval(() => {
+  watchdog.tick();
+}, HEARTBEAT_INTERVAL_MS);
+// Allow the watchdog process to exit naturally if its parent goes away
+// before sending dispose (e.g. main hard-crashes). The interval shouldn't
+// hold the event loop open.
+intervalHandle.unref();
+
+port.on("message", (rawMsg: unknown) => {
+  // parentPort wraps messages as { data, ports } — unwrap defensively.
+  const msg =
+    rawMsg && typeof rawMsg === "object" && "data" in rawMsg
+      ? ((rawMsg as { data: unknown }).data as WatchdogMessage)
+      : (rawMsg as WatchdogMessage);
+
+  const handled = watchdog.handleMessage(msg);
+  if (!handled) return;
+
+  if (msg.type === "dispose") {
+    clearInterval(intervalHandle);
+    try {
+      port.postMessage({ type: "disposed" });
+    } catch {
+      // postMessage can throw if the channel is already closed — that just
+      // means main has already moved on; nothing to do.
+    }
+    process.exit(0);
+  }
+});
+
+console.log(
+  `[WatchdogHost] Started; main PID=${mainPid ?? "<missing>"}, interval=${HEARTBEAT_INTERVAL_MS}ms, threshold=${MAX_MISSED}`
+);

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, powerMonitor } from "electron";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
+import type { MainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import type { ProjectStatsService } from "../services/ProjectStatsService.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
@@ -19,6 +20,7 @@ export function clearResumeTimeout(): void {
 export interface PowerMonitorDeps {
   getPtyClient: () => PtyClient | null;
   getWorkspaceClient: () => WorkspaceClient | null;
+  getMainProcessWatchdogClient?: () => MainProcessWatchdogClient | null;
 }
 
 export function setupPowerMonitor(deps: PowerMonitorDeps): void {
@@ -28,6 +30,7 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
     clearResumeTimeout();
     const ptyClient = deps.getPtyClient();
     const workspaceClient = deps.getWorkspaceClient();
+    const watchdog = deps.getMainProcessWatchdogClient?.() ?? null;
     if (ptyClient) {
       ptyClient.pauseHealthCheck();
       ptyClient.pauseAll();
@@ -35,6 +38,12 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
     if (workspaceClient) {
       workspaceClient.pauseHealthCheck();
       workspaceClient.setPollingEnabled(false);
+    }
+    if (watchdog) {
+      // Suppresses kill-on-miss across suspend. Without this, a long sleep
+      // would accumulate enough missed pings for the watchdog to SIGKILL
+      // main on wake — exactly the false-positive we have to avoid.
+      watchdog.pause();
     }
     suspendTime = Date.now();
   });
@@ -50,6 +59,12 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
       try {
         const ptyClient = deps.getPtyClient();
         const workspaceClient = deps.getWorkspaceClient();
+        const watchdog = deps.getMainProcessWatchdogClient?.() ?? null;
+        if (watchdog) {
+          // Resume before pty/workspace so the watchdog is actively armed
+          // by the time the heavier post-wake refresh work begins.
+          watchdog.resume();
+        }
         if (ptyClient) {
           ptyClient.resumeAll();
           ptyClient.resumeHealthCheck();

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -8,6 +8,7 @@ import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.
 import { PtyClient, disposePtyClient } from "../services/PtyClient.js";
 import {
   MainProcessWatchdogClient,
+  getMainProcessWatchdogClient,
   disposeMainProcessWatchdog,
 } from "../services/MainProcessWatchdogClient.js";
 import {
@@ -689,7 +690,9 @@ export async function setupWindowServices(
     // PtyClient still starts normally.
     if (!mainProcessWatchdogClient) {
       try {
-        mainProcessWatchdogClient = new MainProcessWatchdogClient();
+        // Use the singleton accessor so `disposeMainProcessWatchdog()` in
+        // shutdown.ts reaches the running instance instead of a no-op.
+        mainProcessWatchdogClient = getMainProcessWatchdogClient();
       } catch (err) {
         console.error("[MAIN] Failed to start main-process watchdog:", err);
         mainProcessWatchdogClient = null;

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -7,6 +7,10 @@ import { distributePortsToView } from "./portDistribution.js";
 import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.js";
 import { PtyClient, disposePtyClient } from "../services/PtyClient.js";
 import {
+  MainProcessWatchdogClient,
+  disposeMainProcessWatchdog,
+} from "../services/MainProcessWatchdogClient.js";
+import {
   getWorkspaceClient,
   disposeWorkspaceClient,
   WorkspaceClient,
@@ -101,6 +105,7 @@ let processArgvCliHandled = false;
 
 // ── Global service refs (shared across all windows) ──
 let ptyClient: PtyClient | null = null;
+let mainProcessWatchdogClient: MainProcessWatchdogClient | null = null;
 let workspaceClient: WorkspaceClient | null = null;
 let cliAvailabilityService: CliAvailabilityService | null = null;
 let agentVersionService: AgentVersionService | null = null;
@@ -134,6 +139,9 @@ export function getPtyClient(): PtyClient | null {
 }
 export function setPtyClientRef(v: PtyClient | null): void {
   ptyClient = v;
+}
+export function getMainProcessWatchdogClientRef(): MainProcessWatchdogClient | null {
+  return mainProcessWatchdogClient;
 }
 export function getWorkspaceClientRef(): WorkspaceClient | null {
   return workspaceClient;
@@ -674,6 +682,19 @@ export async function setupWindowServices(
   // Critical services (global, first window only)
   if (!ptyClient) {
     console.log("[MAIN] Starting critical services...");
+
+    // Start the external main-process watchdog before PtyClient so a deadlock
+    // during PTY host fork (worst case: a synchronous spawn that hangs) is
+    // still recoverable. The watchdog is fail-open: if its own fork throws,
+    // PtyClient still starts normally.
+    if (!mainProcessWatchdogClient) {
+      try {
+        mainProcessWatchdogClient = new MainProcessWatchdogClient();
+      } catch (err) {
+        console.error("[MAIN] Failed to start main-process watchdog:", err);
+        mainProcessWatchdogClient = null;
+      }
+    }
 
     ptyClient = new PtyClient({
       maxRestartAttempts: 3,
@@ -1273,6 +1294,10 @@ export async function setupWindowServices(
     if (ptyClient) ptyClient.dispose();
     ptyClient = null;
     disposePtyClient();
+
+    if (mainProcessWatchdogClient) mainProcessWatchdogClient.dispose();
+    mainProcessWatchdogClient = null;
+    disposeMainProcessWatchdog();
 
     // Clean up IPC handlers and reset guards so next window re-registers fresh
     if (cleanupIpcHandlers) {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,8 @@ const config: KnipConfig = {
     "electron/pty-host-bootstrap.ts",
     "electron/workspace-host.ts",
     "electron/workspace-host-bootstrap.ts",
+    "electron/watchdog-host.ts",
+    "electron/watchdog-host-bootstrap.ts",
     "electron/preload.cts",
 
     // Web workers instantiated via `new Worker(new URL(...))`. Static analysis

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -105,6 +105,8 @@ async function run() {
       "electron/pty-host-bootstrap.ts",
       "electron/workspace-host.ts",
       "electron/workspace-host-bootstrap.ts",
+      "electron/watchdog-host.ts",
+      "electron/watchdog-host-bootstrap.ts",
     ],
     outdir: "dist-electron/electron",
     format: "esm",


### PR DESCRIPTION
## Summary

- Adds a tiny `UtilityProcess` watchdog with no business logic that receives the main PID via `argv`, expects a heartbeat ping every 5s, and sends `SIGKILL` to main after 3 missed beats (~15s total)
- `MainProcessWatchdogClient` manages the watchdog lifecycle: forks, pings every 5s, pauses/resumes around sleep/wake transitions, and restarts with full-jitter backoff capped at 3 attempts
- The only crash class in the audit with zero recovery path — a hung main process currently requires a manual force-quit; this closes that gap using the same heartbeat pattern already proven in `PtyClient` and `WorkspaceHostProcess`

Resolves #6274

## Changes

- `electron/watchdog-host.ts` — entry point for the watchdog `UtilityProcess`
- `electron/watchdog-host-core.ts` — pure watchdog logic (separated for testability)
- `electron/watchdog-host-bootstrap.ts` — process bootstrap
- `electron/services/MainProcessWatchdogClient.ts` — main-side manager (singleton via `getMainProcessWatchdogClient()`)
- Wired into `windowServices.ts` (first-window critical block), `powerMonitor.ts` (suspend/resume), `shutdown.ts` (disposal), and `scripts/build-main.mjs` (esbuild entries)

## Testing

36 unit tests across `watchdog-host-core.test.ts` and `MainProcessWatchdogClient.test.ts` covering: heartbeat timeout, missed-beat counting, sleep/wake suppression, jitter backoff, restart cap, and stable-uptime reset.