### PR TITLE
feat(ui): add SkeletonHint for long-tail load states

### DIFF
--- a/src/components/Browser/BrowserPaneSkeleton.tsx
+++ b/src/components/Browser/BrowserPaneSkeleton.tsx
@@ -1,47 +1,60 @@
+import { SkeletonHint } from "@/components/ui/Skeleton";
+
 interface BrowserPaneSkeletonProps {
   label?: string;
 }
 
 export function BrowserPaneSkeleton({ label = "Loading browser panel" }: BrowserPaneSkeletonProps) {
   return (
-    <div className="flex flex-col h-full w-full" role="status" aria-busy="true" aria-label={label}>
-      <span className="sr-only">{label}</span>
-
-      {/* Header row — matches PanelHeader h-8 in grid location */}
+    <div className="relative flex flex-col h-full w-full">
       <div
-        className="flex items-center justify-between px-3 shrink-0 h-8 border-b border-divider bg-surface"
-        aria-hidden="true"
+        className="flex flex-col h-full w-full"
+        role="status"
+        aria-busy="true"
+        aria-label={label}
       >
-        <div className="flex items-center gap-2">
-          <div className="animate-pulse-delayed h-3.5 w-3.5 bg-muted rounded" />
-          <div className="animate-pulse-delayed h-3 w-24 bg-muted rounded" />
+        <span className="sr-only">{label}</span>
+
+        {/* Header row — matches PanelHeader h-8 in grid location */}
+        <div
+          className="flex items-center justify-between px-3 shrink-0 h-8 border-b border-divider bg-surface"
+          aria-hidden="true"
+        >
+          <div className="flex items-center gap-2">
+            <div className="animate-pulse-delayed h-3.5 w-3.5 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-3 w-24 bg-muted rounded" />
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+          </div>
         </div>
-        <div className="flex items-center gap-1">
-          <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
-          <div className="animate-pulse-delayed h-4 w-4 bg-muted rounded" />
+
+        {/* Toolbar row — matches BrowserToolbar layout */}
+        <div
+          className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay shrink-0"
+          aria-hidden="true"
+        >
+          {/* Nav button placeholders */}
+          <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
+          <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
+          <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
+
+          {/* URL bar placeholder */}
+          <div className="animate-pulse-delayed flex-1 h-7 bg-muted rounded" />
+
+          {/* Action button placeholders */}
+          <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
+          <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
         </div>
+
+        {/* Content area — empty, no animation */}
+        <div className="flex-1 min-h-0 bg-daintree-bg" />
       </div>
 
-      {/* Toolbar row — matches BrowserToolbar layout */}
-      <div
-        className="flex items-center gap-1.5 px-2 py-1.5 bg-surface border-b border-overlay shrink-0"
-        aria-hidden="true"
-      >
-        {/* Nav button placeholders */}
-        <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
-
-        {/* URL bar placeholder */}
-        <div className="animate-pulse-delayed flex-1 h-7 bg-muted rounded" />
-
-        {/* Action button placeholders */}
-        <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
-        <div className="animate-pulse-delayed h-7 w-7 bg-muted rounded" />
-      </div>
-
-      {/* Content area — empty, no animation */}
-      <div className="flex-1 min-h-0 bg-daintree-bg" />
+      {/* Long-tail loading hint — sibling of role="status" so the live region
+       * isn't silenced by aria-busy. Stays invisible until 5s, then fades in. */}
+      <SkeletonHint className="absolute bottom-8 left-1/2 -translate-x-1/2 pointer-events-auto" />
     </div>
   );
 }

--- a/src/components/Browser/__tests__/BrowserPaneSkeleton.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPaneSkeleton.test.tsx
@@ -44,4 +44,14 @@ describe("BrowserPaneSkeleton", () => {
     // header row + toolbar row = 2
     expect(hiddenRows.length).toBe(2);
   });
