### PR TITLE
fix(toolbar): restore five-state ladder for toolbar icon-buttons

### DIFF
--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -19,10 +19,8 @@
     transform 150ms ease;
 }
 
-.toolbar-icon-button:hover,
-.toolbar-icon-button:focus-visible {
+.toolbar-icon-button:hover {
   background: var(--toolbar-control-hover-bg, var(--theme-overlay-elevated));
-  color: var(--_hover-fg);
   box-shadow: var(--_hover-shadow);
 }
 
@@ -34,14 +32,26 @@
   box-shadow: var(--_hover-shadow);
 }
 
+.toolbar-icon-button:focus-visible,
 .toolbar-agent-button:focus-visible {
   outline: 2px solid var(--theme-accent-primary);
   outline-offset: 2px;
+  background: var(--toolbar-control-hover-bg, var(--theme-overlay-elevated));
+}
+
+.toolbar-icon-button[aria-pressed="true"],
+.toolbar-icon-button[aria-expanded="true"],
+.toolbar-icon-button[data-state="open"],
+.toolbar-agent-button[aria-pressed="true"],
+.toolbar-agent-button[aria-expanded="true"],
+.toolbar-agent-button[data-state="open"] {
+  background: var(--toolbar-control-armed-bg, var(--theme-overlay-emphasis));
 }
 
 .toolbar-icon-button:active,
 .toolbar-agent-button:active {
   transform: scale(0.98);
+  background: var(--toolbar-control-active-bg, var(--theme-overlay-emphasis));
 }
 
 .toolbar-divider {

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -32,11 +32,19 @@
   box-shadow: var(--_hover-shadow);
 }
 
-.toolbar-icon-button:focus-visible,
-.toolbar-agent-button:focus-visible {
+.toolbar-icon-button:focus-visible {
   outline: 2px solid var(--theme-accent-primary);
   outline-offset: 2px;
   background: var(--toolbar-control-hover-bg, var(--theme-overlay-elevated));
+}
+
+.toolbar-agent-button:focus-visible {
+  outline: 2px solid var(--theme-accent-primary);
+  outline-offset: 2px;
+  background: var(
+    --toolbar-agent-hover-bg,
+    var(--toolbar-control-hover-bg, var(--theme-overlay-elevated))
+  );
 }
 
 .toolbar-icon-button[aria-pressed="true"],


### PR DESCRIPTION
## Summary

- `toolbar.css` had `:hover` and `:focus-visible` merged into a single rule, making the two states visually identical and painting accent color on hover (a direct violation of the accent-restraint rule)
- Armed/toggled state (`aria-pressed="true"`, `aria-expanded="true"`, `data-state="open"`) had no CSS targeting it, so the attribute was functionally dead
- `:active` only applied `scale(0.98)` with no fill change, so press feedback had no tactile weight

Resolves #6411

## Changes

- Split the merged `:hover` / `:focus-visible` rule into separate selectors on both `.toolbar-icon-button` and `.toolbar-agent-button`
- Removed accent paint from hover; hover now uses overlay-subtle fill only
- `focus-visible` gets a 2px accent outline ring plus overlay-hover fill (matching the existing `.toolbar-agent-button` pattern)
- Added armed selectors (`[aria-pressed="true"]`, `[aria-expanded="true"]`, `[data-state="open"]`) using `--theme-overlay-emphasis` for a persistent deeper fill
- Deepened `:active` with overlay-emphasis fill in addition to `scale(0.98)`
- Two CSS custom property escape hatches: `--toolbar-control-armed-bg` and `--toolbar-control-active-bg`

Pure CSS change -- no JavaScript involved.

## Testing

- Verified each state visually in the toolbar: neutral, hover, focus-visible (tab navigation), armed (sidebar toggle `aria-pressed`, overflow menu `data-state="open"`), and active (click hold)
- Confirmed no accent bleed on multi-button hover
- Confirmed armed state is distinct from hover and focus states