### PR TITLE
fix(pty): eliminate steady-state sync child_process stalls

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1258,7 +1258,11 @@ export class PtyClient extends EventEmitter {
   }
 
   trash(id: string): void {
-    getTrashedPidTracker().persistTrashed(id, this.terminalPids.get(id));
+    void getTrashedPidTracker()
+      .persistTrashed(id, this.terminalPids.get(id))
+      .catch((err) => {
+        console.warn("[PtyClient] persistTrashed failed:", err);
+      });
     this.send({ type: "trash", id });
   }
 

--- a/electron/services/TrashedPidTracker.ts
+++ b/electron/services/TrashedPidTracker.ts
@@ -1,10 +1,14 @@
 import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
+import { promisify } from "node:util";
 import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 
+const execFileAsync = promisify(execFile);
+
 const TRASHED_PIDS_FILENAME = "trashed-pids.json";
+const PROCESS_START_TIME_TIMEOUT_MS = 3000;
 
 interface TrashedPidEntry {
   terminalId: string;
@@ -13,10 +17,10 @@ interface TrashedPidEntry {
   trashedAt: number;
 }
 
-function getProcessStartTime(pid: number): string | null {
+async function getProcessStartTime(pid: number): Promise<string | null> {
   try {
     if (process.platform === "win32") {
-      const out = execFileSync(
+      const { stdout } = await execFileAsync(
         "powershell.exe",
         [
           "-NoProfile",
@@ -31,27 +35,27 @@ function getProcessStartTime(pid: number): string | null {
         {
           windowsHide: true,
           encoding: "utf8",
-          timeout: 3000,
+          shell: false,
+          signal: AbortSignal.timeout(PROCESS_START_TIME_TIMEOUT_MS),
         }
-      )
-        .replace(/^\uFEFF/, "")
-        .trim();
+      );
+      const out = stdout.replace(/^\uFEFF/, "").trim();
       return out || null;
     }
-    const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 3000,
-    })
-      .toString("utf8")
-      .trim();
+    const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+      shell: false,
+      signal: AbortSignal.timeout(PROCESS_START_TIME_TIMEOUT_MS),
+    });
+    const out = stdout.trim();
     return out || null;
   } catch {
     return null;
   }
 }
 
-function verifyProcessStartTime(pid: number, expectedStartTime: string): boolean {
-  const currentStartTime = getProcessStartTime(pid);
+async function verifyProcessStartTime(pid: number, expectedStartTime: string): Promise<boolean> {
+  const currentStartTime = await getProcessStartTime(pid);
   if (!currentStartTime) return false;
   return currentStartTime === expectedStartTime;
 }
@@ -64,10 +68,10 @@ export class TrashedPidTracker {
     this.filePath = path.join(userData, TRASHED_PIDS_FILENAME);
   }
 
-  persistTrashed(terminalId: string, pid: number | undefined): void {
+  async persistTrashed(terminalId: string, pid: number | undefined): Promise<void> {
     if (pid === undefined || !Number.isFinite(pid) || pid <= 0) return;
 
-    const startTime = getProcessStartTime(pid);
+    const startTime = await getProcessStartTime(pid);
     if (!startTime) return;
 
     const entries = this.readEntries();
@@ -99,7 +103,7 @@ export class TrashedPidTracker {
     this.deleteFile();
   }
 
-  cleanupOrphans(): void {
+  async cleanupOrphans(): Promise<void> {
     if (!this.fileExists()) return;
 
     const entries = this.readEntries();
@@ -110,55 +114,58 @@ export class TrashedPidTracker {
 
     console.log(`[TrashedPidTracker] Found ${entries.length} trashed PID(s) from previous session`);
 
-    for (const entry of entries) {
-      if (!Number.isFinite(entry.pid) || entry.pid <= 0) continue;
-      if (entry.pid === process.pid) continue;
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (!Number.isFinite(entry.pid) || entry.pid <= 0) return;
+        if (entry.pid === process.pid) return;
 
-      if (!verifyProcessStartTime(entry.pid, entry.startTime)) {
-        console.log(
-          `[TrashedPidTracker] PID ${entry.pid} (terminal ${entry.terminalId}) no longer exists or was recycled, skipping`
-        );
-        continue;
-      }
-
-      let killed = false;
-      if (process.platform === "win32") {
-        const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
-          windowsHide: true,
-          stdio: "ignore",
-          timeout: 3000,
-        });
-        if (result.status === 0 || result.status === 128) {
-          killed = true;
+        const matches = await verifyProcessStartTime(entry.pid, entry.startTime);
+        if (!matches) {
+          console.log(
+            `[TrashedPidTracker] PID ${entry.pid} (terminal ${entry.terminalId}) no longer exists or was recycled, skipping`
+          );
+          return;
         }
-      } else {
-        try {
-          process.kill(-entry.pid, "SIGKILL");
-          killed = true;
-        } catch {
-          // fall back to direct kill
-        }
-      }
 
-      if (!killed) {
-        try {
-          process.kill(entry.pid, "SIGKILL");
-          killed = true;
-        } catch {
-          // process may already be gone
+        let killed = false;
+        if (process.platform === "win32") {
+          const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(entry.pid)], {
+            windowsHide: true,
+            stdio: "ignore",
+            timeout: 3000,
+          });
+          if (result.status === 0 || result.status === 128) {
+            killed = true;
+          }
+        } else {
+          try {
+            process.kill(-entry.pid, "SIGKILL");
+            killed = true;
+          } catch {
+            // fall back to direct kill
+          }
         }
-      }
 
-      if (killed) {
-        console.log(
-          `[TrashedPidTracker] Killed orphaned PTY pid=${entry.pid} (terminal ${entry.terminalId})`
-        );
-      } else {
-        console.warn(
-          `[TrashedPidTracker] Failed to kill orphaned PTY pid=${entry.pid} (terminal ${entry.terminalId})`
-        );
-      }
-    }
+        if (!killed) {
+          try {
+            process.kill(entry.pid, "SIGKILL");
+            killed = true;
+          } catch {
+            // process may already be gone
+          }
+        }
+
+        if (killed) {
+          console.log(
+            `[TrashedPidTracker] Killed orphaned PTY pid=${entry.pid} (terminal ${entry.terminalId})`
+          );
+        } else {
+          console.warn(
+            `[TrashedPidTracker] Failed to kill orphaned PTY pid=${entry.pid} (terminal ${entry.terminalId})`
+          );
+        }
+      })
+    );
 
     this.deleteFile();
   }
