### PR TITLE
perf(bundle): single LazyMotion provider with dynamic features (#6391)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,7 +137,9 @@ import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { isAgentLaunchable } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
-import { LazyMotion, MotionConfig, domAnimation } from "framer-motion";
+import { LazyMotion, MotionConfig } from "framer-motion";
+
+const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
@@ -496,7 +498,7 @@ function App() {
   }
 
   return (
-    <LazyMotion features={domAnimation}>
+    <LazyMotion strict features={loadMotionFeatures}>
       <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
         <ErrorBoundary variant="fullscreen" componentName="App">
           <TooltipProvider delayDuration={500} skipDelayDuration={150}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,8 +138,6 @@ import { isAgentLaunchable } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
 import { LazyMotion, MotionConfig } from "framer-motion";
-
-const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
@@ -148,6 +146,8 @@ import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
 
 import { SidebarContent, preloadNewWorktreeDialog, E2EFaultInjector } from "./components/Sidebar";
+
+const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);
 
 function App() {
   useErrors();

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { motion, type TransformProperties, type Transition } from "framer-motion";
+import { m, type TransformProperties, type Transition } from "framer-motion";
 import { cn } from "@/lib/utils";
 import type { TerminalInstance } from "@/store";
 import type { DragData } from "./DndProvider";
@@ -74,7 +74,7 @@ export function SortableTerminal({
   void _tabIndex;
 
   return (
-    <motion.div
+    <m.div
       layout="position"
       transition={layoutTransition}
       transformTemplate={pixelSnapTransform}
@@ -93,6 +93,6 @@ export function SortableTerminal({
       >
         <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>
       </div>
-    </motion.div>
+    </m.div>
   );
 }

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -12,7 +12,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
-import { LayoutGroup, LazyMotion, domMax } from "framer-motion";
+import { LayoutGroup } from "framer-motion";
 import { ChevronDown, Plus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
@@ -579,128 +579,126 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
           >
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-              <LazyMotion features={domMax}>
-                <LayoutGroup id={`dock-tabs-${group.id}`}>
-                  <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
-                    <div
-                      ref={setTabListEl}
-                      className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
-                      role="tablist"
-                      aria-label="Dock panel tabs"
-                      onKeyDown={handleTabListKeyDown}
-                    >
-                      {panels.map((panel) => {
-                        const tabChrome = deriveTerminalChrome({
-                          kind: panel.kind,
-                          launchAgentId: panel.launchAgentId,
-                          runtimeIdentity: panel.runtimeIdentity,
-                          detectedAgentId: panel.detectedAgentId,
-                          detectedProcessId: panel.detectedProcessId,
-                          agentState: panel.agentState,
-                          runtimeStatus: panel.runtimeStatus,
-                          exitCode: panel.exitCode,
-                          presetColor: panelPresetColors.get(panel.id),
-                        });
-                        return (
-                          <SortableTabButton
-                            key={panel.id}
-                            id={panel.id}
-                            title={getBaseTitle(panel.title)}
-                            chrome={tabChrome}
-                            kind={panel.kind ?? "terminal"}
-                            agentState={
-                              tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
-                            }
-                            isActive={panel.id === activeTabId}
-                            presetColor={panelPresetColors.get(panel.id)}
-                            isUsingFallback={panel.isUsingFallback}
-                            onClick={() => handleTabClick(panel.id)}
-                            onClose={() => handleTabClose(panel.id)}
-                            onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                          />
-                        );
-                      })}
+              <LayoutGroup id={`dock-tabs-${group.id}`}>
+                <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
+                  <div
+                    ref={setTabListEl}
+                    className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
+                    role="tablist"
+                    aria-label="Dock panel tabs"
+                    onKeyDown={handleTabListKeyDown}
+                  >
+                    {panels.map((panel) => {
+                      const tabChrome = deriveTerminalChrome({
+                        kind: panel.kind,
+                        launchAgentId: panel.launchAgentId,
+                        runtimeIdentity: panel.runtimeIdentity,
+                        detectedAgentId: panel.detectedAgentId,
+                        detectedProcessId: panel.detectedProcessId,
+                        agentState: panel.agentState,
+                        runtimeStatus: panel.runtimeStatus,
+                        exitCode: panel.exitCode,
+                        presetColor: panelPresetColors.get(panel.id),
+                      });
+                      return (
+                        <SortableTabButton
+                          key={panel.id}
+                          id={panel.id}
+                          title={getBaseTitle(panel.title)}
+                          chrome={tabChrome}
+                          kind={panel.kind ?? "terminal"}
+                          agentState={
+                            tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
+                          }
+                          isActive={panel.id === activeTabId}
+                          presetColor={panelPresetColors.get(panel.id)}
+                          isUsingFallback={panel.isUsingFallback}
+                          onClick={() => handleTabClick(panel.id)}
+                          onClose={() => handleTabClose(panel.id)}
+                          onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                        />
+                      );
+                    })}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleAddTab();
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                          aria-label="Duplicate panel as new tab"
+                          type="button"
+                        >
+                          <Plus className="w-3 h-3" aria-hidden="true" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                    </Tooltip>
+                  </div>
+                  {hiddenTabIds.size > 0 && (
+                    <DropdownMenu>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleAddTab();
-                            }}
-                            onPointerDown={(e) => e.stopPropagation()}
-                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                            aria-label="Duplicate panel as new tab"
-                            type="button"
-                          >
-                            <Plus className="w-3 h-3" aria-hidden="true" />
-                          </button>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              onPointerDown={(e) => e.stopPropagation()}
+                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                              aria-label="Show hidden tabs"
+                              aria-haspopup="menu"
+                              data-testid="dock-tabs-overflow"
+                            >
+                              <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                              <span className="sr-only"> ({hiddenTabIds.size} hidden)</span>
+                            </button>
+                          </DropdownMenuTrigger>
                         </TooltipTrigger>
-                        <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                        <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
                       </Tooltip>
-                    </div>
-                    {hiddenTabIds.size > 0 && (
-                      <DropdownMenu>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type="button"
-                                onPointerDown={(e) => e.stopPropagation()}
-                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                                aria-label="Show hidden tabs"
-                                aria-haspopup="menu"
-                                data-testid="dock-tabs-overflow"
+                      <DropdownMenuContent
+                        align="end"
+                        className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+                      >
+                        {panels
+                          .filter((p) => hiddenTabIds.has(p.id))
+                          .map((panel) => {
+                            const tabChrome = deriveTerminalChrome({
+                              kind: panel.kind,
+                              launchAgentId: panel.launchAgentId,
+                              runtimeIdentity: panel.runtimeIdentity,
+                              detectedAgentId: panel.detectedAgentId,
+                              detectedProcessId: panel.detectedProcessId,
+                              agentState: panel.agentState,
+                              runtimeStatus: panel.runtimeStatus,
+                              exitCode: panel.exitCode,
+                              presetColor: panelPresetColors.get(panel.id),
+                            });
+                            const isActive = panel.id === activeTabId;
+                            return (
+                              <DropdownMenuItem
+                                key={panel.id}
+                                onSelect={() => handleTabClick(panel.id)}
+                                aria-current={isActive ? "true" : undefined}
+                                className={cn(isActive && "font-medium")}
                               >
-                                <ChevronDown className="w-3 h-3" aria-hidden="true" />
-                                <span className="sr-only"> ({hiddenTabIds.size} hidden)</span>
-                              </button>
-                            </DropdownMenuTrigger>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
-                        </Tooltip>
-                        <DropdownMenuContent
-                          align="end"
-                          className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
-                        >
-                          {panels
-                            .filter((p) => hiddenTabIds.has(p.id))
-                            .map((panel) => {
-                              const tabChrome = deriveTerminalChrome({
-                                kind: panel.kind,
-                                launchAgentId: panel.launchAgentId,
-                                runtimeIdentity: panel.runtimeIdentity,
-                                detectedAgentId: panel.detectedAgentId,
-                                detectedProcessId: panel.detectedProcessId,
-                                agentState: panel.agentState,
-                                runtimeStatus: panel.runtimeStatus,
-                                exitCode: panel.exitCode,
-                                presetColor: panelPresetColors.get(panel.id),
-                              });
-                              const isActive = panel.id === activeTabId;
-                              return (
-                                <DropdownMenuItem
-                                  key={panel.id}
-                                  onSelect={() => handleTabClick(panel.id)}
-                                  aria-current={isActive ? "true" : undefined}
-                                  className={cn(isActive && "font-medium")}
-                                >
-                                  <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
-                                    <TerminalIcon
-                                      kind={panel.kind ?? "terminal"}
-                                      chrome={tabChrome}
-                                      className="w-3.5 h-3.5"
-                                    />
-                                  </span>
-                                  <span className="truncate">{getBaseTitle(panel.title)}</span>
-                                </DropdownMenuItem>
-                              );
-                            })}
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
-                  </div>
-                </LayoutGroup>
-              </LazyMotion>
+                                <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
+                                  <TerminalIcon
+                                    kind={panel.kind ?? "terminal"}
+                                    chrome={tabChrome}
+                                    className="w-3.5 h-3.5"
+                                  />
+                                </span>
+                                <span className="truncate">{getBaseTitle(panel.title)}</span>
+                              </DropdownMenuItem>
+                            );
+                          })}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </div>
+              </LayoutGroup>
             </SortableContext>
           </DndContext>
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -37,7 +37,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
-import { LayoutGroup, LazyMotion, domMax } from "framer-motion";
+import { LayoutGroup } from "framer-motion";
 import type { PanelKind } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { formatShortcutForTooltip, createTooltipWithShortcut } from "@/lib/platform";
@@ -559,56 +559,54 @@ function PanelHeaderComponent({
                   aria-label="Panel tabs"
                   onKeyDown={handleTabListKeyDown}
                 >
-                  <LazyMotion features={domMax}>
-                    <LayoutGroup id={`panel-tabs-${id}`}>
-                      <div className="flex items-center">
-                        {tabs.map((tab) => (
-                          <SortableTabButton
-                            key={tab.id}
-                            id={tab.id}
-                            title={getBaseTitle(tab.title)}
-                            chrome={tab.chrome}
-                            kind={tab.kind}
-                            agentState={tab.agentState}
-                            isActive={tab.isActive}
-                            presetColor={tab.presetColor}
-                            isUsingFallback={tab.isUsingFallback}
-                            fallbackTooltip={tab.fallbackTooltip}
-                            hasDangerousFlags={tab.hasDangerousFlags}
-                            onClick={() => onTabClick?.(tab.id)}
-                            onClose={() => onTabClose?.(tab.id)}
-                            onRename={
-                              onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                            }
-                          />
-                        ))}
-                        {onAddTab && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  onAddTab();
-                                }}
-                                onPointerDown={(e) => e.stopPropagation()}
-                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                                aria-label="Duplicate panel as new tab"
-                                type="button"
-                              >
-                                <Plus className="w-3 h-3" aria-hidden="true" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">
-                              {createTooltipWithShortcut(
-                                "Duplicate panel as new tab",
-                                duplicateShortcut
-                              )}
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                      </div>
-                    </LayoutGroup>
-                  </LazyMotion>
+                  <LayoutGroup id={`panel-tabs-${id}`}>
+                    <div className="flex items-center">
+                      {tabs.map((tab) => (
+                        <SortableTabButton
+                          key={tab.id}
+                          id={tab.id}
+                          title={getBaseTitle(tab.title)}
+                          chrome={tab.chrome}
+                          kind={tab.kind}
+                          agentState={tab.agentState}
+                          isActive={tab.isActive}
+                          presetColor={tab.presetColor}
+                          isUsingFallback={tab.isUsingFallback}
+                          fallbackTooltip={tab.fallbackTooltip}
+                          hasDangerousFlags={tab.hasDangerousFlags}
+                          onClick={() => onTabClick?.(tab.id)}
+                          onClose={() => onTabClose?.(tab.id)}
+                          onRename={
+                            onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                          }
+                        />
+                      ))}
+                      {onAddTab && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onAddTab();
+                              }}
+                              onPointerDown={(e) => e.stopPropagation()}
+                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                              aria-label="Duplicate panel as new tab"
+                              type="button"
+                            >
+                              <Plus className="w-3 h-3" aria-hidden="true" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {createTooltipWithShortcut(
+                              "Duplicate panel as new tab",
+                              duplicateShortcut
+                            )}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                  </LayoutGroup>
                 </div>
                 {overflowTrigger}
               </div>
@@ -623,56 +621,51 @@ function PanelHeaderComponent({
               aria-label="Panel tabs"
               onKeyDown={handleTabListKeyDown}
             >
-              <LazyMotion features={domMax}>
-                <LayoutGroup id={`panel-tabs-${id}`}>
-                  <div className="flex items-center">
-                    {tabs.map((tab) => (
-                      <TabButton
-                        key={tab.id}
-                        id={tab.id}
-                        title={getBaseTitle(tab.title)}
-                        chrome={tab.chrome}
-                        kind={tab.kind}
-                        agentState={tab.agentState}
-                        isActive={tab.isActive}
-                        presetColor={tab.presetColor}
-                        isUsingFallback={tab.isUsingFallback}
-                        fallbackTooltip={tab.fallbackTooltip}
-                        hasDangerousFlags={tab.hasDangerousFlags}
-                        onClick={() => onTabClick?.(tab.id)}
-                        onClose={() => onTabClose?.(tab.id)}
-                        onRename={
-                          onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                        }
-                      />
-                    ))}
-                    {onAddTab && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onAddTab();
-                            }}
-                            onPointerDown={(e) => e.stopPropagation()}
-                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                            aria-label="Duplicate panel as new tab"
-                            type="button"
-                          >
-                            <Plus className="w-3 h-3" aria-hidden="true" />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom">
-                          {createTooltipWithShortcut(
-                            "Duplicate panel as new tab",
-                            duplicateShortcut
-                          )}
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                </LayoutGroup>
-              </LazyMotion>
+              <LayoutGroup id={`panel-tabs-${id}`}>
+                <div className="flex items-center">
+                  {tabs.map((tab) => (
+                    <TabButton
+                      key={tab.id}
+                      id={tab.id}
+                      title={getBaseTitle(tab.title)}
+                      chrome={tab.chrome}
+                      kind={tab.kind}
+                      agentState={tab.agentState}
+                      isActive={tab.isActive}
+                      presetColor={tab.presetColor}
+                      isUsingFallback={tab.isUsingFallback}
+                      fallbackTooltip={tab.fallbackTooltip}
+                      hasDangerousFlags={tab.hasDangerousFlags}
+                      onClick={() => onTabClick?.(tab.id)}
+                      onClose={() => onTabClose?.(tab.id)}
+                      onRename={
+                        onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
+                      }
+                    />
+                  ))}
+                  {onAddTab && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onAddTab();
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                          aria-label="Duplicate panel as new tab"
+                          type="button"
+                        >
+                          <Plus className="w-3 h-3" aria-hidden="true" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {createTooltipWithShortcut("Duplicate panel as new tab", duplicateShortcut)}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </LayoutGroup>
             </div>
             {overflowTrigger}
           </div>

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -5,7 +5,7 @@ import { useDroppable } from "@dnd-kit/core";
 import {
   AnimatePresence,
   LayoutGroup,
-  motion,
+  m,
   type TransformProperties,
   type Transition,
 } from "framer-motion";
@@ -1225,7 +1225,7 @@ export function ContentGrid({
                           }
                         }
                         return (
-                          <motion.div
+                          <m.div
                             key={terminal.id}
                             layout="position"
                             transition={layoutTransition}
@@ -1240,7 +1240,7 @@ export function ContentGrid({
                               isFleetScope
                               titleOverride={titleOverride}
                             />
-                          </motion.div>
+                          </m.div>
                         );
                       })}
                     </AnimatePresence>

--- a/src/components/Terminal/__tests__/contentGridMotion.test.ts
+++ b/src/components/Terminal/__tests__/contentGridMotion.test.ts
@@ -18,7 +18,8 @@ describe("ContentGrid panel motion (issue #6162)", () => {
     expect(content).toContain('from "framer-motion"');
     expect(content).toContain("AnimatePresence");
     expect(content).toContain("LayoutGroup");
-    expect(content).toContain("motion");
+    expect(content).toContain("<m.div");
+    expect(content).not.toMatch(/<motion\./);
   });
 
   it("scopes FLIP coordination per grid via LayoutGroup", async () => {

--- a/src/lib/motionFeatures.ts
+++ b/src/lib/motionFeatures.ts
@@ -1,0 +1,1 @@
+export { domMax as default } from "framer-motion";


### PR DESCRIPTION
## Summary

- Consolidates multiple `LazyMotion` providers into a single root-level provider in `App.tsx`, eliminating the nested providers in `PanelHeader` and `DockedTabGroup`
- Switches the feature pack to a dynamic import via a new `src/lib/motionFeatures.ts` module, moving `domMax` (~25KB gzip) off the entry chunk into an async chunk that lands post-paint
- Enables `strict` mode on the root provider so any future `motion.*` proxy usage throws at runtime instead of silently inflating the bundle

## Changes

- `src/lib/motionFeatures.ts` — new async chunk boundary, default-exports `domMax`
- `src/App.tsx` — root `<LazyMotion strict features={loadMotionFeatures}>`, dropped `domAnimation` static import
- `src/components/Panel/PanelHeader.tsx` — removed two nested `<LazyMotion features={domMax}>` wrappers
- `src/components/Layout/DockedTabGroup.tsx` — removed one nested `<LazyMotion features={domMax}>` wrapper
- `src/components/Terminal/ContentGrid.tsx` — `motion.div` → `m.div` (2 sites)
- `src/components/DragDrop/SortableTerminal.tsx` — `motion.div` → `m.div` (2 sites)
- `src/components/Terminal/__tests__/contentGridMotion.test.ts` — tightened assertion to verify `m.div` usage

## Testing

All 512 unit tests pass across affected directories. Bundle budgets (entry chunk and total JS gzip) are within the 5% PR threshold — both baselines remain unwidened. The `transformTemplate` Chromium pixel-snap workaround in `SortableTerminal` ports unchanged since it's a prop, not a feature.

Resolves #6391