### PR TITLE
feat(panel): confirm before closing a tab whose agent is working

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -275,8 +275,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   }, [pendingCloseTabId, doCloseTab]);
 
   const handleCancelClose = useCallback(() => {
+    const tabId = pendingCloseTabId;
     setPendingCloseTabId(null);
-  }, []);
+    // The popover was closed before the dialog opened so the Radix
+    // outside-click guard wouldn't collapse it behind the modal. Restore it
+    // on cancel so the user lands back where they started.
+    if (tabId) openDockTerminal(tabId);
+  }, [pendingCloseTabId, openDockTerminal]);
 
   // Sensors for tab drag-and-drop (require small distance to differentiate from clicks)
   const tabSensors = useSensors(

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -51,6 +51,8 @@ import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplication
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 
 interface DockedTabGroupProps {
   group: TabGroup;
@@ -232,9 +234,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     [group.id, setActiveTab, setFocused, openDockTerminal]
   );
 
-  const handleTabClose = useCallback(
+  const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(null);
+
+  const doCloseTab = useCallback(
     (tabId: string) => {
-      // If closing the active tab, switch to another tab first
       if (tabId === activeTabId) {
         const currentIndex = panels.findIndex((p) => p.id === tabId);
         const nextPanel = panels[currentIndex + 1] ?? panels[currentIndex - 1];
@@ -243,11 +246,37 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           setFocused(nextPanel.id);
         }
       }
-      // Trash the terminal (store auto-removes from group)
       trashPanel(tabId);
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );
+
+  // Confirm before closing a tab whose agent is mid-task. The dock popover
+  // collapses when the body-portalled ConfirmDialog appears (via Radix's
+  // onInteractOutside), so close it explicitly first to keep state transitions
+  // clean — otherwise cancel would leave the user with no popover to return to.
+  const handleTabClose = useCallback(
+    (tabId: string) => {
+      const panel = panels.find((p) => p.id === tabId);
+      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+        closeDockTerminal();
+        setPendingCloseTabId(tabId);
+        return;
+      }
+      doCloseTab(tabId);
+    },
+    [panels, closeDockTerminal, doCloseTab]
+  );
+
+  const handleConfirmClose = useCallback(() => {
+    const tabId = pendingCloseTabId;
+    setPendingCloseTabId(null);
+    if (tabId) doCloseTab(tabId);
+  }, [pendingCloseTabId, doCloseTab]);
+
+  const handleCancelClose = useCallback(() => {
+    setPendingCloseTabId(null);
+  }, []);
 
   // Sensors for tab drag-and-drop (require small distance to differentiate from clicks)
   const tabSensors = useSensors(
@@ -411,194 +440,211 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     : null;
 
   return (
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
-        <PopoverTrigger asChild>
-          <button
-            className={cn(
-              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
-              "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
-              "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-              "cursor-grab active:cursor-grabbing",
-              isOpen &&
-                "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
-              !isOpen &&
-                showDockAgentHighlights &&
-                blockedState === "waiting" &&
-                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-              isDeprioritized && "opacity-50"
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (e.detail >= 2) return;
-              if (isOpen) {
-                closeDockTerminal();
-              } else {
-                openDockTerminal(activeTabId);
-              }
-            }}
-            onDoubleClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const moved = moveTerminalToGrid(activePanel.id);
-              if (moved) closeDockTerminal();
-            }}
-            aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
-          >
-            <div className="flex items-center justify-center shrink-0">
-              <TerminalIcon kind={activePanel.kind} chrome={activeChrome} className="w-3.5 h-3.5" />
-            </div>
-            <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
-              {displayTitle}
-            </span>
+    <>
+      <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
+          <PopoverTrigger asChild>
+            <button
+              className={cn(
+                "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+                "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+                "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                "cursor-grab active:cursor-grabbing",
+                isOpen &&
+                  "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
+                !isOpen &&
+                  showDockAgentHighlights &&
+                  blockedState === "waiting" &&
+                  "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
+                isDeprioritized && "opacity-50"
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.detail >= 2) return;
+                if (isOpen) {
+                  closeDockTerminal();
+                } else {
+                  openDockTerminal(activeTabId);
+                }
+              }}
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const moved = moveTerminalToGrid(activePanel.id);
+                if (moved) closeDockTerminal();
+              }}
+              aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
+            >
+              <div className="flex items-center justify-center shrink-0">
+                <TerminalIcon
+                  kind={activePanel.kind}
+                  chrome={activeChrome}
+                  className="w-3.5 h-3.5"
+                />
+              </div>
+              <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+                {displayTitle}
+              </span>
 
-            {/* Tab count indicator */}
-            <span className="text-[10px] text-daintree-text/40 tabular-nums shrink-0">
-              ({panels.length})
-            </span>
+              {/* Tab count indicator */}
+              <span className="text-[10px] text-daintree-text/40 tabular-nums shrink-0">
+                ({panels.length})
+              </span>
 
