### PR TITLE
feat(sidebar): show keyboard shortcuts in sidebar header tooltips

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -299,6 +299,9 @@ interface SidebarContentProps {
 
 function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const overviewShortcut = useKeybindingDisplay("worktree.overview");
+  const armFocusedShortcut = useKeybindingDisplay("fleet.armFocused");
+  const refreshShortcut = useKeybindingDisplay("worktree.refresh");
+  const createWorktreeShortcut = useKeybindingDisplay("worktree.createDialog.open");
   const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
@@ -947,7 +950,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   <Zap className="w-3.5 h-3.5" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Select terminals to arm</TooltipContent>
+              <TooltipContent side="bottom">
+                {createTooltipWithShortcut("Select terminals to arm", armFocusedShortcut)}
+              </TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -960,7 +965,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
                 </button>
               </TooltipTrigger>
-              <TooltipContent side="bottom">Refresh sidebar</TooltipContent>
+              <TooltipContent side="bottom">
+                {createTooltipWithShortcut("Refresh sidebar", refreshShortcut)}
+              </TooltipContent>
             </Tooltip>
           </div>
           <Tooltip>
@@ -977,7 +984,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <Plus className="w-3.5 h-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">Create new worktree</TooltipContent>
+            <TooltipContent side="bottom">
+              {createTooltipWithShortcut("Create new worktree", createWorktreeShortcut)}
+            </TooltipContent>
           </Tooltip>
         </div>
       </div>

--- a/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts
@@ -15,6 +15,18 @@ describe("SidebarContent shortcut tooltips — issue #5843", () => {
     it("uses dynamic hook for worktree.overview", () => {
       expect(source).toContain('useKeybindingDisplay("worktree.overview")');
     });
+
+    it("uses dynamic hook for fleet.armFocused", () => {
+      expect(source).toContain('useKeybindingDisplay("fleet.armFocused")');
+    });
+
+    it("uses dynamic hook for worktree.refresh", () => {
+      expect(source).toContain('useKeybindingDisplay("worktree.refresh")');
+    });
+
+    it("uses dynamic hook for worktree.createDialog.open", () => {
+      expect(source).toContain('useKeybindingDisplay("worktree.createDialog.open")');
+    });
   });
 
   describe("no hardcoded shortcut strings in tooltips", () => {
@@ -32,6 +44,22 @@ describe("SidebarContent shortcut tooltips — issue #5843", () => {
     it("uses createTooltipWithShortcut for Open worktrees overview tooltip", () => {
       expect(source).toContain(
         'createTooltipWithShortcut("Open worktrees overview", overviewShortcut)'
+      );
+    });
+
+    it("uses createTooltipWithShortcut for Select terminals to arm tooltip", () => {
+      expect(source).toContain(
+        'createTooltipWithShortcut("Select terminals to arm", armFocusedShortcut)'
+      );
+    });
+
+    it("uses createTooltipWithShortcut for Refresh sidebar tooltip", () => {
+      expect(source).toContain('createTooltipWithShortcut("Refresh sidebar", refreshShortcut)');
+    });
+
+    it("uses createTooltipWithShortcut for Create new worktree tooltip", () => {
+      expect(source).toContain(
+        'createTooltipWithShortcut("Create new worktree", createWorktreeShortcut)'
       );
     });
   });


### PR DESCRIPTION
## Summary
- Three icon-only sidebar header buttons (arm focused, refresh, create worktree) had hardcoded tooltip labels without shortcut hints, while the overview button already used `createTooltipWithShortcut`.
- Added `useKeybindingDisplay` hooks for `fleet.armFocused`, `worktree.refresh`, and `worktree.createDialog.open`, then replaced the hardcoded strings with `createTooltipWithShortcut` calls.
- Updated shortcut test assertions to cover all four header buttons.

Resolves #6332

## Changes
- `src/components/Sidebar/SidebarContent.tsx` -- three `useKeybindingDisplay` hooks added; hardcoded tooltip strings replaced with `createTooltipWithShortcut`
- `src/components/Sidebar/__tests__/SidebarContent.shortcuts.test.ts` -- test assertions extended for `fleet.armFocused`, `worktree.refresh`, and `worktree.createDialog.open`

## Testing
- Unit tests confirm all four sidebar header buttons use `useKeybindingDisplay` + `createTooltipWithShortcut` and contain no hardcoded shortcut strings.