### PR TITLE
feat(ipc): add IPC trust envelope size and arg-count gate

### DIFF
--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -44,14 +44,16 @@ function parseIpcPayload<S extends z.ZodTypeAny>(
 
 const rateLimitTimestamps = new Map<string, number[]>();
 
-type RateLimitCategory = "fileOps" | "gitOps" | "terminalSpawn";
+export type IpcChannelCategory = "fileOps" | "artifactOps" | "gitOps" | "terminalSpawn";
 
-const channelToCategory: Record<string, RateLimitCategory> = {
+export const channelToCategory: Record<string, IpcChannelCategory> = {
   "copytree:generate": "fileOps",
   "copytree:generate-and-copy-file": "fileOps",
   "copytree:inject": "fileOps",
   "copytree:get-file-tree": "fileOps",
   "copytree:test-config": "fileOps",
+  "artifact:apply-patch": "artifactOps",
+  "artifact:save-to-file": "artifactOps",
   "worktree:create": "gitOps",
   "worktree:delete": "gitOps",
   "worktree:create-for-task": "gitOps",

--- a/electron/setup/__tests__/security.test.ts
+++ b/electron/setup/__tests__/security.test.ts
@@ -81,6 +81,7 @@ import {
   enforceIpcSenderValidation,
   sanitizeErrorForRenderer,
   validateIpcInvokeEnvelope,
+  containsBinary,
   MAX_IPC_ARG_COUNT,
   PAYLOAD_BUDGETS,
   DEFAULT_PAYLOAD_BUDGET,
@@ -620,8 +621,82 @@ describe("validateIpcInvokeEnvelope", () => {
     expect(() => validateIpcInvokeEnvelope("any:channel", [buf])).not.toThrow();
   });
 
+  it("falls through silently when a typed array is nested inside a plain object", () => {
+    const buf = new Uint8Array(DEFAULT_PAYLOAD_BUDGET + 1024);
+    expect(() => validateIpcInvokeEnvelope("any:channel", [{ blob: buf }])).not.toThrow();
+  });
+
+  it("falls through silently when payload contains a Map or Set", () => {
+    expect(() => validateIpcInvokeEnvelope("any:channel", [new Map()])).not.toThrow();
+    expect(() => validateIpcInvokeEnvelope("any:channel", [new Set([1, 2, 3])])).not.toThrow();
+  });
+
+  it("does not let BigInt silently bypass the byte budget", () => {
+    const oversize = "x".repeat(DEFAULT_PAYLOAD_BUDGET + 1024);
+    let caught: unknown;
+    try {
+      validateIpcInvokeEnvelope("any:channel", [{ data: oversize, n: 1n }]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("PAYLOAD_TOO_LARGE");
+  });
+
+  it("rejects oversize payloads on artifact:apply-patch above the artifactOps budget", () => {
+    const oversize = "x".repeat(PAYLOAD_BUDGETS.artifactOps + 1024);
+    let caught: unknown;
+    try {
+      validateIpcInvokeEnvelope("artifact:apply-patch", [oversize]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("PAYLOAD_TOO_LARGE");
+    expect((caught as AppError).context).toMatchObject({ category: "artifactOps" });
+  });
+
+  it("accepts artifact:apply-patch payloads under the artifactOps budget", () => {
+    const justUnder = "x".repeat(PAYLOAD_BUDGETS.artifactOps - 4096);
+    expect(() => validateIpcInvokeEnvelope("artifact:apply-patch", [justUnder])).not.toThrow();
+  });
+
   it("accepts an empty arg list", () => {
     expect(() => validateIpcInvokeEnvelope("any:channel", [])).not.toThrow();
+  });
+});
+
+describe("containsBinary", () => {
+  it("returns false for primitives", () => {
+    expect(containsBinary(null)).toBe(false);
+    expect(containsBinary(undefined)).toBe(false);
+    expect(containsBinary("string")).toBe(false);
+    expect(containsBinary(42)).toBe(false);
+    expect(containsBinary(true)).toBe(false);
+  });
+
+  it("detects ArrayBuffer and typed arrays at the top level", () => {
+    expect(containsBinary(new Uint8Array(8))).toBe(true);
+    expect(containsBinary(new ArrayBuffer(8))).toBe(true);
+    expect(containsBinary(new Int32Array(2))).toBe(true);
+  });
+
+  it("detects binary nested inside arrays", () => {
+    expect(containsBinary([1, 2, new Uint8Array(8)])).toBe(true);
+  });
+
+  it("detects binary nested inside plain objects", () => {
+    expect(containsBinary({ blob: new Uint8Array(8) })).toBe(true);
+    expect(containsBinary({ a: { b: { c: new Uint8Array(8) } } })).toBe(true);
+  });
+
+  it("treats Map and Set as binary-like (size unknowable via JSON)", () => {
+    expect(containsBinary(new Map())).toBe(true);
+    expect(containsBinary(new Set())).toBe(true);
+  });
+
+  it("returns false for plain object trees with no binary or Map/Set", () => {
+    expect(containsBinary({ a: 1, b: { c: "x", d: [1, 2, 3] } })).toBe(false);
   });
 });
 
@@ -711,6 +786,31 @@ describe("enforceIpcSenderValidation envelope guards", () => {
     expect(envelope.ok).toBe(false);
     expect(envelope.error?.code).toBe("ARG_COUNT_EXCEEDED");
     errSpy.mockRestore();
+  });
+
+  it("preserves PAYLOAD_TOO_LARGE through the packaged-build prod-strip path", async () => {
+    appMock.isPackaged = true;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn();
+    const oversize = "x".repeat(DEFAULT_PAYLOAD_BUDGET + 1024);
+    const envelope = (await invokeWrappedHandle("handle", "test:channel", handler, [oversize])) as {
+      ok: boolean;
+      error?: { code?: string; context?: unknown };
+    };
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("PAYLOAD_TOO_LARGE");
+    // context is stripped in packaged builds — must not leak budget/bytes
+    expect(envelope.error?.context).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  it("rejects oversized payloads on ipcMain.handleOnce", async () => {
+    const handler = vi.fn();
+    const oversize = "x".repeat(DEFAULT_PAYLOAD_BUDGET + 1024);
+    const envelope = await invokeWrappedHandle("handleOnce", "once:channel", handler, [oversize]);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/setup/__tests__/security.test.ts
+++ b/electron/setup/__tests__/security.test.ts
@@ -80,9 +80,14 @@ import {
   setupPermissionLockdown,
   enforceIpcSenderValidation,
   sanitizeErrorForRenderer,
+  validateIpcInvokeEnvelope,
+  MAX_IPC_ARG_COUNT,
+  PAYLOAD_BUDGETS,
+  DEFAULT_PAYLOAD_BUDGET,
   _resetPermissionLockdownForTesting,
 } from "../security.js";
 import { assertIpcSecurityReady, _resetIpcGuardForTesting } from "../../ipc/ipcGuard.js";
+import { AppError } from "../../utils/errorTypes.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockWebContents = {} as any;
@@ -540,6 +545,171 @@ describe("enforceIpcSenderValidation", () => {
     expect(envelope.error.userMessage).toBe("Please try again later");
 
     logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});
+
+describe("validateIpcInvokeEnvelope", () => {
+  it("throws ARG_COUNT_EXCEEDED when args exceed MAX_IPC_ARG_COUNT", () => {
+    const tooMany = Array.from({ length: MAX_IPC_ARG_COUNT + 1 }, (_, i) => i);
+    let caught: unknown;
+    try {
+      validateIpcInvokeEnvelope("any:channel", tooMany);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("ARG_COUNT_EXCEEDED");
+    expect((caught as AppError).context).toMatchObject({
+      channel: "any:channel",
+      argCount: MAX_IPC_ARG_COUNT + 1,
+      maxArgCount: MAX_IPC_ARG_COUNT,
+    });
+  });
+
+  it("accepts arg counts at the cap", () => {
+    const atCap = Array.from({ length: MAX_IPC_ARG_COUNT }, (_, i) => i);
+    expect(() => validateIpcInvokeEnvelope("any:channel", atCap)).not.toThrow();
+  });
+
+  it("throws PAYLOAD_TOO_LARGE on uncategorized channel above DEFAULT_PAYLOAD_BUDGET", () => {
+    const oversize = "x".repeat(DEFAULT_PAYLOAD_BUDGET + 1024);
+    let caught: unknown;
+    try {
+      validateIpcInvokeEnvelope("uncategorized:channel", [oversize]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("PAYLOAD_TOO_LARGE");
+    const ctx = (caught as AppError).context as { category: string | null; budget: number };
+    expect(ctx.category).toBeNull();
+    expect(ctx.budget).toBe(DEFAULT_PAYLOAD_BUDGET);
+  });
+
+  it("applies tighter budget on terminalSpawn category", () => {
+    const oversize = "x".repeat(PAYLOAD_BUDGETS.terminalSpawn + 1024);
+    let caught: unknown;
+    try {
+      validateIpcInvokeEnvelope("terminal:spawn", [oversize]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(AppError);
+    expect((caught as AppError).code).toBe("PAYLOAD_TOO_LARGE");
+    const ctx = (caught as AppError).context as { category: string; budget: number };
+    expect(ctx.category).toBe("terminalSpawn");
+    expect(ctx.budget).toBe(PAYLOAD_BUDGETS.terminalSpawn);
+  });
+
+  it("allows large payloads on fileOps category up to the 4 MB budget", () => {
+    const justUnderFileOpsBudget = "x".repeat(PAYLOAD_BUDGETS.fileOps - 1024);
+    expect(() =>
+      validateIpcInvokeEnvelope("copytree:get-file-tree", [justUnderFileOpsBudget])
+    ).not.toThrow();
+  });
+
+  it("falls through silently when JSON.stringify cannot serialize args", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => validateIpcInvokeEnvelope("any:channel", [circular])).not.toThrow();
+  });
+
+  it("falls through silently for non-JSON-serializable payloads (typed arrays)", () => {
+    const buf = new Uint8Array(DEFAULT_PAYLOAD_BUDGET + 1024);
+    expect(() => validateIpcInvokeEnvelope("any:channel", [buf])).not.toThrow();
+  });
+
+  it("accepts an empty arg list", () => {
+    expect(() => validateIpcInvokeEnvelope("any:channel", [])).not.toThrow();
+  });
+});
+
+describe("enforceIpcSenderValidation envelope guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetIpcGuardForTesting();
+    appMock.isPackaged = false;
+    ipcMainMock.handle = vi.fn();
+    ipcMainMock.handleOnce = vi.fn();
+    ipcMainMock.on = vi.fn();
+    ipcMainMock.removeListener = vi.fn();
+    ipcMainMock.removeAllListeners = vi.fn();
+    ipcMainMock.off = vi.fn();
+  });
+
+  async function invokeWrappedHandle(
+    register: "handle" | "handleOnce",
+    channel: string,
+    listener: (...args: unknown[]) => unknown,
+    invokeArgs: unknown[]
+  ): Promise<{ ok: boolean; error?: { code?: string } }> {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const original = register === "handle" ? ipcMainMock.handle : ipcMainMock.handleOnce;
+      enforceIpcSenderValidation();
+      const wrapper = register === "handle" ? ipcMainMock.handle : ipcMainMock.handleOnce;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      wrapper(channel, listener as any);
+      const lastCall = original.mock.calls[original.mock.calls.length - 1];
+      const wrappedListener = lastCall[1] as (
+        event: unknown,
+        ...args: unknown[]
+      ) => Promise<unknown>;
+      const fakeEvent = { senderFrame: { url: "http://localhost:3000" } };
+      return (await wrappedListener(fakeEvent, ...invokeArgs)) as {
+        ok: boolean;
+        error?: { code?: string };
+      };
+    } finally {
+      logSpy.mockRestore();
+    }
+  }
+
+  it("rejects ipcMain.handle calls that exceed the arg-count cap", async () => {
+    const handler = vi.fn();
+    const tooMany = Array.from({ length: MAX_IPC_ARG_COUNT + 1 }, (_, i) => i);
+    const envelope = await invokeWrappedHandle("handle", "test:channel", handler, tooMany);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("ARG_COUNT_EXCEEDED");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized payloads on uncategorized channels", async () => {
+    const handler = vi.fn();
+    const oversize = "x".repeat(DEFAULT_PAYLOAD_BUDGET + 1024);
+    const envelope = await invokeWrappedHandle("handle", "uncategorized:channel", handler, [
+      oversize,
+    ]);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("invokes the listener for valid envelopes", async () => {
+    const handler = vi.fn().mockReturnValue("ok");
+    const envelope = await invokeWrappedHandle("handle", "test:channel", handler, [{ a: 1 }]);
+    expect(envelope.ok).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the same guards to ipcMain.handleOnce", async () => {
+    const handler = vi.fn();
+    const tooMany = Array.from({ length: MAX_IPC_ARG_COUNT + 1 }, (_, i) => i);
+    const envelope = await invokeWrappedHandle("handleOnce", "once:channel", handler, tooMany);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("ARG_COUNT_EXCEEDED");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("preserves the rejection code through the packaged-build prod-strip path", async () => {
+    appMock.isPackaged = true;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = vi.fn();
+    const tooMany = Array.from({ length: MAX_IPC_ARG_COUNT + 1 }, (_, i) => i);
+    const envelope = await invokeWrappedHandle("handle", "test:channel", handler, tooMany);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error?.code).toBe("ARG_COUNT_EXCEEDED");
     errSpy.mockRestore();
   });
 });

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -34,7 +34,10 @@ export const PAYLOAD_BUDGETS: Record<IpcChannelCategory, number> = {
   fileOps: 4 * 1024 * 1024,
   artifactOps: 4 * 1024 * 1024,
   gitOps: 512 * 1024,
-  terminalSpawn: 64 * 1024,
+  // Spawn carries env-var dictionaries that can include base64 cert bundles
+  // (3–8 KiB each) plus accumulated PATH/HOME/PROXY entries; 256 KiB keeps
+  // the budget tight while accommodating realistic project env overrides.
+  terminalSpawn: 256 * 1024,
 };
 
 export const DEFAULT_PAYLOAD_BUDGET = 1 * 1024 * 1024;
@@ -47,11 +50,32 @@ export const DEFAULT_PAYLOAD_BUDGET = 1 * 1024 * 1024;
  *
  * @internal Exported for testing.
  */
-function containsBinary(value: unknown): boolean {
+/**
+ * Detect values whose JSON-stringified size is an unreliable proxy for the
+ * structured-clone wire size, so the byte gate can skip them and defer to
+ * Mojo's 128 MiB ceiling. Catches binary buffers (`{"0":...}` overestimates),
+ * `Map`/`Set` (serialise to `{}`, underestimates), and walks plain objects
+ * and arrays so a buffer nested inside `{ blob: new Uint8Array(...) }` is
+ * still caught. Depth-bounded to keep the check cheap on legitimate payloads.
+ *
+ * @internal Exported for testing.
+ */
+export function containsBinary(value: unknown, depth = 0): boolean {
+  if (depth > 32) return true;
   if (value === null || typeof value !== "object") return false;
   if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) return true;
-  if (Array.isArray(value)) return value.some(containsBinary);
+  if (value instanceof Map || value instanceof Set) return true;
+  if (Array.isArray(value)) return value.some((v) => containsBinary(v, depth + 1));
+  for (const key of Object.keys(value)) {
+    if (containsBinary((value as Record<string, unknown>)[key], depth + 1)) return true;
+  }
   return false;
+}
+
+// JSON.stringify throws on BigInt; coerce to string so a single `1n` slipped
+// into args cannot silently defeat the byte gate.
+function bigintSafeReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
 }
 
 export function validateIpcInvokeEnvelope(channel: string, args: unknown[]): void {
@@ -64,18 +88,17 @@ export function validateIpcInvokeEnvelope(channel: string, args: unknown[]): voi
     });
   }
 
-  // Binary args (Uint8Array, ArrayBuffer) JSON-stringify to giant `{"0":...}`
-  // shapes that wildly overestimate the wire size. Skip the byte check for
-  // these and trust Mojo's 128 MiB ceiling as the backstop — handler-level
-  // caps (e.g. clipboard PNG, artifact patch) provide the precise limit.
-  if (args.some(containsBinary)) return;
+  // Binary / Map / Set payloads make `JSON.stringify` an unreliable size
+  // estimator. Skip the byte check and let Mojo's 128 MiB ceiling and the
+  // handler-level caps (clipboard PNG, artifact patch) act as the backstop.
+  if (args.some((arg) => containsBinary(arg))) return;
 
   const category = channelToCategory[channel];
   const budget = category !== undefined ? PAYLOAD_BUDGETS[category] : DEFAULT_PAYLOAD_BUDGET;
 
   let bytes: number;
   try {
-    bytes = Buffer.byteLength(JSON.stringify(args), "utf8");
+    bytes = Buffer.byteLength(JSON.stringify(args, bigintSafeReplacer), "utf8");
   } catch {
     return;
   }
@@ -177,6 +200,9 @@ export function enforceIpcSenderValidation(): void {
             console.error(`[IPC] Error on channel ${channel}:`, error);
             const serialized = serializeError(error);
             serialized.message = sanitizeErrorForRenderer(serialized.message);
+            if (typeof serialized.userMessage === "string") {
+              serialized.userMessage = sanitizeErrorForRenderer(serialized.userMessage);
+            }
             serialized.stack = undefined;
             serialized.path = undefined;
             serialized.context = undefined;

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -9,7 +9,86 @@ import {
 } from "../../shared/utils/ipcErrorSerialization.js";
 import { FAULT_MODE_ENABLED, applyInvokeFault, initFaultRegistry } from "../ipc/faultRegistry.js";
 import { markIpcSecurityReady } from "../ipc/ipcGuard.js";
+import { channelToCategory, type IpcChannelCategory } from "../ipc/utils.js";
+import { AppError } from "../utils/errorTypes.js";
 import { scrubSecrets } from "../utils/secretScrubber.js";
+
+/**
+ * Coarse cap on the number of arguments a renderer may pass to a handler in a
+ * single `ipcMain.invoke` call. Every typed channel in this codebase passes a
+ * single structured object; 8 gives ~4x headroom over the realistic max while
+ * still defeating `Array.prototype` poisoning / deep-spread variants that try
+ * to overwhelm the handler with thousands of args.
+ */
+export const MAX_IPC_ARG_COUNT = 8;
+
+/**
+ * Per-category byte budgets enforced after sender-frame validation, before
+ * the listener is invoked. Channels not in {@link channelToCategory} fall back
+ * to {@link DEFAULT_PAYLOAD_BUDGET}. `JSON.stringify` is used to estimate UTF-8
+ * size (cheaper than `v8.serialize` and the established codebase pattern from
+ * `electron/utils/performance.ts`); on failure (circular refs, binary buffers)
+ * the check is skipped and Mojo's 128 MiB ceiling acts as the backstop.
+ */
+export const PAYLOAD_BUDGETS: Record<IpcChannelCategory, number> = {
+  fileOps: 4 * 1024 * 1024,
+  artifactOps: 4 * 1024 * 1024,
+  gitOps: 512 * 1024,
+  terminalSpawn: 64 * 1024,
+};
+
+export const DEFAULT_PAYLOAD_BUDGET = 1 * 1024 * 1024;
+
+/**
+ * Throws an {@link AppError} with a stable {@link AppErrorCode} when the
+ * incoming invoke envelope exceeds the arg-count cap or the per-category byte
+ * budget. Caller is expected to call this inside the wrapper's try/catch so
+ * the existing prod-strip path serialises the error.
+ *
+ * @internal Exported for testing.
+ */
+function containsBinary(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) return true;
+  if (Array.isArray(value)) return value.some(containsBinary);
+  return false;
+}
+
+export function validateIpcInvokeEnvelope(channel: string, args: unknown[]): void {
+  if (args.length > MAX_IPC_ARG_COUNT) {
+    throw new AppError({
+      code: "ARG_COUNT_EXCEEDED",
+      message: `IPC argument count exceeded for ${channel}: ${args.length} > ${MAX_IPC_ARG_COUNT}`,
+      userMessage: "Request rejected — too many arguments.",
+      context: { channel, argCount: args.length, maxArgCount: MAX_IPC_ARG_COUNT },
+    });
+  }
+
+  // Binary args (Uint8Array, ArrayBuffer) JSON-stringify to giant `{"0":...}`
+  // shapes that wildly overestimate the wire size. Skip the byte check for
+  // these and trust Mojo's 128 MiB ceiling as the backstop — handler-level
+  // caps (e.g. clipboard PNG, artifact patch) provide the precise limit.
+  if (args.some(containsBinary)) return;
+
+  const category = channelToCategory[channel];
+  const budget = category !== undefined ? PAYLOAD_BUDGETS[category] : DEFAULT_PAYLOAD_BUDGET;
+
+  let bytes: number;
+  try {
+    bytes = Buffer.byteLength(JSON.stringify(args), "utf8");
+  } catch {
+    return;
+  }
+
+  if (bytes > budget) {
+    throw new AppError({
+      code: "PAYLOAD_TOO_LARGE",
+      message: `IPC payload too large for ${channel}: ${bytes} > ${budget} bytes`,
+      userMessage: "Request rejected — payload exceeds the allowed size.",
+      context: { channel, bytes, budget, category: category ?? null },
+    });
+  }
+}
 
 function sanitizePaths(msg: string): string {
   return msg
@@ -50,6 +129,7 @@ export function enforceIpcSenderValidation(): void {
         );
       }
       try {
+        validateIpcInvokeEnvelope(channel, args);
         if (FAULT_MODE_ENABLED) await applyInvokeFault(channel);
         const result = await listener(event, ...args);
         return wrapSuccess(result);
@@ -88,6 +168,7 @@ export function enforceIpcSenderValidation(): void {
           );
         }
         try {
+          validateIpcInvokeEnvelope(channel, args);
           if (FAULT_MODE_ENABLED) await applyInvokeFault(channel);
           const result = await listener(event, ...args);
           return wrapSuccess(result);

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -18,4 +18,6 @@ export type AppErrorCode =
   | "RATE_LIMITED"
   | "VALIDATION"
   | "PERMISSION"
+  | "ARG_COUNT_EXCEEDED"
+  | "PAYLOAD_TOO_LARGE"
   | "INTERNAL";


### PR DESCRIPTION
## Summary

- Adds `validateIpcInvokeEnvelope` in `electron/setup/security.ts` — caps argument count at 8 and enforces per-category byte budgets so a trusted sender can't push pathologically-large payloads through any of the ~87 channels
- Binary args (`Uint8Array`, `ArrayBuffer`, `Map`, `Set`) skip the byte check automatically; Mojo's 128 MiB ceiling backstops those instead
- Both `ipcMain.handle` and `ipcMain.handleOnce` wrappers now call the helper, closing a pre-existing gap where `handleOnce` had inconsistent `userMessage` scrubbing

Resolves #6393

## Changes

- `shared/types/appError.ts` — two new error codes: `ARG_COUNT_EXCEEDED`, `PAYLOAD_TOO_LARGE`
- `electron/ipc/utils.ts` — renamed `RateLimitCategory` to `IpcChannelCategory`, exported `channelToCategory`, added `artifactOps` category covering `artifact:apply-patch` and `artifact:save-to-file`
- `electron/setup/security.ts` — `validateIpcInvokeEnvelope` with per-category budgets (fileOps/artifactOps 4 MiB, gitOps 512 KiB, terminalSpawn 256 KiB, default 1 MiB); `containsBinary` helper recurses depth-bounded through plain objects and arrays; BigInt-safe `JSON.stringify` replacer so a single `1n` can't silently bypass the byte gate
- Rejection errors flow through the existing prod-strip + secret-scrub path with stable codes

## Testing

26 new tests in `electron/setup/__tests__/security.test.ts` (72 total) covering arg-count cap, all four byte-budget categories, Map/Set/BigInt/nested-binary fall-through, `handleOnce` parity, and packaged-build prod-strip code preservation. `utils.test.ts` unchanged (46 tests still passing).

Typecheck, lint ratchet (no new warnings), format check, and channel drift check all pass.