### PR TITLE
fix(dialog): restore focus when trigger unmounts before close (#6441)

### DIFF
--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -86,10 +86,19 @@ export function AppDialog({
   const portalOffset = portalOpen ? portalWidth : 0;
 
   const restoreFocus = useCallback(() => {
-    if (previousActiveElement.current) {
-      previousActiveElement.current.focus();
-      previousActiveElement.current = null;
+    const el = previousActiveElement.current;
+    previousActiveElement.current = null;
+    if (!el) return;
+    if (document.contains(el)) {
+      el.focus();
+      return;
     }
+    // Trigger was unmounted before close (e.g., the row that opened
+    // a destructive confirm dialog was removed by the action itself).
+    // Hand focus to the first tabbable child of the app shell rather
+    // than letting it silently fall to <body>.
+    const root = document.getElementById("root");
+    root?.querySelector<HTMLElement>(TABBABLE_SELECTOR)?.focus();
   }, []);
 
   const { isVisible, shouldRender } = useAnimatedPresence({

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -78,6 +78,16 @@ export function AppPaletteDialog({
     }
   }, [isOpen]);
 
+  // If the host of an open palette unmounts before the exit animation
+  // finishes, useAnimatedPresence's cleanup deliberately does NOT call
+  // onAnimateOut — so this is the only place restoreFocus runs in that
+  // path. Mirrors the cleanup AppDialog already has.
+  useEffect(() => {
+    return () => {
+      restoreFocus();
+    };
+  }, [restoreFocus]);
+
   // Backstop Escape on document bubble. The bubble-phase escape
   // stack dispatcher (`useGlobalEscapeDispatcher`) bails when
   // `defaultPrevented` is true, which Radix DismissableLayers

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -21,6 +21,9 @@ import {
 export const KBD_CLASS =
   "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60";
 
+const TABBABLE_SELECTOR =
+  'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), audio[controls], video[controls], [contenteditable]:not([contenteditable="false"]), [tabindex]:not([tabindex^="-"])';
+
 export interface AppPaletteDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -41,12 +44,18 @@ export function AppPaletteDialog({
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const restoreFocus = useCallback(() => {
-    if (previousFocusRef.current) {
-      if (!usePaletteStore.getState().activePaletteId) {
-        previousFocusRef.current.focus();
-      }
-      previousFocusRef.current = null;
+    const el = previousFocusRef.current;
+    previousFocusRef.current = null;
+    if (!el) return;
+    // Palette-to-palette handoff: the next palette will install its
+    // own focus, so skip restore entirely.
+    if (usePaletteStore.getState().activePaletteId) return;
+    if (document.contains(el)) {
+      el.focus();
+      return;
     }
+    const root = document.getElementById("root");
+    root?.querySelector<HTMLElement>(TABBABLE_SELECTOR)?.focus();
   }, []);
 
   const { isVisible, shouldRender } = useAnimatedPresence({

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,6 +1,9 @@
 import type React from "react";
 import { AppDialog, type DialogZIndex } from "@/components/ui/AppDialog";
 
+const DESTRUCTIVE_CONFIRM_LABEL_RE =
+  /^\s*(delete|remove|destroy|erase|wipe|purge|abort|reset|revoke|terminate|uninstall)\b/i;
+
 export interface ConfirmDialogProps {
   isOpen: boolean;
   onClose?: () => void;
@@ -29,6 +32,17 @@ export function ConfirmDialog({
   zIndex,
 }: ConfirmDialogProps) {
   const handleClose = onClose ?? (() => {});
+
+  if (
+    import.meta.env.DEV &&
+    variant !== "destructive" &&
+    DESTRUCTIVE_CONFIRM_LABEL_RE.test(confirmLabel)
+  ) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[ConfirmDialog] Destructive confirmLabel "${confirmLabel}" rendered with variant="${variant}". Use variant="destructive" so the primary button gets the destructive styling.`
+    );
+  }
 
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="sm" variant={variant} zIndex={zIndex}>

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -194,6 +194,39 @@ describe("AppDialog focus trapping", () => {
     document.body.removeChild(outerButton);
   });
 
+  it("falls back via cleanup effect when the dialog host unmounts while open", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    const fallbackButton = document.createElement("button");
+    fallbackButton.textContent = "Fallback";
+    root.appendChild(fallbackButton);
+    document.body.appendChild(root);
+
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = render(
+      <>
+        <Dispatcher />
+        <AppDialog isOpen={true} onClose={() => {}} data-testid="test-dialog">
+          <AppDialog.Body>
+            <button type="button">Inner</button>
+          </AppDialog.Body>
+        </AppDialog>
+      </>
+    );
+    await act(() => vi.runAllTimersAsync());
+
+    document.body.removeChild(trigger);
+    unmount();
+
+    expect(document.activeElement).toBe(fallbackButton);
+    expect(document.activeElement).not.toBe(document.body);
+    document.body.removeChild(root);
+  });
+
   it("falls back to first tabbable in #root when trigger was unmounted before close", async () => {
     const root = document.createElement("div");
     root.id = "root";

--- a/src/components/ui/__tests__/AppDialog.test.tsx
+++ b/src/components/ui/__tests__/AppDialog.test.tsx
@@ -194,6 +194,52 @@ describe("AppDialog focus trapping", () => {
     document.body.removeChild(outerButton);
   });
 
+  it("falls back to first tabbable in #root when trigger was unmounted before close", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    const fallbackButton = document.createElement("button");
+    fallbackButton.textContent = "Fallback";
+    root.appendChild(fallbackButton);
+    document.body.appendChild(root);
+
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(
+      <>
+        <Dispatcher />
+        <AppDialog isOpen={true} onClose={() => {}} data-testid="test-dialog">
+          <AppDialog.Body>
+            <button type="button">Inner</button>
+          </AppDialog.Body>
+        </AppDialog>
+      </>
+    );
+    await act(() => vi.runAllTimersAsync());
+
+    // Trigger gets unmounted by the action that ran inside the dialog
+    // (e.g., the row containing it was deleted).
+    document.body.removeChild(trigger);
+
+    rerender(
+      <>
+        <Dispatcher />
+        <AppDialog isOpen={false} onClose={() => {}} data-testid="test-dialog">
+          <AppDialog.Body>
+            <button type="button">Inner</button>
+          </AppDialog.Body>
+        </AppDialog>
+      </>
+    );
+
+    expect(document.activeElement).toBe(fallbackButton);
+    expect(document.activeElement).not.toBe(document.body);
+    document.body.removeChild(root);
+  });
+
   it("does not interfere with focus in portaled popovers outside dialogRef", async () => {
     renderDialog();
     await act(() => vi.runAllTimersAsync());

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -135,6 +135,30 @@ describe("AppPaletteDialog focus restore", () => {
     document.body.removeChild(trigger);
   });
 
+  it("restores focus when the palette host unmounts mid-flight", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    const fallbackButton = document.createElement("button");
+    fallbackButton.textContent = "Fallback";
+    root.appendChild(fallbackButton);
+    document.body.appendChild(root);
+
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { unmount } = renderPalette({ isOpen: true });
+    await act(() => vi.runAllTimersAsync());
+
+    document.body.removeChild(trigger);
+    unmount();
+
+    expect(document.activeElement).toBe(fallbackButton);
+    expect(document.activeElement).not.toBe(document.body);
+    document.body.removeChild(root);
+  });
+
   it("restores to the original trigger when it is still mounted", async () => {
     const trigger = document.createElement("button");
     trigger.textContent = "Trigger";

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { render, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppPaletteDialog } from "../AppPaletteDialog";
+import { usePaletteStore } from "@/store/paletteStore";
+import { _resetForTests } from "@/lib/escapeStack";
+import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({
+    isOpen,
+    onAnimateOut,
+  }: {
+    isOpen: boolean;
+    onAnimateOut?: () => void;
+  }) => {
+    // Mirror real timing closely enough for focus assertions: the exit
+    // path runs onAnimateOut synchronously when isOpen flips to false.
+    if (!isOpen && onAnimateOut) onAnimateOut();
+    return { isVisible: isOpen, shouldRender: isOpen };
+  },
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function Dispatcher() {
+  useGlobalEscapeDispatcher();
+  return null;
+}
+
+function renderPalette(props: { isOpen: boolean }) {
+  return render(
+    <>
+      <Dispatcher />
+      <AppPaletteDialog isOpen={props.isOpen} onClose={() => {}} ariaLabel="Test palette">
+        <input type="text" placeholder="Palette input" />
+      </AppPaletteDialog>
+    </>
+  );
+}
+
+describe("AppPaletteDialog focus restore", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    usePaletteStore.setState({ activePaletteId: null });
+    vi.useRealTimers();
+  });
+
+  it("falls back to first tabbable in #root when trigger was unmounted", async () => {
+    const root = document.createElement("div");
+    root.id = "root";
+    const fallbackButton = document.createElement("button");
+    fallbackButton.textContent = "Fallback";
+    root.appendChild(fallbackButton);
+    document.body.appendChild(root);
+
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { rerender } = renderPalette({ isOpen: true });
+    await act(() => vi.runAllTimersAsync());
+
+    document.body.removeChild(trigger);
+
+    rerender(
+      <>
+        <Dispatcher />
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+          <input type="text" placeholder="Palette input" />
+        </AppPaletteDialog>
+      </>
+    );
+
+    expect(document.activeElement).toBe(fallbackButton);
+    expect(document.activeElement).not.toBe(document.body);
+    document.body.removeChild(root);
+  });
+
+  it("skips focus restore when activePaletteId is set (palette handoff)", async () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { rerender } = renderPalette({ isOpen: true });
+    await act(() => vi.runAllTimersAsync());
+
+    // The next palette has taken over — we should NOT focus back into the trigger.
+    usePaletteStore.setState({ activePaletteId: "action" });
+
+    // Move focus elsewhere so we can prove restore did NOT happen.
+    const sentinel = document.createElement("input");
+    document.body.appendChild(sentinel);
+    sentinel.focus();
+    expect(document.activeElement).toBe(sentinel);
+
+    rerender(
+      <>
+        <Dispatcher />
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+          <input type="text" placeholder="Palette input" />
+        </AppPaletteDialog>
+      </>
+    );
+
+    // Focus stayed on the sentinel — no restore back to the original trigger.
+    expect(document.activeElement).toBe(sentinel);
+    expect(document.activeElement).not.toBe(trigger);
+
+    document.body.removeChild(sentinel);
+    document.body.removeChild(trigger);
+  });
+
+  it("restores to the original trigger when it is still mounted", async () => {
+    const trigger = document.createElement("button");
+    trigger.textContent = "Trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { rerender } = renderPalette({ isOpen: true });
+    await act(() => vi.runAllTimersAsync());
+
+    rerender(
+      <>
+        <Dispatcher />
+        <AppPaletteDialog isOpen={false} onClose={() => {}} ariaLabel="Test palette">
+          <input type="text" placeholder="Palette input" />
+        </AppPaletteDialog>
+      </>
+    );
+
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
+  });
+});

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfirmDialog } from "../ConfirmDialog";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+describe("ConfirmDialog destructive-label dev guard", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("warns when confirmLabel looks destructive but variant is default", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0]?.[0]).toContain("[ConfirmDialog]");
+    expect(errorSpy.mock.calls[0]?.[0]).toContain("Delete worktree");
+    expect(errorSpy.mock.calls[0]?.[0]).toContain('variant="default"');
+  });
+
+  it("is silent when variant is destructive", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when label does not look destructive", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Save?"
+        confirmLabel="Save changes"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("matches case-insensitively and tolerates leading whitespace", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Remove?"
+        confirmLabel="REMOVE recipe"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("is silent in production builds", () => {
+    vi.stubEnv("DEV", false);
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- When the element that opened a dialog was unmounted before the dialog closed, `restoreFocus` had no valid target and landed on `document.body`. This fixes that by storing the trigger in a per-instance ref and guarding the restore with `document.contains()`, falling back to `#root` if the trigger is gone.
- Palette handoff skip is preserved before the `contains` check so opening a palette from a dialog still bypasses the focus-restore path correctly.
- `ConfirmDialog` gets a DEV-only `console.error` when a destructive-variant button carries a non-destructive label (or vice versa), catching the mismatch during development.

Resolves #6441

## Changes

- `AppDialog.tsx` — per-instance `triggerRef`, `document.contains()` guard, `#root` fallback in `restoreFocus`
- `AppPaletteDialog.tsx` — same guard; palette-handoff skip preserved before contains-check; cleanup `useEffect` handles unmount-while-open so focus returns even if the normal close path never runs
- `ConfirmDialog.tsx` — DEV-gated warning for destructive-label / variant mismatch
- `AppDialog.test.tsx` — two new tests: detached-trigger fallback on close, cleanup-effect fallback on unmount-while-open
- `AppPaletteDialog.test.tsx` — new file, 4 tests covering the same edge cases
- `ConfirmDialog.test.tsx` — new file, 5 tests

**Why no shared LIFO focus stack?** Each `WebContentsView` already runs in its own V8 context, so focus is naturally scoped per window. A per-instance ref plus the `contains` check handles nested dialogs without any cross-instance coordination needed.

## Testing

- 18 targeted unit tests added, all passing
- Full `check` (typecheck, lint, format, build) clean