### PR TITLE
feat(worktree): show per-chip match counts in filter popover

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -49,6 +49,7 @@ import {
   groupByType,
   findIntegrationWorktree,
   scoreWorktree,
+  computeChipCounts,
   type DerivedWorktreeMeta,
   type FilterState,
 } from "@/lib/worktreeFilters";
@@ -523,6 +524,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     return counts;
   }, [deferredWorktrees, derivedMetaMap, mainWorktree, integrationWorktree]);
 
+  const chipCounts = useMemo(() => {
+    const nonMain = deferredWorktrees.filter(
+      (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
+    );
+    return computeChipCounts(nonMain, derivedMetaMap, activeWorktreeId);
+  }, [deferredWorktrees, derivedMetaMap, mainWorktree, integrationWorktree, activeWorktreeId]);
+
   const mainWorktreeAggregateCounts = useMemo(() => {
     const nonMainCount = deferredWorktrees.length - 1 - (integrationWorktree ? 1 : 0);
     if (
@@ -983,7 +991,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       </div>
 
       {/* Inline search bar — only when there are non-main worktrees */}
-      {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
+      {hasNonMainWorktrees && (
+        <WorktreeSidebarSearchBar inputRef={searchInputRef} chipCounts={chipCounts} />
+      )}
 
       {/* Arm all terminals matching the active filter — only when a filter narrows the list */}
       {hasNonMainWorktrees && hasFilters && filteredWorktrees.length > 0 && (

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -12,6 +12,7 @@ import {
   type SessionFilter,
   type ActivityFilter,
 } from "@/store/worktreeFilterStore";
+import type { ChipCounts } from "@/lib/worktreeFilters";
 
 interface FilterSectionProps {
   title: string;
@@ -50,9 +51,12 @@ interface FilterChipProps {
   label: string;
   isActive: boolean;
   onClick: () => void;
+  count?: number;
 }
 
-function FilterChip({ label, isActive, onClick }: FilterChipProps) {
+function FilterChip({ label, isActive, onClick, count }: FilterChipProps) {
+  const showCount = count !== undefined && (count > 0 || isActive);
+  const isDimmed = count === 0 && !isActive;
   return (
     <button
       type="button"
@@ -62,10 +66,12 @@ function FilterChip({ label, isActive, onClick }: FilterChipProps) {
         "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full border transition-colors",
         isActive
           ? "bg-tint/[0.08] border-daintree-border text-daintree-text"
-          : "bg-daintree-bg border-daintree-border text-daintree-text/60 hover:bg-overlay-medium hover:text-daintree-text/80"
+          : isDimmed
+            ? "bg-daintree-bg border-daintree-border text-daintree-text/30 hover:bg-overlay-soft hover:text-daintree-text/50"
+            : "bg-daintree-bg border-daintree-border text-daintree-text/60 hover:bg-overlay-medium hover:text-daintree-text/80"
       )}
     >
-      {label}
+      {showCount ? `${label} (${count})` : label}
     </button>
   );
 }
@@ -127,9 +133,13 @@ const ORDER_OPTIONS: { value: OrderBy; label: string }[] = [
 
 interface WorktreeFilterPopoverProps {
   hideSearchInput?: boolean;
+  chipCounts?: ChipCounts;
 }
 
-export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilterPopoverProps) {
+export function WorktreeFilterPopover({
+  hideSearchInput = false,
+  chipCounts,
+}: WorktreeFilterPopoverProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [localQuery, setLocalQuery] = useState("");
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -322,6 +332,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                   label={option.label}
                   isActive={statusFilters.has(option.value)}
                   onClick={() => toggleStatusFilter(option.value)}
+                  count={chipCounts?.status[option.value]}
                 />
               ))}
             </div>
@@ -335,6 +346,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                   label={option.label}
                   isActive={typeFilters.has(option.value)}
                   onClick={() => toggleTypeFilter(option.value)}
+                  count={chipCounts?.branchType[option.value]}
                 />
               ))}
             </div>
@@ -348,6 +360,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                   label={option.label}
                   isActive={githubFilters.has(option.value)}
                   onClick={() => toggleGitHubFilter(option.value)}
+                  count={chipCounts?.github[option.value]}
                 />
               ))}
             </div>
@@ -361,6 +374,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                   label={option.label}
                   isActive={sessionFilters.has(option.value)}
                   onClick={() => toggleSessionFilter(option.value)}
+                  count={chipCounts?.sessions[option.value]}
                 />
               ))}
             </div>
