### PR TITLE
fix(agent): clear presetId when selecting default in toolbar dropdowns

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -505,6 +505,9 @@ export function AgentButton({
                 <DropdownMenuRadioItem
                   value=""
                   onSelect={() => {
+                    void useAgentSettingsStore.getState().updateAgent(type, {
+                      presetId: undefined,
+                    });
                     persistWorktreePick(undefined);
                   }}
                 >

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -641,6 +641,9 @@ export function AgentButton({
                 <ContextMenuRadioItem
                   value=""
                   onSelect={() => {
+                    void useAgentSettingsStore.getState().updateAgent(type, {
+                      presetId: undefined,
+                    });
                     persistWorktreePick(undefined);
                     void actionService.dispatch(
                       "agent.launch",

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -480,6 +480,12 @@ export function AgentTrayButton({
   const handleLaunch = useCallback(
     (agentId: BuiltInAgentId, presetId?: string | null) => {
       setOpen(false);
+      // `null` = explicit default — clear both the worktree-scoped override
+      // and the agent-level presetId so resolveEffectivePresetId returns
+      // undefined and the radio group visually selects "Default".
+      if (presetId === null) {
+        void useAgentSettingsStore.getState().updateAgent(agentId, { presetId: undefined });
+      }
       // Persist the pick to the worktree-scoped slot so a subsequent main-
       // button press on this worktree relaunches the same preset while other
       // worktrees keep their own. `null` clears the scoped override (and

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -552,9 +552,12 @@ describe("AgentButton preset UX", () => {
     });
 
     it("dropdown Agent default clears the worktree override without launching", () => {
+      // Seed an agent-level presetId so the updateAgent assertion proves the
+      // fix actually clears it — without a stale agent-level value to fall
+      // through to, the original #6358 bug couldn't manifest.
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({
-        claude: { worktreePresets: { "wt-A": "user-alpha" } },
+        claude: { presetId: "user-alpha", worktreePresets: { "wt-A": "user-alpha" } },
       });
       mockMergedPresetsFn = () => [
         { id: "user-alpha", name: "Alpha" },
@@ -769,7 +772,7 @@ describe("AgentButton preset UX", () => {
       // the bug from #6358 returns.
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({
-        claude: { worktreePresets: { "wt-A": "user-blue" } },
+        claude: { presetId: "user-blue", worktreePresets: { "wt-A": "user-blue" } },
       });
       mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
 

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -22,6 +22,7 @@ import type { AgentSettings, CliAvailability } from "@shared/types";
 
 const dispatchMock = vi.fn();
 const updateWorktreePresetMock = vi.fn();
+const updateAgentMock = vi.fn().mockResolvedValue(undefined);
 let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
 let dropdownPointerDownOutsideSpy: (() => void) | null = null;
 
@@ -44,6 +45,7 @@ vi.mock("@/store/agentSettingsStore", () => ({
       getState: () => ({
         setAgentPinned: vi.fn(),
         updateWorktreePreset: updateWorktreePresetMock,
+        updateAgent: updateAgentMock,
       }),
     }
   ),
@@ -301,6 +303,7 @@ describe("AgentButton preset UX", () => {
   beforeEach(() => {
     dispatchMock.mockClear();
     updateWorktreePresetMock.mockClear();
+    updateAgentMock.mockClear();
     mockSettings = null;
     mockActiveWorktreeId = null;
     mockCcrPresetsByAgent = {};
@@ -565,6 +568,7 @@ describe("AgentButton preset UX", () => {
       const defaultItem = items.find((el) => el.textContent?.includes("Agent default"))!;
       fireEvent.click(defaultItem);
 
+      expect(updateAgentMock).toHaveBeenCalledWith("claude", { presetId: undefined });
       expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
       expect(dispatchMock).not.toHaveBeenCalled();
     });
@@ -759,9 +763,10 @@ describe("AgentButton preset UX", () => {
     });
 
     it("context-menu Agent default clears the override and still launches with null preset", () => {
-      // The context-menu sub is intentionally a launcher (unlike the chevron).
-      // Verify the Agent default row mirrors that contract: clear the
-      // worktree-scoped override AND dispatch a null-preset launch.
+      // The context-menu sub is a launcher, but it must also clear the
+      // agent-level presetId — otherwise resolveEffectivePresetId falls back
+      // to the stale agent-level value on the next plain primary click and
+      // the bug from #6358 returns.
       mockActiveWorktreeId = "wt-A";
       mockSettings = settingsWith({
         claude: { worktreePresets: { "wt-A": "user-blue" } },
@@ -775,6 +780,7 @@ describe("AgentButton preset UX", () => {
       const defaultItem = items.find((el) => el.textContent?.includes("Agent default"))!;
       fireEvent.click(defaultItem);
 
+      expect(updateAgentMock).toHaveBeenCalledWith("claude", { presetId: undefined });
       expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -7,6 +7,7 @@ import type { ActionFrecencyEntry } from "@shared/types/actions";
 const dispatchMock = vi.fn();
 const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
 const updateWorktreePresetMock = vi.fn().mockResolvedValue(undefined);
+const updateAgentMock = vi.fn().mockResolvedValue(undefined);
 const setFocusedMock = vi.fn();
 const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
 let openChangeSpy: ((open: boolean) => void) | null = null;
@@ -53,12 +54,19 @@ type MockAgentStoreState = {
 };
 
 vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (selector: (s: MockAgentStoreState) => unknown) =>
-    selector({
-      settings: mockSettings,
-      setAgentPinned: setAgentPinnedMock,
-      updateWorktreePreset: updateWorktreePresetMock,
-    }),
+  useAgentSettingsStore: Object.assign(
+    (selector: (s: MockAgentStoreState) => unknown) =>
+      selector({
+        settings: mockSettings,
+        setAgentPinned: setAgentPinnedMock,
+        updateWorktreePreset: updateWorktreePresetMock,
+      }),
+    {
+      getState: () => ({
+        updateAgent: updateAgentMock,
+      }),
+    }
+  ),
 }));
 
 vi.mock("@/store/actionMruStore", () => ({
@@ -310,6 +318,7 @@ describe("AgentTrayButton", () => {
     dispatchMock.mockClear();
     setAgentPinnedMock.mockClear();
     updateWorktreePresetMock.mockClear();
+    updateAgentMock.mockClear();
     setFocusedMock.mockClear();
     refreshAvailabilityMock.mockClear();
     openChangeSpy = null;
@@ -1070,6 +1079,7 @@ describe("AgentTrayButton", () => {
 
       fireEvent.keyDown(submenuTrigger, { key: "Enter" });
 
+      expect(updateAgentMock).toHaveBeenCalledWith("claude", { presetId: undefined });
       expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
       expect(dispatchMock).toHaveBeenCalledWith(
         "agent.launch",

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1072,8 +1072,18 @@ describe("AgentTrayButton", () => {
     }
 
     it("Default keyboard launch clears the scoped override and dispatches presetId: null", () => {
+      // Seed an agent-level presetId so the updateAgent assertion proves the
+      // fix actually clears it — without a stale agent-level value to fall
+      // through to, the original #6358 bug couldn't manifest.
       mockActiveWorktreeId = "wt-A";
       const availability = arrangeAgentWithPresets();
+      mockSettings = settingsWith({
+        claude: {
+          pinned: false,
+          presetId: "user-alpha",
+          worktreePresets: { "wt-A": "user-alpha" },
+        },
+      });
       const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
       const submenuTrigger = getAllByTestId("submenu-trigger")[0]!;
 

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -299,7 +299,12 @@ vi.mock("lucide-react", () => ({
 
 import { AgentTrayButton } from "../AgentTrayButton";
 
-function settingsWith(overrides: Record<string, { pinned?: boolean }>): AgentSettings {
+function settingsWith(
+  overrides: Record<
+    string,
+    { pinned?: boolean; presetId?: string; worktreePresets?: Record<string, string> }
+  >
+): AgentSettings {
   return { agents: overrides } as unknown as AgentSettings;
 }
 


### PR DESCRIPTION
## Summary

- Selecting "Agent default" / "Default" in the toolbar chevron and agent tray preset dropdowns now clears both the worktree-scoped override **and** the agent-level `presetId`, so `resolveEffectivePresetId` returns `undefined` and the radio group correctly reflects the selection.

## Root Cause

Both dropdowns only cleared the worktree-scoped preset override. `resolveEffectivePresetId` fell through to the agent-level `presetId`, so the old preset remained selected visually and functionally.

## Test plan

- [ ] Configure a CCR preset (e.g., Z.AI) for Claude
- [ ] Select Z.AI from the toolbar chevron dropdown → observe Z.AI shows as selected
- [ ] Open the dropdown and click "Agent default" → observe it now shows as selected
- [ ] Click the main Claude toolbar button → launches without preset env vars
- [ ] Same flow via agent tray (Plug icon → Claude → Default)
- [ ] Switch worktrees and verify preset selections are scoped correctly

Closes #6358

🤖 Generated with [Claude Code](https://claude.com/claude-code)