### PR TITLE
fix(worktree): polish row interaction states

### DIFF
--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -89,6 +89,7 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    isolation: isDragging ? "auto" : "isolate",
     ...(!isDragging && {
       contentVisibility: "auto",
       containIntrinsicSize: "auto 180px",

--- a/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { SortableWorktreeCard } from "../SortableWorktreeCard";
+
+let mockIsDragging = false;
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: { role: "listitem" },
+    listeners: undefined,
+    setNodeRef: vi.fn(),
+    setActivatorNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: mockIsDragging,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: {
+    Transform: {
+      toString: () => undefined,
+    },
+  },
+}));
+
+describe("SortableWorktreeCard", () => {
+  it("isolates the card at idle so the flash overlay's blend mode anchors to the active background", () => {
+    mockIsDragging = false;
+    const { container } = render(
+      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.isolation).toBe("isolate");
+    expect(wrapper.style.contentVisibility).toBe("auto");
+  });
+
+  it("clears isolation during drag so dnd-kit transforms compose with the card root", () => {
+    mockIsDragging = true;
+    const { container } = render(
+      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.isolation).toBe("auto");
+    expect(wrapper.style.contentVisibility).toBe("");
+  });
+});

--- a/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
@@ -33,7 +33,8 @@ describe("SortableWorktreeCard", () => {
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
-    const wrapper = container.firstChild as HTMLElement;
+    const wrapper = container.firstChild;
+    if (!(wrapper instanceof HTMLElement)) throw new Error("Expected wrapper to be an HTMLElement");
     expect(wrapper.style.isolation).toBe("isolate");
     expect(wrapper.style.contentVisibility).toBe("auto");
   });