@@ -374,6 +388,7 @@ export function WorktreeFilterPopover({ hideSearchInput = false }: WorktreeFilte
                   label={option.label}
                   isActive={activityFilters.has(option.value)}
                   onClick={() => toggleActivityFilter(option.value)}
+                  count={chipCounts?.activity[option.value]}
                 />
               ))}
             </div>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -15,6 +15,7 @@ import {
   matchesFilters,
   sortWorktrees,
   groupByType,
+  computeChipCounts,
   type DerivedWorktreeMeta,
   type FilterState,
   type GroupedSection,
@@ -245,6 +246,11 @@ export function WorktreeOverviewModal({
     }
     return map;
   }, [worktrees, panelsById, panelIds]);
+
+  const chipCounts = useMemo(() => {
+    const candidates = hideMainWorktree ? worktrees.filter((w) => !w.isMainWorktree) : worktrees;
+    return computeChipCounts(candidates, derivedMetaMap, activeWorktreeId);
+  }, [worktrees, derivedMetaMap, activeWorktreeId, hideMainWorktree]);
 
   // Compute aggregate statistics from derivedMetaMap
   const aggregateStats = useMemo(() => {
@@ -488,7 +494,7 @@ export function WorktreeOverviewModal({
               </Tooltip>
             )}
             {/* Filter Popover */}
-            <WorktreeFilterPopover />
+            <WorktreeFilterPopover chipCounts={chipCounts} />
             {/* Clear Filters Button - only shown when filters are active */}
             {hasActiveFilters() && (
               <Tooltip>

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -3,9 +3,11 @@ import { Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { WorktreeFilterPopover } from "./WorktreeFilterPopover";
+import type { ChipCounts } from "@/lib/worktreeFilters";
 
 interface WorktreeSidebarSearchBarProps {
   inputRef?: React.Ref<HTMLInputElement>;
+  chipCounts?: ChipCounts;
 }
 
 function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
@@ -16,7 +18,7 @@ function assignForwardedRef<T>(ref: React.Ref<T> | undefined, value: T | null): 
   }
 }
 
-export function WorktreeSidebarSearchBar({ inputRef }: WorktreeSidebarSearchBarProps) {
+export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSidebarSearchBarProps) {
   const query = useWorktreeFilterStore((state) => state.query);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
   const clearAll = useWorktreeFilterStore((state) => state.clearAll);
@@ -123,7 +125,7 @@ export function WorktreeSidebarSearchBar({ inputRef }: WorktreeSidebarSearchBarP
               <X className="w-3 h-3" />
             </button>
           )}
-          <WorktreeFilterPopover hideSearchInput />
+          <WorktreeFilterPopover hideSearchInput chipCounts={chipCounts} />
         </div>
       </div>
     </div>

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -1391,6 +1391,23 @@ describe("computeChipCounts", () => {
     expect(counts.activity.last7d).toBe(0);
   });
 
+  it("treats lastActivityTimestamp === 0 the same as missing", () => {
+    const worktrees = [createMockWorktree({ id: "1", lastActivityTimestamp: 0 })];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.activity.last15m).toBe(0);
+    expect(counts.activity.last7d).toBe(0);
+  });
+
+  it("excludes worktrees at the exact window boundary (strict less-than)", () => {
+    const now = Date.now();
+    const worktrees = [
+      createMockWorktree({ id: "1", lastActivityTimestamp: now - 15 * 60 * 1000 }),
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.activity.last15m).toBe(0);
+    expect(counts.activity.last1h).toBe(1);
+  });
+
   it("does not crash when derivedMetaMap is missing entries", () => {
     const worktrees = [createMockWorktree({ id: "1", branch: "feature/a" })];
     const counts = computeChipCounts(worktrees, new Map(), null);

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -12,6 +12,8 @@ import {
   hasAnyFilters,
   findIntegrationWorktree,
   filterTriageWorktrees,
+  computeChipCounts,
+  emptyChipCounts,
   type DerivedWorktreeMeta,
   type FilterState,
 } from "../worktreeFilters";
@@ -1258,5 +1260,141 @@ describe("matchesQuickStateFilter", () => {
   it('"finished" does NOT match chipState "waiting"', () => {
     const meta = { ...createEmptyMeta(), chipState: "waiting" as const };
     expect(matchesQuickStateFilter("finished", meta)).toBe(false);
+  });
+});
+
+describe("computeChipCounts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns all-zero counts for an empty worktree list", () => {
+    const counts = computeChipCounts([], new Map(), null);
+    expect(counts).toEqual(emptyChipCounts());
+  });
+
+  it("counts branch types independently", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a" }),
+      createMockWorktree({ id: "2", branch: "feature/b" }),
+      createMockWorktree({ id: "3", branch: "bugfix/c" }),
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.branchType.feature).toBe(2);
+    expect(counts.branchType.bugfix).toBe(1);
+    expect(counts.branchType.refactor).toBe(0);
+  });
+
+  it("counts GitHub chips by issue and PR state", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", issueNumber: 100, prNumber: 200, prState: "open" }),
+      createMockWorktree({ id: "2", issueNumber: 101 }),
+      createMockWorktree({ id: "3", prNumber: 202, prState: "merged" }),
+      createMockWorktree({ id: "4", prNumber: 203, prState: "closed" }),
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.github.hasIssue).toBe(2);
+    expect(counts.github.hasPR).toBe(3);
+    expect(counts.github.prOpen).toBe(1);
+    expect(counts.github.prMerged).toBe(1);
+    expect(counts.github.prClosed).toBe(1);
+  });
+
+  it("counts status chips and respects activeWorktreeId for the 'active' chip", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1", branch: "feature/a", mood: "stale" }),
+      createMockWorktree({
+        id: "2",
+        branch: "feature/b",
+        worktreeChanges: {
+          worktreeId: "2",
+          rootPath: "/x",
+          changedFileCount: 3,
+          changes: [],
+        },
+      }),
+      createMockWorktree({ id: "3", branch: "feature/c" }),
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), "3");
+    expect(counts.status.active).toBe(1);
+    expect(counts.status.dirty).toBe(1);
+    expect(counts.status.stale).toBe(1);
+    // id 2 is dirty (not idle); id 3 is active-only -> idle; id 1 is stale (not idle)
+    expect(counts.status.idle).toBe(1);
+  });
+
+  it("counts session chips from derivedMetaMap", () => {
+    const worktrees = [
+      createMockWorktree({ id: "1" }),
+      createMockWorktree({ id: "2" }),
+      createMockWorktree({ id: "3" }),
+    ];
+    const map = new Map<string, DerivedWorktreeMeta>([
+      [
+        "1",
+        {
+          ...createEmptyMeta(),
+          terminalCount: 2,
+          hasWorkingAgent: true,
+        },
+      ],
+      [
+        "2",
+        {
+          ...createEmptyMeta(),
+          terminalCount: 1,
+          hasWaitingAgent: true,
+        },
+      ],
+      [
+        "3",
+        {
+          ...createEmptyMeta(),
+          hasCompletedAgent: true,
+          hasExitedAgent: true,
+        },
+      ],
+    ]);
+    const counts = computeChipCounts(worktrees, map, null);
+    expect(counts.sessions.hasTerminals).toBe(2);
+    expect(counts.sessions.working).toBe(1);
+    expect(counts.sessions.waiting).toBe(1);
+    expect(counts.sessions.completed).toBe(1);
+    expect(counts.sessions.exited).toBe(1);
+  });
+
+  it("counts activity chips against current time windows (cumulative)", () => {
+    const now = Date.now();
+    const worktrees = [
+      createMockWorktree({ id: "1", lastActivityTimestamp: now - 5 * 60 * 1000 }), // 5m
+      createMockWorktree({ id: "2", lastActivityTimestamp: now - 30 * 60 * 1000 }), // 30m
+      createMockWorktree({ id: "3", lastActivityTimestamp: now - 5 * 60 * 60 * 1000 }), // 5h
+      createMockWorktree({ id: "4", lastActivityTimestamp: now - 3 * 24 * 60 * 60 * 1000 }), // 3d
+      createMockWorktree({ id: "5", lastActivityTimestamp: now - 30 * 24 * 60 * 60 * 1000 }), // 30d
+    ];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.activity.last15m).toBe(1);
+    expect(counts.activity.last1h).toBe(2);
+    expect(counts.activity.last24h).toBe(3);
+    expect(counts.activity.last7d).toBe(4);
+  });
+
+  it("ignores worktrees with no lastActivityTimestamp for activity chips", () => {
+    const worktrees = [createMockWorktree({ id: "1" })];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.activity.last15m).toBe(0);
+    expect(counts.activity.last7d).toBe(0);
+  });
+
+  it("does not crash when derivedMetaMap is missing entries", () => {
+    const worktrees = [createMockWorktree({ id: "1", branch: "feature/a" })];
+    const counts = computeChipCounts(worktrees, new Map(), null);
+    expect(counts.branchType.feature).toBe(1);
+    expect(counts.sessions.working).toBe(0);
   });
 });

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -452,13 +452,7 @@ const TYPE_KEYS: TypeFilter[] = [
   "other",
 ];
 const GITHUB_KEYS: GitHubFilter[] = ["hasIssue", "hasPR", "prOpen", "prMerged", "prClosed"];
