### PR TITLE
feat(input-bar): polish hybrid input chips

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -51,6 +51,7 @@ import type { CommandContext, CommandResult } from "@shared/types/commands";
 import { isEnterLikeLineBreakInputEvent } from "./hybridInputEvents";
 import {
   buildInputBarTheme,
+  chipEntranceTheme,
   createContentAttributes,
   createPlaceholder,
   createSlashChipField,
@@ -1045,6 +1046,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         doc: value,
         extensions: [
           themeCompartmentRef.current.of(buildInputBarTheme(effectiveTheme)),
+          chipEntranceTheme,
           EditorView.lineWrapping,
           drawSelection(),
           createContentAttributes(),

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { EditorState } from "@codemirror/state";
+import type { Extension } from "@codemirror/state";
 import { EditorView, runScopeHandlers } from "@codemirror/view";
 import type { ITheme } from "@xterm/xterm";
 import {
@@ -1377,13 +1378,32 @@ describe("buildInputBarTheme", () => {
     expect(state.doc.toString()).toBe("test");
   });
 
-  it("resolves slash chip color to chipColor (neutral), not accent", () => {
+  it("styles slash chip with chipColor (neutral), not accent", () => {
+    const css = readGeneratedCss([buildInputBarTheme(theme)]);
     const colors = resolveInputBarColors(theme);
     expect(colors.chipColor).not.toBe(colors.accent);
-    expect(colors.chipColor).toBe("#8be9fd");
-    expect(colors.accent).toBe("#ff79c6");
+    const slashRule = extractRuleBody(css, ".cm-slash-command-chip");
+    expect(slashRule).toContain(`color: ${colors.chipColor}`);
+    expect(slashRule).not.toContain(`color: ${colors.accent}`);
+  });
+
+  it("retains errorColor on the .cm-slash-command-chip-invalid rule", () => {
+    const css = readGeneratedCss([buildInputBarTheme(theme)]);
+    const colors = resolveInputBarColors(theme);
+    const invalidRule = extractRuleBody(css, ".cm-slash-command-chip-invalid");
+    expect(invalidRule).toContain(`color: ${colors.errorColor}`);
   });
 });
+
+const ALL_CHIP_SELECTORS = [
+  ".cm-file-chip",
+  ".cm-slash-command-chip",
+  ".cm-image-chip",
+  ".cm-file-drop-chip",
+  ".cm-diff-chip",
+  ".cm-terminal-chip",
+  ".cm-selection-chip",
+];
 
 describe("chipEntranceTheme", () => {
   it("is a valid Extension", () => {
@@ -1404,4 +1424,74 @@ describe("chipEntranceTheme", () => {
     });
     expect(state.doc.toString()).toBe("hello");
   });
+
+  it("defines a chip-enter @keyframes with opacity + translateY drift", () => {
+    const css = readGeneratedCss([chipEntranceTheme]);
+    expect(css).toMatch(/@keyframes\s+chip-enter/);
+    expect(css).toMatch(/opacity:\s*0/);
+    expect(css).toMatch(/translateY\(2px\)/);
+  });
+
+  it("applies the chip-enter animation with fill-mode 'both' to all 7 chip classes", () => {
+    const css = readGeneratedCss([chipEntranceTheme]);
+    for (const selector of ALL_CHIP_SELECTORS) {
+      const rule = extractRuleBody(css, selector);
+      expect(rule, `${selector} animation rule`).toMatch(/animation:\s*chip-enter/);
+      expect(rule, `${selector} fill-mode`).toContain("both");
+    }
+  });
+
+  it("disables the animation under prefers-reduced-motion", () => {
+    const css = readGeneratedCss([chipEntranceTheme]);
+    const reducedBlock = extractAtRuleBody(css, "@media (prefers-reduced-motion: reduce)");
+    for (const selector of ALL_CHIP_SELECTORS) {
+      const rule = extractRuleBody(reducedBlock, selector);
+      expect(rule, `${selector} reduced-motion override`).toContain("animation: none");
+    }
+  });
+
+  it("disables the animation under body[data-reduce-animations='true']", () => {
+    const css = readGeneratedCss([chipEntranceTheme]);
+    for (const selector of ALL_CHIP_SELECTORS) {
+      const composed = `body[data-reduce-animations="true"] ${selector}`;
+      const rule = extractRuleBody(css, composed);
+      expect(rule, `${composed} override`).toContain("animation: none");
+    }
+  });
 });
+
+function readGeneratedCss(extensions: Extension[]) {
+  const state = EditorState.create({ doc: "", extensions });
+  const modules = state.facet(EditorView.styleModule);
+  return modules.map((m) => m.getRules()).join("\n");
+}
+
+function extractRuleBody(css: string, selector: string): string {
+  // Match the selector at a brace boundary so ".cm-slash-command-chip" doesn't
+  // accidentally capture ".cm-slash-command-chip-invalid".
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`(?:^|[,}\\s])${escaped}\\s*\\{([^}]*)\\}`));
+  if (!match || match[1] === undefined) {
+    throw new Error(`selector ${selector} not found in CSS`);
+  }
+  return match[1];
+}
+
+function extractAtRuleBody(css: string, atRule: string): string {
+  const idx = css.indexOf(atRule);
+  if (idx === -1) {
+    throw new Error(`at-rule ${atRule} not found in CSS`);
+  }
+  let depth = 0;
+  let start = -1;
+  for (let i = idx; i < css.length; i++) {
+    if (css[i] === "{") {
+      if (depth === 0) start = i + 1;
+      depth++;
+    } else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(start, i);
+    }
+  }
+  throw new Error(`unterminated at-rule ${atRule}`);
+}

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -7,6 +7,7 @@ import { EditorView, runScopeHandlers } from "@codemirror/view";
 import type { ITheme } from "@xterm/xterm";
 import {
   buildInputBarTheme,
+  chipEntranceTheme,
   computeAutoSize,
   createAutoSize,
   createCustomKeymap,
@@ -1374,5 +1375,33 @@ describe("buildInputBarTheme", () => {
       extensions: [buildInputBarTheme(theme)],
     });
     expect(state.doc.toString()).toBe("test");
+  });
+
+  it("resolves slash chip color to chipColor (neutral), not accent", () => {
+    const colors = resolveInputBarColors(theme);
+    expect(colors.chipColor).not.toBe(colors.accent);
+    expect(colors.chipColor).toBe("#8be9fd");
+    expect(colors.accent).toBe("#ff79c6");
+  });
+});
+
+describe("chipEntranceTheme", () => {
+  it("is a valid Extension", () => {
+    expect(chipEntranceTheme).toBeDefined();
+    expect(chipEntranceTheme).not.toBeNull();
+  });
+
+  it("can be used to create an EditorState alongside buildInputBarTheme", () => {
+    const theme: ITheme = {
+      background: "#282a36",
+      foreground: "#f8f8f2",
+      cursor: "#ff79c6",
+      cyan: "#8be9fd",
+    };
+    const state = EditorState.create({
+      doc: "hello",
+      extensions: [buildInputBarTheme(theme), chipEntranceTheme],
+    });
+    expect(state.doc.toString()).toBe("hello");
   });
 });

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -76,6 +76,9 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         padding: "0",
       },
       ".cm-slash-command-chip": {
+        // inline-block (not the default inline) so the chip-enter transform
+        // applies — non-replaced inline elements aren't transformable.
+        display: "inline-block",
         fontWeight: 600,
         color: c.chipColor,
         textDecoration: "underline dotted 1px",
@@ -87,6 +90,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         textUnderlineOffset: "2px",
       },
       ".cm-file-chip": {
+        display: "inline-block",
         fontWeight: 600,
         color: c.chipColor,
         textDecoration: "underline dotted 1px",
@@ -195,8 +199,13 @@ export const chipEntranceTheme: Extension = EditorView.baseTheme({
     to: { opacity: "1", transform: "translateY(0)" },
   },
   ...Object.fromEntries(CHIP_CLASSES.map((cls) => [cls, { animation: CHIP_ANIMATION }])),
+  // Honor the OS-level prefers-reduced-motion and the Daintree-level
+  // "Reduce UI animations" toggle (body[data-reduce-animations]). WCAG 2.3.3.
   "@media (prefers-reduced-motion: reduce)": Object.fromEntries(
     CHIP_CLASSES.map((cls) => [cls, { animation: "none" }])
+  ),
+  ...Object.fromEntries(
+    CHIP_CLASSES.map((cls) => [`body[data-reduce-animations="true"] ${cls}`, { animation: "none" }])
   ),
 });
 

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -4,6 +4,7 @@ import { StateField, StateEffect, Prec } from "@codemirror/state";
 import { insertNewline } from "@codemirror/commands";
 import type { ITheme } from "@xterm/xterm";
 import { resolveInputBarColors } from "@/utils/terminalTheme";
