### PR TITLE
feat(palettes): replace accent-tinted match highlighting with foreground emphasis

### DIFF
--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
+import { HighlightedText, findMatchIndices } from "@/components/ui/HighlightedText";
 import type { PanelKindOption } from "@/hooks/usePanelPalette";
 import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
 import { PanelKindIcon } from "./PanelKindIcon";
@@ -22,30 +23,6 @@ interface PanelPaletteProps {
   onSelect: (kind: PanelKindOption) => void;
   onConfirm: () => void;
   onClose: () => void;
-}
-
-function HighlightText({
-  text,
-  indices,
-}: {
-  text: string;
-  indices: readonly [number, number][] | undefined;
-}) {
-  if (!indices?.length) return <>{text}</>;
-  const sorted = [...indices].sort((a, b) => a[0] - b[0]);
-  const parts: React.ReactNode[] = [];
-  let lastIndex = 0;
-  sorted.forEach(([start, end], i) => {
-    if (start > lastIndex) parts.push(text.substring(lastIndex, start));
-    parts.push(
-      <mark key={i} className="bg-daintree-accent/25 text-inherit rounded-sm">
-        {text.substring(start, end + 1)}
-      </mark>
-    );
-    lastIndex = end + 1;
-  });
-  if (lastIndex < text.length) parts.push(text.substring(lastIndex));
-  return <>{parts}</>;
 }
 
 const SECTION_LABELS: Record<"agent" | "tool" | "resume", string> = {
@@ -158,15 +135,10 @@ export function PanelPalette({
         </div>
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium text-daintree-text">
-            {(() => {
-              const kindMatches = matchesById.get(kind.id);
-              const nameMatch = kindMatches?.find((m) => m.key === "name");
-              return nameMatch ? (
-                <HighlightText text={kind.name} indices={nameMatch.indices} />
-              ) : (
-                kind.name
-              );
-            })()}
+            <HighlightedText
+              text={kind.name}
+              indices={findMatchIndices(matchesById.get(kind.id), "name")}
+            />
           </div>
           {kind.description && (
             <div className="text-xs text-daintree-text/50 truncate">{kind.description}</div>

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -146,20 +146,21 @@ describe("countMatchesPerTab", () => {
 describe("HighlightText", () => {
   it("renders plain text when query is empty", () => {
     const html = renderToStaticMarkup(HighlightText({ text: "Hello World", query: "" }));
-    expect(html).not.toContain("<mark");
+    expect(html).not.toContain("text-search-highlight-text");
     expect(html).toContain("Hello World");
   });
 
-  it("wraps matching text in a mark element", () => {
+  it("wraps matching text in a highlight span", () => {
     const html = renderToStaticMarkup(HighlightText({ text: "Font size setting", query: "font" }));
-    expect(html).toContain("<mark");
-    // The matched portion should be inside a mark
+    expect(html).toContain("text-search-highlight-text");
+    expect(html).toContain("font-semibold");
+    // The matched portion should be inside the highlight span
     expect(html.toLowerCase()).toContain(">font<");
   });
 
   it("is case-insensitive in highlighting", () => {
     const html = renderToStaticMarkup(HighlightText({ text: "GitHub Token", query: "github" }));
-    expect(html).toContain("<mark");
+    expect(html).toContain("text-search-highlight-text");
     // Original casing preserved
     expect(html).toContain("GitHub");
   });
@@ -168,8 +169,8 @@ describe("HighlightText", () => {
     const html = renderToStaticMarkup(
       HighlightText({ text: "font family font size", query: "font" })
     );
-    const markCount = (html.match(/<mark/g) ?? []).length;
-    expect(markCount).toBeGreaterThanOrEqual(2);
+    const highlightCount = (html.match(/text-search-highlight-text/g) ?? []).length;
+    expect(highlightCount).toBeGreaterThanOrEqual(2);
   });
 
   it("preserves full text content after highlighting", () => {

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -174,9 +174,9 @@ export function HighlightText({ text, query }: HighlightTextProps) {
       <span>
         {parts.map((part, i) =>
           lowerTokens.some((t) => part.toLowerCase() === t) ? (
-            <mark key={i} className="bg-daintree-accent/25 text-inherit rounded-sm not-italic">
+            <span key={i} className="text-search-highlight-text font-semibold">
               {part}
-            </mark>
+            </span>
           ) : (
             <span key={i}>{part}</span>
           )

--- a/src/components/ui/HighlightedText.tsx
+++ b/src/components/ui/HighlightedText.tsx
@@ -10,7 +10,12 @@ export function HighlightedText({ text, indices }: HighlightedTextProps) {
   const sorted = [...indices].sort((a, b) => a[0] - b[0]);
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
-  sorted.forEach(([start, end], i) => {
+  sorted.forEach(([rawStart, rawEnd], i) => {
+    // Clamp overlapping ranges — Fuse can emit unsorted/overlapping indices
+    // when a query is split across BitapSearch chunks.
+    const start = Math.max(rawStart, lastIndex);
+    const end = Math.max(rawEnd, lastIndex - 1);
+    if (start > end) return;
     if (start > lastIndex) parts.push(text.substring(lastIndex, start));
     parts.push(
       <span key={i} className="text-search-highlight-text font-semibold">

--- a/src/components/ui/HighlightedText.tsx
+++ b/src/components/ui/HighlightedText.tsx
@@ -1,0 +1,31 @@
+import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
+
+interface HighlightedTextProps {
+  text: string;
+  indices: readonly [number, number][] | undefined;
+}
+
+export function HighlightedText({ text, indices }: HighlightedTextProps) {
+  if (!indices?.length) return <>{text}</>;
+  const sorted = [...indices].sort((a, b) => a[0] - b[0]);
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  sorted.forEach(([start, end], i) => {
+    if (start > lastIndex) parts.push(text.substring(lastIndex, start));
+    parts.push(
+      <span key={i} className="text-search-highlight-text font-semibold">
+        {text.substring(start, end + 1)}
+      </span>
+    );
+    lastIndex = end + 1;
+  });
+  if (lastIndex < text.length) parts.push(text.substring(lastIndex));
+  return <>{parts}</>;
+}
+
+export function findMatchIndices(
+  matches: readonly FuseResultMatch[] | undefined,
+  key: string
+): readonly [number, number][] | undefined {
+  return matches?.find((m) => m.key === key)?.indices;
+}

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
 import { useEscapeStack } from "@/hooks";
+import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
 
 export interface SearchablePaletteProps<T> {
   isOpen: boolean;
@@ -21,16 +22,26 @@ export interface SearchablePaletteProps<T> {
    * forward it to the item's `onPointerMove` so mouse hover keeps `selectedIndex`
    * in sync with the visually highlighted row. Use `onPointerMove` (not
    * `onMouseEnter`) so keyboard scrolling doesn't trigger spurious selection
-   * changes when items move under a stationary cursor.
+   * changes when items move under a stationary cursor. The optional 5th
+   * argument is the Fuse match ranges for this item — pair with
+   * `HighlightedText` from `@/components/ui/HighlightedText` to render
+   * per-character match emphasis on string fields.
    */
   renderItem: (
     item: T,
     index: number,
     isSelected: boolean,
-    onHoverIndex: (index: number) => void
+    onHoverIndex: (index: number) => void,
+    matches: readonly FuseResultMatch[] | undefined
   ) => React.ReactNode;
   /** Called when the pointer hovers a row, for keeping selectedIndex in sync. */
   onHoverIndex?: (index: number) => void;
+  /**
+   * Optional Fuse match ranges keyed by item ID. When provided, each item's
+   * matches are forwarded to `renderItem` as the 5th argument. Produced by
+   * `useSearchablePalette({ includeMatches: true })`.
+   */
+  matchesById?: ReadonlyMap<string, readonly FuseResultMatch[]>;
 
   /** Label shown above the search input */
   label: string;
@@ -91,6 +102,7 @@ export function SearchablePalette<T>({
   getItemId,
   renderItem,
   onHoverIndex,
+  matchesById,
   label,
   keyHint,
   ariaLabel,
@@ -222,7 +234,13 @@ export function SearchablePalette<T>({
             ) : (
               <div ref={listRef} id={listId} role="listbox" aria-label={label}>
                 {results.map((item, index) =>
-                  renderItem(item, index, index === selectedIndex, hoverIndexHandler)
+                  renderItem(
+                    item,
+                    index,
+                    index === selectedIndex,
+                    hoverIndexHandler,
+                    matchesById?.get(getItemId(item))
+                  )
                 )}
               </div>
             )}

--- a/src/components/ui/__tests__/HighlightedText.test.tsx
+++ b/src/components/ui/__tests__/HighlightedText.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { FuseResultMatch } from "@/hooks/useSearchablePalette";
+
+import { HighlightedText, findMatchIndices } from "../HighlightedText";
+
+describe("HighlightedText", () => {
+  it("renders plain text when indices are missing", () => {
+    const { container } = render(<HighlightedText text="New Terminal" indices={undefined} />);
+    expect(container.textContent).toBe("New Terminal");
+    expect(container.querySelector(".text-search-highlight-text")).toBeNull();
+  });
+
+  it("renders plain text when indices are empty", () => {
+    const { container } = render(<HighlightedText text="New Terminal" indices={[]} />);
+    expect(container.textContent).toBe("New Terminal");
+    expect(container.querySelector(".text-search-highlight-text")).toBeNull();
+  });
+
+  it("highlights the matched range and preserves full text content", () => {
+    const { container } = render(<HighlightedText text="New Terminal" indices={[[4, 11]]} />);
+    expect(container.textContent).toBe("New Terminal");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]?.textContent).toBe("Terminal");
+    expect(marks[0]?.classList.contains("font-semibold")).toBe(true);
+  });
+
+  it("highlights a single character", () => {
+    const { container } = render(<HighlightedText text="abc" indices={[[1, 1]]} />);
+    expect(container.textContent).toBe("abc");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]?.textContent).toBe("b");
+  });
+
+  it("renders multiple disjoint matches in order", () => {
+    const { container } = render(
+      <HighlightedText
+        text="font font"
+        indices={[
+          [5, 8],
+          [0, 3],
+        ]}
+      />
+    );
+    expect(container.textContent).toBe("font font");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(2);
+    expect(marks[0]?.textContent).toBe("font");
+    expect(marks[1]?.textContent).toBe("font");
+  });
+
+  it("clamps overlapping indices without duplicating text", () => {
+    // Fuse.js can emit overlapping/unsorted ranges when patterns split across
+    // BitapSearch chunks. The component must not render duplicate characters.
+    const { container } = render(
+      <HighlightedText
+        text="abcdefghij"
+        indices={[
+          [0, 4],
+          [2, 6],
+        ]}
+      />
+    );
+    expect(container.textContent).toBe("abcdefghij");
+  });
+});
+
+describe("findMatchIndices", () => {
+  const matches: FuseResultMatch[] = [
+    { key: "name", value: "Terminal", indices: [[0, 7]] },
+    { key: "description", value: "A shell window", indices: [[2, 6]] },
+  ];
+
+  it("returns indices for a matching key", () => {
+    expect(findMatchIndices(matches, "name")).toEqual([[0, 7]]);
+    expect(findMatchIndices(matches, "description")).toEqual([[2, 6]]);
+  });
+
+  it("returns undefined for a missing key", () => {
+    expect(findMatchIndices(matches, "nonexistent")).toBeUndefined();
+  });
+
+  it("returns undefined when matches is undefined", () => {
+    expect(findMatchIndices(undefined, "name")).toBeUndefined();
+  });
+});

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -113,6 +113,9 @@ const DURABLE_ALLOWLIST = new Set([
   // Current worktree card left-edge accent bar (single primary anchor per view)
   "src/components/Worktree/WorktreeCard.tsx",
 
+  // PanelPalette selected-row left-edge accent stripe (single primary anchor per view)
+  "src/components/PanelPalette/PanelPalette.tsx",
+
   // Setup wizard step indicators, accent icon, telemetry toggle (one-time setup flow)
   "src/components/Setup/AgentSetupWizard.tsx",
 
@@ -187,7 +190,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx",
     "src/components/LogLevelPalette/LogLevelPalette.tsx",
     "src/components/Notifications/NotificationCenterEntry.tsx",
-    "src/components/PanelPalette/PanelPalette.tsx",
     "src/components/Portal/PortalDock.tsx",
     "src/components/Portal/PortalToolbar.tsx",
     "src/components/Project/AutomationTab.tsx",
@@ -220,7 +222,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Settings/ResourceEnvironmentsSection.tsx",
     "src/components/Settings/SettingsDialog.tsx",
     "src/components/Settings/SettingsInput.tsx",
-    "src/components/Settings/settingsSearchUtils.tsx",
     "src/components/Settings/SettingsSelect.tsx",
     "src/components/Settings/SettingsSubtabBar.tsx",
     "src/components/Settings/SettingsTextarea.tsx",


### PR DESCRIPTION
## Summary

- Replaced the `bg-daintree-accent/25` `<mark>` treatment in `PanelPalette` and the Settings search highlighter with a foreground color shift (`text-search-highlight-text`) plus `font-semibold` — color alone doesn't satisfy WCAG 1.4.1, and the accent background competed with the row's own selection state
- Extracted a shared `HighlightedText` component (`src/components/ui/HighlightedText.tsx`) with a `findMatchIndices` helper and overlap clamping for unsorted/overlapping Fuse index pairs
- Threaded `matchesById` through `SearchablePalette.renderItem` as an optional 5th argument so other palettes can opt into character-level match emphasis without touching `useSearchablePalette`

Resolves #6412

## Changes

- `src/components/ui/HighlightedText.tsx` — new shared component
- `src/components/ui/SearchablePalette.tsx` — `matchesById` prop + 5th `renderItem` arg
- `src/components/PanelPalette/PanelPalette.tsx` — switched to `HighlightedText`, removed `<mark>`
- `src/components/Settings/settingsSearchUtils.tsx` — switched to `text-search-highlight-text font-semibold`, removed `<mark>`
- `src/config/__tests__/accentGuard.contract.test.ts` — moved `PanelPalette.tsx` to `DURABLE_ALLOWLIST` (selection stripe is the canonical anchor); removed `settingsSearchUtils.tsx` from pre-existing allowlist
- `src/components/ui/__tests__/HighlightedText.test.tsx` — 9 unit tests covering missing/empty indices, single-char, multi-range ordering, overlap clamping, and `findMatchIndices` key selectivity
- `src/components/Settings/__tests__/settingsSearchUtils.test.ts` — updated to assert highlight class instead of `<mark>` tag

## Testing

- 9 new `HighlightedText` unit tests all pass
- Updated Settings search utils tests assert the correct highlight class
- `npm run check` clean