### PR TITLE
fix(worktree): replace stacked safety mechanisms with two-tier severity routing

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { AlertTriangle, Trash2 } from "lucide-react";
@@ -15,7 +15,6 @@ interface WorktreeDeleteDialogProps {
   worktree: WorktreeState;
 }
 
-const ARMED_TIMEOUT_MS = 4000;
 const PROTECTED_BRANCHES = ["main", "master", "develop", "development"];
 
 export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDeleteDialogProps) {
@@ -23,9 +22,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const [force, setForce] = useState(false);
   const [closeTerminals, setCloseTerminals] = useState(true);
   const [deleteBranch, setDeleteBranch] = useState(false);
-  const [isArmed, setIsArmed] = useState(false);
+  const [confirmInput, setConfirmInput] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const armedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deleteInFlightRef = useRef(false);
 
   const { counts: terminalCounts } = useWorktreeTerminals(worktree.id);
   const bulkCloseByWorktree = usePanelStore((state) => state.bulkCloseByWorktree);
@@ -37,61 +36,46 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const hasTerminals = terminalCounts.total > 0;
 
   const isProtectedBranch =
-    worktree.branch && PROTECTED_BRANCHES.includes(worktree.branch.toLowerCase());
+    !!worktree.branch && PROTECTED_BRANCHES.includes(worktree.branch.toLowerCase());
   const isDetachedHead = !worktree.branch;
   const canDeleteBranch =
     !isProtectedBranch && !isDetachedHead && worktree.isMainWorktree === false;
 
-  const clearArmedTimer = useCallback(() => {
-    if (armedTimerRef.current) {
-      clearTimeout(armedTimerRef.current);
-      armedTimerRef.current = null;
-    }
-  }, []);
-
-  const disarm = useCallback(() => {
-    clearArmedTimer();
-    setIsArmed(false);
-  }, [clearArmedTimer]);
+  const confirmTarget = worktree.branch ?? worktree.name;
+  const isHighTier = force && (isProtectedBranch || worktree.isMainWorktree === true);
+  const isConfirmMatched = confirmInput === confirmTarget;
+  const canSubmit = !isDeleting && (!isHighTier || isConfirmMatched);
 
   useEffect(() => {
     if (isOpen) {
       setForce(false);
       setDeleteBranch(false);
+      setConfirmInput("");
       setError(null);
-      disarm();
     }
-    return () => clearArmedTimer();
-  }, [isOpen, worktree.id, disarm, clearArmedTimer]);
+  }, [isOpen, worktree.id]);
 
   useEffect(() => {
-    if (!deleteBranch && isArmed) {
-      disarm();
+    if (!force) {
+      setConfirmInput("");
     }
-  }, [deleteBranch, isArmed, disarm]);
+  }, [force]);
 
   useEffect(() => {
-    if (!canDeleteBranch && (deleteBranch || isArmed)) {
+    if (!canDeleteBranch && deleteBranch) {
       setDeleteBranch(false);
-      disarm();
     }
-  }, [canDeleteBranch, deleteBranch, isArmed, disarm]);
+  }, [canDeleteBranch, deleteBranch]);
 
   const handleDelete = async () => {
-    const effectiveDeleteBranch = deleteBranch && canDeleteBranch;
+    if (deleteInFlightRef.current) return;
+    if (isHighTier && !isConfirmMatched) return;
 
-    if (effectiveDeleteBranch && !isArmed) {
-      setIsArmed(true);
-      clearArmedTimer();
-      armedTimerRef.current = setTimeout(() => {
-        setIsArmed(false);
-      }, ARMED_TIMEOUT_MS);
-      return;
-    }
-
+    deleteInFlightRef.current = true;
     setIsDeleting(true);
     setError(null);
-    disarm();
+
+    const effectiveDeleteBranch = deleteBranch && canDeleteBranch;
 
     try {
       if (closeTerminals && hasTerminals) {
@@ -111,14 +95,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       setError(msg);
     } finally {
       setIsDeleting(false);
+      deleteInFlightRef.current = false;
     }
   };
 
-  const getDeleteButtonText = () => {
-    if (isDeleting) return "Deleting...";
-    if (deleteBranch && canDeleteBranch && isArmed) return "Click again to confirm";
-    return "Delete worktree";
-  };
+  const deleteButtonLabel = isHighTier ? `Delete '${confirmTarget}'` : "Delete worktree";
 
   return (
     <AppDialog
@@ -134,116 +115,161 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
           <div className="p-2 bg-status-error/10 rounded-full">
             <Trash2 className="w-6 h-6" />
           </div>
-          <AppDialog.Title>Delete '{worktree.branch ?? worktree.name}'?</AppDialog.Title>
+          <AppDialog.Title>Delete '{confirmTarget}'?</AppDialog.Title>
         </div>
 
-        <div className="space-y-4">
-          <p className="text-sm text-daintree-text/80">
-            This will permanently delete the worktree directory
-            {deleteBranch && worktree.branch && (
-              <>
-                {" "}
-                and branch{" "}
-                <span className="font-mono font-medium text-daintree-text">{worktree.branch}</span>
-              </>
-            )}
-            .{closeTerminals && hasTerminals && " All associated terminals will be closed."}
-            {hasChanges &&
-              " Uncommitted changes will be lost unless the worktree is first restored from git."}
-          </p>
-
-          <div className="text-xs text-daintree-text/60 bg-daintree-bg/50 p-3 rounded border border-daintree-border font-mono break-all">
-            {worktree.path}
+        {isDeleting ? (
+          <div
+            role="status"
+            aria-busy="true"
+            aria-live="polite"
+            className="space-y-4"
+            data-testid="delete-worktree-skeleton"
+          >
+            <span className="sr-only">Deleting worktree…</span>
+            <div className="animate-pulse-delayed h-4 w-3/4 bg-muted rounded" />
+            <div className="animate-pulse-delayed h-4 w-full bg-muted rounded" />
+            <div className="animate-pulse-delayed h-8 w-full bg-muted rounded" />
           </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-daintree-text/80">
+              This will permanently delete the worktree directory
+              {deleteBranch && worktree.branch && (
+                <>
+                  {" "}
+                  and branch{" "}
+                  <span className="font-mono font-medium text-daintree-text">
+                    {worktree.branch}
+                  </span>
+                </>
+              )}
+              .{closeTerminals && hasTerminals && " All associated terminals will be closed."}
+              {hasChanges &&
+                " Uncommitted changes will be lost unless the worktree is first restored from git."}
+              {" This cannot be undone."}
+            </p>
 
-          {hasChanges && !force && (
-            <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded text-status-warning text-xs">
-              <AlertTriangle className="w-4 h-4 shrink-0" />
-              <p>
-                This worktree has{" "}
-                {hasTrackedChanges && hasUntrackedFiles
-                  ? "uncommitted changes and untracked files"
-                  : hasTrackedChanges
-                    ? "uncommitted changes"
-                    : "untracked files"}
-                . Standard deletion will fail.
-              </p>
+            <div className="text-xs text-daintree-text/60 bg-daintree-bg/50 p-3 rounded border border-daintree-border font-mono break-all">
+              {worktree.path}
             </div>
-          )}
 
-          {error && (
-            <div
-              role="alert"
-              aria-live="assertive"
-              className="p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
-            >
-              {error}
-            </div>
-          )}
+            {hasChanges && !force && (
+              <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded text-status-warning text-xs">
+                <AlertTriangle className="w-4 h-4 shrink-0" />
+                <p>
+                  This worktree has{" "}
+                  {hasTrackedChanges && hasUntrackedFiles
+                    ? "uncommitted changes and untracked files"
+                    : hasTrackedChanges
+                      ? "uncommitted changes"
+                      : "untracked files"}
+                  . Standard deletion will fail.
+                </p>
+              </div>
+            )}
 
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={force}
-              onChange={(e) => {
-                setForce(e.target.checked);
-                setError(null);
-              }}
-              className="rounded border-daintree-border bg-daintree-bg text-status-error focus:ring-status-error"
-            />
-            <span className="text-sm text-daintree-text">
-              {hasTrackedChanges && hasUntrackedFiles
-                ? "Force delete (lose uncommitted changes and untracked files)"
-                : hasUntrackedFiles
-                  ? "Force delete (remove untracked files)"
-                  : "Force delete (lose uncommitted changes)"}
-            </span>
-          </label>
+            {error && (
+              <div
+                role="alert"
+                aria-live="assertive"
+                className="p-3 bg-status-error/10 border border-status-error/20 rounded text-status-error text-xs"
+              >
+                {error}
+              </div>
+            )}
 
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={closeTerminals}
-              onChange={(e) => setCloseTerminals(e.target.checked)}
-              className="rounded border-daintree-border bg-daintree-bg text-daintree-accent focus:ring-daintree-accent"
-            />
-            <span className="text-sm text-daintree-text">
-              Close all terminals{hasTerminals ? ` (${terminalCounts.total})` : ""}
-            </span>
-          </label>
-
-          {canDeleteBranch && (
-            <label className="flex items-start gap-2 cursor-pointer">
+            <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                checked={deleteBranch}
+                checked={force}
                 onChange={(e) => {
-                  setDeleteBranch(e.target.checked);
-                  if (!e.target.checked) {
-                    disarm();
-                  }
+                  setForce(e.target.checked);
+                  setError(null);
                 }}
-                className="mt-0.5 rounded border-daintree-border bg-daintree-bg text-status-error focus:ring-status-error"
+                className="rounded border-daintree-border bg-daintree-bg text-status-error focus:ring-status-error"
               />
               <span className="text-sm text-daintree-text">
-                <span className="flex items-center gap-1.5">
-                  <FolderGit2 className="w-3.5 h-3.5" />
-                  Delete branch{" "}
-                  <code className="text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
-                    {worktree.branch}
-                  </code>
-                </span>
-                {deleteBranch && (
-                  <span className="block text-xs text-daintree-text/60 mt-1">
-                    {force
-                      ? "Branch will be force-deleted (git branch -D)"
-                      : "Safe delete - fails if branch has unmerged changes"}
-                  </span>
-                )}
+                {hasTrackedChanges && hasUntrackedFiles
+                  ? "Force delete (lose uncommitted changes and untracked files)"
+                  : hasUntrackedFiles
+                    ? "Force delete (remove untracked files)"
+                    : "Force delete (lose uncommitted changes)"}
               </span>
             </label>
-          )}
-        </div>
+
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={closeTerminals}
+                onChange={(e) => setCloseTerminals(e.target.checked)}
+                className="rounded border-daintree-border bg-daintree-bg text-daintree-accent focus:ring-daintree-accent"
+              />
+              <span className="text-sm text-daintree-text">
+                Close all terminals{hasTerminals ? ` (${terminalCounts.total})` : ""}
+              </span>
+            </label>
+
+            {canDeleteBranch && (
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={deleteBranch}
+                  onChange={(e) => setDeleteBranch(e.target.checked)}
+                  className="mt-0.5 rounded border-daintree-border bg-daintree-bg text-status-error focus:ring-status-error"
+                />
+                <span className="text-sm text-daintree-text">
+                  <span className="flex items-center gap-1.5">
+                    <FolderGit2 className="w-3.5 h-3.5" />
+                    Delete branch{" "}
+                    <code className="text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+                      {worktree.branch}
+                    </code>
+                  </span>
+                  {deleteBranch && (
+                    <span className="block text-xs text-daintree-text/60 mt-1">
+                      {force
+                        ? "Branch will be force-deleted (git branch -D)"
+                        : "Safe delete - fails if branch has unmerged changes"}
+                    </span>
+                  )}
+                </span>
+              </label>
+            )}
+
+            {isHighTier && (
+              <div className="space-y-2 p-3 bg-status-error/5 border border-status-error/20 rounded">
+                <p id="worktree-delete-confirm-instructions" className="text-sm text-daintree-text">
+                  Force-deleting this protected worktree is irreversible. Type{" "}
+                  <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+                    {confirmTarget}
+                  </code>{" "}
+                  to confirm.
+                </p>
+                <input
+                  type="text"
+                  value={confirmInput}
+                  onChange={(e) => setConfirmInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && isConfirmMatched) {
+                      e.preventDefault();
+                      void handleDelete();
+                    }
+                  }}
+                  aria-describedby="worktree-delete-confirm-instructions"
+                  aria-label={`Type ${confirmTarget} to confirm deletion`}
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-daintree-border rounded focus:outline-none focus:ring-2 focus:ring-status-error"
+                  data-testid="delete-worktree-confirm-input"
+                />
+                <span className="sr-only" aria-live="polite">
+                  {isConfirmMatched ? "Name confirmed. You may now delete." : ""}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
       </AppDialog.Body>
 
       <AppDialog.Footer>
@@ -253,11 +279,10 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
         <Button
           variant="destructive"
           onClick={handleDelete}
-          disabled={isDeleting}
-          className={isArmed ? "animate-pulse ring-2 ring-status-error" : ""}
+          disabled={!canSubmit}
           data-testid="delete-worktree-confirm"
         >
-          {getDeleteButtonText()}
+          {isDeleting ? "Deleting…" : deleteButtonLabel}
         </Button>
       </AppDialog.Footer>
     </AppDialog>

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -49,6 +49,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   useEffect(() => {
     if (isOpen) {
       setForce(false);
+      setCloseTerminals(true);
       setDeleteBranch(false);
       setConfirmInput("");
       setError(null);
@@ -78,9 +79,6 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     const effectiveDeleteBranch = deleteBranch && canDeleteBranch;
 
     try {
-      if (closeTerminals && hasTerminals) {
-        bulkCloseByWorktree(worktree.id);
-      }
       const result = await actionService.dispatch(
         "worktree.delete",
         { worktreeId: worktree.id, force, deleteBranch: effectiveDeleteBranch },
@@ -88,6 +86,9 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
       );
       if (!result.ok) {
         throw new Error(result.error.message);
+      }
+      if (closeTerminals && hasTerminals) {
+        bulkCloseByWorktree(worktree.id);
       }
       onClose();
     } catch (err) {
@@ -228,9 +229,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   </span>
                   {deleteBranch && (
                     <span className="block text-xs text-daintree-text/60 mt-1">
-                      {force
-                        ? "Branch will be force-deleted (git branch -D)"
-                        : "Safe delete - fails if branch has unmerged changes"}
+                      Safe delete — fails if branch has unmerged changes
                     </span>
                   )}
                 </span>

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -259,7 +259,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   aria-label={`Type ${confirmTarget} to confirm deletion`}
                   autoComplete="off"
                   spellCheck={false}
-                  className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-daintree-border rounded focus:outline-none focus:ring-2 focus:ring-status-error"
+                  className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-daintree-border rounded focus:outline-hidden focus:ring-2 focus:ring-status-error"
                   data-testid="delete-worktree-confirm-input"
                 />
                 <span className="sr-only" aria-live="polite">

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
 import type { WorktreeState } from "@/types";
 import type { WorktreeChanges, GitStatus } from "shared/types/git";
 
@@ -15,9 +15,13 @@ vi.stubGlobal(
   }
 );
 
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
 vi.mock("@/services/ActionService", () => ({
   actionService: {
-    dispatch: vi.fn().mockResolvedValue({ ok: true }),
+    dispatch: dispatchMock,
   },
 }));
 
@@ -62,8 +66,11 @@ vi.mock("@/components/ui/button", () => ({
 
 import { WorktreeDeleteDialog } from "../WorktreeDeleteDialog";
 
-function makeWorktree(worktreeChanges: WorktreeChanges | null = null): WorktreeState {
-  return {
+function makeWorktree(
+  worktreeChanges: WorktreeChanges | null = null,
+  overrides: Partial<WorktreeState> = {}
+): WorktreeState {
+  const base = {
     id: "wt-1",
     path: "/test/worktree",
     name: "feature/test",
@@ -80,6 +87,7 @@ function makeWorktree(worktreeChanges: WorktreeChanges | null = null): WorktreeS
     mood: "stable",
     moodLabel: null,
   } as unknown as WorktreeState;
+  return { ...base, ...overrides };
 }
 
 function makeChanges(files: Array<{ path: string; status: GitStatus }>): WorktreeChanges {
@@ -99,6 +107,7 @@ function makeChanges(files: Array<{ path: string; status: GitStatus }>): Worktre
 describe("WorktreeDeleteDialog — warning messages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    dispatchMock.mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -191,5 +200,275 @@ describe("WorktreeDeleteDialog — warning messages", () => {
     expect(
       screen.getByText(/Force delete \(lose uncommitted changes and untracked files\)/)
     ).toBeDefined();
+  });
+});
+
+describe("WorktreeDeleteDialog — body copy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("ends body copy with 'This cannot be undone.' in medium tier", () => {
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).toMatch(/This cannot be undone\.$/);
+  });
+
+  it("ends body copy with 'This cannot be undone.' in high tier", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).toMatch(/This cannot be undone\.$/);
+  });
+});
+
+describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("non-protected branch + force does not require name confirmation", () => {
+    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(button.textContent).toBe("Delete worktree");
+  });
+
+  it("dispatches delete on click without typing", async () => {
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />);
+
+    const button = screen.getByTestId("delete-worktree-confirm");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "worktree.delete",
+      { worktreeId: "wt-1", force: false, deleteBranch: false },
+      { source: "user" }
+    );
+  });
+});
+
+describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders type-to-confirm input when force-deleting a protected branch", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.textContent).toBe("Delete 'main'");
+    expect(button.disabled).toBe(true);
+  });
+
+  it("renders type-to-confirm input when force-deleting the main worktree", () => {
+    const worktree = makeWorktree(makeChanges([]), {
+      branch: "feature/x",
+      name: "feature/x",
+      isMainWorktree: true,
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("enables the destructive button only when the typed name matches exactly", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+
+    fireEvent.change(input, { target: { value: "mai" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "Main" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "main" } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it("uses worktree.name as the confirmation target for detached HEAD", () => {
+    const worktree = makeWorktree(makeChanges([]), {
+      branch: undefined,
+      name: "abc1234",
+      isMainWorktree: true,
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.textContent).toBe("Delete 'abc1234'");
+
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "abc1234" } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it("clears typed name and reverts to medium tier when force is unchecked", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
+    fireEvent.click(forceCheckbox);
+
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "main" } });
+    expect(input.value).toBe("main");
+
+    fireEvent.click(forceCheckbox);
+
+    expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.textContent).toBe("Delete worktree");
+    expect(button.disabled).toBe(false);
+  });
+
+  it("submits on Enter when name is matched", async () => {
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "main" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not submit on Enter when name is unmatched", () => {
+    const worktree = makeWorktree(makeChanges([]), { branch: "main", name: "main" });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "mai" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorktreeDeleteDialog — in-flight skeleton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the skeleton and hides body copy while delete is in flight", async () => {
+    let resolveDispatch: (value: { ok: true }) => void = () => {};
+    dispatchMock.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          resolveDispatch = resolve;
+        })
+    );
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByTestId("delete-worktree-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-worktree-skeleton")).toBeDefined();
+    });
+    expect(screen.queryByText(/This will permanently delete the worktree directory/)).toBeNull();
+
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe("Deleting…");
+
+    await act(async () => {
+      resolveDispatch({ ok: true });
+    });
+  });
+});
+
+describe("WorktreeDeleteDialog — reentrancy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("dispatches at most once when the destructive button is clicked rapidly", async () => {
+    let resolveDispatch: (value: { ok: true }) => void = () => {};
+    dispatchMock.mockImplementationOnce(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          resolveDispatch = resolve;
+        })
+    );
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const button = screen.getByTestId("delete-worktree-confirm");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("delete-worktree-skeleton")).toBeDefined();
+    });
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveDispatch({ ok: true });
+    });
   });
 });

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -437,6 +437,66 @@ describe("WorktreeDeleteDialog — in-flight skeleton", () => {
   });
 });
 
