### PR TITLE
fix(sidebar): keep header reveal buttons in keyboard tab order

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -967,7 +967,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           )}
         </div>
         <div className="flex items-center gap-1">
-          <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">
+          <div className="opacity-0 pointer-events-none transition-opacity duration-150 group-hover/header:opacity-100 group-hover/header:pointer-events-auto group-focus-within/header:opacity-100 group-focus-within/header:pointer-events-auto flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+describe("SidebarContent header reveal — issue #6420", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("does not use visibility:hidden (invisible/visible) for the header reveal — breaks keyboard focus", () => {
+    expect(source).not.toMatch(/invisible[^"']*group-(hover|focus-within)\/header:visible/);
+  });
+
+  it("hides the header reveal wrapper with opacity-0 + pointer-events-none so buttons stay in tab order", () => {
+    expect(source).toContain("opacity-0");
+    expect(source).toContain("pointer-events-none");
+    expect(source).toContain("group-hover/header:opacity-100");
+    expect(source).toContain("group-hover/header:pointer-events-auto");
+    expect(source).toContain("group-focus-within/header:opacity-100");
+    expect(source).toContain("group-focus-within/header:pointer-events-auto");
+  });
+
+  it("keeps the named group/header parent so focus-within and hover variants resolve", () => {
+    expect(source).toMatch(/className="[^"]*\bgroup\/header\b/);
+  });
+
+  it("uses Tier 1 transition-opacity duration-150 for the reveal", () => {
+    expect(source).toMatch(/transition-opacity[^"]*duration-150/);
+  });
+});


### PR DESCRIPTION
## Summary

- The overview, arm, and refresh buttons in the sidebar header were unreachable by keyboard. The wrapper used `visibility: hidden`, which removes elements from the tab order entirely — so the `group-focus-within` reveal selector was a dead selector that could never fire.
- Replaced the wrapper's visibility toggle with `opacity-0`/`opacity-100` + `pointer-events-none`/`pointer-events-auto`, matching the pattern already used in `WorktreeHeader.tsx`. Buttons stay in the tab order while remaining visually hidden.
- Added a regression test (`SidebarContent.headerReveal.test.ts`) that asserts the wrapper does not use the broken `invisible`/`visible` pattern and does use opacity + pointer-events + named-group focus-within reveal.

Resolves #6420

## Changes

- `src/components/Sidebar/SidebarContent.tsx` — swap `invisible`/`group-focus-within/header:visible` for `opacity-0 pointer-events-none`/`group-hover/header:opacity-100 group-focus-within/header:opacity-100` (+ pointer-events counterparts)
- `src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts` — new regression test locking in the keyboard-reachable contract

## Testing

- Regression test covers the exact class pattern; will catch any silent reversion to `invisible`/`visible`.
- Manually verified buttons are focusable via Tab and trigger correctly on focus.