### PR TITLE
feat(panel-tabs): replace chevron-scroll tab overflow with Priority+ menu

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -106,7 +106,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Track when popover was just programmatically opened
   const wasJustOpenedRef = useRef(false);
   const prevIsOpenRef = useRef(isOpen);
-  const tabListRef = useRef<HTMLDivElement>(null);
+  const [tabListEl, setTabListEl] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     prevIsOpenRef.current = isOpen;
@@ -303,7 +303,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Tab IDs for sortable context
   const tabIds = useMemo(() => panels.map((p) => p.id), [panels]);
 
-  const hiddenTabIds = useTabOverflow(tabListRef, tabIds);
+  const hiddenTabIds = useTabOverflow(tabListEl, tabIds);
 
   // Handle tab reorder drag end
   const handleTabDragEnd = useCallback(
@@ -363,13 +363,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       if (nextPanel) {
         handleTabClick(nextPanel.id);
         // Focus the new tab button
-        const tabButton = tabListRef.current?.querySelector(
+        const tabButton = tabListEl?.querySelector(
           `[data-tab-id="${nextPanel.id}"]`
         ) as HTMLElement | null;
         tabButton?.focus();
       }
     },
-    [panels, activeTabId, handleTabClick]
+    [panels, activeTabId, handleTabClick, tabListEl]
   );
 
   // Handle add tab - duplicate the current panel as a new tab
@@ -583,7 +583,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 <LayoutGroup id={`dock-tabs-${group.id}`}>
                   <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
                     <div
