### PR TITLE
feat(ui): soften skeleton-to-content swap with 150ms fade-in

### DIFF
--- a/src/components/GitHub/CommitList.tsx
+++ b/src/components/GitHub/CommitList.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, type KeyboardEvent } from "re
 import { useDebounce } from "@/hooks/useDebounce";
 import { Search, RefreshCw, AlertCircle, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
 import { cn } from "@/lib/utils";
 import { CommitListItem } from "./CommitListItem";
 import type { GitCommit, GitCommitListResponse } from "@shared/types/github";
@@ -237,7 +238,7 @@ export function CommitList({ projectPath, branch, onClose, initialCount }: Commi
             <CommitListSkeleton count={initialCount} />
           )
         ) : data.length > 0 ? (
-          <>
+          <ContentFadeIn>
             {error && renderError()}
             <div
               ref={listRef}
@@ -291,7 +292,7 @@ export function CommitList({ projectPath, branch, onClose, initialCount }: Commi
                 </Button>
               </div>
             )}
-          </>
+          </ContentFadeIn>
         ) : error ? (
           <div className="p-8 text-center text-muted-foreground">
             <AlertCircle className="h-5 w-5 mx-auto mb-2 opacity-50" />

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/githubResourceCache";
 import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
+import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -1198,7 +1199,7 @@ export function GitHubResourceList({
             />
           </div>
         ) : data.length > 0 ? (
-          <>
+          <ContentFadeIn className="flex-1 min-h-0 flex flex-col">
             {error && (
               <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
                 <WifiOff className="h-3.5 w-3.5 shrink-0" />
@@ -1265,7 +1266,7 @@ export function GitHubResourceList({
                 )}
               />
             </div>
-          </>
+          </ContentFadeIn>
         ) : error ? (
           <div className="p-8 text-center text-muted-foreground">
             <WifiOff className="h-5 w-5 mx-auto mb-2 opacity-50" />

--- a/src/components/ui/ContentFadeIn.tsx
+++ b/src/components/ui/ContentFadeIn.tsx
@@ -1,0 +1,20 @@
+import { type HTMLAttributes, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type ContentFadeInProps = HTMLAttributes<HTMLDivElement> & {
+  children: ReactNode;
+};
+
+export function ContentFadeIn({ children, className, ...rest }: ContentFadeInProps) {
+  return (
+    <div
+      {...rest}
+      className={cn(
+        "content-fade-in motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/ContentFadeIn.test.tsx
+++ b/src/components/ui/__tests__/ContentFadeIn.test.tsx
@@ -52,9 +52,7 @@ describe("ContentFadeIn", () => {
     });
 
     it("merges custom className", () => {
-      const { container } = render(
-        <ContentFadeIn className="my-custom flex-1">x</ContentFadeIn>
-      );
+      const { container } = render(<ContentFadeIn className="my-custom flex-1">x</ContentFadeIn>);
       const root = container.firstElementChild;
       expect(root?.className).toContain("my-custom");
       expect(root?.className).toContain("flex-1");

--- a/src/components/ui/__tests__/ContentFadeIn.test.tsx
+++ b/src/components/ui/__tests__/ContentFadeIn.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+import { ContentFadeIn } from "../ContentFadeIn";
+
+describe("ContentFadeIn", () => {
+  describe("animation classes", () => {
+    it("applies motion-safe entry animation classes on the wrapper", () => {
+      const { container } = render(
+        <ContentFadeIn>
+          <span>child</span>
+        </ContentFadeIn>
+      );
+      const root = container.firstElementChild;
+      expect(root).toBeTruthy();
+      expect(root?.className).toContain("motion-safe:animate-in");
+      expect(root?.className).toContain("motion-safe:fade-in");
+      expect(root?.className).toContain("motion-safe:duration-150");
+    });
+
+    it("includes the content-fade-in marker class for CSS overrides", () => {
+      const { container } = render(<ContentFadeIn>x</ContentFadeIn>);
+      expect(container.firstElementChild?.className).toContain("content-fade-in");
+    });
+
+    it("does not use transition-all", () => {
+      const { container } = render(<ContentFadeIn>x</ContentFadeIn>);
+      expect(container.innerHTML).not.toContain("transition-all");
+    });
+
+    it("does not apply will-change in JSX (CSS owns that lifecycle)", () => {
+      const { container } = render(<ContentFadeIn>x</ContentFadeIn>);
+      expect(container.innerHTML).not.toContain("will-change");
+    });
+  });
+
+  describe("rendering", () => {
+    it("renders children", () => {
+      render(
+        <ContentFadeIn>
+          <span data-testid="child">hello</span>
+        </ContentFadeIn>
+      );
+      expect(screen.getByTestId("child")).toBeTruthy();
+    });
+
+    it("merges custom className", () => {
+      const { container } = render(
+        <ContentFadeIn className="my-custom flex-1">x</ContentFadeIn>
+      );
+      const root = container.firstElementChild;
+      expect(root?.className).toContain("my-custom");
+      expect(root?.className).toContain("flex-1");
+    });
+
+    it("forwards arbitrary HTML attributes (role, data-*, aria-*)", () => {
+      const { container } = render(
+        <ContentFadeIn role="presentation" data-testid="root" aria-label="content">
+          x
+        </ContentFadeIn>
+      );
+      const root = container.firstElementChild;
+      expect(root?.getAttribute("role")).toBe("presentation");
+      expect(root?.getAttribute("data-testid")).toBe("root");
+      expect(root?.getAttribute("aria-label")).toBe("content");
+    });
+  });
+});
+
+describe("content-fade-in CSS contract", () => {
+  // Read the source CSS once. Build pipeline transforms (Tailwind, autoprefixer)
+  // shouldn't matter — we're asserting authored intent in src/index.css.
+  const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf8");
+
+  it("declares the data-reduce-animations override for .content-fade-in", () => {
+    const block = css.match(
+      /body\[data-reduce-animations="true"\]\s+\.content-fade-in\s*\{[^}]*\}/
+    )?.[0];
+    expect(block).toBeTruthy();
+    expect(block).toMatch(/animation:\s*none/);
+    expect(block).toMatch(/opacity:\s*1/);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1512,6 +1512,11 @@ body[data-reduce-animations="true"] .animate-skeleton-shimmer::after {
   will-change: auto;
 }
 
+body[data-reduce-animations="true"] .content-fade-in {
+  animation: none;
+  opacity: 1;
+}
+
 body[data-reduce-animations="true"] .animate-fleet-bar-refocus-pulse::before,
 body[data-reduce-animations="true"] .animate-fleet-bar-commit-flash::before {
   animation: none;

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -11,6 +11,7 @@ import type { PanelSnapshot } from "@shared/types/project";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
+import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
 
 import { serializePtyPanel } from "./terminal/serializer";
 import { createTerminalDefaults } from "./terminal/defaults";
@@ -57,7 +58,9 @@ function BrowserPaneWrapper(props: ComponentProps<typeof LazyBrowserPane>) {
   return (
     <ErrorBoundary variant="component" componentName="BrowserPane">
       <Suspense fallback={<BrowserPaneSkeleton />}>
-        <LazyBrowserPane {...props} />
+        <ContentFadeIn className="flex flex-col h-full w-full">
+          <LazyBrowserPane {...props} />
+        </ContentFadeIn>
       </Suspense>
     </ErrorBoundary>
   );
@@ -67,7 +70,9 @@ function DevPreviewPaneWrapper(props: ComponentProps<typeof LazyDevPreviewPane>)
   return (
     <ErrorBoundary variant="component" componentName="DevPreviewPane">
       <Suspense fallback={<BrowserPaneSkeleton label="Loading dev preview panel" />}>
-        <LazyDevPreviewPane {...props} />
+        <ContentFadeIn className="flex flex-col h-full w-full">
+          <LazyDevPreviewPane {...props} />
+        </ContentFadeIn>
       </Suspense>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary

- Adds a stateless `ContentFadeIn` wrapper (`src/components/ui/ContentFadeIn.tsx`) that applies a 150ms fade-in when skeleton content is replaced with real content, using `motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150` and a `content-fade-in` marker class
- Adds a CSS override in `src/index.css` for `body[data-reduce-animations="true"]` — the `motion-safe:` prefix only responds to OS-level `prefers-reduced-motion`, not Daintree's in-app toggle; `data-performance-mode` is already covered by the existing wildcard rule
- Adopted on 4 surfaces with verified dimensional match: browser pane and dev preview pane in `src/panels/registry.tsx`, `GitHubResourceList`, and `CommitList`

Resolves #6423

## Changes

- `src/components/ui/ContentFadeIn.tsx` — new stateless wrapper component; no `useState`, `onAnimationEnd`, or `will-change` in JSX (per CLAUDE.md, `will-change: opacity` lives on the CSS utility class)
- `src/index.css` — `body[data-reduce-animations="true"] .content-fade-in` override to disable the animation when Daintree's own reduced-motion toggle is active
- `src/panels/registry.tsx` — wraps browser pane and dev preview pane content with `ContentFadeIn`
- `src/components/GitHub/GitHubResourceList.tsx` and `CommitList.tsx` — wrapped at the skeleton/content boundary
- Skipped `IssueSelector` — adding a wrapper `div` inside `<div role="listbox">` would break ARIA semantics, and the 3-row `immediate` skeleton is short enough that the swap isn't visually significant

## Testing

8 new tests in `src/components/ui/__tests__/ContentFadeIn.test.tsx`:

- Animation classes present (`animate-in`, `fade-in`, `duration-150`)
- `content-fade-in` marker class present
- No `transition-all` in class output
- No `will-change` attribute in JSX
- Children render correctly
- `className` prop merges correctly
- HTML attributes forward correctly
- CSS source assertion for the `body[data-reduce-animations="true"]` override

Existing EmptyState (59 tests) and panels registry (32 tests) pass unaffected. Typecheck, lint, format, and build all clean.