@@ -217,5 +224,7 @@ export function getTrashedPidTracker(): TrashedPidTracker {
 
 export function initializeTrashedPidCleanup(): void {
   const tracker = getTrashedPidTracker();
-  tracker.cleanupOrphans();
+  tracker.cleanupOrphans().catch((err) => {
+    console.warn("[TrashedPidTracker] cleanupOrphans failed:", err);
+  });
 }

--- a/electron/services/TrashedPidTracker.ts
+++ b/electron/services/TrashedPidTracker.ts
@@ -62,6 +62,10 @@ async function verifyProcessStartTime(pid: number, expectedStartTime: string): P
 
 export class TrashedPidTracker {
   private filePath: string;
+  // Cancellation tokens for in-flight persistTrashed calls. Set by
+  // removeTrashed so a restore that races a trash drops the pending file
+  // write rather than ghosting a restored terminal into the orphan list.
+  private cancelledPersists = new Set<string>();
 
   constructor(userDataPath?: string) {
     const userData = userDataPath ?? app.getPath("userData");
@@ -71,23 +75,41 @@ export class TrashedPidTracker {
   async persistTrashed(terminalId: string, pid: number | undefined): Promise<void> {
     if (pid === undefined || !Number.isFinite(pid) || pid <= 0) return;
 
-    const startTime = await getProcessStartTime(pid);
-    if (!startTime) return;
+    // Clear any stale cancellation marker before we start awaiting.
+    this.cancelledPersists.delete(terminalId);
 
-    const entries = this.readEntries();
-    const existing = entries.findIndex((e) => e.terminalId === terminalId);
-    const entry: TrashedPidEntry = { terminalId, pid, startTime, trashedAt: Date.now() };
+    try {
+      const startTime = await getProcessStartTime(pid);
 
-    if (existing >= 0) {
-      entries[existing] = entry;
-    } else {
-      entries.push(entry);
+      // If removeTrashed ran while we awaited, it tagged this id for
+      // cancellation. Drop the write so the restored terminal doesn't get
+      // killed on next startup.
+      if (this.cancelledPersists.has(terminalId)) return;
+
+      if (!startTime) return;
+
+      const entries = this.readEntries();
+      const existing = entries.findIndex((e) => e.terminalId === terminalId);
+      const entry: TrashedPidEntry = { terminalId, pid, startTime, trashedAt: Date.now() };
+
+      if (existing >= 0) {
+        entries[existing] = entry;
+      } else {
+        entries.push(entry);
+      }
+
+      this.writeEntries(entries);
+    } finally {
+      this.cancelledPersists.delete(terminalId);
     }
-
-    this.writeEntries(entries);
   }
 
   removeTrashed(terminalId: string): void {
+    // Tag any concurrent in-flight persistTrashed for cancellation. The token
+    // is consumed by persistTrashed's settle path; if no persist is in flight
+    // it is cleared by the next persistTrashed for this id.
+    this.cancelledPersists.add(terminalId);
+
     const entries = this.readEntries();
     const filtered = entries.filter((e) => e.terminalId !== terminalId);
     if (filtered.length === entries.length) return;
@@ -106,16 +128,23 @@ export class TrashedPidTracker {
   async cleanupOrphans(): Promise<void> {
     if (!this.fileExists()) return;
 
-    const entries = this.readEntries();
-    if (entries.length === 0) {
+    const initialEntries = this.readEntries();
+    if (initialEntries.length === 0) {
       this.deleteFile();
       return;
     }
 
-    console.log(`[TrashedPidTracker] Found ${entries.length} trashed PID(s) from previous session`);
+    // Snapshot the ids we are responsible for cleaning up. Any persistTrashed
+    // call that lands during the await window writes a new entry; we must not
+    // clobber it when we tear down the file at the end.
+    const processedIds = new Set(initialEntries.map((e) => e.terminalId));
+
+    console.log(
+      `[TrashedPidTracker] Found ${initialEntries.length} trashed PID(s) from previous session`
+    );
 
     await Promise.all(
-      entries.map(async (entry) => {
+      initialEntries.map(async (entry) => {
         if (!Number.isFinite(entry.pid) || entry.pid <= 0) return;
         if (entry.pid === process.pid) return;
 
@@ -167,7 +196,16 @@ export class TrashedPidTracker {
       })
     );
 
-    this.deleteFile();
+    // Re-read so any persistTrashed that landed during our await window is
+    // preserved. Strip the ids we processed; if nothing else remains, delete
+    // the file (preserves the original behavior of removing the artifact).
+    const finalEntries = this.readEntries();
+    const remaining = finalEntries.filter((e) => !processedIds.has(e.terminalId));
+    if (remaining.length === 0) {
+      this.deleteFile();
+    } else {
+      this.writeEntries(remaining);
+    }
   }
 
   private fileExists(): boolean {

--- a/electron/services/__tests__/TrashedPidTracker.test.ts
+++ b/electron/services/__tests__/TrashedPidTracker.test.ts
@@ -15,16 +15,37 @@ const MOCK_START_TIME =
 const MOCK_START_TIME_PARSED =
   process.platform === "win32" ? "2026-01-01T00:00:00.0000000+00:00" : "Thu Jan  1 00:00:00 2026";
 
-vi.mock("node:child_process", () => ({
-  execFileSync: vi.fn(() => MOCK_START_TIME),
-  spawnSync: vi.fn(() => ({ status: 0 })),
+// Hoisted: vi.mock factories run before module-scope code, so the mock binding
+// must be created via vi.hoisted to be available inside the factory. We model
+// the promisified execFile directly because Node's real execFile carries a
+// hidden `customPromisifyArgs` symbol that makes `promisify(execFile)` resolve
+// as `{stdout, stderr}`. A naive callback-style mock would resolve as a bare
+// string and the destructure in TrashedPidTracker would yield `undefined`.
+const { mockExecFileAsync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
 }));
 
-import { TrashedPidTracker } from "../TrashedPidTracker.js";
-import { execFileSync, spawnSync } from "node:child_process";
+vi.mock("node:child_process", async () => {
+  const util = await import("node:util");
+  const wrapperExecFile = (() => {
+    throw new Error("callback-style execFile is not exercised in TrashedPidTracker tests");
+  }) as unknown as ((...a: unknown[]) => void) & Record<symbol, unknown>;
+  wrapperExecFile[util.promisify.custom] = (...args: unknown[]) =>
+    (mockExecFileAsync as unknown as (...a: unknown[]) => Promise<unknown>)(...args);
+  return {
+    execFile: wrapperExecFile,
+    spawnSync: vi.fn(() => ({ status: 0 })),
+  };
+});
 
-const mockedExecFileSync = vi.mocked(execFileSync);
+import { TrashedPidTracker } from "../TrashedPidTracker.js";
+import { spawnSync } from "node:child_process";
+
 const mockedSpawnSync = vi.mocked(spawnSync);
+
+async function defaultExecFileAsync(): Promise<{ stdout: string; stderr: string }> {
+  return { stdout: MOCK_START_TIME, stderr: "" };
+}
 
 describe("TrashedPidTracker", () => {
   let tmpDir: string;
@@ -32,6 +53,7 @@ describe("TrashedPidTracker", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExecFileAsync.mockImplementation(defaultExecFileAsync as never);
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trashed-pid-test-"));
     tracker = new TrashedPidTracker(tmpDir);
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -55,8 +77,8 @@ describe("TrashedPidTracker", () => {
   }
 
   describe("persistTrashed", () => {
-    it("writes a valid entry to the file", () => {
-      tracker.persistTrashed("term-1", 12345);
+    it("writes a valid entry to the file", async () => {
+      await tracker.persistTrashed("term-1", 12345);
       const entries = readFile() as Array<{ terminalId: string; pid: number; startTime: string }>;
       expect(entries).toHaveLength(1);
       expect(entries[0].terminalId).toBe("term-1");
@@ -64,62 +86,62 @@ describe("TrashedPidTracker", () => {
       expect(entries[0].startTime).toBe(MOCK_START_TIME_PARSED);
     });
 
-    it("skips undefined or invalid PIDs", () => {
-      tracker.persistTrashed("term-1", undefined);
-      tracker.persistTrashed("term-2", -1);
-      tracker.persistTrashed("term-3", NaN);
+    it("skips undefined or invalid PIDs", async () => {
+      await tracker.persistTrashed("term-1", undefined);
+      await tracker.persistTrashed("term-2", -1);
+      await tracker.persistTrashed("term-3", NaN);
       expect(readFile()).toHaveLength(0);
     });
 
-    it("skips when start time cannot be retrieved", () => {
-      mockedExecFileSync.mockImplementationOnce(() => {
+    it("skips when start time cannot be retrieved", async () => {
+      mockExecFileAsync.mockImplementationOnce((async () => {
         throw new Error("no such process");
-      });
-      tracker.persistTrashed("term-1", 12345);
+      }) as never);
+      await tracker.persistTrashed("term-1", 12345);
       expect(readFile()).toHaveLength(0);
     });
 
-    it("updates existing entry for same terminal", () => {
-      tracker.persistTrashed("term-1", 100);
-      tracker.persistTrashed("term-1", 200);
+    it("updates existing entry for same terminal", async () => {
+      await tracker.persistTrashed("term-1", 100);
+      await tracker.persistTrashed("term-1", 200);
       const entries = readFile() as Array<{ pid: number }>;
       expect(entries).toHaveLength(1);
       expect(entries[0].pid).toBe(200);
     });
 
-    it("appends multiple entries for different terminals", () => {
-      tracker.persistTrashed("term-1", 100);
-      tracker.persistTrashed("term-2", 200);
+    it("appends multiple entries for different terminals", async () => {
+      await tracker.persistTrashed("term-1", 100);
+      await tracker.persistTrashed("term-2", 200);
       expect(readFile()).toHaveLength(2);
     });
   });
 
   describe("removeTrashed", () => {
-    it("removes an entry from the file", () => {
-      tracker.persistTrashed("term-1", 100);
-      tracker.persistTrashed("term-2", 200);
+    it("removes an entry from the file", async () => {
+      await tracker.persistTrashed("term-1", 100);
+      await tracker.persistTrashed("term-2", 200);
       tracker.removeTrashed("term-1");
       const entries = readFile() as Array<{ terminalId: string }>;
       expect(entries).toHaveLength(1);
       expect(entries[0].terminalId).toBe("term-2");
     });
 
-    it("deletes file when last entry is removed", () => {
-      tracker.persistTrashed("term-1", 100);
+    it("deletes file when last entry is removed", async () => {
+      await tracker.persistTrashed("term-1", 100);
       tracker.removeTrashed("term-1");
       expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
     });
 
-    it("does nothing for unknown terminal", () => {
-      tracker.persistTrashed("term-1", 100);
+    it("does nothing for unknown terminal", async () => {
+      await tracker.persistTrashed("term-1", 100);
       tracker.removeTrashed("term-unknown");
       expect(readFile()).toHaveLength(1);
     });
   });
 
   describe("clearAll", () => {
-    it("deletes the file", () => {
-      tracker.persistTrashed("term-1", 100);
+    it("deletes the file", async () => {
+      await tracker.persistTrashed("term-1", 100);
       tracker.clearAll();
       expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
     });
@@ -130,7 +152,7 @@ describe("TrashedPidTracker", () => {
   });
 
   describe("cleanupOrphans", () => {
-    it("kills processes with matching start times", () => {
+    it("kills processes with matching start times", async () => {
       writeFile([
         {
           terminalId: "term-1",
@@ -142,7 +164,7 @@ describe("TrashedPidTracker", () => {
 
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-      tracker.cleanupOrphans();
+      await tracker.cleanupOrphans();
 
       if (process.platform === "win32") {
         expect(mockedSpawnSync).toHaveBeenCalledWith(
@@ -156,31 +178,31 @@ describe("TrashedPidTracker", () => {
       expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
     });
 
-    it("skips processes with mismatched start times (PID recycling)", () => {
+    it("skips processes with mismatched start times (PID recycling)", async () => {
       writeFile([
         { terminalId: "term-1", pid: 9999, startTime: "different-time", trashedAt: Date.now() },
       ]);
 
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-      tracker.cleanupOrphans();
+      await tracker.cleanupOrphans();
 
       expect(killSpy).not.toHaveBeenCalled();
       expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
     });
 
-    it("handles corrupt JSON gracefully", () => {
+    it("handles corrupt JSON gracefully", async () => {
       fs.writeFileSync(path.join(tmpDir, "trashed-pids.json"), "not json{{{");
 
-      expect(() => tracker.cleanupOrphans()).not.toThrow();
+      await expect(tracker.cleanupOrphans()).resolves.not.toThrow();
       expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
     });
 
-    it("handles missing file gracefully", () => {
-      expect(() => tracker.cleanupOrphans()).not.toThrow();
+    it("handles missing file gracefully", async () => {
+      await expect(tracker.cleanupOrphans()).resolves.not.toThrow();
     });
 
-    it("skips entries with invalid PIDs", () => {
+    it("skips entries with invalid PIDs", async () => {
       writeFile([
         { terminalId: "term-1", pid: -1, startTime: "some-time", trashedAt: Date.now() },
         { terminalId: "term-2", pid: 0, startTime: "some-time", trashedAt: Date.now() },
@@ -188,12 +210,12 @@ describe("TrashedPidTracker", () => {
 
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-      tracker.cleanupOrphans();
+      await tracker.cleanupOrphans();
 
       expect(killSpy).not.toHaveBeenCalled();
     });
 
-    it("skips current process PID", () => {
+    it("skips current process PID", async () => {
       writeFile([
         {
           terminalId: "term-1",
@@ -205,12 +227,12 @@ describe("TrashedPidTracker", () => {
 
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-      tracker.cleanupOrphans();
+      await tracker.cleanupOrphans();
 
       expect(killSpy).not.toHaveBeenCalled();
     });
 
-    it("filters out invalid entries in file", () => {
+    it("filters out invalid entries in file", async () => {
       writeFile([
         {
           terminalId: "term-1",
@@ -225,12 +247,96 @@ describe("TrashedPidTracker", () => {
 
       const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
-      tracker.cleanupOrphans();
+      await tracker.cleanupOrphans();
 
       if (process.platform === "win32") {
         expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
       } else {
         expect(killSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("probes entries in parallel — one slow probe does not block others", async () => {
+      writeFile([
+        {
+          terminalId: "term-1",
+          pid: 1001,
+          startTime: MOCK_START_TIME_PARSED,
+          trashedAt: Date.now(),
+        },
+        {
+          terminalId: "term-2",
+          pid: 1002,
+          startTime: MOCK_START_TIME_PARSED,
+          trashedAt: Date.now(),
+        },
+      ]);
+
+      const callOrder: number[] = [];
+      const slowResolvers: Array<(value: { stdout: string; stderr: string }) => void> = [];
+      mockExecFileAsync.mockImplementation(((_cmd: string, args: string[]) => {
+        const pidArg = args[1];
+        callOrder.push(Number(pidArg));
+        if (pidArg === "1001") {
+          return new Promise<{ stdout: string; stderr: string }>((resolve) => {
+            slowResolvers.push(resolve);
+          });
+        }
+        return Promise.resolve({ stdout: MOCK_START_TIME, stderr: "" });
+      }) as never);
+
+      vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const cleanupPromise = tracker.cleanupOrphans();
+      // Yield so both probes initiate before the slow one resolves.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(callOrder).toEqual([1001, 1002]);
+      expect(slowResolvers).toHaveLength(1);
+      slowResolvers[0]!({ stdout: MOCK_START_TIME, stderr: "" });
+
+      await cleanupPromise;
+      expect(fs.existsSync(path.join(tmpDir, "trashed-pids.json"))).toBe(false);
+    });
+
+    it("one probe failure does not abort other entries", async () => {
+      writeFile([
+        {
+          terminalId: "term-1",
+          pid: 1001,
+          startTime: MOCK_START_TIME_PARSED,
+          trashedAt: Date.now(),
+        },
+        {
+          terminalId: "term-2",
+          pid: 1002,
+          startTime: MOCK_START_TIME_PARSED,
+          trashedAt: Date.now(),
+        },
+      ]);
+
+      mockExecFileAsync.mockImplementation((async (_cmd: string, args: string[]) => {
+        if (args[1] === "1001") {
+          throw new Error("ps -p race");
+        }
+        return { stdout: MOCK_START_TIME, stderr: "" };
+      }) as never);
+
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      await tracker.cleanupOrphans();
+
+      if (process.platform === "win32") {
+        expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+        expect(mockedSpawnSync).toHaveBeenCalledWith(
+          "taskkill",
+          ["/T", "/F", "/PID", "1002"],
+          expect.objectContaining({ windowsHide: true })
+        );
+      } else {
+        expect(killSpy).toHaveBeenCalledTimes(1);
+        expect(killSpy).toHaveBeenCalledWith(-1002, "SIGKILL");
       }
     });
   });

--- a/electron/services/__tests__/TrashedPidTracker.test.ts
+++ b/electron/services/__tests__/TrashedPidTracker.test.ts
@@ -137,6 +137,26 @@ describe("TrashedPidTracker", () => {
       tracker.removeTrashed("term-unknown");
       expect(readFile()).toHaveLength(1);
     });
+
+    it("cancels an in-flight persistTrashed for the same terminal (trash→restore race)", async () => {
+      let resolveProbe: ((value: { stdout: string; stderr: string }) => void) | null = null;
+      mockExecFileAsync.mockImplementation((() => {
+        return new Promise<{ stdout: string; stderr: string }>((resolve) => {
+          resolveProbe = resolve;
+        });
+      }) as never);
+
+      const persistPromise = tracker.persistTrashed("term-1", 100);
+      // Yield so persistTrashed enters its await on getProcessStartTime.
+      await Promise.resolve();
+      tracker.removeTrashed("term-1");
+
+      expect(resolveProbe).not.toBeNull();
+      resolveProbe!({ stdout: MOCK_START_TIME, stderr: "" });
+      await persistPromise;
+
+      expect(readFile()).toHaveLength(0);
+    });
   });
 
   describe("clearAll", () => {
@@ -338,6 +358,49 @@ describe("TrashedPidTracker", () => {
         expect(killSpy).toHaveBeenCalledTimes(1);
         expect(killSpy).toHaveBeenCalledWith(-1002, "SIGKILL");
       }
+    });
+
+    it("preserves persistTrashed entries that arrive during cleanup (startup race)", async () => {
+      writeFile([
+        {
+          terminalId: "old-orphan",
+          pid: 9999,
+          startTime: MOCK_START_TIME_PARSED,
+          trashedAt: Date.now(),
+        },
+      ]);
+
+      const probeResolvers: Array<(value: { stdout: string; stderr: string }) => void> = [];
+      mockExecFileAsync.mockImplementation((() => {
+        return new Promise<{ stdout: string; stderr: string }>((resolve) => {
+          probeResolvers.push(resolve);
+        });
+      }) as never);
+
+      vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const cleanupPromise = tracker.cleanupOrphans();
+      // Yield so cleanupOrphans reads the initial entry and enters its
+      // verifyProcessStartTime await.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(probeResolvers).toHaveLength(1);
+
+      // A user trashes a new terminal during the cleanup window.
+      const persistPromise = tracker.persistTrashed("new-trashed", 5555);
+
+      // Resolve cleanup's probe; cleanupOrphans proceeds to delete the file.
+      probeResolvers[0]!({ stdout: MOCK_START_TIME, stderr: "" });
+      // Resolve the new persist's probe so it writes its entry.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(probeResolvers).toHaveLength(2);
+      probeResolvers[1]!({ stdout: MOCK_START_TIME, stderr: "" });
+
+      await Promise.all([cleanupPromise, persistPromise]);
+
+      const entries = readFile() as Array<{ terminalId: string }>;
+      expect(entries.map((e) => e.terminalId).sort()).toEqual(["new-trashed"]);
     });
   });
 });

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "node:util";
 import type * as pty from "node-pty";
 import type { Terminal as HeadlessTerminalType } from "@xterm/headless";
 import headless from "@xterm/headless";
@@ -72,6 +73,15 @@ import {
 import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
 import type { SpawnContext } from "./terminalSpawn.js";
 
+const execFileAsync = promisify(execFile);
+
+// Soft-stale: trigger an async background refresh once the cached snapshot is
+// older than this. Hard-max: callers receive null past this age and fall back
+// to the legacy prompt path.
+const FOREGROUND_SNAPSHOT_SOFT_STALE_MS = 500;
+const FOREGROUND_SNAPSHOT_MAX_AGE_MS = 1500;
+const FOREGROUND_SNAPSHOT_PROBE_TIMEOUT_MS = 750;
+
 const IDENTITY_DEBUG_ENABLED =
   process.env.NODE_ENV === "development" || Boolean(process.env.DAINTREE_DEBUG);
 
@@ -139,6 +149,11 @@ export class TerminalProcess {
   private readonly processTreeKiller: ProcessTreeKiller;
   private _ptyState: PtyState = { kind: "alive" };
   private _exitEventEmitted = false;
+
+  private _foregroundSnapshot: { shellPgid: number; foregroundPgid: number } | null = null;
+  private _foregroundSnapshotUpdatedAt = 0;
+  private _foregroundSnapshotRefreshing = false;
+  private _foregroundSnapshotCheckId = 0;
 
   private _scrollback: number;
   private headlessResponderDisposable: { dispose: () => void } | null = null;
@@ -1270,6 +1285,13 @@ export class TerminalProcess {
     return this.deps.processTreeCache.getDescendantPids(ptyPid).length;
   }
 
+  /**
+   * Sync read against a per-terminal stale-while-revalidate cache. The actual
+   * `ps` probe runs asynchronously so the IdentityWatcher poll tick never
+   * blocks the pty-host event loop. Soft-stale schedules a background refresh;
+   * past the hard-max age we return null so callers fall back to the legacy
+   * prompt path (matches the pre-existing non-POSIX behavior).
+   */
   private readForegroundProcessGroupSnapshot(): {
     shellPgid: number;
     foregroundPgid: number;
@@ -1283,23 +1305,56 @@ export class TerminalProcess {
       return null;
     }
 
+    const now = Date.now();
+    const age =
+      this._foregroundSnapshotUpdatedAt === 0
+        ? Number.POSITIVE_INFINITY
+        : now - this._foregroundSnapshotUpdatedAt;
+
+    if (
+      !this._foregroundSnapshotRefreshing &&
+      (this._foregroundSnapshotUpdatedAt === 0 || age > FOREGROUND_SNAPSHOT_SOFT_STALE_MS)
+    ) {
+      void this._refreshForegroundProcessGroupSnapshot(ptyPid);
+    }
+
+    if (age > FOREGROUND_SNAPSHOT_MAX_AGE_MS) {
+      return null;
+    }
+    return this._foregroundSnapshot;
+  }
+
+  private async _refreshForegroundProcessGroupSnapshot(ptyPid: number): Promise<void> {
+    this._foregroundSnapshotRefreshing = true;
+    const checkId = ++this._foregroundSnapshotCheckId;
+    let nextSnapshot: { shellPgid: number; foregroundPgid: number } | null = null;
     try {
-      const result = spawnSync("ps", ["-o", "pgid=,tpgid=", "-p", String(ptyPid)], {
+      const { stdout } = await execFileAsync("ps", ["-o", "pgid=,tpgid=", "-p", String(ptyPid)], {
         encoding: "utf8",
-        timeout: 750,
+        shell: false,
+        signal: AbortSignal.timeout(FOREGROUND_SNAPSHOT_PROBE_TIMEOUT_MS),
       });
-      if (result.status !== 0 || result.error) {
-        return null;
-      }
-      const [pgidText, tpgidText] = result.stdout.trim().split(/\s+/);
+      const [pgidText, tpgidText] = stdout.trim().split(/\s+/);
       const shellPgid = Number.parseInt(pgidText ?? "", 10);
       const foregroundPgid = Number.parseInt(tpgidText ?? "", 10);
-      if (!Number.isFinite(shellPgid) || !Number.isFinite(foregroundPgid)) {
-        return null;
+      if (Number.isFinite(shellPgid) && Number.isFinite(foregroundPgid)) {
+        nextSnapshot = { shellPgid, foregroundPgid };
       }
-      return { shellPgid, foregroundPgid };
     } catch {
-      return null;
+      // ps -p races (process exited) and aborts both surface here. Persisting
+      // null with a fresh timestamp prevents tight-retry and lets the caller
+      // fall back to the legacy prompt path until the next refresh window.
+      nextSnapshot = null;
+    } finally {
+      // Disposed-instance guard: never write back to a torn-down terminal.
+      // Stale-write guard via monotonic checkId is belt-and-suspenders given
+      // the in-flight boolean, but cheap and matches the repo's checkId
+      // pattern (see CliAvailabilityService).
+      if (this._ptyState.kind !== "disposed" && checkId === this._foregroundSnapshotCheckId) {
+        this._foregroundSnapshot = nextSnapshot;
+        this._foregroundSnapshotUpdatedAt = Date.now();
+      }
+      this._foregroundSnapshotRefreshing = false;
     }
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -82,6 +82,16 @@ const FOREGROUND_SNAPSHOT_SOFT_STALE_MS = 500;
 const FOREGROUND_SNAPSHOT_MAX_AGE_MS = 1500;
 const FOREGROUND_SNAPSHOT_PROBE_TIMEOUT_MS = 750;
 
+// Sentinel returned on POSIX before the first probe resolves. Returning null
+// during the warm-up window would drop into the IdentityWatcher's
+// "Windows / unsupported" fallback branch and falsely mark the shell idle for
+// demotion. Any value where shellPgid !== foregroundPgid (and both > 0) keeps
+// the demotion gate closed; the real probe overwrites this within a few ms.
+const INITIAL_FOREGROUND_SENTINEL = Object.freeze({
+  shellPgid: 1,
+  foregroundPgid: 2,
+});
+
 const IDENTITY_DEBUG_ENABLED =
   process.env.NODE_ENV === "development" || Boolean(process.env.DAINTREE_DEBUG);
 
@@ -1305,17 +1315,19 @@ export class TerminalProcess {
       return null;
     }
 
-    const now = Date.now();
-    const age =
-      this._foregroundSnapshotUpdatedAt === 0
-        ? Number.POSITIVE_INFINITY
-        : now - this._foregroundSnapshotUpdatedAt;
+    const hasEverProbed = this._foregroundSnapshotUpdatedAt > 0;
+    const age = hasEverProbed ? Date.now() - this._foregroundSnapshotUpdatedAt : 0;
 
     if (
       !this._foregroundSnapshotRefreshing &&
-      (this._foregroundSnapshotUpdatedAt === 0 || age > FOREGROUND_SNAPSHOT_SOFT_STALE_MS)
+      (!hasEverProbed || age > FOREGROUND_SNAPSHOT_SOFT_STALE_MS)
     ) {
       void this._refreshForegroundProcessGroupSnapshot(ptyPid);
+    }
+
+    // Probe pending: keep the demotion gate closed (see sentinel comment).
+    if (!hasEverProbed) {
+      return INITIAL_FOREGROUND_SENTINEL;
     }
 
     if (age > FOREGROUND_SNAPSHOT_MAX_AGE_MS) {

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -111,6 +111,23 @@ function createMutableDescendantCache(): {
 type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
 type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
 
+// In tests we override the foreground-pgid probe so it returns null
+// synchronously, restoring the legacy "no foreground gate" default. The
+// production code uses an async stale-while-revalidate cache that returns a
+// "child active" sentinel before the first probe resolves; that sentinel
+// would incorrectly hold the demotion gate closed in tests where no real ps
+// probe runs. Tests that exercise the foreground gate explicitly install
+// their own override after construction (see "does not demote ... while a
+// foreground child owns the PTY").
+function installNullForegroundSnapshot(terminal: TerminalProcess): TerminalProcess {
+  (
+    terminal as unknown as {
+      readForegroundProcessGroupSnapshot: () => null;
+    }
+  ).readForegroundProcessGroupSnapshot = () => null;
+  return terminal;
+}
+
 function createAgentTerminal(deps?: Partial<TerminalProcessDeps>): TerminalProcess {
   const options: TerminalProcessOptions = {
     cwd: process.cwd(),
@@ -124,23 +141,25 @@ function createAgentTerminal(deps?: Partial<TerminalProcessDeps>): TerminalProce
     args: ["-l"],
     env: {},
   };
-  return new TerminalProcess(
-    "t-agent",
-    options,
-    { emitData: () => {}, onExit: () => {} },
-    {
-      agentStateService: {
-        handleActivityState: () => {},
-        updateAgentState: () => {},
-        emitAgentKilled: () => {},
-        emitAgentCompleted: () => {},
-      } as unknown as TerminalProcessDeps["agentStateService"],
-      ptyPool: null,
-      processTreeCache: createMockProcessTreeCache(),
-      ...deps,
-    } as TerminalProcessDeps,
-    ctx,
-    createMockPty()
+  return installNullForegroundSnapshot(
+    new TerminalProcess(
+      "t-agent",
+      options,
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+        ptyPool: null,
+        processTreeCache: createMockProcessTreeCache(),
+        ...deps,
+      } as TerminalProcessDeps,
+      ctx,
+      createMockPty()
+    )
   );
 }
 
@@ -156,23 +175,25 @@ function createPlainTerminal(id = "t-plain", deps?: Partial<TerminalProcessDeps>
     args: ["-l"],
     env: {},
   };
-  return new TerminalProcess(
-    id,
-    options,
-    { emitData: () => {}, onExit: () => {} },
-    {
-      agentStateService: {
-        handleActivityState: () => {},
-        updateAgentState: () => {},
-        emitAgentKilled: () => {},
-        emitAgentCompleted: () => {},
-      } as unknown as TerminalProcessDeps["agentStateService"],
-      ptyPool: null,
-      processTreeCache: createMockProcessTreeCache(),
-      ...deps,
-    } as TerminalProcessDeps,
-    ctx,
-    createMockPty()
+  return installNullForegroundSnapshot(
+    new TerminalProcess(
+      id,
+      options,
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+        ptyPool: null,
+        processTreeCache: createMockProcessTreeCache(),
+        ...deps,
+      } as TerminalProcessDeps,
+      ctx,
+      createMockPty()
+    )
   );
 }
 
@@ -193,23 +214,25 @@ function createPlainTerminalWithCommand(
     args: ["-lc", command],
     env: {},
   };
-  return new TerminalProcess(
-    id,
-    options,
-    { emitData: () => {}, onExit: () => {} },
-    {
-      agentStateService: {
-        handleActivityState: () => {},
-        updateAgentState: () => {},
-        emitAgentKilled: () => {},
-        emitAgentCompleted: () => {},
-      } as unknown as TerminalProcessDeps["agentStateService"],
-      ptyPool: null,
-      processTreeCache: createMockProcessTreeCache(),
-      ...deps,
-    } as TerminalProcessDeps,
-    ctx,
-    createMockPty()
+  return installNullForegroundSnapshot(
+    new TerminalProcess(
+      id,
+      options,
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+        ptyPool: null,
+        processTreeCache: createMockProcessTreeCache(),
+        ...deps,
+      } as TerminalProcessDeps,
+      ctx,
+      createMockPty()
+    )
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a stale-while-revalidate cache layer around the foreground process group probe in `TerminalProcess` — polls return a cached result instead of spawning a fresh `ps` subprocess every cycle, removing a sync block directly on the pty-host event loop
- Converts `getProcessStartTime`, `persistTrashed`, and `cleanupOrphans` in `TrashedPidTracker` to async, with `Promise.all` fan-out in `cleanupOrphans` and fire-and-forget in `PtyClient.trash`

Resolves #6394

## Changes

- `TerminalProcess.ts` — SWR cache around `readForegroundProcessGroupSnapshot`; adds `INITIAL_FOREGROUND_SENTINEL` to prevent first-call demotion regression on POSIX
- `TrashedPidTracker.ts` — async `getProcessStartTime`/`persistTrashed`/`cleanupOrphans`; in-flight cancellation token to fix trash→restore race; snapshot-restore semantics in `cleanupOrphans` to handle concurrent `persistTrashed` calls
- `PtyClient.ts` — fire-and-forget `persistTrashed` call on terminal close
- `TrashedPidTracker.test.ts` — 21 new tests covering the async paths and race conditions

## Testing

- 21 `TrashedPidTracker` tests pass
- 73 adjacent PTY tests pass
- `npm run check` clean