### PR TITLE
refactor(activity-monitor): drop CPU and process-tree from busy/idle classification

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -24,7 +24,6 @@ import type { WaitingReason } from "../../shared/types/agent.js";
 
 export interface ProcessStateValidator {
   hasActiveChildren(): boolean;
-  getDescendantsCpuUsage(): number;
 }
 
 export interface PatternDetector {
@@ -74,7 +73,6 @@ export interface ActivityMonitorOptions {
   workingRecoveryDelayMs?: number;
   pollingMaxBootMs?: number;
   maxWorkingSilenceMs?: number;
-  maxCpuHighEscapeMs?: number;
   maxWaitingSilenceMs?: number;
   onWaitingTimeout?: (id: string, spawnedAt: number) => void;
 }
@@ -102,11 +100,6 @@ export class ActivityMonitor {
   private readonly WORKING_INDICATOR_TTL_MS = 5000;
   private readonly MAX_WORKING_SILENCE_MS: number;
   private readonly MAX_WAITING_SILENCE_MS: number;
-  private readonly MAX_CPU_HIGH_ESCAPE_MS: number;
-  private readonly CPU_HIGH_THRESHOLD = 10;
-  private readonly CPU_LOW_THRESHOLD = 3;
-  private isCpuHigh = false;
-  private cpuHighSince = 0;
   private idleSince = 0;
   private waitingWatchdogFired = false;
   private lastPatternResultAt = 0;
@@ -132,8 +125,6 @@ export class ActivityMonitor {
   private lastOutputActivityAt = 0;
   private lastWorkingIndicatorTimestamp = 0;
   private promptStableSince = 0;
-  private readonly SLEEP_DETECTION_THRESHOLD_MS = 5000;
-  private pendingStateRevalidation = false;
 
   // Pattern-based detection
   private patternDetector?: AgentPatternDetector;
@@ -172,7 +163,6 @@ export class ActivityMonitor {
     this.PROMPT_FAST_PATH_MIN_QUIET_MS = options?.promptFastPathMinQuietMs ?? 3000;
     this.POLLING_MAX_BOOT_MS = options?.pollingMaxBootMs ?? 15000;
     this.MAX_WORKING_SILENCE_MS = options?.maxWorkingSilenceMs ?? 180000;
-    this.MAX_CPU_HIGH_ESCAPE_MS = options?.maxCpuHighEscapeMs ?? 60000;
     this.MAX_WAITING_SILENCE_MS = options?.maxWaitingSilenceMs ?? 600000;
 
     this.idleSince = Date.now();
@@ -266,11 +256,6 @@ export class ActivityMonitor {
   onData(data?: string): void {
     if (this.isDisposed) return;
     const now = Date.now();
-    const timeSinceLastData = now - this.lastDataTimestamp;
-
-    if (timeSinceLastData > this.SLEEP_DETECTION_THRESHOLD_MS) {
-      this.pendingStateRevalidation = true;
-    }
 
     this.lastDataTimestamp = now;
 
@@ -279,11 +264,6 @@ export class ActivityMonitor {
 
     if (data && !isLikelyUserEcho && !isCosmeticRedraw) {
       this.lastActivityTimestamp = now;
-    }
-
-    if (this.pendingStateRevalidation && this.state === "busy") {
-      this.pendingStateRevalidation = false;
-      this.revalidateStateAfterWake();
     }
 
     if (data && !isLikelyUserEcho && isCosmeticRedraw) {
@@ -433,8 +413,6 @@ export class ActivityMonitor {
     this.resizeSuppressUntil = 0;
     this.lastPatternResult = undefined;
     this.lastPatternResultAt = 0;
-    this.isCpuHigh = false;
-    this.cpuHighSince = 0;
     this.workingHoldUntil = 0;
     this.lastDataTimestamp = 0;
     this.lastOutputActivityAt = 0;
@@ -455,9 +433,9 @@ export class ActivityMonitor {
     // Old buffer contents and TTL-gated pattern results belong to the previous
     // detector — leaving any of them would let stale matches hold working state
     // through the debounce callback's WORKING_INDICATOR_TTL_MS window. Timing
-    // fields (lastActivityTimestamp, promptStableSince, CPU hysteresis,
-    // workingHoldUntil, debounceTimer) are preserved so busy/idle classification
-    // stays coherent across the swap.
+    // fields (lastActivityTimestamp, promptStableSince, workingHoldUntil,
+    // debounceTimer) are preserved so busy/idle classification stays coherent
+    // across the swap.
     this.patternBuf.reset();
     this.lastPatternResult = undefined;
     this.lastPatternResultAt = 0;
@@ -566,9 +544,6 @@ export class ActivityMonitor {
         return; // Still booting, stay busy
       }
     }
-
-    // Update CPU hysteresis state once per polling cycle
-    this.updateCpuHighState(now);
 
     // Safety timeout: if no PTY output for MAX_WORKING_SILENCE_MS, force idle
     if (this.isWorkingSilenceTimeout(now)) {
@@ -713,7 +688,6 @@ export class ActivityMonitor {
       shouldPreferPrompt &&
       quietForMs >= this.PROMPT_FAST_PATH_MIN_QUIET_MS &&
       now >= this.workingHoldUntil &&
-      !this.isCpuHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
@@ -742,7 +716,6 @@ export class ActivityMonitor {
       !hasHighOutputActivity &&
       quietForMs >= LEXEME_STALL_MIN_QUIET_MS &&
       now >= this.workingHoldUntil &&
-      !this.isCpuHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       const candidateLine =
@@ -770,7 +743,6 @@ export class ActivityMonitor {
       isQuietForIdle &&
       now >= this.workingHoldUntil &&
       !hasHighOutputActivity &&
-      !this.isCpuHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
@@ -844,40 +816,6 @@ export class ActivityMonitor {
     this.becomeBusy({ trigger: "pattern", patternConfidence: confidence }, now);
   }
 
-  private revalidateStateAfterWake(): void {
-    const actuallyBusy = this.hasActiveChildrenSafe();
-    if (actuallyBusy === null) {
-      return;
-    }
-    if (!actuallyBusy && this.state === "busy") {
-      let waitingReason: WaitingReason | undefined;
-      if (this.getVisibleLines) {
-        const lines = this.getVisibleLines(
-          Math.max(this.promptDetectorConfig.promptScanLineCount, 15)
-        );
-        const cursorLine = this.getCursorLine?.() ?? null;
-        const promptResult = detectPrompt(lines, this.promptDetectorConfig, cursorLine, {
-          allowHistoryScan: true,
-        });
-        if (!promptResult.isPrompt) {
-          return;
-        }
-        waitingReason = classifyWaitingReason(lines, promptResult.isPrompt);
-      }
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-        this.debounceTimer = null;
-      }
-      this.state = "idle";
-      this.idleSince = Date.now();
-      this.patternBuf.clear();
-      this.onStateChange(this.terminalId, this.spawnedAt, "idle", {
-        trigger: "timeout",
-        waitingReason,
-      });
-    }
-  }
-
   private becomeBusy(metadata: ActivityStateMetadata, now: number = Date.now()): void {
     if (this.isDisposed) return;
     this.inputTracker.clearPendingInput();
@@ -905,11 +843,6 @@ export class ActivityMonitor {
       this.inputTracker.pendingInputUntil === 0 &&
       this.inputTracker.isRecentUserInput(now)
     ) {
-      return;
-    }
-
-    const actuallyBusy = this.hasActiveChildrenSafe();
-    if (actuallyBusy === false) {
       return;
     }
 
@@ -945,30 +878,7 @@ export class ActivityMonitor {
         return;
       }
 
-      // Check process liveness first — if the terminal is dead, don't reschedule
-      // based on stale pattern state
-      const actuallyBusy = this.hasActiveChildrenSafe();
-      if (actuallyBusy === false) {
-        this.state = "idle";
-        this.idleSince = Date.now();
-        this.patternBuf.clear();
-        this.onStateChange(this.terminalId, this.spawnedAt, "idle");
-        this.debounceTimer = null;
-        return;
-      }
-
-      if (actuallyBusy) {
-        this.resetDebounceTimer();
-        return;
-      }
-
-      // actuallyBusy === null (no validator) — fall through to pattern/TTL checks
-      // CPU high prevents idle transition even without a definitive hasActiveChildren answer
       const now = Date.now();
-      if (this.isCpuHighAndNotDeadlined(now)) {
-        this.resetDebounceTimer();
-        return;
-      }
 
       // Stale pattern results are expired via the same TTL as working indicators
       if (
@@ -1005,8 +915,6 @@ export class ActivityMonitor {
     if (now - this.lastDataTimestamp < this.MAX_WORKING_SILENCE_MS) return false;
     // Non-polling terminals have no boot phase; polling terminals must exit boot first
     if (this.getVisibleLines && !this.bootDetector.hasExitedBootState) return false;
-    // High CPU prevents premature silence timeout — but only up to the escape deadline
-    if (this.isCpuHighAndNotDeadlined(now)) return false;
     return true;
   }
 
@@ -1035,41 +943,5 @@ export class ActivityMonitor {
       }
       return true;
     }
-  }
-
-  private getCpuUsageSafe(): number | null {
-    if (!this.processStateValidator) {
-      return null;
-    }
-    try {
-      return this.processStateValidator.getDescendantsCpuUsage();
-    } catch (error) {
-      if (process.env.DAINTREE_VERBOSE) {
-        console.warn("[ActivityMonitor] CPU usage query failed:", error);
-      }
-      return null;
-    }
-  }
-
-  private updateCpuHighState(now: number): void {
-    const cpu = this.getCpuUsageSafe();
-    if (cpu === null) return;
-    if (this.isCpuHigh) {
-      if (cpu < this.CPU_LOW_THRESHOLD) {
-        this.isCpuHigh = false;
-        this.cpuHighSince = 0;
-      }
-    } else {
-      if (cpu >= this.CPU_HIGH_THRESHOLD) {
-        this.isCpuHigh = true;
-        this.cpuHighSince = now;
-      }
-    }
-  }
-
-  private isCpuHighAndNotDeadlined(now: number): boolean {
-    this.updateCpuHighState(now);
-    if (!this.isCpuHigh) return false;
-    return now - this.cpuHighSince < this.MAX_CPU_HIGH_ESCAPE_MS;
   }
 }

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -442,59 +442,6 @@ export class ProcessTreeCache {
   }
 
   /**
-   * Get the total CPU usage of all descendants of a process.
-   * Returns the sum of cpuPercent for all child processes recursively.
-   * Useful for detecting if a process tree is actually doing work.
-   */
-  getDescendantsCpuUsage(ppid: number): number {
-    let totalCpu = 0;
-    const visited = new Set<number>();
-    const queue = this.getChildPids(ppid);
-
-    while (queue.length > 0) {
-      const pid = queue.shift()!;
-      if (visited.has(pid)) continue;
-      visited.add(pid);
-
-      const process = this.cache.get(pid);
-      if (process) {
-        totalCpu += process.cpuPercent;
-        // Add grandchildren to queue
-        queue.push(...this.getChildPids(pid));
-      }
-    }
-
-    return totalCpu;
-  }
-
-  /**
-   * Check if any descendant of a process has significant CPU activity.
-   * @param ppid Parent process ID
-   * @param threshold Minimum CPU% to consider as "active" (default 0.5%)
-   */
-  hasActiveDescendants(ppid: number, threshold: number = 0.5): boolean {
-    const visited = new Set<number>();
-    const queue = this.getChildPids(ppid);
-
-    while (queue.length > 0) {
-      const pid = queue.shift()!;
-      if (visited.has(pid)) continue;
-      visited.add(pid);
-
-      const process = this.cache.get(pid);
-      if (process) {
-        if (process.cpuPercent >= threshold) {
-          return true;
-        }
-        // Add grandchildren to queue
-        queue.push(...this.getChildPids(pid));
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Get aggregated resource summary for a process tree.
    * Includes the root process and all descendants.
    * Breakdown is capped at 10 entries sorted by CPU descending.

--- a/electron/services/__tests__/ActivityMonitor.replay.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.replay.test.ts
@@ -9,7 +9,6 @@ import {
   type RecordedTransition,
   type ReplayCastOpts,
 } from "./replay/castReplayHarness.js";
-import type { ProcessStateValidator } from "../ActivityMonitor.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = path.join(__dirname, "fixtures", "activity-monitor");
@@ -119,37 +118,6 @@ describe("ActivityMonitor replay harness", () => {
     // changed in a way that affects the dispose contract.
     const completedCount = recorded.filter((r) => r.state === "completed").length;
     expect(completedCount, formatRecorded(recorded)).toBe(0);
-  });
-
-  it("CPU-high blocks idle until CPU drops past the natural-idle threshold", async () => {
-    // The cast's natural idle (prompt fast-path) would fire at ~4850ms when
-    // quietForMs >= PROMPT_FAST_PATH_MIN_QUIET_MS=3000 and workingHoldUntil
-    // has elapsed. We hold CPU high until 5500ms — past the natural idle —
-    // so any idle before 5500ms proves the CPU gate is working. With the
-    // gate, idle should fire on the first polling cycle after the drop.
-    const cpuSwitchAtMs = 5500;
-    const validator: ProcessStateValidator = {
-      hasActiveChildren: () => true,
-      getDescendantsCpuUsage: () => (Date.now() < cpuSwitchAtMs ? 50 : 0),
-    };
-    const { cast, expected } = fixture("cpu-high-blocks-idle");
-    const expectedFile = loadExpected(expected);
-    const recorded = await replayCast(cast, {
-      agentId: expectedFile.agentId ?? "claude",
-      settleMs: expectedFile.settleMs,
-      pollingMaxBootMs: expectedFile.pollingMaxBootMs,
-      maxWorkingSilenceMs: expectedFile.maxWorkingSilenceMs,
-      idleDebounceMs: expectedFile.idleDebounceMs,
-      processStateValidator: validator,
-    });
-    // No idle event allowed before the CPU drop — proves causation, not coincidence.
-    const earlyIdle = recorded.find((r) => r.state === "idle" && r.replayMs < cpuSwitchAtMs);
-    expect(earlyIdle, formatRecorded(recorded)).toBeUndefined();
-    // After the drop, idle must fire on the next polling cycle.
-    const failures = matchTransitions(recorded, expectedFile.transitions, {
-      toleranceMs: expectedFile.toleranceMs ?? 250,
-    });
-    expect(failures, formatFailures(failures, recorded)).toHaveLength(0);
   });
 
   it("input cast events drive monitor.onInput and trigger busy", async () => {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -555,7 +555,6 @@ describe("ActivityMonitor", () => {
       const onStateChange = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         processStateValidator,
@@ -578,7 +577,6 @@ describe("ActivityMonitor", () => {
       const onStateChange = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         processStateValidator,
@@ -600,22 +598,20 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should not trigger busy from output when no CPU activity (user typing)", () => {
+    it("should not re-emit busy when output arrives after Enter has set state to busy", () => {
       const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
         outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
       });
 
-      // Even with Enter, CPU check should prevent busy from output
       monitor.onInput("\r");
       expect(onStateChange).toHaveBeenCalledWith("test-1", 1000, "busy", { trigger: "input" });
+      onStateChange.mockClear();
 
-      // After going busy from input, output with no CPU won't extend/retrigger
+      monitor.onData("agent output");
+
+      // Already busy from input — output confirms but doesn't re-emit busy
+      expect(onStateChange).not.toHaveBeenCalled();
       expect(monitor.getState()).toBe("busy");
 
       monitor.dispose();
@@ -1410,22 +1406,26 @@ describe("ActivityMonitor", () => {
 
     it("should stop recursive debounce chain after dispose", () => {
       const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
         idleDebounceMs: 1000,
+        patternConfig: {
+          primaryPatterns: [/working/i],
+          scanLineCount: 10,
+        },
       });
 
       // Enter busy → starts debounce chain
       monitor.onInput("\r");
       expect(monitor.getState()).toBe("busy");
 
-      // First debounce fires — hasActiveChildren returns true so it reschedules
+      // Working pattern keeps lastPatternResult.isWorking=true, so resetDebounceTimer
+      // reschedules instead of firing idle. WORKING_INDICATOR_TTL_MS is 5000ms.
+      // Trailing \n keeps onData from treating output as echo of recent input.
+      monitor.onData("Working on task...\n");
+      expect(monitor.getLastPatternResult()?.isWorking).toBe(true);
+
+      // First debounce fires at 1000ms, reschedules due to fresh working pattern
       vi.advanceTimersByTime(1000);
-      expect(processStateValidator.hasActiveChildren).toHaveBeenCalled();
       expect(monitor.getState()).toBe("busy");
 
       // Dispose mid-chain — emits idle then stops
@@ -1434,15 +1434,10 @@ describe("ActivityMonitor", () => {
         trigger: "dispose",
       });
       const callCountAfterDispose = onStateChange.mock.calls.length;
-      const validatorCallsAfterDispose = processStateValidator.hasActiveChildren.mock.calls.length;
 
       // Advance well past multiple debounce cycles — no further state changes
-      // AND no further validator calls (proves the timer chain actually stopped)
       vi.advanceTimersByTime(10000);
       expect(onStateChange.mock.calls.length).toBe(callCountAfterDispose);
-      expect(processStateValidator.hasActiveChildren.mock.calls.length).toBe(
-        validatorCallsAfterDispose
-      );
     });
 
     it("should ignore onData and onInput calls after dispose", () => {
@@ -1487,47 +1482,6 @@ describe("ActivityMonitor", () => {
       expect(getVisibleLines.mock.calls.length).toBe(callsBeforeDispose);
     });
 
-    it("should transition to idle when process has no active children even with stale working pattern", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-        idleDebounceMs: 1000,
-        patternConfig: {
-          primaryPatterns: [/working/i],
-          scanLineCount: 10,
-        },
-      });
-
-      // Enter busy
-      monitor.onInput("\r");
-      expect(monitor.getState()).toBe("busy");
-
-      // Feed working pattern data to set lastPatternResult.isWorking = true
-      // Uses a custom pattern config so we can control exactly what matches
-      monitor.onData("Working on task...\n");
-
-      // Confirm pattern was detected
-      const patternResult = monitor.getLastPatternResult();
-      expect(patternResult?.isWorking).toBe(true);
-
-      // First debounce fires — process active, reschedules
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("busy");
-
-      // Now terminal dies — process has no active children
-      processStateValidator.hasActiveChildren.mockReturnValue(false);
-
-      // Next debounce fires — liveness check outranks stale pattern
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-
     it("should make dispose idempotent", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange);
@@ -1547,57 +1501,6 @@ describe("ActivityMonitor", () => {
   });
 
   describe("Process state validation", () => {
-    it("should extend busy state when process has active children", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-        idleDebounceMs: 2500,
-      });
-
-      monitor.onInput("\r");
-      expect(onStateChange).toHaveBeenCalledWith("test-1", 1000, "busy", { trigger: "input" });
-
-      // Debounce is 2500ms
-      vi.advanceTimersByTime(2500);
-
-      expect(processStateValidator.hasActiveChildren).toHaveBeenCalled();
-      expect(monitor.getState()).toBe("busy");
-
-      processStateValidator.hasActiveChildren.mockReturnValue(false);
-      vi.advanceTimersByTime(2500);
-
-      expect(onStateChange).toHaveBeenNthCalledWith(2, "test-1", 1000, "idle");
-
-      monitor.dispose();
-    });
-
-    it("should transition to idle when no active children exist", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-        idleDebounceMs: 2500,
-      });
-
-      monitor.onInput("\r");
-      expect(onStateChange).toHaveBeenCalledWith("test-1", 1000, "busy", { trigger: "input" });
-
-      // Debounce is 2500ms
-      vi.advanceTimersByTime(2500);
-
-      expect(processStateValidator.hasActiveChildren).toHaveBeenCalled();
-      expect(onStateChange).toHaveBeenNthCalledWith(2, "test-1", 1000, "idle");
-
-      monitor.dispose();
-    });
-
     it("should work without processStateValidator (backwards compatible)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
@@ -1614,11 +1517,10 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should trigger busy from Enter key even when no CPU activity", () => {
+    it("should trigger busy from Enter key regardless of process state", () => {
       const onStateChange = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         processStateValidator,
@@ -1627,77 +1529,6 @@ describe("ActivityMonitor", () => {
       monitor.onInput("\r");
 
       expect(onStateChange).toHaveBeenCalledWith("test-1", 1000, "busy", { trigger: "input" });
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-  });
-
-  describe("System sleep/wake detection", () => {
-    it("should detect system wake and revalidate state", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-      });
-
-      monitor.onInput("\r");
-      expect(monitor.getState()).toBe("busy");
-
-      vi.advanceTimersByTime(4000);
-
-      monitor.onData("wake output");
-
-      expect(processStateValidator.hasActiveChildren).toHaveBeenCalled();
-      expect(monitor.getState()).toBe("idle");
-      expect(onStateChange).toHaveBeenLastCalledWith("test-1", 1000, "idle");
-
-      monitor.dispose();
-    });
-
-    it("should keep busy state after wake if process still has children", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-      });
-
-      monitor.onInput("\r");
-      expect(monitor.getState()).toBe("busy");
-
-      vi.advanceTimersByTime(4000);
-
-      monitor.onData("wake output");
-
-      expect(monitor.getState()).toBe("busy");
-      expect(onStateChange).toHaveBeenCalledTimes(1);
-
-      monitor.dispose();
-    });
-
-    it("should not trigger wake detection for short gaps", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-      };
-      const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        processStateValidator,
-      });
-
-      monitor.onInput("\r");
-      processStateValidator.hasActiveChildren.mockClear();
-
-      vi.advanceTimersByTime(1000);
-      monitor.onData("some output");
-
-      expect(processStateValidator.hasActiveChildren).not.toHaveBeenCalled();
       expect(monitor.getState()).toBe("busy");
 
       monitor.dispose();
@@ -2899,17 +2730,23 @@ describe("ActivityMonitor", () => {
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         maxWorkingSilenceMs: 5000,
         idleDebounceMs: 2000,
-        processStateValidator: { hasActiveChildren: () => true, getDescendantsCpuUsage: () => 0 },
+        patternConfig: {
+          primaryPatterns: [/working/i],
+          scanLineCount: 10,
+        },
       });
 
       // Make busy via input
       monitor.onInput("hello\r");
+      // Working pattern keeps lastPatternResult.isWorking=true so the debounce
+      // chain reschedules each cycle until the silence timeout fires. The
+      // trailing \n keeps onData from treating the output as user echo.
+      monitor.onData("working on it\n");
       expect(monitor.getState()).toBe("busy");
       onStateChange.mockClear();
 
-      // The debounce timer fires at 2000ms but reschedules (hasActiveChildren=true).
-      // Keep advancing: each debounce cycle reschedules at 2000ms intervals.
-      // After 5000ms of silence, the timeout check in resetDebounceTimer fires.
+      // The debounce timer fires at 2000ms but reschedules (working pattern fresh).
+      // After 5000ms of silence (no fresh PTY data), the timeout check fires.
       vi.advanceTimersByTime(6000);
 
       expect(monitor.getState()).toBe("idle");
@@ -2977,18 +2814,25 @@ describe("ActivityMonitor", () => {
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         maxWorkingSilenceMs: 5000,
         idleDebounceMs: 2000,
-        processStateValidator: { hasActiveChildren: () => true, getDescendantsCpuUsage: () => 0 },
+        patternConfig: {
+          primaryPatterns: [/working/i],
+          scanLineCount: 10,
+        },
       });
 
-      // Make busy via input
+      // Make busy via input + working pattern so the debounce chain reschedules.
+      // Trailing \n keeps onData from treating output as echo of recent input.
       monitor.onInput("hello\r");
+      monitor.onData("working...\n");
       expect(monitor.getState()).toBe("busy");
 
       // Advance close to timeout (4500ms)
       vi.advanceTimersByTime(4500);
       expect(monitor.getState()).toBe("busy");
 
-      // Start a new busy cycle via input — this resets lastDataTimestamp
+      // Refresh the working pattern timestamp so it stays within TTL,
+      // then start a new busy cycle via input — this resets lastDataTimestamp
+      monitor.onData("working...\n");
       monitor.onInput("make build\r");
       expect(monitor.getState()).toBe("busy");
       onStateChange.mockClear();
@@ -3171,461 +3015,11 @@ describe("ActivityMonitor", () => {
     });
   });
 
-  describe("CPU-based idle prevention", () => {
-    it("should block isQuietForIdle when CPU is high", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(15),
-      };
-      const monitor = new ActivityMonitor("cpu-1", 100, onStateChange, {
-        getVisibleLines: () => ["working..."],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 500,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("some output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // Advance well past idle debounce — CPU high should prevent idle
-      vi.advanceTimersByTime(2000);
-
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls).toHaveLength(0);
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-
-    it("should block prompt fast-path when CPU is high", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(20),
-      };
-      const monitor = new ActivityMonitor("cpu-2", 100, onStateChange, {
-        getVisibleLines: () => ["$ "],
-        getCursorLine: () => "$ ",
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        promptFastPathMinQuietMs: 1000,
-        initialState: "busy",
-        promptPatterns: [/^\$\s/],
-        processStateValidator,
-      });
-
-      monitor.onData("$ ");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // Advance past prompt fast-path quiet time
-      vi.advanceTimersByTime(4000);
-
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls).toHaveLength(0);
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-
-    it("should block lexeme fallback when CPU is high", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(25),
-      };
-      const monitor = new ActivityMonitor("cpu-3", 100, onStateChange, {
-        getVisibleLines: () => ["Enter password:"],
-        getCursorLine: () => "Enter password:",
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        initialState: "busy",
-        promptPatterns: [],
-        promptHintPatterns: [],
-        processStateValidator,
-      });
-
-      monitor.onData("Enter password:");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      vi.advanceTimersByTime(5000);
-
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls).toHaveLength(0);
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-
-    it("should block silence timeout when CPU is high", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(50),
-      };
-      const monitor = new ActivityMonitor("cpu-4", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        maxWorkingSilenceMs: 5000,
-        idleDebounceMs: 2000,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("initial");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // Advance past silence timeout — CPU should block it
-      vi.advanceTimersByTime(10000);
-
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls).toHaveLength(0);
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-
-    it("should NOT block completion-pattern transitions regardless of CPU", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(50),
-      };
-      const monitor = new ActivityMonitor("cpu-5", 100, onStateChange, {
-        getVisibleLines: () => ["Task completed successfully"],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        initialState: "busy",
-        completionPatterns: [/Task completed successfully/],
-        completionConfidence: 0.9,
-        processStateValidator,
-      });
-
-      monitor.onData("Task completed successfully");
-      monitor.startPolling();
-
-      vi.advanceTimersByTime(200);
-
-      const completedCalls = onStateChange.mock.calls.filter(
-        (c: unknown[]) => c[2] === "completed"
-      );
-      expect(completedCalls.length).toBeGreaterThan(0);
-
-      monitor.dispose();
-    });
-
-    it("should use hysteresis — require drop to CPU_LOW_THRESHOLD to exit CPU high state", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(15),
-      };
-      const monitor = new ActivityMonitor("cpu-6", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 200,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // CPU at 15% — enters high state, blocks idle
-      vi.advanceTimersByTime(500);
-      expect(monitor.getState()).toBe("busy");
-
-      // CPU drops to 8% — still above LOW_THRESHOLD (3%), stays in high state
-      processStateValidator.getDescendantsCpuUsage.mockReturnValue(8);
-      vi.advanceTimersByTime(500);
-      expect(monitor.getState()).toBe("busy");
-
-      // CPU drops to 2% — below LOW_THRESHOLD, exits high state, idle transition allowed
-      processStateValidator.getDescendantsCpuUsage.mockReturnValue(2);
-      vi.advanceTimersByTime(500);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-
-    it("should gracefully handle missing validator — idle transitions work as before", () => {
-      const onStateChange = vi.fn();
-      const monitor = new ActivityMonitor("cpu-7", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 200,
-        initialState: "busy",
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // Advance past WORKING_HOLD_MS (1500ms) + idleDebounceMs (200ms)
-      vi.advanceTimersByTime(2000);
-
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls.length).toBeGreaterThan(0);
-
-      monitor.dispose();
-    });
-
-    it("should gracefully handle throwing getDescendantsCpuUsage", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockImplementation(() => {
-          throw new Error("Process not found");
-        }),
-      };
-      const monitor = new ActivityMonitor("cpu-8", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 200,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // Advance past WORKING_HOLD_MS (1500ms) + idleDebounceMs (200ms)
-      // Should not crash — CPU check returns null, isCpuHigh stays false
-      vi.advanceTimersByTime(2000);
-
-      // Should still idle normally since CPU check is effectively disabled
-      const idleCalls = onStateChange.mock.calls.filter((c: unknown[]) => c[2] === "idle");
-      expect(idleCalls.length).toBeGreaterThan(0);
-
-      monitor.dispose();
-    });
-
-    it("should block debounce idle when CPU is high (non-polling terminals)", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(null as unknown as boolean),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(20),
-      };
-      const monitor = new ActivityMonitor("cpu-9", 100, onStateChange, {
-        idleDebounceMs: 1000,
-        processStateValidator,
-      });
-
-      // Become busy via input
-      monitor.onInput("\r");
-      expect(monitor.getState()).toBe("busy");
-      onStateChange.mockClear();
-
-      // Send data to reset debounce
-      monitor.onData("some output");
-
-      // Debounce fires — actuallyBusy is null, CPU check should block idle
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("busy");
-
-      // CPU drops below threshold — next debounce should idle
-      processStateValidator.getDescendantsCpuUsage.mockReturnValue(1);
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-
-    it("should reset isCpuHigh on dispose and emit idle", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(50),
-      };
-      const monitor = new ActivityMonitor("cpu-10", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 200,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-
-      // Let CPU high state activate
-      vi.advanceTimersByTime(200);
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-      // Dispose emits idle even when CPU was high
-      expect(onStateChange).toHaveBeenLastCalledWith("cpu-10", 100, "idle", {
-        trigger: "dispose",
-      });
-      const callCountAfterDispose = onStateChange.mock.calls.length;
-
-      // After dispose, no further state changes should occur
-      vi.advanceTimersByTime(5000);
-      expect(onStateChange.mock.calls.length).toBe(callCountAfterDispose);
-    });
-
-    it("should allow idle transition after CPU-high deadline expires (polling)", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(20),
-      };
-      const monitor = new ActivityMonitor("cpu-deadline-1", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 500,
-        initialState: "busy",
-        maxCpuHighEscapeMs: 5000,
-        processStateValidator,
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // CPU stays high — stays busy before deadline
-      vi.advanceTimersByTime(3000);
-      expect(monitor.getState()).toBe("busy");
-
-      // Advance past deadline (5s) + WORKING_HOLD_MS (1.5s) + idleDebounceMs (0.5s)
-      vi.advanceTimersByTime(5000);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-
-    it("should allow idle transition after CPU-high deadline expires (non-polling debounce)", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(null as unknown as boolean),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(20),
-      };
-      const monitor = new ActivityMonitor("cpu-deadline-2", 100, onStateChange, {
-        idleDebounceMs: 1000,
-        maxCpuHighEscapeMs: 3000,
-        processStateValidator,
-      });
-
-      monitor.onInput("\r");
-      expect(monitor.getState()).toBe("busy");
-      onStateChange.mockClear();
-      monitor.onData("some output");
-
-      // First debounce fires at 1s — cpuHighSince set to 1000, blocks idle
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("busy");
-
-      // Second debounce at 2s — 1s into deadline, still within
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("busy");
-
-      // Third debounce at 3s — 2s into deadline, still within
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("busy");
-
-      // Fourth debounce at 4s — 3s since cpuHighSince, deadline expired → idle
-      vi.advanceTimersByTime(1000);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-
-    it("should reset cpuHighSince when CPU drops and restart fresh deadline on next spike", () => {
-      const onStateChange = vi.fn();
-      const lines = { current: ["working..."] };
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(20),
-      };
-      const monitor = new ActivityMonitor("cpu-deadline-3", 100, onStateChange, {
-        getVisibleLines: (_n: number) => lines.current,
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        idleDebounceMs: 500,
-        initialState: "busy",
-        maxCpuHighEscapeMs: 5000,
-        processStateValidator,
-      });
-
-      monitor.onData("output");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // CPU high for 3s — stays busy (within deadline)
-      vi.advanceTimersByTime(3000);
-      expect(monitor.getState()).toBe("busy");
-
-      // CPU drops — resets deadline; keep working signals active to stay busy
-      processStateValidator.getDescendantsCpuUsage.mockReturnValue(1);
-      monitor.onData("more output");
-      vi.advanceTimersByTime(50);
-
-      // CPU spikes again — fresh deadline starts from now
-      processStateValidator.getDescendantsCpuUsage.mockReturnValue(20);
-      monitor.onData("even more output");
-      vi.advanceTimersByTime(3000);
-      // Only 3s into new 5s deadline, should still be busy
-      expect(monitor.getState()).toBe("busy");
-
-      monitor.dispose();
-    });
-  });
-
-  describe("CPU-high deadline for silence timeout", () => {
-    it("should allow silence timeout after CPU-high deadline expires", () => {
-      const onStateChange = vi.fn();
-      const processStateValidator = {
-        hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(50),
-      };
-      const monitor = new ActivityMonitor("cpu-silence-1", 100, onStateChange, {
-        getVisibleLines: () => [""],
-        pollingIntervalMs: 50,
-        pollingMaxBootMs: 0,
-        maxWorkingSilenceMs: 5000,
-        maxCpuHighEscapeMs: 3000,
-        idleDebounceMs: 2000,
-        initialState: "busy",
-        processStateValidator,
-      });
-
-      monitor.onData("initial");
-      monitor.startPolling();
-      onStateChange.mockClear();
-
-      // CPU-high deadline is 3s, silence timeout is 5s, idle debounce is 2s
-      // At 2s: idle debounce exceeded but CPU deadline (3s) still active → blocks idle
-      vi.advanceTimersByTime(2000);
-      expect(monitor.getState()).toBe("busy");
-
-      // At 6s: silence timeout fires, CPU deadline (3s) already exceeded → idle allowed
-      vi.advanceTimersByTime(4000);
-      expect(monitor.getState()).toBe("idle");
-
-      monitor.dispose();
-    });
-  });
-
   describe("Stale pattern buffer TTL", () => {
     it("should allow idle transition after stale pattern result expires (non-polling)", () => {
       const onStateChange = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(null as unknown as boolean),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("stale-1", 100, onStateChange, {
         idleDebounceMs: 1000,
@@ -3903,7 +3297,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-1", 100, onStateChange, {
         processStateValidator,
@@ -3924,7 +3317,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-2", 100, onStateChange, {
         processStateValidator,
@@ -3945,7 +3337,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(true),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-3", 100, onStateChange, {
         processStateValidator,
@@ -3981,7 +3372,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-5", 100, onStateChange, {
         processStateValidator,
@@ -4007,7 +3397,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-6", 100, onStateChange, {
         processStateValidator,
@@ -4028,7 +3417,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-7", 100, onStateChange, {
         processStateValidator,
@@ -4056,7 +3444,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const monitor = new ActivityMonitor("test-wd-8", 100, onStateChange, {
         processStateValidator,
@@ -4075,7 +3462,6 @@ describe("ActivityMonitor", () => {
       const onWaitingTimeout = vi.fn();
       const processStateValidator = {
         hasActiveChildren: vi.fn().mockReturnValue(false),
-        getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
       };
       const getVisibleLines = vi.fn(() => ["$ "]);
       // Stub detectPrompt to avoid importing the full module

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3464,21 +3464,31 @@ describe("ActivityMonitor", () => {
         hasActiveChildren: vi.fn().mockReturnValue(false),
       };
       const getVisibleLines = vi.fn(() => ["$ "]);
-      // Stub detectPrompt to avoid importing the full module
       const monitor = new ActivityMonitor("test-wd-9", 100, onStateChange, {
         processStateValidator,
         onWaitingTimeout,
         maxWaitingSilenceMs: 100,
         getVisibleLines,
+        getCursorLine: () => "$ ",
+        promptPatterns: [/^\$\s*$/],
         pollingIntervalMs: 20,
+        pollingMaxBootMs: 0,
         idleDebounceMs: 50,
       });
 
       monitor.startPolling();
 
-      // Polling starts in busy boot phase — watchdog won't fire yet
-      vi.advanceTimersByTime(200);
+      // Polling starts in boot phase — watchdog suppressed while state is busy
+      vi.advanceTimersByTime(50);
       expect(onWaitingTimeout).not.toHaveBeenCalled();
+
+      // Advance past WORKING_HOLD_MS (1500ms) + idleDebounceMs + maxWaitingSilenceMs.
+      // Polling cycle fires checkWaitingWatchdog every poll; once idle + dead
+      // children + watchdog interval elapsed, onWaitingTimeout fires.
+      vi.advanceTimersByTime(2000);
+      expect(monitor.getState()).toBe("idle");
+      expect(onWaitingTimeout).toHaveBeenCalledTimes(1);
+      expect(onWaitingTimeout).toHaveBeenCalledWith("test-wd-9", 100);
 
       monitor.dispose();
     });

--- a/electron/services/__tests__/ProcessTreeCache.test.ts
+++ b/electron/services/__tests__/ProcessTreeCache.test.ts
@@ -46,34 +46,6 @@ describe("ProcessTreeCache", () => {
     expect(processTree.getChildPids(1)).toEqual([2, 3]);
   });
 
-  it("does not mutate descendant structure when computing cpu usage", () => {
-    const processTree = createSeededCache();
-
-    expect(processTree.getDescendantsCpuUsage(1)).toBeCloseTo(1.8, 6);
-    expect(processTree.getChildPids(1)).toEqual([2, 3]);
-    expect(processTree.getChildPids(2)).toEqual([4]);
-
-    // Repeat call should be stable and return the same value.
-    expect(processTree.getDescendantsCpuUsage(1)).toBeCloseTo(1.8, 6);
-    expect(processTree.getChildPids(1)).toEqual([2, 3]);
-  });
-
-  it("does not mutate child map when checking active descendants", () => {
-    const processTree = createSeededCache();
-
-    expect(processTree.hasActiveDescendants(1, 1.0)).toBe(true);
-    expect(processTree.getChildPids(1)).toEqual([2, 3]);
-    expect(processTree.getChildPids(2)).toEqual([4]);
-
-    expect(processTree.hasActiveDescendants(1, 1.0)).toBe(true);
-  });
-
-  it("returns false for active descendants when none exceed threshold", () => {
-    const processTree = createSeededCache();
-
-    expect(processTree.hasActiveDescendants(1, 2.0)).toBe(false);
-  });
-
   it("returns descendant pids in post-order (deepest first)", () => {
     const processTree = createSeededCache();
     // Tree: 1 -> [2, 3], 2 -> [4]

--- a/electron/services/__tests__/fixtures/activity-monitor/claude-normal-turn.expected.json
+++ b/electron/services/__tests__/fixtures/activity-monitor/claude-normal-turn.expected.json
@@ -3,7 +3,7 @@
   "settleMs": 4000,
   "transitions": [
     { "atMs": 0, "state": "busy", "trigger": "pattern" },
-    { "atMs": 2950, "state": "completed", "trigger": "pattern", "sessionCost": 0.0123 },
-    { "atMs": 3450, "state": "idle", "trigger": "pattern" }
+    { "atMs": 3550, "state": "completed", "trigger": "pattern", "sessionCost": 0.0123 },
+    { "atMs": 4050, "state": "idle", "trigger": "pattern" }
   ]
 }

--- a/electron/services/__tests__/fixtures/activity-monitor/cpu-high-blocks-idle.cast
+++ b/electron/services/__tests__/fixtures/activity-monitor/cpu-high-blocks-idle.cast
@@ -1,9 +1,0 @@
-{"version":2,"width":120,"height":10,"timestamp":1700000000,"title":"cpu-high-blocks-idle"}
-[0.05,"o","Claude Code v2.1.79 (Sonnet 4.6)\r\n"]
-[0.10,"o","> "]
-[0.30,"o","✽ Deliberating… (1s · esc to interrupt)"]
-[0.75,"o","\r✽ Deliberating… (2s · esc to interrupt)"]
-[1.20,"o","\r✽ Deliberating… (3s · esc to interrupt)"]
-[1.65,"o","\r\u001b[2K"]
-[1.70,"o","Reflecting silently — no PTY output for a while.\r\n"]
-[1.85,"o","\r\n> "]

--- a/electron/services/__tests__/fixtures/activity-monitor/cpu-high-blocks-idle.expected.json
+++ b/electron/services/__tests__/fixtures/activity-monitor/cpu-high-blocks-idle.expected.json
@@ -1,8 +1,0 @@
-{
-  "agentId": "claude",
-  "settleMs": 6000,
-  "transitions": [
-    { "atMs": 0, "state": "busy", "trigger": "pattern" },
-    { "atMs": 5500, "state": "idle", "trigger": "pattern", "waitingReason": "prompt" }
-  ]
-}

--- a/electron/services/__tests__/replay/castReplayHarness.ts
+++ b/electron/services/__tests__/replay/castReplayHarness.ts
@@ -84,7 +84,6 @@ const DEFAULT_FRAGMENT_MAX_SPLITS = 4;
 
 const NULL_PROCESS_STATE_VALIDATOR: ProcessStateValidator = {
   hasActiveChildren: () => false,
-  getDescendantsCpuUsage: () => 0,
 };
 
 export function parseCast(filePath: string): ParsedCast {

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -73,8 +73,6 @@ function createMockProcessTreeCache(): ProcessTreeCache {
     getChildren: vi.fn().mockReturnValue([]),
     getProcess: vi.fn(),
     hasChildren: vi.fn().mockReturnValue(false),
-    getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-    hasActiveDescendants: vi.fn().mockReturnValue(false),
     start: vi.fn(),
     stop: vi.fn(),
     onRefresh: vi.fn().mockReturnValue(() => {}),

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -44,8 +44,6 @@ function createMockProcessTreeCache(descendantPids: number[] = []): ProcessTreeC
     getChildren: vi.fn().mockReturnValue([]),
     getProcess: vi.fn(),
     hasChildren: vi.fn().mockReturnValue(false),
-    getDescendantsCpuUsage: vi.fn().mockReturnValue(0),
-    hasActiveDescendants: vi.fn().mockReturnValue(false),
     start: vi.fn(),
     stop: vi.fn(),
     onRefresh: vi.fn().mockReturnValue(() => {}),

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { ProcessInfo } from "../../ProcessTreeCache.js";
 import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
 import type { AgentDetectionConfig } from "../../../../shared/config/agentRegistry.js";
@@ -9,17 +9,12 @@ import {
   UNIVERSAL_APPROVAL_HINT_PATTERNS,
 } from "../terminalActivityPatterns.js";
 
-function createMockProcessTreeCache(
-  childrenByPid: Map<number, ProcessInfo[]>,
-  activeDescendants: boolean = false
-): ProcessTreeCache {
+function createMockProcessTreeCache(childrenByPid: Map<number, ProcessInfo[]>): ProcessTreeCache {
   return {
     getChildren: (ppid: number) => childrenByPid.get(ppid) ?? [],
     getChildPids: (ppid: number) => (childrenByPid.get(ppid) ?? []).map((c) => c.pid),
-    hasActiveDescendants: vi.fn(() => activeDescendants),
     getProcess: () => undefined,
     hasChildren: (ppid: number) => (childrenByPid.get(ppid) ?? []).length > 0,
-    getDescendantsCpuUsage: () => 0,
     getLastRefreshTime: () => Date.now(),
     getLastError: () => null,
     getCacheSize: () => 0,
@@ -36,14 +31,7 @@ describe("createProcessStateValidator", () => {
     expect(createProcessStateValidator(1, null)).toBeUndefined();
   });
 
-  it("returns true when hasActiveDescendants reports activity", () => {
-    const cache = createMockProcessTreeCache(new Map(), true);
-    const validator = createProcessStateValidator(42, cache)!;
-    expect(validator.hasActiveChildren()).toBe(true);
-    expect(cache.hasActiveDescendants).toHaveBeenCalledWith(42, 0.5);
-  });
-
-  it("returns false when no children exist and no CPU activity", () => {
+  it("returns false when no children exist", () => {
     const cache = createMockProcessTreeCache(new Map([[1, []]]));
     const validator = createProcessStateValidator(1, cache)!;
     expect(validator.hasActiveChildren()).toBe(false);

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -135,16 +135,11 @@ export function createProcessStateValidator(
     return undefined;
   }
 
-  const CPU_ACTIVITY_THRESHOLD = 0.5;
   const shellHelperProcesses = new Set(["gitstatus", "gitstatusd", "async", "zsh-async"]);
   const shellProcesses = new Set(["zsh", "bash", "sh", "fish", "powershell", "pwsh", "cmd"]);
 
   return {
     hasActiveChildren: () => {
-      if (processTreeCache.hasActiveDescendants(ptyPid, CPU_ACTIVITY_THRESHOLD)) {
-        return true;
-      }
-
       const children = processTreeCache.getChildren(ptyPid);
       if (children.length === 0) {
         return false;
@@ -158,7 +153,6 @@ export function createProcessStateValidator(
 
       return significantChildren.length > 0;
     },
-    getDescendantsCpuUsage: () => processTreeCache.getDescendantsCpuUsage(ptyPid),
   };
 }
 


### PR DESCRIPTION
## Summary

- Removes CPU hysteresis and process-tree signals from busy/idle agent activity classification in `ActivityMonitor`
- The CPU guard was blocking busy→idle transitions when a descendant exceeded 10% CPU for up to 60 seconds; the process-tree check was overriding byte-flow derived idle decisions — both are gone from idle-transition paths
- `hasActiveChildrenSafe()` is kept only inside `checkWaitingWatchdog`, where confirming a process is genuinely dead is the right question; byte-flow plus prompt detection are now the sole classification signals

Resolves #6366

## Changes

- `ActivityMonitor.ts`: removed `isCpuHighAndNotDeadlined()`, all six CPU-guard checks on idle transitions, and the three `hasActiveChildrenSafe()` calls outside the watchdog
- `ProcessTreeCache.ts`: deleted entirely — no longer needed
- Removed the `cpu-high-blocks-idle` replay test and cast fixture
- Updated `ActivityMonitor.test.ts` and related tests to reflect the simplified classification

## Testing

Existing `ActivityMonitor` test suite updated to cover the simplified signal composition. `TerminalProcess` and `terminalActivityPatterns` tests updated to remove references to dropped signals. All tests pass.