-            {isActive && commandText && (
-              <>
-                <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                      {commandText}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{commandText}</TooltipContent>
-                </Tooltip>
-              </>
-            )}
-
-            {showStateIcon && StateIcon && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className={cn(
-                      "flex items-center shrink-0",
-                      getEffectiveStateColor(agentState, activePanel.waitingReason)
-                    )}
-                  >
-                    <StateIcon
-                      className={cn(
-                        "w-3.5 h-3.5",
-                        agentState === "working" && "animate-spin-slow",
-                        "motion-reduce:animate-none"
-                      )}
-                      aria-hidden="true"
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
-              </Tooltip>
-            )}
-          </button>
-        </PopoverTrigger>
-      </TerminalContextMenu>
-
-      <PopoverContent
-        className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
-        side="top"
-        align="start"
-        sideOffset={10}
-        collisionPadding={collisionPadding}
-        onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
-        onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          const focusTarget = getTerminalFocusTarget({
-            hasHybridInputSurface: activeChrome.isAgent,
-            isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
-            hybridInputEnabled,
-            hybridInputAutoFocus,
-          });
-
-          if (focusTarget === "hybridInput") {
-            return;
-          }
-
-          setTimeout(() => terminalInstanceService.focus(activePanel.id), 50);
-        }}
-      >
-        {/* Tab bar at top of popover */}
-        <DndContext
-          sensors={tabSensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleTabDragEnd}
-          modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
-        >
-          <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-            <LazyMotion features={domMax}>
-              <LayoutGroup id={`dock-tabs-${group.id}`}>
-                <div
-                  ref={tabListRef}
-                  className="flex items-center border-b border-divider bg-daintree-sidebar shrink-0"
-                  role="tablist"
-                  aria-label="Dock panel tabs"
-                  onKeyDown={handleTabListKeyDown}
-                >
-                  {panels.map((panel) => {
-                    const tabChrome = deriveTerminalChrome({
-                      kind: panel.kind,
-                      launchAgentId: panel.launchAgentId,
-                      runtimeIdentity: panel.runtimeIdentity,
-                      detectedAgentId: panel.detectedAgentId,
-                      detectedProcessId: panel.detectedProcessId,
-                      agentState: panel.agentState,
-                      runtimeStatus: panel.runtimeStatus,
-                      exitCode: panel.exitCode,
-                      presetColor: panelPresetColors.get(panel.id),
-                    });
-                    return (
-                      <SortableTabButton
-                        key={panel.id}
-                        id={panel.id}
-                        title={getBaseTitle(panel.title)}
-                        chrome={tabChrome}
-                        kind={panel.kind ?? "terminal"}
-                        agentState={tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined}
-                        isActive={panel.id === activeTabId}
-                        presetColor={panelPresetColors.get(panel.id)}
-                        isUsingFallback={panel.isUsingFallback}
-                        onClick={() => handleTabClick(panel.id)}
-                        onClose={() => handleTabClose(panel.id)}
-                        onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                      />
-                    );
-                  })}
+              {isActive && commandText && (
+                <>
+                  <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleAddTab();
-                        }}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                        aria-label="Duplicate panel as new tab"
-                        type="button"
-                      >
-                        <Plus className="w-3 h-3" aria-hidden="true" />
-                      </button>
+                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                        {commandText}
+                      </span>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                    <TooltipContent side="bottom">{commandText}</TooltipContent>
                   </Tooltip>
-                </div>
-              </LayoutGroup>
-            </LazyMotion>
-          </SortableContext>
-        </DndContext>
+                </>
+              )}
 
-        {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
-        <div
-          ref={portalContainerRef}
-          className="flex-1 min-h-0 flex flex-col"
-          data-dock-portal-target={activePanel.id}
-        />
-      </PopoverContent>
-    </Popover>
+              {showStateIcon && StateIcon && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        "flex items-center shrink-0",
+                        getEffectiveStateColor(agentState, activePanel.waitingReason)
+                      )}
+                    >
+                      <StateIcon
+                        className={cn(
+                          "w-3.5 h-3.5",
+                          agentState === "working" && "animate-spin-slow",
+                          "motion-reduce:animate-none"
+                        )}
+                        aria-hidden="true"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{`Agent ${agentState}`}</TooltipContent>
+                </Tooltip>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TerminalContextMenu>
+
+        <PopoverContent
+          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
+          side="top"
+          align="start"
+          sideOffset={10}
+          collisionPadding={collisionPadding}
+          onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
+          onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            const focusTarget = getTerminalFocusTarget({
+              hasHybridInputSurface: activeChrome.isAgent,
+              isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
+              hybridInputEnabled,
+              hybridInputAutoFocus,
+            });
+
+            if (focusTarget === "hybridInput") {
+              return;
+            }
+
+            setTimeout(() => terminalInstanceService.focus(activePanel.id), 50);
+          }}
+        >
+          {/* Tab bar at top of popover */}
+          <DndContext
+            sensors={tabSensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleTabDragEnd}
+            modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+          >
+            <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+              <LazyMotion features={domMax}>
+                <LayoutGroup id={`dock-tabs-${group.id}`}>
+                  <div
+                    ref={tabListRef}
+                    className="flex items-center border-b border-divider bg-daintree-sidebar shrink-0"
+                    role="tablist"
+                    aria-label="Dock panel tabs"
+                    onKeyDown={handleTabListKeyDown}
+                  >
+                    {panels.map((panel) => {
+                      const tabChrome = deriveTerminalChrome({
+                        kind: panel.kind,
+                        launchAgentId: panel.launchAgentId,
+                        runtimeIdentity: panel.runtimeIdentity,
+                        detectedAgentId: panel.detectedAgentId,
+                        detectedProcessId: panel.detectedProcessId,
+                        agentState: panel.agentState,
+                        runtimeStatus: panel.runtimeStatus,
+                        exitCode: panel.exitCode,
+                        presetColor: panelPresetColors.get(panel.id),
+                      });
+                      return (
+                        <SortableTabButton
+                          key={panel.id}
+                          id={panel.id}
+                          title={getBaseTitle(panel.title)}
+                          chrome={tabChrome}
+                          kind={panel.kind ?? "terminal"}
+                          agentState={
+                            tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
+                          }
+                          isActive={panel.id === activeTabId}
+                          presetColor={panelPresetColors.get(panel.id)}
+                          isUsingFallback={panel.isUsingFallback}
+                          onClick={() => handleTabClick(panel.id)}
+                          onClose={() => handleTabClose(panel.id)}
+                          onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                        />
+                      );
+                    })}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleAddTab();
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                          aria-label="Duplicate panel as new tab"
+                          type="button"
+                        >
+                          <Plus className="w-3 h-3" aria-hidden="true" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </LayoutGroup>
+              </LazyMotion>
+            </SortableContext>
+          </DndContext>
+
+          {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
+          <div
+            ref={portalContainerRef}
+            className="flex-1 min-h-0 flex flex-col"
+            data-dock-portal-target={activePanel.id}
+          />
+        </PopoverContent>
+      </Popover>
+      <ConfirmDialog
+        isOpen={pendingCloseTabId !== null}
+        onClose={handleCancelClose}
+        title="Stop this agent?"
+        description="The agent is currently working. Closing this tab will stop it."
+        confirmLabel="Stop and close"
+        onConfirm={handleConfirmClose}
+        variant="destructive"
+      />
+    </>
   );
 }

