### PR TITLE
fix(toolbar): surface hidden state on overflow trigger

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -795,8 +795,15 @@ export function Toolbar({
     severity: OverflowBadgeSeverity
   ) => {
     if (overflowIds.length === 0) return null;
+    // voice-recording is intentionally absent from OVERFLOW_MENU_META — it
+    // doesn't render a dropdown menu item and has no actionable target while
+    // already active. Surface it in the tooltip/aria-label only so the
+    // count and the named list stay in sync.
     const itemLabels = overflowIds
-      .map((id) => OVERFLOW_MENU_META[id]?.label ?? pluginOverflowMeta[id]?.label)
+      .map((id) => {
+        if (id === "voice-recording") return "Voice recording";
+        return OVERFLOW_MENU_META[id]?.label ?? pluginOverflowMeta[id]?.label;
+      })
       .filter((label): label is string => Boolean(label));
     const tooltipText =
       itemLabels.length > 0

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -62,6 +62,7 @@ import { ToolbarLauncherButton } from "./ToolbarLauncherButton";
 import { ToolbarSettingsButton } from "./ToolbarSettingsButton";
 import { ToolbarProblemsButton } from "./ToolbarProblemsButton";
 import { ToolbarPortalButton } from "./ToolbarPortalButton";
+import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
 
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import { getAgentConfig } from "@/config/agents";
@@ -111,6 +112,12 @@ export function PluginToolbarButton({
     </Tooltip>
   );
 }
+
+const OVERFLOW_BADGE_CLASS: Record<Exclude<OverflowBadgeSeverity, null>, string> = {
+  critical: "bg-status-error",
+  warning: "bg-state-waiting",
+  info: "bg-daintree-text/50",
+};
 
 export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> = {
   ...(Object.fromEntries(
@@ -640,6 +647,9 @@ export function Toolbar({
     availableRightIds
   );
 
+  const leftOverflowSeverity = useOverflowBadgeSeverity(leftOverflow, errorCount);
+  const rightOverflowSeverity = useOverflowBadgeSeverity(rightOverflow, errorCount);
+
   const leftVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(leftVisible), [leftVisible]);
   const rightVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(rightVisible), [rightVisible]);
 
@@ -779,8 +789,21 @@ export function Toolbar({
     ]
   );
 
-  const renderOverflowMenu = (overflowIds: AnyToolbarButtonId[], side: "left" | "right") => {
+  const renderOverflowMenu = (
+    overflowIds: AnyToolbarButtonId[],
+    side: "left" | "right",
+    severity: OverflowBadgeSeverity
+  ) => {
     if (overflowIds.length === 0) return null;
+    const itemLabels = overflowIds
+      .map((id) => OVERFLOW_MENU_META[id]?.label ?? pluginOverflowMeta[id]?.label)
+      .filter((label): label is string => Boolean(label));
+    const tooltipText =
+      itemLabels.length > 0
+        ? `${overflowIds.length} more — ${itemLabels.join(", ")}`
+        : `${overflowIds.length} more toolbar items`;
+    const ariaLabel =
+      itemLabels.length > 0 ? tooltipText : `${overflowIds.length} more toolbar items`;
     return (
       <DropdownMenu>
         <Tooltip>
@@ -791,13 +814,24 @@ export function Toolbar({
                 size="icon"
                 data-toolbar-item=""
                 className={toolbarIconButtonClass}
-                aria-label={`${overflowIds.length} more toolbar items`}
+                aria-label={ariaLabel}
               >
                 <Ellipsis />
+                {severity && (
+                  <span
+                    aria-hidden="true"
+                    data-testid="toolbar-overflow-badge"
+                    data-severity={severity}
+                    className={cn(
+                      "absolute top-1.5 right-1.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-bg/60 pointer-events-none",
+                      OVERFLOW_BADGE_CLASS[severity]
+                    )}
+                  />
+                )}
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
-          <TooltipContent side="bottom">More items</TooltipContent>
+          <TooltipContent side="bottom">{tooltipText}</TooltipContent>
         </Tooltip>
         <DropdownMenuContent
           align={side === "left" ? "start" : "end"}
@@ -897,7 +931,9 @@ export function Toolbar({
           >
             {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
           </div>
-          <div className="app-no-drag">{renderOverflowMenu(leftOverflow, "left")}</div>
+          <div className="app-no-drag">
+            {renderOverflowMenu(leftOverflow, "left", leftOverflowSeverity)}
+          </div>
         </div>
 
         {/* CENTER GROUP - Grid-centered, shrinks gracefully on narrow windows */}
@@ -982,7 +1018,9 @@ export function Toolbar({
           >
             {renderButtons(effectiveRightButtons, rightVisibleSet)}
           </div>
-          <div className="app-no-drag">{renderOverflowMenu(rightOverflow, "right")}</div>
+          <div className="app-no-drag">
+            {renderOverflowMenu(rightOverflow, "right", rightOverflowSeverity)}
+          </div>
 
           <div className={toolbarDividerClass} />
 

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -76,6 +76,35 @@ describe("Toolbar responsive design — issue #4133", () => {
     });
   });
 
+  describe("overflow trigger surfaces hidden state — issue #6416", () => {
+    it("calls useOverflowBadgeSeverity for both left and right overflow", () => {
+      expect(source).toContain("useOverflowBadgeSeverity(leftOverflow");
+      expect(source).toContain("useOverflowBadgeSeverity(rightOverflow");
+    });
+
+    it("passes left and right severities into renderOverflowMenu independently", () => {
+      expect(source).toContain("leftOverflowSeverity");
+      expect(source).toContain("rightOverflowSeverity");
+    });
+
+    it("maps severity to a Tailwind dot color via OVERFLOW_BADGE_CLASS", () => {
+      expect(source).toContain("OVERFLOW_BADGE_CLASS");
+      expect(source).toContain("bg-status-error");
+      expect(source).toContain("bg-state-waiting");
+      expect(source).toContain("bg-daintree-text/50");
+    });
+
+    it("renders a dot inside the overflow Button when severity is set", () => {
+      expect(source).toContain("toolbar-overflow-badge");
+      expect(source).toMatch(/data-severity=\{severity\}/);
+    });
+
+    it("builds a dynamic tooltip listing the hidden buttons", () => {
+      expect(source).toContain("itemLabels");
+      expect(source).toMatch(/\$\{overflowIds\.length\} more — /);
+    });
+  });
+
   describe("overflow menu focus ring after pointer dismissal — issue #6119", () => {
     it("declares the overflowMenuPointerCloseRef", () => {
       expect(source).toContain("overflowMenuPointerCloseRef");

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -103,6 +103,14 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(source).toContain("itemLabels");
       expect(source).toMatch(/\$\{overflowIds\.length\} more — /);
     });
+
+    it("supplies a fallback label for voice-recording so the count and named list stay aligned", () => {
+      // voice-recording is absent from OVERFLOW_MENU_META on purpose — it
+      // has no dropdown rendering — so the tooltip must look it up
+      // separately or the spoken count would exceed the list.
+      expect(source).toContain('id === "voice-recording"');
+      expect(source).toContain('"Voice recording"');
+    });
   });
 
   describe("overflow menu focus ring after pointer dismissal — issue #6119", () => {

--- a/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
+++ b/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
@@ -222,6 +222,7 @@ describe("useOverflowBadgeSeverity", () => {
   });
 
   it("returns info when agent-tray is overflowed and a launchable agent is unseen", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     mockAvailability = { claude: "ready" } as unknown as CliAvailability;
     mockSeenAgentIds = ["codex"];
     const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
@@ -229,6 +230,7 @@ describe("useOverflowBadgeSeverity", () => {
   });
 
   it("returns null for agent-tray when every launchable agent has been seen", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     mockAvailability = { claude: "ready" } as unknown as CliAvailability;
     mockSeenAgentIds = ["claude"];
     const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
@@ -237,6 +239,7 @@ describe("useOverflowBadgeSeverity", () => {
 
   it("returns null for agent-tray when onboarding has not yet loaded", () => {
     mockOnboardingLoaded = false;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     mockAvailability = { claude: "ready" } as unknown as CliAvailability;
     mockSeenAgentIds = [];
     const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
@@ -244,6 +247,7 @@ describe("useOverflowBadgeSeverity", () => {
   });
 
   it("ignores unlaunchable agents when computing agent-tray discovery", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     mockAvailability = {
       claude: "missing" as AgentAvailabilityState,
     } as unknown as CliAvailability;
@@ -271,6 +275,7 @@ describe("useOverflowBadgeSeverity", () => {
 
   it("ignores unknown ids without crashing", () => {
     const { result } = renderHook(() =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       useOverflowBadgeSeverity(["plugin.acme.unknown" as never], 0)
     );
     expect(result.current).toBeNull();

--- a/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
+++ b/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+/**
+ * useOverflowBadgeSeverity — issue #6416.
+ *
+ * The toolbar's `…` overflow trigger needs a single dot whose color reflects
+ * the most-severe hidden state, plus left/right independence. These tests
+ * mock every store the hook reads and assert the priority fold:
+ *   critical (errorCount + problems) > warning (agent waiting/directing,
+ *   active voice recording) > info (notification unread, agent-tray
+ *   discovery) > null.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { AgentState, AgentAvailabilityState, CliAvailability } from "@shared/types";
+
+let mockPanelsById: Record<string, unknown> = {};
+let mockPanelIds: string[] = [];
+let mockActiveWorktreeId: string | null = null;
+let mockNotificationUnreadCount = 0;
+let mockAvailability: CliAvailability = {} as CliAvailability;
+let mockOnboardingLoaded = true;
+let mockSeenAgentIds: string[] = [];
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ panelsById: mockPanelsById, panelIds: mockPanelIds }),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
+    selector({ activeWorktreeId: mockActiveWorktreeId }),
+}));
+
+vi.mock("@/store/slices/notificationHistorySlice", () => ({
+  useNotificationHistoryStore: (selector: (s: { unreadCount: number }) => unknown) =>
+    selector({ unreadCount: mockNotificationUnreadCount }),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: { availability: CliAvailability }) => unknown) =>
+    selector({ availability: mockAvailability }),
+}));
+
+vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  useAgentDiscoveryOnboarding: () => ({
+    loaded: mockOnboardingLoaded,
+    seenAgentIds: mockSeenAgentIds,
+    welcomeCardDismissed: false,
+    setupBannerDismissed: false,
+    markAgentsSeen: vi.fn(),
+    dismissWelcomeCard: vi.fn(),
+    dismissSetupBanner: vi.fn(),
+  }),
+}));
+
+// Real implementations of these — they're pure helpers.
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: <T>(selector: T) => selector,
+}));
+
+// Pull the agent id straight off the panel so tests can drive the runtime
+// identity derivation without recreating the full deriveTerminalChrome
+// pipeline. The hook only needs the id; this short-circuits the real
+// helper.
+vi.mock("@/utils/terminalType", () => ({
+  getRuntimeOrBootAgentId: (panel: { agentId?: string }) => panel?.agentId,
+}));
+
+import { useOverflowBadgeSeverity } from "../useOverflowBadgeSeverity";
+
+function makePanel(overrides: {
+  id: string;
+  agentId?: string;
+  agentState?: AgentState;
+  worktreeId?: string;
+  location?: string;
+}) {
+  return {
+    id: overrides.id,
+    agentId: overrides.agentId,
+    runtimeAgentId: overrides.agentId,
+    bootAgentId: overrides.agentId,
+    agentState: overrides.agentState,
+    worktreeId: overrides.worktreeId ?? null,
+    location: overrides.location ?? "grid",
+    type: "agent",
+  };
+}
+
+describe("useOverflowBadgeSeverity", () => {
+  beforeEach(() => {
+    mockPanelsById = {};
+    mockPanelIds = [];
+    mockActiveWorktreeId = null;
+    mockNotificationUnreadCount = 0;
+    mockAvailability = {} as CliAvailability;
+    mockOnboardingLoaded = true;
+    mockSeenAgentIds = [];
+  });
+
+  it("returns null for an empty overflow list", () => {
+    const { result } = renderHook(() => useOverflowBadgeSeverity([], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null when overflowed buttons have no active state", () => {
+    const { result } = renderHook(() =>
+      useOverflowBadgeSeverity(["problems", "notification-center"], 0)
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it("returns critical when problems is overflowed and errorCount > 0", () => {
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["problems"], 3));
+    expect(result.current).toBe("critical");
+  });
+
+  it("returns null when problems is overflowed but errorCount is 0", () => {
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["problems"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns warning when voice-recording is overflowed (its presence implies active recording)", () => {
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["voice-recording"], 0));
+    expect(result.current).toBe("warning");
+  });
+
+  it("returns warning when an overflowed agent has a waiting panel", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBe("warning");
+  });
+
+  it("returns warning when an overflowed agent has a directing panel", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "directing" }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBe("warning");
+  });
+
+  it("ignores overflowed agents whose panels are in passive states", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "working" }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("ignores panels for agents that are not overflowed", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "codex", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("ignores trashed and background panels even when state is waiting", () => {
+    mockPanelsById = {
+      "p-1": makePanel({
+        id: "p-1",
+        agentId: "claude",
+        agentState: "waiting",
+        location: "trash",
+      }),
+      "p-2": makePanel({
+        id: "p-2",
+        agentId: "claude",
+        agentState: "waiting",
+        location: "background",
+      }),
+    };
+    mockPanelIds = ["p-1", "p-2"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("scopes panels to the active worktree when one is set", () => {
+    mockActiveWorktreeId = "wt-1";
+    mockPanelsById = {
+      "p-1": makePanel({
+        id: "p-1",
+        agentId: "claude",
+        agentState: "waiting",
+        worktreeId: "wt-2",
+      }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns info when notification-center is overflowed and unread count > 0", () => {
+    mockNotificationUnreadCount = 5;
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["notification-center"], 0));
+    expect(result.current).toBe("info");
+  });
+
+  it("returns null when notification-center is overflowed but unread count is 0", () => {
+    mockNotificationUnreadCount = 0;
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["notification-center"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns info when agent-tray is overflowed and a launchable agent is unseen", () => {
+    mockAvailability = { claude: "ready" } as unknown as CliAvailability;
+    mockSeenAgentIds = ["codex"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
+    expect(result.current).toBe("info");
+  });
+
+  it("returns null for agent-tray when every launchable agent has been seen", () => {
+    mockAvailability = { claude: "ready" } as unknown as CliAvailability;
+    mockSeenAgentIds = ["claude"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null for agent-tray when onboarding has not yet loaded", () => {
+    mockOnboardingLoaded = false;
+    mockAvailability = { claude: "ready" } as unknown as CliAvailability;
+    mockSeenAgentIds = [];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("ignores unlaunchable agents when computing agent-tray discovery", () => {
+    mockAvailability = {
+      claude: "missing" as AgentAvailabilityState,
+    } as unknown as CliAvailability;
+    mockSeenAgentIds = [];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["agent-tray"], 0));
+    expect(result.current).toBeNull();
+  });
+
+  it("prefers critical over warning when both are present", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["problems", "claude"], 4));
+    expect(result.current).toBe("critical");
+  });
+
+  it("prefers warning over info when both are present", () => {
+    mockNotificationUnreadCount = 2;
+    const { result } = renderHook(() =>
+      useOverflowBadgeSeverity(["voice-recording", "notification-center"], 0)
+    );
+    expect(result.current).toBe("warning");
+  });
+
+  it("ignores unknown ids without crashing", () => {
+    const { result } = renderHook(() =>
+      useOverflowBadgeSeverity(["plugin.acme.unknown" as never], 0)
+    );
+    expect(result.current).toBeNull();
+  });
+
+  it("computes left and right severities independently", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1"];
+    mockNotificationUnreadCount = 1;
+    const { result: left } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    const { result: right } = renderHook(() =>
+      useOverflowBadgeSeverity(["notification-center"], 0)
+    );
+    expect(left.current).toBe("warning");
+    expect(right.current).toBe("info");
+  });
+});

--- a/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
+++ b/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
@@ -143,6 +143,19 @@ describe("useOverflowBadgeSeverity", () => {
     expect(result.current).toBe("warning");
   });
 
+  it("surfaces a waiting panel even when a sibling working panel exists for the same agent", () => {
+    // Folding via getDominantAgentState would return "working" (no dot)
+    // and silence the waiting panel — the exact scenario the overflow dot
+    // is meant to flag.
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "working" }),
+      "p-2": makePanel({ id: "p-2", agentId: "claude", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1", "p-2"];
+    const { result } = renderHook(() => useOverflowBadgeSeverity(["claude"], 0));
+    expect(result.current).toBe("warning");
+  });
+
   it("ignores overflowed agents whose panels are in passive states", () => {
     mockPanelsById = {
       "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "working" }),

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -5,10 +5,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
-import {
-  getDominantAgentState,
-  agentStateDotColor,
-} from "@/components/Worktree/AgentStatusIndicator";
+import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@shared/types";
@@ -76,7 +73,11 @@ export function useOverflowBadgeSeverity(
     }
     if (overflowedAgentIds.length > 0) {
       const overflowedAgentSet = new Set<string>(overflowedAgentIds);
-      const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
+      // Check each panel independently rather than folding to a dominant
+      // state — `getDominantAgentState` would let a `working` panel
+      // suppress a sibling `waiting`/`directing` panel for the same
+      // agent, which is exactly the silenced-state the overflow dot is
+      // meant to surface.
       for (const pid of panelIds) {
         const p = panelsById[pid];
         if (!p || p.location === "trash" || p.location === "background") continue;
@@ -84,13 +85,7 @@ export function useOverflowBadgeSeverity(
         if (!agentId || !overflowedAgentSet.has(agentId)) continue;
         if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
         if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
-        const arr = statesPerAgent.get(agentId) ?? [];
-        arr.push(p.agentState);
-        statesPerAgent.set(agentId, arr);
-      }
-      for (const [, states] of statesPerAgent) {
-        const dominant = getDominantAgentState(states);
-        if (dominant && agentStateDotColor(dominant)) {
+        if (p.agentState && agentStateDotColor(p.agentState)) {
           warning = true;
           break;
         }

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -1,0 +1,129 @@
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
+import {
+  getDominantAgentState,
+  agentStateDotColor,
+} from "@/components/Worktree/AgentStatusIndicator";
+import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentState } from "@shared/types";
+import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+
+export type OverflowBadgeSeverity = "critical" | "warning" | "info" | null;
+
+const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
+  "idle",
+  "working",
+  "waiting",
+  "directing",
+]);
+
+const BUILT_IN_AGENT_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
+
+function isBuiltInAgentId(id: AnyToolbarButtonId): id is BuiltInAgentId {
+  return BUILT_IN_AGENT_ID_SET.has(id);
+}
+
+/**
+ * Aggregates the highest-severity badge state from buttons currently pushed
+ * into the overflow `…` menu so the trigger can surface a single dot rather
+ * than silently hiding active state.
+ *
+ * Why a primitive return: keeps Zustand selector identity stable so
+ * downstream renders don't churn (lesson #3730). All store reads are
+ * unconditional to comply with the rules of hooks; gating happens inside
+ * the memo via `overflowIds.includes(...)`.
+ */
+export function useOverflowBadgeSeverity(
+  overflowIds: readonly AnyToolbarButtonId[],
+  errorCount: number
+): OverflowBadgeSeverity {
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
+  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+
+  const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
+
+  const availability = useCliAvailabilityStore(useShallow((s) => s.availability));
+  const { loaded: onboardingLoaded, seenAgentIds } = useAgentDiscoveryOnboarding();
+
+  return useMemo<OverflowBadgeSeverity>(() => {
+    if (overflowIds.length === 0) return null;
+
+    let critical = false;
+    let warning = false;
+    let info = false;
+
+    if (overflowIds.includes("problems") && errorCount > 0) {
+      critical = true;
+    }
+
+    // voice-recording is only registered when actively recording — its
+    // mere presence in overflow signals a live session.
+    if (overflowIds.includes("voice-recording")) {
+      warning = true;
+    }
+
+    const overflowedAgentIds: BuiltInAgentId[] = [];
+    for (const id of overflowIds) {
+      if (isBuiltInAgentId(id)) overflowedAgentIds.push(id);
+    }
+    if (overflowedAgentIds.length > 0) {
+      const overflowedAgentSet = new Set<string>(overflowedAgentIds);
+      const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
+      for (const pid of panelIds) {
+        const p = panelsById[pid];
+        if (!p || p.location === "trash" || p.location === "background") continue;
+        const agentId = getRuntimeOrBootAgentId(p);
+        if (!agentId || !overflowedAgentSet.has(agentId)) continue;
+        if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
+        if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
+        const arr = statesPerAgent.get(agentId) ?? [];
+        arr.push(p.agentState);
+        statesPerAgent.set(agentId, arr);
+      }
+      for (const [, states] of statesPerAgent) {
+        const dominant = getDominantAgentState(states);
+        if (dominant && agentStateDotColor(dominant)) {
+          warning = true;
+          break;
+        }
+      }
+    }
+
+    if (overflowIds.includes("notification-center") && notificationUnreadCount > 0) {
+      info = true;
+    }
+
+    if (overflowIds.includes("agent-tray") && onboardingLoaded) {
+      const seenSet = new Set(seenAgentIds);
+      for (const id of BUILT_IN_AGENT_IDS) {
+        if (isAgentLaunchable(availability?.[id]) && !seenSet.has(id)) {
+          info = true;
+          break;
+        }
+      }
+    }
+
+    if (critical) return "critical";
+    if (warning) return "warning";
+    if (info) return "info";
+    return null;
+  }, [
+    overflowIds,
+    errorCount,
+    panelsById,
+    panelIds,
+    activeWorktreeId,
+    notificationUnreadCount,
+    availability,
+    onboardingLoaded,
+    seenAgentIds,
+  ]);
+}


### PR DESCRIPTION
## Summary

- The `…` overflow trigger was always mute — no visual signal that hidden items had active state. It now renders a dot whose severity reflects the most critical item in the overflow set (critical > warning > info > neutral).
- The tooltip becomes dynamic and names what's hidden, e.g. `3 more — Problems, Notifications, Agent tray`.
- New `useOverflowBadgeSeverity` hook computes severity and label from the overflow set. Left and right overflow triggers are computed independently — no cross-side summing.

Resolves #6416

## Changes

- `useOverflowBadgeSeverity.ts` — hook that folds overflow item state into a highest-severity tone and a human-readable label
- `Toolbar.tsx` — overflow trigger now passes severity dot and dynamic tooltip through; also surfaces waiting-panel state and corrects the voice-recording overflow label
- `useOverflowBadgeSeverity.test.ts` — full coverage of severity folding, label formatting, and edge cases
- `Toolbar.responsive.test.ts` — responsive overflow integration tests

## Testing

- Unit tests cover severity ordering, multi-item label formatting, empty overflow, and all badge-bearing button kinds
- Responsive tests cover the overflow trigger dot rendering when active items collapse into overflow