+
+  it("includes a SkeletonHint sibling outside the role=status element", () => {
+    const { container } = render(<BrowserPaneSkeleton />);
+    // SkeletonHint always renders an aria-live="polite" sr-only region; that
+    // region must NOT live inside the role="status" subtree, otherwise
+    // aria-busy="true" will silence the escalating copy on modern AT.
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).toBeTruthy();
+    expect(live!.closest('[role="status"]')).toBeNull();
+  });
 });

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 const TEXT_LINE_WIDTHS = ["w-full", "w-3/4", "w-1/2"] as const;
 const MAX_TEXT_LINES = 100;
@@ -156,6 +158,111 @@ export function SkeletonText({
           )}
         />
       ))}
+    </div>
+  );
+}
+
+const DEFAULT_FIRST_THRESHOLD_MS = 5_000;
+const DEFAULT_SECOND_THRESHOLD_MS = 10_000;
+const DEFAULT_ACTION_THRESHOLD_MS = 15_000;
+
+const FIRST_HINT_COPY = "Still working…";
+const SECOND_HINT_COPY = "Taking longer than usual…";
+const CANCEL_LABEL = "Cancel";
+const RETRY_LABEL = "Retry";
+
+type HintPhase = "hidden" | "first" | "second" | "action";
+
+function safeThreshold(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function hintCopy(phase: HintPhase): string {
+  if (phase === "first") return FIRST_HINT_COPY;
+  if (phase === "second" || phase === "action") return SECOND_HINT_COPY;
+  return "";
+}
+
+export interface SkeletonHintProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "role" | "aria-live" | "children"
+> {
+  /** Delay before "Still working…" appears. Default 5000ms. */
+  firstThreshold?: number;
+  /** Delay before copy escalates to "Taking longer than usual…". Default 10000ms. */
+  secondThreshold?: number;
+  /** Delay before Cancel/Retry buttons surface (only when handlers are passed). Default 15000ms. */
+  actionThreshold?: number;
+  /** When provided, a Cancel button appears at actionThreshold and fires this handler. */
+  onCancel?: () => void;
+  /** When provided, a Retry button appears at actionThreshold and fires this handler. */
+  onRetry?: () => void;
+}
+
+/**
+ * Companion to `<Skeleton>` for long-tail loads (>5s). Stays invisible until the
+ * first threshold, then fades in escalating copy and surfaces a Cancel/Retry
+ * affordance at the action threshold. Place as a sibling to the `<Skeleton>`
+ * wrapper — never nested inside, because the wrapper's `aria-busy="true"`
+ * silences mutations within its subtree on modern screen readers.
+ *
+ * The sr-only span is always rendered so screen readers register the live
+ * region up front; only its text content updates on phase change.
+ */
+export function SkeletonHint({
+  firstThreshold,
+  secondThreshold,
+  actionThreshold,
+  onCancel,
+  onRetry,
+  className,
+  ...rest
+}: SkeletonHintProps) {
+  const [phase, setPhase] = useState<HintPhase>("hidden");
+
+  const first = safeThreshold(firstThreshold, DEFAULT_FIRST_THRESHOLD_MS);
+  const second = safeThreshold(secondThreshold, DEFAULT_SECOND_THRESHOLD_MS);
+  const action = safeThreshold(actionThreshold, DEFAULT_ACTION_THRESHOLD_MS);
+
+  useEffect(() => {
+    const ids: ReturnType<typeof setTimeout>[] = [
+      setTimeout(() => setPhase("first"), first),
+      setTimeout(() => setPhase("second"), second),
+      setTimeout(() => setPhase("action"), action),
+    ];
+    return () => {
+      for (const id of ids) clearTimeout(id);
+    };
+  }, [first, second, action]);
+
+  const visibleCopy = hintCopy(phase);
+  const showActions = phase === "action" && (onCancel !== undefined || onRetry !== undefined);
+
+  return (
+    <div {...rest} className={className}>
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {visibleCopy}
+      </span>
+      {phase !== "hidden" && (
+        <div
+          key={phase}
+          className="animate-hint-fade-in flex items-center gap-2 text-text-secondary text-xs"
+        >
+          <span aria-hidden="true">{visibleCopy}</span>
+          {showActions && onCancel !== undefined && (
+            <Button variant="ghost" size="sm" onClick={onCancel} type="button">
+              {CANCEL_LABEL}
+            </Button>
+          )}
+          {showActions && onRetry !== undefined && (
+            <Button variant="ghost" size="sm" onClick={onRetry} type="button">
+              {RETRY_LABEL}
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -185,6 +185,20 @@ function hintCopy(phase: HintPhase): string {
   return "";
 }
 
+function actionAffordanceCopy(hasCancel: boolean, hasRetry: boolean): string {
+  if (hasCancel && hasRetry) return "Cancel and retry options available.";
+  if (hasCancel) return "Cancel option available.";
+  if (hasRetry) return "Retry option available.";
+  return "";
+}
+
+function liveRegionCopy(phase: HintPhase, hasCancel: boolean, hasRetry: boolean): string {
+  const base = hintCopy(phase);
+  if (phase !== "action") return base;
+  const action = actionAffordanceCopy(hasCancel, hasRetry);
+  return action ? `${base} ${action}` : base;
+}
+
 export interface SkeletonHintProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   "role" | "aria-live" | "children"
@@ -222,9 +236,12 @@ export function SkeletonHint({
 }: SkeletonHintProps) {
   const [phase, setPhase] = useState<HintPhase>("hidden");
 
+  // Clamp thresholds to monotonic ascending order so a misconfigured prop (e.g.
+  // actionThreshold smaller than the default secondThreshold) can't make the
+  // phase walk backward when the later setTimeout fires.
   const first = safeThreshold(firstThreshold, DEFAULT_FIRST_THRESHOLD_MS);
-  const second = safeThreshold(secondThreshold, DEFAULT_SECOND_THRESHOLD_MS);
-  const action = safeThreshold(actionThreshold, DEFAULT_ACTION_THRESHOLD_MS);
+  const second = Math.max(first, safeThreshold(secondThreshold, DEFAULT_SECOND_THRESHOLD_MS));
+  const action = Math.max(second, safeThreshold(actionThreshold, DEFAULT_ACTION_THRESHOLD_MS));
 
   useEffect(() => {
     const ids: ReturnType<typeof setTimeout>[] = [
@@ -237,26 +254,35 @@ export function SkeletonHint({
     };
   }, [first, second, action]);
 
+  const hasCancel = onCancel !== undefined;
+  const hasRetry = onRetry !== undefined;
   const visibleCopy = hintCopy(phase);
-  const showActions = phase === "action" && (onCancel !== undefined || onRetry !== undefined);
+  const showActions = phase === "action" && (hasCancel || hasRetry);
+
+  // Key the visible row on its rendered state, not the raw phase. When phase
+  // moves "second" → "action" with no handlers, the visible content is
+  // identical, so React preserves the DOM node and the fade-in does NOT
+  // re-fire. The key only changes when the user-visible content actually
+  // changes (copy escalation, or buttons appearing).
+  const visibleKey = `${visibleCopy}|${showActions ? "actions" : "noactions"}`;
 
   return (
     <div {...rest} className={className}>
       <span className="sr-only" aria-live="polite" aria-atomic="true">
-        {visibleCopy}
+        {liveRegionCopy(phase, hasCancel, hasRetry)}
       </span>
       {phase !== "hidden" && (
         <div
-          key={phase}
+          key={visibleKey}
           className="animate-hint-fade-in flex items-center gap-2 text-text-secondary text-xs"
         >
           <span aria-hidden="true">{visibleCopy}</span>
-          {showActions && onCancel !== undefined && (
+          {showActions && hasCancel && (
             <Button variant="ghost" size="sm" onClick={onCancel} type="button">
               {CANCEL_LABEL}
             </Button>
           )}
-          {showActions && onRetry !== undefined && (
+          {showActions && hasRetry && (
             <Button variant="ghost" size="sm" onClick={onRetry} type="button">
               {RETRY_LABEL}
             </Button>

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -300,6 +300,30 @@ describe("SkeletonHint", () => {
     expect(live.textContent).toBe("Taking longer than usual…");
   });
 
+  it("appends an action affordance announcement to the live region at the action phase", () => {
+    const { container } = render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(15_000);
+    expect(live.textContent).toBe("Taking longer than usual… Cancel and retry options available.");
+  });
+
+  it("scopes the action affordance announcement to the handlers actually passed", () => {
+    const { container, rerender } = render(<SkeletonHint onCancel={() => {}} />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(15_000);
+    expect(live.textContent).toBe("Taking longer than usual… Cancel option available.");
+    rerender(<SkeletonHint onRetry={() => {}} />);
+    advance(15_000);
+    expect(live.textContent).toBe("Taking longer than usual… Retry option available.");
+  });
+
+  it("does not append an action affordance announcement when no handlers are passed", () => {
+    const { container } = render(<SkeletonHint />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    advance(15_000);
+    expect(live.textContent).toBe("Taking longer than usual…");
+  });
+
   it("does not show action buttons at 15000ms when no handlers are passed", () => {
     render(<SkeletonHint />);
     advance(15_000);
@@ -354,6 +378,27 @@ describe("SkeletonHint", () => {
     expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
   });
 
+  it("clamps out-of-order thresholds to monotonic ascending so phase can't regress", () => {
+    // actionThreshold is intentionally smaller than secondThreshold's default —
+    // without clamping, buttons would flash at 6s then disappear at 10s when
+    // setPhase("second") fires. With clamping, action is held to >= second.
+    render(<SkeletonHint actionThreshold={6_000} onCancel={() => {}} />);
+    advance(6_000);
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    advance(4_000);
+    // At 10s the clamped action threshold finally fires alongside second.
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("clamps secondThreshold below firstThreshold to firstThreshold (no backward jump)", () => {
+    render(<SkeletonHint firstThreshold={5_000} secondThreshold={2_000} />);
+    advance(5_000);
+    // Both first and second clamped to fire together at 5s — second wins on
+    // tick order, so the displayed copy is the second-phase copy.
+    expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Still working…")).toBeNull();
+  });
+
   it("falls back to defaults for non-finite or negative thresholds", () => {
     render(
       <SkeletonHint
@@ -366,6 +411,18 @@ describe("SkeletonHint", () => {
     expect(screen.queryByText("Still working…")).toBeNull();
     advance(1);
     expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
+  });
+
+  it("marks the visible copy span as aria-hidden so AT only hears the live region", () => {
+    const { container } = render(<SkeletonHint />);
+    advance(5_000);
+    const visible = container.querySelector(".animate-hint-fade-in > span[aria-hidden='true']");
+    expect(visible).toBeTruthy();
+    expect(visible?.textContent).toBe("Still working…");
+    // Live region is sr-only; the visible span must NOT carry aria-live.
+    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions.length).toBe(1);
+    expect(liveRegions[0]?.classList.contains("sr-only")).toBe(true);
   });
 
   it("the hint root is not nested inside any role=status element", () => {
@@ -381,7 +438,7 @@ describe("SkeletonHint", () => {
     expect(hint.closest('[role="status"]')).toBeNull();
   });
 
-  it("re-keys the visible row on phase change so the fade-in re-fires", () => {
+  it("re-keys the visible row when copy escalates so the fade-in re-fires", () => {
     const { container } = render(<SkeletonHint />);
     advance(5_000);
     const first = container.querySelector(".animate-hint-fade-in");
@@ -389,9 +446,33 @@ describe("SkeletonHint", () => {
     advance(5_000);
     const second = container.querySelector(".animate-hint-fade-in");
     expect(second).toBeTruthy();
-    // React replaces the keyed node on phase change; the new element is a
-    // different DOM reference, so the animation restarts.
+    // Copy changed ("Still working…" → "Taking longer than usual…"), so the
+    // keyed node is replaced and the animation restarts.
     expect(second).not.toBe(first);
+  });
+
+  it("preserves the visible node at action phase when no handlers are passed (no spurious re-fade)", () => {
+    const { container } = render(<SkeletonHint />);
+    advance(10_000);
+    const before = container.querySelector(".animate-hint-fade-in");
+    expect(before).toBeTruthy();
+    // Crossing the action threshold with no handlers must NOT remount the node:
+    // visible content is identical, key is stable, fade-in does not re-fire.
+    advance(5_000);
+    const after = container.querySelector(".animate-hint-fade-in");
+    expect(after).toBe(before);
+  });
+
+  it("re-keys at action phase when handlers appear so the fade-in re-fires", () => {
+    const { container } = render(<SkeletonHint onCancel={() => {}} />);
+    advance(10_000);
+    const before = container.querySelector(".animate-hint-fade-in");
+    expect(before).toBeTruthy();
+    advance(5_000);
+    const after = container.querySelector(".animate-hint-fade-in");
+    expect(after).toBeTruthy();
+    // Buttons appearing is a meaningful visual change — re-fade is desired.
+    expect(after).not.toBe(before);
   });
 
   it("does not use transition-all", () => {

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));
 
-import { Skeleton, SkeletonBone, SkeletonText } from "../Skeleton";
+import { Skeleton, SkeletonBone, SkeletonHint, SkeletonText } from "../Skeleton";
 
 const BONE_TEST_ID = "bone";
 const TEXT_TEST_ID = "text";
@@ -240,6 +240,213 @@ describe("SkeletonText", () => {
   it("does not use transition-all", () => {
     const { container } = render(<SkeletonText lines={3} />);
     expect(container.innerHTML).not.toContain("transition-all");
+  });
+});
+
+describe("SkeletonHint", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function advance(ms: number) {
+    act(() => {
+      vi.advanceTimersByTime(ms);
+    });
+  }
+
+  it("renders nothing visible before the first threshold", () => {
+    const { container } = render(<SkeletonHint />);
+    expect(container.querySelector(".animate-hint-fade-in")).toBeNull();
+    expect(screen.queryByText("Still working…")).toBeNull();
+  });
+
+  it("always renders an aria-live region so AT registers it up front", () => {
+    const { container } = render(<SkeletonHint />);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).toBeTruthy();
+    expect(live?.getAttribute("aria-atomic")).toBe("true");
+    expect(live?.classList.contains("sr-only")).toBe(true);
+    expect(live?.textContent).toBe("");
+  });
+
+  it('shows "Still working…" at exactly 5000ms', () => {
+    render(<SkeletonHint />);
+    advance(4_999);
+    expect(screen.queryByText("Still working…")).toBeNull();
+    advance(1);
+    expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
+  });
+
+  it('escalates to "Taking longer than usual…" at 10000ms', () => {
+    render(<SkeletonHint />);
+    advance(10_000);
+    expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Still working…")).toBeNull();
+  });
+
+  it("updates the sr-only live region copy on phase change", () => {
+    const { container } = render(<SkeletonHint />);
+    const live = container.querySelector('[aria-live="polite"]')!;
+    expect(live.textContent).toBe("");
+
+    advance(5_000);
+    expect(live.textContent).toBe("Still working…");
+
+    advance(5_000);
+    expect(live.textContent).toBe("Taking longer than usual…");
+  });
+
+  it("does not show action buttons at 15000ms when no handlers are passed", () => {
+    render(<SkeletonHint />);
+    advance(15_000);
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("renders Cancel at 15000ms and fires the handler when clicked", () => {
+    const onCancel = vi.fn();
+    render(<SkeletonHint onCancel={onCancel} />);
+    advance(15_000);
+    const button = screen.getByRole("button", { name: "Cancel" });
+    fireEvent.click(button);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders Retry at 15000ms and fires the handler when clicked", () => {
+    const onRetry = vi.fn();
+    render(<SkeletonHint onRetry={onRetry} />);
+    advance(15_000);
+    const button = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders both Cancel and Retry when both handlers are passed", () => {
+    render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
+    advance(15_000);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("does not show buttons before the action threshold even with handlers", () => {
+    render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
+    advance(10_000);
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("clears all timers on unmount (no leaks)", () => {
+    const { unmount } = render(<SkeletonHint />);
+    advance(4_999);
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("respects custom thresholds", () => {
+    render(<SkeletonHint firstThreshold={1_000} secondThreshold={2_000} actionThreshold={3_000} />);
+    advance(1_000);
+    expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
+    advance(1_000);
+    expect(screen.getAllByText("Taking longer than usual…").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to defaults for non-finite or negative thresholds", () => {
+    render(
+      <SkeletonHint
+        firstThreshold={Number.NaN}
+        secondThreshold={-100}
+        actionThreshold={Number.POSITIVE_INFINITY}
+      />
+    );
+    advance(4_999);
+    expect(screen.queryByText("Still working…")).toBeNull();
+    advance(1);
+    expect(screen.getAllByText("Still working…").length).toBeGreaterThan(0);
+  });
+
+  it("the hint root is not nested inside any role=status element", () => {
+    const { container } = render(
+      <div>
+        <Skeleton>
+          <SkeletonBone />
+        </Skeleton>
+        <SkeletonHint data-testid="hint" />
+      </div>
+    );
+    const hint = container.querySelector('[data-testid="hint"]')!;
+    expect(hint.closest('[role="status"]')).toBeNull();
+  });
+
+  it("re-keys the visible row on phase change so the fade-in re-fires", () => {
+    const { container } = render(<SkeletonHint />);
+    advance(5_000);
+    const first = container.querySelector(".animate-hint-fade-in");
+    expect(first).toBeTruthy();
+    advance(5_000);
+    const second = container.querySelector(".animate-hint-fade-in");
+    expect(second).toBeTruthy();
+    // React replaces the keyed node on phase change; the new element is a
+    // different DOM reference, so the animation restarts.
+    expect(second).not.toBe(first);
+  });
+
+  it("does not use transition-all", () => {
+    const { container } = render(<SkeletonHint />);
+    advance(5_000);
+    expect(container.innerHTML).not.toContain("transition-all");
+  });
+
+  it("Cancel/Retry buttons use the ghost variant (no accent color)", () => {
+    render(<SkeletonHint onCancel={() => {}} onRetry={() => {}} />);
+    advance(15_000);
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const retry = screen.getByRole("button", { name: "Retry" });
+    // Ghost variant uses text-text-secondary, not text-accent-* / bg-primary
+    for (const button of [cancel, retry]) {
+      expect(button.className).toContain("text-text-secondary");
+      expect(button.className).not.toContain("bg-primary");
+      expect(button.className).not.toContain("text-accent");
+    }
+  });
+
+  it("merges custom className on the wrapper", () => {
+    const { container } = render(<SkeletonHint className="my-hint" data-testid="hint" />);
+    const hint = container.querySelector('[data-testid="hint"]')!;
+    expect(hint.className).toContain("my-hint");
+  });
+});
+
+describe("animate-hint-fade-in CSS contract", () => {
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf8");
+
+  it("declares the hint-fade-in keyframe", () => {
+    expect(css).toMatch(/@keyframes\s+hint-fade-in\b/);
+  });
+
+  it("declares the .animate-hint-fade-in utility class", () => {
+    expect(css).toMatch(/\.animate-hint-fade-in\s*\{/);
+  });
+
+  it("disables the fade under prefers-reduced-motion", () => {
+    const block = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/)?.[0];
+    expect(block).toBeTruthy();
+    expect(block).toMatch(/\.animate-hint-fade-in/);
+  });
+
+  it("disables the fade under body[data-reduce-animations]", () => {
+    expect(css).toMatch(
+      /body\[data-reduce-animations="true"\][\s\S]*?\.animate-hint-fade-in[\s\S]*?animation:\s*none/
+    );
+  });
+
+  it("forces opacity 1 under body[data-performance-mode]", () => {
+    expect(css).toMatch(
+      /body\[data-performance-mode="true"\][\s\S]*?\.animate-hint-fade-in[\s\S]*?opacity:\s*1/
+    );
   });
 });
 

--- a/src/index.css
+++ b/src/index.css
@@ -1129,6 +1129,26 @@ body,
   will-change: transform;
 }
 
+/* Companion to long-running skeletons. SkeletonHint renders this class on its
+ * visible row when the hint phase escalates so the new copy crossfades in
+ * rather than snapping. Opacity-only — no spatial motion — so reduced-motion
+ * bypasses just need to skip past the entry frame to opacity: 1.
+ */
+@keyframes hint-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-hint-fade-in {
+  opacity: 0;
+  animation: hint-fade-in 500ms ease-out forwards;
+  will-change: opacity;
+}
+
 /* Agent status working state - pulsing gradient animation */
 @keyframes status-pulse {
   0%,
@@ -1385,6 +1405,7 @@ body,
   .animate-pulse-delayed,
   .animate-pulse-immediate,
   .animate-skeleton-shimmer,
+  .animate-hint-fade-in,
   .status-working,
   .animate-badge-bump,
   .animate-activity-blip,
@@ -1493,6 +1514,7 @@ body[data-reduce-animations="true"]
     .animate-pulse-delayed,
     .animate-pulse-immediate,
     .animate-skeleton-shimmer,
+    .animate-hint-fade-in,
     .status-working,
     .animate-badge-bump,
     .animate-activity-blip,
@@ -2261,7 +2283,8 @@ body[data-performance-mode="true"] *::after {
 
 /* Ensure delayed skeletons don't stay invisible when animations are disabled */
 body[data-performance-mode="true"] .animate-pulse-delayed,
-body[data-performance-mode="true"] .animate-pulse-immediate {
+body[data-performance-mode="true"] .animate-pulse-immediate,
+body[data-performance-mode="true"] .animate-hint-fade-in {
   opacity: 1 !important;
 }
 


### PR DESCRIPTION
## Summary

- Adds `SkeletonHint` as a peer export from `src/components/ui/Skeleton.tsx` — fades in "Still working…" at 5s, escalates to "Taking longer than usual…" at 10s, surfaces optional ghost-variant Cancel/Retry buttons at 15s when handlers are passed.
- New `animate-hint-fade-in` keyframe in `src/index.css`, with bypass coverage in `prefers-reduced-motion`, `data-reduce-animations`, and `data-performance-mode` blocks.
- `BrowserPaneSkeleton` restructured so `SkeletonHint` is a sibling of the `role=status` wrapper — `aria-busy="true"` silences nested live regions on modern AT, so the live region has to sit outside.

Resolves #6418

## Changes

- `src/components/ui/Skeleton.tsx` — new `SkeletonHint` component with defensive threshold normalization (NaN/negative/Infinity fall back to defaults), monotonic phase clamping to prevent regression on out-of-order props, content-keyed row to avoid spurious re-fades when phase advances without new content, and a distinct `sr-only` affordance announcement when action buttons appear.
- `src/components/Browser/BrowserPaneSkeleton.tsx` — wires up `SkeletonHint` as a structural sibling.
- `src/index.css` — `animate-hint-fade-in` keyframe.

## Testing

77 tests pass across `Skeleton.test.tsx` and `BrowserPaneSkeleton.test.tsx`. `npm run check` clean.