### PR TITLE
feat(ui): add JSX tooltip-shortcut helper and chord-pill Kbd rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,7 @@ import { SendToAgentPalette } from "./components/Terminal/SendToAgentPalette";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
+import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { PanelLimitConfirmDialog } from "./components/Terminal/PanelLimitConfirmDialog";
 import { ThemePalette } from "./components/ThemePalette";
 import { LogLevelPalette } from "./components/LogLevelPalette";
@@ -499,7 +500,10 @@ function App() {
     <LazyMotion features={domAnimation}>
       <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
         <ErrorBoundary variant="fullscreen" componentName="App">
-          <TooltipProvider delayDuration={500} skipDelayDuration={150}>
+          <TooltipProvider
+            delayDuration={UI_TOOLTIP_DELAY_DURATION}
+            skipDelayDuration={UI_TOOLTIP_SKIP_DELAY_DURATION}
+          >
             <E2EFaultInjector />
             {isSafeMode && <SafeModeBanner />}
             <GitHubTokenBanner />

--- a/src/components/Commands/CommandPickerButton.tsx
+++ b/src/components/Commands/CommandPickerButton.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
-import { createTooltipWithShortcut } from "@/lib/platform";
+import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { SquareTerminal } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -35,7 +35,7 @@ export const CommandPickerButton = forwardRef<HTMLButtonElement, CommandPickerBu
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          {createTooltipWithShortcut("Open command picker", "Cmd+K")}
+          {createTooltipContent("Open command picker", "Cmd+K")}
         </TooltipContent>
       </Tooltip>
     );

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -1,4 +1,7 @@
+import { Fragment } from "react";
 import { cn } from "@/lib/utils";
