### PR TITLE
fix(telemetry): align Sentry normalizeDepth with scrubber depth cap, document field-omission contract

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -84,6 +84,14 @@ export function sanitizeEvent(event: SentryEvent): SentryEvent | null {
   // `beforeSend` must never throw — a throw causes Sentry to drop the event
   // silently. Fail closed on unexpected input rather than leaking unscrubbed
   // data by returning the event as-is.
+  //
+  // Deliberately skips deep-walking event.tags / event.user / event.contexts.
+  // This is safe only while: zero Sentry.setUser() calls exist in the codebase;
+  // the sole setTag() call (setOnboardingCompleteTag) passes fixed "true"/"false"
+  // strings; initial-scope tags are process-controlled (platform, arch, node);
+  // and @sentry/electron's MainContext integration does not capture process.argv
+  // into app_arguments. Adding user-populated data to any of these fields would
+  // silently bypass scrubbing with no warning at the call site.
   try {
     if (Array.isArray(event.exception?.values)) {
       for (const ex of event.exception.values) {
@@ -194,6 +202,14 @@ export async function initializeTelemetry(): Promise<void> {
         // crash time, and JS-level beforeSend cannot scrub binary data. JS
         // crashes remain captured via globalErrorHandlers.ts / main-crash.log.
         integrations: (defaults) => defaults.filter((i) => i.name !== "SentryMinidump"),
+        // Sentry normalizes events (default depth 3) *before* beforeSend fires,
+        // replacing nested objects/arrays past the cap with the literal strings
+        // "[Object]"/"[Array]". Raise to match MAX_DEEP_SANITIZE_DEPTH so the
+        // deep-walk scrubber inspects real data, not already-flattened stubs.
+        // Freeze normalizeMaxBreadth at its current SDK default to insulate
+        // against a future change silently narrowing the breadth limit.
+        normalizeDepth: MAX_DEEP_SANITIZE_DEPTH,
+        normalizeMaxBreadth: 1000,
         // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
         // performance tracing is ever added, use `tracesSampleRate` instead.
         // The local `SentryEvent` interface is a narrower projection of the

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -625,6 +625,13 @@ describe("initializeTelemetry", () => {
     // capture) and any value < 1 silently drops that fraction of crash
     // reports. Fail closed so reintroduction at any value is caught. See #5255.
     expect(options).not.toHaveProperty("sampleRate");
+    // normalizeDepth must match MAX_DEEP_SANITIZE_DEPTH so the deep-walk
+    // scrubber inspects real data, not already-flattened [Object]/[Array] stubs
+    // produced by Sentry's default depth-3 normalization.
+    expect(options.normalizeDepth).toBe(10);
+    // normalizeMaxBreadth is frozen at the current SDK default to insulate
+    // against a future SDK change silently narrowing the breadth limit.
+    expect(options.normalizeMaxBreadth).toBe(1000);
     process.env.SENTRY_DSN = original;
   });
 


### PR DESCRIPTION
## Summary
- `normalizeDepth` was at the SDK default of 3, but the scrubber's `MAX_DEEP_SANITIZE_DEPTH` is 10 -- so past depth 3 the scrubber was only inspecting already-flattened `[Object]`/`[Array]` stubs, not real data.
- `normalizeMaxBreadth` is now frozen at the current SDK default (1000) so a future SDK change can't silently narrow the breadth limit out from under the scrubber.
- Added a comment documenting which event fields the scrubber deliberately skips and the conditions that keep that omission safe.

Resolves #6399

## Changes
- Set `normalizeDepth: MAX_DEEP_SANITIZE_DEPTH` in `Sentry.init`
- Set `normalizeMaxBreadth: 1000` in `Sentry.init`
- Added field-omission contract comment in `sanitizeEvent`
- Added test assertions for both normalize config values

## Testing
- Unit tests verify both `normalizeDepth` (10) and `normalizeMaxBreadth` (1000) are passed to Sentry init.
- Typecheck, lint, and format all pass clean.