-const SESSION_KEYS: SessionFilter[] = [
-  "hasTerminals",
-  "working",
-  "waiting",
-  "completed",
-  "exited",
-];
+const SESSION_KEYS: SessionFilter[] = ["hasTerminals", "working", "waiting", "completed", "exited"];
 const ACTIVITY_KEYS: ActivityFilter[] = ["last15m", "last1h", "last24h", "last7d"];
 
 const ACTIVITY_WINDOW_MS: Record<ActivityFilter, number> = {

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -424,3 +424,105 @@ export function findIntegrationWorktree<T extends Worktree | WorktreeState>(
     ) ?? null
   );
 }
+
+export interface ChipCounts {
+  status: Record<StatusFilter, number>;
+  branchType: Record<TypeFilter, number>;
+  github: Record<GitHubFilter, number>;
+  sessions: Record<SessionFilter, number>;
+  activity: Record<ActivityFilter, number>;
+}
+
+const STATUS_KEYS: StatusFilter[] = ["active", "dirty", "stale", "idle"];
+const TYPE_KEYS: TypeFilter[] = [
+  "feature",
+  "bugfix",
+  "refactor",
+  "chore",
+  "docs",
+  "test",
+  "release",
+  "ci",
+  "deps",
+  "perf",
+  "style",
+  "wip",
+  "main",
+  "detached",
+  "other",
+];
+const GITHUB_KEYS: GitHubFilter[] = ["hasIssue", "hasPR", "prOpen", "prMerged", "prClosed"];
+const SESSION_KEYS: SessionFilter[] = [
+  "hasTerminals",
+  "working",
+  "waiting",
+  "completed",
+  "exited",
+];
+const ACTIVITY_KEYS: ActivityFilter[] = ["last15m", "last1h", "last24h", "last7d"];
+
+const ACTIVITY_WINDOW_MS: Record<ActivityFilter, number> = {
+  last15m: 15 * 60 * 1000,
+  last1h: 60 * 60 * 1000,
+  last24h: 24 * 60 * 60 * 1000,
+  last7d: 7 * 24 * 60 * 60 * 1000,
+};
+
+function emptyRecord<K extends string>(keys: readonly K[]): Record<K, number> {
+  const result = {} as Record<K, number>;
+  for (const key of keys) result[key] = 0;
+  return result;
+}
+
+export function emptyChipCounts(): ChipCounts {
+  return {
+    status: emptyRecord(STATUS_KEYS),
+    branchType: emptyRecord(TYPE_KEYS),
+    github: emptyRecord(GITHUB_KEYS),
+    sessions: emptyRecord(SESSION_KEYS),
+    activity: emptyRecord(ACTIVITY_KEYS),
+  };
+}
+
+export function computeChipCounts(
+  worktrees: readonly (Worktree | WorktreeState)[],
+  derivedMetaMap: Map<string, DerivedWorktreeMeta>,
+  activeWorktreeId: string | null
+): ChipCounts {
+  const counts = emptyChipCounts();
+  const now = Date.now();
+
+  for (const worktree of worktrees) {
+    const isActive = worktree.id === activeWorktreeId;
+    const statuses = computeStatus(worktree, isActive);
+    for (const status of statuses) counts.status[status]++;
+
+    const type = getWorktreeType(worktree);
+    counts.branchType[type]++;
+
+    if (worktree.issueNumber) counts.github.hasIssue++;
+    if (worktree.prNumber) counts.github.hasPR++;
+    if (worktree.prState === "open") counts.github.prOpen++;
+    if (worktree.prState === "merged") counts.github.prMerged++;
+    if (worktree.prState === "closed") counts.github.prClosed++;
+
+    const meta = derivedMetaMap.get(worktree.id);
+    if (meta) {
+      if (meta.terminalCount > 0) counts.sessions.hasTerminals++;
+      if (meta.hasWorkingAgent) counts.sessions.working++;
+      if (meta.hasWaitingAgent) counts.sessions.waiting++;
+      if (meta.hasCompletedAgent) counts.sessions.completed++;
+      if (meta.hasExitedAgent) counts.sessions.exited++;
+    }
+
+    const lastActivity = worktree.lastActivityTimestamp ?? 0;
+    if (lastActivity > 0) {
+      const elapsed = now - lastActivity;
+      for (const key of ACTIVITY_KEYS) {
+        if (elapsed < ACTIVITY_WINDOW_MS[key]) counts.activity[key]++;
+      }
+    }
+  }
+
+  return counts;
+}


