### PR TITLE
feat(terminal): show empty-state row in autocomplete when there are no matches

### DIFF
--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -25,12 +25,27 @@ export interface AutocompleteMenuProps {
   style?: React.CSSProperties;
   title?: string;
   ariaLabel?: string;
+  emptyMessage: string;
 }
 
 export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps>(
-  ({ isOpen, items, selectedIndex, isLoading = false, onSelect, style, title, ariaLabel }, ref) => {
+  (
+    {
+      isOpen,
+      items,
+      selectedIndex,
+      isLoading = false,
+      onSelect,
+      style,
+      title,
+      ariaLabel,
+      emptyMessage,
+    },
+    ref
+  ) => {
     if (!isOpen) return null;
-    if (!isLoading && items.length === 0) return null;
+
+    const isEmpty = !isLoading && items.length === 0;
 
     return (
       <div
@@ -40,7 +55,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
           "z-50"
         )}
         style={style}
-        role="listbox"
+        role={isEmpty ? undefined : "listbox"}
         aria-label={ariaLabel ?? title ?? "Autocomplete"}
       >
         {title && (
@@ -51,6 +66,17 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
         <ScrollShadow className="max-h-64" scrollClassName="p-1">
           {isLoading && items.length === 0 && (
             <div className="px-2 py-2 text-xs font-mono text-daintree-text/40">Searching…</div>
+          )}
+
+          {isEmpty && (
+            <div
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              className="px-2 py-2 text-xs font-mono text-daintree-text/40"
+            >
+              {emptyMessage}
+            </div>
           )}
 
           {items.map((item, idx) => {

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1315,6 +1315,15 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
                         ? "Diff autocomplete"
                         : "File autocomplete"
               }
+              emptyMessage={
+                activeMode === "command"
+                  ? "No commands match"
+                  : activeMode === "file"
+                    ? "No files match"
+                    : activeMode === "terminal"
+                      ? "No terminals match"
+                      : "No matches"
+              }
             />
             {isDragOverFiles && (
               <div className="absolute inset-0 z-10 flex items-center justify-center rounded-sm bg-daintree-bg/80 pointer-events-none">

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/ui/ScrollShadow", () => ({
+  ScrollShadow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { AutocompleteMenu, type AutocompleteItem } from "../AutocompleteMenu";
+
+const noop = () => {};
+
+describe("AutocompleteMenu", () => {
+  it("returns nothing when isOpen is false", () => {
+    const { container } = render(
+      <AutocompleteMenu
+        isOpen={false}
+        items={[]}
+        selectedIndex={0}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an empty-state status row when items are empty and not loading", () => {
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={[]}
+        selectedIndex={0}
+        onSelect={noop}
+        emptyMessage="No files match"
+      />
+    );
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toBe("No files match");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.getAttribute("aria-atomic")).toBe("true");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.queryByRole("option")).toBeNull();
+  });
+
+  it("does not render the empty status row when isLoading is true", () => {
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={[]}
+        selectedIndex={0}
+        isLoading={true}
+        onSelect={noop}
+        emptyMessage="No files match"
+      />
+    );
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByText("Searching…")).toBeTruthy();
+  });
+
+  it("renders listbox with options when items are present", () => {
+    const items: AutocompleteItem[] = [
+      { key: "a", label: "alpha", value: "alpha" },
+      { key: "b", label: "beta", value: "beta" },
+    ];
+
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+
+    expect(screen.getByRole("listbox")).toBeTruthy();
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- When a search query had zero results, the autocomplete dropdown silently closed — users couldn't tell whether the menu dismissed or broke
- Adds a persistent empty-state row with mode-specific copy (`No commands match`, `No files match`, `No terminals match`, `No matches`) so the user always gets a clear signal
- The empty-state row is not keyboard-selectable and carries `role="status" aria-live="polite"` so screen readers announce it without polluting the `listbox` role

Resolves #6342

## Changes

- `AutocompleteMenu.tsx` — adds required `emptyMessage` prop; replaces the silent `return null` early-exit with a proper empty-state branch; drops `role="listbox"` on the wrapper when empty to keep ARIA valid
- `HybridInputBar.tsx` — maps `activeMode` to mode-appropriate copy and passes it to `<AutocompleteMenu>`
- `src/components/Terminal/__tests__/AutocompleteMenu.test.tsx` (new) — 4 unit tests covering closed, empty, loading, and populated states

## Testing

- All 4 unit tests pass (`npx vitest run src/components/Terminal/__tests__/AutocompleteMenu.test.tsx`)
- TypeScript clean on changed files (`npx tsc --noEmit`)
- Lint baseline preserved — no new warnings introduced