+import { isMac } from "@/lib/platform";
+import { parseChord } from "@/lib/kbdShortcut";
 
 export interface KbdProps {
   children: React.ReactNode;
@@ -17,5 +20,67 @@ export function Kbd({ children, className }: KbdProps) {
     >
       {children}
     </kbd>
+  );
+}
+
+export interface KbdChordProps {
+  shortcut: string;
+  /** Override platform detection. Defaults to `isMac()`. */
+  isMac?: boolean;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * Renders a keyboard chord as per-key pills using the neutral overlay surface.
+ * macOS uses glyph keys with no `+` separator; Win/Linux uses spelled-out keys
+ * separated by a small `+` character. Two-step chords (`Cmd+K T`) are joined
+ * by a comma+space, matching the `keyHint` convention used elsewhere.
+ */
+export function KbdChord({
+  shortcut,
+  isMac: isMacProp,
+  className,
+  "aria-label": ariaLabel,
+}: KbdChordProps) {
+  const mac = isMacProp ?? isMac();
+  const steps = parseChord(shortcut, mac);
+  if (steps.length === 0) return null;
+
+  return (
+    <span
+      className={cn("inline-flex items-center gap-1", className)}
+      aria-label={ariaLabel ?? shortcut}
+    >
+      {steps.map((tokens, stepIndex) => (
+        <Fragment key={stepIndex}>
+          {stepIndex > 0 && (
+            <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+              ,
+            </span>
+          )}
+          <span className="inline-flex items-center gap-0.5">
+            {tokens.map((token, tokenIndex) => (
+              <Fragment key={tokenIndex}>
+                {tokenIndex > 0 && !mac && (
+                  <span className="text-daintree-text/40 text-[10px] select-none" aria-hidden>
+                    +
+                  </span>
+                )}
+                <kbd
+                  className={cn(
+                    "px-1.5 py-0.5 rounded text-xs font-mono leading-none",
+                    "bg-overlay-subtle text-daintree-text/70",
+                    "border border-border-subtle"
+                  )}
+                >
+                  {token}
+                </kbd>
+              </Fragment>
+            ))}
+          </span>
+        </Fragment>
+      ))}
+    </span>
   );
 }

--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { parseChord } from "../kbdShortcut";
+
+describe("parseChord — macOS glyphs", () => {
+  it("maps Cmd/Option/Shift/Ctrl to glyphs", () => {
+    expect(parseChord("Cmd+Shift+P", true)).toEqual([["⌘", "⇧", "P"]]);
+    expect(parseChord("Ctrl+Option+T", true)).toEqual([["⌃", "⌥", "T"]]);
+  });
+
+  it("maps Return/Enter to ⏎", () => {
+    expect(parseChord("Cmd+Return", true)).toEqual([["⌘", "⏎"]]);
+    expect(parseChord("Cmd+Enter", true)).toEqual([["⌘", "⏎"]]);
+  });
+
+  it("maps Escape/Esc to ⎋", () => {
+    expect(parseChord("Escape", true)).toEqual([["⎋"]]);
+    expect(parseChord("Esc", true)).toEqual([["⎋"]]);
+  });
+
+  it("maps Tab/Backspace/Delete glyphs", () => {
+    expect(parseChord("Tab", true)).toEqual([["⇥"]]);
+    expect(parseChord("Backspace", true)).toEqual([["⌫"]]);
+    expect(parseChord("Delete", true)).toEqual([["⌦"]]);
+    expect(parseChord("Del", true)).toEqual([["⌦"]]);
+  });
+
+  it("maps modifier aliases (cmd/command/meta) to ⌘", () => {
+    expect(parseChord("Cmd+P", true)).toEqual([["⌘", "P"]]);
+    expect(parseChord("Command+P", true)).toEqual([["⌘", "P"]]);
+    expect(parseChord("Meta+P", true)).toEqual([["⌘", "P"]]);
+  });
+
+  it("maps ctrl/control to ⌃", () => {
+    expect(parseChord("Ctrl+A", true)).toEqual([["⌃", "A"]]);
+    expect(parseChord("Control+A", true)).toEqual([["⌃", "A"]]);
+  });
+
+  it("maps option/alt to ⌥", () => {
+    expect(parseChord("Option+T", true)).toEqual([["⌥", "T"]]);
+    expect(parseChord("Alt+T", true)).toEqual([["⌥", "T"]]);
+  });
+});
+
+describe("parseChord — Win/Linux spelled-out", () => {
+  it("maps Cmd/Command/Meta to Ctrl", () => {
+    expect(parseChord("Cmd+P", false)).toEqual([["Ctrl", "P"]]);
+    expect(parseChord("Command+P", false)).toEqual([["Ctrl", "P"]]);
+    expect(parseChord("Meta+P", false)).toEqual([["Ctrl", "P"]]);
+  });
+
+  it("keeps Ctrl as Ctrl", () => {
+    expect(parseChord("Ctrl+Shift+P", false)).toEqual([["Ctrl", "Shift", "P"]]);
+  });
+
+  it("maps Option to Alt", () => {
+    expect(parseChord("Option+T", false)).toEqual([["Alt", "T"]]);
+    expect(parseChord("Alt+T", false)).toEqual([["Alt", "T"]]);
+  });
+
+  it("uses spelled-out Enter/Esc/Tab/Backspace/Delete", () => {
+    expect(parseChord("Return", false)).toEqual([["Enter"]]);
+    expect(parseChord("Escape", false)).toEqual([["Esc"]]);
+    expect(parseChord("Tab", false)).toEqual([["Tab"]]);
+    expect(parseChord("Backspace", false)).toEqual([["Backspace"]]);
+    expect(parseChord("Delete", false)).toEqual([["Delete"]]);
+  });
+});
+
+describe("parseChord — arrow keys (glyphs on every platform)", () => {
+  it("renders arrows as glyphs on macOS", () => {
+    expect(parseChord("Cmd+Up", true)).toEqual([["⌘", "↑"]]);
+    expect(parseChord("Cmd+Down", true)).toEqual([["⌘", "↓"]]);
+    expect(parseChord("Cmd+Left", true)).toEqual([["⌘", "←"]]);
+    expect(parseChord("Cmd+Right", true)).toEqual([["⌘", "→"]]);
+  });
+
+  it("renders arrows as glyphs on Win/Linux", () => {
+    expect(parseChord("Ctrl+Up", false)).toEqual([["Ctrl", "↑"]]);
+    expect(parseChord("Ctrl+ArrowDown", false)).toEqual([["Ctrl", "↓"]]);
+  });
+});
+
+describe("parseChord — multi-step chords", () => {
+  it("splits on whitespace into chord steps", () => {
+    expect(parseChord("Cmd+K T", true)).toEqual([["⌘", "K"], ["T"]]);
+  });
+
+  it("handles two-step chords with shared prefix", () => {
+    expect(parseChord("Cmd+K Cmd+W", true)).toEqual([
+      ["⌘", "K"],
+      ["⌘", "W"],
+    ]);
+  });
+
+  it("collapses extra whitespace between steps", () => {
+    expect(parseChord("Cmd+K   T", true)).toEqual([["⌘", "K"], ["T"]]);
+  });
+});
+
+describe("parseChord — edge cases", () => {
+  it("returns [] for empty string", () => {
+    expect(parseChord("", true)).toEqual([]);
+  });
+
+  it("returns [] for whitespace only", () => {
+    expect(parseChord("   ", true)).toEqual([]);
+  });
+
+  it("handles literal + key (Ctrl++)", () => {
+    expect(parseChord("Ctrl++", false)).toEqual([["Ctrl", "+"]]);
+    expect(parseChord("Ctrl++", true)).toEqual([["⌃", "+"]]);
+  });
+
+  it("handles literal + key with shift", () => {
+    expect(parseChord("Cmd+Shift++", true)).toEqual([["⌘", "⇧", "+"]]);
+  });
+
+  it("passes through unknown tokens (Hyper)", () => {
+    expect(parseChord("Hyper+P", true)).toEqual([["Hyper", "P"]]);
+  });
+
+  it("is case insensitive", () => {
+    expect(parseChord("CMD+SHIFT+P", true)).toEqual([["⌘", "⇧", "P"]]);
+    expect(parseChord("cmd+shift+p", true)).toEqual([["⌘", "⇧", "P"]]);
+  });
+
+  it("trims whitespace around + separators", () => {
+    expect(parseChord(" Cmd + Shift + P ", true)).toEqual([["⌘", "⇧", "P"]]);
+  });
+});

--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -127,4 +127,17 @@ describe("parseChord — edge cases", () => {
   it("trims whitespace around + separators", () => {
     expect(parseChord(" Cmd + Shift + P ", true)).toEqual([["⌘", "⇧", "P"]]);
   });
+
+  it("treats a bare + as a literal + key", () => {
+    expect(parseChord("+", false)).toEqual([["+"]]);
+  });
+
+  it("ignores a single trailing + (Ctrl+ alone) as malformed", () => {
+    expect(parseChord("Ctrl+", false)).toEqual([["Ctrl"]]);
+  });
+
+  it("preserves casing of unknown multi-char tokens (PageUp)", () => {
+    expect(parseChord("PageUp", false)).toEqual([["PageUp"]]);
+    expect(parseChord("Cmd+NumpadEnter", true)).toEqual([["⌘", "NumpadEnter"]]);
+  });
 });

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -40,6 +40,11 @@ export const UI_EXIT_DURATION = 120;
 export const UI_PALETTE_ENTER_DURATION = DURATION_150;
 export const UI_PALETTE_EXIT_DURATION = DURATION_100;
 
+// Tooltip hover/skip delays consumed by the Radix `TooltipProvider` at the app
+// root. These are wait times before a tooltip opens, not animation durations.
+export const UI_TOOLTIP_DELAY_DURATION = 500;
+export const UI_TOOLTIP_SKIP_DELAY_DURATION = DURATION_150;
+
 export const UI_ENTER_EASING = EASE_SPRING_CRITICAL;
 export const UI_EXIT_EASING = "cubic-bezier(0.2, 0, 0.7, 0)";
 

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure chord-parsing utility for keyboard shortcuts. Returns display tokens
+ * grouped by chord step so React components can render per-key pills without
+ * touching `navigator` directly.
+ *
+ * Steps (two-step chords) are separated by whitespace: `"Cmd+K T"` →
+ * `[["⌘","K"],["T"]]`. Keys within a step are separated by `+`.
+ *
+ * `isMac` is injected as a parameter so the parser can be tested without
+ * mutating the cached `navigator.platform` lookup in `src/lib/platform.ts`.
+ */
+
+const MAC_GLYPHS: Record<string, string> = {
+  cmd: "⌘",
+  command: "⌘",
+  meta: "⌘",
+  ctrl: "⌃",
+  control: "⌃",
+  alt: "⌥",
+  option: "⌥",
+  shift: "⇧",
+  return: "⏎",
+  enter: "⏎",
+  escape: "⎋",
+  esc: "⎋",
+  tab: "⇥",
+  backspace: "⌫",
+  delete: "⌦",
+  del: "⌦",
+};
+
+const WIN_LABELS: Record<string, string> = {
+  cmd: "Ctrl",
+  command: "Ctrl",
+  meta: "Ctrl",
+  ctrl: "Ctrl",
+  control: "Ctrl",
+  alt: "Alt",
+  option: "Alt",
+  shift: "Shift",
+  return: "Enter",
+  enter: "Enter",
+  escape: "Esc",
+  esc: "Esc",
+  tab: "Tab",
+  backspace: "Backspace",
+  delete: "Delete",
+  del: "Delete",
+};
+
+// Arrow keys render as glyphs on every platform — they're unambiguous and
+// take less horizontal space than the spelled-out names.
+const ARROW_GLYPHS: Record<string, string> = {
+  up: "↑",
+  arrowup: "↑",
+  down: "↓",
+  arrowdown: "↓",
+  left: "←",
+  arrowleft: "←",
+  right: "→",
+  arrowright: "→",
+};
+
+export const MODIFIER_GLYPH_MAP = MAC_GLYPHS;
+export const MODIFIER_TEXT_MAP = WIN_LABELS;
+
+function capitalize(token: string): string {
+  if (!token) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+}
+
+function mapToken(rawToken: string, isMac: boolean): string {
+  const lower = rawToken.toLowerCase();
+  const arrow = ARROW_GLYPHS[lower];
+  if (arrow) return arrow;
+  const table = isMac ? MAC_GLYPHS : WIN_LABELS;
+  const mapped = table[lower];
+  if (mapped) return mapped;
+  return capitalize(rawToken);
+}
+
+function splitStepKeys(step: string): string[] {
+  // `Ctrl++` means Control + literal `+` key. Splitting on `+` naively
+  // produces empty strings; preserve the trailing `+` as a literal token.
+  const trimmed = step.trim();
+  if (!trimmed) return [];
+
+  const trailingPlus = /\+$/.test(trimmed) && trimmed.length > 1;
+  const body = trailingPlus ? trimmed.slice(0, -1) : trimmed;
+  const parts = body
+    .split("+")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (trailingPlus) parts.push("+");
+  return parts;
+}
+
+/**
+ * Parse a shortcut string into display tokens grouped by chord step.
+ *
+ * @example
+ * parseChord("Cmd+Shift+P", true)   // [["⌘","⇧","P"]]
+ * parseChord("Cmd+K T", true)        // [["⌘","K"],["T"]]
+ * parseChord("Ctrl++", false)        // [["Ctrl","+"]]
+ * parseChord("", true)               // []
+ */
+export function parseChord(shortcut: string, isMac: boolean): string[][] {
+  if (!shortcut || !shortcut.trim()) return [];
+
+  // Collapse whitespace around `+` first so " Cmd + Shift + P " stays a single
+  // chord step. Remaining whitespace is the chord-step separator.
+  const normalized = shortcut.trim().replace(/\s*\+\s*/g, "+");
+  const steps = normalized
+    .split(/\s+/)
+    .map((step) => splitStepKeys(step))
+    .filter((tokens) => tokens.length > 0);
+
+  return steps.map((tokens) => tokens.map((token) => mapToken(token, isMac)));
+}

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -64,11 +64,6 @@ const ARROW_GLYPHS: Record<string, string> = {
 export const MODIFIER_GLYPH_MAP = MAC_GLYPHS;
 export const MODIFIER_TEXT_MAP = WIN_LABELS;
 
-function capitalize(token: string): string {
-  if (!token) return token;
-  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
-}
-
 function mapToken(rawToken: string, isMac: boolean): string {
   const lower = rawToken.toLowerCase();
   const arrow = ARROW_GLYPHS[lower];
@@ -76,23 +71,30 @@ function mapToken(rawToken: string, isMac: boolean): string {
   const table = isMac ? MAC_GLYPHS : WIN_LABELS;
   const mapped = table[lower];
   if (mapped) return mapped;
-  return capitalize(rawToken);
+  // Single-char keys are uppercased ("p" → "P"). Multi-char unknowns keep
+  // their original casing so labels like "PageUp" or "NumpadEnter" don't
+  // get mangled to "Pageup".
+  if (rawToken.length === 1) return rawToken.toUpperCase();
+  return rawToken;
 }
 
 function splitStepKeys(step: string): string[] {
-  // `Ctrl++` means Control + literal `+` key. Splitting on `+` naively
-  // produces empty strings; preserve the trailing `+` as a literal token.
   const trimmed = step.trim();
   if (!trimmed) return [];
 
-  const trailingPlus = /\+$/.test(trimmed) && trimmed.length > 1;
-  const body = trailingPlus ? trimmed.slice(0, -1) : trimmed;
+  // A bare `+` step or a `++` suffix means a literal `+` key (e.g. `Ctrl++`
+  // for zoom). A single trailing `+` (e.g. `Ctrl+`) is malformed and
+  // ignored — only `++` promotes the trailing plus to a literal.
+  if (trimmed === "+") return ["+"];
+
+  const literalPlus = trimmed.endsWith("++");
+  const body = literalPlus ? trimmed.slice(0, -1) : trimmed;
   const parts = body
     .split("+")
     .map((part) => part.trim())
     .filter((part) => part.length > 0);
 
-  if (trailingPlus) parts.push("+");
+  if (literalPlus) parts.push("+");
   return parts;
 }
 

--- a/src/lib/tooltipShortcut.tsx
+++ b/src/lib/tooltipShortcut.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement, ReactNode } from "react";
+import { KbdChord } from "@/components/ui/Kbd";
+
+/**
+ * Build tooltip content as a flex row: action label on the left, chord pills
+ * on the right. For consumers that need a plain string (e.g. `aria-label`),
+ * use `createTooltipWithShortcut` from `@/lib/platform` instead.
+ */
+export function createTooltipContent(label: ReactNode, shortcut?: string): ReactElement {
+  if (!shortcut || !shortcut.trim()) {
+    return <span>{label}</span>;
+  }
+
+  return (
+    <span className="flex items-center justify-between gap-4 w-full">
+      <span>{label}</span>
+      <KbdChord shortcut={shortcut} />
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/kbdShortcut.ts` — a pure chord parser that accepts an `isMac` flag so tests don't need `vi.resetModules`. Handles macOS glyphs, Win/Linux spelled-out keys, two-step chords, the literal `+` key, and unknown-token passthrough.
- Adds `src/lib/tooltipShortcut.tsx` — `createTooltipContent` returns a JSX flex row (label left, chord pills right) ready to drop into any Radix `TooltipContent`. `KbdChord` in `src/components/ui/Kbd.tsx` renders each key as a pill using `bg-overlay-subtle` / `border-border-subtle`; macOS skips `+` separators between glyphs, Win/Linux uses `+`.
- Names `UI_TOOLTIP_DELAY_DURATION` and `UI_TOOLTIP_SKIP_DELAY_DURATION` in `src/lib/animationUtils.ts` and consumes them in `src/App.tsx`, per the CLAUDE.md named-constants rule.

The existing string-returning `createTooltipWithShortcut` in `src/lib/platform.ts` is untouched — it's still the right choice for `aria-label` consumers.

Resolves #6431

## Changes

- `src/lib/kbdShortcut.ts` — new pure chord parser
- `src/lib/tooltipShortcut.tsx` — new JSX tooltip content helper
- `src/components/ui/Kbd.tsx` — added `KbdChord` composite component
- `src/lib/animationUtils.ts` — added tooltip delay constants
- `src/App.tsx` — `TooltipProvider` consumes the new constants
- `src/lib/__tests__/kbdShortcut.test.ts` — 26 unit tests

## Testing

26 unit tests cover macOS glyphs, Win/Linux spelled-out keys, multi-step chords (`Cmd+K T`), the literal `+` key (`Ctrl++`), bare `+`, malformed `Ctrl+`, unknown-key passthrough (`PageUp`), case insensitivity, and whitespace handling. TypeScript clean, ESLint baseline maintained, Prettier clean.