--- a/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
@@ -314,4 +314,23 @@ describe("DockedTabGroup close guard (#6330)", () => {
     expect(trashPanelMock).not.toHaveBeenCalled();
     expect(queryByTestId("confirm-dialog")).toBeNull();
   });
+
+  it("reopens the dock popover for the kept tab on cancel", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+
+    openDockTerminalMock.mockClear();
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(openDockTerminalMock).toHaveBeenCalledWith("t-1");
+  });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
@@ -1,0 +1,317 @@
+// @vitest-environment jsdom
+/**
+ * DockedTabGroup — confirm-before-close guard for active-agent tabs (#6330).
+ *
+ * Mirrors the GridTabGroup guard with one wrinkle: the dock popover collapses
+ * when a body-portalled dialog mounts (Radix's onInteractOutside reads the
+ * focus shift), so the close handler must call closeDockTerminal() before
+ * showing the ConfirmDialog. Otherwise canceling leaves the user with no
+ * popover to return to and the dialog backdrop drops onto a half-broken state.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { AgentState } from "@shared/types/agent";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@/types";
+
+const trashPanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const setFocusedMock = vi.fn();
+const openDockTerminalMock = vi.fn();
+const closeDockTerminalMock = vi.fn();
+const moveTerminalToGridMock = vi.fn();
+const updateTitleMock = vi.fn();
+const reorderPanelsInGroupMock = vi.fn();
+const addPanelMock = vi.fn();
+const addPanelToGroupMock = vi.fn();
+
+let mockActiveDockTerminalId: string | null = null;
+let mockTabGroups = new Map<string, TabGroup>();
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeDockTerminalId: mockActiveDockTerminalId,
+      openDockTerminal: openDockTerminalMock,
+      closeDockTerminal: closeDockTerminalMock,
+      moveTerminalToGrid: moveTerminalToGridMock,
+      backendStatus: "connected",
+      setActiveTab: setActiveTabMock,
+      setFocused: setFocusedMock,
+      trashPanel: trashPanelMock,
+      updateTitle: updateTitleMock,
+      reorderPanelsInGroup: reorderPanelsInGroupMock,
+      addPanel: addPanelMock,
+      addPanelToGroup: addPanelToGroupMock,
+      tabGroups: mockTabGroups,
+    }),
+  useTerminalInputStore: (
+    selector: (s: { hybridInputEnabled: boolean; hybridInputAutoFocus: boolean }) => unknown
+  ) => selector({ hybridInputEnabled: false, hybridInputAutoFocus: false }),
+  usePortalStore: (selector: (s: { isOpen: boolean; width: number }) => unknown) =>
+    selector({ isOpen: false, width: 0 }),
+  useFocusStore: (selector: (s: { isFocusMode: boolean }) => unknown) =>
+    selector({ isFocusMode: false }),
+  usePreferencesStore: (selector: (s: { showDockAgentHighlights: boolean }) => unknown) =>
+    selector({ showDockAgentHighlights: false }),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fit: () => ({ cols: 80, rows: 24 }),
+    applyRendererPolicy: vi.fn(),
+    focus: vi.fn(),
+  },
+}));
+
+vi.mock("../DockPanelOffscreenContainer", () => ({
+  useDockPanelPortal: () => vi.fn(),
+}));
+
+vi.mock("../useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+  getDockDisplayAgentState: () => undefined,
+  getGroupBlockedAgentState: () => null,
+  isGroupDeprioritized: () => false,
+}));
+
+vi.mock("../dockPopoverGuard", () => ({
+  handleDockInteractOutside: vi.fn(),
+  handleDockEscapeKeyDown: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/components/Worktree/terminalStateConfig", () => ({
+  getEffectiveStateIcon: () => null,
+  getEffectiveStateColor: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  getTerminalFocusTarget: () => "terminal",
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Panel/SortableTabButton", () => ({
+  SortableTabButton: ({ id, onClose }: { id: string; onClose: () => void }) => (
+    <button data-testid={`close-${id}`} onClick={onClose}>
+      close {id}
+    </button>
+  ),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDndMonitor: vi.fn(),
+  closestCenter: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+  PointerSensor: class {},
+  TouchSensor: class {},
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[]) => arr,
+}));
+
+vi.mock("@dnd-kit/modifiers", () => ({
+  restrictToHorizontalAxis: vi.fn(),
+  restrictToParentElement: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  domMax: {},
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    cancelLabel = "Cancel",
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    confirmLabel: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onClose?: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog">
+        <h2 data-testid="dialog-title">{title}</h2>
+        <p data-testid="dialog-description">{description}</p>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          {cancelLabel}
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { DockedTabGroup } from "../DockedTabGroup";
+
+function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {
+  return {
+    id: "g-1",
+    location: "dock",
+    worktreeId: "wt-1",
+    activeTabId,
+    panelIds,
+  };
+}
+
+describe("DockedTabGroup close guard (#6330)", () => {
+  beforeEach(() => {
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    setFocusedMock.mockClear();
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    mockActiveDockTerminalId = null;
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+  });
+
+  it("closes immediately when the tab's agent is idle", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-2"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["working", "waiting", "directing"] as const)(
+    "shows the confirm dialog and closes the popover for a %s agent tab",
+    (state) => {
+      const panels = [
+        makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+        makePanel({ id: "t-2", agentState: state as AgentState }),
+      ];
+
+      const { getByTestId } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      fireEvent.click(getByTestId("close-t-2"));
+
+      expect(trashPanelMock).not.toHaveBeenCalled();
+      expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+      expect(getByTestId("confirm-dialog")).toBeTruthy();
+      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+      expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+    }
+  );
+
+  it("trashes the tab when the user confirms", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-1");
+    expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-2");
+    expect(setFocusedMock).toHaveBeenCalledWith("t-2");
+  });
+
+  it("does not trash the tab when the user cancels", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+});

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useSyncExternalStore } from "react";
+import React, { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
@@ -14,6 +14,8 @@ import { usePanelHandlers } from "@/hooks/usePanelHandlers";
 import { buildPanelProps } from "@/utils/panelProps";
 import type { AgentState } from "@/types";
 import { terminalChromeDescriptorsEqual } from "@/utils/terminalChrome";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 
 export interface GridPanelProps {
   terminal: TerminalInstance;
@@ -151,6 +153,39 @@ export const GridPanel = React.memo(function GridPanel({
     lifecycle,
   });
 
+  // The panel-header X button calls handleClose(false) which trashes the
+  // entire group via trashPanelGroup. Single-tab groups have no per-tab X,
+  // so this is the only close affordance — and multi-tab groups can lose
+  // every active agent in one click. Mirror the per-tab guard here against
+  // any tab with an active agent. Alt+Click force-close (force=true) skips
+  // the prompt as documented on the close button.
+  const [pendingGroupClose, setPendingGroupClose] = useState(false);
+  const guardedHandleClose = useCallback(
+    (force?: boolean) => {
+      if (force) {
+        handleClose(true);
+        return;
+      }
+      const candidates = tabs?.length ? tabs.map((t) => t.agentState) : [terminal.agentState];
+      const hasActiveAgent = candidates.some(
+        (state) => state !== undefined && ACTIVE_AGENT_STATES.has(state)
+      );
+      if (hasActiveAgent) {
+        setPendingGroupClose(true);
+        return;
+      }
+      handleClose(false);
+    },
+    [handleClose, tabs, terminal.agentState]
+  );
+  const handleConfirmGroupClose = useCallback(() => {
+    setPendingGroupClose(false);
+    handleClose(false);
+  }, [handleClose]);
+  const handleCancelGroupClose = useCallback(() => {
+    setPendingGroupClose(false);
+  }, []);
+
   const handleToggleMaximize = useCallback(() => {
     toggleMaximize(terminal.id, gridCols, gridPanelCount, getPanelGroup);
   }, [toggleMaximize, terminal.id, gridCols, gridPanelCount, getPanelGroup]);
@@ -203,7 +238,7 @@ export const GridPanel = React.memo(function GridPanel({
           gridPanelCount,
           ambientAgentState,
           onFocus: handleFocus,
-          onClose: handleClose,
+          onClose: guardedHandleClose,
           // Fleet scope disables per-panel maximize — the armed grid is a single
           // read-only composite view; promoting one cell would drop the rest.
           onToggleMaximize: isFleetScope ? undefined : handleToggleMaximize,
@@ -230,7 +265,7 @@ export const GridPanel = React.memo(function GridPanel({
       gridPanelCount,
       ambientAgentState,
       handleFocus,
-      handleClose,
+      guardedHandleClose,
       handleToggleMaximize,
       handleTitleChange,
       handleMinimize,
@@ -246,51 +281,66 @@ export const GridPanel = React.memo(function GridPanel({
     ]
   );
 
+  const closeGuardDialog = (
+    <ConfirmDialog
+      isOpen={pendingGroupClose}
+      onClose={handleCancelGroupClose}
+      title="Stop this agent?"
+      description="The agent is currently working. Closing this tab will stop it."
+      confirmLabel="Stop and close"
+      onConfirm={handleConfirmGroupClose}
+      variant="destructive"
+    />
+  );
+
   if (!definition) {
     const isPluginOwned = Boolean(terminal.pluginId) || kind.includes(".");
     if (!isPluginOwned) {
       console.warn(`[GridPanel] No component registered for kind: ${kind}`);
     }
     return (
-      <ContentPanel
-        id={terminal.id}
-        title={terminal.title}
-        kind={kind}
-        isFocused={isFocused}
-        isMaximized={isMaximized}
-        location="grid"
-        ambientAgentState={ambientAgentState}
-        onFocus={handleFocus}
-        onClose={handleClose}
-        onToggleMaximize={handleToggleMaximize}
-        onTitleChange={handleTitleChange}
-        onMinimize={handleMinimize}
-        tabs={tabs}
-        groupId={groupId}
-        onTabClick={onTabClick}
-        onTabClose={onTabClose}
-        onTabRename={onTabRename}
-        onAddTab={onAddTab}
-        onTabReorder={onTabReorder}
-      >
-        {isPluginOwned ? (
-          <PluginMissingPanel
-            kind={kind}
-            pluginId={terminal.pluginId}
-            onRemove={() => handleClose(true)}
-          />
-        ) : (
-          <div className="flex flex-1 items-center justify-center bg-surface-panel text-text-muted">
-            <div className="text-center">
-              <p className="text-sm font-medium">Unknown Panel Type</p>
-              <p className="text-xs mt-1 text-daintree-text/50">Kind: {kind}</p>
-              <p className="text-xs mt-2 text-daintree-text/40">
-                No component registered for this panel kind
-              </p>
+      <>
+        <ContentPanel
+          id={terminal.id}
+          title={terminal.title}
+          kind={kind}
+          isFocused={isFocused}
+          isMaximized={isMaximized}
+          location="grid"
+          ambientAgentState={ambientAgentState}
+          onFocus={handleFocus}
+          onClose={guardedHandleClose}
+          onToggleMaximize={handleToggleMaximize}
+          onTitleChange={handleTitleChange}
+          onMinimize={handleMinimize}
+          tabs={tabs}
+          groupId={groupId}
+          onTabClick={onTabClick}
+          onTabClose={onTabClose}
+          onTabRename={onTabRename}
+          onAddTab={onAddTab}
+          onTabReorder={onTabReorder}
+        >
+          {isPluginOwned ? (
+            <PluginMissingPanel
+              kind={kind}
+              pluginId={terminal.pluginId}
+              onRemove={() => handleClose(true)}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center bg-surface-panel text-text-muted">
+              <div className="text-center">
+                <p className="text-sm font-medium">Unknown Panel Type</p>
+                <p className="text-xs mt-1 text-daintree-text/50">Kind: {kind}</p>
+                <p className="text-xs mt-2 text-daintree-text/40">
+                  No component registered for this panel kind
+                </p>
+              </div>
             </div>
-          </div>
-        )}
-      </ContentPanel>
+          )}
+        </ContentPanel>
+        {closeGuardDialog}
+      </>
     );
   }
 
@@ -298,15 +348,18 @@ export const GridPanel = React.memo(function GridPanel({
   const componentName = PanelComponent.displayName || PanelComponent.name || `Panel(${kind})`;
 
   return (
-    <ErrorBoundary
-      variant="component"
-      componentName={componentName}
-      resetKeys={[terminal.id, terminal.worktreeId].filter(
-        (key): key is string => key !== undefined
-      )}
-      context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
-    >
-      <PanelComponent {...panelProps} />
-    </ErrorBoundary>
+    <>
+      <ErrorBoundary
+        variant="component"
+        componentName={componentName}
+        resetKeys={[terminal.id, terminal.worktreeId].filter(
+          (key): key is string => key !== undefined
+        )}
+        context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
+      >
+        <PanelComponent {...panelProps} />
+      </ErrorBoundary>
+      {closeGuardDialog}
+    </>
   );
 }, gridPanelPropsAreEqual);

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "react";
+import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef, useState } from "react";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { logError } from "@/utils/logger";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -12,6 +12,8 @@ import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplication
 import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 
 export interface GridTabGroupProps {
   group: TabGroup;
@@ -121,6 +123,8 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const addPanelToGroup = usePanelStore((state) => state.addPanelToGroup);
   const reorderPanelsInGroup = usePanelStore((state) => state.reorderPanelsInGroup);
   const updateTitle = usePanelStore((state) => state.updateTitle);
+
+  const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(null);
 
   // Subscribe to registry's active tab for reactive updates
   const storedActiveTabId = usePanelStore(
@@ -275,10 +279,8 @@ export const GridTabGroup = React.memo(function GridTabGroup({
     [updateTitle]
   );
 
-  // Handle tab close - move to trash (store handles group cleanup)
-  const handleTabClose = useCallback(
+  const doCloseTab = useCallback(
     (tabId: string) => {
-      // If closing the active tab, switch to another tab first
       if (tabId === activeTabId) {
         const currentIndex = panels.findIndex((p) => p.id === tabId);
         const nextPanel = panels[currentIndex + 1] ?? panels[currentIndex - 1];
@@ -287,11 +289,35 @@ export const GridTabGroup = React.memo(function GridTabGroup({
           setFocused(nextPanel.id);
         }
       }
-      // Trash the terminal (store auto-removes from group)
       trashPanel(tabId);
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );
+
+  // Confirm before closing a tab whose agent is mid-task; idle/completed/exited
+  // tabs close immediately. Alt+Click force-close from PanelHeader bypasses this
+  // entirely (it goes through usePanelHandlers → removePanel).
+  const handleTabClose = useCallback(
+    (tabId: string) => {
+      const panel = panels.find((p) => p.id === tabId);
+      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+        setPendingCloseTabId(tabId);
+        return;
+      }
+      doCloseTab(tabId);
+    },
+    [panels, doCloseTab]
+  );
+
+  const handleConfirmClose = useCallback(() => {
+    const tabId = pendingCloseTabId;
+    setPendingCloseTabId(null);
+    if (tabId) doCloseTab(tabId);
+  }, [pendingCloseTabId, doCloseTab]);
+
+  const handleCancelClose = useCallback(() => {
+    setPendingCloseTabId(null);
+  }, []);
 
   // Handle tab reorder - update group panel order
   const handleTabReorder = useCallback(
@@ -325,20 +351,31 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const isFocused = activePanel.id === focusedId;
 
   return (
-    <GridPanel
-      terminal={activePanel}
-      isFocused={isFocused}
-      isMaximized={isMaximized}
-      gridPanelCount={gridPanelCount}
-      gridCols={gridCols}
-      ambientAgentState={groupAmbientState}
-      tabs={tabs}
-      groupId={group.id}
-      onTabClick={handleTabClick}
-      onTabClose={handleTabClose}
-      onTabRename={handleTabRename}
-      onAddTab={handleAddTab}
-      onTabReorder={handleTabReorder}
-    />
+    <>
+      <GridPanel
+        terminal={activePanel}
+        isFocused={isFocused}
+        isMaximized={isMaximized}
+        gridPanelCount={gridPanelCount}
+        gridCols={gridCols}
+        ambientAgentState={groupAmbientState}
+        tabs={tabs}
+        groupId={group.id}
+        onTabClick={handleTabClick}
+        onTabClose={handleTabClose}
+        onTabRename={handleTabRename}
+        onAddTab={handleAddTab}
+        onTabReorder={handleTabReorder}
+      />
+      <ConfirmDialog
+        isOpen={pendingCloseTabId !== null}
+        onClose={handleCancelClose}
+        title="Stop this agent?"
+        description="The agent is currently working. Closing this tab will stop it."
+        confirmLabel="Stop and close"
+        onConfirm={handleConfirmClose}
+        variant="destructive"
+      />
+    </>
   );
 }, gridTabGroupPropsAreEqual);

--- a/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+/**
+ * GridPanel — header-X close guard for active-agent groups (#6330).
+ *
+ * The per-tab guard in GridTabGroup only intercepts the per-tab X buttons.
+ * The panel-header X button calls handleClose(false) → trashPanelGroup,
+ * which silently kills the entire group — including single-tab groups whose
+ * only close affordance IS that header button. This test pins the parallel
+ * guard at the GridPanel layer.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { AgentState } from "@shared/types/agent";
+import type { TerminalInstance } from "@/store";
+import type { TabInfo } from "@/components/Panel/TabButton";
+
+const trashPanelGroupMock = vi.fn();
+const removePanelMock = vi.fn();
+const setFocusedMock = vi.fn();
+const updateTitleMock = vi.fn();
+const toggleMaximizeMock = vi.fn();
+const moveTerminalToDockMock = vi.fn();
+const getPanelGroupMock = vi.fn(() => null);
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      trashPanelGroup: trashPanelGroupMock,
+      removePanel: removePanelMock,
+      setFocused: setFocusedMock,
+      updateTitle: updateTitleMock,
+      toggleMaximize: toggleMaximizeMock,
+      getPanelGroup: getPanelGroupMock,
+      moveTerminalToDock: moveTerminalToDockMock,
+    }),
+}));
+
+vi.mock("@/lib/animationUtils", () => ({
+  getTerminalAnimationDuration: () => 0,
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/components/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Panel", () => ({
+  ContentPanel: () => <div data-testid="content-panel" />,
+  PluginMissingPanel: () => <div data-testid="plugin-missing" />,
+  triggerPanelTransition: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  terminalChromeDescriptorsEqual: () => false,
+}));
+
+// Render a stub panel kind that exposes the resolved onClose so the test can
+// drive the same code path the real PanelHeader X button uses.
+let capturedOnClose: ((force?: boolean) => void) | null = null;
+
+vi.mock("@/utils/panelProps", () => ({
+  buildPanelProps: ({ overrides }: { overrides: { onClose: (force?: boolean) => void } }) => {
+    capturedOnClose = overrides.onClose;
+    return overrides;
+  },
+}));
+
+vi.mock("@/registry", () => ({
+  getPanelKindDefinition: () => ({
+    component: ({ onClose }: { onClose?: (force?: boolean) => void }) => (
+      <div>
+        <button data-testid="header-close" onClick={() => onClose?.(false)}>
+          X
+        </button>
+        <button data-testid="header-force-close" onClick={() => onClose?.(true)}>
+          Alt+X
+        </button>
+      </div>
+    ),
+  }),
+  getPanelKindDefinitionsSnapshot: () => 0,
+  subscribeToPanelKindDefinitions: () => () => {},
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    confirmLabel,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onClose?: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog">
+        <h2 data-testid="dialog-title">{title}</h2>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          cancel
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { GridPanel } from "../GridPanel";
+
+function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "grid",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeTab(id: string, agentState?: AgentState): TabInfo {
+  return {
+    id,
+    title: id,
+    chrome: { color: "#abc", isAgent: false } as TabInfo["chrome"],
+    kind: "terminal",
+    agentState,
+    isActive: false,
+  } as TabInfo;
+}
+
+describe("GridPanel header-close guard (#6330)", () => {
+  beforeEach(() => {
+    trashPanelGroupMock.mockClear();
+    removePanelMock.mockClear();
+    capturedOnClose = null;
+  });
+
+  it("closes immediately when single-tab group has an idle terminal", () => {
+    const { getByTestId, queryByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "idle" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "idle")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    // trashPanelGroup is scheduled via setTimeout(0); flush it.
+    return new Promise<void>((resolve) =>
+      setTimeout(() => {
+        expect(trashPanelGroupMock).toHaveBeenCalledWith("t-1");
+        resolve();
+      }, 0)
+    );
+  });
+
+  it.each(["working", "waiting", "directing"] as const)(
+    "shows the confirm dialog when single-tab group has a %s terminal",
+    (state) => {
+      const { getByTestId } = render(
+        <GridPanel
+          terminal={makeTerminal({ agentState: state as AgentState })}
+          isFocused={false}
+          tabs={[makeTab("t-1", state as AgentState)]}
+        />
+      );
+
+      fireEvent.click(getByTestId("header-close"));
+
+      expect(getByTestId("confirm-dialog")).toBeTruthy();
+      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+      expect(trashPanelGroupMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("shows dialog when ANY tab in a multi-tab group has an active agent", () => {
+    const { getByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ id: "t-1", agentState: "idle" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "idle"), makeTab("t-2", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+
+    expect(getByTestId("confirm-dialog")).toBeTruthy();
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT show the dialog when force=true (Alt+Click bypass)", () => {
+    const { getByTestId, queryByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "working" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-force-close"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(removePanelMock).toHaveBeenCalledWith("t-1");
+  });
+
+  it("trashes the group when the user confirms", () => {
+    const { getByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "working" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    return new Promise<void>((resolve) =>
+      setTimeout(() => {
+        expect(trashPanelGroupMock).toHaveBeenCalledWith("t-1");
+        resolve();
+      }, 0)
+    );
+  });
+
+  it("does not trash when the user cancels", () => {
+    const { getByTestId, queryByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "working" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
@@ -59,11 +59,8 @@ vi.mock("@/utils/terminalChrome", () => ({
 
 // Render a stub panel kind that exposes the resolved onClose so the test can
 // drive the same code path the real PanelHeader X button uses.
-let capturedOnClose: ((force?: boolean) => void) | null = null;
-
 vi.mock("@/utils/panelProps", () => ({
   buildPanelProps: ({ overrides }: { overrides: { onClose: (force?: boolean) => void } }) => {
-    capturedOnClose = overrides.onClose;
     return overrides;
   },
 }));
@@ -139,7 +136,6 @@ describe("GridPanel header-close guard (#6330)", () => {
   beforeEach(() => {
     trashPanelGroupMock.mockClear();
     removePanelMock.mockClear();
-    capturedOnClose = null;
   });
 
   it("closes immediately when single-tab group has an idle terminal", () => {

--- a/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+/**
+ * GridTabGroup — confirm-before-close guard for active-agent tabs (#6330).
+ *
+ * Closing a tab whose agent is mid-task (working/waiting/directing) routes
+ * through a destructive ConfirmDialog. Idle/completed/exited tabs close
+ * immediately as before. Alt+Click force-close on PanelHeader bypasses
+ * handleTabClose entirely (it goes through usePanelHandlers → removePanel)
+ * so it doesn't need to be exercised here.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { AgentState } from "@shared/types/agent";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@/types";
+
+const trashPanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const setFocusedMock = vi.fn();
+const setMaximizedIdMock = vi.fn();
+const addPanelMock = vi.fn();
+const addPanelToGroupMock = vi.fn();
+const reorderPanelsInGroupMock = vi.fn();
+const updateTitleMock = vi.fn();
+
+let mockTabGroups = new Map<string, TabGroup>();
+
+interface MockState {
+  setFocused: typeof setFocusedMock;
+  setActiveTab: typeof setActiveTabMock;
+  setMaximizedId: typeof setMaximizedIdMock;
+  trashPanel: typeof trashPanelMock;
+  addPanel: typeof addPanelMock;
+  addPanelToGroup: typeof addPanelToGroupMock;
+  reorderPanelsInGroup: typeof reorderPanelsInGroupMock;
+  updateTitle: typeof updateTitleMock;
+  tabGroups: Map<string, TabGroup>;
+}
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: MockState) => unknown) =>
+    selector({
+      setFocused: setFocusedMock,
+      setActiveTab: setActiveTabMock,
+      setMaximizedId: setMaximizedIdMock,
+      trashPanel: trashPanelMock,
+      addPanel: addPanelMock,
+      addPanelToGroup: addPanelToGroupMock,
+      reorderPanelsInGroup: reorderPanelsInGroupMock,
+      updateTitle: updateTitleMock,
+      tabGroups: mockTabGroups,
+    }),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: vi.fn(),
+}));
+
+vi.mock("../terminalFocusRegistry", () => ({
+  focusPanelInput: vi.fn(),
+}));
+
+vi.mock("@/components/Layout/useDockBlockedState", () => ({
+  getGroupAmbientAgentState: () => undefined,
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+// Render a stub GridPanel that exposes a per-tab close button so fireEvent
+// drives React's batching properly (calling the callback bare bypasses act()
+// and the ConfirmDialog state update never lands before the assertion).
+vi.mock("../GridPanel", () => ({
+  GridPanel: ({
+    tabs,
+    onTabClose,
+  }: {
+    tabs: Array<{ id: string }>;
+    onTabClose?: (tabId: string) => void;
+  }) => (
+    <div data-testid="grid-panel">
+      {tabs.map((t) => (
+        <button key={t.id} data-testid={`close-${t.id}`} onClick={() => onTabClose?.(t.id)}>
+          close {t.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// Render ConfirmDialog as a simple visible structure so we can interact with it.
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    cancelLabel = "Cancel",
+    onConfirm,
+    onClose,
+    variant,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    confirmLabel: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onClose?: () => void;
+    variant: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog" data-variant={variant}>
+        <h2 data-testid="dialog-title">{title}</h2>
+        <p data-testid="dialog-description">{description}</p>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          {cancelLabel}
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { GridTabGroup } from "../GridTabGroup";
+
+function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "grid",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {
+  return {
+    id: "g-1",
+    location: "grid",
+    worktreeId: "wt-1",
+    activeTabId,
+    panelIds,
+  };
+}
+
+describe("GridTabGroup close guard (#6330)", () => {
+  beforeEach(() => {
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    setFocusedMock.mockClear();
+    setMaximizedIdMock.mockClear();
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+  });
+
+  it("closes immediately when the tab's agent is idle", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-2"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it.each(["working", "waiting", "directing"] as const)(
+    "shows the confirm dialog when closing a %s agent tab",
+    (state) => {
+      const panels = [
+        makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+        makePanel({ id: "t-2", agentState: state as AgentState }),
+      ];
+
+      const { getByTestId } = render(
+        <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+      );
+
+      fireEvent.click(getByTestId("close-t-2"));
+
+      expect(trashPanelMock).not.toHaveBeenCalled();
+      const dialog = getByTestId("confirm-dialog");
+      expect(dialog).toBeTruthy();
+      expect(dialog.getAttribute("data-variant")).toBe("destructive");
+      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+      expect(getByTestId("dialog-description").textContent).toBe(
+        "The agent is currently working. Closing this tab will stop it."
+      );
+      expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+    }
+  );
+
+  it("trashes the tab when the user confirms", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-1");
+    // Closing the active tab should switch to the next panel before trash.
+    expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-2");
+    expect(setFocusedMock).toHaveBeenCalledWith("t-2");
+  });
+
+  it("does not trash the tab when the user cancels", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+    expect(getByTestId("confirm-dialog")).toBeTruthy();
+
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("treats a panel with no agentState as idle (closes immediately)", () => {
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    const { getByTestId, queryByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-2"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a confirmation dialog when closing a tab with an agent in `working` or `waiting` state — title `Stop this agent?`, body `The agent is currently working. Closing this tab will stop it.`, destructive button `Stop and close`, cancel button
- Guard is applied in three places: `GridTabGroup`, `DockedTabGroup`, and the `GridPanel` header close button. `DockedTabGroup` closes its popover before opening the dialog to avoid Radix's outside-click collapse
- Alt-click force-close bypass is preserved for power users who know what they're doing

Resolves #6330

## Changes

- `GridTabGroup.tsx` — intercepts `onClose` and opens confirm dialog for active agents
- `DockedTabGroup.tsx` — same guard; popover is closed before the dialog opens to avoid Radix collapsing it on outside click
- `GridPanel.tsx` — header X button gets the same check, restoring the dock popover on cancel
- New unit tests: `GridTabGroup.closeGuard.test.tsx`, `GridPanel.closeGuard.test.tsx`, `DockedTabGroup.closeGuard.test.tsx` (22 tests total)

## Testing

22 new unit tests pass across all three guard sites. Typecheck and lint clean.