### PR TITLE
fix(agent-state): long-running agents flip to waiting mid-thought (#6365)

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -346,11 +346,21 @@ export class ActivityMonitor {
       return;
     }
 
+    // Filter idle-only protocol sequences (DECSET toggles, OSC metadata, CPR
+    // responses, DSR queries, bracketed-paste markers) before byte-volume gates
+    // see them — these carry no work-progress information and would otherwise
+    // spuriously escalate idle→busy at low minBytes thresholds. Computed up
+    // front because the debounce-reset path also gates on it: pure protocol
+    // noise must not keep a busy monitor alive forever.
+    const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
+
     // Spinner frames and other cosmetic redraws ARE evidence the agent is alive —
     // long-running model thinking can emit only spinner ticks for tens of seconds.
     // Reset the debounce timer before short-circuiting on cosmetic redraws so
-    // already-busy agents don't flip to idle mid-thought (issue #6365).
-    if (this.state === "busy") {
+    // already-busy agents don't flip to idle mid-thought (issue #6365). Pure
+    // idle-protocol noise (filteredLength === 0 and not a spinner frame) is
+    // NOT liveness evidence and is excluded from this guard.
+    if (this.state === "busy" && (isCosmeticRedraw || filteredLength > 0)) {
       this.resetDebounceTimer();
     }
 
@@ -377,12 +387,6 @@ export class ActivityMonitor {
     if (this.isResizeSuppressed(now)) {
       return;
     }
-
-    // Filter idle-only protocol sequences (DECSET toggles, OSC metadata, CPR
-    // responses, DSR queries, bracketed-paste markers) before byte-volume gates
-    // see them — these carry no work-progress information and would otherwise
-    // spuriously escalate idle→busy at low minBytes thresholds.
-    const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
 
     if (filteredLength === 0) {
       return;

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -10,6 +10,7 @@ import { OutputVolumeDetector } from "./pty/OutputVolumeDetector.js";
 import { HighOutputDetector } from "./pty/HighOutputDetector.js";
 import { WorkingSignalDebouncer } from "./pty/WorkingSignalDebouncer.js";
 import { LineRewriteDetector, isStatusLineRewrite } from "./pty/LineRewriteDetector.js";
+import { stripIdleTerminalSequences } from "./pty/IdleSequenceFilter.js";
 import {
   detectPrompt,
   detectPromptLexeme,
@@ -345,12 +346,16 @@ export class ActivityMonitor {
       return;
     }
 
-    if (isCosmeticRedraw) {
-      return;
-    }
-
+    // Spinner frames and other cosmetic redraws ARE evidence the agent is alive —
+    // long-running model thinking can emit only spinner ticks for tens of seconds.
+    // Reset the debounce timer before short-circuiting on cosmetic redraws so
+    // already-busy agents don't flip to idle mid-thought (issue #6365).
     if (this.state === "busy") {
       this.resetDebounceTimer();
+    }
+
+    if (isCosmeticRedraw) {
+      return;
     }
 
     // Update pattern buffer and check for working patterns (non-polling terminals only)
@@ -369,14 +374,22 @@ export class ActivityMonitor {
       }
     }
 
-    const dataLength = Buffer.byteLength(data, "utf8");
-
     if (this.isResizeSuppressed(now)) {
       return;
     }
 
+    // Filter idle-only protocol sequences (DECSET toggles, OSC metadata, CPR
+    // responses, DSR queries, bracketed-paste markers) before byte-volume gates
+    // see them — these carry no work-progress information and would otherwise
+    // spuriously escalate idle→busy at low minBytes thresholds.
+    const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
+
+    if (filteredLength === 0) {
+      return;
+    }
+
     // Track high output activity
-    this.highOutputDetector.update(dataLength, now);
+    this.highOutputDetector.update(filteredLength, now);
 
     // High output recovery
     if (this.state === "idle" && this.highOutputDetector.shouldTriggerRecovery(now)) {
@@ -389,7 +402,7 @@ export class ActivityMonitor {
       return;
     }
 
-    if (this.outputVolumeDetector.update(dataLength, now)) {
+    if (this.outputVolumeDetector.update(filteredLength, now)) {
       this.becomeBusyFromOutput(now);
     }
   }

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -361,7 +361,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should transition to idle when only spinner-style cosmetic redraws are present (Issue #3189)", () => {
+    it("should transition to idle once spinner stream stops and debounce expires (#3189 / #6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 200,
@@ -371,13 +371,17 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("busy");
       onStateChange.mockClear();
 
+      // Spinner ticks reset the debounce timer (#6365), so the agent stays busy
+      // throughout the stream.
       for (let i = 0; i < 5; i++) {
         monitor.onData("\r⠋ Working (esc to interrupt)");
         vi.advanceTimersByTime(100);
       }
+      expect(monitor.getState()).toBe("busy");
 
-      // Advance past debounce window — spinner redraws should NOT have reset it
-      vi.advanceTimersByTime(200);
+      // Stream stops — last reset was at the final tick. After debounce(200ms)
+      // expires with no further data, state goes idle.
+      vi.advanceTimersByTime(300);
 
       expect(monitor.getState()).toBe("idle");
 
@@ -385,8 +389,14 @@ describe("ActivityMonitor", () => {
     });
   });
 
-  describe("Cosmetic redraw filtering (Issue #3189)", () => {
-    it("should not reset debounce for Braille spinner redraws", () => {
+  describe("Cosmetic redraw filtering (Issue #3189 / #6365)", () => {
+    // #3189 introduced cosmetic-redraw classification so spinner-only output
+    // wouldn't escalate idle→busy on its own (becomeBusy gate). #6365 corrected
+    // the over-broad consequence: spinner ticks ARE liveness evidence and must
+    // reset the debounce timer when the agent is already busy. Tests below
+    // exercise both contracts.
+
+    it("should keep busy state alive across a Braille spinner stream (#6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 300,
@@ -396,19 +406,19 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("busy");
       onStateChange.mockClear();
 
-      // Send Braille spinner frames — these should be filtered as cosmetic
+      // Spinner ticks every 100ms across 1s — well past the 300ms debounce.
+      // Each tick must reset the debounce so state stays busy mid-thought.
       for (let i = 0; i < 10; i++) {
         monitor.onData("\r⠙ Working (esc to interrupt)");
         vi.advanceTimersByTime(100);
       }
 
-      // Debounce should have fired (300ms window, not reset by spinners)
-      expect(monitor.getState()).toBe("idle");
+      expect(monitor.getState()).toBe("busy");
 
       monitor.dispose();
     });
 
-    it("should not reset debounce for Ink cursor-up redraws", () => {
+    it("should keep busy state alive across Ink cursor-up redraws (#6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 300,
@@ -418,14 +428,13 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("busy");
       onStateChange.mockClear();
 
-      // Send Ink-style cursor-up redraw frames (Claude Code / Gemini CLI)
+      // Ink-style cursor-up + erase-line + spinner (Claude Code / Gemini CLI)
       for (let i = 0; i < 10; i++) {
         monitor.onData("\x1b[1A\x1b[2K✽ Deliberating… (esc to interrupt)");
         vi.advanceTimersByTime(100);
       }
 
-      // Debounce should have fired
-      expect(monitor.getState()).toBe("idle");
+      expect(monitor.getState()).toBe("busy");
 
       monitor.dispose();
     });
@@ -453,7 +462,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should filter Gemini CLI tool-use status lines", () => {
+    it("should keep busy state alive across Gemini CLI tool-use status lines (#6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 300,
@@ -468,7 +477,53 @@ describe("ActivityMonitor", () => {
         vi.advanceTimersByTime(100);
       }
 
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("should go idle once spinner stream stops and debounce expires (#6365)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+      });
+
+      monitor.onInput("run\r");
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      // Spinner ticks for 1s — state stays busy
+      for (let i = 0; i < 10; i++) {
+        monitor.onData("\r⠙ Working (esc to interrupt)");
+        vi.advanceTimersByTime(100);
+      }
+      expect(monitor.getState()).toBe("busy");
+
+      // Stream stops — last reset was at the final tick, debounce(300ms) fires
+      vi.advanceTimersByTime(400);
       expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("should not escalate idle→busy from spinner-only output (#3189)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+      });
+
+      // Monitor starts idle. Spinner output alone must NOT escalate to busy —
+      // spinner is liveness evidence only when already in a busy cycle.
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      for (let i = 0; i < 10; i++) {
+        monitor.onData("\r⠙ Working (esc to interrupt)");
+        vi.advanceTimersByTime(100);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
 
       monitor.dispose();
     });
@@ -499,6 +554,34 @@ describe("ActivityMonitor", () => {
       // After full debounce window with no more output, should go idle
       vi.advanceTimersByTime(300);
       expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("should not escalate idle→busy from idle-noise sequences with low minBytes (#6365)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+        outputActivityDetection: {
+          enabled: true,
+          windowMs: 1000,
+          minFrames: 2,
+          minBytes: 1,
+        },
+      });
+
+      // Monitor is idle. A stream of pure DECSET/OSC/CPR noise must not
+      // trigger volume-based idle→busy escalation now that minBytes is 1.
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      for (let i = 0; i < 20; i++) {
+        monitor.onData("\x1b[?25h\x1b]133;A\x07\x1b[24;80R\x1b[?25l");
+        vi.advanceTimersByTime(50);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
 
       monitor.dispose();
     });

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -585,6 +585,86 @@ describe("ActivityMonitor", () => {
 
       monitor.dispose();
     });
+
+    it("should NOT keep busy alive forever from pure protocol noise (#6365)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+      });
+
+      monitor.onInput("run\r");
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      // After agent completion the shell may emit OSC 133 / DECSET noise on
+      // prompt redisplay. These bytes are NOT classified as cosmetic redraw
+      // (no \r + spinner pattern), so the older fix would have hit the broad
+      // `state === "busy"` debounce reset and held busy until MAX_WORKING_SILENCE_MS.
+      for (let i = 0; i < 30; i++) {
+        monitor.onData("\x1b[?25h\x1b]133;A\x07\x1b[24;80R\x1b[?25l");
+        vi.advanceTimersByTime(50);
+      }
+
+      // Total elapsed: 1500ms — well past 300ms debounce. Pure protocol noise
+      // must not have reset the timer. State must transition to idle.
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+
+    it("should not escalate idle→busy from OSC 2 window-title bursts (#6365)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+        outputActivityDetection: {
+          enabled: true,
+          windowMs: 1000,
+          minFrames: 2,
+          minBytes: 1,
+        },
+      });
+
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Some agents/shells set the window title via OSC 2 every prompt redraw.
+      // These must be filtered as idle-noise, not counted toward volume gates.
+      for (let i = 0; i < 10; i++) {
+        monitor.onData("\x1b]2;Claude — Working\x07");
+        vi.advanceTimersByTime(100);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("should not escalate idle→busy from a single noise frame at minBytes:1 (#6365)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
+        idleDebounceMs: 300,
+        outputActivityDetection: {
+          enabled: true,
+          windowMs: 1000,
+          minFrames: 2,
+          minBytes: 1,
+        },
+      });
+
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // A single chunk that gets past the filter (e.g. an OSC variant we
+      // don't recognize) must not escalate idle→busy on its own — minFrames
+      // is the per-chunk guard once minBytes is lowered to 1.
+      monitor.onData("\x1b]999;some-experimental-payload\x07");
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
   });
 
   describe("notifySubmission (hybrid input bar)", () => {

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -1,0 +1,32 @@
+// Strip deterministic "idle-only" terminal control sequences from a PTY chunk
+// before byte-volume activity gates see it. Targets sequences that agents emit
+// every frame regardless of work progress — DECSET toggles, OSC metadata, CPR
+// responses, DSR queries, and bracketed-paste markers — so OutputVolumeDetector
+// and HighOutputDetector don't escalate idle→busy on pure protocol noise once
+// minBytes is lowered. Spinner frames (\r + status-line text) are NOT stripped
+// here; cosmetic-redraw classification handles those separately and they remain
+// valid liveness evidence for the debounce path.
+//
+// All quantifiers are bounded so the patterns are safe against ReDoS even with
+// a malicious PTY peer. The OSC negation class [^\x07\x1b]{0,512} avoids the
+// catastrophic backtracking risk of .{0,N} when the terminator is missing.
+
+// eslint-disable-next-line no-control-regex
+const DECSET_NOISE = /\x1b\[\?(?:25|1004|2004|2026|1049)[hl]/gu;
+// eslint-disable-next-line no-control-regex
+const OSC_NOISE = /\x1b\](?:[07-9]|133|633)[;:][^\x07\x1b]{0,512}(?:\x07|\x1b\\)/gu;
+// eslint-disable-next-line no-control-regex
+const CPR_NOISE = /\x1b\[\d{1,4};\d{1,4}R/gu;
+// eslint-disable-next-line no-control-regex
+const DSR_NOISE = /\x1b\[6n/gu;
+// eslint-disable-next-line no-control-regex
+const BPASTE_NOISE = /\x1b\[20[01]~/gu;
+
+export function stripIdleTerminalSequences(data: string): string {
+  return data
+    .replace(OSC_NOISE, "")
+    .replace(DECSET_NOISE, "")
+    .replace(CPR_NOISE, "")
+    .replace(DSR_NOISE, "")
+    .replace(BPASTE_NOISE, "");
+}

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -10,11 +10,16 @@
 // All quantifiers are bounded so the patterns are safe against ReDoS even with
 // a malicious PTY peer. The OSC negation class [^\x07\x1b]{0,512} avoids the
 // catastrophic backtracking risk of .{0,N} when the terminator is missing.
+//
+// The filter is intentionally stateless — escape sequences split across PTY
+// chunk boundaries (rare in practice, since node-pty reads at OS boundaries
+// and most idle-noise sequences are short) are not stripped. OutputVolumeDetector's
+// minFrames gate is the secondary defense for those cases.
 
 // eslint-disable-next-line no-control-regex
 const DECSET_NOISE = /\x1b\[\?(?:25|1004|2004|2026|1049)[hl]/gu;
 // eslint-disable-next-line no-control-regex
-const OSC_NOISE = /\x1b\](?:[07-9]|133|633)[;:][^\x07\x1b]{0,512}(?:\x07|\x1b\\)/gu;
+const OSC_NOISE = /\x1b\](?:[0-9]|133|633)[;:][^\x07\x1b]{0,512}(?:\x07|\x1b\\)/gu;
 // eslint-disable-next-line no-control-regex
 const CPR_NOISE = /\x1b\[\d{1,4};\d{1,4}R/gu;
 // eslint-disable-next-line no-control-regex

--- a/electron/services/pty/OutputVolumeDetector.ts
+++ b/electron/services/pty/OutputVolumeDetector.ts
@@ -37,10 +37,12 @@ export class OutputVolumeDetector {
       this.bytesInWindow += dataLength;
     }
 
-    if (
-      (this.framesInWindow >= this.minFrames && this.bytesInWindow >= this.minBytes) ||
-      this.bytesInWindow >= this.minBytes
-    ) {
+    // Require BOTH frames AND bytes — minFrames is the noise gate that prevents
+    // a single unfiltered control sequence (e.g. an OSC variant we missed, or an
+    // escape split across PTY chunks) from triggering escalation. With
+    // minBytes lowered to 1 (#6365), this gate is the primary defense against
+    // false-positive idle→busy escalation from protocol noise.
+    if (this.framesInWindow >= this.minFrames && this.bytesInWindow >= this.minBytes) {
       this.resetWindow();
       return true;
     }

--- a/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
+++ b/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { stripIdleTerminalSequences } from "../IdleSequenceFilter.js";
+
+describe("stripIdleTerminalSequences", () => {
+  it("returns plain text unchanged", () => {
+    expect(stripIdleTerminalSequences("hello world")).toBe("hello world");
+  });
+
+  it("strips DECSET cursor hide/show", () => {
+    expect(stripIdleTerminalSequences("\x1b[?25l\x1b[?25h")).toBe("");
+  });
+
+  it("strips DECSET focus event toggles", () => {
+    expect(stripIdleTerminalSequences("\x1b[?1004h\x1b[?1004l")).toBe("");
+  });
+
+  it("strips DECSET bracketed-paste mode toggles", () => {
+    expect(stripIdleTerminalSequences("\x1b[?2004h\x1b[?2004l")).toBe("");
+  });
+
+  it("strips DECSET sync-update toggles", () => {
+    expect(stripIdleTerminalSequences("\x1b[?2026h\x1b[?2026l")).toBe("");
+  });
+
+  it("strips DECSET alt-screen toggles", () => {
+    expect(stripIdleTerminalSequences("\x1b[?1049h\x1b[?1049l")).toBe("");
+  });
+
+  it("strips OSC 0 set-window-title", () => {
+    expect(stripIdleTerminalSequences("\x1b]0;Window Title\x07")).toBe("");
+  });
+
+  it("strips OSC 7 set-cwd", () => {
+    expect(stripIdleTerminalSequences("\x1b]7;file:///tmp\x07")).toBe("");
+  });
+
+  it("strips OSC 8 hyperlink", () => {
+    expect(stripIdleTerminalSequences("\x1b]8;;https://example.com\x07")).toBe("");
+  });
+
+  it("strips OSC 9 taskbar progress", () => {
+    expect(stripIdleTerminalSequences("\x1b]9;4;1;50\x07")).toBe("");
+  });
+
+  it("strips OSC 133 shell integration", () => {
+    expect(stripIdleTerminalSequences("\x1b]133;A\x07\x1b]133;B\x07")).toBe("");
+  });
+
+  it("strips OSC 633 VS Code shell integration", () => {
+    expect(stripIdleTerminalSequences("\x1b]633;P;Cwd=/foo\x07")).toBe("");
+  });
+
+  it("strips OSC terminated by ST (ESC \\)", () => {
+    expect(stripIdleTerminalSequences("\x1b]0;Title\x1b\\")).toBe("");
+  });
+
+  it("strips CPR cursor-position responses", () => {
+    expect(stripIdleTerminalSequences("\x1b[24;80R")).toBe("");
+    expect(stripIdleTerminalSequences("\x1b[1;1R")).toBe("");
+  });
+
+  it("strips DSR cursor-position queries", () => {
+    expect(stripIdleTerminalSequences("\x1b[6n")).toBe("");
+  });
+
+  it("strips bracketed-paste markers", () => {
+    expect(stripIdleTerminalSequences("\x1b[200~\x1b[201~")).toBe("");
+  });
+
+  it("preserves spinner frames (CR + braille + text)", () => {
+    expect(stripIdleTerminalSequences("\r⠋ Thinking…")).toBe("\r⠋ Thinking…");
+  });
+
+  it("preserves erase-line sequences (cosmetic, not idle-noise)", () => {
+    expect(stripIdleTerminalSequences("\x1b[2K\r⠋")).toBe("\x1b[2K\r⠋");
+  });
+
+  it("preserves SGR color sequences", () => {
+    expect(stripIdleTerminalSequences("\x1b[31mred\x1b[0m")).toBe("\x1b[31mred\x1b[0m");
+  });
+
+  it("strips noise but keeps wrapped content", () => {
+    const input = "\x1b[?25l\rThinking…\x1b[?25h";
+    expect(stripIdleTerminalSequences(input)).toBe("\rThinking…");
+  });
+
+  it("strips OSC payloads up to 512 chars", () => {
+    const payload = "x".repeat(512);
+    expect(stripIdleTerminalSequences(`\x1b]7;${payload}\x07`)).toBe("");
+  });
+
+  it("does not hang on unterminated OSC sequence", () => {
+    const start = performance.now();
+    const input = `\x1b]7;${"x".repeat(2000)}`;
+    const out = stripIdleTerminalSequences(input);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(50);
+    expect(out).toBe(input);
+  });
+
+  it("does not hang on OSC payload exceeding 512 chars", () => {
+    const start = performance.now();
+    const payload = "x".repeat(2000);
+    const input = `\x1b]7;${payload}\x07`;
+    const out = stripIdleTerminalSequences(input);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(50);
+    expect(out).toBe(input);
+  });
+
+  it("strips multiple noise types interleaved with content", () => {
+    const input = "\x1b[?25l\x1b]133;A\x07hello\x1b[24;80R world\x1b[?25h";
+    expect(stripIdleTerminalSequences(input)).toBe("hello world");
+  });
+
+  it("does not strip 4-digit CPR-shaped numbers in plain text", () => {
+    expect(stripIdleTerminalSequences("price: $1234")).toBe("price: $1234");
+  });
+});

--- a/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
+++ b/electron/services/pty/__tests__/IdleSequenceFilter.test.ts
@@ -30,6 +30,14 @@ describe("stripIdleTerminalSequences", () => {
     expect(stripIdleTerminalSequences("\x1b]0;Window Title\x07")).toBe("");
   });
 
+  it("strips OSC 1 set-icon-name", () => {
+    expect(stripIdleTerminalSequences("\x1b]1;Icon\x07")).toBe("");
+  });
+
+  it("strips OSC 2 set-window-title-only", () => {
+    expect(stripIdleTerminalSequences("\x1b]2;Claude — Working\x07")).toBe("");
+  });
+
   it("strips OSC 7 set-cwd", () => {
     expect(stripIdleTerminalSequences("\x1b]7;file:///tmp\x07")).toBe("");
   });

--- a/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
+++ b/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
@@ -24,14 +24,43 @@ describe("OutputVolumeDetector", () => {
       expect(detector.update(100, 1050)).toBe(false);
     });
 
-    it("triggers when byte threshold met", () => {
-      expect(detector.update(3000, 1000)).toBe(true);
+    it("does not trigger on a single big burst (minFrames not met)", () => {
+      // minFrames is a noise gate — a single chunk, no matter how large, must
+      // pair with at least one follow-up frame before escalation fires.
+      expect(detector.update(3000, 1000)).toBe(false);
     });
 
     it("triggers when both frame and byte thresholds met", () => {
       detector.update(700, 1000);
       detector.update(700, 1050);
       expect(detector.update(700, 1100)).toBe(true);
+    });
+
+    it("does not trigger when frame threshold met but byte threshold missed", () => {
+      expect(detector.update(10, 1000)).toBe(false);
+      expect(detector.update(10, 1050)).toBe(false);
+      expect(detector.update(10, 1100)).toBe(false);
+    });
+
+    it("does not trigger on a single byte even at minBytes:1 (split-sequence guard)", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        windowMs: 500,
+        minFrames: 2,
+        minBytes: 1,
+      });
+      expect(d.update(1, 1000)).toBe(false);
+    });
+
+    it("triggers on second byte after first at minBytes:1", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        windowMs: 500,
+        minFrames: 2,
+        minBytes: 1,
+      });
+      d.update(1, 1000);
+      expect(d.update(1, 1050)).toBe(true);
     });
 
     it("resets window after expiry", () => {

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -220,7 +220,7 @@ describe("buildActivityMonitorOptions", () => {
       enabled: true,
       windowMs: 1000,
       minFrames: 2,
-      minBytes: 32,
+      minBytes: 1,
     });
     expect(result.patternConfig).toBeDefined();
     expect(result.bootCompletePatterns).toBeDefined();

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -185,7 +185,7 @@ export function buildActivityMonitorOptions(
     enabled: true,
     windowMs: 1000,
     minFrames: 2,
-    minBytes: 32,
+    minBytes: 1,
   };
 
   const getVisibleLines = effectiveAgentId ? deps.getVisibleLines : undefined;


### PR DESCRIPTION
## Summary

- Long-running agent terminals were flipping to the *waiting* state mid-thought because `ActivityMonitor.onData` short-circuited on cosmetic redraws, letting the idle debounce count down uninterrupted while a spinner was still ticking
- Fixes this with a new stateless `IdleSequenceFilter` that strips known noise (DECSET, OSC 0–9/133/633, CPR/DSR, bracketed-paste, sync-update wrappers) *before* byte counting — so spinner output clears the filter and correctly resets the debounce
- Defense-in-depth: `OutputVolumeDetector` now requires both `minFrames` AND `minBytes` (was OR-collapsed to bytes-only), and `minBytes` drops from 32 to 1 so any post-strip byte counts

Resolves #6365

## Changes

- `electron/services/pty/IdleSequenceFilter.ts` (new) — stateless, ReDoS-safe sequence stripper; bounded character classes only, no `.*`
- `electron/services/ActivityMonitor.ts` — `onData` control flow restructured: filter idle noise upfront, gate debounce reset on `isCosmeticRedraw OR filteredLength > 0`, route filtered byte count to volume detectors
- `electron/services/pty/OutputVolumeDetector.ts` — AND-gate on `minFrames` + `minBytes`
- `electron/services/pty/terminalActivityPatterns.ts` — `minBytes` 32 → 1

## Testing

269 tests across 6 files — new `IdleSequenceFilter` suite (26 cases including bounded-time ReDoS check), updated `OutputVolumeDetector` suite for the AND-requirement, updated `ActivityMonitor` suite with cosmetic redraw filtering scenarios, and updated `terminalActivityPatterns` assertion. Typecheck, lint, and build all pass.