+describe("WorktreeDeleteDialog — state reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dispatchMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("resets closeTerminals to true when the dialog re-opens", () => {
+    const worktree = makeWorktree(makeChanges([]));
+    const { rerender } = render(
+      <WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />
+    );
+
+    const closeTerminalsCheckbox = screen.getByRole("checkbox", {
+      name: /close all terminals/i,
+    }) as HTMLInputElement;
+    expect(closeTerminalsCheckbox.checked).toBe(true);
+    fireEvent.click(closeTerminalsCheckbox);
+    expect(closeTerminalsCheckbox.checked).toBe(false);
+
+    rerender(<WorktreeDeleteDialog isOpen={false} onClose={vi.fn()} worktree={worktree} />);
+    rerender(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const reopened = screen.getByRole("checkbox", {
+      name: /close all terminals/i,
+    }) as HTMLInputElement;
+    expect(reopened.checked).toBe(true);
+  });
+});
+
+describe("WorktreeDeleteDialog — error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders error message and re-enables controls when dispatch fails", async () => {
+    dispatchMock.mockResolvedValueOnce({ ok: false, error: { message: "git error" } });
+    const onClose = vi.fn();
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={onClose} worktree={worktree} />);
+
+    fireEvent.click(screen.getByTestId("delete-worktree-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("git error");
+    });
+    expect(screen.queryByTestId("delete-worktree-skeleton")).toBeNull();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
 describe("WorktreeDeleteDialog — reentrancy", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

- Replaces the overlapping safety mechanisms in the worktree delete dialog (modal + 4s arm timer + force checkbox) with two-tier severity routing: medium tier uses the standard modal, high tier (force-delete on a protected branch or main worktree) requires typing the branch/worktree name before the destructive button enables
- During in-flight operations, replaces flat `Deleting...` text with an `animate-pulse-delayed` skeleton body that respects the project's 400ms Doherty gate
- Adds "This cannot be undone." to all body copy variants; fixes a UI lie about `git branch -D` (backend always uses `-d`)

Resolves #6439

## Changes

- Two-tier routing: medium = standard modal, high = type-to-confirm input gate (no more 4s arm timer)
- `animate-pulse-delayed` skeleton body replaces flat text during delete operations
- "This cannot be undone." added to all dialog variants
- Fixed `git branch -D` vs `-d` copy discrepancy
- `closeTerminals` state now resets on dialog re-open
- Terminal-close moved to after successful dispatch
- Reentrancy guard added to prevent double-submits

## Testing

- Verified medium-tier path (regular worktree with uncommitted changes, close terminals checkbox) shows standard modal and deletes correctly
- Verified high-tier path (protected branch worktree, main worktree) shows type-to-confirm input and blocks the delete button until branch name matches exactly
- Verified skeleton body appears at the 400ms gate during in-flight operations
- Verified reentrancy guard prevents double-submits on rapid clicks
- Unit tests updated to cover both severity tiers, skeleton state, reentrancy, and state reset on re-open