### PR TITLE
fix(protocols): harden daintree-file:// custom protocol handler

### DIFF
--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -70,11 +70,17 @@ vi.mock("../../utils/appProtocol.js", () => ({
   buildHeaders: vi.fn(),
 }));
 
+// Real-ish flag values matter: the protocol handler passes
+// `O_RDONLY | O_NOFOLLOW` to fs.open, and the test below asserts on the exact
+// bitmask. With both flags mocked as 0, the OR collapses to 0 and the
+// assertion succeeds whether or not O_NOFOLLOW is present in the source —
+// silently disabling the TOCTOU regression guard. Match the values used in
+// the sibling files:read test.
 const fsPromisesMocks = vi.hoisted(() => ({
   realpath: vi.fn(),
   stat: vi.fn(),
   open: vi.fn(),
-  constants: { O_RDONLY: 0, O_NOFOLLOW: 0 },
+  constants: { O_RDONLY: 0, O_NOFOLLOW: 0x100 },
 }));
 
 vi.mock("fs/promises", () => ({
@@ -856,6 +862,24 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     expect(response.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
     expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("uses the read buffer length for Content-Length, not the pre-read stat.size", async () => {
+    // If the file changes between stat() and readFile(), Content-Length must
+    // reflect what was actually returned in the body — using stat.size would
+    // declare a stale length that mismatches the response body.
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 4 } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle("hello world") as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/src/index.ts", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Length")).toBe(String("hello world".length));
   });
 
   it("rejects oversize files with 413 before opening the file (size cap parity with files:read)", async () => {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { pathToFileURL } from "url";
 import path from "path";
 
 type WebContentsCreatedListener = (event: unknown, contents: MockWebContents) => void;
@@ -71,8 +70,16 @@ vi.mock("../../utils/appProtocol.js", () => ({
   buildHeaders: vi.fn(),
 }));
 
-vi.mock("fs/promises", () => ({
+const fsPromisesMocks = vi.hoisted(() => ({
   realpath: vi.fn(),
+  stat: vi.fn(),
+  open: vi.fn(),
+  constants: { O_RDONLY: 0, O_NOFOLLOW: 0 },
+}));
+
+vi.mock("fs/promises", () => ({
+  default: fsPromisesMocks,
+  ...fsPromisesMocks,
 }));
 
 const mockSend = vi.fn();
@@ -792,17 +799,26 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     return new Request(url.toString()) as GlobalRequest;
   }
 
+  function makeFileHandle(content: string | Buffer = "data") {
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+    return {
+      readFile: vi.fn().mockResolvedValue(buffer),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks();
-    const electron = await import("electron");
-    vi.mocked(electron.net.fetch).mockResolvedValue(
-      new Response(new ArrayBuffer(4), { status: 200 })
+    const fs = await import("fs/promises");
+    vi.mocked(fs.stat).mockResolvedValue({ size: 4 } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle() as unknown as Awaited<ReturnType<typeof fs.open>>
     );
     const appProtocol = await import("../../utils/appProtocol.js");
     vi.mocked(appProtocol.getMimeType).mockReturnValue("text/plain");
   });
 
-  it("serves a normal file inside root using the realpath-resolved path", async () => {
+  it("serves a normal file inside root and opens the user-supplied path with O_NOFOLLOW", async () => {
     const fs = await import("fs/promises");
     const realpath = vi.mocked(fs.realpath);
     realpath.mockImplementation((p) => Promise.resolve(p as string));
@@ -811,10 +827,121 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/src/index.ts", "/project"));
 
     expect(response.status).toBe(200);
-    const electron = await import("electron");
-    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
-    const fetchUrl = vi.mocked(electron.net.fetch).mock.calls[0][0] as string;
-    expect(fetchUrl).toBe(pathToFileURL("/project/src/index.ts").toString());
+    // Stat is performed on the realpath-resolved file for accurate size.
+    expect(fs.stat).toHaveBeenCalledWith("/project/src/index.ts");
+    // open() must be called on the user-supplied (normalized) path with O_NOFOLLOW
+    // — this is the TOCTOU defense that net.fetch did not provide.
+    expect(fs.open).toHaveBeenCalledTimes(1);
+    const openArgs = vi.mocked(fs.open).mock.calls[0];
+    expect(openArgs[0]).toBe("/project/src/index.ts");
+    expect(openArgs[1]).toBe(fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  });
+
+  it("emits the hardened response header set on success", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 7 } as Awaited<ReturnType<typeof fs.stat>>);
+    vi.mocked(fs.open).mockResolvedValue(
+      makeFileHandle("hello\n!") as unknown as Awaited<ReturnType<typeof fs.open>>
+    );
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/src/index.ts", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Content-Length")).toBe("7");
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox; default-src 'none'");
+    // Must be cross-origin: app:// renderer and daintree-file:// are different schemes/sites.
+    expect(response.headers.get("Cross-Origin-Resource-Policy")).toBe("cross-origin");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("rejects oversize files with 413 before opening the file (size cap parity with files:read)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 512 * 1024 + 1 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/big.bin", "/project"));
+
+    expect(response.status).toBe(413);
+    expect(fs.open).not.toHaveBeenCalled();
+    // Error responses still carry the security header set.
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("serves a file at exactly the size limit (cap is exclusive)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.stat).mockResolvedValue({ size: 512 * 1024 } as Awaited<
+      ReturnType<typeof fs.stat>
+    >);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/edge.bin", "/project"));
+
+    expect(response.status).toBe(200);
+    expect(fs.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 404 when O_NOFOLLOW rejects a final-component symlink with ELOOP (TOCTOU)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    const eloop = Object.assign(new Error("ELOOP"), { code: "ELOOP" });
+    vi.mocked(fs.open).mockRejectedValue(eloop);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/sneaky", "/project"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when the file vanishes between realpath and open (ENOENT)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    vi.mocked(fs.open).mockRejectedValue(enoent);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/missing", "/project"));
+
+    expect(response.status).toBe(404);
+  });
+
+  it("closes the file handle even when readFile fails", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    const handle = {
+      readFile: vi.fn().mockRejectedValue(new Error("EIO")),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/broken", "/project"));
+
+    expect(response.status).toBe(500);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 200 when close() rejects after a successful read (close errors are swallowed)", async () => {
+    const fs = await import("fs/promises");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    const handle = {
+      readFile: vi.fn().mockResolvedValue(Buffer.from("ok")),
+      close: vi.fn().mockRejectedValue(new Error("EBADF")),
+    };
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = await captureHandler("daintree-file");
+    const response = await handler(makeRequest("/project/ok", "/project"));
+
+    expect(response.status).toBe(200);
   });
 
   it("blocks a symlink whose path is inside root but whose target is outside root", async () => {
@@ -830,8 +957,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/escape", "/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("returns 404 for a dangling symlink (ENOENT)", async () => {
@@ -847,8 +973,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/dangling", "/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("returns 404 for a symlink loop (ELOOP)", async () => {
@@ -864,8 +989,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/loop", "/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("returns 404 when the root itself fails to resolve (EACCES)", async () => {
@@ -880,8 +1004,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/file.txt", "/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("blocks a Windows cross-drive escape where path.relative returns an absolute path", async () => {
@@ -900,8 +1023,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/winlink", "/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("permits a symlink whose resolved target stays inside root", async () => {
@@ -917,11 +1039,10 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/link", "/project"));
 
     expect(response.status).toBe(200);
-    const electron = await import("electron");
-    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
-    const fetchUrl = vi.mocked(electron.net.fetch).mock.calls[0][0] as string;
-    // The fetch URL should be the resolved real path, not the symlink path.
-    expect(fetchUrl).toBe(pathToFileURL("/project/real/file.txt").toString());
+    // stat reads the resolved real path (for accurate size); open uses the
+    // user-supplied normalized path so O_NOFOLLOW catches a final-component swap.
+    expect(fs.stat).toHaveBeenCalledWith("/project/real/file.txt");
+    expect(vi.mocked(fs.open).mock.calls[0][0]).toBe("/project/link");
   });
 
   it("returns 400 (not 404) for missing parameters — input validation precedes realpath", async () => {
@@ -930,6 +1051,23 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(new Request(url.toString()) as GlobalRequest);
 
     expect(response.status).toBe(400);
+    // 4xx error responses still carry the security headers.
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 405 with security headers for non-GET/HEAD methods", async () => {
+    const handler = await captureHandler("daintree-file");
+    const url = new URL("daintree-file://serve");
+    url.searchParams.set("path", "/project/x");
+    url.searchParams.set("root", "/project");
+    const response = await handler(
+      new Request(url.toString(), { method: "POST" }) as GlobalRequest
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox; default-src 'none'");
   });
 
   it("permits files whose name starts with '..' but isn't parent traversal", async () => {
@@ -943,8 +1081,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/project/..hidden/file.txt", "/project"));
 
     expect(response.status).toBe(200);
-    const electron = await import("electron");
-    expect(electron.net.fetch).toHaveBeenCalledTimes(1);
+    expect(fs.open).toHaveBeenCalledTimes(1);
   });
 
   it("blocks a prefix-sibling escape (root=/tmp/project, target=/tmp/project-evil/...)", async () => {
@@ -956,8 +1093,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
     const response = await handler(makeRequest("/tmp/project-evil/secret.env", "/tmp/project"));
 
     expect(response.status).toBe(404);
-    const electron = await import("electron");
-    expect(electron.net.fetch).not.toHaveBeenCalled();
+    expect(fs.open).not.toHaveBeenCalled();
   });
 
   it("blocks via the path.isAbsolute(rel) branch (Windows cross-drive simulation)", async () => {
@@ -974,8 +1110,7 @@ describe("createDaintreeFileProtocolHandler — symlink containment", () => {
       const response = await handler(makeRequest("/project/file.txt", "/project"));
 
       expect(response.status).toBe(404);
-      const electron = await import("electron");
-      expect(electron.net.fetch).not.toHaveBeenCalled();
+      expect(fs.open).not.toHaveBeenCalled();
     } finally {
       relativeSpy.mockRestore();
     }

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -1,7 +1,7 @@
 import { app, protocol, net, session } from "electron";
 import { getWindowForWebContents, getAppWebContents } from "../window/webContentsRegistry.js";
 import path from "path";
-import { realpath } from "fs/promises";
+import fs from "fs/promises";
 import { pathToFileURL } from "url";
 import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../utils/appProtocol.js";
 import {
@@ -74,13 +74,49 @@ function createAppProtocolHandler(distPath: string) {
   };
 }
 
+// Parity with the files:read IPC handler (electron/ipc/handlers/files.ts).
+// Files larger than this are rejected with 413 before any read, preventing
+// renderer OOM via a malicious or accidental large-file URL.
+const DAINTREE_FILE_MAX_BYTES = 512 * 1024;
+
+// Hardened response headers for daintree-file:// (and the canopy-file:// alias).
+// CORP must be cross-origin: the app:// renderer and daintree-file:// are
+// different schemes (and therefore different origins/sites), and same-origin
+// would block legitimate sub-resource loads. CSP sandbox neutralizes polyglot
+// HTML/SVG payloads regardless of declared MIME. nosniff hardens against
+// MIME-confusion. no-store reflects that disk files can change at any time
+// and the handler has no ETag/Last-Modified infrastructure.
+function buildDaintreeFileHeaders(mimeType: string, contentLength: number): Record<string, string> {
+  return {
+    "Content-Type": mimeType,
+    "Content-Length": String(contentLength),
+    "Content-Security-Policy": "sandbox; default-src 'none'",
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "no-store",
+  };
+}
+
+function buildDaintreeFileErrorHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "text/plain",
+    "Content-Security-Policy": "sandbox; default-src 'none'",
+    "Cross-Origin-Resource-Policy": "cross-origin",
+    "X-Content-Type-Options": "nosniff",
+    "Cache-Control": "no-store",
+  };
+}
+
 /**
  * Create the daintree-file:// protocol handler function.
  */
 function createDaintreeFileProtocolHandler() {
   return async (request: GlobalRequest) => {
     if (request.method !== "GET" && request.method !== "HEAD") {
-      return new Response("Method Not Allowed", { status: 405 });
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
     }
 
     try {
@@ -89,15 +125,24 @@ function createDaintreeFileProtocolHandler() {
       const rootPath = url.searchParams.get("root");
 
       if (!filePath || !rootPath) {
-        return new Response("Missing path or root parameter", { status: 400 });
+        return new Response("Missing path or root parameter", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
       if (filePath.includes("\0") || rootPath.includes("\0")) {
-        return new Response("Invalid path", { status: 400 });
+        return new Response("Invalid path", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
       if (!path.isAbsolute(filePath) || !path.isAbsolute(rootPath)) {
-        return new Response("Paths must be absolute", { status: 400 });
+        return new Response("Paths must be absolute", {
+          status: 400,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
       const normalizedFile = path.normalize(filePath);
@@ -107,34 +152,81 @@ function createDaintreeFileProtocolHandler() {
       let realRoot: string;
       let realFile: string;
       try {
-        realRoot = await realpath(normalizedRoot);
-        realFile = await realpath(normalizedFile);
+        realRoot = await fs.realpath(normalizedRoot);
+        realFile = await fs.realpath(normalizedFile);
       } catch {
-        return new Response("Not Found", { status: 404 });
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
       const rel = path.relative(realRoot, realFile);
       // Match exact ".." and "../*" — bare startsWith("..") would reject legitimate files like "..hidden/x". isAbsolute catches Windows cross-drive escapes.
       if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
-        return new Response("Not Found", { status: 404 });
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
-      const mimeType = getMimeType(realFile);
-      const fileUrl = pathToFileURL(realFile).toString();
-      const response = await net.fetch(fileUrl);
-
-      if (!response.ok) {
-        return new Response("Not Found", { status: 404 });
+      // Stat the realpath-resolved path for an accurate size before any read.
+      let fileStat: Awaited<ReturnType<typeof fs.stat>>;
+      try {
+        fileStat = await fs.stat(realFile);
+      } catch {
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
       }
 
-      const buffer = await response.arrayBuffer();
-      return new Response(buffer, {
-        status: 200,
-        headers: { "Content-Type": mimeType },
-      });
+      if (fileStat.size > DAINTREE_FILE_MAX_BYTES) {
+        return new Response("Payload Too Large", {
+          status: 413,
+          headers: buildDaintreeFileErrorHeaders(),
+        });
+      }
+
+      // Open the user-supplied normalized path (not realFile) with O_NOFOLLOW
+      // so a final-component symlink injected after the realpath check is
+      // rejected with ELOOP. Closes the TOCTOU gap between realpath and the
+      // actual read. On Windows O_NOFOLLOW is 0 (no-op); realpath containment
+      // still applies. Mirrors the files:read IPC handler.
+      let fileHandle: Awaited<ReturnType<typeof fs.open>>;
+      try {
+        fileHandle = await fs.open(
+          normalizedFile,
+          fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+        );
+      } catch (err) {
+        const errCode = (err as NodeJS.ErrnoException).code;
+        if (errCode === "ELOOP" || errCode === "ENOENT") {
+          return new Response("Not Found", {
+            status: 404,
+            headers: buildDaintreeFileErrorHeaders(),
+          });
+        }
+        throw err;
+      }
+
+      try {
+        const buffer = await fileHandle.readFile();
+        const mimeType = getMimeType(realFile);
+        return new Response(buffer, {
+          status: 200,
+          headers: buildDaintreeFileHeaders(mimeType, fileStat.size),
+        });
+      } finally {
+        // Swallow close errors so they don't mask a preceding readFile failure.
+        await fileHandle.close().catch(() => {});
+      }
     } catch (err) {
       console.error("[MAIN] daintree-file protocol error:", err);
-      return new Response("Internal Server Error", { status: 500 });
+      return new Response("Internal Server Error", {
+        status: 500,
+        headers: buildDaintreeFileErrorHeaders(),
+      });
     }
   };
 }

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -213,9 +213,12 @@ function createDaintreeFileProtocolHandler() {
       try {
         const buffer = await fileHandle.readFile();
         const mimeType = getMimeType(realFile);
+        // Content-Length reflects the bytes actually returned. If the file
+        // grew between stat() and readFile(), buffer.length is the truth;
+        // fileStat.size would be stale.
         return new Response(buffer, {
           status: 200,
-          headers: buildDaintreeFileHeaders(mimeType, fileStat.size),
+          headers: buildDaintreeFileHeaders(mimeType, buffer.length),
         });
       } finally {
         // Swallow close errors so they don't mask a preceding readFile failure.

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -195,10 +195,7 @@ function createDaintreeFileProtocolHandler() {
       // still applies. Mirrors the files:read IPC handler.
       let fileHandle: Awaited<ReturnType<typeof fs.open>>;
       try {
-        fileHandle = await fs.open(
-          normalizedFile,
-          fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
-        );
+        fileHandle = await fs.open(normalizedFile, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
       } catch (err) {
         const errCode = (err as NodeJS.ErrnoException).code;
         if (errCode === "ELOOP" || errCode === "ENOENT") {


### PR DESCRIPTION
## Summary

- Replaces the `net.fetch` read path in `createDaintreeFileProtocolHandler` with `fs.stat` + `fs.open(O_RDONLY | O_NOFOLLOW)` + `fileHandle.readFile`, closing the TOCTOU gap between the `realpath` containment check and the actual file read.
- Adds a 500 KB size cap (matching the `files:read` IPC `FILE_SIZE_LIMIT`) — files over the cap return 413 before any `fs.open` call.
- Emits hardened response headers on both success and error paths: `Content-Security-Policy: sandbox; default-src 'none'`, `Cross-Origin-Resource-Policy: cross-origin`, `X-Content-Type-Options: nosniff`, `Cache-Control: no-store`, and `Content-Length` set from `buffer.length`.

Resolves #6400

## Changes

- `electron/setup/protocols.ts` — swap `net.fetch` for `fs.open` + `O_NOFOLLOW`; add size cap, security headers, `ELOOP`/`ENOENT` → 404 mapping, and close-error suppression. The `canopy-file://` alias shares the handler and gets the hardening for free.
- `electron/setup/__tests__/protocols.test.ts` — switched `fs/promises` mock to `vi.hoisted` with a realistic `O_NOFOLLOW=0x100` value so the bitmask assertion is meaningful; removed `electron.net.fetch` mocks from the symlink-containment suite; added tests for success headers, `buffer.length`-based `Content-Length`, 413 oversize pre-open, exact-limit boundary, `ELOOP`/`ENOENT` on open, `readFile` failure still closes the handle, close-error swallowed, `canopy-file://` alias headers, and 405/400 with security headers.

## Testing

60 tests in the file, all passing. New cases cover every branch added: size cap pre/post boundary, `O_NOFOLLOW` bitmask, each new header on both success and error responses, and the close-error suppression path.