### PR TITLE
fix(github): branch GitHubResourceList empty state on filter activity

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -908,23 +908,49 @@ export function GitHubResourceList({
   );
 
   const renderEmpty = () => {
-    if (exactNumberNotFound !== null) {
+    const trimmedSearch = debouncedSearch.trim();
+    const isFilterActive =
+      exactNumberNotFound !== null ||
+      numberQuery !== null ||
+      trimmedSearch.length > 0 ||
+      filterState !== "open";
+    const resourceLabel = type === "issue" ? "issues" : "pull requests";
+
+    if (isFilterActive) {
+      const title =
+        exactNumberNotFound !== null
+          ? `${type === "issue" ? "Issue" : "PR"} #${exactNumberNotFound} not found`
+          : trimmedSearch.length > 0
+            ? `No ${resourceLabel} match "${trimmedSearch}"`
+            : `No ${resourceLabel} in this view`;
+
       return (
-        <div className="p-8 text-center text-muted-foreground">
-          <p className="text-sm">
-            {type === "issue" ? "Issue" : "PR"} #{exactNumberNotFound} not found
-          </p>
-        </div>
+        <EmptyState
+          variant="filtered-empty"
+          title={title}
+          action={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setSearchQuery("");
+                setFilterState("open" as StateFilter);
+              }}
+            >
+              Clear filters
+            </Button>
+          }
+          className="flex-1 justify-center"
+        />
       );
     }
 
     return (
-      <div className="p-8 text-center text-muted-foreground">
-        <p className="text-sm">
-          No {type === "issue" ? "issues" : "pull requests"} found
-          {debouncedSearch && ` for "${debouncedSearch}"`}
-        </p>
-      </div>
+      <EmptyState
+        variant="zero-data"
+        title={`No ${resourceLabel} found`}
+        className="flex-1 justify-center"
+      />
     );
   };
 

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -732,6 +732,36 @@ describe("GitHubResourceList empty state branching", () => {
       expect(screen.getByText(/No pull requests match "nonexistent"/)).toBeTruthy();
     });
   });
+
+  it("renders zero-data for PRs when no filters are active and the list is empty", async () => {
+    mockListPRs.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No pull requests found")).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: /clear filters/i })).toBeNull();
+  });
+
+  it("Clear filters action on PR view resets PR-specific store slice, not issue slice", async () => {
+    mockListPRs.mockResolvedValue(makeResponse([]));
+    useGitHubFilterStore.getState().setPrSearchQuery("foo");
+    useGitHubFilterStore.getState().setPrFilter("merged");
+    useGitHubFilterStore.getState().setIssueSearchQuery("untouched-issue-query");
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    const clearButton = await screen.findByRole("button", { name: /clear filters/i });
+    act(() => {
+      clearButton.click();
+    });
+
+    const filterStore = useGitHubFilterStore.getState();
+    expect(filterStore.prSearchQuery).toBe("");
+    expect(filterStore.prFilter).toBe("open");
+    expect(filterStore.issueSearchQuery).toBe("untouched-issue-query");
+  });
 });
 
 describe("GitHubResourceList retry behavior", () => {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -657,6 +657,83 @@ describe("GitHubResourceList no-token empty state", () => {
   });
 });
 
+describe("GitHubResourceList empty state branching", () => {
+  it("renders zero-data variant (no Clear filters button) when no filters are active and the list is empty", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues found")).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: /clear filters/i })).toBeNull();
+  });
+
+  it("renders filtered-empty with a Clear filters action when a search query is active", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("nonexistent");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No issues match "nonexistent"/)).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+  });
+
+  it("renders filtered-empty when a non-default state filter is active", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+    useGitHubFilterStore.getState().setIssueFilter("closed");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues in this view")).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+  });
+
+  it("Clear filters action resets search and state filter to defaults", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("foo");
+    useGitHubFilterStore.getState().setIssueFilter("closed");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const clearButton = await screen.findByRole("button", { name: /clear filters/i });
+    act(() => {
+      clearButton.click();
+    });
+
+    const filterStore = useGitHubFilterStore.getState();
+    expect(filterStore.issueSearchQuery).toBe("");
+    expect(filterStore.issueFilter).toBe("open");
+  });
+
+  it("renders filtered-empty for an exact number not found", async () => {
+    mockGetIssueByNumber.mockResolvedValue(null);
+    useGitHubFilterStore.getState().setIssueSearchQuery("#999");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Issue #999 not found/)).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+  });
+
+  it("renders filtered-empty for PRs with the right resource label", async () => {
+    mockListPRs.mockResolvedValue(makeResponse([]));
+    useGitHubFilterStore.getState().setPrSearchQuery("nonexistent");
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No pull requests match "nonexistent"/)).toBeTruthy();
+    });
+  });
+});
+
 describe("GitHubResourceList retry behavior", () => {
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });


### PR DESCRIPTION
## Summary

- Audited all five `EmptyState` call-sites from #6351. Only `GitHubResourceList` had the bug — it used a hand-rolled `<div>` in `renderEmpty()` instead of the `EmptyState` component and made no distinction between filtered-empty and first-run-empty.
- The other four surfaces (`McpServerSettingsTab`, `RecipeManager`, `RecipesTab`, `NotificationCenter`) have no filter or search input in scope at their empty branches, so `zero-data` is correct for them and needed no change.
- Replaced `renderEmpty()` with proper `EmptyState` branching: `isFilterActive` covers exact-number queries, numeric queries, debounced text search, and non-default state filter. Title variants are tailored per branch. The clear filters action scopes to the active type (issue or PR) and resets both search and state filter to defaults.

Resolves #6351

## Changes

- `src/components/GitHub/GitHubResourceList.tsx` — replace hand-rolled div with `EmptyState`; add `isFilterActive` detection; add per-branch title variants; scope clear filters action
- `src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx` — 8 new tests covering issue + PR paths, search, state filter, exact-number query, and scoped clear filters

## Testing

- 8 new unit tests, all passing (`vitest`)
- `tsc --noEmit` clean
- `eslint` clean (no new errors)