### PR TITLE
fix(errors): fix ErrorBanner dismiss-only X, retry color, correlation ID

### DIFF
--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -52,10 +52,12 @@ export function ErrorBanner({
   const [isExpanded, setIsExpanded] = useState(false);
   const [copiedId, setCopiedId] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyGenerationRef = useRef(0);
 
   const isRetrying = !!error.retryProgress;
 
   useEffect(() => {
+    copyGenerationRef.current += 1;
     setCopiedId(false);
     if (copyTimeoutRef.current) {
       clearTimeout(copyTimeoutRef.current);
@@ -65,6 +67,7 @@ export function ErrorBanner({
 
   useEffect(() => {
     return () => {
+      copyGenerationRef.current += 1;
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
     };
   }, []);
@@ -92,8 +95,11 @@ export function ErrorBanner({
 
   const handleCopyCorrelationId = useCallback(() => {
     if (!error.correlationId) return;
+    if (!navigator.clipboard?.writeText) return;
+    const gen = copyGenerationRef.current;
     void navigator.clipboard.writeText(error.correlationId).then(
       () => {
+        if (gen !== copyGenerationRef.current) return;
         if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
         setCopiedId(true);
         copyTimeoutRef.current = setTimeout(() => {

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -12,6 +12,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { ErrorRecord, RetryAction } from "@/store/errorStore";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 
 export interface ErrorBannerProps {
   error: ErrorRecord;
@@ -49,8 +50,24 @@ export function ErrorBanner({
   compact = false,
 }: ErrorBannerProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [copiedId, setCopiedId] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isRetrying = !!error.retryProgress;
+
+  useEffect(() => {
+    setCopiedId(false);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = null;
+    }
+  }, [error.correlationId]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const handleRetry = useCallback(async () => {
     if (!error.retryAction || !onRetry) return;
@@ -68,6 +85,27 @@ export function ErrorBanner({
   const toggleExpanded = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
+
+  const handleViewErrors = useCallback(() => {
+    useDiagnosticsStore.getState().openDock("problems");
+  }, []);
+
+  const handleCopyCorrelationId = useCallback(() => {
+    if (!error.correlationId) return;
+    void navigator.clipboard.writeText(error.correlationId).then(
+      () => {
+        if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+        setCopiedId(true);
+        copyTimeoutRef.current = setTimeout(() => {
+          setCopiedId(false);
+          copyTimeoutRef.current = null;
+        }, 2000);
+      },
+      () => {
+        // Clipboard rejected — stay silent.
+      }
+    );
+  }, [error.correlationId]);
 
   const typeLabel = ERROR_TYPE_LABELS[error.type] || "Error";
   const TypeIcon = ERROR_TYPE_ICONS[error.type] ?? XCircle;
@@ -101,13 +139,13 @@ export function ErrorBanner({
           </>
         )}
         {!isRetrying && canRetry && (
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={handleRetry}
-            className="border-status-success/50 text-status-success hover:text-status-success/80"
-          >
+          <Button variant="ghost-danger" size="xs" onClick={handleRetry}>
             Retry
+          </Button>
+        )}
+        {!isRetrying && !canRetry && (
+          <Button variant="ghost-danger" size="xs" onClick={handleViewErrors}>
+            View errors
           </Button>
         )}
         <Button
@@ -145,9 +183,16 @@ export function ErrorBanner({
             </p>
           )}
           {error.correlationId && (
-            <span className="font-mono text-[10px] text-status-error/40">
-              Ref: {error.correlationId.split("-")[0]}
-            </span>
+            <button
+              type="button"
+              onClick={handleCopyCorrelationId}
+              aria-label={
+                copiedId ? "Correlation ID copied" : `Copy correlation ID ${error.correlationId}`
+              }
+              className="font-mono text-[10px] text-status-error/40 hover:text-status-error/70 cursor-copy transition-colors text-left break-all"
+            >
+              Ref: {copiedId ? "Copied" : error.correlationId}
+            </button>
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
@@ -171,12 +216,7 @@ export function ErrorBanner({
             </>
           )}
           {!isRetrying && canRetry && (
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={handleRetry}
-              className="border-status-success/50 text-status-success hover:text-status-success/80 hover:bg-status-success/10"
-            >
+            <Button variant="ghost-danger" size="xs" onClick={handleRetry}>
               Retry
             </Button>
           )}

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorBanner } from "../ErrorBanner";
 import type { ErrorRecord } from "@/store/errorStore";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -75,5 +76,136 @@ describe("ErrorBanner", () => {
     expect(screen.getByText("Try pulling first")).toBeTruthy();
     const svgs = container.querySelectorAll("svg");
     expect(svgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  describe("compact dismiss-only fallback", () => {
+    afterEach(() => {
+      useDiagnosticsStore.getState().reset();
+    });
+
+    it("renders 'View errors' alongside dismiss when compact has no retry", () => {
+      render(<ErrorBanner error={makeError()} onDismiss={onDismiss} compact />);
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Dismiss error" })).toBeTruthy();
+    });
+
+    it("opens the diagnostics dock to the problems tab when 'View errors' clicked", () => {
+      render(<ErrorBanner error={makeError()} onDismiss={onDismiss} compact />);
+      expect(useDiagnosticsStore.getState().isOpen).toBe(false);
+      fireEvent.click(screen.getByRole("button", { name: "View errors" }));
+      const state = useDiagnosticsStore.getState();
+      expect(state.isOpen).toBe(true);
+      expect(state.activeTab).toBe("problems");
+    });
+
+    it("does not render 'View errors' when retry is available", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+  });
+
+  describe("retry button styling", () => {
+    it("does not use success-green classes on the compact retry button", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      const retry = screen.getByRole("button", { name: "Retry" });
+      expect(retry.className).not.toMatch(/status-success/);
+      expect(retry.className).toMatch(/status-error/);
+    });
+
+    it("does not use success-green classes on the full retry button", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      const retry = screen.getByRole("button", { name: "Retry" });
+      expect(retry.className).not.toMatch(/status-success/);
+      expect(retry.className).toMatch(/status-error/);
+    });
+  });
+
+  describe("correlation ID copy", () => {
+    let writeText: ReturnType<typeof vi.fn>;
+    const fullId = "abcd1234-5678-90ef-1234-567890abcdef";
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: { writeText },
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("renders the full correlation ID, not just the first segment", () => {
+      render(<ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />);
+      expect(screen.getByText(`Ref: ${fullId}`)).toBeTruthy();
+    });
+
+    it("copies the full ID to clipboard and shows 'Copied' for ~2s", async () => {
+      render(<ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />);
+      const button = screen.getByRole("button", { name: `Copy correlation ID ${fullId}` });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(writeText).toHaveBeenCalledWith(fullId);
+      expect(screen.getByText("Ref: Copied")).toBeTruthy();
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(screen.queryByText("Ref: Copied")).toBeNull();
+      expect(screen.getByText(`Ref: ${fullId}`)).toBeTruthy();
+    });
+
+    it("stays silent when clipboard rejects", async () => {
+      writeText.mockRejectedValueOnce(new Error("denied"));
+      render(<ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />);
+      const button = screen.getByRole("button", { name: `Copy correlation ID ${fullId}` });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      // Allow promise rejection microtask to settle.
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.queryByText("Ref: Copied")).toBeNull();
+      expect(screen.getByText(`Ref: ${fullId}`)).toBeTruthy();
+    });
+
+    it("clears the copied timeout when unmounted", async () => {
+      const { unmount } = render(
+        <ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />
+      );
+      const button = screen.getByRole("button", { name: `Copy correlation ID ${fullId}` });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      unmount();
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      // No assertion error on unmounted state-updates — implicit pass.
+    });
   });
 });

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -101,7 +101,7 @@ describe("ErrorBanner", () => {
     it("does not render 'View errors' when retry is available", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          error={makeError({ isTransient: true, retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
           compact
@@ -114,7 +114,7 @@ describe("ErrorBanner", () => {
     it("renders 'View errors' when isTransient is true but onRetry is missing", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          error={makeError({ isTransient: true, retryAction: "git" })}
           onDismiss={onDismiss}
           compact
         />
@@ -148,7 +148,7 @@ describe("ErrorBanner", () => {
     it("does not use success-green classes on the compact retry button", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          error={makeError({ isTransient: true, retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
           compact
@@ -162,7 +162,7 @@ describe("ErrorBanner", () => {
     it("does not use success-green classes on the full retry button", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          error={makeError({ isTransient: true, retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
         />

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -110,6 +110,38 @@ describe("ErrorBanner", () => {
       expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
       expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
     });
+
+    it("renders 'View errors' when isTransient is true but onRetry is missing", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git.pull" })}
+          onDismiss={onDismiss}
+          compact
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+
+    it("hides 'View errors' while a retry is in progress", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryProgress: { attempt: 1, maxAttempts: 3 },
+          })}
+          onDismiss={onDismiss}
+          onCancelRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    });
+
+    it("does not render 'View errors' in full (non-compact) mode", () => {
+      render(<ErrorBanner error={makeError()} onDismiss={onDismiss} />);
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+    });
   });
 
   describe("retry button styling", () => {
@@ -206,6 +238,50 @@ describe("ErrorBanner", () => {
         vi.advanceTimersByTime(5000);
       });
       // No assertion error on unmounted state-updates — implicit pass.
+    });
+
+    it("resets the 'Copied' label when correlationId changes", async () => {
+      const otherId = "deadbeef-0000-0000-0000-000000000000";
+      const { rerender } = render(
+        <ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />
+      );
+      const button = screen.getByRole("button", { name: `Copy correlation ID ${fullId}` });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      expect(screen.getByText("Ref: Copied")).toBeTruthy();
+      rerender(
+        <ErrorBanner
+          error={makeError({ id: "err-2", correlationId: otherId })}
+          onDismiss={onDismiss}
+        />
+      );
+      expect(screen.queryByText("Ref: Copied")).toBeNull();
+      expect(screen.getByText(`Ref: ${otherId}`)).toBeTruthy();
+    });
+
+    it("extends the 'Copied' window when clicked twice within 2s", async () => {
+      render(<ErrorBanner error={makeError({ correlationId: fullId })} onDismiss={onDismiss} />);
+      const button = screen.getByRole("button", { name: `Copy correlation ID ${fullId}` });
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(screen.getByText("Ref: Copied")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(button);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1500);
+      });
+      // 1500ms after the second click → still within the fresh 2s window.
+      expect(screen.getByText("Ref: Copied")).toBeTruthy();
+      await act(async () => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(screen.queryByText("Ref: Copied")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Compact mode with no retry now renders a `View errors` button alongside the dismiss X, satisfying the no-dismiss-only rule
- Retry buttons in both compact and full variants switched from green success styling to `ghost-danger` — they no longer read as resolved while the error is still active
- Correlation ID renders the full UUID as a clickable copy-to-clipboard button, swapping to `Copied` for 2s; a generation counter prevents stale promise resolutions from flipping state after the ID changes or after unmount

Resolves #6348

## Changes

- `src/components/Errors/ErrorBanner.tsx` — three targeted fixes across compact and full variants
- `src/components/Errors/__tests__/ErrorBanner.test.tsx` — 12 new unit tests covering each fix and edge cases (20 total)

## Testing

All 20 unit tests pass. Typecheck, lint, format, and channel checks are green.