### PR TITLE
fix(worktree): announce labels on drag and add Move Up/Down for keyboard reorder

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -37,12 +37,12 @@ import { useShallow } from "zustand/react/shallow";
 import { TerminalDragPreview } from "./TerminalDragPreview";
 import { WorktreeDragPreview } from "./WorktreeDragPreview";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { arrayMove } from "@dnd-kit/sortable";
 import { parseAccordionDragId } from "./SortableWorktreeTerminal";
 import { isWorktreeSortDragData, parseWorktreeSortDragId } from "./SortableWorktreeCard";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
+import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import type { WorktreeSnapshot } from "@shared/types";
 
 // Placeholder ID used when dragging from dock to grid
@@ -112,8 +112,37 @@ export interface WorktreeDragData extends DragData {
   origin: "accordion";
 }
 
-function getDragLabel(data: DragData | WorktreeDragData | undefined): string {
-  return data?.terminal?.title ?? "panel";
+/**
+ * Resolve the human-readable label used by drag announcements for a worktree
+ * snapshot. Falls back through `issueTitle` → `branch` → `name` so the
+ * announcement reflects whatever the user actually sees on the card.
+ */
+function resolveWorktreeLabel(worktreeId: string): string {
+  const wt = getCurrentViewStore().getState().worktrees.get(worktreeId);
+  return wt?.issueTitle ?? wt?.branch ?? wt?.name ?? "worktree";
+}
+
+function getDragLabel(data: unknown): string {
+  if (isWorktreeSortDragData(data as Record<string, unknown> | undefined)) {
+    const worktreeId = (data as { worktreeId?: string }).worktreeId;
+    return worktreeId ? resolveWorktreeLabel(worktreeId) : "worktree";
+  }
+  const dragData = data as DragData | WorktreeDragData | undefined;
+  return dragData?.terminal?.title ?? "panel";
+}
+
+/**
+ * Resolve the announcement label for a droppable. Worktree-sort uses
+ * `worktree-sort-{id}` for the sortable handle and `worktree-drop-{id}` for
+ * the row's drop target — both should announce the same human-readable label.
+ */
+function getOverDragLabel(over: { id: string | number; data: { current: unknown } }): string {
+  const sortDragId = parseWorktreeSortDragId(over.id);
+  if (sortDragId) return resolveWorktreeLabel(sortDragId);
+  if (typeof over.id === "string" && over.id.startsWith("worktree-drop-")) {
+    return resolveWorktreeLabel(over.id.slice("worktree-drop-".length));
+  }
+  return getDragLabel(over.data.current);
 }
 
 const MEASURING_CONFIG: MeasuringConfiguration = {
@@ -125,25 +154,25 @@ const MEASURING_CONFIG: MeasuringConfiguration = {
 
 const dragAnnouncements: Announcements = {
   onDragStart({ active }) {
-    return `Picked up ${getDragLabel(active.data.current as DragData | undefined)}`;
+    return `Picked up ${getDragLabel(active.data.current)}`;
   },
   onDragOver({ active, over }) {
-    const label = getDragLabel(active.data.current as DragData | undefined);
+    const label = getDragLabel(active.data.current);
     if (over) {
-      const overLabel = getDragLabel(over.data.current as DragData | undefined);
+      const overLabel = getOverDragLabel(over);
       return `${label} is over ${overLabel}`;
     }
     return `${label} is no longer over a droppable area`;
   },
   onDragEnd({ active, over }) {
-    const label = getDragLabel(active.data.current as DragData | undefined);
+    const label = getDragLabel(active.data.current);
     if (over) {
       return `Dropped ${label}`;
     }
     return `${label} returned to its original position`;
   },
   onDragCancel({ active }) {
-    const label = getDragLabel(active.data.current as DragData | undefined);
+    const label = getDragLabel(active.data.current);
     return `Drag cancelled. ${label} returned to its original position`;
   },
 };
@@ -456,26 +485,8 @@ export function DndProvider({ children }: DndProviderProps) {
         const newIndex = dragOrder.indexOf(overWorktreeId);
         if (oldIndex === -1 || newIndex === -1) return;
 
-        const reorderedSubset = arrayMove(dragOrder, oldIndex, newIndex);
-
-        // Merge reordered subset back into full persisted order
-        // so that worktrees hidden by filters don't lose position
         const fullOrder = useWorktreeFilterStore.getState().manualOrder;
-        const subsetSet = new Set(reorderedSubset);
-        const merged: string[] = [];
-        let subsetIdx = 0;
-        // Walk through the full order, replacing subset items in their new order
-        for (const id of fullOrder) {
-          if (subsetSet.has(id)) {
-            merged.push(reorderedSubset[subsetIdx++]!);
-          } else {
-            merged.push(id);
-          }
-        }
-        // Append any subset items not in the full order (first drag or new items)
-        while (subsetIdx < reorderedSubset.length) {
-          merged.push(reorderedSubset[subsetIdx++]!);
-        }
+        const merged = applyManualWorktreeReorder(fullOrder, dragOrder, oldIndex, newIndex);
 
         useWorktreeFilterStore.getState().setManualOrder(merged);
         useWorktreeFilterStore.getState().setOrderBy("manual");

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -480,7 +480,8 @@ export function DndProvider({ children }: DndProviderProps) {
           (overId.startsWith("worktree-drop-") ? overId.slice("worktree-drop-".length) : null);
         if (!activeWorktreeId || !overWorktreeId || activeWorktreeId === overWorktreeId) return;
 
-        const dragOrder = activeRawData.dragStartOrder as string[];
+        const dragOrder = activeRawData.dragStartOrder;
+        if (!Array.isArray(dragOrder)) return;
         const oldIndex = dragOrder.indexOf(activeWorktreeId);
         const newIndex = dragOrder.indexOf(overWorktreeId);
         if (oldIndex === -1 || newIndex === -1) return;

--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -1,45 +1,78 @@
 import { describe, it, expect } from "vitest";
 
-// We test the announcement logic by importing DndProvider and checking the announcements object.
-// Since dragAnnouncements is module-scoped and not directly exported, we test it indirectly
-// by recreating the same logic (getDragLabel + announcement callbacks).
+// We test the announcement logic by recreating the same branching that
+// `getDragLabel` uses inside DndProvider. The production helper is
+// module-scoped (not exported) so the test mirrors its priority chain
+// (issueTitle → branch → name → "worktree") for worktree-sort drags and
+// the terminal-title fallback for everything else.
 
-function getDragLabel(data: { terminal?: { title: string } } | undefined): string {
-  return data?.terminal?.title ?? "panel";
+interface WorktreeFixture {
+  issueTitle?: string;
+  branch?: string;
+  name?: string;
 }
 
-function makeAnnouncements() {
+function makeAnnouncements(worktreeLookup: Map<string, WorktreeFixture>) {
+  function isWorktreeSortDragData(data: unknown): data is { worktreeId: string } {
+    return (
+      data !== null &&
+      typeof data === "object" &&
+      (data as { type?: unknown }).type === "worktree-sort"
+    );
+  }
+
+  function resolveWorktreeLabel(worktreeId: string): string {
+    const wt = worktreeLookup.get(worktreeId);
+    return wt?.issueTitle ?? wt?.branch ?? wt?.name ?? "worktree";
+  }
+
+  function getDragLabel(data: unknown): string {
+    if (isWorktreeSortDragData(data)) {
+      return resolveWorktreeLabel(data.worktreeId);
+    }
+    return (data as { terminal?: { title?: string } } | undefined)?.terminal?.title ?? "panel";
+  }
+
+  function getOverDragLabel(over: { id: string; data: { current: unknown } }): string {
+    if (over.id.startsWith("worktree-sort-")) {
+      return resolveWorktreeLabel(over.id.slice("worktree-sort-".length));
+    }
+    if (over.id.startsWith("worktree-drop-")) {
+      return resolveWorktreeLabel(over.id.slice("worktree-drop-".length));
+    }
+    return getDragLabel(over.data.current);
+  }
+
   return {
     onDragStart(active: { data: { current: unknown } }) {
-      return `Picked up ${getDragLabel(active.data.current as { terminal?: { title: string } })}`;
+      return `Picked up ${getDragLabel(active.data.current)}`;
     },
     onDragOver(
       active: { data: { current: unknown } },
-      over: { data: { current: unknown } } | null
+      over: { id: string; data: { current: unknown } } | null
     ) {
-      const label = getDragLabel(active.data.current as { terminal?: { title: string } });
+      const label = getDragLabel(active.data.current);
       if (over) {
-        const overLabel = getDragLabel(over.data.current as { terminal?: { title: string } });
-        return `${label} is over ${overLabel}`;
+        return `${label} is over ${getOverDragLabel(over)}`;
       }
       return `${label} is no longer over a droppable area`;
     },
     onDragEnd(active: { data: { current: unknown } }, over: { data: { current: unknown } } | null) {
-      const label = getDragLabel(active.data.current as { terminal?: { title: string } });
+      const label = getDragLabel(active.data.current);
       if (over) {
         return `Dropped ${label}`;
       }
       return `${label} returned to its original position`;
     },
     onDragCancel(active: { data: { current: unknown } }) {
-      const label = getDragLabel(active.data.current as { terminal?: { title: string } });
+      const label = getDragLabel(active.data.current);
       return `Drag cancelled. ${label} returned to its original position`;
     },
   };
 }
 
-describe("drag announcements", () => {
-  const announcements = makeAnnouncements();
+describe("drag announcements — terminal panels", () => {
+  const announcements = makeAnnouncements(new Map());
   const withTitle = { data: { current: { terminal: { title: "Claude Agent" } } } };
   const withoutTitle = { data: { current: {} } };
 
@@ -52,7 +85,7 @@ describe("drag announcements", () => {
   });
 
   it("onDragOver with target announces both labels", () => {
-    const over = { data: { current: { terminal: { title: "Terminal" } } } };
+    const over = { id: "term-1", data: { current: { terminal: { title: "Terminal" } } } };
     expect(announcements.onDragOver(withTitle, over)).toBe("Claude Agent is over Terminal");
   });
 
@@ -76,6 +109,77 @@ describe("drag announcements", () => {
   it("onDragCancel announces cancellation", () => {
     expect(announcements.onDragCancel(withTitle)).toBe(
       "Drag cancelled. Claude Agent returned to its original position"
+    );
+  });
+});
+
+describe("drag announcements — worktree sort", () => {
+  const lookup = new Map<string, WorktreeFixture>([
+    ["wt-issue", { issueTitle: "Add OAuth support", branch: "feature/oauth", name: "oauth" }],
+    ["wt-branch", { branch: "feature/login-flow", name: "login-flow" }],
+    ["wt-name", { name: "fallback-name" }],
+    ["wt-empty", {}],
+  ]);
+  const announcements = makeAnnouncements(lookup);
+
+  function activeFor(worktreeId: string) {
+    return {
+      data: { current: { type: "worktree-sort", worktreeId, dragStartOrder: [worktreeId] } },
+    };
+  }
+
+  it("prefers issueTitle when available", () => {
+    expect(announcements.onDragStart(activeFor("wt-issue"))).toBe("Picked up Add OAuth support");
+  });
+
+  it("falls back to branch when issueTitle is missing", () => {
+    expect(announcements.onDragStart(activeFor("wt-branch"))).toBe("Picked up feature/login-flow");
+  });
+
+  it("falls back to name when branch is missing", () => {
+    expect(announcements.onDragStart(activeFor("wt-name"))).toBe("Picked up fallback-name");
+  });
+
+  it("falls back to 'worktree' when no fields are populated", () => {
+    expect(announcements.onDragStart(activeFor("wt-empty"))).toBe("Picked up worktree");
+  });
+
+  it("uses 'worktree' when worktree snapshot is missing entirely", () => {
+    expect(announcements.onDragStart(activeFor("wt-unknown"))).toBe("Picked up worktree");
+  });
+
+  it("onDragOver resolves both labels via worktree-sort id prefix", () => {
+    const active = activeFor("wt-branch");
+    const over = {
+      id: "worktree-sort-wt-issue",
+      data: { current: { type: "worktree-sort", worktreeId: "wt-issue" } },
+    };
+    expect(announcements.onDragOver(active, over)).toBe(
+      "feature/login-flow is over Add OAuth support"
+    );
+  });
+
+  it("onDragOver resolves the over label via worktree-drop id prefix", () => {
+    const active = activeFor("wt-branch");
+    const over = {
+      id: "worktree-drop-wt-issue",
+      data: { current: {} },
+    };
+    expect(announcements.onDragOver(active, over)).toBe(
+      "feature/login-flow is over Add OAuth support"
+    );
+  });
+
+  it("onDragEnd announces drop with worktree label", () => {
+    const over = { data: { current: { type: "worktree-sort", worktreeId: "wt-issue" } } };
+    expect(announcements.onDragEnd(activeFor("wt-branch"), over)).toBe(
+      "Dropped feature/login-flow"
+    );
+  });
+
+  it("onDragCancel announces cancellation with worktree label", () => {
+    expect(announcements.onDragCancel(activeFor("wt-issue"))).toBe(
+      "Drag cancelled. Add OAuth support returned to its original position"
     );
   });
 });

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -36,6 +36,7 @@ import {
   SortableWorktreeCard,
   getWorktreeSortDragId,
 } from "@/components/DragDrop/SortableWorktreeCard";
+import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
 import type { RecipeTerminal } from "@/types";
@@ -86,6 +87,7 @@ interface SidebarWorktreeRowProps {
   dragStartOrder: string[];
   isSortDisabled: boolean;
   isPinned: boolean;
+  rowIndex: number;
 }
 
 const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
@@ -101,6 +103,7 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
   dragStartOrder,
   isSortDisabled,
   isPinned,
+  rowIndex,
 }: SidebarWorktreeRowProps) {
   const worktreeSnap = useWorktreeStore((state) => state.worktrees.get(worktreeId));
   const worktree = useMemo(
@@ -133,12 +136,42 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
     [worktreeActions, worktreeId]
   );
 
+  const showDragHandle = !isSortDisabled && !isPinned;
+
+  // Move up/down menu items mirror the drag pathway and provide a single-pointer
+  // alternative for users who can't perform the drag gesture (WCAG 2.5.7). They
+  // operate on the visible (filtered) order — `applyManualWorktreeReorder`
+  // merges that subset back into `manualOrder` so positions of filter-hidden
+  // worktrees are preserved, and `setOrderBy("manual")` matches the auto-switch
+  // performed at drag end.
+  const handleMoveBy = useCallback(
+    (delta: -1 | 1) => {
+      const targetIndex = rowIndex + delta;
+      if (targetIndex < 0 || targetIndex >= dragStartOrder.length) return;
+      const filterStore = useWorktreeFilterStore.getState();
+      const merged = applyManualWorktreeReorder(
+        filterStore.manualOrder,
+        dragStartOrder,
+        rowIndex,
+        targetIndex
+      );
+      filterStore.setManualOrder(merged);
+      filterStore.setOrderBy("manual");
+    },
+    [dragStartOrder, rowIndex]
+  );
+  const onMoveUp = useCallback(() => handleMoveBy(-1), [handleMoveBy]);
+  const onMoveDown = useCallback(() => handleMoveBy(1), [handleMoveBy]);
+
   if (!worktree) return null;
 
-  const showDragHandle = !isSortDisabled && !isPinned;
   const isActive = worktreeId === activeWorktreeId;
   const isFocused = worktreeId === focusedWorktreeId;
   const isSingleWorktree = totalWorktreeCount === 1;
+  const moveUpHandler = showDragHandle ? onMoveUp : undefined;
+  const moveDownHandler = showDragHandle ? onMoveDown : undefined;
+  const canMoveUp = showDragHandle && rowIndex > 0;
+  const canMoveDown = showDragHandle && rowIndex < dragStartOrder.length - 1;
 
   if (showDragHandle) {
     return (
@@ -171,6 +204,10 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
               dragHandleListeners={dragHandleListeners}
               dragHandleActivatorRef={dragHandleActivatorRef}
               isDraggingSort={isDraggingSort}
+              onMoveUp={moveUpHandler}
+              onMoveDown={moveDownHandler}
+              canMoveUp={canMoveUp}
+              canMoveDown={canMoveDown}
             />
           </ErrorBoundary>
         )}
@@ -1167,7 +1204,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             ) : (
               <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
                 <div className="flex flex-col">
-                  {filteredWorktrees.map((worktree) => {
+                  {filteredWorktrees.map((worktree, idx) => {
                     const isPinned = pinnedWorktrees.includes(worktree.id);
                     return (
                       <SidebarWorktreeRow
@@ -1184,6 +1221,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                         dragStartOrder={dragStartOrder}
                         isSortDisabled={isSortDisabled}
                         isPinned={isPinned}
+                        rowIndex={idx}
                       />
                     );
                   })}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -159,6 +159,10 @@ export interface WorktreeCardProps {
   dragHandleListeners?: SyntheticListenerMap;
   dragHandleActivatorRef?: (node: HTMLElement | null) => void;
   isDraggingSort?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   projectHealth?: import("@shared/types").ProjectHealthData | null;
 }
 
@@ -181,6 +185,10 @@ export const WorktreeCard = React.memo(function WorktreeCard({
   dragHandleListeners,
   dragHandleActivatorRef,
   isDraggingSort,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
   projectHealth,
 }: WorktreeCardProps) {
   "use memo";
@@ -856,6 +864,10 @@ export const WorktreeCard = React.memo(function WorktreeCard({
                     : undefined,
                   isCollapsed: effectiveIsCollapsed,
                   onLaunchAgent,
+                  onMoveUp,
+                  onMoveDown,
+                  canMoveUp,
+                  canMoveDown,
                   onOpenPanelPalette: () => {
                     useWorktreeSelectionStore.getState().setActiveWorktree(worktree.id);
                     void actionService.dispatch("panel.palette", undefined, {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -992,6 +992,10 @@ export const WorktreeCard = React.memo(function WorktreeCard({
             working: workingAgentCount,
           }}
           onLaunchAgent={onLaunchAgent}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
           onCopyContextFull={handleCopyContextFull}
           onCopyContextModified={handleCopyContextModified}
           onCopyPath={() => void navigator.clipboard.writeText(worktree.path)}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -346,6 +346,10 @@ export interface WorktreeHeaderProps {
     onToggleCollapse?: () => void;
     isCollapsed?: boolean;
     onLaunchAgent?: (agentId: string) => void;
+    onMoveUp?: () => void;
+    onMoveDown?: () => void;
+    canMoveUp?: boolean;
+    canMoveDown?: boolean;
     onDockAll: () => void;
     onMaximizeAll: () => void;
     onResetRenderers: () => void;
@@ -716,6 +720,10 @@ export function WorktreeHeader({
                 isPinned={isPinned}
                 counts={menu.counts}
                 onLaunchAgent={menu.onLaunchAgent ? handleLaunchAgent : undefined}
+                onMoveUp={menu.onMoveUp}
+                onMoveDown={menu.onMoveDown}
+                canMoveUp={menu.canMoveUp}
+                canMoveDown={menu.canMoveDown}
                 onCopyContextFull={menu.onCopyContextFull}
                 onCopyContextModified={menu.onCopyContextModified}
                 onCopyPath={menu.onCopyPath}

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/components/ui/context-menu";
 import {
   Activity,
+  ArrowDown,
+  ArrowUp,
   CircleDot,
   Clock,
   Code,
@@ -92,6 +94,10 @@ export interface WorktreeMenuItemsProps {
     working: number;
   };
   onLaunchAgent?: (agentId: string) => void;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
   onCopyContextFull: () => void;
   onCopyContextModified: () => void;
   onCopyPath: () => void;
@@ -142,6 +148,10 @@ export function WorktreeMenuItems({
   isPinned,
   counts,
   onLaunchAgent,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
   onCopyContextFull,
   onCopyContextModified,
   onCopyPath,
@@ -186,9 +196,24 @@ export function WorktreeMenuItems({
   const hasIssueOrPrSection = hasIssueSub || hasPRSub;
   const hasRecipes = recipes.length > 0;
   const hasRecipeSection = hasRecipes || (onSaveLayout && counts.active > 0);
+  const hasMoveSection = Boolean(onMoveUp || onMoveDown);
 
   return (
     <>
+      {hasMoveSection && (
+        <>
+          <C.Item onSelect={onMoveUp} disabled={!onMoveUp || !canMoveUp}>
+            <ArrowUp className="w-3.5 h-3.5 mr-2" />
+            Move Up
+          </C.Item>
+          <C.Item onSelect={onMoveDown} disabled={!onMoveDown || !canMoveDown}>
+            <ArrowDown className="w-3.5 h-3.5 mr-2" />
+            Move Down
+          </C.Item>
+          <C.Separator />
+        </>
+      )}
+
       {/* Launch submenu */}
       <C.Sub>
         <C.SubTrigger>

--- a/src/lib/__tests__/worktreeReorder.test.ts
+++ b/src/lib/__tests__/worktreeReorder.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { applyManualWorktreeReorder } from "../worktreeReorder";
+
+describe("applyManualWorktreeReorder", () => {
+  it("moves a visible item up while preserving filter-hidden positions", () => {
+    const fullOrder = ["hidden-1", "a", "hidden-2", "b", "c", "hidden-3"];
+    const visible = ["a", "b", "c"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 2, 0);
+    expect(result).toEqual(["hidden-1", "c", "hidden-2", "a", "b", "hidden-3"]);
+  });
+
+  it("moves a visible item down while preserving filter-hidden positions", () => {
+    const fullOrder = ["a", "hidden-1", "b", "c", "hidden-2"];
+    const visible = ["a", "b", "c"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 0, 2);
+    expect(result).toEqual(["b", "hidden-1", "c", "a", "hidden-2"]);
+  });
+
+  it("preserves hidden items at the beginning of the full order", () => {
+    const fullOrder = ["hidden-1", "hidden-2", "a", "b"];
+    const visible = ["a", "b"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 0, 1);
+    expect(result).toEqual(["hidden-1", "hidden-2", "b", "a"]);
+  });
+
+  it("preserves hidden items at the end of the full order", () => {
+    const fullOrder = ["a", "b", "hidden-1", "hidden-2"];
+    const visible = ["a", "b"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 0, 1);
+    expect(result).toEqual(["b", "a", "hidden-1", "hidden-2"]);
+  });
+
+  it("appends visible IDs missing from the full order (first-ever drag case)", () => {
+    const fullOrder: string[] = [];
+    const visible = ["a", "b", "c"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 0, 2);
+    expect(result).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns full order unchanged when fromIndex equals toIndex", () => {
+    const fullOrder = ["a", "b", "c"];
+    const visible = ["a", "b", "c"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 1, 1);
+    expect(result).toEqual(fullOrder);
+    expect(result).not.toBe(fullOrder);
+  });
+
+  it("returns full order unchanged for single-element visible subset", () => {
+    const fullOrder = ["hidden", "a"];
+    const visible = ["a"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 0, 0);
+    expect(result).toEqual(fullOrder);
+  });
+
+  it("returns full order unchanged for empty visible subset", () => {
+    const fullOrder = ["a", "b"];
+    const result = applyManualWorktreeReorder(fullOrder, [], 0, 0);
+    expect(result).toEqual(fullOrder);
+  });
+
+  it("guards against negative fromIndex", () => {
+    const fullOrder = ["a", "b", "c"];
+    const result = applyManualWorktreeReorder(fullOrder, ["a", "b", "c"], -1, 0);
+    expect(result).toEqual(fullOrder);
+  });
+
+  it("guards against fromIndex out of range", () => {
+    const fullOrder = ["a", "b"];
+    const result = applyManualWorktreeReorder(fullOrder, ["a", "b"], 5, 0);
+    expect(result).toEqual(fullOrder);
+  });
+
+  it("guards against toIndex out of range", () => {
+    const fullOrder = ["a", "b"];
+    const result = applyManualWorktreeReorder(fullOrder, ["a", "b"], 0, 5);
+    expect(result).toEqual(fullOrder);
+  });
+
+  it("does not mutate the input arrays", () => {
+    const fullOrder = ["a", "b", "c"];
+    const visible = ["a", "b", "c"];
+    const fullCopy = [...fullOrder];
+    const visibleCopy = [...visible];
+    applyManualWorktreeReorder(fullOrder, visible, 0, 2);
+    expect(fullOrder).toEqual(fullCopy);
+    expect(visible).toEqual(visibleCopy);
+  });
+
+  it("handles middle-to-middle move within visible subset", () => {
+    const fullOrder = ["a", "hidden-1", "b", "hidden-2", "c", "d"];
+    const visible = ["a", "b", "c", "d"];
+    const result = applyManualWorktreeReorder(fullOrder, visible, 1, 2);
+    expect(result).toEqual(["a", "hidden-1", "c", "hidden-2", "b", "d"]);
+  });
+});

--- a/src/lib/worktreeReorder.ts
+++ b/src/lib/worktreeReorder.ts
@@ -1,0 +1,42 @@
+import { arrayMove } from "@dnd-kit/sortable";
+
+/**
+ * Reorder a worktree within the visible (filtered) subset, then merge that
+ * reordering back into the persisted full-order array so positions of
+ * worktrees hidden by filters are preserved.
+ *
+ * Used by both the drag-end handler in DndProvider and the keyboard-accessible
+ * "Move up" / "Move down" menu items, so behaviour stays in lockstep.
+ *
+ * Out-of-range indices, single-element subsets, and no-op moves return
+ * `fullOrder` unchanged. Visible IDs missing from `fullOrder` are appended
+ * after the merge so a first-ever drag still produces a complete order.
+ */
+export function applyManualWorktreeReorder(
+  fullOrder: readonly string[],
+  visibleIds: readonly string[],
+  fromIndex: number,
+  toIndex: number
+): string[] {
+  if (visibleIds.length < 2) return fullOrder.slice();
+  if (fromIndex === toIndex) return fullOrder.slice();
+  if (fromIndex < 0 || fromIndex >= visibleIds.length) return fullOrder.slice();
+  if (toIndex < 0 || toIndex >= visibleIds.length) return fullOrder.slice();
+
+  const reorderedSubset = arrayMove(visibleIds.slice(), fromIndex, toIndex);
+  const subsetSet = new Set(reorderedSubset);
+  const merged: string[] = [];
+  let subsetIdx = 0;
+
+  for (const id of fullOrder) {
+    if (subsetSet.has(id)) {
+      merged.push(reorderedSubset[subsetIdx++]!);
+    } else {
+      merged.push(id);
+    }
+  }
+  while (subsetIdx < reorderedSubset.length) {
+    merged.push(reorderedSubset[subsetIdx++]!);
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

- `getDragLabel` didn't have a case for `WorktreeSortDragData`, so screen readers announced "Picked up panel" for every worktree drag. The fallback chain now resolves `issueTitle ?? branch ?? name ?? "worktree"`.
- Reordering worktrees was mouse-only, which violates WCAG 2.5.7 Dragging Movements. Move Up and Move Down items are now in both the more-actions dropdown and the right-click context menu, dispatching to the same persisted-order store as drag.
- Extracted a shared `worktreeReorder.ts` helper so menu-driven and drag-driven moves stay in lockstep and continue to preserve filter-hidden worktrees' positions in `manualOrder`.

Resolves #6425

## Changes

- `src/components/DragDrop/DndProvider.tsx` — updated `getDragLabel` to recognise `WorktreeSortDragData` and resolve the worktree label
- `src/lib/worktreeReorder.ts` — new shared reorder helper (extracted from drag handler)
- `src/components/Worktree/WorktreeMenuItems.tsx` — added Move Up / Move Down items
- `src/components/Worktree/WorktreeCard.tsx` and `WorktreeCard/WorktreeHeader.tsx` — wire Move Up/Down into the more-actions dropdown
- `src/components/Sidebar/SidebarContent.tsx` — wire Move Up/Down into the right-click context menu
- Tests for both the announcer fix and the reorder helper

## Testing

- Worktree drag with VoiceOver — announcements use the worktree label (issueTitle, branch, or name), not "panel"
- More-actions dropdown and right-click context menu both show Move Up / Move Down
- Move Up/Down disabled at the first/last visible row; hidden with an active filter or for pinned rows
- Moving a worktree auto-switches `orderBy` to "manual" if it wasn't already
- Hidden (filtered-out) worktrees keep their relative positions in `manualOrder` after a menu-driven move