+import { UI_PALETTE_ENTER_DURATION, EASE_OUT_EXPO } from "@/lib/animationUtils";
 
 const MAX_TEXTAREA_HEIGHT_PX = 160;
 const LINE_HEIGHT_PX = 20;
@@ -76,7 +77,7 @@ export function buildInputBarTheme(theme: ITheme): Extension {
       },
       ".cm-slash-command-chip": {
         fontWeight: 600,
-        color: c.accent,
+        color: c.chipColor,
         textDecoration: "underline dotted 1px",
         textUnderlineOffset: "2px",
       },
@@ -172,6 +173,32 @@ export function buildInputBarTheme(theme: ITheme): Extension {
     { dark: true }
   );
 }
+
+const CHIP_CLASSES = [
+  ".cm-file-chip",
+  ".cm-slash-command-chip",
+  ".cm-image-chip",
+  ".cm-file-drop-chip",
+  ".cm-diff-chip",
+  ".cm-terminal-chip",
+  ".cm-selection-chip",
+];
+
+const CHIP_ANIMATION = `chip-enter ${UI_PALETTE_ENTER_DURATION}ms ${EASE_OUT_EXPO} both`;
+
+// Lives outside the swappable buildInputBarTheme compartment so terminal
+// color-scheme changes don't re-inject @keyframes and re-trigger the entrance
+// animation on already-rendered chips.
+export const chipEntranceTheme: Extension = EditorView.baseTheme({
+  "@keyframes chip-enter": {
+    from: { opacity: "0", transform: "translateY(2px)" },
+    to: { opacity: "1", transform: "translateY(0)" },
+  },
+  ...Object.fromEntries(CHIP_CLASSES.map((cls) => [cls, { animation: CHIP_ANIMATION }])),
+  "@media (prefers-reduced-motion: reduce)": Object.fromEntries(
+    CHIP_CLASSES.map((cls) => [cls, { animation: "none" }])
+  ),
+});
 
 const interimMark = Decoration.mark({ class: "cm-voice-interim" });
 

