### PR TITLE
feat(terminal): gate reflow during BSU and surface sync-mode in diagnostics

### DIFF
--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -6,7 +6,15 @@ import { logError } from "@/utils/logger";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TerminalInfoPayload } from "@/types/electron";
 import { actionService } from "@/services/ActionService";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+const SYNC_MODE_POLL_MS = 250;
+
+function formatSyncMode(value: boolean | null): string {
+  if (value === null) return "Unavailable";
+  return value ? "On" : "Off";
+}
 
 interface TerminalInfoDialogProps {
   isOpen: boolean;
@@ -121,12 +129,14 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const [info, setInfo] = useState<TerminalInfoPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [syncMode, setSyncMode] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (!isOpen) {
       setInfo(null);
       setError(null);
       setLoading(false);
+      setSyncMode(null);
       return;
     }
 
@@ -163,6 +173,21 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
 
     return () => {
       isMounted = false;
+    };
+  }, [isOpen, terminalId]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // xterm 6 mutates terminal.modes asynchronously as the parser consumes
+    // BSU/ESU sequences, and there is no change event. Poll at the same
+    // cadence as REFLOW_THROTTLE_MS (250ms) — enough resolution to catch
+    // most BSU blocks while the dialog is open.
+    setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId));
+    const intervalId = window.setInterval(() => {
+      setSyncMode(terminalInstanceService.getSynchronizedOutputMode(terminalId));
+    }, SYNC_MODE_POLL_MS);
+    return () => {
+      window.clearInterval(intervalId);
     };
   }, [isOpen, terminalId]);
 
@@ -251,6 +276,7 @@ Activity Metrics:
 Performance & Diagnostics:
   Output Buffer Size: ${info.outputBufferSize} lines
   Semantic Buffer: ${info.semanticBufferLines} lines