@@ -45,7 +46,8 @@ describe("SortableWorktreeCard", () => {
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
-    const wrapper = container.firstChild as HTMLElement;
+    const wrapper = container.firstChild;
+    if (!(wrapper instanceof HTMLElement)) throw new Error("Expected wrapper to be an HTMLElement");
     expect(wrapper.style.isolation).toBe("auto");
     expect(wrapper.style.contentVisibility).toBe("");
   });

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -680,12 +680,10 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         <div
           ref={droppableRef}
           className={cn(
-            "sidebar-worktree-card group/card relative transition duration-150",
+            "sidebar-worktree-card group/card relative isolate transition duration-150",
             variant === "sidebar" && "border-b border-border-default",
             variant === "grid" && "rounded-lg border border-divider bg-overlay-subtle",
-            isActive &&
-              variant !== "sidebar" &&
-              "bg-surface-panel-elevated shadow-[var(--theme-shadow-ambient)]",
+            isActive && variant !== "sidebar" && "bg-surface-panel-elevated",
             !isActive &&
               variant === "grid" &&
               "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]",
@@ -711,7 +709,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
           <button
             type="button"
             className={cn(
-              "absolute inset-0 z-0 outline-hidden",
+              "absolute inset-0 z-0 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent",
               variant === "grid" && "rounded-lg",
               (isDraggingSort || isWorktreeSortDragging) && "pointer-events-none"
             )}
@@ -730,7 +728,8 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               key={flashKey}
               className={cn(
                 "absolute inset-0 z-20 pointer-events-none border border-overlay animate-border-flash",
-                variant === "grid" && "rounded-lg"
+                variant === "grid" && "rounded-lg",
+                isActive && "mix-blend-screen dark:mix-blend-plus-lighter"
               )}
               aria-hidden="true"
             />

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -643,7 +643,7 @@ export function WorktreeHeader({
               ? "opacity-100"
               : isActive
                 ? "opacity-100"
-                : "opacity-0 pointer-events-none group-hover/card:opacity-100 group-hover/card:pointer-events-auto group-focus-within/card:opacity-100 group-focus-within/card:pointer-events-auto"
+                : "opacity-50 group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-has-[[data-state=open]]/card:opacity-100"
           )}
         >
           {onCleanupWorktree && (

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -96,15 +96,15 @@ function getWrapper() {
 }
 
 describe("WorktreeHeader menu button", () => {
-  it("has pointer-events-none and hover/focus reveal classes when inactive", () => {
+  it("starts dimmed and reveals on hover, focus, or open menu when inactive", () => {
     renderHeader({ isActive: false });
     const wrapper = getWrapper();
-    expect(wrapper.className).toContain("pointer-events-none");
-    expect(wrapper.className).toContain("opacity-0");
-    expect(wrapper.className).toContain("group-hover/card:pointer-events-auto");
+    expect(wrapper.className).not.toContain("pointer-events-none");
+    expect(wrapper.className).not.toContain("opacity-0");
+    expect(wrapper.className).toContain("opacity-50");
     expect(wrapper.className).toContain("group-hover/card:opacity-100");
-    expect(wrapper.className).toContain("group-focus-within/card:pointer-events-auto");
     expect(wrapper.className).toContain("group-focus-within/card:opacity-100");
+    expect(wrapper.className).toContain("group-has-[[data-state=open]]/card:opacity-100");
   });
 
   it("does not have pointer-events-none when active", () => {
@@ -839,15 +839,17 @@ describe("WorktreeHeader cleanup button", () => {
     expect(wrapper.contains(button)).toBe(true);
   });
 
-  it("hides the cleanup button alongside other actions on inactive, non-collapsed cards", () => {
+  it("dims the cleanup button alongside other actions on inactive, non-collapsed cards", () => {
     renderHeader({ onCleanupWorktree: vi.fn(), isActive: false, isCollapsed: false });
     const button = screen.getByTestId("worktree-cleanup-button");
     const wrapper = screen.getByTestId("worktree-actions-wrapper");
-    // The hover-gated wrapper hides on inactive cards and reveals on group hover/focus.
-    expect(wrapper.className).toContain("opacity-0");
-    expect(wrapper.className).toContain("pointer-events-none");
+    // The wrapper persists at reduced opacity so keyboard and touch users can reach it,
+    // and reveals fully on group hover/focus or when a contained menu opens.
+    expect(wrapper.className).toContain("opacity-50");
+    expect(wrapper.className).not.toContain("pointer-events-none");
     expect(wrapper.className).toContain("group-hover/card:opacity-100");
     expect(wrapper.className).toContain("group-focus-within/card:opacity-100");
+    expect(wrapper.className).toContain("group-has-[[data-state=open]]/card:opacity-100");
     // The cleanup button inherits visibility through the wrapper, not its own classes.
     expect(wrapper.contains(button)).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Action cluster now persists at `opacity-50` when idle so keyboard and touch users can always reach it, revealing fully on hover, `focus-within`, or when a Radix popover inside the row is open (`group-has-[[data-state=open]]`); previously `opacity-0 pointer-events-none` made it invisible to anyone without a hover
- Full-card click button gets a `focus-visible` accent outline so keyboard users can see which row is focused; active grid card drops its ambient shadow so it reads as seated rather than floating; `flashKey` overlay gets `mix-blend-screen` / `dark:mix-blend-plus-lighter` with `isolate` on the card root so the border flash anchors to the selection instead of overlaying it on a separate plane
- `SortableWorktreeCard` resets isolation during drag, mirroring the existing `content-visibility` interlock, to keep dnd-kit transforms clean; new test file guards that interlock

Resolves #6419

## Changes

- `WorktreeHeader.tsx` — actions cluster persists at `opacity-50` idle; added `group-has-[[data-state=open]]/card` reveal to prevent Radix portal flicker
- `WorktreeCard.tsx` — card root gets `isolate`; full-card button gets `focus-visible:outline-2 focus-visible:outline-daintree-accent`; active grid card removes ambient shadow; `flashKey` overlay gets blend mode classes
- `SortableWorktreeCard.tsx` — `isolate` reset during drag mirrors content-visibility interlock
- `WorktreeHeader.test.tsx` — updated assertions for `opacity-50` idle and `group-has` selector
- `SortableWorktreeCard.test.tsx` (new) — guards the cross-file isolate/drag interlock

## Testing

- Unit tests updated and passing for `WorktreeHeader` opacity states and `SortableWorktreeCard` isolation interlock
- All five interaction fixes verified against Tailwind v4 class resolution; blend modes confirmed supported in Electron 41 (Chromium 146)
- No new dependencies; Tier 1 motion (150ms) and reduced-motion gates unchanged