--- a/src/components/Terminal/inputEditorExtensions/index.ts
+++ b/src/components/Terminal/inputEditorExtensions/index.ts
@@ -1,5 +1,6 @@
 export {
   buildInputBarTheme,
+  chipEntranceTheme,
   setInterimRange,
   interimMarkField,
   setPendingAIRanges,


### PR DESCRIPTION
## Summary

- Drops the accent color from recognized `/slash` command chips — they now use the neutral `chipColor` token, matching file chips. `font-weight: 600` and the dotted underline are sufficient redundant cues; the accent was the outlier and violated the accent-restraint rule.
- Adds a subtle entrance animation to all 7 chip classes: opacity `0→1` plus a `2px` vertical drift, `150ms` `cubic-bezier(0.16, 1, 0.3, 1)` (`ease-out-expo`), `animation-fill-mode: both`. The animation lives in a new `EditorView.baseTheme` outside the swappable `buildInputBarTheme` compartment, so color-scheme changes don't re-trigger it. Mark chips (`cm-slash-command-chip`, `cm-file-chip`) get `display: inline-block` so the transform applies.
- Respects both `prefers-reduced-motion` and `body[data-reduce-animations]` for WCAG 2.3.3 compliance.

Resolves #6339

## Changes

- `inputEditorExtensions/base.ts` — new `chipEntranceTheme` via `EditorView.baseTheme`; slash chip color changed from `c.accent` to `c.chipColor`; mark chip classes get `display: inline-block`
- `inputEditorExtensions/index.ts` — exports `chipEntranceTheme`
- `HybridInputBar.tsx` — applies `chipEntranceTheme` extension alongside the existing compartment-based theme
- `__tests__/inputEditorExtensions.test.tsx` — 7 new tests covering chip entrance CSS rules and confirming slash chip no longer uses the accent token

## Testing

87 vitest tests pass (7 new). New tests inspect actual generated CSS rules via `state.facet(EditorView.styleModule)` to verify opacity/transform keyframes, `animation-fill-mode`, reduced-motion media query, and the neutral color on slash chips.