### PR TITLE
fix(errors): add 'View errors' fallback to ErrorBanner full variant

### DIFF
--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -226,6 +226,11 @@ export function ErrorBanner({
               Retry
             </Button>
           )}
+          {!isRetrying && !canRetry && !error.details && (
+            <Button variant="ghost-danger" size="xs" onClick={handleViewErrors}>
+              View errors
+            </Button>
+          )}
           <Button
             variant="ghost-danger"
             size="icon-sm"

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -137,10 +137,71 @@ describe("ErrorBanner", () => {
       expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
       expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
     });
+  });
 
-    it("does not render 'View errors' in full (non-compact) mode", () => {
+  describe("full variant dismiss-only fallback", () => {
+    afterEach(() => {
+      useDiagnosticsStore.getState().reset();
+    });
+
+    it("renders 'View errors' alongside dismiss when full has no retry and no details", () => {
       render(<ErrorBanner error={makeError()} onDismiss={onDismiss} />);
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Dismiss error" })).toBeTruthy();
+    });
+
+    it("opens the diagnostics dock to the problems tab when 'View errors' clicked", () => {
+      render(<ErrorBanner error={makeError()} onDismiss={onDismiss} />);
+      expect(useDiagnosticsStore.getState().isOpen).toBe(false);
+      fireEvent.click(screen.getByRole("button", { name: "View errors" }));
+      const state = useDiagnosticsStore.getState();
+      expect(state.isOpen).toBe(true);
+      expect(state.activeTab).toBe("problems");
+    });
+
+    it("does not render 'View errors' when retry is available", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
       expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+
+    it("does not render 'View errors' when error.details is present", () => {
+      render(
+        <ErrorBanner error={makeError({ details: "stack trace here" })} onDismiss={onDismiss} />
+      );
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Details" })).toBeTruthy();
+    });
+
+    it("hides 'View errors' while a retry is in progress", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryProgress: { attempt: 1, maxAttempts: 3 },
+          })}
+          onDismiss={onDismiss}
+          onCancelRetry={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    });
+
+    it("renders 'View errors' when isTransient is true but onRetry is missing", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ isTransient: true, retryAction: "git" })}
+          onDismiss={onDismiss}
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- The full variant of `ErrorBanner` only rendered a `Dismiss` button when `canRetry` is false and `error.details` is empty, leaving users with no recourse
- The compact variant already has this covered with a `View errors` fallback button; this mirrors that same behaviour into the full variant, shown only when no other actions are available
- New test covers the no-retry, no-details condition for the full variant

Resolves #6430

## Changes

- `src/components/Errors/ErrorBanner.tsx` — added `View errors` fallback to the full variant action row, guarded by `!canRetry && !error.details`
- `src/components/Errors/__tests__/ErrorBanner.test.tsx` — test coverage for the new fallback condition

## Testing

- Existing `ErrorBanner` tests pass
- New test confirms the `View errors` button renders in the full variant when no retry is available and no details are present, and that clicking it opens the diagnostics dock at the Problems tab