-                      ref={tabListRef}
+                      ref={setTabListEl}
                       className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
                       role="tablist"
                       aria-label="Dock panel tabs"

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -13,10 +13,17 @@ import {
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { LayoutGroup, LazyMotion, domMax } from "framer-motion";
-import { Plus } from "lucide-react";
+import { ChevronDown, Plus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { logError } from "@/utils/logger";
+import { useTabOverflow } from "@/hooks";
 import {
   useTerminalInputStore,
   usePanelStore,
@@ -296,6 +303,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Tab IDs for sortable context
   const tabIds = useMemo(() => panels.map((p) => p.id), [panels]);
 
+  const hiddenTabIds = useTabOverflow(tabListRef, tabIds);
+
   // Handle tab reorder drag end
   const handleTabDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -572,61 +581,123 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
               <LazyMotion features={domMax}>
                 <LayoutGroup id={`dock-tabs-${group.id}`}>
-                  <div
-                    ref={tabListRef}
-                    className="flex items-center border-b border-divider bg-daintree-sidebar shrink-0"
-                    role="tablist"
-                    aria-label="Dock panel tabs"
-                    onKeyDown={handleTabListKeyDown}
-                  >
-                    {panels.map((panel) => {
-                      const tabChrome = deriveTerminalChrome({
-                        kind: panel.kind,
-                        launchAgentId: panel.launchAgentId,
-                        runtimeIdentity: panel.runtimeIdentity,
-                        detectedAgentId: panel.detectedAgentId,
-                        detectedProcessId: panel.detectedProcessId,
-                        agentState: panel.agentState,
-                        runtimeStatus: panel.runtimeStatus,
-                        exitCode: panel.exitCode,
-                        presetColor: panelPresetColors.get(panel.id),
-                      });
-                      return (
-                        <SortableTabButton
-                          key={panel.id}
-                          id={panel.id}
-                          title={getBaseTitle(panel.title)}
-                          chrome={tabChrome}
-                          kind={panel.kind ?? "terminal"}
-                          agentState={
-                            tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
-                          }
-                          isActive={panel.id === activeTabId}
-                          presetColor={panelPresetColors.get(panel.id)}
-                          isUsingFallback={panel.isUsingFallback}
-                          onClick={() => handleTabClick(panel.id)}
-                          onClose={() => handleTabClose(panel.id)}
-                          onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
-                        />
-                      );
-                    })}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleAddTab();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
-                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                          aria-label="Duplicate panel as new tab"
-                          type="button"
+                  <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
+                    <div
+                      ref={tabListRef}
+                      className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
+                      role="tablist"
+                      aria-label="Dock panel tabs"
+                      onKeyDown={handleTabListKeyDown}
+                    >
+                      {panels.map((panel) => {
+                        const tabChrome = deriveTerminalChrome({
+                          kind: panel.kind,
+                          launchAgentId: panel.launchAgentId,
+                          runtimeIdentity: panel.runtimeIdentity,
+                          detectedAgentId: panel.detectedAgentId,
+                          detectedProcessId: panel.detectedProcessId,
+                          agentState: panel.agentState,
+                          runtimeStatus: panel.runtimeStatus,
+                          exitCode: panel.exitCode,
+                          presetColor: panelPresetColors.get(panel.id),
+                        });
+                        return (
+                          <SortableTabButton
+                            key={panel.id}
+                            id={panel.id}
+                            title={getBaseTitle(panel.title)}
+                            chrome={tabChrome}
+                            kind={panel.kind ?? "terminal"}
+                            agentState={
+                              tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
+                            }
+                            isActive={panel.id === activeTabId}
+                            presetColor={panelPresetColors.get(panel.id)}
+                            isUsingFallback={panel.isUsingFallback}
+                            onClick={() => handleTabClick(panel.id)}
+                            onClose={() => handleTabClose(panel.id)}
+                            onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                          />
+                        );
+                      })}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleAddTab();
+                            }}
+                            onPointerDown={(e) => e.stopPropagation()}
+                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                            aria-label="Duplicate panel as new tab"
+                            type="button"
+                          >
+                            <Plus className="w-3 h-3" aria-hidden="true" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                      </Tooltip>
+                    </div>
+                    {hiddenTabIds.size > 0 && (
+                      <DropdownMenu>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                type="button"
+                                onPointerDown={(e) => e.stopPropagation()}
+                                className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                                aria-label="Show hidden tabs"
+                                aria-haspopup="menu"
+                                data-testid="dock-tabs-overflow"
+                              >
+                                <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                                <span className="sr-only"> ({hiddenTabIds.size} hidden)</span>
+                              </button>
+                            </DropdownMenuTrigger>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
+                        </Tooltip>
+                        <DropdownMenuContent
+                          align="end"
+                          className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
                         >
-                          <Plus className="w-3 h-3" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
-                    </Tooltip>
+                          {panels
+                            .filter((p) => hiddenTabIds.has(p.id))
+                            .map((panel) => {
+                              const tabChrome = deriveTerminalChrome({
+                                kind: panel.kind,
+                                launchAgentId: panel.launchAgentId,
+                                runtimeIdentity: panel.runtimeIdentity,
+                                detectedAgentId: panel.detectedAgentId,
+                                detectedProcessId: panel.detectedProcessId,
+                                agentState: panel.agentState,
+                                runtimeStatus: panel.runtimeStatus,
+                                exitCode: panel.exitCode,
+                                presetColor: panelPresetColors.get(panel.id),
+                              });
+                              const isActive = panel.id === activeTabId;
+                              return (
+                                <DropdownMenuItem
+                                  key={panel.id}
+                                  onSelect={() => handleTabClick(panel.id)}
+                                  aria-current={isActive ? "true" : undefined}
+                                  className={cn(isActive && "font-medium")}
+                                >
+                                  <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
+                                    <TerminalIcon
+                                      kind={panel.kind ?? "terminal"}
+                                      chrome={tabChrome}
+                                      className="w-3.5 h-3.5"
+                                    />
+                                  </span>
+                                  <span className="truncate">{getBaseTitle(panel.title)}</span>
+                                </DropdownMenuItem>
+                              );
+                            })}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
                   </div>
                 </LayoutGroup>
               </LazyMotion>

--- a/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
@@ -56,6 +56,12 @@ vi.mock("@/store", () => ({
     selector({ showDockAgentHighlights: false }),
 }));
 
+let mockHiddenTabIds: ReadonlySet<string> = new Set();
+
+vi.mock("@/hooks", () => ({
+  useTabOverflow: () => mockHiddenTabIds,
+}));
+
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
     selector({ settings: null }),
@@ -144,6 +150,27 @@ vi.mock("@/components/Panel/SortableTabButton", () => ({
   SortableTabButton: ({ id, onClose }: { id: string; onClose: () => void }) => (
     <button data-testid={`close-${id}`} onClick={onClose}>
       close {id}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dock-overflow-menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    [key: string]: unknown;
+  }) => (
+    <button {...rest} onClick={() => onSelect?.(new Event("select"))}>
+      {children}
     </button>
   ),
 }));
@@ -239,6 +266,7 @@ describe("DockedTabGroup close guard (#6330)", () => {
     mockActiveDockTerminalId = null;
     mockTabGroups = new Map();
     mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+    mockHiddenTabIds = new Set();
   });
 
   it("closes immediately when the tab's agent is idle", () => {
@@ -332,5 +360,68 @@ describe("DockedTabGroup close guard (#6330)", () => {
     fireEvent.click(getByTestId("dialog-cancel"));
 
     expect(openDockTerminalMock).toHaveBeenCalledWith("t-1");
+  });
+});
+
+describe("DockedTabGroup tab overflow menu (#6429)", () => {
+  beforeEach(() => {
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    setFocusedMock.mockClear();
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    mockActiveDockTerminalId = null;
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2", "t-3"]));
+    mockHiddenTabIds = new Set();
+  });
+
+  it("does not render the overflow trigger when no dock tabs are hidden", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+    const { queryByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+    expect(queryByTestId("dock-tabs-overflow")).toBeNull();
+  });
+
+  it("renders the overflow trigger when dock tabs are hidden", () => {
+    mockHiddenTabIds = new Set(["t-3"]);
+    const panels = [
+      makePanel({ id: "t-1", title: "Alpha", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", title: "Beta", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-3", title: "Gamma", agentState: "idle" as AgentState }),
+    ];
+    const { getByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
+    );
+    const trigger = getByTestId("dock-tabs-overflow");
+    expect(trigger.getAttribute("aria-label")).toBe("Show hidden tabs");
+    expect(trigger.getAttribute("aria-haspopup")).toBe("menu");
+    const menu = getByTestId("dock-overflow-menu");
+    expect(menu.textContent).toContain("Gamma");
+    expect(menu.textContent).not.toContain("Alpha");
+  });
+
+  it("activates and focuses a hidden dock tab when its menu item is selected", () => {
+    mockHiddenTabIds = new Set(["t-3"]);
+    const panels = [
+      makePanel({ id: "t-1", title: "Alpha", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", title: "Beta", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-3", title: "Gamma", agentState: "idle" as AgentState }),
+    ];
+    const { getByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
+    );
+    const menu = getByTestId("dock-overflow-menu");
+    const item = Array.from(menu.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Gamma")
+    );
+    item?.click();
+    expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-3");
+    expect(setFocusedMock).toHaveBeenCalledWith("t-3");
+    expect(openDockTerminalMock).toHaveBeenCalledWith("t-3");
   });
 });

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -362,33 +362,32 @@ function PanelHeaderComponent({
   };
 
   const hasTabs = tabs && tabs.length > 1;
-  const tabListRef = useRef<HTMLDivElement>(null);
+  const [tabListEl, setTabListEl] = useState<HTMLDivElement | null>(null);
   const canReorderTabs = hasTabs && !!onTabReorder && !!groupId;
   const tabIds = tabs?.map((t) => t.id) ?? [];
 
-  const hiddenTabIds = useTabOverflow(tabListRef, tabIds);
+  const hiddenTabIds = useTabOverflow(tabListEl, tabIds);
   const hiddenTabs = tabs?.filter((t) => hiddenTabIds.has(t.id)) ?? [];
 
   const activeTabId = tabs?.find((t) => t.isActive)?.id ?? null;
 
   useLayoutEffect(() => {
-    const container = tabListRef.current;
-    if (!container || !activeTabId || isDragging) return;
+    if (!tabListEl || !activeTabId || isDragging) return;
 
-    const tabEl = container.querySelector(`[data-tab-id="${activeTabId}"]`) as HTMLElement | null;
+    const tabEl = tabListEl.querySelector(`[data-tab-id="${activeTabId}"]`) as HTMLElement | null;
     if (!tabEl) return;
 
-    const containerLeft = container.scrollLeft;
-    const containerRight = containerLeft + container.clientWidth;
+    const containerLeft = tabListEl.scrollLeft;
+    const containerRight = containerLeft + tabListEl.clientWidth;
     const tabLeft = tabEl.offsetLeft;
     const tabRight = tabLeft + tabEl.offsetWidth;
 
     if (tabLeft < containerLeft) {
-      container.scrollTo({ left: tabLeft, behavior: "smooth" });
+      tabListEl.scrollTo({ left: tabLeft, behavior: "smooth" });
     } else if (tabRight > containerRight) {
-      container.scrollTo({ left: tabRight - container.clientWidth, behavior: "smooth" });
+      tabListEl.scrollTo({ left: tabRight - tabListEl.clientWidth, behavior: "smooth" });
     }
-  }, [activeTabId, isDragging]);
+  }, [activeTabId, isDragging, tabListEl]);
 
   // Sensors for tab drag-and-drop (require small distance to differentiate from clicks)
   const tabSensors = useSensors(
@@ -451,13 +450,13 @@ function PanelHeaderComponent({
       if (nextTab) {
         onTabClick(nextTab.id);
         // Focus the new tab button
-        const tabButton = tabListRef.current?.querySelector(
+        const tabButton = tabListEl?.querySelector(
           `[data-tab-id="${nextTab.id}"]`
         ) as HTMLElement | null;
         tabButton?.focus();
       }
     },
-    [tabs, onTabClick]
+    [tabs, onTabClick, tabListEl]
   );
 
   const overflowTrigger = hiddenTabs.length > 0 && (
@@ -554,7 +553,7 @@ function PanelHeaderComponent({
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
               <div className="relative min-w-0 flex-1 flex">
                 <div
-                  ref={tabListRef}
+                  ref={setTabListEl}
                   className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
                   role="tablist"
                   aria-label="Panel tabs"
@@ -618,7 +617,7 @@ function PanelHeaderComponent({
         ) : (
           <div className="relative min-w-0 flex-1 flex">
             <div
-              ref={tabListRef}
+              ref={setTabListEl}
               className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
               role="tablist"
               aria-label="Panel tabs"

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -16,8 +16,7 @@ import {
   Plus,
   Bell,
   BellOff,
-  ChevronLeft,
-  ChevronRight,
+  ChevronDown,
   CopyPlus,
   Ellipsis,
   Lock,
@@ -47,11 +46,7 @@ import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { BellDot, FolderGit2 } from "@/components/icons";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
-import {
-  useBackgroundPanelStats,
-  useHorizontalScrollControls,
-  useKeybindingDisplay,
-} from "@/hooks";
+import { useBackgroundPanelStats, useKeybindingDisplay, useTabOverflow } from "@/hooks";
 import { usePanelStore } from "@/store/panelStore";
 import {
   DropdownMenu,
@@ -371,12 +366,8 @@ function PanelHeaderComponent({
   const canReorderTabs = hasTabs && !!onTabReorder && !!groupId;
   const tabIds = tabs?.map((t) => t.id) ?? [];
 
-  const {
-    canScrollLeft: tabsCanScrollLeft,
-    canScrollRight: tabsCanScrollRight,
-    scrollLeft: tabsScrollLeft,
-    scrollRight: tabsScrollRight,
-  } = useHorizontalScrollControls(tabListRef);
+  const hiddenTabIds = useTabOverflow(tabListRef, tabIds);
+  const hiddenTabs = tabs?.filter((t) => hiddenTabIds.has(t.id)) ?? [];
 
   const activeTabId = tabs?.find((t) => t.isActive)?.id ?? null;
 
@@ -469,13 +460,51 @@ function PanelHeaderComponent({
     [tabs, onTabClick]
   );
 
-  const tabFadeFrom = isMaximized
-    ? "from-daintree-sidebar"
-    : location === "dock"
-      ? "from-surface"
-      : isFocused
-        ? "from-overlay-subtle"
-        : "from-surface";
+  const overflowTrigger = hiddenTabs.length > 0 && (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+              aria-label="Show hidden tabs"
+              aria-haspopup="menu"
+              data-testid="panel-tabs-overflow"
+            >
+              <ChevronDown className="w-3 h-3" aria-hidden="true" />
+              <span className="sr-only"> ({hiddenTabs.length} hidden)</span>
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="end"
+        className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+      >
+        {hiddenTabs.map((tab) => (
+          <DropdownMenuItem
+            key={tab.id}
+            onSelect={() => onTabClick?.(tab.id)}
+            aria-current={tab.isActive ? "true" : undefined}
+            className={cn(tab.isActive && "font-medium")}
+          >
+            <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
+              <TerminalIcon
+                kind={tab.kind}
+                chrome={tab.chrome}
+                className="w-3.5 h-3.5"
+                brandColor={tab.presetColor ?? tab.chrome.color}
+              />
+            </span>
+            <span className="truncate">{getBaseTitle(tab.title)}</span>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 
   return (
     <div
@@ -524,24 +553,6 @@ function PanelHeaderComponent({
           >
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
               <div className="relative min-w-0 flex-1 flex">
-                {tabsCanScrollLeft && (
-                  <div
-                    className={cn(
-                      "absolute left-0 inset-y-0 w-8 pointer-events-none z-10 bg-gradient-to-r to-transparent flex items-center",
-                      tabFadeFrom
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={tabsScrollLeft}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="pointer-events-auto p-1 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                      aria-label="Scroll left"
-                    >
-                      <ChevronLeft className="w-3 h-3" aria-hidden="true" />
-                    </button>
-                  </div>
-                )}
                 <div
                   ref={tabListRef}
                   className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
@@ -600,47 +611,12 @@ function PanelHeaderComponent({
                     </LayoutGroup>
                   </LazyMotion>
                 </div>
-                {tabsCanScrollRight && (
-                  <div
-                    className={cn(
-                      "absolute right-0 inset-y-0 w-8 pointer-events-none z-10 bg-gradient-to-l to-transparent flex items-center justify-end",
-                      tabFadeFrom
-                    )}
-                  >
-                    <button
-                      type="button"
-                      onClick={tabsScrollRight}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="pointer-events-auto p-1 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                      aria-label="Scroll right"
-                    >
-                      <ChevronRight className="w-3 h-3" aria-hidden="true" />
-                    </button>
-                  </div>
-                )}
+                {overflowTrigger}
               </div>
             </SortableContext>
           </DndContext>
         ) : (
           <div className="relative min-w-0 flex-1 flex">
-            {tabsCanScrollLeft && (
-              <div
-                className={cn(
-                  "absolute left-0 inset-y-0 w-8 pointer-events-none z-10 bg-gradient-to-r to-transparent flex items-center",
-                  tabFadeFrom
-                )}
-              >
-                <button
-                  type="button"
-                  onClick={tabsScrollLeft}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  className="pointer-events-auto p-1 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                  aria-label="Scroll left"
-                >
-                  <ChevronLeft className="w-3 h-3" aria-hidden="true" />
-                </button>
-              </div>
-            )}
             <div
               ref={tabListRef}
               className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
@@ -699,24 +675,7 @@ function PanelHeaderComponent({
                 </LayoutGroup>
               </LazyMotion>
             </div>
-            {tabsCanScrollRight && (
-              <div
-                className={cn(
-                  "absolute right-0 inset-y-0 w-8 pointer-events-none z-10 bg-gradient-to-l to-transparent flex items-center justify-end",
-                  tabFadeFrom
-                )}
-              >
-                <button
-                  type="button"
-                  onClick={tabsScrollRight}
-                  onPointerDown={(e) => e.stopPropagation()}
-                  className="pointer-events-auto p-1 text-daintree-text/60 hover:text-daintree-text transition-colors"
-                  aria-label="Scroll right"
-                >
-                  <ChevronRight className="w-3 h-3" aria-hidden="true" />
-                </button>
-              </div>
-            )}
+            {overflowTrigger}
           </div>
         )
       ) : (

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -37,19 +37,11 @@ vi.mock("framer-motion", () => {
   };
 });
 
-const mockScrollLeft = vi.fn();
-const mockScrollRight = vi.fn();
-let mockScrollControls = {
-  isOverflowing: false,
-  canScrollLeft: false,
-  canScrollRight: false,
-  scrollLeft: mockScrollLeft,
-  scrollRight: mockScrollRight,
-};
+let mockHiddenTabIds: ReadonlySet<string> = new Set();
 
 vi.mock("@/hooks", () => ({
   useBackgroundPanelStats: () => ({ activeCount: 0, workingCount: 0 }),
-  useHorizontalScrollControls: () => mockScrollControls,
+  useTabOverflow: () => mockHiddenTabIds,
   useKeybindingDisplay: () => "",
 }));
 
@@ -124,8 +116,17 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     onOpenChange?: (open: boolean) => void;
   }) => <div>{children}</div>,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="overflow-menu">{children}</div>
+  DropdownMenuContent: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    align?: string;
+  }) => (
+    <div data-testid="overflow-menu" className={className}>
+      {children}
+    </div>
   ),
   DropdownMenuItem: ({
     children,
@@ -180,13 +181,7 @@ describe("PanelHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockHasPty = false;
-    mockScrollControls = {
-      isOverflowing: false,
-      canScrollLeft: false,
-      canScrollRight: false,
-      scrollLeft: mockScrollLeft,
-      scrollRight: mockScrollRight,
-    };
+    mockHiddenTabIds = new Set();
     mockStoreState = {
       watchedPanels: new Set<string>(),
       watchPanel: mockWatchPanel,
@@ -456,8 +451,8 @@ describe("PanelHeader", () => {
     });
   });
 
-  describe("tab scroll arrows", () => {
-    const twoTabs = [
+  describe("tab overflow menu (#6429)", () => {
+    const threeTabs = [
       {
         id: "t1",
         title: "Tab 1",
@@ -472,47 +467,75 @@ describe("PanelHeader", () => {
         chrome: deriveTerminalChrome(),
         isActive: false,
       },
+      {
+        id: "t3",
+        title: "Tab 3",
+        kind: "terminal" as const,
+        chrome: deriveTerminalChrome(),
+        isActive: false,
+      },
     ];
 
-    it("renders scroll arrows when tabs overflow", () => {
-      mockScrollControls = {
-        ...mockScrollControls,
-        canScrollLeft: true,
-        canScrollRight: true,
-      };
-      render(<PanelHeader {...makeProps({ tabs: twoTabs, onTabClick: vi.fn() })} />);
-      expect(screen.getByLabelText("Scroll left")).toBeDefined();
-      expect(screen.getByLabelText("Scroll right")).toBeDefined();
+    it("does not render the overflow trigger when no tabs are hidden", () => {
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick: vi.fn() })} />);
+      expect(screen.queryByLabelText("Show hidden tabs")).toBeNull();
+      expect(screen.queryByTestId("panel-tabs-overflow")).toBeNull();
     });
 
-    it("does not render scroll arrows when tabs do not overflow", () => {
-      render(<PanelHeader {...makeProps({ tabs: twoTabs, onTabClick: vi.fn() })} />);
-      expect(screen.queryByLabelText("Scroll left")).toBeNull();
-      expect(screen.queryByLabelText("Scroll right")).toBeNull();
+    it("renders the overflow trigger when one or more tabs are hidden", () => {
+      mockHiddenTabIds = new Set(["t2", "t3"]);
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick: vi.fn() })} />);
+      const trigger = screen.getByLabelText("Show hidden tabs");
+      expect(trigger).toBeDefined();
+      expect(trigger.getAttribute("aria-haspopup")).toBe("menu");
     });
 
-    it("calls scrollLeft/scrollRight when arrows are clicked", () => {
-      mockScrollControls = {
-        ...mockScrollControls,
-        canScrollLeft: true,
-        canScrollRight: true,
-      };
-      render(<PanelHeader {...makeProps({ tabs: twoTabs, onTabClick: vi.fn() })} />);
-      screen.getByLabelText("Scroll left").click();
-      expect(mockScrollLeft).toHaveBeenCalledTimes(1);
-      screen.getByLabelText("Scroll right").click();
-      expect(mockScrollRight).toHaveBeenCalledTimes(1);
+    it("lists hidden tabs by full title in the dropdown", () => {
+      mockHiddenTabIds = new Set(["t2", "t3"]);
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick: vi.fn() })} />);
+      const menus = screen.getAllByTestId("overflow-menu");
+      const tabsMenu = menus.find((m) => m.textContent?.includes("Tab 2"));
+      expect(tabsMenu).toBeDefined();
+      expect(tabsMenu!.textContent).toContain("Tab 2");
+      expect(tabsMenu!.textContent).toContain("Tab 3");
+      expect(tabsMenu!.textContent).not.toContain("Tab 1");
     });
 
-    it("renders only the right arrow when scrolled to the start", () => {
-      mockScrollControls = {
-        ...mockScrollControls,
-        canScrollLeft: false,
-        canScrollRight: true,
-      };
-      render(<PanelHeader {...makeProps({ tabs: twoTabs, onTabClick: vi.fn() })} />);
-      expect(screen.queryByLabelText("Scroll left")).toBeNull();
-      expect(screen.getByLabelText("Scroll right")).toBeDefined();
+    it("calls onTabClick with the hidden tab id when a menu item is selected", () => {
+      mockHiddenTabIds = new Set(["t2", "t3"]);
+      const onTabClick = vi.fn();
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick })} />);
+      const menus = screen.getAllByTestId("overflow-menu");
+      const tabsMenu = menus.find((m) => m.textContent?.includes("Tab 2"))!;
+      const tab2Item = Array.from(tabsMenu.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Tab 2")
+      );
+      tab2Item?.click();
+      expect(onTabClick).toHaveBeenCalledWith("t2");
+    });
+
+    it("marks an active hidden tab with aria-current and font-medium", () => {
+      mockHiddenTabIds = new Set(["t1", "t2"]);
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick: vi.fn() })} />);
+      const menus = screen.getAllByTestId("overflow-menu");
+      const tabsMenu = menus.find((m) => m.textContent?.includes("Tab 1"))!;
+      const items = Array.from(tabsMenu.querySelectorAll("button"));
+      const activeItem = items.find((b) => b.textContent?.includes("Tab 1"));
+      expect(activeItem?.getAttribute("aria-current")).toBe("true");
+      expect(activeItem?.className).toContain("font-medium");
+      const inactiveItem = items.find((b) => b.textContent?.includes("Tab 2"));
+      expect(inactiveItem?.getAttribute("aria-current")).toBeNull();
+    });
+
+    it("constrains the dropdown content height to available viewport (#4402)", () => {
+      mockHiddenTabIds = new Set(["t2"]);
+      render(<PanelHeader {...makeProps({ tabs: threeTabs, onTabClick: vi.fn() })} />);
+      const menus = screen.getAllByTestId("overflow-menu");
+      const tabsMenu = menus.find((m) => m.textContent?.includes("Tab 2"))!;
+      expect(tabsMenu.className).toContain(
+        "max-h-[var(--radix-dropdown-menu-content-available-height)]"
+      );
+      expect(tabsMenu.className).toContain("overflow-y-auto");
     });
   });
 

--- a/src/hooks/__tests__/useTabOverflow.test.tsx
+++ b/src/hooks/__tests__/useTabOverflow.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useRef } from "react";
+import { useTabOverflow } from "../useTabOverflow";
+
+type IOEntry = { target: HTMLElement; isIntersecting: boolean };
+
+interface IORecord {
+  callback: (entries: IOEntry[]) => void;
+  observe: (el: HTMLElement) => void;
+  disconnect: () => void;
+  observed: Set<HTMLElement>;
+  options?: IntersectionObserverInit;
+}
+
+let lastIO: IORecord | null = null;
+
+class MockIntersectionObserver {
+  callback: (entries: IOEntry[]) => void;
+  observed = new Set<HTMLElement>();
+  options?: IntersectionObserverInit;
+
+  constructor(callback: (entries: IOEntry[]) => void, options?: IntersectionObserverInit) {
+    this.callback = callback;
+    this.options = options;
+    lastIO = {
+      callback,
+      observe: (el) => this.observe(el),
+      disconnect: () => this.disconnect(),
+      observed: this.observed,
+      options,
+    };
+  }
+
+  observe(el: HTMLElement): void {
+    this.observed.add(el);
+  }
+
+  unobserve(el: HTMLElement): void {
+    this.observed.delete(el);
+  }
+
+  disconnect(): void {
+    this.observed.clear();
+    if (lastIO?.observed === this.observed) lastIO = null;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  lastIO = null;
+  // @ts-expect-error - injecting mock
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+});
+
+function setupContainer(ids: string[]): HTMLDivElement {
+  const container = document.createElement("div");
+  for (const id of ids) {
+    const child = document.createElement("div");
+    child.setAttribute("data-tab-id", id);
+    container.appendChild(child);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+function emit(entries: { id: string; visible: boolean }[]) {
+  if (!lastIO) throw new Error("No IntersectionObserver was created");
+  const observed = Array.from(lastIO.observed);
+  const ioEntries: IOEntry[] = entries.map((e) => {
+    const target = observed.find((el) => el.dataset.tabId === e.id);
+    if (!target) throw new Error(`No observed target for tab id ${e.id}`);
+    return { target, isIntersecting: e.visible };
+  });
+  act(() => {
+    lastIO!.callback(ioEntries);
+  });
+}
+
+describe("useTabOverflow", () => {
+  it("returns an empty set when no tabs are clipped", () => {
+    const container = setupContainer(["a", "b"]);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a", "b"]);
+    });
+    expect(result.current.size).toBe(0);
+  });
+
+  it("adds tab ids reported as not intersecting and removes them when they re-intersect", () => {
+    const container = setupContainer(["a", "b", "c"]);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a", "b", "c"]);
+    });
+
+    emit([
+      { id: "a", visible: true },
+      { id: "b", visible: false },
+      { id: "c", visible: false },
+    ]);
+    expect(Array.from(result.current).sort()).toEqual(["b", "c"]);
+
+    emit([{ id: "b", visible: true }]);
+    expect(Array.from(result.current).sort()).toEqual(["c"]);
+  });
+
+  it("observes every child with a data-tab-id attribute", () => {
+    const container = setupContainer(["a", "b", "c"]);
+    renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a", "b", "c"]);
+    });
+    expect(lastIO?.observed.size).toBe(3);
+  });
+
+  it("uses threshold 0.98 (Chromium subpixel rounding gotcha)", () => {
+    const container = setupContainer(["a"]);
+    renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a"]);
+    });
+    expect(lastIO?.options?.threshold).toBe(0.98);
+  });
+
+  it("scopes the observer root to the container", () => {
+    const container = setupContainer(["a"]);
+    renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a"]);
+    });
+    expect(lastIO?.options?.root).toBe(container);
+  });
+
+  it("does nothing when IntersectionObserver is unavailable", () => {
+    // @ts-expect-error - intentionally removing mock
+    delete globalThis.IntersectionObserver;
+    const container = setupContainer(["a", "b"]);
+    const { result } = renderHook(() => {
+      const ref = useRef<HTMLElement | null>(container);
+      return useTabOverflow(ref, ["a", "b"]);
+    });
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/useTabOverflow.test.tsx
+++ b/src/hooks/__tests__/useTabOverflow.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useRef } from "react";
 import { useTabOverflow } from "../useTabOverflow";
 
 type IOEntry = { target: HTMLElement; isIntersecting: boolean };
@@ -84,19 +83,13 @@ function emit(entries: { id: string; visible: boolean }[]) {
 describe("useTabOverflow", () => {
   it("returns an empty set when no tabs are clipped", () => {
     const container = setupContainer(["a", "b"]);
-    const { result } = renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a", "b"]);
-    });
+    const { result } = renderHook(() => useTabOverflow(container, ["a", "b"]));
     expect(result.current.size).toBe(0);
   });
 
   it("adds tab ids reported as not intersecting and removes them when they re-intersect", () => {
     const container = setupContainer(["a", "b", "c"]);
-    const { result } = renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a", "b", "c"]);
-    });
+    const { result } = renderHook(() => useTabOverflow(container, ["a", "b", "c"]));
 
     emit([
       { id: "a", visible: true },
@@ -111,28 +104,19 @@ describe("useTabOverflow", () => {
 
   it("observes every child with a data-tab-id attribute", () => {
     const container = setupContainer(["a", "b", "c"]);
-    renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a", "b", "c"]);
-    });
+    renderHook(() => useTabOverflow(container, ["a", "b", "c"]));
     expect(lastIO?.observed.size).toBe(3);
   });
 
   it("uses threshold 0.98 (Chromium subpixel rounding gotcha)", () => {
     const container = setupContainer(["a"]);
-    renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a"]);
-    });
+    renderHook(() => useTabOverflow(container, ["a"]));
     expect(lastIO?.options?.threshold).toBe(0.98);
   });
 
   it("scopes the observer root to the container", () => {
     const container = setupContainer(["a"]);
-    renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a"]);
-    });
+    renderHook(() => useTabOverflow(container, ["a"]));
     expect(lastIO?.options?.root).toBe(container);
   });
 
@@ -140,10 +124,59 @@ describe("useTabOverflow", () => {
     // @ts-expect-error - intentionally removing mock
     delete globalThis.IntersectionObserver;
     const container = setupContainer(["a", "b"]);
-    const { result } = renderHook(() => {
-      const ref = useRef<HTMLElement | null>(container);
-      return useTabOverflow(ref, ["a", "b"]);
-    });
+    const { result } = renderHook(() => useTabOverflow(container, ["a", "b"]));
     expect(result.current.size).toBe(0);
+  });
+
+  it("does not throw when container is null and creates no observer", () => {
+    const { result } = renderHook(() => useTabOverflow(null, ["a", "b"]));
+    expect(result.current.size).toBe(0);
+    expect(lastIO).toBeNull();
+  });
+
+  it("rebuilds the observer when the container element first becomes available", () => {
+    const container = setupContainer(["a", "b"]);
+    const { rerender } = renderHook(
+      ({ el }: { el: HTMLElement | null }) => useTabOverflow(el, ["a", "b"]),
+      { initialProps: { el: null as HTMLElement | null } }
+    );
+    expect(lastIO).toBeNull();
+    rerender({ el: container });
+    expect(lastIO).not.toBeNull();
+    expect(lastIO?.observed.size).toBe(2);
+  });
+
+  it("does not recreate the observer when tab ids array reference changes but contents do not", () => {
+    const container = setupContainer(["a", "b"]);
+    const { rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useTabOverflow(container, ids),
+      { initialProps: { ids: ["a", "b"] } }
+    );
+    const initialIO = lastIO;
+    expect(initialIO).not.toBeNull();
+
+    rerender({ ids: ["a", "b"] });
+    expect(lastIO).toBe(initialIO);
+  });
+
+  it("drops removed tab ids from hiddenIds when the tab list shrinks", () => {
+    const container = setupContainer(["a", "b", "c"]);
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: string[] }) => useTabOverflow(container, ids),
+      { initialProps: { ids: ["a", "b", "c"] } }
+    );
+
+    emit([
+      { id: "a", visible: true },
+      { id: "b", visible: false },
+      { id: "c", visible: false },
+    ]);
+    expect(Array.from(result.current).sort()).toEqual(["b", "c"]);
+
+    // Remove "c" from the tab list (and from the DOM container).
+    container.querySelector('[data-tab-id="c"]')?.remove();
+    rerender({ ids: ["a", "b"] });
+
+    expect(result.current.has("c")).toBe(false);
   });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -72,6 +72,8 @@ export type { UseMenuActionsOptions } from "./useMenuActions";
 export { useHorizontalScrollControls } from "./useHorizontalScrollControls";
 export type { UseHorizontalScrollControlsReturn } from "./useHorizontalScrollControls";
 
+export { useTabOverflow } from "./useTabOverflow";
+
 export { useVerticalScrollShadows } from "./useVerticalScrollShadows";
 export type { UseVerticalScrollShadowsReturn } from "./useVerticalScrollShadows";
 

--- a/src/hooks/useTabOverflow.ts
+++ b/src/hooks/useTabOverflow.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState, type RefObject } from "react";
+
+// Chromium 130+ subpixel rounding can land fully-visible elements at
+// intersectionRatio ≈ 0.9999 instead of 1.0 on high-DPI displays — observe at
+// 0.98 and rely on isIntersecting (not strict equality with 1).
+const VISIBILITY_THRESHOLD = 0.98;
+
+/**
+ * Tracks which descendants of `containerRef` are clipped by horizontal
+ * overflow. Children must carry `data-tab-id="<id>"` — the hook queries for
+ * those nodes inside the container, observes their intersection with the
+ * container's viewport, and returns the set of ids that are currently hidden.
+ *
+ * Re-observes whenever the `tabIds` array changes so newly-added or reordered
+ * tabs participate in the next visibility check.
+ */
+export function useTabOverflow(
+  containerRef: RefObject<HTMLElement | null>,
+  tabIds: readonly string[]
+): ReadonlySet<string> {
+  const [hiddenIds, setHiddenIds] = useState<ReadonlySet<string>>(() => new Set<string>());
+
+  // Memoize the dependency by joining ids — useEffect uses referential equality
+  // and a new array each render would re-run the effect every render.
+  const tabIdsKey = tabIds.join("|");
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setHiddenIds((prev) => {
+          const next = new Set(prev);
+          let changed = false;
+          for (const entry of entries) {
+            const id = (entry.target as HTMLElement).dataset.tabId;
+            if (!id) continue;
+            if (entry.isIntersecting) {
+              if (next.delete(id)) changed = true;
+            } else if (!next.has(id)) {
+              next.add(id);
+              changed = true;
+            }
+          }
+          return changed ? next : prev;
+        });
+      },
+      { root: container, threshold: VISIBILITY_THRESHOLD }
+    );
+
+    const observed = container.querySelectorAll<HTMLElement>("[data-tab-id]");
+    observed.forEach((el) => observer.observe(el));
+
+    // Reconcile to only currently-known tab ids — drops any stale entries from
+    // tabs that have been removed since the previous run.
+    const known = new Set(tabIds);
+    setHiddenIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (known.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+
+    return () => observer.disconnect();
+  }, [containerRef, tabIdsKey, tabIds]);
+
+  return hiddenIds;
+}

--- a/src/hooks/useTabOverflow.ts
+++ b/src/hooks/useTabOverflow.ts
@@ -38,7 +38,9 @@ export function useTabOverflow(
           const next = new Set(prev);
           let changed = false;
           for (const entry of entries) {
-            const id = (entry.target as HTMLElement).dataset.tabId;
+            const target = entry.target;
+            if (!(target instanceof HTMLElement)) continue;
+            const id = target.dataset.tabId;
             if (!id) continue;
             if (entry.isIntersecting) {
               if (next.delete(id)) changed = true;

--- a/src/hooks/useTabOverflow.ts
+++ b/src/hooks/useTabOverflow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, type RefObject } from "react";
+import { useEffect, useState } from "react";
 
 // Chromium 130+ subpixel rounding can land fully-visible elements at
 // intersectionRatio ≈ 0.9999 instead of 1.0 on high-DPI displays — observe at
@@ -6,28 +6,30 @@ import { useEffect, useState, type RefObject } from "react";
 const VISIBILITY_THRESHOLD = 0.98;
 
 /**
- * Tracks which descendants of `containerRef` are clipped by horizontal
- * overflow. Children must carry `data-tab-id="<id>"` — the hook queries for
- * those nodes inside the container, observes their intersection with the
- * container's viewport, and returns the set of ids that are currently hidden.
+ * Tracks which descendants of `container` are clipped by horizontal overflow.
+ * Children must carry `data-tab-id="<id>"` — the hook queries for those nodes
+ * inside the container, observes their intersection with the container's
+ * viewport, and returns the set of ids that are currently hidden.
  *
- * Re-observes whenever the `tabIds` array changes so newly-added or reordered
+ * Pass the element itself (typically held in `useState`, not `useRef`) so that
+ * mounting/unmounting the container — e.g. inside a Radix popover that
+ * unmounts on close — re-runs the effect and rebuilds the observer.
+ *
+ * Re-observes whenever the joined tab ids change so newly-added or reordered
  * tabs participate in the next visibility check.
  */
 export function useTabOverflow(
-  containerRef: RefObject<HTMLElement | null>,
+  container: HTMLElement | null,
   tabIds: readonly string[]
 ): ReadonlySet<string> {
   const [hiddenIds, setHiddenIds] = useState<ReadonlySet<string>>(() => new Set<string>());
 
-  // Memoize the dependency by joining ids — useEffect uses referential equality
-  // and a new array each render would re-run the effect every render.
+  // Stable string dep — a new array reference each render would otherwise
+  // tear down and recreate the observer on every parent re-render.
   const tabIdsKey = tabIds.join("|");
 
   useEffect(() => {
-    const container = containerRef.current;
     if (!container) return;
-
     if (typeof IntersectionObserver === "undefined") return;
 
     const observer = new IntersectionObserver(
@@ -56,7 +58,7 @@ export function useTabOverflow(
 
     // Reconcile to only currently-known tab ids — drops any stale entries from
     // tabs that have been removed since the previous run.
-    const known = new Set(tabIds);
+    const known = new Set(tabIdsKey ? tabIdsKey.split("|") : []);
     setHiddenIds((prev) => {
       let changed = false;
       const next = new Set<string>();
@@ -68,7 +70,7 @@ export function useTabOverflow(
     });
 
     return () => observer.disconnect();
-  }, [containerRef, tabIdsKey, tabIds]);
+  }, [container, tabIdsKey]);
 
   return hiddenIds;
 }


### PR DESCRIPTION
## Summary

- Replaces the left/right chevron scroll buttons in the tab strip with a Priority+ overflow menu — a `…` button that opens a dropdown of hidden tabs with their full titles
- Adds a `useTabOverflow` hook backed by `IntersectionObserver` to detect which tabs are out of view without polling; the observer is rebuilt when the container remounts
- Applied to both `PanelHeader` and `DockedTabGroup` surfaces so both the main panel tab strip and the dock popover behave consistently

Resolves #6429

## Changes

- `src/hooks/useTabOverflow.ts` — new hook; watches tab visibility via `IntersectionObserver`, returns the set of hidden tab IDs and a ref to attach to the scroll container
- `src/hooks/index.ts` — barrel export for `useTabOverflow`
- `src/components/Panel/PanelHeader.tsx` — removes the chevron scroll block (both sortable and non-sortable branches); adds the `…` overflow button with `aria-label="Show hidden tabs"` to distinguish it from the existing "More panel actions" menu
- `src/components/Layout/DockedTabGroup.tsx` — same treatment for the dock tab strip
- `src/hooks/__tests__/useTabOverflow.test.tsx` — unit tests covering the observer, remount rebuild, and threshold boundary cases
- `src/components/Panel/__tests__/PanelHeader.test.tsx` — updated tests
- `src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx` — updated close-guard tests

## Testing

Unit tests added for `useTabOverflow` covering: tabs all visible (no overflow button rendered), tabs partially hidden (overflow button appears with correct list), container remount rebuilding the observer, and `instanceof` guard replacing the previous unsafe `HTMLElement` cast. Existing `PanelHeader` and `DockedTabGroup` tests updated to match the new markup.