### PR TITLE
fix(worktree): make keyboard focus ring visible on worktree cards

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -711,9 +711,8 @@ export const WorktreeCard = React.memo(function WorktreeCard({
           <button
             type="button"
             className={cn(
-              "absolute inset-0 z-0",
+              "absolute inset-0 z-0 outline-hidden",
               variant === "grid" && "rounded-lg",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2",
               (isDraggingSort || isWorktreeSortDragging) && "pointer-events-none"
             )}
             aria-label={`Select worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}`}

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -110,7 +110,7 @@ const DURABLE_ALLOWLIST = new Set([
   // HealthChip accent tone routing + color-mix CSS custom property usage
   "src/components/Pulse/ProjectPulseCard.tsx",
 
-  // Focused worktree card left-edge accent bar (single primary anchor per view)
+  // Current worktree card left-edge accent bar (single primary anchor per view)
   "src/components/Worktree/WorktreeCard.tsx",
 
   // Setup wizard step indicators, accent icon, telemetry toggle (one-time setup flow)

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -19,6 +19,16 @@
   background: var(--sidebar-hover-bg, rgba(255, 255, 255, 0.015));
 }
 
+.sidebar-worktree-card:has(> button:focus-visible) {
+  box-shadow: inset 0 0 0 2px var(--sidebar-ring);
+}
+
+.sidebar-worktree-card[data-active="true"]:has(> button:focus-visible) {
+  box-shadow:
+    inset 2px 0 0 var(--theme-overlay-selected),
+    inset 0 0 0 2px var(--sidebar-ring);
+}
+
 .sidebar-action-button:hover {
   background: var(--sidebar-action-hover-bg, var(--theme-overlay-hover));
 }

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -46,3 +46,10 @@
 body[data-reduce-animations="true"] .sidebar-worktree-card {
   transition: none;
 }
+
+@media (forced-colors: active) {
+  .sidebar-worktree-card:has(> button:focus-visible) {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}


### PR DESCRIPTION
## Summary

- The focus ring on worktree cards was invisible because it lived on the hidden absolute-positioned button underlay, not the visible row container
- On the current worktree, the accent stripe masked it entirely — focus and current state cancelled each other out rather than composing
- Moves focus ring handling to the container via a CSS `:has(> button:focus-visible)` rule with an inset `box-shadow` using `--sidebar-ring`, keeping the accent stripe as the sole accent signal on this surface

Resolves #6329

## Changes

- `WorktreeCard.tsx` — removes `focus-visible:outline-*` classes from the button underlay
- `src/styles/components/sidebar.css` — adds `:has()` focus rule and a `forced-colors` fallback block (high contrast mode ignores `box-shadow`, so falls back to `outline`)
- `src/config/__tests__/accentGuard.contract.test.ts` — comment polish only

## Testing

- Tabbed through worktree cards in normal and current states, confirmed ring is visible in both
- Verified forced-colors fallback compiles and the `forced-colors` media block is present in the built CSS
- `npm run check` passes clean