### PR TITLE
feat(ui): add shared Skeleton primitive

### DIFF
--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,144 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+const TEXT_LINE_WIDTHS = ["w-full", "w-3/4", "w-1/2"] as const;
+
+function pulseClass(immediate: boolean): string {
+  return immediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
+}
+
+function clampLines(lines: number): number {
+  if (!Number.isFinite(lines)) return 0;
+  return Math.max(0, Math.floor(lines));
+}
+
+export interface SkeletonProps extends Omit<HTMLAttributes<HTMLDivElement>, "role"> {
+  /** Accessible label announced to assistive tech. Defaults to "Loading". */
+  label?: string;
+  /** Children compose the bones; each bone should be `aria-hidden`. */
+  children?: ReactNode;
+  /** Hide the wrapper from AT (e.g., when nested in another `role="status"`). */
+  inert?: boolean;
+}
+
+/**
+ * ARIA status wrapper for loading skeletons. Owns `role="status"`, `aria-live="polite"`,
+ * `aria-busy="true"`, and an sr-only label. Compose bones as children with `aria-hidden`
+ * and one of the pulse / shimmer animation classes (`animate-pulse-delayed`,
+ * `animate-pulse-immediate`, `animate-skeleton-shimmer`). Or use `<SkeletonText>` /
+ * `<SkeletonBone>` for the common cases.
+ */
+export function Skeleton({
+  label = "Loading",
+  children,
+  inert = false,
+  className,
+  ...rest
+}: SkeletonProps) {
+  if (inert) {
+    return (
+      <div aria-hidden="true" className={className} {...rest}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={label}
+      className={className}
+      {...rest}
+    >
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true">{children}</div>
+    </div>
+  );
+}
+
+export interface SkeletonBoneProps extends HTMLAttributes<HTMLDivElement> {
+  /** Skip the 400ms anti-flicker delay; bone is visible immediately. */
+  immediate?: boolean;
+  /** Layer a transform-based shimmer sweep on top of the opacity pulse. */
+  shimmer?: boolean;
+  /** Set a fixed pixel height to prevent layout shift when content loads. */
+  heightPx?: number;
+}
+
+/**
+ * Single skeleton bone. `aria-hidden` and class-merged so callers can size it freely.
+ * Default animation is the 400ms-delayed opacity pulse; `shimmer` adds a sweep.
+ */
+export function SkeletonBone({
+  immediate = false,
+  shimmer = false,
+  heightPx,
+  className,
+  style,
+  ...rest
+}: SkeletonBoneProps) {
+  const merged: CSSProperties | undefined =
+    heightPx !== undefined ? { height: `${heightPx}px`, ...style } : style;
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "bg-muted rounded",
+        pulseClass(immediate),
+        shimmer && "animate-skeleton-shimmer",
+        className
+      )}
+      style={merged}
+      {...rest}
+    />
+  );
+}
+
+export interface SkeletonTextProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+  /** Number of text lines. Clamped to >= 0; defaults to 3. */
+  lines?: number;
+  /** Skip the 400ms anti-flicker delay. */
+  immediate?: boolean;
+  /** Layer the shimmer sweep on each line. */
+  shimmer?: boolean;
+  /** Tailwind height class for each line. Defaults to `h-4`. */
+  lineHeightClassName?: string;
+  /** Vertical gap between lines. Defaults to `space-y-2`. */
+  gapClassName?: string;
+}
+
+/**
+ * Multi-line text skeleton. Cycles widths through `[w-full, w-3/4, w-1/2]` to mimic
+ * ragged-right typography (uniform widths look like a picket fence).
+ */
+export function SkeletonText({
+  lines = 3,
+  immediate = false,
+  shimmer = false,
+  lineHeightClassName = "h-4",
+  gapClassName = "space-y-2",
+  className,
+  ...rest
+}: SkeletonTextProps) {
+  const count = clampLines(lines);
+
+  return (
+    <div aria-hidden="true" className={cn(gapClassName, className)} {...rest}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            "bg-muted rounded",
+            lineHeightClassName,
+            TEXT_LINE_WIDTHS[i % TEXT_LINE_WIDTHS.length],
+            pulseClass(immediate),
+            shimmer && "animate-skeleton-shimmer"
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 const TEXT_LINE_WIDTHS = ["w-full", "w-3/4", "w-1/2"] as const;
+const MAX_TEXT_LINES = 100;
 
 function pulseClass(immediate: boolean): string {
   return immediate ? "animate-pulse-immediate" : "animate-pulse-delayed";
@@ -9,13 +10,26 @@ function pulseClass(immediate: boolean): string {
 
 function clampLines(lines: number): number {
   if (!Number.isFinite(lines)) return 0;
-  return Math.max(0, Math.floor(lines));
+  return Math.min(Math.max(0, Math.floor(lines)), MAX_TEXT_LINES);
 }
 
-export interface SkeletonProps extends Omit<HTMLAttributes<HTMLDivElement>, "role"> {
+function safeHeightPx(value: number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isFinite(value) || value < 0) return undefined;
+  return `${value}px`;
+}
+
+export interface SkeletonProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "role" | "aria-live" | "aria-busy"
+> {
   /** Accessible label announced to assistive tech. Defaults to "Loading". */
   label?: string;
-  /** Children compose the bones; each bone should be `aria-hidden`. */
+  /**
+   * Children compose the bones. Each bone should be `aria-hidden` — `<SkeletonBone>`
+   * and `<SkeletonText>` already are. Apply layout classes (`flex`, `grid`, `space-y-*`)
+   * on `className` here; the wrapper is the only DOM element.
+   */
   children?: ReactNode;
   /** Hide the wrapper from AT (e.g., when nested in another `role="status"`). */
   inert?: boolean;
@@ -23,10 +37,9 @@ export interface SkeletonProps extends Omit<HTMLAttributes<HTMLDivElement>, "rol
 
 /**
  * ARIA status wrapper for loading skeletons. Owns `role="status"`, `aria-live="polite"`,
- * `aria-busy="true"`, and an sr-only label. Compose bones as children with `aria-hidden`
- * and one of the pulse / shimmer animation classes (`animate-pulse-delayed`,
- * `animate-pulse-immediate`, `animate-skeleton-shimmer`). Or use `<SkeletonText>` /
- * `<SkeletonBone>` for the common cases.
+ * `aria-busy="true"`, and an sr-only label. The sr-only span is absolutely positioned
+ * and takes no layout space, so flex/grid classes on `className` apply directly to the
+ * bone children.
  */
 export function Skeleton({
   label = "Loading",
@@ -37,7 +50,7 @@ export function Skeleton({
 }: SkeletonProps) {
   if (inert) {
     return (
-      <div aria-hidden="true" className={className} {...rest}>
+      <div {...rest} aria-hidden="true" className={className}>
         {children}
       </div>
     );
@@ -45,20 +58,20 @@ export function Skeleton({
 
   return (
     <div
+      {...rest}
       role="status"
       aria-live="polite"
       aria-busy="true"
       aria-label={label}
       className={className}
-      {...rest}
     >
       <span className="sr-only">{label}</span>
-      <div aria-hidden="true">{children}</div>
+      {children}
     </div>
   );
 }
 
-export interface SkeletonBoneProps extends HTMLAttributes<HTMLDivElement> {
+export interface SkeletonBoneProps extends Omit<HTMLAttributes<HTMLDivElement>, "aria-hidden"> {
   /** Skip the 400ms anti-flicker delay; bone is visible immediately. */
   immediate?: boolean;
   /** Layer a transform-based shimmer sweep on top of the opacity pulse. */
@@ -70,6 +83,7 @@ export interface SkeletonBoneProps extends HTMLAttributes<HTMLDivElement> {
 /**
  * Single skeleton bone. `aria-hidden` and class-merged so callers can size it freely.
  * Default animation is the 400ms-delayed opacity pulse; `shimmer` adds a sweep.
+ * `heightPx` wins over an explicit `style.height` to keep the layout-shift contract.
  */
 export function SkeletonBone({
   immediate = false,
@@ -79,11 +93,12 @@ export function SkeletonBone({
   style,
   ...rest
 }: SkeletonBoneProps) {
-  const merged: CSSProperties | undefined =
-    heightPx !== undefined ? { height: `${heightPx}px`, ...style } : style;
+  const height = safeHeightPx(heightPx);
+  const merged: CSSProperties | undefined = height !== undefined ? { ...style, height } : style;
 
   return (
     <div
+      {...rest}
       aria-hidden="true"
       className={cn(
         "bg-muted rounded",
@@ -92,13 +107,15 @@ export function SkeletonBone({
         className
       )}
       style={merged}
-      {...rest}
     />
   );
 }
 
-export interface SkeletonTextProps extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
-  /** Number of text lines. Clamped to >= 0; defaults to 3. */
+export interface SkeletonTextProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children" | "aria-hidden"
+> {
+  /** Number of text lines. Clamped to [0, 100]; defaults to 3. */
   lines?: number;
   /** Skip the 400ms anti-flicker delay. */
   immediate?: boolean;
@@ -126,7 +143,7 @@ export function SkeletonText({
   const count = clampLines(lines);
 
   return (
-    <div aria-hidden="true" className={cn(gapClassName, className)} {...rest}>
+    <div {...rest} aria-hidden="true" className={cn(gapClassName, className)}>
       {Array.from({ length: count }).map((_, i) => (
         <div
           key={i}

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -10,6 +10,9 @@ vi.mock("@/lib/utils", () => ({
 
 import { Skeleton, SkeletonBone, SkeletonText } from "../Skeleton";
 
+const BONE_TEST_ID = "bone";
+const TEXT_TEST_ID = "text";
+
 describe("Skeleton", () => {
   describe("ARIA contract", () => {
     it('uses role="status" on the wrapper', () => {
@@ -43,13 +46,12 @@ describe("Skeleton", () => {
     });
 
     it("hides each bone from assistive tech via aria-hidden", () => {
-      const { container } = render(
+      render(
         <Skeleton>
-          <SkeletonBone data-testid="bone" />
+          <SkeletonBone data-testid={BONE_TEST_ID} />
         </Skeleton>
       );
-      const bone = container.querySelector('[data-testid="bone"]');
-      expect(bone?.getAttribute("aria-hidden")).toBe("true");
+      expect(screen.getByTestId(BONE_TEST_ID).getAttribute("aria-hidden")).toBe("true");
     });
 
     it("is queryable by accessible name", () => {
@@ -60,14 +62,13 @@ describe("Skeleton", () => {
 
   describe("inert mode", () => {
     it("renders only an aria-hidden wrapper without status semantics", () => {
-      const { container } = render(
-        <Skeleton inert>
+      render(
+        <Skeleton inert data-testid="root">
           <SkeletonBone />
         </Skeleton>
       );
       expect(screen.queryByRole("status")).toBeNull();
-      const root = container.firstElementChild;
-      expect(root?.getAttribute("aria-hidden")).toBe("true");
+      expect(screen.getByTestId("root").getAttribute("aria-hidden")).toBe("true");
     });
 
     it("does not render the sr-only label when inert", () => {
@@ -86,73 +87,67 @@ describe("Skeleton", () => {
 
 describe("SkeletonBone", () => {
   it("is aria-hidden and carries the muted background", () => {
-    const { container } = render(<SkeletonBone />);
-    const bone = container.firstElementChild as HTMLElement;
+    render(<SkeletonBone data-testid={BONE_TEST_ID} />);
+    const bone = screen.getByTestId(BONE_TEST_ID);
     expect(bone.getAttribute("aria-hidden")).toBe("true");
     expect(bone.className).toContain("bg-muted");
   });
 
   it("uses animate-pulse-delayed by default", () => {
-    const { container } = render(<SkeletonBone />);
-    expect((container.firstElementChild as HTMLElement).className).toContain(
-      "animate-pulse-delayed"
-    );
+    render(<SkeletonBone data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).className).toContain("animate-pulse-delayed");
   });
 
   it("switches to animate-pulse-immediate when immediate is set", () => {
-    const { container } = render(<SkeletonBone immediate />);
-    const cls = (container.firstElementChild as HTMLElement).className;
+    render(<SkeletonBone immediate data-testid={BONE_TEST_ID} />);
+    const cls = screen.getByTestId(BONE_TEST_ID).className;
     expect(cls).toContain("animate-pulse-immediate");
     expect(cls).not.toContain("animate-pulse-delayed");
   });
 
   it("does not include shimmer class by default", () => {
-    const { container } = render(<SkeletonBone />);
-    expect((container.firstElementChild as HTMLElement).className).not.toContain(
-      "animate-skeleton-shimmer"
-    );
+    render(<SkeletonBone data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).className).not.toContain("animate-skeleton-shimmer");
   });
 
   it("adds animate-skeleton-shimmer when shimmer is set", () => {
-    const { container } = render(<SkeletonBone shimmer />);
-    expect((container.firstElementChild as HTMLElement).className).toContain(
-      "animate-skeleton-shimmer"
-    );
+    render(<SkeletonBone shimmer data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).className).toContain("animate-skeleton-shimmer");
   });
 
   it("applies a fixed pixel height when heightPx is provided", () => {
-    const { container } = render(<SkeletonBone heightPx={68} />);
-    expect((container.firstElementChild as HTMLElement).style.height).toBe("68px");
+    render(<SkeletonBone heightPx={68} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).style.height).toBe("68px");
   });
 
   it("heightPx wins over an explicit style.height", () => {
-    const { container } = render(<SkeletonBone heightPx={68} style={{ height: "40px" }} />);
-    expect((container.firstElementChild as HTMLElement).style.height).toBe("68px");
+    render(<SkeletonBone heightPx={68} style={{ height: "40px" }} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).style.height).toBe("68px");
   });
 
   it("ignores NaN heightPx", () => {
-    const { container } = render(<SkeletonBone heightPx={Number.NaN} />);
-    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+    render(<SkeletonBone heightPx={Number.NaN} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).style.height).toBe("");
   });
 
   it("ignores negative heightPx", () => {
-    const { container } = render(<SkeletonBone heightPx={-20} />);
-    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+    render(<SkeletonBone heightPx={-20} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).style.height).toBe("");
   });
 
   it("ignores Infinity heightPx", () => {
-    const { container } = render(<SkeletonBone heightPx={Number.POSITIVE_INFINITY} />);
-    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+    render(<SkeletonBone heightPx={Number.POSITIVE_INFINITY} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).style.height).toBe("");
   });
 
   it("forces aria-hidden true even if a caller passes aria-hidden={false}", () => {
-    const { container } = render(<SkeletonBone aria-hidden={false} />);
-    expect((container.firstElementChild as HTMLElement).getAttribute("aria-hidden")).toBe("true");
+    render(<SkeletonBone aria-hidden={false} data-testid={BONE_TEST_ID} />);
+    expect(screen.getByTestId(BONE_TEST_ID).getAttribute("aria-hidden")).toBe("true");
   });
 
   it("merges custom className", () => {
-    const { container } = render(<SkeletonBone className="w-12 h-4" />);
-    const cls = (container.firstElementChild as HTMLElement).className;
+    render(<SkeletonBone className="w-12 h-4" data-testid={BONE_TEST_ID} />);
+    const cls = screen.getByTestId(BONE_TEST_ID).className;
     expect(cls).toContain("w-12");
     expect(cls).toContain("h-4");
   });
@@ -160,40 +155,40 @@ describe("SkeletonBone", () => {
 
 describe("SkeletonText", () => {
   it("renders 3 lines by default", () => {
-    const { container } = render(<SkeletonText />);
-    expect(container.firstElementChild?.children.length).toBe(3);
+    render(<SkeletonText data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).children.length).toBe(3);
   });
 
   it("renders the requested line count", () => {
-    const { container } = render(<SkeletonText lines={5} />);
-    expect(container.firstElementChild?.children.length).toBe(5);
+    render(<SkeletonText lines={5} data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).children.length).toBe(5);
   });
 
   it("clamps negative line counts to 0", () => {
-    const { container } = render(<SkeletonText lines={-2} />);
-    expect(container.firstElementChild?.children.length).toBe(0);
+    render(<SkeletonText lines={-2} data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).children.length).toBe(0);
   });
 
   it("clamps non-finite line counts to 0", () => {
-    const { container } = render(<SkeletonText lines={Number.NaN} />);
-    expect(container.firstElementChild?.children.length).toBe(0);
+    render(<SkeletonText lines={Number.NaN} data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).children.length).toBe(0);
   });
 
   it("floors fractional line counts", () => {
-    const { container } = render(<SkeletonText lines={3.9} />);
-    expect(container.firstElementChild?.children.length).toBe(3);
+    render(<SkeletonText lines={3.9} data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).children.length).toBe(3);
   });
 
   it("clamps absurdly large line counts to a sane ceiling", () => {
-    const { container } = render(<SkeletonText lines={1_000_000} />);
-    const rendered = container.firstElementChild?.children.length ?? 0;
+    render(<SkeletonText lines={1_000_000} data-testid={TEXT_TEST_ID} />);
+    const rendered = screen.getByTestId(TEXT_TEST_ID).children.length;
     expect(rendered).toBeLessThanOrEqual(100);
     expect(rendered).toBeGreaterThan(0);
   });
 
   it("cycles widths through [w-full, w-3/4, w-1/2]", () => {
-    const { container } = render(<SkeletonText lines={4} />);
-    const lines = Array.from(container.firstElementChild?.children ?? []);
+    render(<SkeletonText lines={4} data-testid={TEXT_TEST_ID} />);
+    const lines = Array.from(screen.getByTestId(TEXT_TEST_ID).children);
     expect(lines[0]?.className).toContain("w-full");
     expect(lines[1]?.className).toContain("w-3/4");
     expect(lines[2]?.className).toContain("w-1/2");
@@ -201,39 +196,45 @@ describe("SkeletonText", () => {
   });
 
   it("is aria-hidden on the container", () => {
-    const { container } = render(<SkeletonText lines={1} />);
-    expect(container.firstElementChild?.getAttribute("aria-hidden")).toBe("true");
+    render(<SkeletonText lines={1} data-testid={TEXT_TEST_ID} />);
+    expect(screen.getByTestId(TEXT_TEST_ID).getAttribute("aria-hidden")).toBe("true");
   });
 
   it("uses animate-pulse-delayed by default on each line", () => {
-    const { container } = render(<SkeletonText lines={2} />);
-    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
-      expect((line as HTMLElement).className).toContain("animate-pulse-delayed");
-    });
+    render(<SkeletonText lines={2} data-testid={TEXT_TEST_ID} />);
+    for (const line of Array.from(screen.getByTestId(TEXT_TEST_ID).children)) {
+      expect(line.className).toContain("animate-pulse-delayed");
+    }
   });
 
   it("switches to animate-pulse-immediate when immediate is set", () => {
-    const { container } = render(<SkeletonText lines={2} immediate />);
-    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
-      expect((line as HTMLElement).className).toContain("animate-pulse-immediate");
-    });
+    render(<SkeletonText lines={2} immediate data-testid={TEXT_TEST_ID} />);
+    for (const line of Array.from(screen.getByTestId(TEXT_TEST_ID).children)) {
+      expect(line.className).toContain("animate-pulse-immediate");
+    }
   });
 
   it("layers shimmer on each line when shimmer is set", () => {
-    const { container } = render(<SkeletonText lines={2} shimmer />);
-    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
-      expect((line as HTMLElement).className).toContain("animate-skeleton-shimmer");
-    });
+    render(<SkeletonText lines={2} shimmer data-testid={TEXT_TEST_ID} />);
+    for (const line of Array.from(screen.getByTestId(TEXT_TEST_ID).children)) {
+      expect(line.className).toContain("animate-skeleton-shimmer");
+    }
   });
 
   it("respects custom line height and gap classes", () => {
-    const { container } = render(
-      <SkeletonText lines={2} lineHeightClassName="h-6" gapClassName="space-y-4" />
+    render(
+      <SkeletonText
+        lines={2}
+        lineHeightClassName="h-6"
+        gapClassName="space-y-4"
+        data-testid={TEXT_TEST_ID}
+      />
     );
-    expect(container.firstElementChild?.className).toContain("space-y-4");
-    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
-      expect((line as HTMLElement).className).toContain("h-6");
-    });
+    const root = screen.getByTestId(TEXT_TEST_ID);
+    expect(root.className).toContain("space-y-4");
+    for (const line of Array.from(root.children)) {
+      expect(line.className).toContain("h-6");
+    }
   });
 
   it("does not use transition-all", () => {

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { Skeleton, SkeletonBone, SkeletonText } from "../Skeleton";
+
+describe("Skeleton", () => {
+  describe("ARIA contract", () => {
+    it('uses role="status" on the wrapper', () => {
+      render(
+        <Skeleton>
+          <SkeletonBone />
+        </Skeleton>
+      );
+      expect(screen.getByRole("status")).toBeTruthy();
+    });
+
+    it('sets aria-live="polite" and aria-busy="true"', () => {
+      render(<Skeleton />);
+      const status = screen.getByRole("status");
+      expect(status.getAttribute("aria-live")).toBe("polite");
+      expect(status.getAttribute("aria-busy")).toBe("true");
+    });
+
+    it("uses default label when none provided", () => {
+      render(<Skeleton />);
+      const status = screen.getByRole("status");
+      expect(status.getAttribute("aria-label")).toBe("Loading");
+      expect(status.querySelector(".sr-only")?.textContent).toBe("Loading");
+    });
+
+    it("respects a custom label", () => {
+      render(<Skeleton label="Loading commits" />);
+      const status = screen.getByRole("status");
+      expect(status.getAttribute("aria-label")).toBe("Loading commits");
+      expect(status.querySelector(".sr-only")?.textContent).toBe("Loading commits");
+    });
+
+    it("hides the bone container from assistive tech", () => {
+      const { container } = render(
+        <Skeleton>
+          <SkeletonBone data-testid="bone" />
+        </Skeleton>
+      );
+      const hidden = container.querySelector('[aria-hidden="true"]');
+      expect(hidden).toBeTruthy();
+      expect(hidden?.querySelector('[data-testid="bone"]')).toBeTruthy();
+    });
+  });
+
+  describe("inert mode", () => {
+    it("renders only an aria-hidden wrapper without status semantics", () => {
+      const { container } = render(
+        <Skeleton inert>
+          <SkeletonBone />
+        </Skeleton>
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+      const root = container.firstElementChild;
+      expect(root?.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("does not render the sr-only label when inert", () => {
+      const { container } = render(<Skeleton inert label="Loading" />);
+      expect(container.querySelector(".sr-only")).toBeNull();
+    });
+  });
+
+  describe("className passthrough", () => {
+    it("merges custom className on the wrapper", () => {
+      render(<Skeleton className="my-skeleton" />);
+      expect(screen.getByRole("status").className).toContain("my-skeleton");
+    });
+  });
+});
+
+describe("SkeletonBone", () => {
+  it("is aria-hidden and carries the muted background", () => {
+    const { container } = render(<SkeletonBone />);
+    const bone = container.firstElementChild as HTMLElement;
+    expect(bone.getAttribute("aria-hidden")).toBe("true");
+    expect(bone.className).toContain("bg-muted");
+  });
+
+  it("uses animate-pulse-delayed by default", () => {
+    const { container } = render(<SkeletonBone />);
+    expect((container.firstElementChild as HTMLElement).className).toContain(
+      "animate-pulse-delayed"
+    );
+  });
+
+  it("switches to animate-pulse-immediate when immediate is set", () => {
+    const { container } = render(<SkeletonBone immediate />);
+    const cls = (container.firstElementChild as HTMLElement).className;
+    expect(cls).toContain("animate-pulse-immediate");
+    expect(cls).not.toContain("animate-pulse-delayed");
+  });
+
+  it("does not include shimmer class by default", () => {
+    const { container } = render(<SkeletonBone />);
+    expect((container.firstElementChild as HTMLElement).className).not.toContain(
+      "animate-skeleton-shimmer"
+    );
+  });
+
+  it("adds animate-skeleton-shimmer when shimmer is set", () => {
+    const { container } = render(<SkeletonBone shimmer />);
+    expect((container.firstElementChild as HTMLElement).className).toContain(
+      "animate-skeleton-shimmer"
+    );
+  });
+
+  it("applies a fixed pixel height when heightPx is provided", () => {
+    const { container } = render(<SkeletonBone heightPx={68} />);
+    expect((container.firstElementChild as HTMLElement).style.height).toBe("68px");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<SkeletonBone className="w-12 h-4" />);
+    const cls = (container.firstElementChild as HTMLElement).className;
+    expect(cls).toContain("w-12");
+    expect(cls).toContain("h-4");
+  });
+});
+
+describe("SkeletonText", () => {
+  it("renders 3 lines by default", () => {
+    const { container } = render(<SkeletonText />);
+    expect(container.firstElementChild?.children.length).toBe(3);
+  });
+
+  it("renders the requested line count", () => {
+    const { container } = render(<SkeletonText lines={5} />);
+    expect(container.firstElementChild?.children.length).toBe(5);
+  });
+
+  it("clamps negative line counts to 0", () => {
+    const { container } = render(<SkeletonText lines={-2} />);
+    expect(container.firstElementChild?.children.length).toBe(0);
+  });
+
+  it("clamps non-finite line counts to 0", () => {
+    const { container } = render(<SkeletonText lines={Number.NaN} />);
+    expect(container.firstElementChild?.children.length).toBe(0);
+  });
+
+  it("floors fractional line counts", () => {
+    const { container } = render(<SkeletonText lines={3.9} />);
+    expect(container.firstElementChild?.children.length).toBe(3);
+  });
+
+  it("cycles widths through [w-full, w-3/4, w-1/2]", () => {
+    const { container } = render(<SkeletonText lines={4} />);
+    const lines = Array.from(container.firstElementChild?.children ?? []);
+    expect(lines[0]?.className).toContain("w-full");
+    expect(lines[1]?.className).toContain("w-3/4");
+    expect(lines[2]?.className).toContain("w-1/2");
+    expect(lines[3]?.className).toContain("w-full");
+  });
+
+  it("is aria-hidden on the container", () => {
+    const { container } = render(<SkeletonText lines={1} />);
+    expect(container.firstElementChild?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("uses animate-pulse-delayed by default on each line", () => {
+    const { container } = render(<SkeletonText lines={2} />);
+    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
+      expect((line as HTMLElement).className).toContain("animate-pulse-delayed");
+    });
+  });
+
+  it("switches to animate-pulse-immediate when immediate is set", () => {
+    const { container } = render(<SkeletonText lines={2} immediate />);
+    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
+      expect((line as HTMLElement).className).toContain("animate-pulse-immediate");
+    });
+  });
+
+  it("layers shimmer on each line when shimmer is set", () => {
+    const { container } = render(<SkeletonText lines={2} shimmer />);
+    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
+      expect((line as HTMLElement).className).toContain("animate-skeleton-shimmer");
+    });
+  });
+
+  it("respects custom line height and gap classes", () => {
+    const { container } = render(
+      <SkeletonText lines={2} lineHeightClassName="h-6" gapClassName="space-y-4" />
+    );
+    expect(container.firstElementChild?.className).toContain("space-y-4");
+    Array.from(container.firstElementChild?.children ?? []).forEach((line) => {
+      expect((line as HTMLElement).className).toContain("h-6");
+    });
+  });
+
+  it("does not use transition-all", () => {
+    const { container } = render(<SkeletonText lines={3} />);
+    expect(container.innerHTML).not.toContain("transition-all");
+  });
+});

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -40,15 +42,19 @@ describe("Skeleton", () => {
       expect(status.querySelector(".sr-only")?.textContent).toBe("Loading commits");
     });
 
-    it("hides the bone container from assistive tech", () => {
+    it("hides each bone from assistive tech via aria-hidden", () => {
       const { container } = render(
         <Skeleton>
           <SkeletonBone data-testid="bone" />
         </Skeleton>
       );
-      const hidden = container.querySelector('[aria-hidden="true"]');
-      expect(hidden).toBeTruthy();
-      expect(hidden?.querySelector('[data-testid="bone"]')).toBeTruthy();
+      const bone = container.querySelector('[data-testid="bone"]');
+      expect(bone?.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("is queryable by accessible name", () => {
+      render(<Skeleton label="Loading commits" />);
+      expect(screen.getByRole("status", { name: "Loading commits" })).toBeTruthy();
     });
   });
 
@@ -119,6 +125,31 @@ describe("SkeletonBone", () => {
     expect((container.firstElementChild as HTMLElement).style.height).toBe("68px");
   });
 
+  it("heightPx wins over an explicit style.height", () => {
+    const { container } = render(<SkeletonBone heightPx={68} style={{ height: "40px" }} />);
+    expect((container.firstElementChild as HTMLElement).style.height).toBe("68px");
+  });
+
+  it("ignores NaN heightPx", () => {
+    const { container } = render(<SkeletonBone heightPx={Number.NaN} />);
+    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+  });
+
+  it("ignores negative heightPx", () => {
+    const { container } = render(<SkeletonBone heightPx={-20} />);
+    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+  });
+
+  it("ignores Infinity heightPx", () => {
+    const { container } = render(<SkeletonBone heightPx={Number.POSITIVE_INFINITY} />);
+    expect((container.firstElementChild as HTMLElement).style.height).toBe("");
+  });
+
+  it("forces aria-hidden true even if a caller passes aria-hidden={false}", () => {
+    const { container } = render(<SkeletonBone aria-hidden={false} />);
+    expect((container.firstElementChild as HTMLElement).getAttribute("aria-hidden")).toBe("true");
+  });
+
   it("merges custom className", () => {
     const { container } = render(<SkeletonBone className="w-12 h-4" />);
     const cls = (container.firstElementChild as HTMLElement).className;
@@ -151,6 +182,13 @@ describe("SkeletonText", () => {
   it("floors fractional line counts", () => {
     const { container } = render(<SkeletonText lines={3.9} />);
     expect(container.firstElementChild?.children.length).toBe(3);
+  });
+
+  it("clamps absurdly large line counts to a sane ceiling", () => {
+    const { container } = render(<SkeletonText lines={1_000_000} />);
+    const rendered = container.firstElementChild?.children.length ?? 0;
+    expect(rendered).toBeLessThanOrEqual(100);
+    expect(rendered).toBeGreaterThan(0);
   });
 
   it("cycles widths through [w-full, w-3/4, w-1/2]", () => {
@@ -201,5 +239,37 @@ describe("SkeletonText", () => {
   it("does not use transition-all", () => {
     const { container } = render(<SkeletonText lines={3} />);
     expect(container.innerHTML).not.toContain("transition-all");
+  });
+});
+
+describe("animate-skeleton-shimmer CSS contract", () => {
+  // Read the source CSS once. Build pipeline transforms (Tailwind, autoprefixer)
+  // shouldn't matter — we're asserting authored intent in src/index.css.
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf8");
+
+  it("declares the skeleton-shimmer keyframe", () => {
+    expect(css).toMatch(/@keyframes\s+skeleton-shimmer\b/);
+  });
+
+  it("declares the .animate-skeleton-shimmer utility class", () => {
+    expect(css).toMatch(/\.animate-skeleton-shimmer\s*\{/);
+  });
+
+  it("hides the ::after sweep under prefers-reduced-motion", () => {
+    const block = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/)?.[0];
+    expect(block).toBeTruthy();
+    expect(block).toMatch(/\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/);
+  });
+
+  it("hides the ::after sweep under body[data-reduce-animations]", () => {
+    expect(css).toMatch(
+      /body\[data-reduce-animations="true"\]\s+\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/
+    );
+  });
+
+  it("hides the ::after sweep under body[data-performance-mode]", () => {
+    expect(css).toMatch(
+      /body\[data-performance-mode="true"\]\s+\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/
+    );
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1094,6 +1094,40 @@ body,
   will-change: opacity;
 }
 
+/* Opt-in shimmer sweep for skeleton bones. Layered on top of the opacity pulse;
+ * the ::after pseudo-element rides a translateX so the work stays on the
+ * compositor (transform > background-position for GPU cost — see #4738).
+ * Bundles position: relative + overflow: hidden so callers don't need to add
+ * them separately.
+ */
+@keyframes skeleton-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.animate-skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.animate-skeleton-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in oklab, var(--color-daintree-text) 8%, transparent) 50%,
+    transparent 100%
+  );
+  animation: skeleton-shimmer 1.8s ease-in-out infinite;
+  will-change: transform;
+}
+
 /* Agent status working state - pulsing gradient animation */
 @keyframes status-pulse {
   0%,
@@ -1349,6 +1383,7 @@ body,
   .animate-spin-slow,
   .animate-pulse-delayed,
   .animate-pulse-immediate,
+  .animate-skeleton-shimmer,
   .status-working,
   .animate-badge-bump,
   .animate-activity-blip,
@@ -1359,6 +1394,14 @@ body,
     animation: none;
     opacity: 1;
     transform: none;
+    will-change: auto;
+  }
+
+  /* Hide the shimmer sweep entirely — `animation: none` alone leaves a static
+   * gradient stripe visible. WCAG 2.3.3: remove motion, don't freeze it.
+   */
+  .animate-skeleton-shimmer::after {
+    display: none;
     will-change: auto;
   }
 
@@ -1438,6 +1481,7 @@ body[data-reduce-animations="true"]
     .animate-spin-slow,
     .animate-pulse-delayed,
     .animate-pulse-immediate,
+    .animate-skeleton-shimmer,
     .status-working,
     .animate-badge-bump,
     .animate-activity-blip,
@@ -1449,6 +1493,11 @@ body[data-reduce-animations="true"]
   animation: none;
   opacity: 1;
   transform: none;
+  will-change: auto;
+}
+
+body[data-reduce-animations="true"] .animate-skeleton-shimmer::after {
+  display: none;
   will-change: auto;
 }
 
@@ -2154,6 +2203,13 @@ body[data-performance-mode="true"] *::after {
 body[data-performance-mode="true"] .animate-pulse-delayed,
 body[data-performance-mode="true"] .animate-pulse-immediate {
   opacity: 1 !important;
+}
+
+/* The global wildcard above kills the shimmer animation but the ::after
+ * pseudo-element still paints its static gradient stripe — hide it.
+ */
+body[data-performance-mode="true"] .animate-skeleton-shimmer::after {
+  display: none !important;
 }
 
 /* Disable backdrop effects in performance mode */


### PR DESCRIPTION
## Summary

- Adds `<Skeleton>`, `<SkeletonBone>`, and `<SkeletonText>` to the UI component library — a shared primitive for async loading surfaces so each call-site stops re-rolling ARIA contracts, motion-safe wrappers, and width randomisation
- Default animation is `animate-pulse-delayed` (opacity pulse, 400ms anti-flicker delay). Opt-in shimmer via `animate-skeleton-shimmer` uses a compositor-only transform-based `::after` pseudo-element — no layout cost, no extra GPU layers unless you ask for it
- `animate-skeleton-shimmer` is added to all three motion-override blocks in `src/index.css` with explicit `::after { display: none }` rules, so reduced-motion and performance-mode suppression work the same way as the existing pulse classes

Resolves #6345

## Changes

- `src/components/ui/Skeleton.tsx` — three components with correct ARIA contract (`role="status"`, `aria-live="polite"`, `aria-busy="true"`, sr-only label)
- `src/index.css` — `animate-skeleton-shimmer` keyframe + additions to all three motion-override blocks
- `src/components/ui/__tests__/Skeleton.test.tsx` — 39 unit tests including a CSS contract regression test that asserts the `::after { display: none }` hide rule exists in each override block

Existing skeletons (`BrowserPaneSkeleton`, `GitHubDropdownSkeletons`) are not migrated — that's a follow-on and out of scope here.

## Testing

- 39 unit tests pass
- `npm run check` clean (2431 warnings — matches baseline, zero new)