### PR TITLE
feat(palette): improve empty state and placeholder copy

### DIFF
--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -64,12 +64,11 @@ export function ActionPalette({
       label="Actions"
       keyHint="⇧⇧"
       ariaLabel="Action palette"
-      searchPlaceholder="Search actions..."
+      searchPlaceholder="Search actions"
       searchAriaLabel="Search actions"
       listId="action-palette-list"
       itemIdPrefix="action-option"
       emptyMessage="No actions available"
-      noMatchMessage={`No actions match "${query}"`}
       totalResults={totalResults}
       emptyContent={
         <p className="mt-2 text-xs text-daintree-text/40">

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -158,7 +158,7 @@ export function CommandPicker({
         label="Commands"
         keyHint="⌘K"
         ariaLabel="Command picker"
-        searchPlaceholder="Search commands..."
+        searchPlaceholder="Search commands"
         searchAriaLabel="Search commands"
         listId="command-list"
         itemIdPrefix="command"
@@ -235,12 +235,11 @@ export function CommandPicker({
       label="Commands"
       keyHint="⌘K"
       ariaLabel="Command picker"
-      searchPlaceholder="Search commands..."
+      searchPlaceholder="Search commands"
       searchAriaLabel="Search commands"
       listId="command-list"
       itemIdPrefix="command"
       emptyMessage="No commands available"
-      noMatchMessage={`No commands match "${query}"`}
       emptyContent={
         <p className="mt-2 text-xs text-daintree-text/40">
           Commands are context-dependent and may vary by project.

--- a/src/components/LogLevelPalette/LogLevelPalette.tsx
+++ b/src/components/LogLevelPalette/LogLevelPalette.tsx
@@ -149,7 +149,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
         getItemId={(item) => item.id}
         label="Set Log Level"
         ariaLabel="Set log level — choose a module"
-        searchPlaceholder="Search modules..."
+        searchPlaceholder="Search modules"
         searchAriaLabel="Search log modules"
         emptyMessage="No modules registered"
         renderItem={(item, _index, isSelected) => (
@@ -188,7 +188,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
       getItemId={(item) => item.id}
       label={`Level for ${pendingLogger ?? ""}`}
       ariaLabel="Set log level — choose a level"
-      searchPlaceholder="Search levels..."
+      searchPlaceholder="Search levels"
       emptyMessage="No levels available"
       renderItem={(item) => (
         <div className="flex-1 min-w-0">

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -222,7 +222,7 @@ export function PanelPalette({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Select a panel type..."
+          placeholder="Select a panel type"
           role="combobox"
           aria-expanded={isOpen}
           aria-haspopup="listbox"
@@ -239,7 +239,9 @@ export function PanelPalette({
       <AppPaletteDialog.Body>
         <div id="panel-list" role="listbox" aria-label="Panel types">
           {results.length === 0 ? (
-            <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">{`No panel types match "${query}"`}</div>
+            <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">
+              No results found
+            </div>
           ) : isSearching ? (
             results.map((kind, index) => renderOption(kind, index))
           ) : (

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -387,7 +387,7 @@ function ProjectListContent({
           <div className="p-2">
             <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">
               {query.trim() ? (
-                <div>{`No projects match "${query}"`}</div>
+                <div>No results found</div>
               ) : mode === "modal" ? (
                 "No active projects"
               ) : (
@@ -608,7 +608,7 @@ function ProjectPaletteInner({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Search projects..."
+          placeholder="Search projects"
           role="combobox"
           aria-expanded={true}
           aria-haspopup="listbox"

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -67,12 +67,11 @@ export function QuickSwitcher({
       label="Quick switch"
       keyHint="⌘P"
       ariaLabel="Quick switcher"
-      searchPlaceholder="Search terminals, agents, worktrees..."
+      searchPlaceholder="Search terminals, agents, worktrees"
       searchAriaLabel="Search terminals, agents, and worktrees"
       listId="quick-switcher-list"
       itemIdPrefix="qs-option"
       emptyMessage="No panels open"
-      noMatchMessage={`No items match "${query}"`}
       totalResults={totalResults}
       emptyContent={
         <p className="mt-2 text-xs text-daintree-text/40">

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -134,7 +134,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
       label="Prompt History"
       keyHint="⌘R"
       ariaLabel="Prompt history search"
-      searchPlaceholder="Search prompt history..."
+      searchPlaceholder="Search prompt history"
       listId="prompt-history-list"
       itemIdPrefix="prompt-history-option"
       emptyMessage="No history yet"

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -114,12 +114,11 @@ export function SendToAgentPalette({
       label="Send selection to"
       keyHint="⌘⇧E"
       ariaLabel="Send selection to agent"
-      searchPlaceholder="Search terminals and agents..."
+      searchPlaceholder="Search terminals and agents"
       searchAriaLabel="Search terminals and agents"
       listId="send-to-agent-list"
       itemIdPrefix="send-to-agent-option"
       emptyMessage="No other terminals available"
-      noMatchMessage={`No terminals match "${query}"`}
       totalResults={totalResults}
       emptyContent={
         <p className="mt-2 text-xs text-daintree-text/40">

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -197,12 +197,11 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
       label="Theme switcher"
       keyHint="⌘K, T"
       ariaLabel="Theme palette"
-      searchPlaceholder="Search themes..."
+      searchPlaceholder="Search themes"
       searchAriaLabel="Search themes"
       listId="theme-palette-list"
       itemIdPrefix="theme-option"
       emptyMessage="No themes available"
-      noMatchMessage={`No themes match "${query}"`}
       totalResults={totalResults}
     />
   );

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -136,7 +136,7 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
       )}
       label="Quick create worktree"
       ariaLabel="Quick create worktree palette"
-      searchPlaceholder="Search recipes..."
+      searchPlaceholder="Search recipes"
       searchAriaLabel="Search recipes"
       listId="quick-create-palette-list"
       itemIdPrefix="quick-create-option"
@@ -158,7 +158,6 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
           </Button>
         </div>
       }
-      noMatchMessage={`No recipes match "${palette.query}"`}
       totalResults={palette.totalResults}
       afterList={
         showAssignToggle ? (

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -109,12 +109,11 @@ export function WorktreePalette({
       label="Worktree switcher"
       keyHint="⌘K, W"
       ariaLabel="Worktree palette"
-      searchPlaceholder="Search worktrees..."
+      searchPlaceholder="Search worktrees"
       searchAriaLabel="Search worktrees"
       listId="worktree-palette-list"
       itemIdPrefix="worktree-option"
       emptyMessage="No worktrees yet"
-      noMatchMessage={`No worktrees match "${query}"`}
       totalResults={totalResults}
       emptyContent={
         <p className="mt-2 text-xs text-daintree-text/40">

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -323,7 +323,13 @@ interface AppPaletteEmptyProps {
   query: string;
   emptyMessage?: string;
   noMatchMessage?: string;
-  /** Productive rows shown below the no-match title (filtered-empty state) */
+  /**
+   * Productive rows shown below the no-match title (filtered-empty state).
+   *
+   * Note: interactive elements here are not reachable via the default
+   * Tab/Enter palette key handlers. Use mouse-only affordances or have
+   * the consuming palette extend its `onKeyDown` to focus the slot.
+   */
   filteredEmptyContent?: React.ReactNode;
   children?: React.ReactNode;
 }

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -323,13 +323,16 @@ interface AppPaletteEmptyProps {
   query: string;
   emptyMessage?: string;
   noMatchMessage?: string;
+  /** Productive rows shown below the no-match title (filtered-empty state) */
+  filteredEmptyContent?: React.ReactNode;
   children?: React.ReactNode;
 }
 
 AppPaletteDialog.Empty = function AppPaletteEmpty({
   query,
   emptyMessage = "No items available",
-  noMatchMessage,
+  noMatchMessage = "No results found",
+  filteredEmptyContent,
   children,
 }: AppPaletteEmptyProps) {
   const trimmedQuery = query.trim();
@@ -337,7 +340,8 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
     return (
       <EmptyState
         variant="filtered-empty"
-        title={noMatchMessage || `No items match "${trimmedQuery}"`}
+        title={noMatchMessage}
+        action={filteredEmptyContent}
         className="px-3 py-8"
       />
     );

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -40,7 +40,13 @@ export interface SearchablePaletteProps<T> {
   noMatchMessage?: string;
   /** Content shown below the empty message (no-data state only, hidden during search) */
   emptyContent?: React.ReactNode;
-  /** Productive rows shown below the no-match title (filtered-empty state, query non-empty) */
+  /**
+   * Productive rows shown below the no-match title (filtered-empty state, query non-empty).
+   *
+   * Note: interactive elements here are not reachable via the default
+   * Tab/Enter palette key handlers. Use mouse-only affordances or pass an
+   * `onKeyDown` override that routes focus into the slot.
+   */
   filteredEmptyContent?: React.ReactNode;
 
   /** Additional keyboard handler called before default handling */

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -40,6 +40,8 @@ export interface SearchablePaletteProps<T> {
   noMatchMessage?: string;
   /** Content shown below the empty message (no-data state only, hidden during search) */
   emptyContent?: React.ReactNode;
+  /** Productive rows shown below the no-match title (filtered-empty state, query non-empty) */
+  filteredEmptyContent?: React.ReactNode;
 
   /** Additional keyboard handler called before default handling */
   onKeyDown?: (e: React.KeyboardEvent) => void;
@@ -74,13 +76,14 @@ export function SearchablePalette<T>({
   label,
   keyHint,
   ariaLabel,
-  searchPlaceholder = "Search...",
+  searchPlaceholder = "Search",
   searchAriaLabel,
   listId = "searchable-palette-list",
   itemIdPrefix = "palette-option",
   emptyMessage = "No items available",
   noMatchMessage,
   emptyContent,
+  filteredEmptyContent,
   onKeyDown,
   footer,
   bodyClassName,
@@ -170,7 +173,7 @@ export function SearchablePalette<T>({
           role="combobox"
           aria-expanded={isOpen}
           aria-haspopup="listbox"
-          aria-label={searchAriaLabel ?? searchPlaceholder.replace("...", "")}
+          aria-label={searchAriaLabel ?? searchPlaceholder}
           aria-controls={listId}
           aria-activedescendant={activeDescendant}
         />
@@ -186,7 +189,8 @@ export function SearchablePalette<T>({
               <AppPaletteDialog.Empty
                 query={query}
                 emptyMessage={emptyMessage}
-                noMatchMessage={noMatchMessage ?? `No items match "${query}"`}
+                noMatchMessage={noMatchMessage}
+                filteredEmptyContent={filteredEmptyContent}
               >
                 {emptyContent}
               </AppPaletteDialog.Empty>

--- a/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
+++ b/src/components/ui/__tests__/PaletteEmptyStates.test.tsx
@@ -43,7 +43,33 @@ describe("AppPaletteDialog.Empty", () => {
       </AppPaletteDialog.Empty>
     );
     expect(screen.queryByTestId("cta")).toBeNull();
-    expect(screen.getByText(/No items match "foo"/)).toBeTruthy();
+    expect(screen.getByText("No results found")).toBeTruthy();
+  });
+
+  it("renders filteredEmptyContent below the no-match title when query has text", () => {
+    render(
+      <AppPaletteDialog.Empty
+        query="foo"
+        emptyMessage="No items available"
+        filteredEmptyContent={<button data-testid="productive-row">Create "foo"</button>}
+      >
+        <span data-testid="cta">Create a terminal</span>
+      </AppPaletteDialog.Empty>
+    );
+    expect(screen.getByTestId("productive-row")).toBeTruthy();
+    expect(screen.queryByTestId("cta")).toBeNull();
+    expect(screen.getByText("No results found")).toBeTruthy();
+  });
+
+  it("does NOT render filteredEmptyContent when query is empty (zero-data state)", () => {
+    render(
+      <AppPaletteDialog.Empty
+        query=""
+        emptyMessage="No items available"
+        filteredEmptyContent={<button data-testid="productive-row">Create something</button>}
+      />
+    );
+    expect(screen.queryByTestId("productive-row")).toBeNull();
   });
 
   it("renders without children when none provided", () => {
@@ -85,8 +111,14 @@ describe("AppPaletteDialog.Empty", () => {
     expect(status.getAttribute("aria-live")).toBe("polite");
   });
 
-  it("trims whitespace from query when rendering the default no-match copy", () => {
-    render(<AppPaletteDialog.Empty query="  foo  " emptyMessage="No items available" />);
-    expect(screen.getByText('No items match "foo"')).toBeTruthy();
+  it("treats whitespace-only query as the no-data state, not no-match", () => {
+    render(
+      <AppPaletteDialog.Empty query="   " emptyMessage="No items available">
+        <span data-testid="cta">Create a terminal</span>
+      </AppPaletteDialog.Empty>
+    );
+    expect(screen.getByText("No items available")).toBeTruthy();
+    expect(screen.queryByText("No results found")).toBeNull();
+    expect(screen.getByTestId("cta")).toBeTruthy();
   });
 });

--- a/src/components/ui/__tests__/SearchablePalette.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: () => {},
+  useEscapeStack: () => {},
+}));
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+function renderPalette(
+  overrides: Partial<React.ComponentProps<typeof SearchablePalette<Item>>> = {}
+) {
+  return render(
+    <SearchablePalette<Item>
+      isOpen={true}
+      query=""
+      results={[]}
+      selectedIndex={-1}
+      onQueryChange={() => {}}
+      onSelectPrevious={() => {}}
+      onSelectNext={() => {}}
+      onConfirm={() => {}}
+      onClose={() => {}}
+      getItemId={(item) => item.id}
+      renderItem={(item) => <div key={item.id}>{item.name}</div>}
+      label="Test palette"
+      ariaLabel="Test palette"
+      {...overrides}
+    />
+  );
+}
+
+describe("SearchablePalette empty state and placeholders", () => {
+  it("threads filteredEmptyContent through to the no-match state when query is non-empty", () => {
+    renderPalette({
+      query: "abc",
+      results: [],
+      filteredEmptyContent: <button data-testid="productive-row">Create &quot;abc&quot;</button>,
+    });
+    expect(screen.getByTestId("productive-row")).toBeTruthy();
+    expect(screen.getByText("No results found")).toBeTruthy();
+  });
+
+  it("does not leak filteredEmptyContent into the zero-data state", () => {
+    renderPalette({
+      query: "",
+      results: [],
+      emptyContent: <span data-testid="empty-content">Empty hint</span>,
+      filteredEmptyContent: <button data-testid="productive-row">Should not show</button>,
+    });
+    expect(screen.getByTestId("empty-content")).toBeTruthy();
+    expect(screen.queryByTestId("productive-row")).toBeNull();
+  });
+
+  it("uses a static 'No results found' default when noMatchMessage is not provided", () => {
+    renderPalette({ query: "zzz", results: [] });
+    expect(screen.getByText("No results found")).toBeTruthy();
+    // Old dynamic copy must not leak back via the wrapper fallback.
+    expect(screen.queryByText(/No items match "zzz"/)).toBeNull();
+  });
+
+  it("preserves a custom static noMatchMessage when provided", () => {
+    renderPalette({
+      query: "zzz",
+      results: [],
+      noMatchMessage: "No prompts match your search",
+    });
+    expect(screen.getByText("No prompts match your search")).toBeTruthy();
+    expect(screen.queryByText("No results found")).toBeNull();
+  });
+
+  it("defaults the search input placeholder and aria-label to 'Search' (no trailing ellipsis)", () => {
+    renderPalette({});
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.placeholder).toBe("Search");
+    expect(input.getAttribute("aria-label")).toBe("Search");
+  });
+
+  it("uses searchPlaceholder as the aria-label when searchAriaLabel is not provided", () => {
+    renderPalette({ searchPlaceholder: "Search recipes" });
+    const input = screen.getByRole("combobox") as HTMLInputElement;
+    expect(input.placeholder).toBe("Search recipes");
+    expect(input.getAttribute("aria-label")).toBe("Search recipes");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `filteredEmptyContent` slot to `AppPaletteDialog.Empty` and `SearchablePalette` so individual palettes can surface productive rows (Create…, Search…) in the zero-result state instead of a dead end
- Replaces dynamic `No actions match "${query}"` / `No items match "${query}"` templates with a static "No results found" — the query is already visible in the input, no need to repeat it
- Drops the trailing ellipsis from `searchPlaceholder` strings across 11 palette files (12 placeholders total)

Resolves #6346

## Changes

- `AppPaletteDialog.tsx` — `filteredEmptyContent` prop added to `Empty`; default "No results found" copy consolidated here as single source of truth; JSDoc notes keyboard wiring is a follow-up
- `SearchablePalette.tsx` — threads `filteredEmptyContent` through to `AppPaletteDialog.Empty`; `noMatchMessage` default removed (inherits from `AppPaletteDialog`)
- 9 palette consumers — `noMatchMessage` overrides removed (they were just restating the default); `searchPlaceholder` ellipsis stripped
- `PanelPalette.tsx`, `ProjectSwitcherPalette.tsx` — bespoke palettes that bypass `SearchablePalette`; placeholder ellipsis stripped directly
- `PromptHistoryPalette.tsx` — keeps its custom static "No prompts match your search" (intentionally context-specific)

## Testing

- `PaletteEmptyStates.test.tsx` updated — new `filteredEmptyContent` and zero-data leak tests; dynamic-copy assertions replaced with static-copy assertions
- New `SearchablePalette.test.tsx` — 6 integration tests covering `filteredEmptyContent` threading, default placeholder, custom `noMatchMessage` preservation, and `aria-label` fallback
- 16 tests pass; typecheck, lint (ratchet -2), and format all clean