### PR TITLE
fix(ui): detect cached images in Avatar to prevent stuck skeletons

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { User } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -13,10 +13,15 @@ interface AvatarProps {
 export function Avatar({ src, alt, title, className }: AvatarProps) {
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
     setLoaded(false);
     setError(false);
+    const img = imgRef.current;
+    if (img?.complete && img.naturalWidth > 0) {
+      setLoaded(true);
+    }
   }, [src]);
 
   const avatarContent = (
@@ -41,11 +46,12 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
       )}
       {!error && (
         <img
+          ref={imgRef}
           src={src}
           alt={alt}
           onLoad={() => setLoaded(true)}
           onError={() => setError(true)}
-          className="rounded-full transition-opacity duration-200 w-full h-full"
+          className="rounded-full transition-opacity duration-150 ease-out w-full h-full"
           style={{ opacity: loaded ? 1 : 0 }}
         />
       )}

--- a/src/components/ui/__tests__/Avatar.test.tsx
+++ b/src/components/ui/__tests__/Avatar.test.tsx
@@ -24,14 +24,37 @@ describe("Avatar", () => {
     expect(skeleton).toBeTruthy();
   });
 
-  it("probes complete/naturalWidth on mount to detect cached images", () => {
-    const { container } = render(<Avatar src="cached.jpg" alt="Cached" />);
-    const img = container.querySelector("img");
+  it("shows skeleton when complete is true but naturalWidth is 0", () => {
+    const origComplete = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "complete");
+    const origNaturalWidth = Object.getOwnPropertyDescriptor(
+      HTMLImageElement.prototype,
+      "naturalWidth"
+    );
 
-    expect(img).toBeTruthy();
-    // For uncached images (jsdom default), skeleton is shown and opacity is 0
-    expect(img!.style.opacity).toBe("0");
-    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+    Object.defineProperty(HTMLImageElement.prototype, "complete", {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", {
+      value: 0,
+      configurable: true,
+    });
+
+    try {
+      const { container } = render(<Avatar src="broken-cached.jpg" alt="Broken" />);
+      const img = container.querySelector("img");
+      expect(img).toBeTruthy();
+      // naturalWidth=0 means a broken cached image — skeleton should remain
+      expect(img!.style.opacity).toBe("0");
+      expect(container.querySelector(".animate-pulse")).toBeTruthy();
+    } finally {
+      if (origComplete) {
+        Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
+      }
+      if (origNaturalWidth) {
+        Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", origNaturalWidth);
+      }
+    }
   });
 
   it("sets loaded=true when cached image is detected at mount", () => {
@@ -106,13 +129,37 @@ describe("Avatar", () => {
     // Content should still render through the mocked tooltip
   });
 
-  it("does not probe when error state removes the img element", () => {
-    const { container } = render(<Avatar src="broken.jpg" alt="Broken" />);
-    const img = container.querySelector("img")!;
-    act(() => {
-      fireEvent.error(img);
+  it("loads immediately when src changes between two cached images", () => {
+    const origComplete = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "complete");
+    const origNaturalWidth = Object.getOwnPropertyDescriptor(
+      HTMLImageElement.prototype,
+      "naturalWidth"
+    );
+
+    Object.defineProperty(HTMLImageElement.prototype, "complete", {
+      value: true,
+      configurable: true,
     });
-    expect(container.querySelector("img")).toBeFalsy();
-    expect(container.querySelector(".ring-2")).toBeTruthy();
+    Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", {
+      value: 48,
+      configurable: true,
+    });
+
+    try {
+      const { container, rerender } = render(<Avatar src="a.jpg" alt="A" />);
+      expect(container.querySelector("img")!.style.opacity).toBe("1");
+
+      rerender(<Avatar src="b.jpg" alt="B" />);
+      // Src change resets state and effect re-probes the reused img node
+      expect(container.querySelector("img")!.style.opacity).toBe("1");
+      expect(container.querySelector(".animate-pulse")).toBeFalsy();
+    } finally {
+      if (origComplete) {
+        Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
+      }
+      if (origNaturalWidth) {
+        Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", origNaturalWidth);
+      }
+    }
   });
 });

--- a/src/components/ui/__tests__/Avatar.test.tsx
+++ b/src/components/ui/__tests__/Avatar.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { render, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Avatar } from "../Avatar";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("Avatar", () => {
+  it("shows skeleton on initial render", () => {
+    const { container } = render(<Avatar src="test.jpg" alt="Test" />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img!.style.opacity).toBe("0");
+    const skeleton = container.querySelector(".animate-pulse");
+    expect(skeleton).toBeTruthy();
+  });
+
+  it("probes complete/naturalWidth on mount to detect cached images", () => {
+    const { container } = render(<Avatar src="cached.jpg" alt="Cached" />);
+    const img = container.querySelector("img");
+
+    expect(img).toBeTruthy();
+    // For uncached images (jsdom default), skeleton is shown and opacity is 0
+    expect(img!.style.opacity).toBe("0");
+    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+  });
+
+  it("sets loaded=true when cached image is detected at mount", () => {
+    // Simulate a cached image by overriding complete/naturalWidth before the
+    // useEffect fires. In jsdom the effect fires synchronously in a microtask
+    // after render, so we need to patch the prototype.
+    const origComplete = Object.getOwnPropertyDescriptor(HTMLImageElement.prototype, "complete");
+    const origNaturalWidth = Object.getOwnPropertyDescriptor(
+      HTMLImageElement.prototype,
+      "naturalWidth"
+    );
+
+    Object.defineProperty(HTMLImageElement.prototype, "complete", {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", {
+      value: 48,
+      configurable: true,
+    });
+
+    try {
+      const { container } = render(<Avatar src="cached.jpg" alt="Cached" />);
+      const img = container.querySelector("img");
+      expect(img).toBeTruthy();
+      expect(img!.style.opacity).toBe("1");
+      expect(container.querySelector(".animate-pulse")).toBeFalsy();
+    } finally {
+      if (origComplete) {
+        Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
+      }
+      if (origNaturalWidth) {
+        Object.defineProperty(HTMLImageElement.prototype, "naturalWidth", origNaturalWidth);
+      }
+    }
+  });
+
+  it("shows error state when onError fires", () => {
+    const { container } = render(<Avatar src="broken.jpg" alt="Broken" />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+
+    act(() => {
+      fireEvent.error(img!);
+    });
+
+    expect(container.querySelector("img")).toBeFalsy();
+    expect(container.querySelector(".ring-2")).toBeTruthy();
+    const userIcon = container.querySelector("svg");
+    expect(userIcon).toBeTruthy();
+  });
+
+  it("resets state when src changes", () => {
+    const { container, rerender } = render(<Avatar src="first.jpg" alt="First" />);
+
+    const img = container.querySelector("img")!;
+    act(() => {
+      fireEvent.load(img);
+    });
+    expect(img.style.opacity).toBe("1");
+
+    rerender(<Avatar src="second.jpg" alt="Second" />);
+    const newImg = container.querySelector("img")!;
+    expect(newImg.style.opacity).toBe("0");
+    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+  });
+
+  it("renders tooltip wrapper when title is provided", () => {
+    const { container } = render(<Avatar src="test.jpg" alt="Test" title="Test User" />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    // Content should still render through the mocked tooltip
+  });
+
+  it("does not probe when error state removes the img element", () => {
+    const { container } = render(<Avatar src="broken.jpg" alt="Broken" />);
+    const img = container.querySelector("img")!;
+    act(() => {
+      fireEvent.error(img);
+    });
+    expect(container.querySelector("img")).toBeFalsy();
+    expect(container.querySelector(".ring-2")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed a race in `Avatar` where browser-cached images fire `load` before React attaches `onLoad`, leaving avatars stuck on the skeleton.
- Added a `useRef` + `useEffect` cache probe that checks `img.complete` and `naturalWidth` on mount so cached images are detected immediately.
- Tightened the reveal animation to consistent Tier 1 timing (`duration-150 ease-out`).

Resolves #6385

## Changes
- `src/components/ui/Avatar.tsx` — added `imgRef`, cache-probe effect keyed on `src`, consistent animation timing
- `src/components/ui/__tests__/Avatar.test.tsx` — 7 tests: cache hit, cache miss (naturalWidth=0), error state, src change, cached-to-cached src change, plus existing coverage

## Testing
All 7 Avatar tests pass. Typecheck and lint pass.