### PR TITLE
perf(diagnostics): renderer-side event-loop sampling reported to main

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -118,6 +118,7 @@ export const CHANNELS = {
   DIAGNOSTICS_GET_HEAP_STATS: "diagnostics:get-heap-stats",
   DIAGNOSTICS_GET_INFO: "diagnostics:get-info",
   SYSTEM_REPORT_BLINK_MEMORY: "system:report-blink-memory",
+  SYSTEM_REPORT_RENDERER_ELU: "system:report-renderer-elu",
 
   PR_DETECTED: "pr:detected",
   PR_CLEARED: "pr:cleared",

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -39,6 +39,9 @@ vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   app: appMock,
   dialog: dialogMock,
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => null),
+  },
 }));
 
 vi.mock("node:v8", () => ({
@@ -203,30 +206,26 @@ describe("registerDiagnosticsHandlers", () => {
       });
     });
 
-    it("ignores suppressed samples (preload startup window)", () => {
-      registerDiagnosticsHandlers(deps);
-      const handler = getHandlerFn("system:report-renderer-elu");
-      handler(makeEvent(42), {
-        requestId: "elu-1",
-        blockingDurationMs: 0,
-        sampleWindowMs: 1000,
-        suppressed: true,
-      });
-      expect(recordEluSampleMock).not.toHaveBeenCalled();
-    });
-
-    it("rejects malformed payloads (NaN, missing fields, non-positive window)", () => {
+    it("rejects malformed payloads (NaN, non-positive window, negative blocking, null/missing)", () => {
       registerDiagnosticsHandlers(deps);
       const handler = getHandlerFn("system:report-renderer-elu");
 
+      // NaN blocking duration
       handler(makeEvent(42), {
         requestId: "x",
         blockingDurationMs: Number.NaN,
         sampleWindowMs: 1000,
       });
+      // Zero window
       handler(makeEvent(42), { requestId: "x", blockingDurationMs: 0, sampleWindowMs: 0 });
+      // Negative blocking
       handler(makeEvent(42), { requestId: "x", blockingDurationMs: -1, sampleWindowMs: 1000 });
+      // Null payload
       handler(makeEvent(42), null);
+      // Missing blockingDurationMs (undefined coerces to NaN through Number.isFinite)
+      handler(makeEvent(42), { requestId: "x", sampleWindowMs: 1000 });
+      // Missing sampleWindowMs
+      handler(makeEvent(42), { requestId: "x", blockingDurationMs: 500 });
 
       expect(recordEluSampleMock).not.toHaveBeenCalled();
     });

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -68,6 +68,14 @@ vi.mock("../../../services/DiagnosticsCollector.js", () => ({
   collectDiagnostics: vi.fn(() => Promise.resolve({})),
 }));
 
+const recordBlinkSampleMock = vi.hoisted(() => vi.fn());
+const recordEluSampleMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../services/ProcessMemoryMonitor.js", () => ({
+  recordBlinkSample: recordBlinkSampleMock,
+  recordEluSample: recordEluSampleMock,
+}));
+
 import { registerDiagnosticsHandlers } from "../diagnostics.js";
 
 function getHandlerFn(channelName: string): (...args: unknown[]) => unknown {
@@ -92,6 +100,8 @@ describe("registerDiagnosticsHandlers", () => {
     expect(channels).toContain("diagnostics:get-heap-stats");
     expect(channels).toContain("diagnostics:get-info");
     expect(channels).toContain("system:download-diagnostics");
+    expect(channels).toContain("system:report-blink-memory");
+    expect(channels).toContain("system:report-renderer-elu");
     cleanup();
   });
 
@@ -172,6 +182,64 @@ describe("registerDiagnosticsHandlers", () => {
 
       expect(result.uptimeSeconds).toBeGreaterThanOrEqual(0);
       expect(result.eventLoopP99Ms).toBe(12);
+    });
+  });
+
+  describe("handleReportRendererElu", () => {
+    function makeEvent(senderId = 42, destroyed = false) {
+      return {
+        sender: { id: senderId, isDestroyed: () => destroyed },
+      };
+    }
+
+    it("records ELU samples for live senders, taking webContentsId from event.sender", () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:report-renderer-elu");
+      handler(makeEvent(42), { requestId: "elu-1", blockingDurationMs: 800, sampleWindowMs: 1000 });
+
+      expect(recordEluSampleMock).toHaveBeenCalledWith(42, {
+        blockingDurationMs: 800,
+        sampleWindowMs: 1000,
+      });
+    });
+
+    it("ignores suppressed samples (preload startup window)", () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:report-renderer-elu");
+      handler(makeEvent(42), {
+        requestId: "elu-1",
+        blockingDurationMs: 0,
+        sampleWindowMs: 1000,
+        suppressed: true,
+      });
+      expect(recordEluSampleMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed payloads (NaN, missing fields, non-positive window)", () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:report-renderer-elu");
+
+      handler(makeEvent(42), {
+        requestId: "x",
+        blockingDurationMs: Number.NaN,
+        sampleWindowMs: 1000,
+      });
+      handler(makeEvent(42), { requestId: "x", blockingDurationMs: 0, sampleWindowMs: 0 });
+      handler(makeEvent(42), { requestId: "x", blockingDurationMs: -1, sampleWindowMs: 1000 });
+      handler(makeEvent(42), null);
+
+      expect(recordEluSampleMock).not.toHaveBeenCalled();
+    });
+
+    it("drops late replies from destroyed senders", () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:report-renderer-elu");
+      handler(makeEvent(42, true), {
+        requestId: "elu-1",
+        blockingDurationMs: 500,
+        sampleWindowMs: 1000,
+      });
+      expect(recordEluSampleMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -183,12 +183,9 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   );
 
   // Renderer ELU report. webContents id is taken from event.sender.id.
-  // Suppressed samples (fired during the preload's startup-suppression window)
-  // are dropped here so the streak counter can't latch on cold-start noise.
   handlers.push(
     typedHandleWithContext(CHANNELS.SYSTEM_REPORT_RENDERER_ELU, (ctx, payload) => {
       if (!payload) return;
-      if (payload.suppressed === true) return;
       if (
         !Number.isFinite(payload.blockingDurationMs) ||
         !Number.isFinite(payload.sampleWindowMs) ||

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -18,7 +18,7 @@ import type {
   DiagnosticsBundleSavePayload,
 } from "../../../shared/types/ipc/system.js";
 import type * as DiagnosticsCollectorModule from "../../services/DiagnosticsCollector.js";
-import { recordBlinkSample } from "../../services/ProcessMemoryMonitor.js";
+import { recordBlinkSample, recordEluSample } from "../../services/ProcessMemoryMonitor.js";
 
 let cachedDiagnosticsCollector: typeof DiagnosticsCollectorModule | null = null;
 async function getDiagnosticsCollector(): Promise<typeof DiagnosticsCollectorModule> {
@@ -178,6 +178,29 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
         marked: optionalKb(payload.marked),
         total: optionalKb(payload.total),
         partitionAlloc: optionalKb(payload.partitionAlloc),
+      });
+    })
+  );
+
+  // Renderer ELU report. webContents id is taken from event.sender.id.
+  // Suppressed samples (fired during the preload's startup-suppression window)
+  // are dropped here so the streak counter can't latch on cold-start noise.
+  handlers.push(
+    typedHandleWithContext(CHANNELS.SYSTEM_REPORT_RENDERER_ELU, (ctx, payload) => {
+      if (!payload) return;
+      if (payload.suppressed === true) return;
+      if (
+        !Number.isFinite(payload.blockingDurationMs) ||
+        !Number.isFinite(payload.sampleWindowMs) ||
+        payload.blockingDurationMs < 0 ||
+        payload.sampleWindowMs <= 0
+      ) {
+        return;
+      }
+      if (ctx.event.sender.isDestroyed()) return;
+      recordEluSample(ctx.webContentsId, {
+        blockingDurationMs: payload.blockingDurationMs,
+        sampleWindowMs: payload.sampleWindowMs,
       });
     })
   );

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -37,6 +37,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "window:destroy-hidden-webviews": "external",
   "window:disk-space-status": "external",
   "window:sample-blink-memory": "external",
+  "window:sample-renderer-elu": "external",
   "system:wake": "external",
   "app-agent:dispatch-action-request": "external",
   "app-agent:confirmation-request": "external",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2587,20 +2587,18 @@ _eventBusOn("window:sample-blink-memory", ({ requestId }) => {
 // JS thread saturation. blockingDuration is 0 for entries < 50ms by spec —
 // that's the intended noise floor for "long task" detection.
 //
-// Startup window is suppressed because LoAF buffered:true may replay early
-// entries from page boot, and ProcessMemoryMonitor's main-side warmup does
-// not gate per-renderer startup.
-const RENDERER_ELU_STARTUP_SUPPRESSION_MS = 5_000;
+// No startup suppression: ProcessMemoryMonitor's poll cadence is 30s, so any
+// LoAF replay from `buffered: true` is diluted across a full window before
+// the first sample. The 0.85 ratio + 6-sample streak threshold on the main
+// side absorbs the residual cold-start noise.
 type LoAFEntry = PerformanceEntry & { blockingDuration?: number };
 let eluAccumulatedBlockingMs = 0;
-let eluWindowStartMs = 0;
-const eluObserverStartMs =
+let eluWindowStartMs =
   typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
     : 0;
 try {
   if (typeof PerformanceObserver === "function") {
-    eluWindowStartMs = eluObserverStartMs;
     const observer = new PerformanceObserver((list) => {
       for (const entry of list.getEntries() as LoAFEntry[]) {
         const blocking = entry.blockingDuration;
@@ -2626,14 +2624,12 @@ _eventBusOn("window:sample-renderer-elu", ({ requestId }) => {
         : Date.now();
     const sampleWindowMs = Math.max(0, Math.round(now - eluWindowStartMs));
     const blockingDurationMs = Math.max(0, Math.round(eluAccumulatedBlockingMs));
-    const suppressed = now - eluObserverStartMs < RENDERER_ELU_STARTUP_SUPPRESSION_MS;
     eluAccumulatedBlockingMs = 0;
     eluWindowStartMs = now;
     void ipcRenderer.invoke(CHANNELS.SYSTEM_REPORT_RENDERER_ELU, {
       requestId,
       blockingDurationMs,
       sampleWindowMs,
-      suppressed,
     });
   } catch {
     /* observability is best-effort */

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2579,6 +2579,67 @@ _eventBusOn("window:sample-blink-memory", ({ requestId }) => {
   }
 });
 
+// Renderer event-loop utilization sampler. The Node ELU API
+// (performance.eventLoopUtilization) is unavailable under sandbox: true, so we
+// observe the Web `long-animation-frame` PerformanceObserver and accumulate
+// `blockingDuration` between sample events. The preload runs on the same
+// renderer main thread as the page, so LoAF entries reflect the user-visible
+// JS thread saturation. blockingDuration is 0 for entries < 50ms by spec —
+// that's the intended noise floor for "long task" detection.
+//
+// Startup window is suppressed because LoAF buffered:true may replay early
+// entries from page boot, and ProcessMemoryMonitor's main-side warmup does
+// not gate per-renderer startup.
+const RENDERER_ELU_STARTUP_SUPPRESSION_MS = 5_000;
+type LoAFEntry = PerformanceEntry & { blockingDuration?: number };
+let eluAccumulatedBlockingMs = 0;
+let eluWindowStartMs = 0;
+const eluObserverStartMs =
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : 0;
+try {
+  if (typeof PerformanceObserver === "function") {
+    eluWindowStartMs = eluObserverStartMs;
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries() as LoAFEntry[]) {
+        const blocking = entry.blockingDuration;
+        if (typeof blocking === "number" && blocking > 0) {
+          eluAccumulatedBlockingMs += blocking;
+        }
+      }
+    });
+    // long-animation-frame is in Chromium 123+. Older runtimes throw on
+    // observe() — caught and ignored; the handler will report 0 blocking.
+    // The observer is intentionally not stored — it lives for the renderer's
+    // lifetime and never needs to be disconnected.
+    observer.observe({ type: "long-animation-frame", buffered: true });
+  }
+} catch {
+  /* observer unavailable — sampler reports 0/window */
+}
+_eventBusOn("window:sample-renderer-elu", ({ requestId }) => {
+  try {
+    const now =
+      typeof performance !== "undefined" && typeof performance.now === "function"
+        ? performance.now()
+        : Date.now();
+    const sampleWindowMs = Math.max(0, Math.round(now - eluWindowStartMs));
+    const blockingDurationMs = Math.max(0, Math.round(eluAccumulatedBlockingMs));
+    const suppressed = now - eluObserverStartMs < RENDERER_ELU_STARTUP_SUPPRESSION_MS;
+    eluAccumulatedBlockingMs = 0;
+    eluWindowStartMs = now;
+    void ipcRenderer.invoke(CHANNELS.SYSTEM_REPORT_RENDERER_ELU, {
+      requestId,
+      blockingDurationMs,
+      sampleWindowMs,
+      suppressed,
+    });
+  } catch {
+    /* observability is best-effort */
+  }
+});
+
 // E2E test bridge: expose renderer-side IPC listener introspection in fault mode.
 // Gated by DAINTREE_E2E_FAULT_MODE to avoid production surface area.
 if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -86,6 +86,93 @@ export function getBlinkSamples(): ReadonlyMap<number, BlinkMemorySample> {
   return blinkSamples;
 }
 
+/** Ratio (blocking / sample window) considered "saturated" for a single sample. */
+export const RENDERER_ELU_HIGH_RATIO = 0.85;
+
+/**
+ * Number of consecutive saturated samples required before logging a
+ * sustained-high warning. POLL_INTERVAL_MS is 30s, so 6 samples = 3 minutes
+ * of continuous saturation. A single sub-threshold sample resets the streak.
+ */
+export const RENDERER_ELU_HIGH_SAMPLE_COUNT = 6;
+
+export interface RendererEluSample {
+  /** Total LoAF blockingDuration accumulated by the preload over the window, in ms. */
+  blockingDurationMs: number;
+  /** Wall-clock width of the sample window the preload measured against, in ms. */
+  sampleWindowMs: number;
+  /** Derived ratio = blockingDurationMs / sampleWindowMs, clamped to [0, 1]. */
+  ratio: number;
+  /** Wall-clock time the sample was recorded. */
+  timestamp: number;
+}
+
+const eluSamples = new Map<number, RendererEluSample>();
+const eluHighStreak = new Map<number, number>();
+
+/**
+ * Called by the IPC handler when a renderer reports its accumulated long-
+ * animation-frame blocking time. Keyed by webContents id; cleared on view
+ * eviction via `forgetEluSample`. Logs at debug level for every sample;
+ * emits exactly one `renderer-elu-sustained-high` warn when the per-view
+ * streak first hits {@link RENDERER_ELU_HIGH_SAMPLE_COUNT}. The streak
+ * continues incrementing past the threshold, but only the boundary crossing
+ * is logged to avoid flooding.
+ */
+export function recordEluSample(
+  webContentsId: number,
+  payload: { blockingDurationMs: number; sampleWindowMs: number }
+): void {
+  const { blockingDurationMs, sampleWindowMs } = payload;
+  if (sampleWindowMs <= 0) return;
+  const rawRatio = blockingDurationMs / sampleWindowMs;
+  const ratio = rawRatio < 0 ? 0 : rawRatio > 1 ? 1 : rawRatio;
+  const stored: RendererEluSample = {
+    blockingDurationMs,
+    sampleWindowMs,
+    ratio,
+    timestamp: Date.now(),
+  };
+  eluSamples.set(webContentsId, stored);
+  logDebug("renderer-elu-sample", {
+    webContentsId,
+    ratio: Math.round(ratio * 100) / 100,
+    blockingDurationMs: Math.round(blockingDurationMs),
+    sampleWindowMs,
+  });
+
+  if (ratio >= RENDERER_ELU_HIGH_RATIO) {
+    const next = (eluHighStreak.get(webContentsId) ?? 0) + 1;
+    eluHighStreak.set(webContentsId, next);
+    if (next === RENDERER_ELU_HIGH_SAMPLE_COUNT) {
+      logWarn("renderer-elu-sustained-high", {
+        webContentsId,
+        ratio: Math.round(ratio * 100) / 100,
+        consecutiveSamples: next,
+        windowMs: sampleWindowMs * next,
+      });
+    }
+  } else {
+    eluHighStreak.delete(webContentsId);
+  }
+}
+
+/** Drop a renderer's last ELU sample and streak (call from view eviction). */
+export function forgetEluSample(webContentsId: number): void {
+  eluSamples.delete(webContentsId);
+  eluHighStreak.delete(webContentsId);
+}
+
+/** Read-only view for diagnostics / tests. */
+export function getEluSamples(): ReadonlyMap<number, RendererEluSample> {
+  return eluSamples;
+}
+
+/** Read-only view of per-view consecutive saturated-sample counts (tests). */
+export function getEluHighStreaks(): ReadonlyMap<number, number> {
+  return eluHighStreak;
+}
+
 export interface MemoryPressureActions {
   clearCaches: () => Promise<void>;
   destroyHiddenWebviews: (tier: 1 | 2) => Promise<void>;
@@ -99,6 +186,14 @@ export interface MemoryPressureActions {
    * `system:report-blink-memory` IPC channel which calls `recordBlinkSample`.
    */
   sampleBlinkMemory?: () => void;
+  /**
+   * Optional renderer event-loop utilization sampler. If wired, fans a
+   * `window:sample-renderer-elu` push event to every active renderer (cached
+   * views are skipped — JS timer throttling makes their samples meaningless).
+   * Renderers reply via `system:report-renderer-elu` which calls
+   * `recordEluSample`. Failures are non-critical observability.
+   */
+  sampleRendererElu?: () => void;
 }
 
 function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
@@ -121,6 +216,13 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       // populate `blinkSamples` for the next poll's diagnostics.
       try {
         actions?.sampleBlinkMemory?.();
+      } catch {
+        /* non-critical */
+      }
+      // Kick off a renderer-ELU sample fan-out alongside Blink-memory. Replies
+      // arrive via SYSTEM_REPORT_RENDERER_ELU and populate `eluSamples`.
+      try {
+        actions?.sampleRendererElu?.();
       } catch {
         /* non-critical */
       }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -385,18 +385,18 @@ describe("McpServerService", () => {
     const { window } = createMockWindow({
       getManifest: () => [
         createManifestEntry({
-          id: "github.listPRs" as ActionId,
+          id: "github.listPullRequests" as ActionId,
           title: "List PRs",
           description: "List pull requests",
           category: "github",
           kind: "query",
         }),
         createManifestEntry({
-          id: "browser.navigate" as ActionId,
-          title: "Navigate",
-          description: "Navigate the browser",
-          category: "browser",
-          kind: "command",
+          id: "system.checkCommand" as ActionId,
+          title: "Check Command",
+          description: "Check if a command exists",
+          category: "system",
+          kind: "query",
         }),
         createManifestEntry({
           id: "worktree.create" as ActionId,
@@ -413,12 +413,12 @@ describe("McpServerService", () => {
     transports.push(transport);
 
     const result = await client.listTools();
-    const ghTool = result.tools.find((t) => t.name === "github.listPRs");
-    const browserTool = result.tools.find((t) => t.name === "browser.navigate");
+    const ghTool = result.tools.find((t) => t.name === "github.listPullRequests");
+    const systemTool = result.tools.find((t) => t.name === "system.checkCommand");
     const wtTool = result.tools.find((t) => t.name === "worktree.create");
 
     expect(ghTool?.annotations?.openWorldHint).toBe(true);
-    expect(browserTool?.annotations?.openWorldHint).toBe(true);
+    expect(systemTool?.annotations?.openWorldHint).toBe(true);
     expect(wtTool?.annotations?.openWorldHint).toBe(false);
   });
 

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -826,6 +826,31 @@ describe("ProcessMemoryMonitor", () => {
       expect(getEluHighStreaks().has(42)).toBe(false);
     });
 
+    // Documents current behavior: a view that goes "active" → "cached" →
+    // "active" without an intervening below-threshold sample retains its
+    // streak. The fan-out filter skips cached views, so no samples arrive
+    // during the cached phase. If the streak was at N-1 before caching and
+    // the next active sample is high, the warning fires immediately. This is
+    // bounded — view eviction always calls forgetEluSample — but the logged
+    // `windowMs` may overstate the contiguous observation period. Acceptable
+    // for telemetry-only signal; if upgraded to a proactive trigger, the
+    // streak should become gap-aware.
+    it("(known limitation) streak survives caching gaps", () => {
+      const blocking = Math.ceil(RENDERER_ELU_HIGH_RATIO * 1000) + 1;
+      // Build streak to N-1 while view is active.
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT - 1; i++) {
+        recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      }
+      // No samples arrive while the view is cached (fan-out skips it).
+      // Then the view is reactivated and the next sample is also high.
+      recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+
+      const highCalls = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(highCalls).toHaveLength(1);
+    });
+
     it("startAppMetricsMonitor invokes actions.sampleRendererElu once per poll", () => {
       const sampleRendererElu = vi.fn();
       const actions: MemoryPressureActions = {

--- a/electron/services/__tests__/ProcessMemoryMonitor.test.ts
+++ b/electron/services/__tests__/ProcessMemoryMonitor.test.ts
@@ -35,6 +35,12 @@ import {
   recordBlinkSample,
   forgetBlinkSample,
   getBlinkSamples,
+  recordEluSample,
+  forgetEluSample,
+  getEluSamples,
+  getEluHighStreaks,
+  RENDERER_ELU_HIGH_RATIO,
+  RENDERER_ELU_HIGH_SAMPLE_COUNT,
   type MemoryPressureActions,
 } from "../ProcessMemoryMonitor.js";
 
@@ -696,6 +702,177 @@ describe("ProcessMemoryMonitor", () => {
       stop = startAppMetricsMonitor(actions);
 
       // Should not throw — sampleBlinkMemory is optional.
+      expect(() => vi.advanceTimersByTime(30_000)).not.toThrow();
+    });
+  });
+
+  describe("renderer ELU sampling (issue #6276)", () => {
+    beforeEach(() => {
+      for (const wcId of Array.from(getEluSamples().keys())) {
+        forgetEluSample(wcId);
+      }
+    });
+
+    it("recordEluSample stores ratio derived from blocking and window", () => {
+      recordEluSample(42, { blockingDurationMs: 1500, sampleWindowMs: 3000 });
+      const stored = getEluSamples().get(42);
+      expect(stored?.blockingDurationMs).toBe(1500);
+      expect(stored?.sampleWindowMs).toBe(3000);
+      expect(stored?.ratio).toBeCloseTo(0.5, 5);
+      expect(typeof stored?.timestamp).toBe("number");
+    });
+
+    it("ignores samples with non-positive sampleWindowMs", () => {
+      recordEluSample(42, { blockingDurationMs: 1500, sampleWindowMs: 0 });
+      expect(getEluSamples().has(42)).toBe(false);
+    });
+
+    it("clamps ratio to [0, 1]", () => {
+      recordEluSample(1, { blockingDurationMs: -100, sampleWindowMs: 1000 });
+      expect(getEluSamples().get(1)?.ratio).toBe(0);
+
+      recordEluSample(2, { blockingDurationMs: 5000, sampleWindowMs: 1000 });
+      expect(getEluSamples().get(2)?.ratio).toBe(1);
+    });
+
+    it("emits debug log with rounded ratio for every sample", () => {
+      recordEluSample(7, { blockingDurationMs: 250, sampleWindowMs: 1000 });
+      expect(logDebug).toHaveBeenCalledWith(
+        "renderer-elu-sample",
+        expect.objectContaining({ webContentsId: 7, ratio: 0.25 })
+      );
+    });
+
+    it("does NOT log sustained-high warning while below threshold", () => {
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT * 2; i++) {
+        recordEluSample(42, { blockingDurationMs: 100, sampleWindowMs: 1000 });
+      }
+      expect(logWarn).not.toHaveBeenCalledWith("renderer-elu-sustained-high", expect.anything());
+    });
+
+    it("logs sustained-high warning exactly once when streak hits threshold", () => {
+      const blocking = Math.ceil(RENDERER_ELU_HIGH_RATIO * 1000) + 1;
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT; i++) {
+        recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      }
+      const highCalls = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(highCalls).toHaveLength(1);
+      expect(highCalls[0]![1]).toMatchObject({
+        webContentsId: 42,
+        consecutiveSamples: RENDERER_ELU_HIGH_SAMPLE_COUNT,
+      });
+
+      // Subsequent saturated samples should not emit additional warnings.
+      recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      const stillOne = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(stillOne).toHaveLength(1);
+    });
+
+    it("a single below-threshold sample resets the streak", () => {
+      const blocking = Math.ceil(RENDERER_ELU_HIGH_RATIO * 1000) + 1;
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT - 1; i++) {
+        recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      }
+      // One quiet sample: streak resets.
+      recordEluSample(42, { blockingDurationMs: 50, sampleWindowMs: 1000 });
+      expect(getEluHighStreaks().has(42)).toBe(false);
+
+      // Now we need a fresh full streak before the warning fires.
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT - 1; i++) {
+        recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      }
+      const noHighYet = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(noHighYet).toHaveLength(0);
+
+      recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      const highNow = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(highNow).toHaveLength(1);
+    });
+
+    it("streaks are tracked independently per webContentsId", () => {
+      const blocking = Math.ceil(RENDERER_ELU_HIGH_RATIO * 1000) + 1;
+      for (let i = 0; i < RENDERER_ELU_HIGH_SAMPLE_COUNT - 1; i++) {
+        recordEluSample(1, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+        recordEluSample(2, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      }
+      // Reset only view 1.
+      recordEluSample(1, { blockingDurationMs: 0, sampleWindowMs: 1000 });
+      // Push view 2 over the edge.
+      recordEluSample(2, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+
+      const highCalls = vi
+        .mocked(logWarn)
+        .mock.calls.filter((c) => c[0] === "renderer-elu-sustained-high");
+      expect(highCalls).toHaveLength(1);
+      expect(highCalls[0]![1]).toMatchObject({ webContentsId: 2 });
+    });
+
+    it("forgetEluSample clears both the sample and the streak", () => {
+      const blocking = Math.ceil(RENDERER_ELU_HIGH_RATIO * 1000) + 1;
+      recordEluSample(42, { blockingDurationMs: blocking, sampleWindowMs: 1000 });
+      expect(getEluSamples().has(42)).toBe(true);
+      expect(getEluHighStreaks().has(42)).toBe(true);
+
+      forgetEluSample(42);
+      expect(getEluSamples().has(42)).toBe(false);
+      expect(getEluHighStreaks().has(42)).toBe(false);
+    });
+
+    it("startAppMetricsMonitor invokes actions.sampleRendererElu once per poll", () => {
+      const sampleRendererElu = vi.fn();
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        sampleRendererElu,
+      };
+
+      stop = startAppMetricsMonitor(actions);
+
+      vi.advanceTimersByTime(30_000);
+      expect(sampleRendererElu).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(30_000 * 2);
+      expect(sampleRendererElu).toHaveBeenCalledTimes(3);
+    });
+
+    it("sampleRendererElu throwing does not break the poll loop", () => {
+      const sampleRendererElu = vi.fn().mockImplementation(() => {
+        throw new Error("renderer port closed");
+      });
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+        sampleRendererElu,
+      };
+
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);
+      stop = startAppMetricsMonitor(actions);
+
+      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(30_000);
+
+      expect(sampleRendererElu).toHaveBeenCalledTimes(2);
+      expect(logDebug).toHaveBeenCalledWith("process-memory-sample", expect.any(Object));
+    });
+
+    it("works without sampleRendererElu (optional, backwards compat)", () => {
+      const actions: MemoryPressureActions = {
+        clearCaches: vi.fn().mockResolvedValue(undefined),
+        destroyHiddenWebviews: vi.fn().mockResolvedValue(undefined),
+        hibernateIdleProjects: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200 * 1024, 100)]);
+      stop = startAppMetricsMonitor(actions);
       expect(() => vi.advanceTimersByTime(30_000)).not.toThrow();
     });
   });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -21,7 +21,7 @@ import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
-import { forgetBlinkSample } from "../services/ProcessMemoryMonitor.js";
+import { forgetBlinkSample, forgetEluSample } from "../services/ProcessMemoryMonitor.js";
 import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo, logWarn } from "../utils/logger.js";
@@ -736,6 +736,7 @@ export class ProjectViewManager {
     this.webContentsToProject.delete(wcId);
     unregisterProjectView(wcId);
     forgetBlinkSample(wcId);
+    forgetEluSample(wcId);
 
     // Notify listeners (e.g. WorkspaceClient) so they can clean up direct ports
     this.onViewEvicted?.(wcId);

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -69,6 +69,7 @@ vi.mock("electron", () => {
 
 vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
   forgetBlinkSample: vi.fn(),
+  forgetEluSample: vi.fn(),
 }));
 
 vi.mock("../webContentsRegistry.js", () => ({
@@ -136,7 +137,7 @@ vi.mock("../../services/PtyManager.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
-import { forgetBlinkSample } from "../../services/ProcessMemoryMonitor.js";
+import { forgetBlinkSample, forgetEluSample } from "../../services/ProcessMemoryMonitor.js";
 import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
 
 function createMockWindow() {
@@ -560,6 +561,22 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.switchTo("proj-c", "/path/c");
 
     expect(vi.mocked(forgetBlinkSample)).toHaveBeenCalledWith(wcA.id);
+  });
+
+  it("calls forgetEluSample with the evicted webContents id", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    expect(vi.mocked(forgetEluSample)).toHaveBeenCalledWith(wcA.id);
   });
 });
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -586,6 +586,37 @@ export async function setupWindowServices(
               }
             }
           },
+          sampleRendererElu: () => {
+            if (!windowRegistry) return;
+            const requestId = `elu-${Date.now().toString(36)}`;
+            for (const wCtx of windowRegistry.all()) {
+              const w = wCtx.browserWindow;
+              if (w.isDestroyed()) continue;
+              // Cached/loading views have setBackgroundThrottling(true) which
+              // throttles JS timers and the LoAF observer, producing burst
+              // signal that doesn't reflect user-visible lag. Only sample
+              // active views; fall back to the app webContents for windows
+              // still on the bootstrap shell (no PVM yet).
+              const pvm = wCtx.services.projectViewManager;
+              const targets = pvm
+                ? pvm
+                    .getAllViews()
+                    .filter((v) => v.state === "active")
+                    .map((v) => v.view.webContents)
+                : [getAppWebContents(w)];
+              for (const wc of targets) {
+                if (!wc || wc.isDestroyed()) continue;
+                try {
+                  wc.send(CHANNELS.EVENTS_PUSH, {
+                    name: "window:sample-renderer-elu",
+                    payload: { requestId },
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
         });
       },
     });

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -588,17 +588,15 @@ export interface IpcInvokeMap {
   };
   // Renderer reports event-loop utilization (LoAF blockingDuration accumulated
   // since the prior sample) to ProcessMemoryMonitor. The webContents id is
-  // taken from event.sender on the handler side. `suppressed` is set when the
-  // sample falls inside the preload's startup-suppression window — main skips
-  // recording. `blockingDurationMs` is sub-window blocking time (>=50ms LoAF
-  // events only); main derives the ratio against `sampleWindowMs`.
+  // taken from event.sender on the handler side. `blockingDurationMs` is
+  // sub-window blocking time (>=50ms LoAF events only); main derives the
+  // ratio against `sampleWindowMs`.
   "system:report-renderer-elu": {
     args: [
       payload: {
         requestId: string;
         blockingDurationMs: number;
         sampleWindowMs: number;
-        suppressed?: boolean;
       },
     ];
     result: void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -586,6 +586,23 @@ export interface IpcInvokeMap {
     ];
     result: void;
   };
+  // Renderer reports event-loop utilization (LoAF blockingDuration accumulated
+  // since the prior sample) to ProcessMemoryMonitor. The webContents id is
+  // taken from event.sender on the handler side. `suppressed` is set when the
+  // sample falls inside the preload's startup-suppression window — main skips
+  // recording. `blockingDurationMs` is sub-window blocking time (>=50ms LoAF
+  // events only); main derives the ratio against `sampleWindowMs`.
+  "system:report-renderer-elu": {
+    args: [
+      payload: {
+        requestId: string;
+        blockingDurationMs: number;
+        sampleWindowMs: number;
+        suppressed?: boolean;
+      },
+    ];
+    result: void;
+  };
 
   // App state channels
   "app:get-state": {
@@ -2321,6 +2338,10 @@ export interface IpcEventMap {
   // ProcessMemoryMonitor can see the Blink (DOM/CSS/inter-frame) memory tier
   // that V8 heap stats miss. Renderer replies via SYSTEM_REPORT_BLINK_MEMORY.
   "window:sample-blink-memory": { requestId: string };
+  // Main asks active renderers to report accumulated long-animation-frame
+  // blocking time so ProcessMemoryMonitor can see sustained event-loop
+  // saturation. Renderer replies via SYSTEM_REPORT_RENDERER_ELU.
+  "window:sample-renderer-elu": { requestId: string };
   "window:disk-space-status": {
     status: "normal" | "warning" | "critical";
     availableMb: number;
@@ -2498,6 +2519,7 @@ export type IpcEventBusMap = Pick<
   | "window:destroy-hidden-webviews"
   | "window:disk-space-status"
   | "window:sample-blink-memory"
+  | "window:sample-renderer-elu"
   // System wake (per-webContents)
   | "system:wake"
   // Resource profile (global broadcast)


### PR DESCRIPTION
## Summary

- Adds renderer-side event-loop sampling using a `PerformanceObserver` long-animation-frame (LoAF) observer. `performance.eventLoopUtilization` isn't available in the sandboxed preload, so LoAF is the right hook here.
- Sampling is driven by main-process fan-out rather than a renderer `setInterval` — Chromium throttles JS timers in cached views, so a renderer-owned interval isn't reliable.
- A per-view streak counter emits a single warning at 6 consecutive high-utilization samples (the 3-minute sustained-saturation boundary). No proactive crash trigger — that's deferred to #6274.

Resolves #6276

## Changes

- `electron/preload.cts` — registers the `PerformanceObserver` LoAF handler; exposes `rendererEventLoop.sample` to main via IPC
- `electron/ipc/channels.ts`, `electron/ipc/handlers/diagnostics.ts`, `electron/ipc/handlers/events.ts` — new channel wiring for renderer ELU samples
- `electron/services/ProcessMemoryMonitor.ts` — streak accumulation and single-warn threshold per view
- `electron/window/windowServices.ts` — fan-out from main to all active views on the sampling interval
- `shared/types/ipc/maps.ts` — IPC type definitions for the new channel
- Drops dead startup-suppression code in preload that was never reachable

## Testing

- Unit tests in `electron/services/__tests__/ProcessMemoryMonitor.test.ts` covering streak accumulation and warn threshold
- `electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts` covering the new IPC handler
- `electron/window/__tests__/ProjectViewManager.eviction.test.ts` updated for the fan-out path