### PR TITLE
feat(secretScrubber): expand PATTERNS for 2025-2026 token formats

### DIFF
--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -74,6 +74,16 @@ describe("secretScrubber", () => {
         expected: `OPENAI_API_KEY=${REDACTED}`,
       },
       {
+        name: "openai-admin-key",
+        input: `OPENAI_API_KEY=sk-admin-${"A".repeat(155)}`,
+        expected: `OPENAI_API_KEY=${REDACTED}`,
+      },
+      {
+        name: "openrouter-api-key",
+        input: `OPENROUTER_API_KEY=sk-or-v1-${"a".repeat(64)}`,
+        expected: `OPENROUTER_API_KEY=${REDACTED}`,
+      },
+      {
         name: "openai-api-key",
         input: `OPENAI_API_KEY=sk-${"A".repeat(48)}`,
         expected: `OPENAI_API_KEY=${REDACTED}`,
@@ -104,6 +114,26 @@ describe("secretScrubber", () => {
         expected: REDACTED,
       },
       {
+        name: "slack-app-token",
+        input: `token=xapp-${"A".repeat(100)} end`,
+        expected: `token=${REDACTED} end`,
+      },
+      {
+        name: "slack-access-token-xoxb",
+        input: `token=xoxe.xoxb-${"A".repeat(170)} end`,
+        expected: `token=${REDACTED} end`,
+      },
+      {
+        name: "slack-access-token-xoxp",
+        input: `token=xoxe.xoxp-${"0".repeat(175)}`,
+        expected: `token=${REDACTED}`,
+      },
+      {
+        name: "slack-refresh-token",
+        input: `token=xoxe-${"A".repeat(145)} end`,
+        expected: `token=${REDACTED} end`,
+      },
+      {
         name: "google-api-key",
         input: `url=AIza${"A".repeat(35)}/path`,
         expected: `url=${REDACTED}/path`,
@@ -112,6 +142,16 @@ describe("secretScrubber", () => {
         name: "aws-access-key",
         input: "aws_access_key=AKIAIOSFODNN7EXAMPLE trailing",
         expected: `aws_access_key=${REDACTED} trailing`,
+      },
+      {
+        name: "aws-sts-access-key",
+        input: "aws_access_key=ASIAIOSFODNN7EXAMPLE trailing",
+        expected: `aws_access_key=${REDACTED} trailing`,
+      },
+      {
+        name: "aws-sts-variant-key",
+        input: "aws_access_key=ABIAIOSFODNN7EXAMPLE",
+        expected: `aws_access_key=${REDACTED}`,
       },
       {
         name: "aws-secret-access-key-credentials-file",
@@ -184,6 +224,36 @@ describe("secretScrubber", () => {
         expected: `SUPABASE_KEY=${REDACTED} next`,
       },
       {
+        name: "replicate-api-token",
+        input: `REPLICATE_API_TOKEN=r8_${"A".repeat(37)}`,
+        expected: `REPLICATE_API_TOKEN=${REDACTED}`,
+      },
+      {
+        name: "huggingface-api-token",
+        input: `HF_TOKEN=hf_${"a".repeat(34)} end`,
+        expected: `HF_TOKEN=${REDACTED} end`,
+      },
+      {
+        name: "groq-api-key",
+        input: `GROQ_API_KEY=gsk_${"z".repeat(50)} end`,
+        expected: `GROQ_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "linear-api-key",
+        input: `LINEAR_API_KEY=lin_api_${"A".repeat(40)}`,
+        expected: `LINEAR_API_KEY=${REDACTED}`,
+      },
+      {
+        name: "notion-api-key",
+        input: `NOTION_API_KEY=ntn_${"a".repeat(47)} end`,
+        expected: `NOTION_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "sendgrid-api-key",
+        input: `SENDGRID_API_KEY=SG.${"A".repeat(22)}.${"z".repeat(43)} end`,
+        expected: `SENDGRID_API_KEY=${REDACTED} end`,
+      },
+      {
         name: "azure-connection-string",
         input: `conn=DefaultEndpointsProtocol=https;AccountName=myacct;AccountKey=${"A".repeat(86)}== end`,
         expected: `conn=${REDACTED} end`,
@@ -243,6 +313,11 @@ describe("secretScrubber", () => {
         name: "generic-client-secret-fallback",
         input: `client_secret = ${"x".repeat(40)}`,
         expected: REDACTED,
+      },
+      {
+        name: "slack-signing-secret-fallback",
+        input: `SLACK_SIGNING_SECRET=${"a".repeat(32)} end`,
+        expected: `${REDACTED} end`,
       },
     ];
 
@@ -328,6 +403,95 @@ describe("secretScrubber", () => {
     it("does not flag a URL without basic-auth credentials", () => {
       const url = "https://example.com/path?foo=bar";
       expect(scrubSecrets(url)).toBe(url);
+    });
+
+    it("does not flag sk-or-v1- with uppercase hex body", () => {
+      const upperHex = `sk-or-v1-${"A".repeat(64)}`;
+      expect(scrubSecrets(upperHex)).toBe(upperHex);
+    });
+
+    it("does not flag a too-short openrouter key", () => {
+      const tooShort = `sk-or-v1-${"a".repeat(54)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag bare 32-char hex without slack_signing_secret context", () => {
+      const bareHex = `${"a".repeat(32)}`;
+      expect(scrubSecrets(bareHex)).toBe(bareHex);
+    });
+
+    it("does not flag a too-short xapp token", () => {
+      const tooShort = `xapp-${"A".repeat(89)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag xoxe- with too-short body", () => {
+      const tooShort = `xoxe-${"A".repeat(139)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("partially redacts xoxe.xoxb- with too-short body via slack-token fallback", () => {
+      // 159-char body is below the {160,180} access-token floor, but the
+      // `xoxb-` portion still matches the existing slack-token pattern.
+      const tooShort = `xoxe.xoxb-${"A".repeat(159)}`;
+      expect(scrubSecrets(tooShort)).toBe(`xoxe.${REDACTED}`);
+    });
+
+    it("does not flag ACIA as an AWS key (wrong prefix)", () => {
+      const wrongPrefix = "ACIAIOSFODNN7EXAMPLE";
+      expect(scrubSecrets(wrongPrefix)).toBe(wrongPrefix);
+    });
+
+    it("does not flag too-short r8_ token", () => {
+      const tooShort = `r8_${"A".repeat(29)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag too-short hf_ token", () => {
+      const tooShort = `hf_${"a".repeat(24)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag too-short gsk_ token", () => {
+      const tooShort = `gsk_${"z".repeat(44)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag too-short lin_api_ token", () => {
+      const tooShort = `lin_api_${"A".repeat(34)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag too-short ntn_ token", () => {
+      const tooShort = `ntn_${"a".repeat(39)}`;
+      expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag sendgrid with wrong segment count (2 segments)", () => {
+      const malformed = `SG.${"A".repeat(22)}`;
+      expect(scrubSecrets(malformed)).toBe(malformed);
+    });
+
+    it("scrubs valid-key portion of sendgrid-like string with trailing segment", () => {
+      // The first three segments form a valid key shape; the regex scrubs them
+      // and the trailing `.extra` is preserved as non-secret context.
+      const withExtra = `SG.${"A".repeat(22)}.${"b".repeat(43)}.extra`;
+      expect(scrubSecrets(withExtra)).toBe(`${REDACTED}.extra`);
+    });
+
+    it("does not flag sendgrid with wrong segment lengths", () => {
+      const malformed = `SG.${"A".repeat(21)}.${"b".repeat(42)}`;
+      expect(scrubSecrets(malformed)).toBe(malformed);
+    });
+
+    it("does not flag r8_ as substring in ordinary text", () => {
+      const ordinary = "The car8_example text here is not a secret key at all";
+      expect(scrubSecrets(ordinary)).toBe(ordinary);
+    });
+
+    it("does not flag hf_ as substring in ordinary text", () => {
+      const ordinary = "The chef_example text here is not a secret key at all";
+      expect(scrubSecrets(ordinary)).toBe(ordinary);
     });
 
     it("redacts realistically-sized Atlassian token bodies fully", () => {
@@ -443,6 +607,24 @@ describe("secretScrubber", () => {
     it("Bearer token at upper bound (4000 chars) is scrubbed", () => {
       const input = `Authorization: Bearer ${"A".repeat(4000)}`;
       expect(scrubSecrets(input)).toBe(`Authorization: Bearer ${REDACTED}`);
+    });
+  });
+
+  describe("ordering regression", () => {
+    it("xoxe.xoxb- access token is fully scrubbed (not partially by xoxe-)", () => {
+      const token = `xoxe.xoxb-${"A".repeat(170)}`;
+      const out = scrubSecrets(token);
+      expect(out).toBe(REDACTED);
+      // If the broader `xoxe-` pattern matched first, we'd see `xoxb-` remnants.
+      expect(out).not.toContain("xoxb");
+      expect(out).not.toContain("xoxe");
+    });
+
+    it("sk-or-v1- token fully scrubbed (not partially by sk-{48})", () => {
+      const token = `sk-or-v1-${"a".repeat(64)}`;
+      const out = scrubSecrets(token);
+      expect(out).toBe(REDACTED);
+      expect(out).not.toContain("or-v1");
     });
   });
 

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -443,7 +443,7 @@ describe("secretScrubber", () => {
     });
 
     it("does not flag too-short r8_ token", () => {
-      const tooShort = `r8_${"A".repeat(29)}`;
+      const tooShort = `r8_${"A".repeat(34)}`;
       expect(scrubSecrets(tooShort)).toBe(tooShort);
     });
 
@@ -453,8 +453,13 @@ describe("secretScrubber", () => {
     });
 
     it("does not flag too-short gsk_ token", () => {
-      const tooShort = `gsk_${"z".repeat(44)}`;
+      const tooShort = `gsk_${"z".repeat(39)}`;
       expect(scrubSecrets(tooShort)).toBe(tooShort);
+    });
+
+    it("does not flag AIIA as an AWS key (invalid prefix)", () => {
+      const invalid = "AIIAIOSFODNN7EXAMPLE";
+      expect(scrubSecrets(invalid)).toBe(invalid);
     });
 
     it("does not flag too-short lin_api_ token", () => {
@@ -625,6 +630,24 @@ describe("secretScrubber", () => {
       const out = scrubSecrets(token);
       expect(out).toBe(REDACTED);
       expect(out).not.toContain("or-v1");
+    });
+
+    it("all four sk- variants redact independently in one string", () => {
+      const input = [
+        `sk-proj-${"A".repeat(120)}`,
+        `sk-svcacct-${"B".repeat(130)}`,
+        `sk-admin-${"C".repeat(155)}`,
+        `sk-or-v1-${"a".repeat(64)}`,
+        `sk-${"D".repeat(48)}`,
+      ].join(" | ");
+      const out = scrubSecrets(input);
+      expect(out).not.toContain("sk-proj");
+      expect(out).not.toContain("sk-svcacct");
+      expect(out).not.toContain("sk-admin");
+      expect(out).not.toContain("sk-or-v1");
+      expect(out).not.toContain("sk-D");
+      const redactionCount = (out.match(/\[REDACTED\]/g) ?? []).length;
+      expect(redactionCount).toBe(5);
     });
   });
 

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -203,7 +203,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     name: "sendgrid-api-key",
     // Three-segment format: `SG.{22-char ID}.{43-char secret}`. No trailing
     // `\b` because the final segment can end with `-` (non-word char).
-    regex: /\bSG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}/g,
+    regex: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g,
     replacement: REDACTED,
   },
   {

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -11,6 +11,10 @@
  *   4. Main-process emergency crash log (`emergencyLogMainFatal`)
  *   5. Pty-host emergency crash log (`emergencyLogFatal`)
  *   6. IPC error envelope (`sanitizeErrorForRenderer` in setup/security.ts)
+ *   7. WorktreeLifecycleService tail-output scrub before renderer
+ *   8. AgentInstallService progress stdout/stderr scrubbing
+ *   9. AgentHelpService command output scrubbing
+ *  10. AgentVersionService error-message scrubbing
  *
  * All patterns use bounded quantifiers for ReDoS safety. See the
  * `secretScrubber.test.ts` sibling for the `safe-regex2` assertion that
@@ -67,7 +71,14 @@ export const PATTERNS: readonly SecretPattern[] = [
     name: "openai-project-key",
     // MUST precede `openai-api-key` so the shorter `sk-` prefix doesn't
     // greedily consume `sk-proj-`/`sk-svcacct-` and leave the body unredacted.
-    regex: /\bsk-(?:proj|svcacct)-[A-Za-z0-9_-]{100,256}\b/g,
+    regex: /\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{100,256}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "openrouter-api-key",
+    // MUST precede `openai-api-key` so the generic `sk-` prefix doesn't
+    // greedily consume `sk-or-v1-` and leave the body unredacted.
+    regex: /\bsk-or-v1-[0-9a-f]{55,70}\b/g,
     replacement: REDACTED,
   },
   {
@@ -86,8 +97,27 @@ export const PATTERNS: readonly SecretPattern[] = [
     replacement: REDACTED,
   },
   {
+    name: "slack-access-token",
+    // MUST precede `slack-refresh-token` (more-specific `xoxe.xox[bp]-`
+    // before broader `xoxe-`) AND `slack-token` (`xox[abprs]-` would
+    // greedily consume `xox[bp]-` from `xoxe.xox[bp]-` tokens).
+    regex: /\bxoxe\.xox[bp]-[A-Z0-9-]{160,180}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "slack-refresh-token",
+    regex: /\bxoxe-[A-Z0-9-]{140,150}\b/g,
+    replacement: REDACTED,
+  },
+  {
     name: "slack-token",
     regex: /\bxox[abprs]-[A-Za-z0-9-]{10,255}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "slack-app-token",
+    // `xapp-` covers Socket Mode and Audit Logs API tokens (post-Dec-2020).
+    regex: /\bxapp-[A-Za-z0-9-]{90,140}\b/g,
     replacement: REDACTED,
   },
   {
@@ -97,7 +127,8 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
   {
     name: "aws-access-key-id",
-    regex: /\bAKIA[0-9A-Z]{16}\b/g,
+    // Covers AKIA (IAM long-term), ASIA (STS short-term), and ABIA (STS variant).
+    regex: /\bA[SKBI]IA[0-9A-Z]{16}\b/g,
     replacement: REDACTED,
   },
   {
@@ -141,6 +172,38 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "supabase-key",
     regex: /\bsb_(?:publishable|secret)_[A-Za-z0-9_]{32,64}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "replicate-api-token",
+    regex: /\br8_[A-Za-z0-9]{30,40}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "huggingface-api-token",
+    regex: /\bhf_[A-Za-z0-9]{25,40}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "groq-api-key",
+    regex: /\bgsk_[A-Za-z0-9]{45,60}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "linear-api-key",
+    regex: /\blin_api_[A-Za-z0-9]{35,45}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "notion-api-key",
+    regex: /\bntn_[A-Za-z0-9]{40,55}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "sendgrid-api-key",
+    // Three-segment format: `SG.{22-char ID}.{43-char secret}`. No trailing
+    // `\b` because the final segment can end with `-` (non-word char).
+    regex: /\bSG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}/g,
     replacement: REDACTED,
   },
   {
@@ -208,7 +271,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // and the listed key names exclude `MAX_TOKENS` / `TOTAL_TOKENS` / request-id
     // shapes by construction.
     regex:
-      /\b(?:api_key|api_secret|access_key|secret_key|private_key|auth_token|auth_secret|client_secret|app_secret|app_key)[ \t]{0,4}=[ \t]{0,4}[A-Za-z0-9/+_-]{16,512}/gi,
+      /\b(?:api_key|api_secret|access_key|secret_key|private_key|auth_token|auth_secret|client_secret|app_secret|app_key|slack_signing_secret)[ \t]{0,4}=[ \t]{0,4}[A-Za-z0-9/+_-]{16,512}/gi,
     replacement: REDACTED,
   },
 ];

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -101,7 +101,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // MUST precede `slack-refresh-token` (more-specific `xoxe.xox[bp]-`
     // before broader `xoxe-`) AND `slack-token` (`xox[abprs]-` would
     // greedily consume `xox[bp]-` from `xoxe.xox[bp]-` tokens).
-    regex: /\bxoxe\.xox[bp]-[A-Z0-9-]{160,180}\b/g,
+    regex: /\bxoxe\.xox[bp]-[A-Za-z0-9-]{160,180}\b/g,
     replacement: REDACTED,
   },
   {
@@ -128,7 +128,7 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "aws-access-key-id",
     // Covers AKIA (IAM long-term), ASIA (STS short-term), and ABIA (STS variant).
-    regex: /\bA[SKBI]IA[0-9A-Z]{16}\b/g,
+    regex: /\bA[SKB]IA[0-9A-Z]{16}\b/g,
     replacement: REDACTED,
   },
   {
@@ -176,7 +176,7 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
   {
     name: "replicate-api-token",
-    regex: /\br8_[A-Za-z0-9]{30,40}\b/g,
+    regex: /\br8_[A-Za-z0-9]{35,40}\b/g,
     replacement: REDACTED,
   },
   {
@@ -186,7 +186,7 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
   {
     name: "groq-api-key",
-    regex: /\bgsk_[A-Za-z0-9]{45,60}\b/g,
+    regex: /\bgsk_[A-Za-z0-9]{40,64}\b/g,
     replacement: REDACTED,
   },
   {


### PR DESCRIPTION
## Summary

This is a pre-0.9 secret-scrubber coverage expansion. The issue (#6396) requested 12 new token formats common in 2026 developer environments -- tokens that routinely appear in `.env` files, shell history, `gh` CLI output, and stack traces flowing through the scrubber's call sites.

The `PATTERNS` allowlist gets new entries covering OpenAI admin keys, post-2020 Slack formats, AWS STS temporary credentials, four AI-inference vendor prefixes, and three other SaaS token shapes. Every new pattern includes positive and negative redaction fixtures in the test file. Guard patterns prevent the two highest false-positive risks (bare 32-char hex and `xoxe-`/`xoxe.xox[bp]-` ordering).

Resolves #6396.

## Changes

- **OpenAI admin key** (`sk-admin-`) -- added as an alternation to the existing project-key pattern so it runs before the generic `sk-{48}` fallback
- **OpenRouter** (`sk-or-v1-`) -- sits between the project-key and generic `sk-` patterns per the ordering contract
- **Slack** -- `xapp-` (Socket Mode / Audit Logs API, >=90 chars), `xoxe-` (refresh tokens), `xoxe.xox[bp]-` (12-hour expiring access tokens, 160-180 chars); the dot-prefixed variants precede `xoxe-` so they match first
- **Slack signing secret** -- bare 32-char hex anchored via `generic-key-fallback` with a `slack_signing_secret` keyword; no standalone hex pattern (would collide with MD5/request-IDs/trace-IDs)
- **AWS STS** -- `ASIA` and `ABIA` prefixes added to the existing access-key pattern (`A[SKB]IA`)
- **AI-inference vendors** -- Replicate (`r8_`), HuggingFace (`hf_`), Groq (`gsk_`), OpenRouter (`sk-or-v1-`)
- **SaaS** -- Linear (`lin_api_`), Notion (`ntn_`), SendGrid (`SG.` with three-segment format)
- **Call-site docs** -- file header updated to list all 10 scrubber call sites (was 6)

## Testing

- Positive redaction fixtures for all 12 new patterns
- Negative fixtures: too-short bodies, wrong prefixes (ACIA, AIIA), bare hex without env-var anchoring, mailformed SendGrid segment counts/lengths, substrings in ordinary text
- Ordering regression tests: `xoxe.xoxb-` fully scrubbed before `xoxe-` can match; `sk-or-v1-` fully scrubbed before `sk-{48}` can match; all five `sk-` variants redact independently in a single string
- Existing `safe-regex2` ReDoS validation covers all new patterns automatically (the test loops over `PATTERNS`)