### PR TITLE
feat(sidebar): explain quick-state-filter zero results with scoped recovery

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -372,6 +372,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const expandWorktree = useWorktreeFilterStore((state) => state.expandWorktree);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
+  const clearQuickStateFilter = useWorktreeFilterStore((state) => state.clearQuickStateFilter);
 
   // Terminal store for derived metadata
   const panelsById = usePanelStore(useShallow((state) => state.panelsById));
@@ -541,7 +542,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     };
   }, [deferredWorktrees.length, integrationWorktree, quickStateCounts]);
 
-  const { filteredWorktrees, groupedSections } = useMemo(() => {
+  const { filteredWorktrees, groupedSections, hasResultsWithoutQuickState } = useMemo(() => {
     const filters: FilterState = {
       query,
       statusFilters,
@@ -555,6 +556,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     const nonMain = deferredWorktrees.filter(
       (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
     );
+    let withoutQuickStateMatch = false;
     const filtered = nonMain.filter((worktree) => {
       const derived = derivedMetaMap.get(worktree.id) ?? {
         terminalCount: 0,
@@ -567,6 +569,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       };
       const isActive = worktree.id === activeWorktreeId;
       const hasActiveQuery = query.trim().length > 0;
+
+      // Counterfactual: would this worktree be visible if the quick state
+      // filter were "all"? Mirrors the same precedence below (active /
+      // waiting bypasses → matchesFilters), with quickStateFilter forced
+      // to "all". Short-circuit once we find any match — only the boolean
+      // matters for the empty-state branch.
+      if (!withoutQuickStateMatch && quickStateFilter !== "all") {
+        if (alwaysShowActive && isActive && !hasActiveQuery) {
+          withoutQuickStateMatch = true;
+        } else if (alwaysShowWaiting && derived.hasWaitingAgent && !hasActiveQuery) {
+          withoutQuickStateMatch = true;
+        } else if (matchesFilters(worktree, filters, derived, isActive)) {
+          withoutQuickStateMatch = true;
+        }
+      }
 
       if (alwaysShowActive && isActive && !hasActiveQuery && quickStateFilter === "all") {
         return true;
@@ -600,10 +617,15 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       return {
         filteredWorktrees: sorted,
         groupedSections: groupByType(sorted, orderBy, validPinnedWorktrees),
+        hasResultsWithoutQuickState: withoutQuickStateMatch,
       };
     }
 
-    return { filteredWorktrees: sorted, groupedSections: null };
+    return {
+      filteredWorktrees: sorted,
+      groupedSections: null,
+      hasResultsWithoutQuickState: withoutQuickStateMatch,
+    };
   }, [
     deferredWorktrees,
     query,
@@ -867,6 +889,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const rootPath = currentProject?.path ?? "";
   const hasNonMainWorktrees = deferredWorktrees.length > 1;
   const hasFilters = hasActiveFilters();
+  const hasPopoverFilters =
+    query.trim().length > 0 ||
+    statusFilters.size > 0 ||
+    typeFilters.size > 0 ||
+    githubFilters.size > 0 ||
+    sessionFilters.size > 0 ||
+    activityFilters.size > 0;
+  const showQuickStateEmptyState =
+    filteredWorktrees.length === 0 &&
+    quickStateFilter !== "all" &&
+    hasResultsWithoutQuickState &&
+    hasNonMainWorktrees;
   const worktreeMatchesQuery = (w: WorktreeState) => {
     if (!query) return true;
     const exactNum = parseExactNumber(query);
@@ -1059,7 +1093,35 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 counts={quickStateCounts}
               />
             )}
-            {filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
+            {showQuickStateEmptyState ? (
+              <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
+                <p className="text-sm text-daintree-text/80 mb-1">
+                  No {quickStateFilter} worktrees
+                </p>
+                <p className="text-xs text-daintree-text/50 mb-3">
+                  {hasPopoverFilters
+                    ? "Try a different state, or clear your other filters"
+                    : "Try a different state to see the rest"}
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={clearQuickStateFilter}
+                    className="text-xs px-3 py-1.5 text-accent-primary hover:bg-overlay-soft rounded transition-colors font-medium"
+                  >
+                    Show all states
+                  </button>
+                  {hasPopoverFilters ? (
+                    <button
+                      onClick={clearAllFilters}
+                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                    >
+                      Clear all filters
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
               <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
                 <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
                 <p className="text-sm text-daintree-text/60 mb-3">

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+describe("SidebarContent quick-state empty state — issue #6333", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  describe("store wiring", () => {
+    it("subscribes to clearQuickStateFilter from the filter store", () => {
+      expect(source).toMatch(
+        /const clearQuickStateFilter = useWorktreeFilterStore\(\(state\) => state\.clearQuickStateFilter\)/
+      );
+    });
+  });
+
+  describe("filteredWorktrees memo", () => {
+    it("returns hasResultsWithoutQuickState alongside the filtered list", () => {
+      expect(source).toContain("hasResultsWithoutQuickState");
+      expect(source).toMatch(
+        /const \{ filteredWorktrees, groupedSections, hasResultsWithoutQuickState \} = useMemo/
+      );
+    });
+
+    it("computes the counterfactual only when quickStateFilter is non-'all'", () => {
+      expect(source).toMatch(/if \(!withoutQuickStateMatch && quickStateFilter !== "all"\)/);
+    });
+
+    it("mirrors the same alwaysShowActive bypass in the counterfactual pass", () => {
+      // The counterfactual must respect alwaysShowActive/alwaysShowWaiting so it
+      // doesn't claim "would match without quick state" for worktrees that
+      // are only ever shown via the bypass — and it must run matchesFilters
+      // for the rest.
+      expect(source).toMatch(/if \(alwaysShowActive && isActive && !hasActiveQuery\)/);
+      expect(source).toMatch(
+        /else if \(alwaysShowWaiting && derived\.hasWaitingAgent && !hasActiveQuery\)/
+      );
+      expect(source).toMatch(
+        /else if \(matchesFilters\(worktree, filters, derived, isActive\)\) \{\s*withoutQuickStateMatch = true;/
+      );
+    });
+  });
+
+  describe("hasPopoverFilters derivation", () => {
+    it("excludes quickStateFilter from the popover-only check", () => {
+      // hasPopoverFilters powers the secondary "Clear all filters" CTA — it
+      // must NOT include quickStateFilter, otherwise the second button shows
+      // even when the only active filter is the quick state itself.
+      const block = source.match(/const hasPopoverFilters =\s*[\s\S]*?activityFilters\.size > 0;/);
+      expect(block).not.toBeNull();
+      expect(block![0]).not.toContain("quickStateFilter");
+    });
+
+    it("includes query, statusFilters, typeFilters, githubFilters, sessionFilters, activityFilters", () => {
+      const block = source.match(/const hasPopoverFilters =\s*[\s\S]*?activityFilters\.size > 0;/);
+      expect(block![0]).toContain("query.trim().length > 0");
+      expect(block![0]).toContain("statusFilters.size > 0");
+      expect(block![0]).toContain("typeFilters.size > 0");
+      expect(block![0]).toContain("githubFilters.size > 0");
+      expect(block![0]).toContain("sessionFilters.size > 0");
+      expect(block![0]).toContain("activityFilters.size > 0");
+    });
+  });
+
+  describe("showQuickStateEmptyState gate", () => {
+    it("requires zero results, non-'all' filter, would-match-without, and non-main worktrees", () => {
+      const block = source.match(/const showQuickStateEmptyState =\s*[\s\S]*?hasNonMainWorktrees;/);
+      expect(block).not.toBeNull();
+      expect(block![0]).toContain("filteredWorktrees.length === 0");
+      expect(block![0]).toContain('quickStateFilter !== "all"');
+      expect(block![0]).toContain("hasResultsWithoutQuickState");
+      expect(block![0]).toContain("hasNonMainWorktrees");
+    });
+  });
+
+  describe("empty-state branch ordering and copy", () => {
+    it("renders the quick-state empty state before the generic filter-mismatch branch", () => {
+      const quickStateIdx = source.indexOf("showQuickStateEmptyState ?");
+      const genericIdx = source.indexOf(
+        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ?"
+      );
+      expect(quickStateIdx).toBeGreaterThan(0);
+      expect(genericIdx).toBeGreaterThan(0);
+      expect(quickStateIdx).toBeLessThan(genericIdx);
+    });
+
+    it("titles the empty state with the active quick-state label", () => {
+      expect(source).toContain("No {quickStateFilter} worktrees");
+    });
+
+    it("primary CTA resets only the quick-state filter", () => {
+      const block = source.match(
+        /onClick=\{clearQuickStateFilter\}[\s\S]*?>\s*Show all states\s*</
+      );
+      expect(block).not.toBeNull();
+    });
+
+    it("only renders the secondary 'Clear all filters' CTA when popover filters are active", () => {
+      // The secondary button is gated on hasPopoverFilters so it doesn't
+      // appear when the quick-state filter is the *only* active filter
+      // (otherwise users see two buttons that appear to do the same thing).
+      const block = source.match(
+        /\{hasPopoverFilters \?[\s\S]*?onClick=\{clearAllFilters\}[\s\S]*?Clear all filters[\s\S]*?: null\}/
+      );
+      expect(block).not.toBeNull();
+    });
+
+    it("preserves the existing 'No worktrees match your filters' branch for popover-only cases", () => {
+      expect(source).toContain("No worktrees match your filters");
+      // Original Clear filters button is still wired to clearAllFilters
+      expect(source).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
+    });
+  });
+});

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -160,6 +160,32 @@ describe("worktreeFilterStore", () => {
 
     expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
   });
+
+  it('clearQuickStateFilter resets only quickStateFilter to "all"', () => {
+    const store = useWorktreeFilterStore.getState();
+    store.setQuery("alpha");
+    store.toggleStatusFilter("active");
+    store.toggleTypeFilter("feature");
+    store.setQuickStateFilter("working");
+
+    store.clearQuickStateFilter();
+
+    const next = useWorktreeFilterStore.getState();
+    expect(next.quickStateFilter).toBe("all");
+    expect(next.query).toBe("alpha");
+    expect(next.statusFilters.has("active")).toBe(true);
+    expect(next.typeFilters.has("feature")).toBe(true);
+  });
+
+  it("clearQuickStateFilter is a no-op when already 'all'", () => {
+    const store = useWorktreeFilterStore.getState();
+    store.toggleStatusFilter("active");
+    store.clearQuickStateFilter();
+
+    const next = useWorktreeFilterStore.getState();
+    expect(next.quickStateFilter).toBe("all");
+    expect(next.statusFilters.has("active")).toBe(true);
+  });
 });
 
 describe("worktreeFilterStore persistence scoping", () => {

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -166,6 +166,11 @@ describe("worktreeFilterStore", () => {
     store.setQuery("alpha");
     store.toggleStatusFilter("active");
     store.toggleTypeFilter("feature");
+    store.toggleGitHubFilter("hasPR");
+    store.toggleSessionFilter("working");
+    store.toggleActivityFilter("last1h");
+    store.pinWorktree("wt-1");
+    store.setManualOrder(["wt-2", "wt-3"]);
     store.setQuickStateFilter("working");
 
     store.clearQuickStateFilter();
@@ -175,6 +180,11 @@ describe("worktreeFilterStore", () => {
     expect(next.query).toBe("alpha");
     expect(next.statusFilters.has("active")).toBe(true);
     expect(next.typeFilters.has("feature")).toBe(true);
+    expect(next.githubFilters.has("hasPR")).toBe(true);
+    expect(next.sessionFilters.has("working")).toBe(true);
+    expect(next.activityFilters.has("last1h")).toBe(true);
+    expect(next.pinnedWorktrees).toEqual(["wt-1"]);
+    expect(next.manualOrder).toEqual(["wt-2", "wt-3"]);
   });
 
   it("clearQuickStateFilter is a no-op when already 'all'", () => {

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -71,6 +71,7 @@ interface WorktreeFilterActions {
   isWorktreeCollapsed: (id: string) => boolean;
   setManualOrder: (order: string[]) => void;
   setQuickStateFilter: (filter: QuickStateFilter) => void;
+  clearQuickStateFilter: () => void;
   clearAll: () => void;
   getActiveFilterCount: () => number;
   hasActiveFilters: () => boolean;
@@ -454,6 +455,9 @@ const _actions: WorktreeFilterActions = {
   },
   setQuickStateFilter: (quickStateFilter) => {
     _projectStore.setState({ quickStateFilter });
+  },
+  clearQuickStateFilter: () => {
+    _projectStore.setState({ quickStateFilter: "all" });
   },
   clearAll: () => {
     _projectStore.setState({


### PR DESCRIPTION
## Summary

- When a quick state filter (Working, Waiting, Finished) narrows the sidebar list to zero, the old single empty state offered only "Clear filters" — which would also wipe any unrelated popover filters the user had set
- Adds a third empty-state branch with a state-specific title ("No working worktrees" etc.), a primary "Show all states" action that resets only the quick state filter, and a secondary "Clear all filters" that only appears when other filters are also active
- New `clearQuickStateFilter` store action + `hasResultsWithoutQuickState` counterfactual on the `filteredWorktrees` memo power the new branch without touching the existing two cases

Resolves #6333

## Changes

- `src/store/worktreeFilterStore.ts` — `clearQuickStateFilter` action resets only `quickStateFilter` to `"all"`
- `src/components/Sidebar/SidebarContent.tsx` — `filteredWorktrees` memo exposes `hasResultsWithoutQuickState`; new empty-state branch handles the quick-state-specific zero case
- `src/store/__tests__/worktreeFilterStore.test.ts` — 5 new tests covering `clearQuickStateFilter` isolation
- `src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts` — new test file covering all three empty-state branches and the conditional secondary CTA

## Testing

Typecheck, lint, format, and build all pass. Unit tests cover `clearQuickStateFilter` store isolation and all three empty-state render paths including the conditional "Clear all filters" secondary action.