### PR TITLE
fix(panel): polish TabButton close button reveal and rename UX

### DIFF
--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -112,6 +112,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
       if ((detail as { id: string }).id === id) {
         setEditValue(title);
         setIsEditing(true);
+        didCommitOrCancelRef.current = false;
       }
     };
 
@@ -170,6 +171,8 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       e.stopPropagation();
       if (e.key === "Enter") {
+        // Don't intercept Enter while an IME composition is being committed.
+        if (e.nativeEvent.isComposing) return;
         e.preventDefault();
         const trimmed = editValue.trim();
         if (!trimmed || trimmed === title) {

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/Worktree/terminalStateConfig";
 import { usePanelStore } from "@/store";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
+import { UI_ANIMATION_DURATION } from "@/lib/animationUtils";
 
 export interface TabInfo {
   id: string;
@@ -67,8 +68,23 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
 ) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(title);
+  const [showRenameError, setShowRenameError] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const didCommitOrCancelRef = useRef(false);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearErrorTimer = useCallback(() => {
+    if (errorTimerRef.current !== null) {
+      clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearErrorTimer();
+    };
+  }, [clearErrorTimer]);
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -156,19 +172,31 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
       if (e.key === "Enter") {
         e.preventDefault();
         const trimmed = editValue.trim();
-        if (trimmed && trimmed !== title) {
-          onRename?.(trimmed);
+        if (!trimmed || trimmed === title) {
+          // Reject empty/unchanged: keep edit mode open and flash the border red.
+          clearErrorTimer();
+          setShowRenameError(true);
+          errorTimerRef.current = setTimeout(() => {
+            setShowRenameError(false);
+            errorTimerRef.current = null;
+          }, UI_ANIMATION_DURATION);
+          return;
         }
+        onRename?.(trimmed);
+        clearErrorTimer();
+        setShowRenameError(false);
         didCommitOrCancelRef.current = true;
         setIsEditing(false);
       } else if (e.key === "Escape") {
         e.preventDefault();
         setEditValue(title);
+        clearErrorTimer();
+        setShowRenameError(false);
         didCommitOrCancelRef.current = true;
         setIsEditing(false);
       }
     },
-    [editValue, title, onRename]
+    [editValue, title, onRename, clearErrorTimer]
   );
 
   const handleInputBlur = useCallback(() => {
@@ -179,8 +207,10 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
         onRename?.(trimmed);
       }
     }
+    clearErrorTimer();
+    setShowRenameError(false);
     setIsEditing(false);
-  }, [editValue, title, onRename]);
+  }, [editValue, title, onRename, clearErrorTimer]);
 
   const handleInputClick = useCallback((e: React.MouseEvent) => {
     // Prevent click from bubbling to tab click handler
@@ -262,7 +292,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
           </span>
 
           {isEditing ? (
-            <input
+            <m.input
               ref={inputRef}
               type="text"
               value={editValue}
@@ -272,8 +302,15 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               onClick={handleInputClick}
               onDoubleClick={handleInputDoubleClick}
               onPointerDown={handleInputPointerDown}
-              className="text-xs bg-daintree-bg/80 border border-border-strong px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.1 }}
+              className={cn(
+                "text-xs bg-daintree-bg/80 border px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text transition-colors duration-150 focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent",
+                showRenameError ? "border-status-error" : "border-border-strong"
+              )}
               aria-label={`Rename tab ${title}`}
+              aria-invalid={showRenameError || undefined}
             />
           ) : (
             <span
@@ -332,7 +369,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
                 onKeyDown={handleCloseKeyDown}
                 className={cn(
                   "shrink-0 p-0.5 -mr-1 rounded transition-colors",
-                  "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
+                  "opacity-0 group-hover/tab:opacity-100 group-focus-visible/tab:opacity-100 focus-visible:opacity-100",
                   "hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)]",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
                   "text-daintree-text/40 hover:text-status-error"

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -291,6 +291,72 @@ describe("TabButton", () => {
       expect(onRename).toHaveBeenCalledWith("Renamed");
       expect(screen.queryByTestId("motion-input")).toBeNull();
     });
+
+    it("ignores Enter while an IME composition is in progress", () => {
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: "Renamed" } });
+      fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+      expect(onRename).not.toHaveBeenCalled();
+      expect(screen.getByTestId("motion-input")).toBe(input);
+      expect(input.className).not.toContain("border-status-error");
+    });
+
+    it("invalid Enter then valid Enter commits exactly once and clears error state", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.className).toContain("border-status-error");
+
+      fireEvent.change(input, { target: { value: "Renamed" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onRename).toHaveBeenCalledTimes(1);
+      expect(onRename).toHaveBeenCalledWith("Renamed");
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+
+      // Pending error timer should be safely no-op after unmount.
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+    });
+  });
+
+  describe("context-menu rename path", () => {
+    it("commits a rename triggered via daintree:rename-terminal even after a prior Escape", () => {
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      // First rename via double-click, then Escape — sets the commit-or-cancel guard.
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      const firstInput = screen.getByTestId("motion-input") as HTMLInputElement;
+      fireEvent.keyDown(firstInput, { key: "Escape" });
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+
+      // Now trigger rename via context-menu event. Without resetting the guard
+      // in the event handler, a follow-up blur would silently drop the change.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("daintree:rename-terminal", { detail: { id: "test-panel-1" } })
+        );
+      });
+
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "FromContextMenu" } });
+      fireEvent.blur(input);
+
+      expect(onRename).toHaveBeenCalledWith("FromContextMenu");
+    });
   });
 
   describe("rename input fade-in", () => {

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { TabButton } from "../TabButton";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 
@@ -26,12 +27,33 @@ vi.mock("framer-motion", () => {
       );
     }
   );
+  const MotionInput = React.forwardRef<
+    HTMLInputElement,
+    React.InputHTMLAttributes<HTMLInputElement>
+  >((props, ref) => {
+    const {
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      layoutId: _layoutId,
+      layout: _layout,
+      ...rest
+    } = props as Record<string, unknown>;
+    return (
+      <input
+        ref={ref}
+        data-testid="motion-input"
+        {...(rest as React.InputHTMLAttributes<HTMLInputElement>)}
+      />
+    );
+  });
   return {
     LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     domAnimation: {},
     domMax: {},
-    m: { div: MotionDiv },
-    motion: { div: MotionDiv },
+    m: { div: MotionDiv, input: MotionInput },
+    motion: { div: MotionDiv, input: MotionInput },
   };
 });
 
