### PR TITLE
feat(palette): add async loading affordance to keyboard palettes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -553,6 +553,7 @@ function App() {
                 results={quickSwitcher.results}
                 totalResults={quickSwitcher.totalResults}
                 selectedIndex={quickSwitcher.selectedIndex}
+                isLoading={quickSwitcher.isLoading}
                 close={quickSwitcher.close}
                 setQuery={quickSwitcher.setQuery}
                 selectPrevious={quickSwitcher.selectPrevious}

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -14,6 +14,7 @@ type QuickSwitcherProps = Pick<
   | "results"
   | "totalResults"
   | "selectedIndex"
+  | "isLoading"
   | "close"
   | "setQuery"
   | "selectPrevious"
@@ -28,6 +29,7 @@ export function QuickSwitcher({
   results,
   totalResults,
   selectedIndex,
+  isLoading,
   close,
   setQuery,
   selectPrevious,
@@ -67,6 +69,7 @@ export function QuickSwitcher({
       label="Quick switch"
       keyHint="⌘P"
       ariaLabel="Quick switcher"
+      isLoading={isLoading}
       searchPlaceholder="Search terminals, agents, worktrees..."
       searchAriaLabel="Search terminals, agents, and worktrees"
       listId="quick-switcher-list"

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -166,6 +166,12 @@ interface AppPaletteHeaderProps {
   keyHint?: string;
   children: React.ReactNode;
   className?: string;
+  /**
+   * Show an indeterminate loading bar pinned to the bottom of the header.
+   * The bar fades in after a short grace period (UI_PALETTE_ENTER_DURATION),
+   * so fast loads never flash a sweep.
+   */
+  isLoading?: boolean;
 }
 
 AppPaletteDialog.Header = function AppPaletteHeader({
@@ -173,14 +179,34 @@ AppPaletteDialog.Header = function AppPaletteHeader({
   keyHint,
   children,
   className,
+  isLoading = false,
 }: AppPaletteHeaderProps) {
   return (
-    <div className={cn("px-3 pt-2 pb-1 border-b border-daintree-border", className)}>
+    <div
+      className={cn(
+        "relative overflow-hidden px-3 pt-2 pb-1 border-b border-daintree-border",
+        className
+      )}
+    >
       <div className="flex justify-between items-center mb-1.5 text-[11px] text-daintree-text/50">
         <span>{label}</span>
         {keyHint && <span className="font-mono">{keyHint}</span>}
       </div>
       {children}
+      <div
+        aria-hidden="true"
+        className="palette-loading-bar transition-opacity motion-reduce:transition-none"
+        data-loading={isLoading ? "true" : "false"}
+        style={{
+          opacity: isLoading ? 1 : 0,
+          transitionDuration: isLoading
+            ? `${UI_PALETTE_ENTER_DURATION}ms`
+            : `${UI_PALETTE_EXIT_DURATION}ms`,
+          transitionDelay: isLoading ? `${UI_PALETTE_ENTER_DURATION}ms` : "0ms",
+        }}
+      >
+        <div className="palette-loading-bar__sweep" />
+      </div>
     </div>
   );
 };

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -57,6 +57,12 @@ export interface SearchablePaletteProps<T> {
   renderBody?: () => React.ReactNode;
   /** Total number of results before truncation, for overflow indicator */
   totalResults?: number;
+  /**
+   * When true, an indeterminate loading bar appears beneath the search input
+   * after a short grace period. Use when the underlying data source is still
+   * populating and the user might otherwise see an empty list.
+   */
+  isLoading?: boolean;
 }
 
 export function SearchablePalette<T>({
@@ -89,6 +95,7 @@ export function SearchablePalette<T>({
   headerClassName,
   renderBody,
   totalResults,
+  isLoading = false,
 }: SearchablePaletteProps<T>) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -160,7 +167,12 @@ export function SearchablePalette<T>({
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>
-      <AppPaletteDialog.Header label={label} keyHint={keyHint} className={headerClassName}>
+      <AppPaletteDialog.Header
+        label={label}
+        keyHint={keyHint}
+        className={headerClassName}
+        isLoading={isLoading}
+      >
         <AppPaletteDialog.Input
           inputRef={inputRef}
           value={query}

--- a/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: () => {},
+  useEscapeStack: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { AppPaletteDialog } from "../AppPaletteDialog";
+import { UI_PALETTE_ENTER_DURATION, UI_PALETTE_EXIT_DURATION } from "@/lib/animationUtils";
+
+function getLoadingBar(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".palette-loading-bar");
+}
+
+describe("AppPaletteDialog.Header loading bar", () => {
+  it("renders the loading bar element so it can fade in/out", () => {
+    render(
+      <AppPaletteDialog.Header label="Quick switch">
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    const bar = getLoadingBar();
+    expect(bar).not.toBeNull();
+    // aria-hidden so screen readers ignore the decorative bar
+    expect(bar?.getAttribute("aria-hidden")).toBe("true");
+    // Inner sweep element is present for the indeterminate animation
+    expect(bar?.querySelector(".palette-loading-bar__sweep")).not.toBeNull();
+  });
+
+  it("keeps the bar invisible when isLoading is omitted", () => {
+    render(
+      <AppPaletteDialog.Header label="Quick switch">
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    const bar = getLoadingBar();
+    expect(bar?.style.opacity).toBe("0");
+    expect(bar?.style.transitionDelay).toBe("0ms");
+    expect(bar?.style.transitionDuration).toBe(`${UI_PALETTE_EXIT_DURATION}ms`);
+    expect(bar?.dataset.loading).toBe("false");
+  });
+
+  it("reveals the bar with a grace-period delay when isLoading is true", () => {
+    render(
+      <AppPaletteDialog.Header label="Quick switch" isLoading>
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    const bar = getLoadingBar();
+    expect(bar?.style.opacity).toBe("1");
+    // Grace period matches the palette enter duration so fast loads never flash
+    expect(bar?.style.transitionDelay).toBe(`${UI_PALETTE_ENTER_DURATION}ms`);
+    expect(bar?.style.transitionDuration).toBe(`${UI_PALETTE_ENTER_DURATION}ms`);
+    expect(bar?.dataset.loading).toBe("true");
+  });
+
+  it("places the bar inside a positioned container that clips overflow", () => {
+    const { container } = render(
+      <AppPaletteDialog.Header label="Quick switch" isLoading>
+        <input aria-label="Search" />
+      </AppPaletteDialog.Header>
+    );
+    // The outer header div must be `relative overflow-hidden` so the
+    // absolute-positioned bar clips at the header boundary, not the
+    // surrounding modal card.
+    const header = container.firstElementChild as HTMLElement;
+    expect(header.className).toContain("relative");
+    expect(header.className).toContain("overflow-hidden");
+  });
+
+  it("still renders header label and child input", () => {
+    render(
+      <AppPaletteDialog.Header label="Quick switch" keyHint="⌘P" isLoading>
+        <input aria-label="Search terminals" />
+      </AppPaletteDialog.Header>
+    );
+    expect(screen.getByText("Quick switch")).toBeTruthy();
+    expect(screen.getByText("⌘P")).toBeTruthy();
+    expect(screen.getByLabelText("Search terminals")).toBeTruthy();
+  });
+});

--- a/src/hooks/__tests__/useQuickSwitcher.test.tsx
+++ b/src/hooks/__tests__/useQuickSwitcher.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+
+const { useWorktreeStoreMock } = vi.hoisted(() => ({
+  useWorktreeStoreMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: useWorktreeStoreMock,
+}));
+
+vi.mock("@/store", async () => {
+  const actual = await vi.importActual<typeof import("@/store")>("@/store");
+  return {
+    ...actual,
+    useWorktreeSelectionStore: Object.assign(
+      (selector: (s: unknown) => unknown) =>
+        selector({ selectWorktree: vi.fn(), activeWorktreeId: null }),
+      { getState: () => ({ activeWorktreeId: null }) }
+    ),
+  };
+});
+
+import { useQuickSwitcher } from "../useQuickSwitcher";
+
+type MockWorktreeState = {
+  worktrees: Map<string, unknown>;
+  isLoading: boolean;
+  isInitialized: boolean;
+  isReconnecting: boolean;
+  error: string | null;
+};
+
+function seedWorktreeState(state: Partial<MockWorktreeState>): void {
+  const fullState: MockWorktreeState = {
+    worktrees: new Map(),
+    isLoading: false,
+    isInitialized: false,
+    isReconnecting: false,
+    error: null,
+    ...state,
+  };
+  useWorktreeStoreMock.mockImplementation((selector: (s: MockWorktreeState) => unknown) =>
+    selector(fullState)
+  );
+}
+
+describe("useQuickSwitcher isLoading", () => {
+  beforeEach(() => {
+    usePanelStore.setState({ panelsById: {}, panelIds: [], mruList: [] });
+    useWorktreeStoreMock.mockReset();
+  });
+
+  it("reports isLoading=true while the worktree store has not yet initialized", () => {
+    seedWorktreeState({ isInitialized: false });
+    const { result } = renderHook(() => useQuickSwitcher());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("reports isLoading=false once the worktree store has hydrated", () => {
+    seedWorktreeState({ isInitialized: true });
+    const { result } = renderHook(() => useQuickSwitcher());
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not flip back to loading just because a refetch sets isLoading on the store", () => {
+    // After cold-start the bar should stay hidden during a transient refresh —
+    // only first-load (`!isInitialized`) is the real "no data yet" signal.
+    seedWorktreeState({ isInitialized: true, isLoading: true });
+    const { result } = renderHook(() => useQuickSwitcher());
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("is reactive to store updates", () => {
+    seedWorktreeState({ isInitialized: false });
+    const { result, rerender } = renderHook(() => useQuickSwitcher());
+    expect(result.current.isLoading).toBe(true);
+    act(() => {
+      seedWorktreeState({ isInitialized: true });
+    });
+    rerender();
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/useQuickSwitcher.test.tsx
+++ b/src/hooks/__tests__/useQuickSwitcher.test.tsx
@@ -73,6 +73,15 @@ describe("useQuickSwitcher isLoading", () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it("does not show the bar after a fatal workspace-host error", () => {
+    // setFatalError clears isInitialized AND isLoading and sets error. Without
+    // the error guard, the bar would spin forever in this state instead of
+    // letting the surrounding UI surface the failure.
+    seedWorktreeState({ isInitialized: false, isLoading: false, error: "host crashed" });
+    const { result } = renderHook(() => useQuickSwitcher());
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it("is reactive to store updates", () => {
     seedWorktreeState({ isInitialized: false });
     const { result, rerender } = renderHook(() => useQuickSwitcher());

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -26,6 +26,7 @@ export interface UseQuickSwitcherReturn {
   results: QuickSwitcherItem[];
   totalResults: number;
   selectedIndex: number;
+  isLoading: boolean;
   open: () => void;
   close: () => void;
   toggle: () => void;
@@ -56,7 +57,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
   const mruList = usePanelStore(useShallow((state) => state.mruList));
   const pruneMru = usePanelStore((state) => state.pruneMru);
 
-  const { worktrees, worktreeMap } = useWorktrees();
+  const { worktrees, worktreeMap, isInitialized: worktreesInitialized } = useWorktrees();
   const { selectWorktree } = useWorktreeSelectionStore(
     useShallow((state) => ({
       selectWorktree: state.selectWorktree,
@@ -204,6 +205,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     results,
     totalResults,
     selectedIndex,
+    isLoading: !worktreesInitialized,
     open,
     close,
     toggle,

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -57,7 +57,12 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
   const mruList = usePanelStore(useShallow((state) => state.mruList));
   const pruneMru = usePanelStore((state) => state.pruneMru);
 
-  const { worktrees, worktreeMap, isInitialized: worktreesInitialized } = useWorktrees();
+  const {
+    worktrees,
+    worktreeMap,
+    isInitialized: worktreesInitialized,
+    error: worktreeError,
+  } = useWorktrees();
   const { selectWorktree } = useWorktreeSelectionStore(
     useShallow((state) => ({
       selectWorktree: state.selectWorktree,
@@ -205,7 +210,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     results,
     totalResults,
     selectedIndex,
-    isLoading: !worktreesInitialized,
+    isLoading: !worktreesInitialized && worktreeError === null,
     open,
     close,
     toggle,

--- a/src/index.css
+++ b/src/index.css
@@ -1844,6 +1844,43 @@ body[data-reduce-animations="true"] .terminal-pane {
   will-change: transform;
 }
 
+/* Palette indeterminate loading bar — sits inside AppPaletteDialog.Header */
+@keyframes palette-loading-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.palette-loading-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--color-daintree-accent) 18%, transparent);
+  pointer-events: none;
+}
+
+.palette-loading-bar__sweep {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 25%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklab, var(--color-daintree-accent) 85%, transparent),
+    transparent
+  );
+  animation: palette-loading-sweep 1.5s ease-in-out infinite;
+  will-change: transform;
+}
+
 /* Success fade - scale in then fade out */
 @keyframes github-status-success-fade {
   0% {
@@ -1904,6 +1941,12 @@ body[data-reduce-animations="true"] .terminal-pane {
     animation: none;
     opacity: 1;
   }
+
+  .palette-loading-bar__sweep {
+    animation: none;
+    width: 100%;
+    background: color-mix(in oklab, var(--color-daintree-accent) 50%, transparent);
+  }
 }
 
 /* Disable in performance mode */
@@ -1913,6 +1956,12 @@ body[data-performance-mode="true"] .github-status-loading::after {
 
 body[data-performance-mode="true"] .github-status-loading {
   background: color-mix(in oklab, var(--color-daintree-accent) 60%, transparent) !important;
+}
+
+body[data-performance-mode="true"] .palette-loading-bar__sweep {
+  animation: none !important;
+  width: 100% !important;
+  background: color-mix(in oklab, var(--color-daintree-accent) 50%, transparent) !important;
 }
 
 body[data-performance-mode="true"] .github-status-success {


### PR DESCRIPTION
## Summary

- Adds a thin horizontal progress bar under the search input in `SearchablePalette` and `AppPaletteDialog.Header` when `isLoading` is true — gives a clear signal that the palette is waiting on async data
- Bar fades in after a 150ms grace period so fast loads never flash, fades out over 100ms; both timings match Tier 2-fast motion (`UI_PALETTE_ENTER_DURATION` / `UI_PALETTE_EXIT_DURATION`)
- `QuickSwitcher` now surfaces `isLoading` from `useWorktrees`, guarding both the initial-load case and a fatal worktree-host crash

Resolves #6344

## Changes

- `SearchablePalette` and `AppPaletteDialog.Header` accept an optional `isLoading?: boolean` prop
- New `@keyframes palette-loading-sweep` animation and `.palette-loading-bar` classes in `src/index.css`, alongside the existing `github-status-shimmer` pattern; reduced-motion and performance-mode fallbacks included
- `useQuickSwitcher` derives `isLoading: !worktreesInitialized && worktreeError === null` from `useWorktrees()` and passes it through via `App.tsx`

## Testing

- 5 new unit tests for `AppPaletteDialog.Header` loading states
- 5 new unit tests for `useQuickSwitcher` loading logic (first-load, fatal-error, initialized)
- Full vitest run across new and adjacent palette tests: 22 passing
- Typecheck, lint, and format all clean