### PR TITLE
fix(auto-updater): harden update path for 0.9

### DIFF
--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -244,19 +244,25 @@ class AutoUpdaterService {
 
       ipcMain.handle(CHANNELS.UPDATE_SET_CHANNEL, async (_event, channel: unknown) => {
         const validated: "stable" | "nightly" = channel === "nightly" ? "nightly" : "stable";
+        const previousChannel = store.get("updateChannel");
         store.set("updateChannel", validated);
-        if (this.initialized) {
-          this.configureFeedForChannel(validated);
-        }
-        // A staged installer from the previous channel must be discarded —
-        // otherwise quit-and-install would run the wrong channel's payload.
-        // Reset all in-memory state tied to the prior feed: download flag,
-        // session dedup version, and any pending retry timer (which would
-        // otherwise re-check against the new feed with stale retryCount).
+
+        // Same-channel re-save (e.g. user opens settings and clicks Save
+        // without changing the channel) must not blow away a validly-staged
+        // installer for the active channel.
+        if (validated === previousChannel) return validated;
+
+        // Discard prior-channel state BEFORE reconfiguring the feed, so a
+        // throw inside configureFeedForChannel can't leave a stale installer
+        // that quit-and-install would later run.
         await this.clearStagedInstaller();
         this.updateDownloaded = false;
         this.lastBroadcastVersion = null;
         this.resetRetryState();
+
+        if (this.initialized) {
+          this.configureFeedForChannel(validated);
+        }
         return validated;
       });
 

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -9,15 +9,53 @@ import { broadcastToRenderer } from "../ipc/utils.js";
 import { getCrashRecoveryService } from "./CrashRecoveryService.js";
 import { store } from "../store.js";
 import { PRODUCT_NAME } from "../utils/productBranding.js";
+import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
+// Issue #6401: bounded backoff for transient network failures. The 4-hour
+// periodic tick is too coarse to recover from a brief CDN blip or DNS hiccup
+// during launch. 30s/2m/8m with ±20% jitter spreads retries across a window
+// that's still useful while not pummeling a degraded feed.
+const RETRY_BASE_DELAYS_MS = [30_000, 120_000, 480_000] as const;
+const MAX_RETRIES = RETRY_BASE_DELAYS_MS.length;
+// Issue #6401: spread CDN load on the launch tick across a 60s window so a
+// fleet of restarts (e.g. after an OS update) doesn't stampede the feed.
+const STARTUP_JITTER_MAX_MS = 60_000;
+// Cap dismiss-version length before any further validation. SemVer with
+// pre-release/build identifiers stays well under 64 chars; anything longer is
+// either malformed or a probe.
+const DISMISS_VERSION_MAX_LEN = 64;
+// SemVer always starts with a numeric major; requiring a leading digit kills
+// the `v1.2.3` / `=1.2.3` tolerance that `semver.valid` permits, so the stored
+// form is always canonical.
+const DISMISS_VERSION_ALLOWLIST = /^[0-9][0-9a-zA-Z._+-]{0,63}$/;
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "EPIPE",
+  "ENETUNREACH",
+]);
+const PERMANENT_CERT_ERROR_CODES = new Set([
+  "CERT_HAS_EXPIRED",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+  "CERT_UNTRUSTED",
+]);
 const STABLE_FEED_URL = "https://updates.daintree.org/releases/";
 const NIGHTLY_FEED_URL = "https://updates.daintree.org/nightly/";
 const { autoUpdater } = electronUpdater;
 
 class AutoUpdaterService {
   private checkInterval: NodeJS.Timeout | null = null;
+  private startupJitterTimeout: NodeJS.Timeout | null = null;
+  private retryTimeout: NodeJS.Timeout | null = null;
+  private retryCount = 0;
   private initialized = false;
   private channelHandlersRegistered = false;
   private updateDownloaded = false;
@@ -29,6 +67,71 @@ class AutoUpdaterService {
   private errorHandler: ((err: Error) => void) | null = null;
   private progressHandler: ((progress: ProgressInfo) => void) | null = null;
   private downloadedHandler: ((info: UpdateInfo) => void) | null = null;
+
+  private clearRetryTimeout(): void {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = null;
+    }
+  }
+
+  private resetRetryState(): void {
+    this.clearRetryTimeout();
+    this.retryCount = 0;
+  }
+
+  // electron-updater 6.3.x doesn't surface a categorized error type, so classify
+  // by Node `err.code` (network/DNS) and `err.statusCode` (HTTP) on the raw
+  // Error. Anything we can't positively prove is transient is treated as
+  // permanent — fail closed so we don't loop on a misconfigured feed.
+  private isTransientUpdateError(err: unknown): boolean {
+    if (!err || typeof err !== "object") return false;
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string") {
+      if (PERMANENT_CERT_ERROR_CODES.has(code)) return false;
+      if (TRANSIENT_ERROR_CODES.has(code)) return true;
+    }
+    const statusCode = (err as { statusCode?: unknown }).statusCode;
+    if (typeof statusCode === "number") {
+      if (statusCode === 404 || statusCode === 401 || statusCode === 403) return false;
+      if (statusCode >= 500 && statusCode < 600) return true;
+      if (statusCode === 408 || statusCode === 429) return true;
+    }
+    return false;
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryCount >= MAX_RETRIES) return;
+    const base = RETRY_BASE_DELAYS_MS[this.retryCount];
+    // ±20% full jitter centered on the base — multiplier in [0.8, 1.2).
+    const jitterFactor = 0.8 + 0.4 * Math.random();
+    const delay = Math.floor(base * jitterFactor);
+    this.retryCount += 1;
+    this.clearRetryTimeout();
+    this.retryTimeout = setTimeout(() => {
+      this.retryTimeout = null;
+      this.runUpdateCheck("Retry");
+    }, delay);
+  }
+
+  private async clearStagedInstaller(): Promise<void> {
+    // `downloadedUpdateHelper` is `protected` on AppUpdater (not part of the
+    // public TS surface), so we reach through with a structural cast. It's
+    // initialized lazily on first download, so the null guard is mandatory.
+    // `clear()` internally swallows fs errors, but wrap defensively in case the
+    // internals change in a future patch.
+    const helper = (
+      autoUpdater as unknown as {
+        downloadedUpdateHelper?: { clear?: () => Promise<void> } | null;
+      }
+    ).downloadedUpdateHelper;
+    if (!helper || typeof helper.clear !== "function") return;
+    try {
+      await helper.clear();
+    } catch (err) {
+      console.warn("[MAIN] Failed to clear staged installer cache:", err);
+    }
+  }
 
   private shouldSuppressUpdateAvailable(version: string): boolean {
     // Manual checks always bypass suppression so users see a result.
@@ -97,7 +200,7 @@ class AutoUpdaterService {
     autoUpdater.allowDowngrade = channel === "nightly";
   }
 
-  private runUpdateCheck(context: "Initial" | "Periodic"): void {
+  private runUpdateCheck(context: "Initial" | "Periodic" | "Retry"): void {
     try {
       const result = autoUpdater.checkForUpdatesAndNotify();
       Promise.resolve(result).catch((err) => {
@@ -139,13 +242,21 @@ class AutoUpdaterService {
         return store.get("updateChannel") ?? "stable";
       });
 
-      ipcMain.handle(CHANNELS.UPDATE_SET_CHANNEL, (_event, channel: unknown) => {
+      ipcMain.handle(CHANNELS.UPDATE_SET_CHANNEL, async (_event, channel: unknown) => {
         const validated: "stable" | "nightly" = channel === "nightly" ? "nightly" : "stable";
         store.set("updateChannel", validated);
         if (this.initialized) {
           this.configureFeedForChannel(validated);
         }
+        // A staged installer from the previous channel must be discarded —
+        // otherwise quit-and-install would run the wrong channel's payload.
+        // Reset all in-memory state tied to the prior feed: download flag,
+        // session dedup version, and any pending retry timer (which would
+        // otherwise re-check against the new feed with stale retryCount).
+        await this.clearStagedInstaller();
         this.updateDownloaded = false;
+        this.lastBroadcastVersion = null;
+        this.resetRetryState();
         return validated;
       });
 
@@ -195,6 +306,10 @@ class AutoUpdaterService {
         console.log("[MAIN] Update available:", info.version);
         const suppressed = this.shouldSuppressUpdateAvailable(info.version);
         this.isManualCheck = false;
+        // A successful check ends the retry cycle regardless of whether we
+        // broadcast — the network round-tripped, so the transient condition
+        // has cleared.
+        this.resetRetryState();
         if (suppressed) return;
         this.lastBroadcastVersion = info.version;
         broadcastToRenderer(CHANNELS.UPDATE_AVAILABLE, { version: info.version });
@@ -203,6 +318,7 @@ class AutoUpdaterService {
 
       this.notAvailableHandler = (_info: UpdateInfo) => {
         console.log("[MAIN] Update not available");
+        this.resetRetryState();
         if (this.isManualCheck) {
           this.isManualCheck = false;
           broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
@@ -219,6 +335,10 @@ class AutoUpdaterService {
         const wasManual = this.isManualCheck;
         this.isManualCheck = false;
         if (wasManual) {
+          // Manual checks surface to the user immediately and offer a Retry
+          // action — don't shadow that with background backoff, the user is
+          // already deciding when to retry.
+          this.resetRetryState();
           broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
             type: "error",
             title: "Update failed",
@@ -228,7 +348,20 @@ class AutoUpdaterService {
               ipcChannel: CHANNELS.UPDATE_CHECK_FOR_UPDATES,
             },
           });
+          return;
         }
+        if (!this.isTransientUpdateError(err)) {
+          // Permanent: 404 (missing latest.yml), cert errors, or any error we
+          // can't classify. Don't retry — wait for the next 4-hour tick or a
+          // manual re-check.
+          this.resetRetryState();
+          return;
+        }
+        if (this.retryCount >= MAX_RETRIES) {
+          this.resetRetryState();
+          return;
+        }
+        this.scheduleRetry();
       };
       autoUpdater.on("error", this.errorHandler);
 
@@ -241,6 +374,7 @@ class AutoUpdaterService {
       this.downloadedHandler = (info: UpdateInfo) => {
         console.log("[MAIN] Update downloaded:", info.version);
         this.updateDownloaded = true;
+        this.resetRetryState();
         broadcastToRenderer(CHANNELS.UPDATE_DOWNLOADED, { version: info.version });
       };
       autoUpdater.on("update-downloaded", this.downloadedHandler);
@@ -266,14 +400,31 @@ class AutoUpdaterService {
 
       // Persist dismiss of the "Update Available" toast — the renderer sends
       // this when the user closes the toast so the same version is suppressed
-      // across app restarts for the 24h cooldown window.
-      ipcMain.handle(CHANNELS.UPDATE_DISMISS_TOAST, (_event, version: unknown) => {
-        if (typeof version !== "string" || version.trim().length === 0) return;
-        store.set("dismissedUpdateVersion", version);
+      // across app restarts for the 24h cooldown window. Validate the sender
+      // origin synchronously (matches recovery.ts and plugin.ts pattern), cap
+      // length, allowlist characters, and require strict semver — defense in
+      // depth on top of contextIsolation + asar integrity.
+      ipcMain.handle(CHANNELS.UPDATE_DISMISS_TOAST, (event, version: unknown) => {
+        const senderUrl = event.senderFrame?.url;
+        if (!senderUrl || !isTrustedRendererUrl(senderUrl)) return;
+        if (typeof version !== "string") return;
+        const trimmed = version.trim();
+        if (trimmed.length === 0 || trimmed.length > DISMISS_VERSION_MAX_LEN) return;
+        if (!DISMISS_VERSION_ALLOWLIST.test(trimmed)) return;
+        if (!semver.valid(trimmed)) return;
+        store.set("dismissedUpdateVersion", trimmed);
         store.set("dismissedUpdateAt", Date.now());
       });
 
-      this.runUpdateCheck("Initial");
+      // Spread the launch-time check across a 60s window so a fleet of
+      // simultaneous restarts (e.g. after an OS update) doesn't stampede the
+      // CDN. Main-process setTimeout is not subject to renderer background
+      // throttling.
+      const startupJitterMs = Math.floor(Math.random() * STARTUP_JITTER_MAX_MS);
+      this.startupJitterTimeout = setTimeout(() => {
+        this.startupJitterTimeout = null;
+        this.runUpdateCheck("Initial");
+      }, startupJitterMs);
 
       this.checkInterval = setInterval(() => {
         this.runUpdateCheck("Periodic");
@@ -292,6 +443,12 @@ class AutoUpdaterService {
       clearInterval(this.checkInterval);
       this.checkInterval = null;
     }
+    if (this.startupJitterTimeout) {
+      clearTimeout(this.startupJitterTimeout);
+      this.startupJitterTimeout = null;
+    }
+    this.clearRetryTimeout();
+    this.retryCount = 0;
 
     if (this.checkingHandler) {
       autoUpdater.off("checking-for-update", this.checkingHandler);

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -20,6 +20,10 @@ const windowMock = vi.hoisted(() => ({
 
 const broadcastMock = vi.hoisted(() => vi.fn());
 
+const downloadedUpdateHelperMock = vi.hoisted(() => ({
+  clear: vi.fn().mockResolvedValue(undefined),
+}));
+
 const autoUpdaterMock = vi.hoisted(() => ({
   autoDownload: false,
   autoInstallOnAppQuit: false,
@@ -30,6 +34,19 @@ const autoUpdaterMock = vi.hoisted(() => ({
   checkForUpdates: vi.fn(),
   quitAndInstall: vi.fn(),
   setFeedURL: vi.fn(),
+  // `downloadedUpdateHelper` is `protected` on AppUpdater (lazy-init at first
+  // download); the channel-switch invalidation reaches through with a
+  // structural cast. Make it always-present in tests so we can assert clear()
+  // is called — null path is covered explicitly.
+  downloadedUpdateHelper: downloadedUpdateHelperMock as typeof downloadedUpdateHelperMock | null,
+}));
+
+const TRUSTED_SENDER = { senderFrame: { url: "app://daintree/index.html" } };
+
+const trustedRendererMock = vi.hoisted(() => ({
+  isTrustedRendererUrl: vi.fn((url: string) => url.startsWith("app://daintree")),
+  isRecoveryPageUrl: vi.fn(() => false),
+  getTrustedOrigins: vi.fn(() => ["app://daintree"]),
 }));
 
 const storeMock = vi.hoisted(() => ({
@@ -70,10 +87,13 @@ vi.mock("../../store.js", () => ({
   store: storeMock,
 }));
 
+vi.mock("../../../shared/utils/trustedRenderer.js", () => trustedRendererMock);
+
 import { autoUpdaterService } from "../AutoUpdaterService.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const STARTUP_JITTER_MAX_MS = 60_000;
 
 describe("AutoUpdaterService", () => {
   const originalPlatform = process.platform;
@@ -96,6 +116,12 @@ describe("AutoUpdaterService", () => {
     fsMock.readFileSync.mockReturnValue("");
     autoUpdaterMock.checkForUpdatesAndNotify.mockResolvedValue(undefined);
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined);
+    autoUpdaterMock.downloadedUpdateHelper = downloadedUpdateHelperMock;
+    downloadedUpdateHelperMock.clear.mockReset().mockResolvedValue(undefined);
+    trustedRendererMock.isTrustedRendererUrl.mockReset();
+    trustedRendererMock.isTrustedRendererUrl.mockImplementation((url: string) =>
+      url.startsWith("app://daintree")
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -121,6 +147,9 @@ describe("AutoUpdaterService", () => {
     });
 
     expect(() => autoUpdaterService.initialize()).not.toThrow();
+    // Initial check is now deferred behind startup jitter — verify the throw
+    // inside the timer callback is also caught.
+    expect(() => vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS)).not.toThrow();
   });
 
   it("does not crash on synchronous throw during periodic checks", () => {
@@ -331,6 +360,7 @@ describe("AutoUpdaterService", () => {
       process.env.APPIMAGE = "/path/to/app.AppImage";
 
       autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
 
       expect(autoUpdaterMock.on).toHaveBeenCalled();
       expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
@@ -342,6 +372,7 @@ describe("AutoUpdaterService", () => {
       fsMock.readFileSync.mockReturnValue("deb");
 
       autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
 
       expect(autoUpdaterMock.on).toHaveBeenCalled();
       expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
@@ -411,6 +442,7 @@ describe("AutoUpdaterService", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
 
       autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
 
       expect(autoUpdaterMock.on).toHaveBeenCalled();
       expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
@@ -440,14 +472,14 @@ describe("AutoUpdaterService", () => {
       expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
 
-    it("SET_CHANNEL persists to store but skips setFeedURL", () => {
+    it("SET_CHANNEL persists to store but skips setFeedURL", async () => {
       autoUpdaterService.initialize();
 
       const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
         (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
       )![1];
 
-      const result = setChannelHandler(null, "nightly");
+      const result = await setChannelHandler(null, "nightly");
       expect(result).toBe("nightly");
       expect(storeMock.set).toHaveBeenCalledWith("updateChannel", "nightly");
       expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
@@ -510,6 +542,7 @@ describe("AutoUpdaterService", () => {
 
     it("calls setFeedURL before initial update check", () => {
       autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
 
       const setFeedOrder = autoUpdaterMock.setFeedURL.mock.invocationCallOrder[0];
       const checkOrder = autoUpdaterMock.checkForUpdatesAndNotify.mock.invocationCallOrder[0];
@@ -527,7 +560,7 @@ describe("AutoUpdaterService", () => {
       expect(getChannelHandler()).toBe("nightly");
     });
 
-    it("IPC UPDATE_SET_CHANNEL persists new channel and reconfigures feed", () => {
+    it("IPC UPDATE_SET_CHANNEL persists new channel and reconfigures feed", async () => {
       autoUpdaterService.initialize();
       autoUpdaterMock.setFeedURL.mockClear();
 
@@ -535,7 +568,7 @@ describe("AutoUpdaterService", () => {
         (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
       )![1];
 
-      const result = setChannelHandler(null, "nightly");
+      const result = await setChannelHandler(null, "nightly");
       expect(result).toBe("nightly");
       expect(storeMock.set).toHaveBeenCalledWith("updateChannel", "nightly");
       expect(autoUpdaterMock.setFeedURL).toHaveBeenCalledWith({
@@ -544,18 +577,18 @@ describe("AutoUpdaterService", () => {
       });
     });
 
-    it("IPC UPDATE_SET_CHANNEL coerces unknown value to stable", () => {
+    it("IPC UPDATE_SET_CHANNEL coerces unknown value to stable", async () => {
       autoUpdaterService.initialize();
 
       const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
         (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
       )![1];
 
-      expect(setChannelHandler(null, "bogus")).toBe("stable");
+      expect(await setChannelHandler(null, "bogus")).toBe("stable");
       expect(storeMock.set).toHaveBeenCalledWith("updateChannel", "stable");
     });
 
-    it("UPDATE_SET_CHANNEL clears updateDownloaded flag", () => {
+    it("UPDATE_SET_CHANNEL clears updateDownloaded flag", async () => {
       autoUpdaterService.initialize();
 
       const downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
@@ -566,7 +599,7 @@ describe("AutoUpdaterService", () => {
       const setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
         (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
       )![1];
-      setChannelHandler(null, "nightly");
+      await setChannelHandler(null, "nightly");
 
       const quitHandler = (ipcMainMock.handle as Mock).mock.calls.find(
         (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
@@ -710,7 +743,7 @@ describe("AutoUpdaterService", () => {
 
     it("UPDATE_DISMISS_TOAST handler persists version and timestamp", () => {
       const before = Date.now();
-      dismissHandler({}, "1.1.0");
+      dismissHandler(TRUSTED_SENDER, "1.1.0");
       const after = Date.now();
 
       expect(storeState.dismissedUpdateVersion).toBe("1.1.0");
@@ -720,10 +753,10 @@ describe("AutoUpdaterService", () => {
     });
 
     it("UPDATE_DISMISS_TOAST ignores empty, whitespace, or non-string versions", () => {
-      dismissHandler({}, "");
-      dismissHandler({}, "   ");
-      dismissHandler({}, 42);
-      dismissHandler({}, null);
+      dismissHandler(TRUSTED_SENDER, "");
+      dismissHandler(TRUSTED_SENDER, "   ");
+      dismissHandler(TRUSTED_SENDER, 42);
+      dismissHandler(TRUSTED_SENDER, null);
 
       expect(storeState.dismissedUpdateVersion).toBeUndefined();
       expect(storeState.dismissedUpdateAt).toBeUndefined();
@@ -790,6 +823,423 @@ describe("AutoUpdaterService", () => {
       autoUpdaterService.dispose();
 
       expect(ipcMainMock.removeHandler).toHaveBeenCalledWith(CHANNELS.UPDATE_DISMISS_TOAST);
+    });
+  });
+
+  describe("UPDATE_DISMISS_TOAST hardening", () => {
+    let dismissHandler: (event: unknown, version: unknown) => void;
+    const storeState: Record<string, unknown> = {};
+
+    function primeStore(values: Record<string, unknown>): void {
+      for (const key of Object.keys(storeState)) delete storeState[key];
+      Object.assign(storeState, values);
+    }
+
+    beforeEach(() => {
+      primeStore({});
+      storeMock.get.mockImplementation((key: string) => storeState[key]);
+      storeMock.set.mockImplementation((key: string, value: unknown) => {
+        storeState[key] = value;
+      });
+
+      autoUpdaterService.initialize();
+
+      dismissHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_DISMISS_TOAST
+      )![1];
+    });
+
+    it("drops the call when senderFrame is missing", () => {
+      dismissHandler({}, "1.1.0");
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+      expect(storeState.dismissedUpdateAt).toBeUndefined();
+    });
+
+    it("drops the call when senderFrame.url is undefined", () => {
+      dismissHandler({ senderFrame: {} }, "1.1.0");
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+    });
+
+    it("drops the call from an untrusted origin", () => {
+      dismissHandler({ senderFrame: { url: "https://evil.example.com/x.html" } }, "1.1.0");
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+      expect(trustedRendererMock.isTrustedRendererUrl).toHaveBeenCalledWith(
+        "https://evil.example.com/x.html"
+      );
+    });
+
+    it("rejects versions longer than 64 chars", () => {
+      const long = `1.${"9".repeat(70)}.0`;
+      dismissHandler(TRUSTED_SENDER, long);
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+    });
+
+    it("rejects versions with characters outside the SemVer allowlist", () => {
+      // Semver allowlist is [0-9a-zA-Z._+-]; spaces, slashes, semicolons, etc.
+      // would slip past `semver.coerce` and corrupt the persisted record.
+      dismissHandler(TRUSTED_SENDER, "1.1.0; rm -rf /");
+      dismissHandler(TRUSTED_SENDER, "1.1.0/../../etc");
+      dismissHandler(TRUSTED_SENDER, "1.1.0 1.2.0");
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+    });
+
+    it("rejects strings that pass the allowlist but are not valid semver", () => {
+      // `semver.coerce` would accept these and pull out a version; `semver.valid`
+      // is the strict gate the issue requires.
+      dismissHandler(TRUSTED_SENDER, "1");
+      dismissHandler(TRUSTED_SENDER, "1.2");
+      dismissHandler(TRUSTED_SENDER, "v1.2.3");
+      dismissHandler(TRUSTED_SENDER, "01.2.3");
+      dismissHandler(TRUSTED_SENDER, "abc");
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+    });
+
+    it("accepts a strict semver from a trusted sender", () => {
+      dismissHandler(TRUSTED_SENDER, "1.2.3");
+
+      expect(storeState.dismissedUpdateVersion).toBe("1.2.3");
+      expect(typeof storeState.dismissedUpdateAt).toBe("number");
+    });
+
+    it("accepts a nightly pre-release semver", () => {
+      dismissHandler(TRUSTED_SENDER, "0.9.0-nightly.20251231");
+
+      expect(storeState.dismissedUpdateVersion).toBe("0.9.0-nightly.20251231");
+    });
+
+    it("stores the trimmed value, not the raw input", () => {
+      dismissHandler(TRUSTED_SENDER, "  1.2.3  ");
+
+      expect(storeState.dismissedUpdateVersion).toBe("1.2.3");
+    });
+
+    it("validates sender BEFORE inspecting payload (no version-shape leak)", () => {
+      // If senderFrame validation runs after typeof checks, an attacker could
+      // probe the validation order via type errors. Ensure the untrusted-sender
+      // drop is the first gate.
+      const untrusted = { senderFrame: { url: "https://evil.example.com/x.html" } };
+      dismissHandler(untrusted, { malicious: true });
+
+      expect(storeState.dismissedUpdateVersion).toBeUndefined();
+    });
+  });
+
+  describe("startup jitter", () => {
+    it("does not invoke checkForUpdatesAndNotify synchronously during initialize()", () => {
+      autoUpdaterService.initialize();
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("invokes the initial check after the jitter window elapses", () => {
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("never schedules the initial check beyond the 60s ceiling", () => {
+      vi.spyOn(Math, "random").mockReturnValueOnce(0.999_999);
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispose() cancels a pending startup jitter so no check fires", () => {
+      autoUpdaterService.initialize();
+      autoUpdaterService.dispose();
+
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS * 2);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("does not block the periodic check from firing later", () => {
+      autoUpdaterService.initialize();
+      // Advance past startup jitter and one full periodic interval.
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS + CHECK_INTERVAL_MS);
+
+      // Initial + first periodic = 2 calls. (Jitter also runs the initial.)
+      expect(autoUpdaterMock.checkForUpdatesAndNotify.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("retry backoff", () => {
+    let errorHandler: (err: unknown) => void;
+    let availableHandler: (info: { version: string }) => void;
+    let notAvailableHandler: (info: object) => void;
+    let downloadedHandler: (info: { version: string }) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      errorHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "error"
+      )![1];
+      availableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-available"
+      )![1];
+      notAvailableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-not-available"
+      )![1];
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+    });
+
+    it("schedules a retry after a transient ECONNRESET error", () => {
+      errorHandler(Object.assign(new Error("conn reset"), { code: "ECONNRESET" }));
+
+      // First retry base is 30s with ±20% jitter — anywhere in [24s, 36s].
+      // Advance well past the ceiling to guarantee the timer fires.
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on ETIMEDOUT and ENOTFOUND", () => {
+      errorHandler(Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }));
+      vi.advanceTimersByTime(36_000);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+      // After the retry fires, the next error is at retryCount=1; second retry
+      // base is 120s with ±20% — fires by 144s.
+      errorHandler(Object.assign(new Error("dns"), { code: "ENOTFOUND" }));
+      vi.advanceTimersByTime(144_000);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on HTTP 5xx (statusCode = 503)", () => {
+      errorHandler(Object.assign(new Error("service unavailable"), { statusCode: 503 }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on HTTP 404 (missing latest.yml)", () => {
+      errorHandler(Object.assign(new Error("not found"), { statusCode: 404 }));
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+
+      // Only the periodic interval tick should have fired.
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on cert errors", () => {
+      errorHandler(Object.assign(new Error("expired"), { code: "CERT_HAS_EXPIRED" }));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("does not retry an uncategorized error (fail closed)", () => {
+      errorHandler(new Error("mystery"));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("does not retry a manual check error (user holds the retry button)", () => {
+      autoUpdaterService.checkForUpdatesManually();
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      errorHandler(Object.assign(new Error("conn reset"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("caps retries at 3 attempts", () => {
+      // First three transient errors should each schedule a retry.
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000); // ≥ 30s * 1.2
+      errorHandler(Object.assign(new Error("b"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(144_000); // ≥ 120s * 1.2
+      errorHandler(Object.assign(new Error("c"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(576_000); // ≥ 480s * 1.2
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(3);
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      // Fourth error: cap reached, no retry.
+      errorHandler(Object.assign(new Error("d"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+
+      // Only the periodic interval tick.
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("update-available resets retry count so a future failure starts fresh", () => {
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+      errorHandler(Object.assign(new Error("b"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(144_000);
+
+      availableHandler({ version: "2.0.0" });
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      // Next transient error should retry at base 30s, not at the 8m ceiling.
+      errorHandler(Object.assign(new Error("c"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("update-not-available resets retry count", () => {
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+
+      notAvailableHandler({});
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      errorHandler(Object.assign(new Error("b"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("update-downloaded resets retry count", () => {
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+
+      downloadedHandler({ version: "2.0.0" });
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      errorHandler(Object.assign(new Error("b"), { code: "ECONNRESET" }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispose() cancels a pending retry timer", () => {
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      autoUpdaterService.dispose();
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("retry uses ±20% jitter (lower bound)", () => {
+      vi.spyOn(Math, "random").mockReturnValueOnce(0); // jitterFactor = 0.8
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+
+      // 30000 * 0.8 = 24000ms exactly.
+      vi.advanceTimersByTime(23_999);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retry uses ±20% jitter (upper bound)", () => {
+      vi.spyOn(Math, "random").mockReturnValueOnce(0.999_999_999); // jitterFactor ≈ 1.2
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+
+      // 30000 * 1.2 = 36000ms (Math.floor lowers it to 35999).
+      vi.advanceTimersByTime(35_998);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(2);
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("channel-switch invalidation", () => {
+    let setChannelHandler: (event: unknown, channel: unknown) => Promise<unknown>;
+    let downloadedHandler: (info: { version: string }) => void;
+    let availableHandler: (info: { version: string }) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1];
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+      availableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-available"
+      )![1];
+    });
+
+    it("clears the staged installer cache when channel changes", async () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      await setChannelHandler(null, "nightly");
+
+      expect(downloadedUpdateHelperMock.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("resets lastBroadcastVersion so a same-version update broadcasts after switch", async () => {
+      availableHandler({ version: "2.0.0" });
+      broadcastMock.mockClear();
+
+      await setChannelHandler(null, "nightly");
+      availableHandler({ version: "2.0.0" });
+
+      // Without the lastBroadcastVersion reset the second `update-available`
+      // would be silently swallowed by the in-session dedup.
+      expect(broadcastMock).toHaveBeenCalledWith(CHANNELS.UPDATE_AVAILABLE, { version: "2.0.0" });
+    });
+
+    it("resets the updateDownloaded flag so quit-and-install no-ops after switch", async () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      await setChannelHandler(null, "nightly");
+
+      const quitHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
+      )![1];
+      quitHandler();
+
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("cancels any in-flight retry timer on channel switch", async () => {
+      const errorHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "error"
+      )![1];
+      errorHandler(Object.assign(new Error("a"), { code: "ECONNRESET" }));
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      await setChannelHandler(null, "nightly");
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op (and does not throw) when downloadedUpdateHelper is null", async () => {
+      autoUpdaterMock.downloadedUpdateHelper = null;
+
+      await expect(setChannelHandler(null, "nightly")).resolves.toBe("nightly");
+      expect(downloadedUpdateHelperMock.clear).not.toHaveBeenCalled();
+    });
+
+    it("still resets in-memory state when clear() rejects", async () => {
+      downloadedHandler({ version: "2.0.0" });
+      downloadedUpdateHelperMock.clear.mockRejectedValueOnce(new Error("EACCES"));
+
+      await expect(setChannelHandler(null, "nightly")).resolves.toBe("nightly");
+
+      const quitHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
+      )![1];
+      quitHandler();
+
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -118,6 +118,12 @@ describe("AutoUpdaterService", () => {
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined);
     autoUpdaterMock.downloadedUpdateHelper = downloadedUpdateHelperMock;
     downloadedUpdateHelperMock.clear.mockReset().mockResolvedValue(undefined);
+    // Reset implementations between tests — `vi.clearAllMocks()` only resets
+    // call history, so a `mockReturnValue("nightly")` set in an earlier test
+    // would otherwise leak into here and trip the same-channel guard.
+    storeMock.get.mockReset().mockImplementation((_key: string) => undefined);
+    storeMock.set.mockReset();
+    storeMock.delete.mockReset();
     trustedRendererMock.isTrustedRendererUrl.mockReset();
     trustedRendererMock.isTrustedRendererUrl.mockImplementation((url: string) =>
       url.startsWith("app://daintree")
@@ -1240,6 +1246,113 @@ describe("AutoUpdaterService", () => {
       quitHandler();
 
       expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("still invalidates state when configureFeedForChannel throws", async () => {
+      // Regression: if setFeedURL throws after the user changes channel, the
+      // staged installer for the old channel must still be discarded —
+      // otherwise quit-and-install would run the wrong channel's payload.
+      downloadedHandler({ version: "2.0.0" });
+      autoUpdaterMock.setFeedURL.mockImplementationOnce(() => {
+        throw new Error("setFeedURL boom");
+      });
+
+      // The handler is allowed to throw or resolve; what matters is that the
+      // state cleanup ran first.
+      await setChannelHandler(null, "nightly").catch(() => {});
+
+      expect(downloadedUpdateHelperMock.clear).toHaveBeenCalledTimes(1);
+
+      const quitHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
+      )![1];
+      quitHandler();
+
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the channel is unchanged (preserves staged installer)", async () => {
+      // Default channel after init is "stable". Re-saving "stable" should not
+      // discard a validly-staged installer.
+      downloadedHandler({ version: "2.0.0" });
+      downloadedUpdateHelperMock.clear.mockClear();
+      autoUpdaterMock.setFeedURL.mockClear();
+
+      // Make the store reflect the current "stable" preference so the guard
+      // sees previousChannel === validated.
+      storeMock.get.mockImplementation((key: string) =>
+        key === "updateChannel" ? "stable" : undefined
+      );
+
+      const result = await setChannelHandler(null, "stable");
+      expect(result).toBe("stable");
+      expect(downloadedUpdateHelperMock.clear).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+
+      const quitHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_QUIT_AND_INSTALL
+      )![1];
+      quitHandler();
+
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("error classification edge cases", () => {
+    let errorHandler: (err: unknown) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      errorHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "error"
+      )![1];
+
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+    });
+
+    it("treats a cert error as permanent even when statusCode is 5xx", () => {
+      // The cert-code check runs before the statusCode check — an error that
+      // tunnels both must NOT be retried (cert wins).
+      errorHandler(
+        Object.assign(new Error("expired"), {
+          code: "CERT_HAS_EXPIRED",
+          statusCode: 503,
+        })
+      );
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("retries on HTTP 408 (request timeout)", () => {
+      errorHandler(Object.assign(new Error("timeout"), { statusCode: 408 }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on HTTP 429 (rate limited)", () => {
+      errorHandler(Object.assign(new Error("rate limited"), { statusCode: 429 }));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on HTTP 401 (unauthorized)", () => {
+      errorHandler(Object.assign(new Error("unauthorized"), { statusCode: 401 }));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("does not retry on HTTP 403 (forbidden)", () => {
+      errorHandler(Object.assign(new Error("forbidden"), { statusCode: 403 }));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Channel switches now properly invalidate the staged installer: clears the `downloadedUpdateHelper` cache directory and resets `lastBroadcastVersion`, so switching from nightly back to stable won't run the stale nightly payload on quit
- `runUpdateCheck` retries transient network failures (ECONNRESET/ETIMEDOUT/5xx) with bounded backoff and jitter — three attempts at 30s/2m/8m ±20%; permanent errors (404, cert) skip retry entirely
- Initial launch check is offset by a random jitter (≤60s) to spread CDN load across boot-time spikes
- `UPDATE_DISMISS_TOAST` IPC handler now validates `senderFrame` via `isTrustedRendererUrl`, caps the version string at 64 characters, restricts to the SemVer character set, and uses `semver.valid` instead of the forgiving `semver.coerce`

Resolves #6401

## Changes

- `electron/services/AutoUpdaterService.ts` — all four hardening items
- `electron/services/__tests__/AutoUpdaterService.test.ts` — 93 tests covering the new retry logic, jitter, channel-switch cache clearing, and IPC handler validation

## Testing

Full unit test suite (93 tests) passes. Typecheck, lint, and format clean. Retry backoff, channel-switch cache invalidation, and IPC validation paths all have direct test coverage.