### PR TITLE
fix(github): clear issue selection after bulk-creating worktrees

### DIFF
--- a/src/components/GitHub/BulkActionBar.tsx
+++ b/src/components/GitHub/BulkActionBar.tsx
@@ -28,9 +28,9 @@ export function BulkActionBar({
 
   const handleOpenDialog = useCallback(() => {
     if (mode === "pr") {
-      openBulkCreateDialogForPRs(selectedPRs);
+      openBulkCreateDialogForPRs(selectedPRs, onClear);
     } else {
-      openBulkCreateDialog(selectedIssues);
+      openBulkCreateDialog(selectedIssues, onClear);
     }
     onCloseDropdown?.();
   }, [
@@ -40,6 +40,7 @@ export function BulkActionBar({
     openBulkCreateDialog,
     openBulkCreateDialogForPRs,
     onCloseDropdown,
+    onClear,
   ]);
 
   return (

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1149,9 +1149,12 @@ export function BulkCreateWorktreeDialog({
   }, [isExecuting, onClose]);
 
   const handleDone = useCallback(() => {
+    // Capture before onComplete()/onClose() — both are wired to closeBulkCreateDialog
+    // upstream, which zeroes out the stored callback as part of its reset.
+    const storedOnComplete = useWorktreeSelectionStore.getState().bulkCreateDialog.onComplete;
     onComplete();
     onClose();
-    useWorktreeSelectionStore.getState().bulkCreateDialog.onComplete?.();
+    storedOnComplete?.();
   }, [onComplete, onClose]);
 
   const handleRecipeSelect = useCallback(

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1151,6 +1151,7 @@ export function BulkCreateWorktreeDialog({
   const handleDone = useCallback(() => {
     onComplete();
     onClose();
+    useWorktreeSelectionStore.getState().bulkCreateDialog.onComplete?.();
   }, [onComplete, onClose]);
 
   const handleRecipeSelect = useCallback(

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1280,8 +1280,23 @@ describe("BulkCreateWorktreeDialog", () => {
   it("invokes stored bulkCreateDialog.onComplete when Done is clicked", async () => {
     const storedOnComplete = vi.fn();
     mockBulkCreateDialog.onComplete = storedOnComplete;
+    // Simulate the real closeBulkCreateDialog behavior: prop onComplete/onClose
+    // zero out the stored callback. This catches the ordering bug where the
+    // stored callback would be read after being cleared.
+    const propOnComplete = vi.fn(() => {
+      mockBulkCreateDialog.onComplete = undefined;
+    });
+    const propOnClose = vi.fn(() => {
+      mockBulkCreateDialog.onComplete = undefined;
+    });
 
-    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+    render(
+      <BulkCreateWorktreeDialog
+        {...defaultProps}
+        onComplete={propOnComplete}
+        onClose={propOnClose}
+      />
+    );
 
     await act(async () => {
       screen.getByTestId("bulk-create-confirm-button").click();
@@ -1614,6 +1629,30 @@ describe("BulkCreateWorktreeDialog — PR mode", () => {
     expect(createCalls[0]![0].fromRemote).toBe(true);
     expect(createCalls[0]![0].baseBranch).toBe("origin/feature/pr-10");
     expect(createCalls[0]![0].newBranch).toBe("feature/pr-10");
+  });
+
+  it("invokes stored bulkCreateDialog.onComplete when Done is clicked in PR mode", async () => {
+    mockListBranches.mockResolvedValue([
+      { name: "origin/feature/pr-10", current: false, remote: true },
+      { name: "origin/feature/pr-20", current: false, remote: true },
+      { name: "origin/feature/pr-30", current: false, remote: true },
+    ]);
+    const storedOnComplete = vi.fn();
+    mockBulkCreateDialog.onComplete = storedOnComplete;
+
+    render(<BulkCreateWorktreeDialog {...prProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+    expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-done-button").click();
+    });
+
+    expect(storedOnComplete).toHaveBeenCalledTimes(1);
   });
 
   it("includes fork PRs in plan", () => {

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -126,12 +126,16 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 
 const mockSetPendingWorktree = vi.fn();
 const mockSelectWorktree = vi.fn();
+const mockBulkCreateDialog: { onComplete: (() => void) | undefined } = {
+  onComplete: undefined,
+};
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: {
     getState: () => ({
       activeWorktreeId: "source-wt",
       setPendingWorktree: mockSetPendingWorktree,
       selectWorktree: mockSelectWorktree,
+      bulkCreateDialog: mockBulkCreateDialog,
     }),
   },
 }));
@@ -262,6 +266,7 @@ beforeEach(() => {
   setupWorktreeCreateMocks();
   mockTerminals = [];
   mockSelectedRecipeId = null;
+  mockBulkCreateDialog.onComplete = undefined;
   mockAddPanel.mockResolvedValue("clone-terminal-id");
   mockAgentSettingsGet.mockResolvedValue({ agents: {} });
   mockSystemGetTmpDir.mockResolvedValue("/tmp");
@@ -1270,6 +1275,39 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
     expect(onComplete).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("invokes stored bulkCreateDialog.onComplete when Done is clicked", async () => {
+    const storedOnComplete = vi.fn();
+    mockBulkCreateDialog.onComplete = storedOnComplete;
+
+    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+    expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-done-button").click();
+    });
+
+    expect(storedOnComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke stored bulkCreateDialog.onComplete when dialog is cancelled", async () => {
+    const storedOnComplete = vi.fn();
+    mockBulkCreateDialog.onComplete = storedOnComplete;
+
+    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+
+    // Cancel from idle state via Cancel button (handleClose path)
+    await act(async () => {
+      screen.getByText("Cancel").click();
+    });
+
+    expect(storedOnComplete).not.toHaveBeenCalled();
   });
 
   it("clone layout generates command for agent panels and preserves plain terminal commands", async () => {

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -210,6 +210,68 @@ describe("worktreeStore", () => {
     expect(createDialog.initialIssue).toBeNull();
   });
 
+  it("openBulkCreateDialog stores onComplete callback", () => {
+    const onComplete = vi.fn();
+    const issue = {
+      number: 1,
+      title: "issue",
+      url: "https://github.com/org/repo/issues/1",
+      state: "OPEN" as const,
+      updatedAt: new Date().toISOString(),
+      author: { login: "u", avatarUrl: "" },
+      assignees: [],
+      commentCount: 0,
+    };
+    useWorktreeSelectionStore.getState().openBulkCreateDialog([issue], onComplete);
+
+    const { bulkCreateDialog } = useWorktreeSelectionStore.getState();
+    expect(bulkCreateDialog.isOpen).toBe(true);
+    expect(bulkCreateDialog.mode).toBe("issue");
+    expect(bulkCreateDialog.onComplete).toBe(onComplete);
+  });
+
+  it("openBulkCreateDialogForPRs stores onComplete callback", () => {
+    const onComplete = vi.fn();
+    const pr = {
+      number: 1,
+      title: "pr",
+      url: "https://github.com/org/repo/pull/1",
+      state: "OPEN" as const,
+      isDraft: false,
+      updatedAt: new Date().toISOString(),
+      author: { login: "u", avatarUrl: "" },
+      headRefName: "feature/pr",
+    };
+    useWorktreeSelectionStore.getState().openBulkCreateDialogForPRs([pr], onComplete);
+
+    const { bulkCreateDialog } = useWorktreeSelectionStore.getState();
+    expect(bulkCreateDialog.isOpen).toBe(true);
+    expect(bulkCreateDialog.mode).toBe("pr");
+    expect(bulkCreateDialog.onComplete).toBe(onComplete);
+  });
+
+  it("closeBulkCreateDialog clears stored onComplete to prevent stale retention", () => {
+    const onComplete = vi.fn();
+    useWorktreeSelectionStore.getState().openBulkCreateDialog([], onComplete);
+    useWorktreeSelectionStore.getState().closeBulkCreateDialog();
+
+    const { bulkCreateDialog } = useWorktreeSelectionStore.getState();
+    expect(bulkCreateDialog.isOpen).toBe(false);
+    expect(bulkCreateDialog.onComplete).toBeUndefined();
+  });
+
+  it("opening bulk dialog twice replaces onComplete — no stale callback carryover", () => {
+    const cbA = vi.fn();
+    const cbB = vi.fn();
+    useWorktreeSelectionStore.getState().openBulkCreateDialog([], cbA);
+    useWorktreeSelectionStore.getState().closeBulkCreateDialog();
+    useWorktreeSelectionStore.getState().openBulkCreateDialog([], cbB);
+
+    const { bulkCreateDialog } = useWorktreeSelectionStore.getState();
+    expect(bulkCreateDialog.onComplete).toBe(cbB);
+    expect(bulkCreateDialog.onComplete).not.toBe(cbA);
+  });
+
   it("openCreateDialogForPR does not throw when window is unavailable", () => {
     const originalWindow = (globalThis as { window?: Window }).window;
     // @ts-expect-error - test intentionally removes browser global

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -46,6 +46,7 @@ interface BulkCreateDialogState {
   mode: "issue" | "pr";
   selectedIssues: GitHubIssue[];
   selectedPRs: GitHubPR[];
+  onComplete?: () => void;
 }
 
 interface CrossDiffDialogState {
@@ -84,8 +85,8 @@ interface WorktreeSelectionState {
   ) => void;
   openCreateDialogForPR: (pr: GitHubPR) => void;
   closeCreateDialog: () => void;
-  openBulkCreateDialog: (selectedIssues: GitHubIssue[]) => void;
-  openBulkCreateDialogForPRs: (selectedPRs: GitHubPR[]) => void;
+  openBulkCreateDialog: (selectedIssues: GitHubIssue[], onComplete?: () => void) => void;
+  openBulkCreateDialogForPRs: (selectedPRs: GitHubPR[], onComplete?: () => void) => void;
   closeBulkCreateDialog: () => void;
   openQuickCreate: (context?: { issue?: GitHubIssue | null; pr?: GitHubPR | null }) => void;
   closeQuickCreate: () => void;
@@ -262,7 +263,13 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     initialRecipeId: null,
     onCreated: undefined,
   },
-  bulkCreateDialog: { isOpen: false, mode: "issue", selectedIssues: [], selectedPRs: [] },
+  bulkCreateDialog: {
+    isOpen: false,
+    mode: "issue",
+    selectedIssues: [],
+    selectedPRs: [],
+    onComplete: undefined,
+  },
   quickCreate: { isOpen: false, issue: null, pr: null },
   crossDiffDialog: { isOpen: false, initialWorktreeId: null },
   _policyGeneration: 0,
@@ -482,22 +489,40 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       },
     }),
 
-  openBulkCreateDialog: (selectedIssues) => {
+  openBulkCreateDialog: (selectedIssues, onComplete) => {
     if (useFocusStore.getState().isFocusMode && typeof window !== "undefined") {
       window.dispatchEvent(new Event("daintree:toggle-focus-mode"));
     }
-    set({ bulkCreateDialog: { isOpen: true, mode: "issue", selectedIssues, selectedPRs: [] } });
+    set({
+      bulkCreateDialog: {
+        isOpen: true,
+        mode: "issue",
+        selectedIssues,
+        selectedPRs: [],
+        onComplete,
+      },
+    });
   },
 
-  openBulkCreateDialogForPRs: (selectedPRs) => {
+  openBulkCreateDialogForPRs: (selectedPRs, onComplete) => {
     if (useFocusStore.getState().isFocusMode && typeof window !== "undefined") {
       window.dispatchEvent(new Event("daintree:toggle-focus-mode"));
     }
-    set({ bulkCreateDialog: { isOpen: true, mode: "pr", selectedIssues: [], selectedPRs } });
+    set({
+      bulkCreateDialog: {
+        isOpen: true,
+        mode: "pr",
+        selectedIssues: [],
+        selectedPRs,
+        onComplete,
+      },
+    });
   },
 
   closeBulkCreateDialog: () =>
-    set((s) => ({ bulkCreateDialog: { ...s.bulkCreateDialog, isOpen: false } })),
+    set((s) => ({
+      bulkCreateDialog: { ...s.bulkCreateDialog, isOpen: false, onComplete: undefined },
+    })),
 
   openQuickCreate: (context) => {
     if (useFocusStore.getState().isFocusMode && typeof window !== "undefined") {
@@ -647,7 +672,13 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
         initialRecipeId: null,
         onCreated: undefined,
       },
-      bulkCreateDialog: { isOpen: false, mode: "issue", selectedIssues: [], selectedPRs: [] },
+      bulkCreateDialog: {
+        isOpen: false,
+        mode: "issue",
+        selectedIssues: [],
+        selectedPRs: [],
+        onComplete: undefined,
+      },
       quickCreate: { isOpen: false, issue: null, pr: null },
       crossDiffDialog: { isOpen: false, initialWorktreeId: null },
       lastFocusedTerminalByWorktree: new Map<string, string>(),


### PR DESCRIPTION
## Summary

- When bulk-creating worktrees from the GitHub Issues dropdown, the issue selection wasn't cleared on completion — reopening the dropdown showed everything still ticked.
- Extended `BulkCreateDialogState` with an optional `onComplete` callback; `BulkActionBar` passes `selection.clear` when opening the dialog, and `handleDone` captures the stored callback before close props clear it, then invokes it.
- `closeBulkCreateDialog` clears the stored callback to prevent stale retention.

Resolves #6376

## Changes

- `src/store/worktreeStore.ts` — added `onComplete` to `BulkCreateDialogState`, `closeBulkCreateDialog` clears it
- `src/components/GitHub/BulkActionBar.tsx` — passes `onClear` as `onComplete` when opening the dialog
- `src/components/GitHub/BulkCreateWorktreeDialog.tsx` — captures stored callback before close props fire, then calls it in `handleDone`

## Testing

- Unit tests added for the success Done path (with close-props-clearing simulation), Cancel path, PR-mode parity, and store lifecycle
- Existing tests unaffected