### PR TITLE
feat(terminal): treat @file and /slash chips as cursor-atomic with two-press Backspace

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -77,6 +77,8 @@ import {
   createSelectionChipTooltip,
   createAutoSize,
   createCustomKeymap,
+  chipPendingDeleteField,
+  createChipBackspaceKeymap,
 } from "./inputEditorExtensions";
 import { AppDialog } from "@/components/ui/AppDialog";
 import {
@@ -1048,6 +1050,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       const state = EditorState.create({
         doc: value,
         extensions: [
+          chipPendingDeleteField,
+          createChipBackspaceKeymap(),
           themeCompartmentRef.current.of(buildInputBarTheme(effectiveTheme)),
           chipEntranceTheme,
           EditorView.lineWrapping,

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -1762,6 +1762,148 @@ describe("slashChipField valid/invalid distinction", () => {
   });
 });
 
+describe("@file chip yields to fileDropChip when ranges overlap", () => {
+  it("does not render @file widget over a fileDropChip range", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "@/Users/test/file.ts ",
+        extensions: [chipPendingDeleteField, createFileChipField(), fileDropChipField],
+      }),
+    });
+
+    view.dispatch({
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    // The rich file-drop chip should be present and own the range; the simple file chip
+    // must not also render a competing widget.
+    const dropChip = view.dom.querySelector(".cm-file-drop-chip");
+    const fileChip = view.dom.querySelector(".cm-file-chip");
+    expect(dropChip).not.toBeNull();
+    expect(fileChip).toBeNull();
+    view.destroy();
+  });
+});
+
+describe("middle-of-text chip deletion", () => {
+  it("preserves surrounding text after two-press delete", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "run @src/App.tsx now",
+        extensions: [chipPendingDeleteField, createFileChipField(), createChipBackspaceKeymap()],
+      }),
+    });
+
+    const chipEnd = "run @src/App.tsx".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe("run  now");
+    view.destroy();
+  });
+});
+
+describe("two-press Backspace edge cases", () => {
+  function makeView(doc: string) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    return new EditorView({
+      parent,
+      state: EditorState.create({
+        doc,
+        extensions: [chipPendingDeleteField, createFileChipField(), createChipBackspaceKeymap()],
+      }),
+    });
+  }
+
+  it("partial selection that does not exactly cover a chip returns false", () => {
+    const view = makeView("@src/App.tsx ");
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: 0, head: chipEnd - 1 } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe("@src/App.tsx ");
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("alreadyStaged path: cursor returns to chip edge then second Backspace deletes", () => {
+    const view = makeView("@src/App.tsx ");
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    // First press: stages + selects the chip.
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.field(chipPendingDeleteField)).not.toBeNull();
+    expect(view.state.selection.main.empty).toBe(false);
+
+    // Collapse the selection back to the chip's right edge — staging must be preserved
+    // because the cursor is still at the chip boundary.
+    view.dispatch({ selection: { anchor: chipEnd } });
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: chipEnd });
+    expect(view.state.selection.main.empty).toBe(true);
+
+    // Second press: alreadyStaged branch deletes via the empty-selection path.
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.doc.toString()).toBe(" ");
+    view.destroy();
+  });
+});
+
+describe("two-press Backspace on diffChip and terminalChip", () => {
+  function makeView(doc: string, field: import("@codemirror/state").Extension) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    return new EditorView({
+      parent,
+      state: EditorState.create({
+        doc,
+        extensions: [chipPendingDeleteField, field, createChipBackspaceKeymap()],
+      }),
+    });
+  }
+
+  it("diffChip: two-press Backspace deletes @diff token", () => {
+    const view = makeView("see @diff please", diffChipField);
+    const chipEnd = "see @diff".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.doc.toString()).toBe("see @diff please");
+    expect(view.state.field(chipPendingDeleteField)).not.toBeNull();
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.doc.toString()).toBe("see  please");
+    view.destroy();
+  });
+
+  it("terminalChip: two-press Backspace deletes @terminal token", () => {
+    const view = makeView("see @terminal please", terminalChipField);
+    const chipEnd = "see @terminal".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe("see  please");
+    view.destroy();
+  });
+});
+
 describe("@file chip widget rendering", () => {
   it("doc text is preserved when chip is rendered as widget", () => {
     const parent = document.createElement("div");

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -31,6 +31,16 @@ import {
   createSlashChipField,
 } from "../inputEditorExtensions";
 import type { SlashCommand } from "@shared/types";
+
+function makeSlashCommand(label: string, description = ""): SlashCommand {
+  return {
+    id: label.replace(/^\//, ""),
+    label,
+    description,
+    scope: "built-in",
+    agentId: "claude",
+  };
+}
 import { resolveInputBarColors } from "@/utils/terminalTheme";
 
 describe("computeAutoSize", () => {
@@ -1696,10 +1706,7 @@ describe("two-press Backspace on /slash chips", () => {
 
   it("first Backspace stages a valid /slash chip", () => {
     const map = new Map<string, SlashCommand>([
-      [
-        "/build",
-        { id: "build", label: "/build", description: "Build the project" } as SlashCommand,
-      ],
+      ["/build", makeSlashCommand("/build", "Build the project")],
     ]);
     const view = makeView("/build ", map);
     const chipEnd = "/build".length;
@@ -1713,9 +1720,7 @@ describe("two-press Backspace on /slash chips", () => {
   });
 
   it("second Backspace deletes a /slash chip", () => {
-    const map = new Map<string, SlashCommand>([
-      ["/build", { id: "build", label: "/build" } as SlashCommand],
-    ]);
+    const map = new Map<string, SlashCommand>([["/build", makeSlashCommand("/build")]]);
     const view = makeView("/build ", map);
     const chipEnd = "/build".length;
     view.dispatch({ selection: { anchor: chipEnd } });
@@ -1745,9 +1750,7 @@ describe("two-press Backspace on /slash chips", () => {
 
 describe("slashChipField valid/invalid distinction", () => {
   it("preserves isValid metadata for known commands", () => {
-    const map = new Map<string, SlashCommand>([
-      ["/build", { id: "build", label: "/build" } as SlashCommand],
-    ]);
+    const map = new Map<string, SlashCommand>([["/build", makeSlashCommand("/build")]]);
     const field = createSlashChipField({ commandMap: map });
     const state = EditorState.create({
       doc: "/build /unknowncmd",

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -24,7 +24,13 @@ import {
   terminalChipField,
   selectionChipField,
   formatFileSize,
+  chipPendingDeleteField,
+  setChipPendingDelete,
+  createChipBackspaceKeymap,
+  isChipSelected,
+  createSlashChipField,
 } from "../inputEditorExtensions";
+import type { SlashCommand } from "@shared/types";
 import { resolveInputBarColors } from "@/utils/terminalTheme";
 
 describe("computeAutoSize", () => {
@@ -1495,3 +1501,304 @@ function extractAtRuleBody(css: string, atRule: string): string {
   }
   throw new Error(`unterminated at-rule ${atRule}`);
 }
+
+describe("chipPendingDeleteField", () => {
+  function makeView(doc: string, extensions: import("@codemirror/state").Extension[] = []) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    return new EditorView({
+      parent,
+      state: EditorState.create({
+        doc,
+        extensions: [chipPendingDeleteField, ...extensions],
+      }),
+    });
+  }
+
+  it("starts null", () => {
+    const view = makeView("hello");
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("stages a range when setChipPendingDelete effect fires", () => {
+    const view = makeView("hello world");
+    view.dispatch({ effects: setChipPendingDelete.of({ from: 0, to: 5 }) });
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: 5 });
+    view.destroy();
+  });
+
+  it("clears when document changes", () => {
+    const view = makeView("hello world");
+    view.dispatch({ effects: setChipPendingDelete.of({ from: 0, to: 5 }) });
+    view.dispatch({ changes: { from: 5, insert: "X" } });
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("clears when cursor moves off the staged range", () => {
+    const view = makeView("hello world");
+    view.dispatch({
+      effects: setChipPendingDelete.of({ from: 0, to: 5 }),
+      selection: { anchor: 0, head: 5 },
+    });
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: 5 });
+
+    view.dispatch({ selection: { anchor: 8 } });
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("preserves staged range while cursor remains at boundary", () => {
+    const view = makeView("hello world");
+    view.dispatch({
+      effects: setChipPendingDelete.of({ from: 0, to: 5 }),
+      selection: { anchor: 0, head: 5 },
+    });
+    view.dispatch({ selection: { anchor: 5 } });
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: 5 });
+    view.destroy();
+  });
+
+  it("explicit null effect clears staging", () => {
+    const view = makeView("hello world");
+    view.dispatch({ effects: setChipPendingDelete.of({ from: 0, to: 5 }) });
+    view.dispatch({ effects: setChipPendingDelete.of(null) });
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("clears invalid out-of-bounds range", () => {
+    const view = makeView("hi");
+    view.dispatch({ effects: setChipPendingDelete.of({ from: 0, to: 100 }) });
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+});
+
+describe("isChipSelected helper", () => {
+  it("returns false when pending is null", () => {
+    expect(isChipSelected(null, 0, 5)).toBe(false);
+  });
+
+  it("returns true when pending matches range", () => {
+    expect(isChipSelected({ from: 0, to: 5 }, 0, 5)).toBe(true);
+  });
+
+  it("returns false when pending range is different", () => {
+    expect(isChipSelected({ from: 0, to: 5 }, 6, 11)).toBe(false);
+  });
+
+  it("returns false when only one boundary matches", () => {
+    expect(isChipSelected({ from: 0, to: 5 }, 0, 6)).toBe(false);
+    expect(isChipSelected({ from: 0, to: 5 }, 1, 5)).toBe(false);
+  });
+});
+
+describe("two-press Backspace on @file chips", () => {
+  function makeView(doc: string) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    return new EditorView({
+      parent,
+      state: EditorState.create({
+        doc,
+        extensions: [chipPendingDeleteField, createFileChipField(), createChipBackspaceKeymap()],
+      }),
+    });
+  }
+
+  it("first Backspace stages chip and selects it without deleting", () => {
+    const view = makeView("@src/App.tsx ");
+    // Cursor right after the chip end (position 12: just before the trailing space)
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe("@src/App.tsx ");
+    const pending = view.state.field(chipPendingDeleteField);
+    expect(pending).not.toBeNull();
+    expect(pending!.from).toBe(0);
+    expect(pending!.to).toBe(chipEnd);
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe(chipEnd);
+    view.destroy();
+  });
+
+  it("second Backspace deletes the chip", () => {
+    const view = makeView("@src/App.tsx ");
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe(" ");
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("Backspace with no chip before cursor returns false and does not stage", () => {
+    const view = makeView("plain text");
+    view.dispatch({ selection: { anchor: 5 } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    // Our chip-backspace handler returns false when no chip is before the cursor; default
+    // Backspace is not part of this scope so the doc remains unchanged.
+    expect(view.state.doc.toString()).toBe("plain text");
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("arrow-away after first press clears staging", () => {
+    const view = makeView("@src/App.tsx ");
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.field(chipPendingDeleteField)).not.toBeNull();
+
+    view.dispatch({ selection: { anchor: chipEnd + 1 } });
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    view.destroy();
+  });
+
+  it("range selection covering exactly the chip deletes immediately", () => {
+    const view = makeView("@src/App.tsx ");
+    const chipEnd = "@src/App.tsx".length;
+    view.dispatch({ selection: { anchor: 0, head: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe(" ");
+    view.destroy();
+  });
+});
+
+describe("two-press Backspace on /slash chips", () => {
+  function makeView(doc: string, commandMap: Map<string, SlashCommand>) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    return new EditorView({
+      parent,
+      state: EditorState.create({
+        doc,
+        extensions: [
+          chipPendingDeleteField,
+          createSlashChipField({ commandMap }),
+          createChipBackspaceKeymap(),
+        ],
+      }),
+    });
+  }
+
+  it("first Backspace stages a valid /slash chip", () => {
+    const map = new Map<string, SlashCommand>([
+      [
+        "/build",
+        { id: "build", label: "/build", description: "Build the project" } as SlashCommand,
+      ],
+    ]);
+    const view = makeView("/build ", map);
+    const chipEnd = "/build".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe("/build ");
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: chipEnd });
+    view.destroy();
+  });
+
+  it("second Backspace deletes a /slash chip", () => {
+    const map = new Map<string, SlashCommand>([
+      ["/build", { id: "build", label: "/build" } as SlashCommand],
+    ]);
+    const view = makeView("/build ", map);
+    const chipEnd = "/build".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+
+    expect(view.state.doc.toString()).toBe(" ");
+    view.destroy();
+  });
+
+  it("two-press also works for invalid /slash commands (still atomic)", () => {
+    const map = new Map<string, SlashCommand>();
+    const view = makeView("/unknowncmd ", map);
+    const chipEnd = "/unknowncmd".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.doc.toString()).toBe("/unknowncmd ");
+    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: chipEnd });
+
+    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
+    expect(view.state.doc.toString()).toBe(" ");
+    view.destroy();
+  });
+});
+
+describe("slashChipField valid/invalid distinction", () => {
+  it("preserves isValid metadata for known commands", () => {
+    const map = new Map<string, SlashCommand>([
+      ["/build", { id: "build", label: "/build" } as SlashCommand],
+    ]);
+    const field = createSlashChipField({ commandMap: map });
+    const state = EditorState.create({
+      doc: "/build /unknowncmd",
+      extensions: [field],
+    });
+    const chipState = state.field(field);
+    expect(chipState.tokens).toHaveLength(2);
+    const validToken = chipState.tokens.find((t) => t.command === "/build");
+    const invalidToken = chipState.tokens.find((t) => t.command === "/unknowncmd");
+    expect(validToken?.isValid).toBe(true);
+    expect(invalidToken?.isValid).toBe(false);
+  });
+});
+
+describe("@file chip widget rendering", () => {
+  it("doc text is preserved when chip is rendered as widget", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "@src/App.tsx hello",
+        extensions: [chipPendingDeleteField, createFileChipField()],
+      }),
+    });
+
+    expect(view.state.doc.toString()).toBe("@src/App.tsx hello");
+    view.destroy();
+  });
+
+  it("renders cm-chip-pending-delete class when chip is staged", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "@src/App.tsx",
+        extensions: [chipPendingDeleteField, createFileChipField()],
+      }),
+    });
+
+    view.dispatch({
+      effects: setChipPendingDelete.of({ from: 0, to: 12 }),
+      selection: { anchor: 0, head: 12 },
+    });
+
+    // Widget DOM should reflect the selected state
+    const chipEl = view.dom.querySelector(".cm-file-chip");
+    expect(chipEl).not.toBeNull();
+    expect(chipEl?.classList.contains("cm-chip-pending-delete")).toBe(true);
+
+    view.destroy();
+  });
+});

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -160,6 +160,11 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         ...chipStyle,
       },
       ".cm-selection-chip svg": CHIP_SVG_SIZE,
+      ".cm-chip-pending-delete": {
+        background: `color-mix(in oklab, ${c.foreground} 14%, transparent)`,
+        outline: `1px solid color-mix(in oklab, ${c.foreground} 28%, transparent)`,
+        outlineOffset: "0px",
+      },
       ".cm-voice-interim": {
         opacity: "0.55",
         fontStyle: "italic",

--- a/src/components/Terminal/inputEditorExtensions/chipBackspace.ts
+++ b/src/components/Terminal/inputEditorExtensions/chipBackspace.ts
@@ -1,0 +1,135 @@
+import { EditorView, keymap, type KeyBinding } from "@codemirror/view";
+import { StateField, StateEffect, Prec, type Extension } from "@codemirror/state";
+
+export interface ChipPendingDelete {
+  from: number;
+  to: number;
+}
+
+export const setChipPendingDelete = StateEffect.define<ChipPendingDelete | null>();
+
+export const chipPendingDeleteField = StateField.define<ChipPendingDelete | null>({
+  create() {
+    return null;
+  },
+  update(value, tr) {
+    if (tr.docChanged) value = null;
+
+    for (const effect of tr.effects) {
+      if (effect.is(setChipPendingDelete)) {
+        value = effect.value;
+      }
+    }
+
+    if (value && tr.selection) {
+      const sel = tr.selection.main;
+      const matchesRange = sel.from === value.from && sel.to === value.to;
+      const cursorAtEdge = sel.empty && (sel.head === value.from || sel.head === value.to);
+      if (!matchesRange && !cursorAtEdge) {
+        value = null;
+      }
+    }
+
+    if (value) {
+      const docLen = tr.state.doc.length;
+      if (value.from < 0 || value.to > docLen || value.from >= value.to) {
+        value = null;
+      }
+    }
+
+    return value;
+  },
+});
+
+function findAtomicRangeBefore(view: EditorView, pos: number): ChipPendingDelete | null {
+  if (pos <= 0) return null;
+  const facets = view.state.facet(EditorView.atomicRanges);
+  let found: ChipPendingDelete | null = null;
+  for (const getRanges of facets) {
+    const set = getRanges(view);
+    if (!set) continue;
+    set.between(pos - 1, pos, (from, to) => {
+      if (to === pos && from < pos) {
+        found = { from, to };
+        return false;
+      }
+      return undefined;
+    });
+    if (found) break;
+  }
+  return found;
+}
+
+function findAtomicRangeCovering(
+  view: EditorView,
+  from: number,
+  to: number
+): ChipPendingDelete | null {
+  if (from >= to) return null;
+  const facets = view.state.facet(EditorView.atomicRanges);
+  let found: ChipPendingDelete | null = null;
+  for (const getRanges of facets) {
+    const set = getRanges(view);
+    if (!set) continue;
+    set.between(from, to, (rFrom, rTo) => {
+      if (rFrom === from && rTo === to) {
+        found = { from: rFrom, to: rTo };
+        return false;
+      }
+      return undefined;
+    });
+    if (found) break;
+  }
+  return found;
+}
+
+const backspaceBinding: KeyBinding = {
+  key: "Backspace",
+  run(view) {
+    const sel = view.state.selection.main;
+
+    if (!sel.empty) {
+      const covered = findAtomicRangeCovering(view, sel.from, sel.to);
+      if (covered) {
+        view.dispatch({
+          changes: { from: covered.from, to: covered.to, insert: "" },
+          effects: setChipPendingDelete.of(null),
+        });
+        return true;
+      }
+      return false;
+    }
+
+    const chip = findAtomicRangeBefore(view, sel.head);
+    if (!chip) return false;
+
+    const staged = view.state.field(chipPendingDeleteField, false) ?? null;
+    const alreadyStaged = !!staged && staged.from === chip.from && staged.to === chip.to;
+
+    if (alreadyStaged) {
+      view.dispatch({
+        changes: { from: chip.from, to: chip.to, insert: "" },
+        effects: setChipPendingDelete.of(null),
+      });
+      return true;
+    }
+
+    view.dispatch({
+      effects: setChipPendingDelete.of(chip),
+      selection: { anchor: chip.from, head: chip.to },
+    });
+    return true;
+  },
+};
+
+export function createChipBackspaceKeymap(): Extension {
+  return Prec.highest(keymap.of([backspaceBinding]));
+}
+
+export function isChipSelected(
+  pending: ChipPendingDelete | null,
+  from: number,
+  to: number
+): boolean {
+  return !!pending && pending.from === from && pending.to === to;
+}

--- a/src/components/Terminal/inputEditorExtensions/diffChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/diffChip.ts
@@ -1,6 +1,7 @@
 import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateField } from "@codemirror/state";
 import { getAllAtDiffTokens, type AtDiffToken, type DiffContextType } from "../hybridInputParsing";
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 const DIFF_LABELS: Record<DiffContextType, string> = {
   unstaged: "Working tree diff",
@@ -11,36 +12,28 @@ const DIFF_LABELS: Record<DiffContextType, string> = {
 const GIT_BRANCH_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>`;
 
 interface DiffChipState {
-  decorations: ReturnType<typeof Decoration.set>;
   tokens: AtDiffToken[];
 }
 
 function buildDiffChipState(text: string): DiffChipState {
-  const tokens = getAllAtDiffTokens(text);
-  if (tokens.length === 0) {
-    return { decorations: Decoration.none, tokens: [] };
-  }
-
-  const decorations = tokens.map((token) =>
-    Decoration.replace({
-      widget: new DiffChipWidget(token.diffType),
-    }).range(token.start, token.end)
-  );
-  return { decorations: Decoration.set(decorations), tokens };
+  return { tokens: getAllAtDiffTokens(text) };
 }
 
 class DiffChipWidget extends WidgetType {
-  constructor(readonly diffType: DiffContextType) {
+  constructor(
+    readonly diffType: DiffContextType,
+    readonly isSelected: boolean
+  ) {
     super();
   }
 
   eq(other: DiffChipWidget) {
-    return this.diffType === other.diffType;
+    return this.diffType === other.diffType && this.isSelected === other.isSelected;
   }
 
   toDOM() {
     const span = document.createElement("span");
-    span.className = "cm-diff-chip";
+    span.className = this.isSelected ? "cm-diff-chip cm-chip-pending-delete" : "cm-diff-chip";
     span.setAttribute("role", "img");
     span.setAttribute("aria-label", `Diff: ${DIFF_LABELS[this.diffType]}`);
 
@@ -72,7 +65,18 @@ export const diffChipField = StateField.define<DiffChipState>({
     return buildDiffChipState(tr.state.doc.toString());
   },
   provide: (f) => [
-    EditorView.decorations.from(f, (state) => state.decorations),
+    EditorView.decorations.of((view) => {
+      const chipState = view.state.field(f, false);
+      if (!chipState || chipState.tokens.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = chipState.tokens.map((token) => {
+        const selected = isChipSelected(pending, token.start, token.end);
+        return Decoration.replace({
+          widget: new DiffChipWidget(token.diffType, selected),
+        }).range(token.start, token.end);
+      });
+      return Decoration.set(ranges, true);
+    }),
     EditorView.atomicRanges.of((view) => {
       const chipState = view.state.field(f, false);
       if (!chipState || chipState.tokens.length === 0) return Decoration.none;

--- a/src/components/Terminal/inputEditorExtensions/fileChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileChip.ts
@@ -2,12 +2,35 @@ import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/vi
 import { StateField } from "@codemirror/state";
 import { getAllAtFileTokens, type AtFileToken } from "../hybridInputParsing";
 import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
+import { fileDropChipField } from "./fileDropChip";
+import { imageChipField } from "./imageChip";
 
 interface FileChipState {
   tokens: AtFileToken[];
 }
 
 const RESERVED_TOKEN_PATHS = new Set(["diff", "diff:staged", "diff:head", "terminal", "selection"]);
+
+interface RangeOwner {
+  from: number;
+  to: number;
+}
+
+function isOwnedByExplicitChip(view: EditorView, start: number, end: number): boolean {
+  const dropEntries: RangeOwner[] | undefined = view.state.field(fileDropChipField, false);
+  if (dropEntries) {
+    for (const e of dropEntries) {
+      if (e.from < end && e.to > start) return true;
+    }
+  }
+  const imageEntries: RangeOwner[] | undefined = view.state.field(imageChipField, false);
+  if (imageEntries) {
+    for (const e of imageEntries) {
+      if (e.from < end && e.to > start) return true;
+    }
+  }
+  return false;
+}
 
 class FileChipWidget extends WidgetType {
   constructor(
@@ -53,18 +76,24 @@ const fileChipStateField = StateField.define<FileChipState>({
       const fieldValue = view.state.field(f, false);
       if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
       const pending = view.state.field(chipPendingDeleteField, false) ?? null;
-      const ranges = fieldValue.tokens.map((token) => {
-        const selected = isChipSelected(pending, token.start, token.end);
-        return Decoration.replace({
-          widget: new FileChipWidget(token.path, selected),
-        }).range(token.start, token.end);
-      });
+      const ranges = fieldValue.tokens
+        .filter((t) => !isOwnedByExplicitChip(view, t.start, t.end))
+        .map((token) => {
+          const selected = isChipSelected(pending, token.start, token.end);
+          return Decoration.replace({
+            widget: new FileChipWidget(token.path, selected),
+          }).range(token.start, token.end);
+        });
+      if (ranges.length === 0) return Decoration.none;
       return Decoration.set(ranges, true);
     }),
     EditorView.atomicRanges.of((view) => {
       const fieldValue = view.state.field(f, false);
       if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
-      const ranges = fieldValue.tokens.map((t) => Decoration.mark({}).range(t.start, t.end));
+      const ranges = fieldValue.tokens
+        .filter((t) => !isOwnedByExplicitChip(view, t.start, t.end))
+        .map((t) => Decoration.mark({}).range(t.start, t.end));
+      if (ranges.length === 0) return Decoration.none;
       return Decoration.set(ranges, true);
     }),
   ],

--- a/src/components/Terminal/inputEditorExtensions/fileChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileChip.ts
@@ -1,24 +1,43 @@
-import { EditorView, Decoration, hoverTooltip } from "@codemirror/view";
+import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateField } from "@codemirror/state";
 import { getAllAtFileTokens, type AtFileToken } from "../hybridInputParsing";
-
-const fileChipMark = Decoration.mark({ class: "cm-file-chip" });
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface FileChipState {
-  decorations: ReturnType<typeof Decoration.set>;
   tokens: AtFileToken[];
 }
 
 const RESERVED_TOKEN_PATHS = new Set(["diff", "diff:staged", "diff:head", "terminal", "selection"]);
 
-function buildFileChipState(text: string): FileChipState {
-  const tokens = getAllAtFileTokens(text).filter((t) => !RESERVED_TOKEN_PATHS.has(t.path));
-  if (tokens.length === 0) {
-    return { decorations: Decoration.none, tokens: [] };
+class FileChipWidget extends WidgetType {
+  constructor(
+    readonly path: string,
+    readonly isSelected: boolean
+  ) {
+    super();
   }
 
-  const decorations = tokens.map((token) => fileChipMark.range(token.start, token.end));
-  return { decorations: Decoration.set(decorations), tokens };
+  eq(other: FileChipWidget) {
+    return this.path === other.path && this.isSelected === other.isSelected;
+  }
+
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = this.isSelected ? "cm-file-chip cm-chip-pending-delete" : "cm-file-chip";
+    span.setAttribute("role", "img");
+    span.setAttribute("aria-label", `File: ${this.path}`);
+    span.textContent = `@${this.path}`;
+    return span;
+  }
+
+  ignoreEvent() {
+    return false;
+  }
+}
+
+function buildFileChipState(text: string): FileChipState {
+  const tokens = getAllAtFileTokens(text).filter((t) => !RESERVED_TOKEN_PATHS.has(t.path));
+  return { tokens };
 }
 
 const fileChipStateField = StateField.define<FileChipState>({
@@ -29,7 +48,26 @@ const fileChipStateField = StateField.define<FileChipState>({
     if (!tr.docChanged) return value;
     return buildFileChipState(tr.state.doc.toString());
   },
-  provide: (f) => EditorView.decorations.from(f, (state) => state.decorations),
+  provide: (f) => [
+    EditorView.decorations.of((view) => {
+      const fieldValue = view.state.field(f, false);
+      if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = fieldValue.tokens.map((token) => {
+        const selected = isChipSelected(pending, token.start, token.end);
+        return Decoration.replace({
+          widget: new FileChipWidget(token.path, selected),
+        }).range(token.start, token.end);
+      });
+      return Decoration.set(ranges, true);
+    }),
+    EditorView.atomicRanges.of((view) => {
+      const fieldValue = view.state.field(f, false);
+      if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
+      const ranges = fieldValue.tokens.map((t) => Decoration.mark({}).range(t.start, t.end));
+      return Decoration.set(ranges, true);
+    }),
+  ],
 });
 
 export function createFileChipField() {

--- a/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
@@ -2,6 +2,7 @@ import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/vi
 import type { Extension } from "@codemirror/state";
 import { StateField, StateEffect } from "@codemirror/state";
 import { formatFileSize, removeChipRange } from "./base";
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface FileDropChipEntry {
   from: number;
@@ -17,18 +18,25 @@ class FileDropChipWidget extends WidgetType {
   constructor(
     readonly filePath: string,
     readonly fileName: string,
-    readonly fileSize?: number
+    readonly fileSize: number | undefined,
+    readonly isSelected: boolean
   ) {
     super();
   }
 
   eq(other: FileDropChipWidget) {
-    return this.filePath === other.filePath && this.fileSize === other.fileSize;
+    return (
+      this.filePath === other.filePath &&
+      this.fileSize === other.fileSize &&
+      this.isSelected === other.isSelected
+    );
   }
 
   toDOM(view: EditorView) {
     const span = document.createElement("span");
-    span.className = "cm-file-drop-chip";
+    span.className = this.isSelected
+      ? "cm-file-drop-chip cm-chip-pending-delete"
+      : "cm-file-drop-chip";
     span.setAttribute("role", "img");
     span.setAttribute("aria-label", `File: ${this.filePath}`);
 
@@ -95,13 +103,16 @@ export const fileDropChipField = StateField.define<FileDropChipEntry[]>({
     return entries;
   },
   provide: (f) => [
-    EditorView.decorations.from(f, (entries) => {
-      if (entries.length === 0) return Decoration.none;
-      const ranges = entries.map((e) =>
-        Decoration.replace({
-          widget: new FileDropChipWidget(e.filePath, e.fileName, e.fileSize),
-        }).range(e.from, e.to)
-      );
+    EditorView.decorations.of((view) => {
+      const entries = view.state.field(f, false);
+      if (!entries || entries.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = entries.map((e) => {
+        const selected = isChipSelected(pending, e.from, e.to);
+        return Decoration.replace({
+          widget: new FileDropChipWidget(e.filePath, e.fileName, e.fileSize, selected),
+        }).range(e.from, e.to);
+      });
       return Decoration.set(ranges, true);
     }),
     EditorView.atomicRanges.of((view) => {

--- a/src/components/Terminal/inputEditorExtensions/imageChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/imageChip.ts
@@ -2,6 +2,7 @@ import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/vi
 import type { Extension } from "@codemirror/state";
 import { StateField, StateEffect } from "@codemirror/state";
 import { formatChipLabel, removeChipRange } from "./base";
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface ImageChipEntry {
   from: number;
@@ -13,18 +14,19 @@ interface ImageChipEntry {
 class ImageChipWidget extends WidgetType {
   constructor(
     readonly filePath: string,
-    readonly thumbnailUrl: string
+    readonly thumbnailUrl: string,
+    readonly isSelected: boolean
   ) {
     super();
   }
 
   eq(other: ImageChipWidget) {
-    return this.filePath === other.filePath;
+    return this.filePath === other.filePath && this.isSelected === other.isSelected;
   }
 
   toDOM(view: EditorView) {
     const span = document.createElement("span");
-    span.className = "cm-image-chip";
+    span.className = this.isSelected ? "cm-image-chip cm-chip-pending-delete" : "cm-image-chip";
     span.setAttribute("role", "img");
     span.setAttribute("aria-label", `Image: ${this.filePath}`);
 
@@ -91,14 +93,16 @@ export const imageChipField = StateField.define<ImageChipEntry[]>({
     return entries;
   },
   provide: (f) => [
-    EditorView.decorations.from(f, (entries) => {
-      if (entries.length === 0) return Decoration.none;
-      const ranges = entries.map((e) =>
-        Decoration.replace({ widget: new ImageChipWidget(e.filePath, e.thumbnailUrl) }).range(
-          e.from,
-          e.to
-        )
-      );
+    EditorView.decorations.of((view) => {
+      const entries = view.state.field(f, false);
+      if (!entries || entries.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = entries.map((e) => {
+        const selected = isChipSelected(pending, e.from, e.to);
+        return Decoration.replace({
+          widget: new ImageChipWidget(e.filePath, e.thumbnailUrl, selected),
+        }).range(e.from, e.to);
+      });
       return Decoration.set(ranges, true);
     }),
     EditorView.atomicRanges.of((view) => {

--- a/src/components/Terminal/inputEditorExtensions/index.ts
+++ b/src/components/Terminal/inputEditorExtensions/index.ts
@@ -38,3 +38,10 @@ export {
 export { diffChipField, createDiffChipTooltip } from "./diffChip";
 export { terminalChipField, createTerminalChipTooltip } from "./terminalChip";
 export { selectionChipField, createSelectionChipTooltip } from "./selectionChip";
+export {
+  chipPendingDeleteField,
+  setChipPendingDelete,
+  createChipBackspaceKeymap,
+  isChipSelected,
+} from "./chipBackspace";
+export type { ChipPendingDelete } from "./chipBackspace";

--- a/src/components/Terminal/inputEditorExtensions/selectionChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/selectionChip.ts
@@ -2,34 +2,30 @@ import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/vi
 import { StateField } from "@codemirror/state";
 import { getAllAtSelectionTokens, type AtSelectionToken } from "../hybridInputParsing";
 import { TERMINAL_ICON_SVG } from "./base";
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface SelectionChipState {
-  decorations: ReturnType<typeof Decoration.set>;
   tokens: AtSelectionToken[];
 }
 
 function buildSelectionChipState(text: string): SelectionChipState {
-  const tokens = getAllAtSelectionTokens(text);
-  if (tokens.length === 0) {
-    return { decorations: Decoration.none, tokens: [] };
-  }
-
-  const decorations = tokens.map((token) =>
-    Decoration.replace({
-      widget: new SelectionChipWidget(),
-    }).range(token.start, token.end)
-  );
-  return { decorations: Decoration.set(decorations), tokens };
+  return { tokens: getAllAtSelectionTokens(text) };
 }
 
 class SelectionChipWidget extends WidgetType {
-  eq() {
-    return true;
+  constructor(readonly isSelected: boolean) {
+    super();
+  }
+
+  eq(other: SelectionChipWidget) {
+    return this.isSelected === other.isSelected;
   }
 
   toDOM() {
     const span = document.createElement("span");
-    span.className = "cm-selection-chip";
+    span.className = this.isSelected
+      ? "cm-selection-chip cm-chip-pending-delete"
+      : "cm-selection-chip";
     span.setAttribute("role", "img");
     span.setAttribute("aria-label", "Terminal selection");
 
@@ -61,7 +57,18 @@ export const selectionChipField = StateField.define<SelectionChipState>({
     return buildSelectionChipState(tr.state.doc.toString());
   },
   provide: (f) => [
-    EditorView.decorations.from(f, (state) => state.decorations),
+    EditorView.decorations.of((view) => {
+      const chipState = view.state.field(f, false);
+      if (!chipState || chipState.tokens.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = chipState.tokens.map((token) => {
+        const selected = isChipSelected(pending, token.start, token.end);
+        return Decoration.replace({
+          widget: new SelectionChipWidget(selected),
+        }).range(token.start, token.end);
+      });
+      return Decoration.set(ranges, true);
+    }),
     EditorView.atomicRanges.of((view) => {
       const chipState = view.state.field(f, false);
       if (!chipState || chipState.tokens.length === 0) return Decoration.none;

--- a/src/components/Terminal/inputEditorExtensions/slashChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/slashChip.ts
@@ -1,35 +1,61 @@
-import { EditorView, Decoration, hoverTooltip } from "@codemirror/view";
+import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/view";
 import { StateField, Compartment } from "@codemirror/state";
 import type { SlashCommand } from "@shared/types";
 import { getAllSlashCommandTokens, type SlashCommandToken } from "../hybridInputParsing";
-
-const slashChipMark = Decoration.mark({ class: "cm-slash-command-chip" });
-const invalidChipMark = Decoration.mark({
-  class: "cm-slash-command-chip cm-slash-command-chip-invalid",
-});
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface SlashChipFieldConfig {
   commandMap: Map<string, SlashCommand>;
 }
 
+interface SlashChipToken extends SlashCommandToken {
+  isValid: boolean;
+}
+
 interface SlashChipState {
-  decorations: ReturnType<typeof Decoration.set>;
-  tokens: SlashCommandToken[];
+  tokens: SlashChipToken[];
+}
+
+class SlashChipWidget extends WidgetType {
+  constructor(
+    readonly command: string,
+    readonly isValid: boolean,
+    readonly isSelected: boolean
+  ) {
+    super();
+  }
+
+  eq(other: SlashChipWidget) {
+    return (
+      this.command === other.command &&
+      this.isValid === other.isValid &&
+      this.isSelected === other.isSelected
+    );
+  }
+
+  toDOM() {
+    const span = document.createElement("span");
+    const classes = ["cm-slash-command-chip"];
+    if (!this.isValid) classes.push("cm-slash-command-chip-invalid");
+    if (this.isSelected) classes.push("cm-chip-pending-delete");
+    span.className = classes.join(" ");
+    span.setAttribute("role", "img");
+    span.setAttribute("aria-label", `Slash command: ${this.command}`);
+    span.textContent = this.command;
+    return span;
+  }
+
+  ignoreEvent() {
+    return false;
+  }
 }
 
 function buildSlashChipState(text: string, config: SlashChipFieldConfig): SlashChipState {
-  const tokens = getAllSlashCommandTokens(text);
-  if (tokens.length === 0) {
-    return { decorations: Decoration.none, tokens: [] };
-  }
-
-  const ranges = tokens.map((token) => {
-    const isValid = config.commandMap.has(token.command);
-    const mark = isValid ? slashChipMark : invalidChipMark;
-    return mark.range(token.start, token.end);
-  });
-
-  return { decorations: Decoration.set(ranges), tokens };
+  const tokens = getAllSlashCommandTokens(text).map((token) => ({
+    ...token,
+    isValid: config.commandMap.has(token.command),
+  }));
+  return { tokens };
 }
 
 export function createSlashChipField(config: SlashChipFieldConfig) {
@@ -41,7 +67,26 @@ export function createSlashChipField(config: SlashChipFieldConfig) {
       if (!tr.docChanged) return value;
       return buildSlashChipState(tr.state.doc.toString(), config);
     },
-    provide: (f) => EditorView.decorations.from(f, (state) => state.decorations),
+    provide: (f) => [
+      EditorView.decorations.of((view) => {
+        const fieldValue = view.state.field(f, false);
+        if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
+        const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+        const ranges = fieldValue.tokens.map((token) => {
+          const selected = isChipSelected(pending, token.start, token.end);
+          return Decoration.replace({
+            widget: new SlashChipWidget(token.command, token.isValid, selected),
+          }).range(token.start, token.end);
+        });
+        return Decoration.set(ranges, true);
+      }),
+      EditorView.atomicRanges.of((view) => {
+        const fieldValue = view.state.field(f, false);
+        if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
+        const ranges = fieldValue.tokens.map((t) => Decoration.mark({}).range(t.start, t.end));
+        return Decoration.set(ranges, true);
+      }),
+    ],
   });
 }
 

--- a/src/components/Terminal/inputEditorExtensions/terminalChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/terminalChip.ts
@@ -2,34 +2,30 @@ import { EditorView, Decoration, WidgetType, hoverTooltip } from "@codemirror/vi
 import { StateField } from "@codemirror/state";
 import { getAllAtTerminalTokens, type AtTerminalToken } from "../hybridInputParsing";
 import { TERMINAL_ICON_SVG } from "./base";
+import { chipPendingDeleteField, isChipSelected } from "./chipBackspace";
 
 interface TerminalChipState {
-  decorations: ReturnType<typeof Decoration.set>;
   tokens: AtTerminalToken[];
 }
 
 function buildTerminalChipState(text: string): TerminalChipState {
-  const tokens = getAllAtTerminalTokens(text);
-  if (tokens.length === 0) {
-    return { decorations: Decoration.none, tokens: [] };
-  }
-
-  const decorations = tokens.map((token) =>
-    Decoration.replace({
-      widget: new TerminalBufferChipWidget(),
-    }).range(token.start, token.end)
-  );
-  return { decorations: Decoration.set(decorations), tokens };
+  return { tokens: getAllAtTerminalTokens(text) };
 }
 
 class TerminalBufferChipWidget extends WidgetType {
-  eq() {
-    return true;
+  constructor(readonly isSelected: boolean) {
+    super();
+  }
+
+  eq(other: TerminalBufferChipWidget) {
+    return this.isSelected === other.isSelected;
   }
 
   toDOM() {
     const span = document.createElement("span");
-    span.className = "cm-terminal-chip";
+    span.className = this.isSelected
+      ? "cm-terminal-chip cm-chip-pending-delete"
+      : "cm-terminal-chip";
     span.setAttribute("role", "img");
     span.setAttribute("aria-label", "Terminal output");
 
@@ -61,7 +57,18 @@ export const terminalChipField = StateField.define<TerminalChipState>({
     return buildTerminalChipState(tr.state.doc.toString());
   },
   provide: (f) => [
-    EditorView.decorations.from(f, (state) => state.decorations),
+    EditorView.decorations.of((view) => {
+      const chipState = view.state.field(f, false);
+      if (!chipState || chipState.tokens.length === 0) return Decoration.none;
+      const pending = view.state.field(chipPendingDeleteField, false) ?? null;
+      const ranges = chipState.tokens.map((token) => {
+        const selected = isChipSelected(pending, token.start, token.end);
+        return Decoration.replace({
+          widget: new TerminalBufferChipWidget(selected),
+        }).range(token.start, token.end);
+      });
+      return Decoration.set(ranges, true);
+    }),
     EditorView.atomicRanges.of((view) => {
       const chipState = view.state.field(f, false);
       if (!chipState || chipState.tokens.length === 0) return Decoration.none;


### PR DESCRIPTION
## Summary

- `@file` mentions and `/slash` command chips were the last two chip kinds still using `Decoration.mark`, making them character-by-character editable while every other chip kind was already cursor-atomic. This migrates both to `Decoration.replace` with widgets and adds `atomicRanges`.
- A shared `chipPendingDeleteField` state field and a `Prec.highest` Backspace keymap layer the two-press delete UX across all chip kinds: first press selects the chip, second press removes it. Previously, a single Backspace could silently wipe an `@diff` or `@terminal` reference.
- A regression caught in review — `fileChip` emitting a widget on ranges already claimed by `fileDropChip` or `imageChip` — was fixed by yielding when those higher-priority decorations are present.

Resolves #6336

## Changes

- **`chipBackspace.ts`** (new) — `chipPendingDeleteField` state field + `Prec.highest` Backspace keymap shared by all chip extensions
- **`fileChip.ts`** — migrated from `Decoration.mark` to `Decoration.replace` widget; yields to `fileDropChip`/`imageChip` on overlap
- **`slashChip.ts`** — migrated to widget; preserves valid/invalid distinction inside the widget render
- **`diffChip.ts`**, **`terminalChip.ts`**, **`selectionChip.ts`**, **`imageChip.ts`**, **`fileDropChip.ts`** — wired into `chipPendingDeleteField` for the two-press behaviour
- **`base.ts`** / **`index.ts`** — exports and extension composition updated
- **`HybridInputBar.tsx`** — extension list updated

### Preserved invariants

- Doc text is unchanged — parsing (`getAllAtFileTokens`, `getAllSlashCommandTokens`) still reads the same underlying text
- Slash valid/invalid distinction carried through into the widget
- Voice transcription decorations (`useVoiceDecorations`) continue to work over chip ranges
- Pending-delete highlight uses neutral surface treatment (`bg-overlay-soft` + outline), not the accent color

## Testing

- [ ] `@file` chip: arrow keys skip over it as a single unit; first Backspace selects it (highlight visible), second deletes
- [ ] `/slash` chip (valid command): same cursor-atomic and two-press behaviour; chip renders with valid styling
- [ ] `/slash` chip (unrecognised command): renders with invalid styling; same two-press delete
- [ ] `@diff`, `@terminal`, `@selection`, image, file-drop chips: two-press Backspace behaviour unchanged from before
- [ ] File drop onto input that already has an `@file` mention on the same token: `fileDropChip` wins, no duplicate widget
- [ ] Image paste on a range overlapping a `fileChip`: `imageChip` wins
- [ ] Arrow away from a selected (pending-delete) chip without pressing Backspace: selection clears, chip stays
- [ ] Backspace with cursor in the middle of regular text: normal character delete, no chip interaction
- [ ] Multiple chips in the input bar: each deletes independently; selecting one does not affect others
- [ ] Voice transcription overlay: decorations still render correctly over chip ranges