### PR TITLE
feat(palette): reflect selected row's action in footer hint

### DIFF
--- a/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
@@ -13,6 +13,9 @@ beforeAll(() => {
   if (typeof globalThis.ResizeObserver === "undefined") {
     globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
   }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function scrollIntoView() {};
+  }
 });
 
 vi.mock("@/lib/utils", () => ({
@@ -106,9 +109,58 @@ describe("QuickSwitcher dynamic footer hint", () => {
   it("falls back to default hints when results are empty", () => {
     renderQuickSwitcher({ results: [], selectedIndex: -1 });
 
-    expect(document.body.textContent).toContain("to select");
+    expect(screen.getByText("to select")).toBeTruthy();
     expect(screen.queryByText("Switch terminal")).toBeNull();
     expect(screen.queryByText("Switch worktree")).toBeNull();
+  });
+
+  it("updates the footer when selection moves between item types", () => {
+    const props = {
+      isOpen: true,
+      query: "",
+      results: [terminalItem, worktreeItem],
+      totalResults: 2,
+      isLoading: false,
+      close: () => {},
+      setQuery: () => {},
+      setSelectedIndex: () => {},
+      selectPrevious: () => {},
+      selectNext: () => {},
+      selectItem: () => {},
+      confirmSelection: () => {},
+    };
+
+    const { rerender } = render(<QuickSwitcher {...props} selectedIndex={0} />);
+    expect(screen.getByText("Switch terminal")).toBeTruthy();
+
+    rerender(<QuickSwitcher {...props} selectedIndex={1} />);
+    expect(screen.getByText("Switch worktree")).toBeTruthy();
+    expect(screen.queryByText("Switch terminal")).toBeNull();
+  });
+
+  it("restores default hints when results transition from populated to empty", () => {
+    const baseProps = {
+      isOpen: true,
+      query: "",
+      totalResults: 0,
+      isLoading: false,
+      close: () => {},
+      setQuery: () => {},
+      setSelectedIndex: () => {},
+      selectPrevious: () => {},
+      selectNext: () => {},
+      selectItem: () => {},
+      confirmSelection: () => {},
+    };
+
+    const { rerender } = render(
+      <QuickSwitcher {...baseProps} results={[terminalItem]} selectedIndex={0} />
+    );
+    expect(screen.getByText("Switch terminal")).toBeTruthy();
+
+    rerender(<QuickSwitcher {...baseProps} results={[]} selectedIndex={-1} />);
+    expect(screen.queryByText("Switch terminal")).toBeNull();
+    expect(screen.getByText("to select")).toBeTruthy();
   });
 
   it("wires aria-describedby on each row to the footer hint id", () => {

--- a/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { render, screen, within } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type { QuickSwitcherItem as QuickSwitcherItemData } from "@/hooks/useQuickSwitcher";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/icons", () => ({
+  FolderGit2: () => <span data-testid="folder-icon" />,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { QuickSwitcher } from "./QuickSwitcher";
+
+const terminalItem: QuickSwitcherItemData = {
+  id: "terminal:t1",
+  type: "terminal",
+  title: "zsh",
+  subtitle: "main",
+  terminalKind: "shell",
+};
+
+const worktreeItem: QuickSwitcherItemData = {
+  id: "worktree:wt1",
+  type: "worktree",
+  title: "feature-branch",
+  subtitle: "/path/to/wt",
+};
+
+interface RenderArgs {
+  results: QuickSwitcherItemData[];
+  selectedIndex: number;
+}
+
+function renderQuickSwitcher({ results, selectedIndex }: RenderArgs) {
+  return render(
+    <QuickSwitcher
+      isOpen
+      query=""
+      results={results}
+      totalResults={results.length}
+      selectedIndex={selectedIndex}
+      isLoading={false}
+      close={() => {}}
+      setQuery={() => {}}
+      setSelectedIndex={() => {}}
+      selectPrevious={() => {}}
+      selectNext={() => {}}
+      selectItem={() => {}}
+      confirmSelection={() => {}}
+    />
+  );
+}
+
+describe("QuickSwitcher dynamic footer hint", () => {
+  it("shows 'Switch terminal' when a terminal row is selected", () => {
+    renderQuickSwitcher({ results: [terminalItem, worktreeItem], selectedIndex: 0 });
+
+    expect(screen.getByText("Switch terminal")).toBeTruthy();
+    expect(screen.queryByText("Switch worktree")).toBeNull();
+  });
+
+  it("shows 'Switch worktree' when a worktree row is selected", () => {
+    renderQuickSwitcher({ results: [terminalItem, worktreeItem], selectedIndex: 1 });
+
+    expect(screen.getByText("Switch worktree")).toBeTruthy();
+    expect(screen.queryByText("Switch terminal")).toBeNull();
+  });
+
+  it("falls back to default hints when results are empty", () => {
+    renderQuickSwitcher({ results: [], selectedIndex: -1 });
+
+    expect(document.body.textContent).toContain("to select");
+    expect(screen.queryByText("Switch terminal")).toBeNull();
+    expect(screen.queryByText("Switch worktree")).toBeNull();
+  });
+
+  it("wires aria-describedby on each row to the footer hint id", () => {
+    renderQuickSwitcher({ results: [terminalItem, worktreeItem], selectedIndex: 0 });
+
+    const listbox = screen.getByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    expect(options).toHaveLength(2);
+
+    const describedBy = options[0]!.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(options[1]!.getAttribute("aria-describedby")).toBe(describedBy);
+
+    const hintEl = document.getElementById(describedBy!);
+    expect(hintEl).not.toBeNull();
+    expect(hintEl?.textContent).toContain("Switch terminal");
+  });
+
+  it("does not render an aria-live region", () => {
+    renderQuickSwitcher({
+      results: [terminalItem, worktreeItem],
+      selectedIndex: 0,
+    });
+
+    expect(document.body.querySelector("[aria-live]")).toBeNull();
+  });
+});

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -8,15 +8,15 @@ import type {
   UseQuickSwitcherReturn,
 } from "@/hooks/useQuickSwitcher";
 
-function getQuickSwitcherActionLabel(item: QuickSwitcherItemData): string | undefined {
+function getQuickSwitcherActionLabel(item: QuickSwitcherItemData): string {
   switch (item.type) {
     case "terminal":
       return "Switch terminal";
     case "worktree":
       return "Switch worktree";
-    default:
-      return undefined;
   }
+  const _exhaustive: never = item.type;
+  return _exhaustive;
 }
 
 type QuickSwitcherProps = Pick<
@@ -62,8 +62,8 @@ export function QuickSwitcher({
 
   const getFooter = useCallback(
     (item: QuickSwitcherItemData | null): React.ReactNode => {
-      const label = item ? getQuickSwitcherActionLabel(item) : undefined;
-      if (!label) return undefined;
+      if (!item) return undefined;
+      const label = getQuickSwitcherActionLabel(item);
       return (
         <div id={footerHintId} className="w-full">
           <PaletteFooterHints

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -1,11 +1,23 @@
-import { useCallback } from "react";
+import { useCallback, useId } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { QuickSwitcherItem } from "./QuickSwitcherItem";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import type {
   QuickSwitcherItem as QuickSwitcherItemData,
   UseQuickSwitcherReturn,
 } from "@/hooks/useQuickSwitcher";
+
+function getQuickSwitcherActionLabel(item: QuickSwitcherItemData): string | undefined {
+  switch (item.type) {
+    case "terminal":
+      return "Switch terminal";
+    case "worktree":
+      return "Switch worktree";
+    default:
+      return undefined;
+  }
+}
 
 type QuickSwitcherProps = Pick<
   UseQuickSwitcherReturn,
@@ -46,6 +58,28 @@ export function QuickSwitcher({
     [selectItem]
   );
 
+  const footerHintId = useId();
+
+  const getFooter = useCallback(
+    (item: QuickSwitcherItemData | null): React.ReactNode => {
+      const label = item ? getQuickSwitcherActionLabel(item) : undefined;
+      if (!label) return undefined;
+      return (
+        <div id={footerHintId} className="w-full">
+          <PaletteFooterHints
+            primaryHint={{ keys: ["↵"], label }}
+            hints={[
+              { keys: ["↑", "↓"], label: "to navigate" },
+              { keys: ["↵"], label },
+              { keys: ["Esc"], label: "to close" },
+            ]}
+          />
+        </div>
+      );
+    },
+    [footerHintId]
+  );
+
   const newTerminalShortcut = useKeybindingDisplay("terminal.new");
 
   return (
@@ -68,8 +102,10 @@ export function QuickSwitcher({
           isSelected={isSelected}
           onSelect={handleSelect}
           onHover={() => onHoverIndex(index)}
+          ariaDescribedBy={footerHintId}
         />
       )}
+      getFooter={getFooter}
       label="Quick switch"
       keyHint="⌘P"
       ariaLabel="Quick switcher"

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -10,6 +10,7 @@ export interface QuickSwitcherItemProps {
   isSelected: boolean;
   onSelect: (item: QuickSwitcherItemData) => void;
   onHover?: () => void;
+  ariaDescribedBy?: string;
 }
 
 export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
@@ -17,6 +18,7 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
   isSelected,
   onSelect,
   onHover,
+  ariaDescribedBy,
 }: QuickSwitcherItemProps) {
   return (
     <button
@@ -36,6 +38,7 @@ export const QuickSwitcherItem = React.memo(function QuickSwitcherItem({
       onClick={() => onSelect(item)}
       aria-selected={isSelected}
       aria-label={item.title}
+      aria-describedby={ariaDescribedBy}
       role="option"
     >
       <span className="shrink-0 text-daintree-text/70" aria-hidden="true">

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -191,9 +191,7 @@ export function SearchablePalette<T>({
   const noopHoverIndex = useCallback(() => {}, []);
   const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
 
-  const footerContent = getFooter
-    ? getFooter(results[selectedIndex] ?? null)
-    : footer;
+  const footerContent = getFooter ? getFooter(results[selectedIndex] ?? null) : footer;
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -58,6 +58,14 @@ export interface SearchablePaletteProps<T> {
   onKeyDown?: (e: React.KeyboardEvent) => void;
   /** Custom footer content. Omit for default keyboard hints. */
   footer?: React.ReactNode;
+  /**
+   * Dynamic footer derived from the currently selected item. Receives `null`
+   * when there is no selection (empty results). Takes precedence over
+   * `footer` when both are provided. Consumed only by `SearchablePalette`
+   * itself — never forwarded to row items, so per-item `React.memo` stays
+   * intact when arrow keys move selection.
+   */
+  getFooter?: (selectedItem: T | null) => React.ReactNode;
   /** Additional className for AppPaletteDialog.Body */
   bodyClassName?: string;
   /** Custom content before the list */
@@ -103,6 +111,7 @@ export function SearchablePalette<T>({
   emptyContent,
   onKeyDown,
   footer,
+  getFooter,
   bodyClassName,
   beforeList,
   afterList,
@@ -182,6 +191,10 @@ export function SearchablePalette<T>({
   const noopHoverIndex = useCallback(() => {}, []);
   const hoverIndexHandler = onHoverIndex ?? noopHoverIndex;
 
+  const footerContent = getFooter
+    ? getFooter(results[selectedIndex] ?? null)
+    : footer;
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>
       <AppPaletteDialog.Header
@@ -234,7 +247,7 @@ export function SearchablePalette<T>({
         )}
       </AppPaletteDialog.Body>
 
-      <AppPaletteDialog.Footer>{footer}</AppPaletteDialog.Footer>
+      <AppPaletteDialog.Footer>{footerContent}</AppPaletteDialog.Footer>
     </AppPaletteDialog>
   );
 }

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -47,12 +47,7 @@ interface RenderArgs {
   getFooter?: (selectedItem: Item | null) => React.ReactNode;
 }
 
-function renderPalette({
-  selectedIndex = 0,
-  results = items,
-  footer,
-  getFooter,
-}: RenderArgs = {}) {
+function renderPalette({ selectedIndex = 0, results = items, footer, getFooter }: RenderArgs = {}) {
   return render(
     <SearchablePalette<Item>
       isOpen
@@ -80,9 +75,8 @@ function renderPalette({
 
 describe("SearchablePalette footer", () => {
   it("calls getFooter with the selected item", () => {
-    const getFooter = vi.fn(
-      (item: Item | null) =>
-        item ? <span data-testid="footer">{item.label}</span> : null
+    const getFooter = vi.fn((item: Item | null) =>
+      item ? <span data-testid="footer">{item.label}</span> : null
     );
 
     const { getByTestId } = renderPalette({ selectedIndex: 1, getFooter });
@@ -92,9 +86,12 @@ describe("SearchablePalette footer", () => {
   });
 
   it("calls getFooter with null when results are empty", () => {
-    const getFooter = vi.fn(
-      (item: Item | null) =>
-        item ? <span data-testid="footer">{item.label}</span> : <span data-testid="footer">empty</span>
+    const getFooter = vi.fn((item: Item | null) =>
+      item ? (
+        <span data-testid="footer">{item.label}</span>
+      ) : (
+        <span data-testid="footer">empty</span>
+      )
     );
 
     const { getByTestId } = renderPalette({ results: [], selectedIndex: -1, getFooter });

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+const items: Item[] = [
+  { id: "a", label: "Alpha" },
+  { id: "b", label: "Bravo" },
+  { id: "c", label: "Charlie" },
+];
+
+interface RenderArgs {
+  selectedIndex?: number;
+  results?: Item[];
+  footer?: React.ReactNode;
+  getFooter?: (selectedItem: Item | null) => React.ReactNode;
+}
+
+function renderPalette({
+  selectedIndex = 0,
+  results = items,
+  footer,
+  getFooter,
+}: RenderArgs = {}) {
+  return render(
+    <SearchablePalette<Item>
+      isOpen
+      query=""
+      results={results}
+      selectedIndex={selectedIndex}
+      onQueryChange={() => {}}
+      onSelectPrevious={() => {}}
+      onSelectNext={() => {}}
+      onConfirm={() => {}}
+      onClose={() => {}}
+      getItemId={(item) => item.id}
+      renderItem={(item) => (
+        <button key={item.id} data-testid={`row-${item.id}`}>
+          {item.label}
+        </button>
+      )}
+      label="Test"
+      ariaLabel="Test palette"
+      footer={footer}
+      getFooter={getFooter}
+    />
+  );
+}
+
+describe("SearchablePalette footer", () => {
+  it("calls getFooter with the selected item", () => {
+    const getFooter = vi.fn(
+      (item: Item | null) =>
+        item ? <span data-testid="footer">{item.label}</span> : null
+    );
+
+    const { getByTestId } = renderPalette({ selectedIndex: 1, getFooter });
+
+    expect(getFooter).toHaveBeenCalledWith(items[1]);
+    expect(getByTestId("footer").textContent).toBe("Bravo");
+  });
+
+  it("calls getFooter with null when results are empty", () => {
+    const getFooter = vi.fn(
+      (item: Item | null) =>
+        item ? <span data-testid="footer">{item.label}</span> : <span data-testid="footer">empty</span>
+    );
+
+    const { getByTestId } = renderPalette({ results: [], selectedIndex: -1, getFooter });
+
+    expect(getFooter).toHaveBeenCalledWith(null);
+    expect(getByTestId("footer").textContent).toBe("empty");
+  });
+
+  it("getFooter takes precedence over the static footer prop", () => {
+    const { getByTestId, queryByTestId } = renderPalette({
+      footer: <span data-testid="static-footer">static</span>,
+      getFooter: () => <span data-testid="dynamic-footer">dynamic</span>,
+    });
+
+    expect(getByTestId("dynamic-footer")).toBeTruthy();
+    expect(queryByTestId("static-footer")).toBeNull();
+  });
+
+  it("renders the static footer when getFooter is omitted", () => {
+    const { getByTestId } = renderPalette({
+      footer: <span data-testid="static-footer">static</span>,
+    });
+
+    expect(getByTestId("static-footer").textContent).toBe("static");
+  });
+
+  it("falls back to default keyboard hints when neither prop is provided", () => {
+    renderPalette();
+
+    expect(document.body.textContent).toContain("to select");
+  });
+
+  it("does not render an aria-live region for the footer", () => {
+    renderPalette({
+      getFooter: (item) => (item ? <span>{item.label}</span> : null),
+    });
+
+    expect(document.body.querySelector("[aria-live]")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `getFooter` callback prop to `SearchablePalette` so each palette can derive its footer from the currently selected item rather than showing static text for every row
- `QuickSwitcher` is the pilot consumer: the footer now reads "Switch terminal" or "Switch worktree" depending on what's selected, updating as you navigate
- ARIA is wired via `aria-describedby` on each `role=option` button rather than `aria-live`, which matches the W3C APG combobox pattern and avoids double-announcing selection changes to screen readers

Resolves #6417

## Changes

- `SearchablePalette`: new `getFooter?: (selectedItem: T | null) => React.ReactNode` prop; takes precedence over the existing static `footer?` prop when present; static prop still works unchanged for all existing consumers (`PanelPalette`, `NewTerminalPalette`, `ActionPalette`)
- `QuickSwitcher`: passes `getFooter` callback; exhaustive switch over item type uses `assertNever` so future `QuickSwitcherItemType` additions break the build rather than silently dropping the ARIA description
- `QuickSwitcherItem`: accepts `ariaDescribedBy?` prop wired to `aria-describedby` on the option button; `useId`-generated id scopes the hint to the palette instance
- `SearchablePalette.footer.test.tsx`: 6 tests covering `getFooter` receiving selected item and null, precedence over static footer, static fallback, `DefaultKeyboardHints` fallback, and no `aria-live`
- `QuickSwitcher.footer.test.tsx`: 7 tests covering terminal/worktree footer text, default fallback, `aria-describedby` wiring, rerender on selection change, populated-to-empty transition, and no `aria-live`

## Testing

- 13 new unit tests across the two new test files; all pass
- Existing palette tests unchanged — backward-compatibility confirmed
- Typecheck and lint clean