### PR TITLE
fix(toaster): tighten Tier-2 enter/exit timing and stop double-announcing errors

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -56,38 +56,50 @@ describe("Toast accessibility", () => {
     fixtureElements = [];
   });
 
-  it("announces non-error toast via polite channel", async () => {
+  it("announces non-error toast via role=status (polite live region)", async () => {
     render(<Toaster />);
     await act(async () => {
       addToast({ type: "success", message: "Saved" });
       vi.advanceTimersByTime(16);
     });
 
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("Saved");
+    const toast = screen.getByRole("status");
+    expect(toast.textContent).toContain("Saved");
+    expect(screen.queryByRole("alert")).toBeNull();
+    // The shared announcer must NOT also fire — role=status is the sole
+    // live-region path so screen readers only announce once (issue #6331).
+    expect(useAnnouncerStore.getState().polite).toBeNull();
     expect(useAnnouncerStore.getState().assertive).toBeNull();
   });
 
-  it("announces error toast via assertive channel", async () => {
+  it("announces error toast via role=alert (assertive live region)", async () => {
     render(<Toaster />);
     await act(async () => {
       addToast({ type: "error", message: "Failed" });
       vi.advanceTimersByTime(16);
     });
 
-    expect(useAnnouncerStore.getState().assertive?.msg).toBe("Failed");
+    const toast = screen.getByRole("alert");
+    expect(toast.textContent).toContain("Failed");
+    // No redundant announcer call — role=alert is sufficient (issue #6331).
+    expect(useAnnouncerStore.getState().assertive).toBeNull();
+    expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 
-  it("includes title in announcement when present", async () => {
+  it("renders title and message inside the live region when present", async () => {
     render(<Toaster />);
     await act(async () => {
       addToast({ title: "Update", message: "Ready" });
       vi.advanceTimersByTime(16);
     });
 
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("Update: Ready");
+    const toast = screen.getByRole("status");
+    expect(toast.textContent).toContain("Update");
+    expect(toast.textContent).toContain("Ready");
+    expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 
-  it("uses inboxMessage fallback for ReactNode messages", async () => {
+  it("renders ReactNode message content visibly when inboxMessage is provided", async () => {
     render(<Toaster />);
     await act(async () => {
       addToast({
@@ -97,7 +109,11 @@ describe("Toast accessibility", () => {
       vi.advanceTimersByTime(16);
     });
 
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("Plain text fallback");
+    const toast = screen.getByRole("status");
+    expect(toast.textContent).toContain("Rich content");
+    // The shared announcer must stay silent — the role node is the sole
+    // live-region path (issue #6331).
+    expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 
   it("pauses auto-dismiss timer on keyboard focus", async () => {
@@ -244,6 +260,42 @@ describe("Toast accessibility", () => {
     expect(toast.className).toContain("motion-reduce:duration-0");
   });
 
+  it("applies Tier 2 enter duration and spring easing once visible (issue #6331)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast();
+    });
+    // rAF (mocked as setTimeout 0) flips isVisible to true; advance after the
+    // first commit so the visible-state re-render lands in its own tick.
+    await act(async () => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const toast = screen.getByRole("status");
+    expect(toast.style.transitionDuration).toBe("200ms");
+    // EASE_SPRING_CRITICAL is a multi-stop linear() spring.
+    expect(toast.style.transitionTimingFunction).toContain("linear(");
+  });
+
+  it("applies Tier 2 exit duration and accelerate-out easing on dismiss (issue #6331)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const dismissButton = screen.getByLabelText("Dismiss notification");
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    const toast = screen.getByRole("status");
+    expect(toast.style.transitionDuration).toBe("120ms");
+    expect(toast.style.transitionTimingFunction).toBe("cubic-bezier(0.2, 0, 0.7, 0)");
+  });
+
   it("resets auto-dismiss timer when the message changes", async () => {
     render(<Toaster />);
     let toastId: string;
@@ -383,12 +435,12 @@ describe("Toast accessibility", () => {
     // ~984ms instead of resetting to a fresh 3000ms.
     expect(screen.getByText("msg-4")).toBeTruthy();
 
-    // Cross the cap; timer fires, then 200ms fade-out removes the toast.
+    // Cross the cap; timer fires, then exit fade removes the toast.
     await act(async () => {
       vi.advanceTimersByTime(1500);
     });
     await act(async () => {
-      vi.advanceTimersByTime(400);
+      vi.advanceTimersByTime(200);
     });
 
     expect(screen.queryByText(/msg-/)).toBeNull();
@@ -442,7 +494,7 @@ describe("Toast accessibility", () => {
       useNotificationStore.getState().dismissNotification(toastId!);
     });
 
-    // User clicks X during the 200ms fade window before removeNotification.
+    // User clicks X during the exit fade window before removeNotification.
     const dismissButton = screen.getByLabelText("Dismiss notification");
     await act(async () => {
       fireEvent.click(dismissButton);
@@ -468,10 +520,10 @@ describe("Toast accessibility", () => {
       fireEvent.click(dismissButton);
     });
 
-    // Toast still enters the fade-out path; after the 200ms cleanup runs it
+    // Toast still enters the fade-out path; after the exit cleanup runs it
     // is removed from the store entirely.
     await act(async () => {
-      vi.advanceTimersByTime(400);
+      vi.advanceTimersByTime(200);
     });
     expect(screen.queryByText("Test message")).toBeNull();
     expect(consoleError).toHaveBeenCalled();
@@ -539,7 +591,7 @@ describe("Toast accessibility", () => {
     expect(iconWrapper?.className).toContain("text-status-error");
   });
 
-  it("re-announces via screen reader when updatedAt changes", async () => {
+  it("re-announces via the live region when message content updates", async () => {
     render(<Toaster />);
     let toastId: string;
     await act(async () => {
@@ -547,7 +599,8 @@ describe("Toast accessibility", () => {
       vi.advanceTimersByTime(16);
     });
 
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("1 agent done");
+    const initial = screen.getByRole("status");
+    expect(initial.textContent).toContain("1 agent done");
 
     await act(async () => {
       useNotificationStore.getState().updateNotification(toastId!, {
@@ -555,7 +608,12 @@ describe("Toast accessibility", () => {
       });
     });
 
-    expect(useAnnouncerStore.getState().polite?.msg).toBe("2 agents done");
+    // role=status mutates in place; screen readers pick up the live-region
+    // change without a separate announcer call (issue #6331).
+    const updated = screen.getByRole("status");
+    expect(updated.textContent).toContain("2 agents done");
+    expect(updated.textContent).not.toContain("1 agent done");
+    expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 });
 
@@ -680,7 +738,7 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     });
     expect(screen.getByText("Failed once")).toBeTruthy();
 
-    // Past 12s + the 200ms fade — gone.
+    // Past 12s + the exit fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
@@ -700,7 +758,7 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     });
     expect(screen.getByText("Saved!")).toBeTruthy();
 
-    // Past 4s + the 200ms fade — gone.
+    // Past 4s + the exit fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -99,18 +99,26 @@ describe("Toast accessibility", () => {
     expect(useAnnouncerStore.getState().polite).toBeNull();
   });
 
-  it("renders ReactNode message content visibly when inboxMessage is provided", async () => {
+  it("uses inboxMessage as the live-region announcement for ReactNode messages", async () => {
     render(<Toaster />);
     await act(async () => {
       addToast({
-        message: (<span>Rich content</span>) as unknown as string,
-        inboxMessage: "Plain text fallback",
+        message: (<span>45% complete</span>) as unknown as string,
+        inboxMessage: "Downloading update: 45%",
       });
       vi.advanceTimersByTime(16);
     });
 
     const toast = screen.getByRole("status");
-    expect(toast.textContent).toContain("Rich content");
+    // sr-only span carries the controlled inboxMessage for assistive tech.
+    const srOnlyNode = toast.querySelector(".sr-only");
+    expect(srOnlyNode?.textContent).toBe("Downloading update: 45%");
+    // The visual ReactNode is aria-hidden so screen readers only hear the
+    // controlled inboxMessage — not both (issue #6331).
+    const visualNode = screen.getByText("45% complete").closest('[aria-hidden="true"]');
+    expect(visualNode).not.toBeNull();
+    // Sighted users still see the rendered JSX content.
+    expect(screen.getByText("45% complete")).toBeTruthy();
     // The shared announcer must stay silent — the role node is the sole
     // live-region path (issue #6331).
     expect(useAnnouncerStore.getState().polite).toBeNull();
@@ -294,6 +302,33 @@ describe("Toast accessibility", () => {
     const toast = screen.getByRole("status");
     expect(toast.style.transitionDuration).toBe("120ms");
     expect(toast.style.transitionTimingFunction).toBe("cubic-bezier(0.2, 0, 0.7, 0)");
+  });
+
+  it("removes the toast from the DOM exactly after UI_EXIT_DURATION (issue #6331)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ message: "Boundary check" });
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(16);
+    });
+
+    const dismissButton = screen.getByLabelText("Dismiss notification");
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    // Just before the 120ms exit window — toast is still mounted.
+    await act(async () => {
+      vi.advanceTimersByTime(119);
+    });
+    expect(screen.queryByText("Boundary check")).toBeTruthy();
+
+    // Cross the exit boundary — toast is unmounted.
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.queryByText("Boundary check")).toBeNull();
   });
 
   it("resets auto-dismiss timer when the message changes", async () => {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -11,8 +11,14 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { logError } from "@/utils/logger";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+  getUiTransitionDuration,
+} from "@/lib/animationUtils";
 import { useNotificationStore, type Notification } from "@/store/notificationStore";
-import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useShallow } from "zustand/react/shallow";
 import {
   DropdownMenu,
@@ -74,15 +80,7 @@ function Toast({ notification }: { notification: Notification }) {
         "[Toaster] non-string message without inboxMessage — aria-live announcement will be empty"
       );
     }
-    const text =
-      typeof notification.message === "string"
-        ? notification.message
-        : (notification.inboxMessage ?? "");
-    if (!text) return;
-    const fullText = notification.title ? `${notification.title}: ${text}` : text;
-    const priority = notification.type === "error" ? "assertive" : "polite";
-    useAnnouncerStore.getState().announce(fullText, priority);
-  }, [notification.id, notification.updatedAt]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [notification.id, notification.updatedAt, notification.message, notification.inboxMessage]);
 
   useEffect(() => {
     const handle = requestAnimationFrame(() => setIsVisible(true));
@@ -97,7 +95,7 @@ function Toast({ notification }: { notification: Notification }) {
 
   const handleDismiss = useCallback(() => {
     // If the notification is already dismissed, this click came in during the
-    // 200ms fade after an eviction (or a double-click race). Skip the
+    // exit fade after an eviction (or a double-click race). Skip the
     // user-dismiss callback so eviction/reentrancy don't fire onDismiss.
     if (notification.dismissed) return;
     restoreFocus();
@@ -110,14 +108,14 @@ function Toast({ notification }: { notification: Notification }) {
     }
     dismissNotification(notification.id);
     setIsVisible(false);
-    setTimeout(() => removeNotification(notification.id), 200);
+    setTimeout(() => removeNotification(notification.id), getUiTransitionDuration("exit"));
   }, [notification, dismissNotification, removeNotification, restoreFocus]);
 
   useEffect(() => {
     if (notification.dismissed && isVisible) {
       restoreFocus();
       setIsVisible(false);
-      setTimeout(() => removeNotification(notification.id), 200);
+      setTimeout(() => removeNotification(notification.id), getUiTransitionDuration("exit"));
     }
   }, [notification.dismissed, notification.id, isVisible, removeNotification, restoreFocus]);
 
@@ -157,11 +155,15 @@ function Toast({ notification }: { notification: Notification }) {
         "text-sm text-daintree-text",
         "shadow-[var(--theme-shadow-floating)]",
         "ring-1 ring-inset ring-tint/[0.05]",
-        "transition-[transform,opacity] duration-200 ease-out",
+        "transition-[transform,opacity]",
         "motion-reduce:transition-none motion-reduce:duration-0",
         isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
         accentClass
       )}
+      style={{
+        transitionDuration: `${isVisible ? UI_ENTER_DURATION : UI_EXIT_DURATION}ms`,
+        transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+      }}
       onMouseEnter={() => setIsPaused(true)}
       onMouseLeave={() => setIsPaused(false)}
       onFocus={() => setIsPaused(true)}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -200,9 +200,21 @@ function Toast({ notification }: { notification: Notification }) {
             </span>
           </div>
         ) : null}
-        <div className="text-xs text-daintree-text/70 leading-snug break-words">
-          {notification.message}
-        </div>
+        {typeof notification.message !== "string" && notification.inboxMessage ? (
+          <>
+            <span className="sr-only">{notification.inboxMessage}</span>
+            <div
+              aria-hidden="true"
+              className="text-xs text-daintree-text/70 leading-snug break-words"
+            >
+              {notification.message}
+            </div>
+          </>
+        ) : (
+          <div className="text-xs text-daintree-text/70 leading-snug break-words">
+            {notification.message}
+          </div>
+        )}
         {(() => {
           const actions = [
             ...(notification.actions ?? []),


### PR DESCRIPTION
## Summary

- Toast enter/exit was using a single 200ms `ease-out` for both directions, ignoring the Tier-2 split (200ms spring enter / 120ms accelerate-out exit). Fixed by switching `transitionDuration` and `transitionTimingFunction` via inline style on `isVisible` — the same pattern `AppDialog` and fixed dropdowns already use.
- Error toasts were being announced twice by screen readers: `role="alert"` on the toast container already implies an assertive live region, and the separate `useAnnouncerStore.announce()` call was firing a second time into `AccessibilityAnnouncer`. Removed the redundant call. When `message` is a `ReactNode` and `inboxMessage` is provided, `inboxMessage` is rendered in an `sr-only` span with the visual JSX aria-hidden, preserving the controlled-announcement contract.
- DOM removal timeout updated from hardcoded 200ms to `getUiTransitionDuration("exit")` so it tracks the 120ms exit and short-circuits cleanly in performance mode.

Resolves #6331

## Changes

- `src/components/ui/toaster.tsx` — split enter/exit timing via inline style; remove `announce()` call; `sr-only` fallback for ReactNode messages; `getUiTransitionDuration("exit")` for removal timeout
- `src/components/ui/__tests__/toaster.test.tsx` — pivot 5 announcer-store assertions to DOM role/text checks; retime two fade-window advances; update 5 timer comments; add 3 new tests (enter-style, exit-style, 119ms vs 120ms removal boundary)

## Testing

41 tests pass (`npx vitest run src/components/ui/__tests__/toaster.test.tsx`). Typecheck, format, and lint clean.