### PR DESCRIPTION
## Summary

- Adds `computeChipCounts` in `src/lib/worktreeFilters.ts` — a pure function that tallies single-chip matches across all five filter sections (Status, Branch Type, GitHub, Sessions, Activity)
- `FilterChip` in `WorktreeFilterPopover` gains an optional `count` prop; renders as `Label (N)` when count > 0 or the chip is selected — zero-match active chips stay visible, zero-match inactive chips dim via reduced opacity (no layout shift from hiding)
- Sidebar candidate set excludes main and integration worktrees (mirrors list-filter semantics); modal candidate set respects the `hideMainWorktree` toggle

Resolves #6334

## Changes

- `src/lib/worktreeFilters.ts` — new `computeChipCounts(worktrees, derivedMetaMap, activeWorktreeId)` function
- `src/components/Worktree/WorktreeFilterPopover.tsx` — `FilterChip` count prop + rendering logic
- `src/components/Worktree/WorktreeSidebarSearchBar.tsx` / `WorktreeOverviewModal.tsx` — thread `chipCounts` through to the popover
- `src/components/Sidebar/SidebarContent.tsx` — pass candidate set to search bar
- `src/lib/__tests__/worktreeFilters.test.ts` — 10 new unit tests covering empty list, branch types, GitHub state, status with `activeWorktreeId`, sessions, activity time windows, missing meta entries, `lastActivityTimestamp === 0`, exact window boundary, and worktrees with no timestamp

## Testing

Vitest 155/155 pass, tsc clean, ESLint warnings decreased by 1, Prettier clean.