@@ -185,6 +207,102 @@ describe("TabButton", () => {
       const after = container.innerHTML;
 
       expect(before).not.toBe(after);
+    });
+  });
+
+  describe("close button visibility", () => {
+    it("reveals on parent tab focus via group-focus-visible/tab variant", () => {
+      render(<TabButton {...defaultProps} />);
+      const closeButton = screen.getByLabelText("Close Test Agent");
+      // jsdom can't compute pseudo-classes; pin the class string so the
+      // parent-focus reveal symmetry survives refactors.
+      expect(closeButton.className).toContain("group-focus-visible/tab:opacity-100");
+      expect(closeButton.className).toContain("group-hover/tab:opacity-100");
+      expect(closeButton.className).toContain("focus-visible:opacity-100");
+    });
+  });
+
+  describe("rename validation feedback", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const enterEditMode = (titleNode: HTMLElement) => {
+      fireEvent.doubleClick(titleNode);
+    };
+
+    it("flashes red border and stays in edit mode when Enter is pressed on an empty value", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: "   " } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(screen.getByTestId("motion-input")).toBe(input);
+      expect(input.className).toContain("border-status-error");
+      expect(input.getAttribute("aria-invalid")).toBe("true");
+      expect(onRename).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(screen.getByTestId("motion-input")).toBe(input);
+      expect(input.className).not.toContain("border-status-error");
+      expect(input.getAttribute("aria-invalid")).toBeNull();
+    });
+
+    it("flashes red border and stays in edit mode when Enter is pressed on an unchanged value", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      // editValue starts as "Test Agent" — unchanged on first Enter.
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(screen.getByTestId("motion-input")).toBe(input);
+      expect(input.className).toContain("border-status-error");
+      expect(onRename).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(input.className).not.toContain("border-status-error");
+    });
+
+    it("commits and exits edit mode when Enter is pressed on a valid changed value", () => {
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.change(input, { target: { value: "Renamed" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onRename).toHaveBeenCalledWith("Renamed");
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+    });
+  });
+
+  describe("rename input fade-in", () => {
+    it("renders the input via m.input (motion wrapper) when entering edit mode", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+
+      const input = screen.getByTestId("motion-input");
+      expect(input).not.toBeNull();
+      expect(input.tagName).toBe("INPUT");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Close button now reveals when the parent tab receives keyboard focus, not just when the close button itself is focused — keyboard users can now discover and reach the × without extra tabbing
- Rename input flashes a red border on invalid input (empty or unchanged value) and keeps the input open instead of silently exiting edit mode
- Rename input border and background fade in over 150ms instead of swapping in a zero-frame paint

Resolves #6328

## Changes

- `TabButton.tsx`: added `group-focus-visible/tab:opacity-100` to the close button reveal, wired up the red-border flash + stay-open guard on Enter, and added a 150ms `transition-colors` on the input surface
- `TabButton.test.tsx`: full unit test coverage for all three behaviours (keyboard reveal, invalid-input feedback, IME Enter guard on context-menu-initiated rename)

## Testing

20 unit tests pass. `npm run check` clean (typecheck + lint + format). Build clean.