+  Synchronized Output (DEC 2026): ${formatSyncMode(syncMode)}
 `;
 
     try {
@@ -365,6 +391,7 @@ Performance & Diagnostics:
             <InfoSection title="Performance & Diagnostics">
               <InfoRow label="Output Buffer Size" value={`${info.outputBufferSize} lines`} />
               <InfoRow label="Semantic Buffer" value={`${info.semanticBufferLines} lines`} />
+              <InfoRow label="Synchronized Output (DEC 2026)" value={formatSyncMode(syncMode)} />
             </InfoSection>
           </div>
         )}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -369,6 +369,12 @@ class TerminalInstanceService {
     // stamping lastReflowAt here would throttle away the next legitimate
     // reflow once it's reattached.
     if (!element.isConnected) return;
+    // xterm 6 buffers row refreshes and renders them atomically at ESU when
+    // DEC mode 2026 (Synchronized Output) is active. Forcing an
+    // IntersectionObserver jitter mid-block would interleave a paint with
+    // the buffered range. Skip without stamping the throttle so we reflow
+    // on the next tick after ESU.
+    if (managed.terminal.modes?.synchronizedOutputMode === true) return;
 
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;
@@ -1669,6 +1675,22 @@ class TerminalInstanceService {
   getAltBufferState(id: string): boolean {
     const managed = this.instances.get(id);
     return managed?.isAltBuffer ?? false;
+  }
+
+  /**
+   * Returns whether DEC private mode 2026 (Synchronized Output / BSU+ESU) is
+   * currently open on the terminal. Returns `null` when the terminal is
+   * unknown or its xterm instance hasn't surfaced the mode (e.g. test mocks).
+   *
+   * Diagnostic-only — the value lags `terminal.write()` by one parser tick
+   * because xterm processes writes asynchronously, so it should not be used
+   * to gate writes synchronously.
+   */
+  getSynchronizedOutputMode(id: string): boolean | null {
+    const managed = this.instances.get(id);
+    if (!managed) return null;
+    const mode = managed.terminal.modes?.synchronizedOutputMode;
+    return typeof mode === "boolean" ? mode : null;
   }
 
   getAgentState(id: string): AgentState | undefined {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -263,6 +263,25 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBeGreaterThan(0);
   });
 
+  it("does not throttle the post-ESU reflow after a BSU skip", () => {
+    const managed = makeManaged();
+    const modes = (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } })
+      .modes;
+    // BSU opens — guard fires, no jitter, no stamp
+    modes.synchronizedOutputMode = true;
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+    expect(managed.lastReflowAt).toBe(0);
+
+    // ESU closes — the next reflow must fire immediately, not be eaten by
+    // the 250ms throttle. This is the invariant that justifies the
+    // no-stamp branch in the guard.
+    modes.synchronizedOutputMode = false;
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
   it("resetRenderer calls forceXtermReflow and clears the throttle", () => {
     const managed = makeManaged({ lastReflowAt: 99999 });
     Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
@@ -411,6 +430,20 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
     vi.advanceTimersByTime(3000);
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
+  it("heartbeat does not reflow or stamp throttle while sync block is open", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
+      synchronizedOutputMode: true,
+    };
+    service.instances.set("t1", managed);
+
+    vi.advanceTimersByTime(3000);
+    // Heartbeat tick fired but the sync-mode guard skipped without
+    // stamping — so the next post-ESU heartbeat will reflow immediately.
+    expect(paddingHistory(managed).length).toBe(0);
+    expect(managed.lastReflowAt).toBe(0);
   });
 
   it("resumes reflows when visibility transitions hidden → visible", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -52,6 +52,7 @@ type ReflowTestService = {
   maybeReflowTerminal: (managed: ManagedTerminal) => void;
   resetRenderer: (id: string) => void;
   resizeController: { fit: (id: string) => unknown };
+  getSynchronizedOutputMode: (id: string) => boolean | null;
 };
 
 function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
@@ -81,7 +82,10 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     paddingTopHistory;
 
   const managed = {
-    terminal: { element: termEl } as unknown as ManagedTerminal["terminal"],
+    terminal: {
+      element: termEl,
+      modes: { synchronizedOutputMode: false },
+    } as unknown as ManagedTerminal["terminal"],
     type: "terminal",
     kind: "terminal",
     hostElement,
@@ -235,6 +239,30 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(paddingHistory(managed).length).toBe(0);
   });
 
+  it("skips — and does not stamp throttle — when synchronized output mode is active", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
+      synchronizedOutputMode: true,
+    };
+
+    service.maybeReflowTerminal(managed);
+    // BSU is open — refreshing now would interleave with xterm's buffered
+    // range. Throttle must not stamp so we reflow on the next tick after ESU.
+    expect(managed.lastReflowAt).toBe(0);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("reflows when synchronized output mode is false", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
+      synchronizedOutputMode: false,
+    };
+
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
   it("resetRenderer calls forceXtermReflow and clears the throttle", () => {
     const managed = makeManaged({ lastReflowAt: 99999 });
     Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
@@ -283,6 +311,53 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // The escape hatch — forceXtermReflow — must still run even if fit throws.
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBe(0);
+  });
+});
+
+describe("TerminalInstanceService getSynchronizedOutputMode", () => {
+  let service: ReflowTestService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: ReflowTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("returns true when xterm reports an open synchronized output block", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
+      synchronizedOutputMode: true,
+    };
+    service.instances.set("t1", managed);
+
+    expect(service.getSynchronizedOutputMode("t1")).toBe(true);
+  });
+
+  it("returns false when xterm reports no synchronized output block", () => {
+    const managed = makeManaged();
+    service.instances.set("t1", managed);
+
+    expect(service.getSynchronizedOutputMode("t1")).toBe(false);
+  });
+
+  it("returns null for an unknown terminal id", () => {
+    expect(service.getSynchronizedOutputMode("missing")).toBeNull();
+  });
+
+  it("returns null when xterm did not surface modes (defensive)", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { modes?: unknown }).modes = undefined;
+    service.instances.set("t1", managed);
+
+    expect(service.getSynchronizedOutputMode("t1")).toBeNull();
   });
 });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -347,10 +347,10 @@ describe("TerminalInstanceService getSynchronizedOutputMode", () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    ({ terminalInstanceService: service } =
-      (await import("../TerminalInstanceService")) as unknown as {
-        terminalInstanceService: ReflowTestService;
-      });
+    const mod = await import("../TerminalInstanceService");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    service = (mod as unknown as { terminalInstanceService: ReflowTestService })
+      .terminalInstanceService;
     service.instances.clear();
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -136,6 +136,22 @@ function paddingHistory(managed: ManagedTerminal): string[] {
   return el.__paddingTopHistory;
 }
 
+// Test-fixture mutation helpers. The terminal mock isn't a full xterm Terminal,
+// so these consolidate the partial-shape casts in one place.
+type MutableModes = { modes?: { synchronizedOutputMode: boolean } | undefined };
+
+function setSyncMode(managed: ManagedTerminal, value: boolean): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const term = managed.terminal as unknown as MutableModes;
+  term.modes = { synchronizedOutputMode: value };
+}
+
+function clearSyncModes(managed: ManagedTerminal): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const term = managed.terminal as unknown as MutableModes;
+  term.modes = undefined;
+}
+
 describe("TerminalInstanceService maybeReflowTerminal", () => {
   let service: ReflowTestService;
 
@@ -241,9 +257,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("skips — and does not stamp throttle — when synchronized output mode is active", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
-      synchronizedOutputMode: true,
-    };
+    setSyncMode(managed, true);
 
     service.maybeReflowTerminal(managed);
     // BSU is open — refreshing now would interleave with xterm's buffered
@@ -254,9 +268,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("reflows when synchronized output mode is false", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
-      synchronizedOutputMode: false,
-    };
+    setSyncMode(managed, false);
 
     service.maybeReflowTerminal(managed);
     expect(paddingHistory(managed)).toContain("0.01px");
@@ -265,10 +277,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   it("does not throttle the post-ESU reflow after a BSU skip", () => {
     const managed = makeManaged();
-    const modes = (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } })
-      .modes;
-    // BSU opens — guard fires, no jitter, no stamp
-    modes.synchronizedOutputMode = true;
+    setSyncMode(managed, true);
     service.maybeReflowTerminal(managed);
     expect(paddingHistory(managed).length).toBe(0);
     expect(managed.lastReflowAt).toBe(0);
@@ -276,7 +285,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     // ESU closes — the next reflow must fire immediately, not be eaten by
     // the 250ms throttle. This is the invariant that justifies the
     // no-stamp branch in the guard.
-    modes.synchronizedOutputMode = false;
+    setSyncMode(managed, false);
     service.maybeReflowTerminal(managed);
     expect(paddingHistory(managed)).toContain("0.01px");
     expect(managed.lastReflowAt).toBeGreaterThan(0);
@@ -338,6 +347,7 @@ describe("TerminalInstanceService getSynchronizedOutputMode", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     ({ terminalInstanceService: service } =
       (await import("../TerminalInstanceService")) as unknown as {
         terminalInstanceService: ReflowTestService;
@@ -352,9 +362,7 @@ describe("TerminalInstanceService getSynchronizedOutputMode", () => {
 
   it("returns true when xterm reports an open synchronized output block", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
-      synchronizedOutputMode: true,
-    };
+    setSyncMode(managed, true);
     service.instances.set("t1", managed);
 
     expect(service.getSynchronizedOutputMode("t1")).toBe(true);
@@ -373,7 +381,7 @@ describe("TerminalInstanceService getSynchronizedOutputMode", () => {
 
   it("returns null when xterm did not surface modes (defensive)", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { modes?: unknown }).modes = undefined;
+    clearSyncModes(managed);
     service.instances.set("t1", managed);
 
     expect(service.getSynchronizedOutputMode("t1")).toBeNull();
@@ -434,9 +442,7 @@ describe("TerminalInstanceService reflowHeartbeatTimer visibility gate", () => {
 
   it("heartbeat does not reflow or stamp throttle while sync block is open", () => {
     const managed = makeManaged();
-    (managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }).modes = {
-      synchronizedOutputMode: true,
-    };
+    setSyncMode(managed, true);
     service.instances.set("t1", managed);
 
     vi.advanceTimersByTime(3000);

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -347,7 +347,6 @@ describe("TerminalInstanceService getSynchronizedOutputMode", () => {
 
   beforeEach(async () => {
     vi.resetModules();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     ({ terminalInstanceService: service } =
       (await import("../TerminalInstanceService")) as unknown as {
         terminalInstanceService: ReflowTestService;


### PR DESCRIPTION
## Summary

- Adds `getSynchronizedOutputMode()` getter on `TerminalInstanceService` (returns `boolean | null`) so the renderer can observe xterm 6's synchronized output state without touching IPC — it's renderer-side state.
- Gates `maybeReflowTerminal` to skip when a sync block is open. Forcing a reflow mid-frame is exactly wrong: xterm 6 is buffering that frame on purpose. The skip doesn't stamp `lastReflowAt`, so the next heartbeat fires normally once the block closes.
- Surfaces live sync-mode state in `TerminalInfoDialog` under Performance & Diagnostics (250ms polling) so we can actually observe when sync blocks are open in the wild before tuning the remaining constants.

Resolves #6294

## Changes

- `TerminalInstanceService.ts` — `getSynchronizedOutputMode()` getter; `maybeReflowTerminal` guard that returns early without side-effects when sync block is open
- `TerminalInfoDialog.tsx` — live "Synchronized output" row under Performance & Diagnostics, 250ms poll via `useInterval`
- `TerminalInstanceService.reflow.test.ts` — 23 tests covering the BSU→ESU round-trip, heartbeat sync-mode skip, and no-stamp invariant

`SETTLED_RESIZE_DELAY_MS=500` is unchanged. The Ratatui SIGWINCH race is a separate concern from BSU canvas-buffer behavior, and the issue explicitly called for visual testing before touching that constant.

## Testing

23 reflow tests pass. Typecheck clean. Lint at baseline (no new errors).