### PR TITLE
feat(mcp): harden local MCP server before 0.9 release

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -174,6 +174,7 @@ export class McpServerService {
   private httpServer: http.Server | null = null;
   private port: number | null = null;
   private registry: WindowRegistry | null = null;
+  private starting = false;
   private sessions = new Map<string, McpSseSession>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
@@ -256,7 +257,7 @@ export class McpServerService {
   async start(registry: WindowRegistry): Promise<void> {
     this.registry = registry;
 
-    if (this.httpServer) {
+    if (this.httpServer || this.starting) {
       return;
     }
 
@@ -265,40 +266,45 @@ export class McpServerService {
       return;
     }
 
-    if (!this.getConfig().apiKey) {
-      await this.generateApiKey();
-    }
-
-    this.setupIpcListeners();
-
-    const server = http.createServer((req, res) => {
-      this.handleRequest(req, res).catch((err) => {
-        console.error("[MCP] Request handler error:", err);
-        if (!res.headersSent) {
-          res.writeHead(500, { "Content-Type": "text/plain" });
-          res.end("Internal server error");
-        }
-      });
-    });
-
-    const configuredPort = this.getConfig().port ?? DEFAULT_PORT;
-    const boundPort = await this.listenWithRetry(server, configuredPort);
-
-    if (boundPort === null) {
-      for (const cleanup of this.cleanupListeners) {
-        cleanup();
+    this.starting = true;
+    try {
+      if (!this.getConfig().apiKey) {
+        await this.generateApiKey();
       }
-      this.cleanupListeners = [];
-      throw new Error(
-        `Failed to bind MCP server: ports ${configuredPort}–${configuredPort + MAX_PORT_RETRIES} all in use`
-      );
-    }
 
-    this.port = boundPort;
-    this.httpServer = server;
-    await this.writeDiscoveryFile();
-    console.log(`[MCP] Server started on http://127.0.0.1:${this.port}/sse`);
-    this.emitStatusChange();
+      this.setupIpcListeners();
+
+      const server = http.createServer((req, res) => {
+        this.handleRequest(req, res).catch((err) => {
+          console.error("[MCP] Request handler error:", err);
+          if (!res.headersSent) {
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            res.end("Internal server error");
+          }
+        });
+      });
+
+      const configuredPort = this.getConfig().port ?? DEFAULT_PORT;
+      const boundPort = await this.listenWithRetry(server, configuredPort);
+
+      if (boundPort === null) {
+        for (const cleanup of this.cleanupListeners) {
+          cleanup();
+        }
+        this.cleanupListeners = [];
+        throw new Error(
+          `Failed to bind MCP server: ports ${configuredPort}–${configuredPort + MAX_PORT_RETRIES} all in use`
+        );
+      }
+
+      this.port = boundPort;
+      this.httpServer = server;
+      await this.writeDiscoveryFile();
+      console.log(`[MCP] Server started on http://127.0.0.1:${this.port}/sse`);
+      this.emitStatusChange();
+    } finally {
+      this.starting = false;
+    }
   }
 
   async stop(): Promise<void> {
@@ -582,12 +588,7 @@ export class McpServerService {
 
   private isValidHost(req: http.IncomingMessage): boolean {
     const host = req.headers.host ?? "";
-    return (
-      host === `127.0.0.1:${this.port}` ||
-      host === `localhost:${this.port}` ||
-      host === "127.0.0.1" ||
-      host === "localhost"
-    );
+    return host === `127.0.0.1:${this.port}` || host === `localhost:${this.port}`;
   }
 
   private isAuthorized(req: http.IncomingMessage): boolean {
@@ -843,13 +844,9 @@ export class McpServerService {
       await resilientAtomicWriteFile(
         DISCOVERY_FILE,
         JSON.stringify({ ...existing, mcpServers }, null, 2) + "\n",
-        "utf-8"
+        "utf-8",
+        { mode: 0o600 }
       );
-      if (process.platform !== "win32") {
-        await fs.chmod(DISCOVERY_FILE, 0o600).catch((err) => {
-          console.error("[MCP] Failed to chmod discovery file:", err);
-        });
-      }
     } catch (err) {
       console.error("[MCP] Failed to write discovery file:", err);
     }
@@ -875,7 +872,8 @@ export class McpServerService {
         await resilientAtomicWriteFile(
           DISCOVERY_FILE,
           JSON.stringify(existing, null, 2) + "\n",
-          "utf-8"
+          "utf-8",
+          { mode: 0o600 }
         );
       }
     } catch {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -2,7 +2,7 @@ import { ipcMain } from "electron";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import http from "node:http";
 import net from "node:net";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
@@ -22,6 +22,7 @@ const MCP_SERVER_KEY = "daintree";
 
 const DEFAULT_PORT = 45454;
 const MAX_PORT_RETRIES = 10;
+const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "browser",
@@ -116,6 +117,11 @@ interface PendingRequest<T> {
   timer: ReturnType<typeof setTimeout>;
 }
 
+interface McpSseSession {
+  transport: SSEServerTransport;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
 function safeSerializeToolResult(value: unknown): string {
   const seen = new WeakSet<object>();
 
@@ -168,7 +174,7 @@ export class McpServerService {
   private httpServer: http.Server | null = null;
   private port: number | null = null;
   private registry: WindowRegistry | null = null;
-  private sessions = new Map<string, SSEServerTransport>();
+  private sessions = new Map<string, McpSseSession>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
@@ -259,6 +265,10 @@ export class McpServerService {
       return;
     }
 
+    if (!this.getConfig().apiKey) {
+      await this.generateApiKey();
+    }
+
     this.setupIpcListeners();
 
     const server = http.createServer((req, res) => {
@@ -292,9 +302,10 @@ export class McpServerService {
   }
 
   async stop(): Promise<void> {
-    for (const transport of this.sessions.values()) {
+    for (const session of this.sessions.values()) {
+      clearTimeout(session.idleTimer);
       try {
-        await transport.close();
+        await session.transport.close();
       } catch {
         // ignore close errors during shutdown
       }
@@ -583,7 +594,16 @@ export class McpServerService {
     const apiKey = this.getConfig().apiKey;
     if (!apiKey) return true;
     const auth = req.headers.authorization ?? "";
-    return auth === `Bearer ${apiKey}`;
+    const expected = `Bearer ${apiKey}`;
+    const actualHash = createHash("sha256").update(auth).digest();
+    const expectedHash = createHash("sha256").update(expected).digest();
+    return timingSafeEqual(actualHash, expectedHash);
+  }
+
+  private isValidOrigin(req: http.IncomingMessage): boolean {
+    const origin = req.headers.origin;
+    if (origin === undefined) return true;
+    return origin === `http://127.0.0.1:${this.port}` || origin === `http://localhost:${this.port}`;
   }
 
   private shouldExposeTool(entry: ActionManifestEntry): boolean {
@@ -718,6 +738,12 @@ export class McpServerService {
       return;
     }
 
+    if (!this.isValidOrigin(req)) {
+      res.writeHead(403, { "Content-Type": "text/plain" });
+      res.end("Forbidden");
+      return;
+    }
+
     if (!this.isAuthorized(req)) {
       res.writeHead(401, { "Content-Type": "text/plain" });
       res.end("Unauthorized");
@@ -727,22 +753,34 @@ export class McpServerService {
     const url = new URL(req.url ?? "/", `http://127.0.0.1:${this.port}`);
 
     if (req.method === "GET" && url.pathname === "/sse") {
-      const transport = new SSEServerTransport("/messages", res);
+      const allowedHosts = [`127.0.0.1:${this.port}`, `localhost:${this.port}`];
+      const allowedOrigins = [`http://127.0.0.1:${this.port}`, `http://localhost:${this.port}`];
+      const transport = new SSEServerTransport("/messages", res, {
+        enableDnsRebindingProtection: true,
+        allowedHosts,
+        allowedOrigins,
+      });
       const server = this.createSessionServer();
       const sessionId = transport.sessionId;
 
-      this.sessions.set(sessionId, transport);
+      const idleTimer = this.createIdleTimer(sessionId);
+      this.sessions.set(sessionId, { transport, idleTimer });
       transport.onclose = () => {
-        this.sessions.delete(sessionId);
+        const session = this.sessions.get(sessionId);
+        if (session) {
+          clearTimeout(session.idleTimer);
+          this.sessions.delete(sessionId);
+        }
       };
 
       await server.connect(transport);
     } else if (req.method === "POST" && url.pathname === "/messages") {
       const sessionId = url.searchParams.get("sessionId") ?? "";
-      const transport = this.sessions.get(sessionId);
+      const session = this.sessions.get(sessionId);
 
-      if (transport) {
-        await transport.handlePostMessage(req, res);
+      if (session) {
+        this.resetIdleTimer(sessionId);
+        await session.transport.handlePostMessage(req, res);
       } else {
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Session not found");
@@ -753,10 +791,35 @@ export class McpServerService {
     }
   }
 
+  private createIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(() => {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+      this.sessions.delete(sessionId);
+      session.transport.close().catch(() => {
+        // ignore close errors during idle timeout cleanup
+      });
+    }, MCP_SSE_IDLE_TIMEOUT_MS);
+    timer.unref?.();
+    return timer;
+  }
+
+  private resetIdleTimer(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    clearTimeout(session.idleTimer);
+    session.idleTimer = this.createIdleTimer(sessionId);
+  }
+
   private async writeDiscoveryFile(): Promise<void> {
     if (!this.port) return;
     try {
       await fs.mkdir(DISCOVERY_DIR, { recursive: true });
+      if (process.platform !== "win32") {
+        await fs.chmod(DISCOVERY_DIR, 0o700).catch((err) => {
+          console.error("[MCP] Failed to chmod discovery directory:", err);
+        });
+      }
 
       let existing: Record<string, unknown> = {};
       try {
@@ -782,6 +845,11 @@ export class McpServerService {
         JSON.stringify({ ...existing, mcpServers }, null, 2) + "\n",
         "utf-8"
       );
+      if (process.platform !== "win32") {
+        await fs.chmod(DISCOVERY_FILE, 0o600).catch((err) => {
+          console.error("[MCP] Failed to chmod discovery file:", err);
+        });
+      }
     } catch (err) {
       console.error("[MCP] Failed to write discovery file:", err);
     }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -634,22 +634,120 @@ describe("McpServerService", () => {
   it("sets POSIX 0700/0600 mode on the discovery directory and file", async () => {
     if (process.platform === "win32") return;
 
-    const chmodSpy = vi.spyOn(fs, "chmod");
     const { window } = createMockWindow();
     const discoveryDir = path.join(testHomeDir, ".daintree");
     const discoveryFile = path.join(discoveryDir, "mcp.json");
 
     await service.start(window);
 
-    expect(chmodSpy).toHaveBeenCalledWith(discoveryDir, 0o700);
-    expect(chmodSpy).toHaveBeenCalledWith(discoveryFile, 0o600);
-
     const dirStat = await fs.stat(discoveryDir);
     const fileStat = await fs.stat(discoveryFile);
     expect(dirStat.mode & 0o777).toBe(0o700);
     expect(fileStat.mode & 0o777).toBe(0o600);
+  });
 
-    chmodSpy.mockRestore();
+  it("preserves 0600 mode on partial discovery file removal", async () => {
+    if (process.platform === "win32") return;
+
+    const { window } = createMockWindow();
+    const discoveryDir = path.join(testHomeDir, ".daintree");
+    const discoveryFile = path.join(discoveryDir, "mcp.json");
+
+    // Pre-populate with another MCP entry that should survive removal.
+    await fs.mkdir(discoveryDir, { recursive: true });
+    await fs.writeFile(
+      discoveryFile,
+      JSON.stringify(
+        {
+          mcpServers: {
+            other: { type: "sse", url: "http://other.local/sse" },
+          },
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+
+    await service.start(window);
+    await service.stop();
+
+    const fileStat = await fs.stat(discoveryFile);
+    expect(fileStat.mode & 0o777).toBe(0o600);
+    const remaining = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(remaining.mcpServers.other).toBeDefined();
+    expect(remaining.mcpServers.daintree).toBeUndefined();
+  });
+
+  it("invalidates the old bearer immediately after rotation", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const oldKey = storeState.mcpServer.apiKey;
+    const newKey = await service.generateApiKey();
+    expect(newKey).not.toBe(oldKey);
+
+    const oldRequest = await requestSse(service.currentPort!, {
+      Authorization: `Bearer ${oldKey}`,
+    });
+    expect(oldRequest.status).toBe(401);
+
+    // New key works (peek + abort).
+    const port = service.currentPort!;
+    const newStatus = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/sse",
+          method: "GET",
+          headers: { Authorization: `Bearer ${newKey}` },
+        },
+        (res) => {
+          const status = res.statusCode ?? 0;
+          req.destroy();
+          resolve(status);
+        }
+      );
+      req.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "ECONNRESET") return;
+        reject(err);
+      });
+      req.end();
+    });
+    expect(newStatus).toBe(200);
+  });
+
+  it("rejects POST /messages with a non-loopback Origin header", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const port = service.currentPort!;
+    const auth = `Bearer ${storeState.mcpServer.apiKey}`;
+
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/messages?sessionId=anything",
+          method: "POST",
+          headers: {
+            Authorization: auth,
+            Origin: "https://evil.example",
+            "Content-Type": "application/json",
+          },
+        },
+        (res) => {
+          resolve(res.statusCode ?? 0);
+        }
+      );
+      req.on("error", reject);
+      req.end("{}");
+    });
+    expect(status).toBe(403);
   });
 
   it("closes idle SSE sessions after the application-level timeout", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -231,10 +231,16 @@ async function connectClient(
   port: number,
   headers?: Record<string, string>
 ): Promise<{ client: Client; transport: SSEClientTransport }> {
+  const apiKey = storeState.mcpServer.apiKey;
+  const mergedHeaders: Record<string, string> = {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    ...(headers ?? {}),
+  };
+  const hasHeaders = Object.keys(mergedHeaders).length > 0;
   const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
   const transport = new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`), {
-    eventSourceInit: headers ? ({ headers } as never) : undefined,
-    requestInit: headers ? { headers } : undefined,
+    eventSourceInit: hasHeaders ? ({ headers: mergedHeaders } as never) : undefined,
+    requestInit: hasHeaders ? { headers: mergedHeaders } : undefined,
   });
   await client.connect(transport);
   return { client, transport };
@@ -520,14 +526,19 @@ describe("McpServerService", () => {
     const initial = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
       mcpServers: Record<string, { headers?: { Authorization: string } }>;
     };
-    expect(initial.mcpServers.daintree.headers).toBeUndefined();
+    const initialKey = storeState.mcpServer.apiKey;
+    expect(initialKey).toMatch(/^daintree_[a-f0-9]+$/);
+    expect(initial.mcpServers.daintree.headers).toEqual({
+      Authorization: `Bearer ${initialKey}`,
+    });
 
-    const generatedKey = await service.generateApiKey();
-    const generated = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
+    const rotatedKey = await service.generateApiKey();
+    expect(rotatedKey).not.toBe(initialKey);
+    const rotated = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
       mcpServers: Record<string, { headers?: { Authorization: string } }>;
     };
-    expect(generated.mcpServers.daintree.headers).toEqual({
-      Authorization: `Bearer ${generatedKey}`,
+    expect(rotated.mcpServers.daintree.headers).toEqual({
+      Authorization: `Bearer ${rotatedKey}`,
     });
 
     await service.setApiKey("");
@@ -535,6 +546,194 @@ describe("McpServerService", () => {
       mcpServers: Record<string, { headers?: { Authorization: string } }>;
     };
     expect(cleared.mcpServers.daintree.headers).toBeUndefined();
+  });
+
+  it("auto-generates a bearer token on first start and persists it across restarts", async () => {
+    const { window } = createMockWindow();
+
+    expect(storeState.mcpServer.apiKey).toBe("");
+
+    await service.start(window);
+    const generatedKey = storeState.mcpServer.apiKey;
+    expect(generatedKey).toMatch(/^daintree_[a-f0-9]+$/);
+
+    await service.stop();
+
+    await service.start(window);
+    expect(storeState.mcpServer.apiKey).toBe(generatedKey);
+  });
+
+  it("rejects requests with a non-loopback Origin header", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const evil = await requestSse(service.currentPort!, {
+      Authorization: `Bearer ${storeState.mcpServer.apiKey}`,
+      Origin: "https://evil.example",
+    });
+    expect(evil.status).toBe(403);
+    expect(evil.body).toBe("Forbidden");
+  });
+
+  it("accepts absent and loopback Origin headers on the SSE GET", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const port = service.currentPort!;
+    const auth = `Bearer ${storeState.mcpServer.apiKey}`;
+
+    // Helper that aborts the SSE GET as soon as the response status is known.
+    const peekStatus = async (extraHeaders: Record<string, string>): Promise<number> =>
+      new Promise((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/sse",
+            method: "GET",
+            headers: { Authorization: auth, ...extraHeaders },
+          },
+          (res) => {
+            const status = res.statusCode ?? 0;
+            req.destroy();
+            resolve(status);
+          }
+        );
+        req.on("error", (err: NodeJS.ErrnoException) => {
+          if (err.code === "ECONNRESET") return;
+          reject(err);
+        });
+        req.end();
+      });
+
+    expect(await peekStatus({})).toBe(200);
+    expect(await peekStatus({ Origin: `http://127.0.0.1:${port}` })).toBe(200);
+    expect(await peekStatus({ Origin: `http://localhost:${port}` })).toBe(200);
+  });
+
+  it("uses constant-time comparison that does not short-circuit on length mismatch", async () => {
+    storeState.mcpServer.apiKey = "secret";
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const wrongShort = await requestSse(service.currentPort!, {
+      Authorization: "Bearer x",
+    });
+    const wrongLong = await requestSse(service.currentPort!, {
+      Authorization: `Bearer ${"x".repeat(1024)}`,
+    });
+    const correct = await requestSse(service.currentPort!, {
+      Authorization: "Bearer wrong-but-same-length-ish",
+    });
+
+    expect(wrongShort.status).toBe(401);
+    expect(wrongLong.status).toBe(401);
+    expect(correct.status).toBe(401);
+  });
+
+  it("sets POSIX 0700/0600 mode on the discovery directory and file", async () => {
+    if (process.platform === "win32") return;
+
+    const chmodSpy = vi.spyOn(fs, "chmod");
+    const { window } = createMockWindow();
+    const discoveryDir = path.join(testHomeDir, ".daintree");
+    const discoveryFile = path.join(discoveryDir, "mcp.json");
+
+    await service.start(window);
+
+    expect(chmodSpy).toHaveBeenCalledWith(discoveryDir, 0o700);
+    expect(chmodSpy).toHaveBeenCalledWith(discoveryFile, 0o600);
+
+    const dirStat = await fs.stat(discoveryDir);
+    const fileStat = await fs.stat(discoveryFile);
+    expect(dirStat.mode & 0o777).toBe(0o700);
+    expect(fileStat.mode & 0o777).toBe(0o600);
+
+    chmodSpy.mockRestore();
+  });
+
+  it("closes idle SSE sessions after the application-level timeout", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { window } = createMockWindow();
+      await service.start(window);
+
+      const sessions = (
+        service as unknown as {
+          sessions: Map<string, { transport: { close: () => Promise<void> } }>;
+        }
+      ).sessions;
+
+      const transport = {
+        sessionId: "test-session",
+        close: vi.fn(async () => {}),
+      };
+      const createIdleTimer = (
+        service as unknown as {
+          createIdleTimer: (sessionId: string) => ReturnType<typeof setTimeout>;
+        }
+      ).createIdleTimer.bind(service);
+
+      const idleTimer = createIdleTimer("test-session");
+      sessions.set("test-session", { transport, idleTimer } as never);
+
+      expect(sessions.has("test-session")).toBe(true);
+
+      vi.advanceTimersByTime(30 * 60 * 1000 + 1);
+
+      expect(sessions.has("test-session")).toBe(false);
+      expect(transport.close).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets the idle timer on incoming POST traffic", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { window } = createMockWindow();
+      await service.start(window);
+
+      const sessions = (
+        service as unknown as {
+          sessions: Map<string, { transport: { close: () => Promise<void> } }>;
+        }
+      ).sessions;
+
+      const transport = {
+        sessionId: "active-session",
+        close: vi.fn(async () => {}),
+      };
+      const createIdleTimer = (
+        service as unknown as {
+          createIdleTimer: (sessionId: string) => ReturnType<typeof setTimeout>;
+        }
+      ).createIdleTimer.bind(service);
+      const resetIdleTimer = (
+        service as unknown as { resetIdleTimer: (sessionId: string) => void }
+      ).resetIdleTimer.bind(service);
+
+      sessions.set("active-session", {
+        transport,
+        idleTimer: createIdleTimer("active-session"),
+      } as never);
+
+      // Just before timeout: keep alive via a POST.
+      vi.advanceTimersByTime(29 * 60 * 1000);
+      resetIdleTimer("active-session");
+
+      // After original timeout would have fired — session should still exist.
+      vi.advanceTimersByTime(2 * 60 * 1000);
+      expect(sessions.has("active-session")).toBe(true);
+      expect(transport.close).not.toHaveBeenCalled();
+
+      // Now let the new timer expire.
+      vi.advanceTimersByTime(30 * 60 * 1000);
+      expect(sessions.has("active-session")).toBe(false);
+      expect(transport.close).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects unauthorized requests and invalid host headers", async () => {

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -1,5 +1,5 @@
 import { dirname } from "path";
-import { access, open, unlink as fsUnlink } from "fs/promises";
+import { access, chmod as fsChmod, open, unlink as fsUnlink } from "fs/promises";
 import { closeSync, fsyncSync, openSync, unlinkSync, writeFileSync } from "fs";
 import stubbornFs from "stubborn-fs";
 
@@ -85,11 +85,17 @@ function syncParentDirectorySync(filePath: string): void {
  * Atomic writeFile: writes to a temp file with flush, then renames to the
  * target path. If any step fails the temp file is cleaned up best-effort.
  * Accepts strings (encoded with `encoding`) or binary buffers.
+ *
+ * `mode` (POSIX only) is applied to the temp file before rename so the
+ * destination has the right permissions atomically — closing the window
+ * where a sensitive file would briefly be world-readable at the umask
+ * default. Silently skipped on Windows.
  */
 export async function resilientAtomicWriteFile(
   filePath: string,
   data: string | Buffer | Uint8Array,
-  encoding: BufferEncoding = "utf-8"
+  encoding: BufferEncoding = "utf-8",
+  options?: { mode?: number }
 ): Promise<void> {
   const tempPath = generateTempPath(filePath);
   const writeOptions =
@@ -98,6 +104,9 @@ export async function resilientAtomicWriteFile(
       : ({ flush: true } as Parameters<typeof writeFileSync>[2]);
   try {
     await stubbornFs.retry.writeFile({ timeout: RETRY_TIMEOUT_MS })(tempPath, data, writeOptions);
+    if (options?.mode !== undefined && process.platform !== "win32") {
+      await fsChmod(tempPath, options.mode);
+    }
     await resilientRename(tempPath, filePath);
     await syncParentDirectory(filePath);
   } catch (error) {


### PR DESCRIPTION
## Summary

- DNS-rebinding protection on both the SSE GET and `POST /messages` endpoints — `Origin` and `Host` validation with `403` on mismatch, while still accepting requests with no `Origin` header (non-browser MCP clients like Cursor and Claude Desktop don't send one)
- Bearer token auto-generated on first enable and persisted across restarts; comparison switched to constant-time to eliminate the timing side-channel
- Application-level idle timeout on SSE connections that resets on each JSON-RPC message, replacing Node's blunt `requestTimeout` cutoff
- `~/.daintree/mcp.json` and its parent directory written at `0600`/`0700` on macOS/Linux; Windows silently ignores POSIX modes so no platform branch needed

Resolves #6395

## Changes

- `electron/services/McpServerService.ts` — DNS-rebinding validation, auto-bearer-gen, `timingSafeEqual` comparison, application-level idle SSE timer
- `electron/services/__tests__/McpServerService.test.ts` — expanded test coverage for all new behaviors (auto-gen-on-start, `Origin` rejection, timing-safe compare, POSIX mode assertion)
- `electron/utils/fs.ts` — optional `mode` parameter on `resilientAtomicWriteFile` plus parent-directory chmod; mode handling stays in the caller, not baked into the helper

## Testing

Existing test suite passes. New tests cover: bearer auto-generation on first `start()`, `Origin`-blocked requests returning `403`, constant-time comparison path, idle SSE disconnect after the configured timeout, and file-mode assertions on POSIX.