### PR TITLE
feat(palette): polish keyboard palette row selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -555,6 +555,7 @@ function App() {
                 selectedIndex={quickSwitcher.selectedIndex}
                 close={quickSwitcher.close}
                 setQuery={quickSwitcher.setQuery}
+                setSelectedIndex={quickSwitcher.setSelectedIndex}
                 selectPrevious={quickSwitcher.selectPrevious}
                 selectNext={quickSwitcher.selectNext}
                 selectItem={quickSwitcher.selectItem}
@@ -755,6 +756,7 @@ function App() {
                 selectedIndex={actionPalette.selectedIndex}
                 close={actionPalette.close}
                 setQuery={actionPalette.setQuery}
+                setSelectedIndex={actionPalette.setSelectedIndex}
                 selectPrevious={actionPalette.selectPrevious}
                 selectNext={actionPalette.selectNext}
                 executeAction={actionPalette.executeAction}

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -15,6 +15,7 @@ type ActionPaletteProps = Pick<
   | "selectedIndex"
   | "close"
   | "setQuery"
+  | "setSelectedIndex"
   | "selectPrevious"
   | "selectNext"
   | "executeAction"
@@ -29,6 +30,7 @@ export function ActionPalette({
   selectedIndex,
   close,
   setQuery,
+  setSelectedIndex,
   selectPrevious,
   selectNext,
   executeAction,
@@ -52,13 +54,15 @@ export function ActionPalette({
       onSelectNext={selectNext}
       onConfirm={confirmSelection}
       onClose={close}
+      onHoverIndex={setSelectedIndex}
       getItemId={(item) => item.id}
-      renderItem={(item, _index, isSelected) => (
+      renderItem={(item, index, isSelected, onHoverIndex) => (
         <ActionPaletteItem
           key={item.id}
           item={item}
           isSelected={isSelected}
           onSelect={handleSelect}
+          onHover={() => onHoverIndex(index)}
         />
       )}
       label="Actions"

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ActionPaletteItem } from "./ActionPaletteItem";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
@@ -114,6 +114,64 @@ describe("ActionPaletteItem", () => {
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
     expect(button?.getAttribute("aria-selected")).toBe("true");
-    expect(button?.className).toContain("bg-overlay-soft");
+    // Selected state is now CSS-driven via aria-selected: variants.
+    expect(button?.className).toContain("aria-selected:bg-overlay-soft");
+    expect(button?.className).toContain("aria-selected:before:bg-daintree-accent");
+    expect(button?.className).toContain("aria-selected:before:content-['']");
+  });
+
+  it("does not branch styling on isSelected — selection is purely aria-driven", () => {
+    const { container: selectedContainer } = render(
+      <ActionPaletteItem item={makeItem()} isSelected={true} onSelect={onSelect} />
+    );
+    const { container: unselectedContainer } = render(
+      <ActionPaletteItem item={makeItem()} isSelected={false} onSelect={onSelect} />
+    );
+
+    const selectedClass = selectedContainer.querySelector("button")?.className;
+    const unselectedClass = unselectedContainer.querySelector("button")?.className;
+    // Class lists must be identical — only aria-selected attribute differs.
+    expect(selectedClass).toBe(unselectedClass);
+  });
+
+  it("lifts keybinding glyph contrast on selection via group-aria-selected", () => {
+    const { container } = render(
+      <ActionPaletteItem
+        item={makeItem({ keybinding: "⌘K" })}
+        isSelected={true}
+        onSelect={onSelect}
+      />
+    );
+
+    const kbd = screen.getByText("⌘K");
+    expect(kbd.className).toContain("text-daintree-text/40");
+    expect(kbd.className).toContain("group-aria-selected:text-daintree-text/60");
+    expect(container.querySelector("button")?.className).toContain("group");
+  });
+
+  it("calls onHover when the pointer moves over the item", () => {
+    const onHover = vi.fn();
+    const { container } = render(
+      <ActionPaletteItem
+        item={makeItem()}
+        isSelected={false}
+        onSelect={onSelect}
+        onHover={onHover}
+      />
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    fireEvent.pointerMove(button!);
+    expect(onHover).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onHover is omitted", () => {
+    const { container } = render(
+      <ActionPaletteItem item={makeItem()} isSelected={false} onSelect={onSelect} />
+    );
+
+    const button = container.querySelector("button");
+    expect(() => fireEvent.pointerMove(button!)).not.toThrow();
   });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -7,12 +7,14 @@ interface ActionPaletteItemProps {
   item: ActionPaletteItemType;
   isSelected: boolean;
   onSelect: (item: ActionPaletteItemType) => void;
+  onHover?: () => void;
 }
 
 export const ActionPaletteItem = React.memo(function ActionPaletteItem({
   item,
   isSelected,
   onSelect,
+  onHover,
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
 
@@ -21,16 +23,19 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
       id={`action-option-${item.id}`}
       tabIndex={-1}
       onPointerDown={(e) => e.preventDefault()}
+      onPointerMove={onHover}
       role="option"
       aria-selected={isSelected}
       aria-disabled={!item.enabled}
       disabled={!item.enabled}
       className={cn(
-        "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
-        !item.enabled && "opacity-40 cursor-not-allowed",
-        isSelected
-          ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-          : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
+        "border border-transparent text-daintree-text/70",
+        "hover:bg-overlay-subtle hover:text-daintree-text",
+        "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
+        "aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
+        !item.enabled && "opacity-40 cursor-not-allowed"
       )}
       onClick={() => item.enabled && onSelect(item)}
     >
@@ -56,7 +61,7 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
       </div>
 
       {item.keybinding && (
-        <span className="shrink-0 text-[11px] font-mono text-daintree-text/40">
+        <span className="shrink-0 text-[11px] font-mono text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
           {item.keybinding}
         </span>
       )}

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -16,6 +16,7 @@ type QuickSwitcherProps = Pick<
   | "selectedIndex"
   | "close"
   | "setQuery"
+  | "setSelectedIndex"
   | "selectPrevious"
   | "selectNext"
   | "selectItem"
@@ -30,6 +31,7 @@ export function QuickSwitcher({
   selectedIndex,
   close,
   setQuery,
+  setSelectedIndex,
   selectPrevious,
   selectNext,
   selectItem,
@@ -55,13 +57,15 @@ export function QuickSwitcher({
       onSelectNext={selectNext}
       onConfirm={confirmSelection}
       onClose={close}
+      onHoverIndex={setSelectedIndex}
       getItemId={(item) => item.id}
-      renderItem={(item, _index, isSelected) => (
+      renderItem={(item, index, isSelected, onHoverIndex) => (
         <QuickSwitcherItem
           key={item.id}
           item={item}
           isSelected={isSelected}
           onSelect={handleSelect}
+          onHover={() => onHoverIndex(index)}
         />
       )}
       label="Quick switch"

--- a/src/components/QuickSwitcher/QuickSwitcherItem.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QuickSwitcherItem } from "./QuickSwitcherItem";
+import type { QuickSwitcherItem as QuickSwitcherItemData } from "@/hooks/useQuickSwitcher";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/icons", () => ({
+  FolderGit2: () => <span data-testid="folder-icon" />,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function makeWorktreeItem(overrides: Partial<QuickSwitcherItemData> = {}): QuickSwitcherItemData {
+  return {
+    id: "worktree:wt-1",
+    type: "worktree",
+    title: "main",
+    subtitle: "/path/to/wt",
+    ...overrides,
+  };
+}
+
+describe("QuickSwitcherItem", () => {
+  const onSelect = vi.fn();
+
+  it("renders worktree row with title", () => {
+    render(<QuickSwitcherItem item={makeWorktreeItem()} isSelected={false} onSelect={onSelect} />);
+    expect(screen.getByText("main")).toBeTruthy();
+  });
+
+  it("applies selection styling via aria-selected variants", () => {
+    const { container } = render(
+      <QuickSwitcherItem item={makeWorktreeItem()} isSelected={true} onSelect={onSelect} />
+    );
+
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("aria-selected")).toBe("true");
+    expect(button?.className).toContain("aria-selected:bg-overlay-soft");
+    expect(button?.className).toContain("aria-selected:before:content-['']");
+    expect(button?.className).toContain("group");
+  });
+
+  it("does not branch styling on isSelected — selection is purely aria-driven", () => {
+    const { container: selectedContainer } = render(
+      <QuickSwitcherItem item={makeWorktreeItem()} isSelected={true} onSelect={onSelect} />
+    );
+    const { container: unselectedContainer } = render(
+      <QuickSwitcherItem item={makeWorktreeItem()} isSelected={false} onSelect={onSelect} />
+    );
+
+    expect(selectedContainer.querySelector("button")?.className).toBe(
+      unselectedContainer.querySelector("button")?.className
+    );
+  });
+
+  it("calls onHover on pointer move", () => {
+    const onHover = vi.fn();
+    const { container } = render(
+      <QuickSwitcherItem
+        item={makeWorktreeItem()}
+        isSelected={false}
+        onSelect={onSelect}
+        onHover={onHover}
+      />
+    );
+
+    fireEvent.pointerMove(container.querySelector("button")!);
+    expect(onHover).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when onHover is omitted", () => {
+    const { container } = render(
+      <QuickSwitcherItem item={makeWorktreeItem()} isSelected={false} onSelect={onSelect} />
+    );
+    expect(() => fireEvent.pointerMove(container.querySelector("button")!)).not.toThrow();
+  });
+});

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -9,12 +9,14 @@ export interface QuickSwitcherItemProps {
   item: QuickSwitcherItemData;
   isSelected: boolean;
   onSelect: (item: QuickSwitcherItemData) => void;
+  onHover?: () => void;
 }
 
 export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
   item,
   isSelected,
   onSelect,
+  onHover,
 }: QuickSwitcherItemProps) {
   return (
     <button
@@ -22,13 +24,14 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
       type="button"
       tabIndex={-1}
       onPointerDown={(e) => e.preventDefault()}
+      onPointerMove={onHover}
       className={cn(
-        "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
-        "transition-colors",
-        "border",
-        isSelected
-          ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-          : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
+        "transition-colors border border-transparent text-daintree-text/70",
+        "hover:bg-overlay-subtle hover:text-daintree-text",
+        "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
+        "aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
       )}
       onClick={() => onSelect(item)}
       aria-selected={isSelected}

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -16,8 +16,21 @@ export interface SearchablePaletteProps<T> {
 
   /** Unique key for each item */
   getItemId: (item: T) => string;
-  /** Render a list item */
-  renderItem: (item: T, index: number, isSelected: boolean) => React.ReactNode;
+  /**
+   * Render a list item. The optional 4th argument is a stable hover callback —
+   * forward it to the item's `onPointerMove` so mouse hover keeps `selectedIndex`
+   * in sync with the visually highlighted row. Use `onPointerMove` (not
+   * `onMouseEnter`) so keyboard scrolling doesn't trigger spurious selection
+   * changes when items move under a stationary cursor.
+   */
+  renderItem: (
+    item: T,
+    index: number,
+    isSelected: boolean,
+    onHoverIndex: (index: number) => void
+  ) => React.ReactNode;
+  /** Called when the pointer hovers a row, for keeping selectedIndex in sync. */
+  onHoverIndex?: (index: number) => void;
 
   /** Label shown above the search input */
   label: string;
@@ -71,6 +84,7 @@ export function SearchablePalette<T>({
   onClose,
   getItemId,
   renderItem,
+  onHoverIndex,
   label,
   keyHint,
   ariaLabel,
@@ -158,6 +172,9 @@ export function SearchablePalette<T>({
       ? `${itemIdPrefix}-${getItemId(results[selectedIndex]!)}`
       : undefined;
 
+  const noopHoverIndex = useCallback(() => {}, []);
+  const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>
       <AppPaletteDialog.Header label={label} keyHint={keyHint} className={headerClassName}>
@@ -192,7 +209,9 @@ export function SearchablePalette<T>({
               </AppPaletteDialog.Empty>
             ) : (
               <div ref={listRef} id={listId} role="listbox" aria-label={label}>
-                {results.map((item, index) => renderItem(item, index, index === selectedIndex))}
+                {results.map((item, index) =>
+                  renderItem(item, index, index === selectedIndex, hoverIndexHandler)
+                )}
               </div>
             )}
             {totalResults != null && (

--- a/src/components/ui/__tests__/SearchablePalette.hover.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.hover.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { fireEvent, render } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+}
+
+const items: Item[] = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+function renderPalette(onHoverIndex?: (index: number) => void) {
+  return render(
+    <SearchablePalette<Item>
+      isOpen
+      query=""
+      results={items}
+      selectedIndex={0}
+      onQueryChange={() => {}}
+      onSelectPrevious={() => {}}
+      onSelectNext={() => {}}
+      onConfirm={() => {}}
+      onClose={() => {}}
+      getItemId={(item) => item.id}
+      onHoverIndex={onHoverIndex}
+      renderItem={(item, index, isSelected, hoverIndex) => (
+        <button
+          key={item.id}
+          data-testid={`row-${item.id}`}
+          aria-selected={isSelected}
+          onPointerMove={() => hoverIndex(index)}
+        >
+          {item.id}
+        </button>
+      )}
+      label="Test"
+      ariaLabel="Test palette"
+    />
+  );
+}
+
+describe("SearchablePalette hover wiring", () => {
+  it("calls onHoverIndex with the correct index when a row's pointer move fires", () => {
+    const onHoverIndex = vi.fn();
+    const { getByTestId } = renderPalette(onHoverIndex);
+
+    fireEvent.pointerMove(getByTestId("row-c"));
+    expect(onHoverIndex).toHaveBeenCalledWith(2);
+
+    fireEvent.pointerMove(getByTestId("row-a"));
+    expect(onHoverIndex).toHaveBeenCalledWith(0);
+
+    expect(onHoverIndex).toHaveBeenCalledTimes(2);
+  });
+
+  it("supplies a stable noop hover callback when onHoverIndex is omitted", () => {
+    const { getByTestId } = renderPalette();
+    expect(() => fireEvent.pointerMove(getByTestId("row-b"))).not.toThrow();
+  });
+});

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -36,6 +36,7 @@ export interface UseActionPaletteReturn {
   close: () => void;
   toggle: () => void;
   setQuery: (query: string) => void;
+  setSelectedIndex: (index: number) => void;
   selectPrevious: () => void;
   selectNext: () => void;
   executeAction: (item: ActionPaletteItem) => void;
@@ -122,6 +123,7 @@ export function useActionPalette(): UseActionPaletteReturn {
     close,
     toggle,
     setQuery,
+    setSelectedIndex,
     selectPrevious,
     selectNext,
   } = useSearchablePalette<ActionPaletteItem>({
@@ -184,6 +186,7 @@ export function useActionPalette(): UseActionPaletteReturn {
     close,
     toggle,
     setQuery,
+    setSelectedIndex,
     selectPrevious,
     selectNext,
     executeAction,

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -30,6 +30,7 @@ export interface UseQuickSwitcherReturn {
   close: () => void;
   toggle: () => void;
   setQuery: (query: string) => void;
+  setSelectedIndex: (index: number) => void;
   selectPrevious: () => void;
   selectNext: () => void;
   selectItem: (item: QuickSwitcherItem) => void;
@@ -153,6 +154,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     close,
     toggle,
     setQuery,
+    setSelectedIndex,
     selectPrevious,
     selectNext,
   } = useSearchablePalette<QuickSwitcherItem>({
@@ -208,6 +210,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     close,
     toggle,
     setQuery,
+    setSelectedIndex,
     selectPrevious,
     selectNext,
     selectItem,


### PR DESCRIPTION
## Summary

- Migrates selection state in `ActionPaletteItem` and `QuickSwitcherItem` to CSS-native `aria-selected` Tailwind v4 variants, replacing JS-conditional `cn()` branches. The accent bar pseudo-element is now driven by `aria-selected:before:content-['']` too.
- Lifts keybinding glyph contrast on selected rows via `group-aria-selected:text-daintree-text/60`, matching the title contrast lift.
- Adds mouse-hover sync: hovering a row updates `selectedIndex` so Enter always fires the visually highlighted item. Uses `onPointerMove` (not `onMouseEnter`) to avoid the keyboard-scroll-under-stationary-cursor regression.

Resolves #6343

## Changes

- `ActionPaletteItem.tsx`, `QuickSwitcherItem.tsx` — aria-selected CSS variants, keybinding contrast lift, `onPointerMove` handler
- `SearchablePalette.tsx` — new optional `onHoverIndex` prop threaded through `renderItem` as a 4th arg
- `useActionPalette.ts`, `useQuickSwitcher.ts` — expose `setSelectedIndex` from hook return
- `App.tsx` — wire `onHoverIndex` through to `SearchablePalette`
- New tests: `QuickSwitcherItem.test.tsx` (5 cases), `SearchablePalette.hover.test.tsx` (integration — covers wiring-bug attack cases)

## Testing

Lint, format, typecheck, and build all pass. 23+ unit tests pass across the changed files.