### PR TITLE
feat(empty-state): add shortcut-hint Kbd nudges to dashboard empty states

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -61,6 +61,7 @@ export type BuiltInKeyAction =
   | "worktree.copyTree"
   | "worktree.openEditor"
   | "worktree.openPalette"
+  | "worktree.createDialog.open"
   | "worktree.overview"
   | "worktree.sessions.minimizeAll"
   | "worktree.sessions.maximizeAll"
@@ -247,6 +248,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "worktree.copyTree",
   "worktree.openEditor",
   "worktree.openPalette",
+  "worktree.createDialog.open",
   "worktree.overview",
   "worktree.sessions.minimizeAll",
   "worktree.sessions.maximizeAll",

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Kbd } from "@/components/ui/Kbd";
 import {
   WorktreeCard,
   type WorktreeCardProps,
@@ -883,6 +884,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               File → Open Directory
             </kbd>
           </p>
+
+          {createWorktreeShortcut && (
+            <p className="text-xs text-daintree-text/60 mb-4 max-w-xs">
+              Press <Kbd>{createWorktreeShortcut}</Kbd> to create a worktree
+            </p>
+          )}
 
           <div className="text-xs text-daintree-text/60 text-left w-full max-w-xs">
             <div className="font-medium mb-1">Quick Start:</div>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -834,6 +834,34 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const dragStartOrder = useMemo(() => filteredWorktrees.map((w) => w.id), [filteredWorktrees]);
 
+  // Hoisted before early returns so the dialog still mounts when the zero-
+  // worktrees branch fires — its empty-state nudge dispatches
+  // worktree.createDialog.open and the dialog has nowhere else to live.
+  const dialogRootPath = currentProject?.path ?? "";
+  const newWorktreeDialogElement = dialogRootPath &&
+    (createDialog.isOpen || hasOpenedNewWorktree) && (
+      <ErrorBoundary
+        variant="component"
+        componentName="NewWorktreeDialog"
+        resetKeys={[Number(createDialog.isOpen)]}
+      >
+        <Suspense fallback={null}>
+          <LazyNewWorktreeDialog
+            isOpen={createDialog.isOpen}
+            onClose={closeCreateDialog}
+            rootPath={dialogRootPath}
+            onWorktreeCreated={(worktreeId) => {
+              refresh();
+              createDialog.onCreated?.(worktreeId);
+            }}
+            initialIssue={createDialog.initialIssue}
+            initialPR={createDialog.initialPR}
+            initialRecipeId={createDialog.initialRecipeId}
+          />
+        </Suspense>
+      </ErrorBoundary>
+    );
+
   if (isLoading && worktrees.length === 0) {
     return (
       <div className="flex flex-col h-full">
@@ -868,43 +896,45 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   if (worktrees.length === 0) {
     return (
-      <div className="flex flex-col h-full">
-        <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
-          <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
-        </div>
+      <>
+        <div className="flex flex-col h-full">
+          <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
+            <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
+          </div>
 
-        <div className="flex flex-col items-center justify-center py-12 px-4 text-center flex-1">
-          <FolderOpen className="w-12 h-12 text-daintree-text/60 mb-3" aria-hidden="true" />
+          <div className="flex flex-col items-center justify-center py-12 px-4 text-center flex-1">
+            <FolderOpen className="w-12 h-12 text-daintree-text/60 mb-3" aria-hidden="true" />
 
-          <h3 className="text-daintree-text font-medium mb-2">No worktrees yet</h3>
+            <h3 className="text-daintree-text font-medium mb-2">No worktrees yet</h3>
 
-          <p className="text-sm text-daintree-text/60 mb-4 max-w-xs">
-            Open a Git repository with worktrees to get started. Use{" "}
-            <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
-              File → Open Directory
-            </kbd>
-          </p>
-
-          {createWorktreeShortcut && (
-            <p className="text-xs text-daintree-text/60 mb-4 max-w-xs">
-              Press <Kbd>{createWorktreeShortcut}</Kbd> to create a worktree
+            <p className="text-sm text-daintree-text/60 mb-4 max-w-xs">
+              Open a Git repository with worktrees to get started. Use{" "}
+              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
+                File → Open Directory
+              </kbd>
             </p>
-          )}
 
-          <div className="text-xs text-daintree-text/60 text-left w-full max-w-xs">
-            <div className="font-medium mb-1">Quick Start:</div>
-            <ol className="space-y-1 list-decimal list-inside">
-              <li>Open a repository</li>
-              <li>Launch an agent</li>
-              <li>Inject context to AI agent</li>
-            </ol>
+            {createWorktreeShortcut && (
+              <p className="text-xs text-daintree-text/60 mb-4 max-w-xs">
+                Press <Kbd>{createWorktreeShortcut}</Kbd> to create a worktree
+              </p>
+            )}
+
+            <div className="text-xs text-daintree-text/60 text-left w-full max-w-xs">
+              <div className="font-medium mb-1">Quick Start:</div>
+              <ol className="space-y-1 list-decimal list-inside">
+                <li>Open a repository</li>
+                <li>Launch an agent</li>
+                <li>Inject context to AI agent</li>
+              </ol>
+            </div>
           </div>
         </div>
-      </div>
+        {newWorktreeDialogElement}
+      </>
     );
   }
 
-  const rootPath = currentProject?.path ?? "";
   const hasNonMainWorktrees = deferredWorktrees.length > 1;
   const hasFilters = hasActiveFilters();
   const hasPopoverFilters =
@@ -1231,28 +1261,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         />
       </ErrorBoundary>
 
-      {rootPath && (createDialog.isOpen || hasOpenedNewWorktree) && (
-        <ErrorBoundary
-          variant="component"
-          componentName="NewWorktreeDialog"
-          resetKeys={[Number(createDialog.isOpen)]}
-        >
-          <Suspense fallback={null}>
-            <LazyNewWorktreeDialog
-              isOpen={createDialog.isOpen}
-              onClose={closeCreateDialog}
-              rootPath={rootPath}
-              onWorktreeCreated={(worktreeId) => {
-                refresh();
-                createDialog.onCreated?.(worktreeId);
-              }}
-              initialIssue={createDialog.initialIssue}
-              initialPR={createDialog.initialPR}
-              initialRecipeId={createDialog.initialRecipeId}
-            />
-          </Suspense>
-        </ErrorBoundary>
-      )}
+      {newWorktreeDialogElement}
 
       <ErrorBoundary
         variant="component"

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -138,7 +138,7 @@ describe("SidebarContent zero-worktrees shortcut nudge — issue #6437", () => {
     // wrapped in a truthy guard so unbound shortcuts (createWorktreeShortcut === "")
     // suppress the line entirely instead of rendering "Press  to create a worktree".
     const branchStart = source.indexOf("if (worktrees.length === 0) {");
-    const branchEnd = source.indexOf("const rootPath = currentProject", branchStart);
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
     expect(branchStart).toBeGreaterThan(0);
     expect(branchEnd).toBeGreaterThan(branchStart);
     const branch = source.slice(branchStart, branchEnd);
@@ -151,5 +151,33 @@ describe("SidebarContent zero-worktrees shortcut nudge — issue #6437", () => {
     // The menu-path pill stays as a raw <kbd> with the existing styling — Kbd
     // is reserved for keyboard shortcuts.
     expect(source).toMatch(/<kbd[^>]*>\s*File → Open Directory\s*<\/kbd>/);
+  });
+
+  it("mounts NewWorktreeDialog from the zero-worktrees branch so the shortcut nudge actually opens it", () => {
+    // Regression guard: the empty-state nudge dispatches
+    // worktree.createDialog.open. Before this PR there was no entry path from
+    // the zero-worktrees branch to the dialog; the dialog mount lived only in
+    // the main return, which is bypassed by the early return. Hoisting
+    // `newWorktreeDialogElement` before the early returns and including it in
+    // the zero-worktrees branch is what makes the shortcut work.
+    expect(source).toContain("const newWorktreeDialogElement");
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    expect(branchStart).toBeGreaterThan(0);
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toContain("{newWorktreeDialogElement}");
+  });
+
+  it("hoists the dialog mount before all early returns so it is reachable from every branch", () => {
+    // The dialog declaration must appear before the first early-return guard
+    // (`isLoading && worktrees.length === 0`); otherwise dispatching
+    // worktree.createDialog.open from outside the populated sidebar (loading,
+    // error, or empty state) would be a no-op.
+    const dialogIdx = source.indexOf("const newWorktreeDialogElement");
+    const firstEarlyReturnIdx = source.indexOf("if (isLoading && worktrees.length === 0)");
+    expect(dialogIdx).toBeGreaterThan(0);
+    expect(firstEarlyReturnIdx).toBeGreaterThan(0);
+    expect(dialogIdx).toBeLessThan(firstEarlyReturnIdx);
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -117,3 +117,39 @@ describe("SidebarContent quick-state empty state — issue #6333", () => {
     });
   });
 });
+
+describe("SidebarContent zero-worktrees shortcut nudge — issue #6437", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("imports the Kbd component for the shortcut hint", () => {
+    expect(source).toMatch(/import \{ Kbd \} from "@\/components\/ui\/Kbd"/);
+  });
+
+  it("subscribes to useKeybindingDisplay for worktree.createDialog.open", () => {
+    expect(source).toContain('useKeybindingDisplay("worktree.createDialog.open")');
+  });
+
+  it("renders the Press <Kbd>...</Kbd> nudge guarded by createWorktreeShortcut in the zero-worktrees branch", () => {
+    // The nudge must live inside the zero-worktrees early-return branch and be
+    // wrapped in a truthy guard so unbound shortcuts (createWorktreeShortcut === "")
+    // suppress the line entirely instead of rendering "Press  to create a worktree".
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const rootPath = currentProject", branchStart);
+    expect(branchStart).toBeGreaterThan(0);
+    expect(branchEnd).toBeGreaterThan(branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toMatch(
+      /\{createWorktreeShortcut && \([\s\S]*?<Kbd>\{createWorktreeShortcut\}<\/Kbd>[\s\S]*?to create a worktree[\s\S]*?\)\}/
+    );
+  });
+
+  it("does not replace the File → Open Directory menu-path pill with Kbd (semantically a menu path, not a shortcut)", () => {
+    // The menu-path pill stays as a raw <kbd> with the existing styling — Kbd
+    // is reserved for keyboard shortcuts.
+    expect(source).toMatch(/<kbd[^>]*>\s*File → Open Directory\s*<\/kbd>/);
+  });
+});

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/lib/terminalLayout";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useProjectBranding } from "@/hooks";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { actionService } from "@/services/ActionService";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { CliAvailability } from "@shared/types";
@@ -88,7 +89,9 @@ function pixelSnapTransform({ x, y }: TransformProperties): string {
 interface TipEntry {
   id: string;
   message: React.ReactNode;
+  messageWithShortcut?: (shortcut: string) => React.ReactNode;
   actionId?: ActionId;
+  shortcutActionId?: ActionId;
   actionLabel?: string;
   requiredAgents?: BuiltInAgentId[];
 }
@@ -101,6 +104,11 @@ const TIPS: TipEntry[] = [
         Press <Kbd>⌘P</Kbd> to jump between open panels
       </>
     ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to jump between open panels
+      </>
+    ),
     actionId: "nav.quickSwitcher",
     actionLabel: "Open Quick Switcher",
   },
@@ -109,6 +117,11 @@ const TIPS: TipEntry[] = [
     message: (
       <>
         Press <Kbd>⌘⌥T</Kbd> to open a new terminal in this worktree
+      </>
+    ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to open a new terminal in this worktree
       </>
     ),
     actionId: "terminal.new",
@@ -121,6 +134,12 @@ const TIPS: TipEntry[] = [
         Press <Kbd>⌘N</Kbd> to open the panel palette — add terminals, browsers, or dev previews
       </>
     ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to open the panel palette — add terminals, browsers, or dev
+        previews
+      </>
+    ),
     actionId: "panel.palette",
     actionLabel: "Open Panel Palette",
   },
@@ -129,6 +148,11 @@ const TIPS: TipEntry[] = [
     message: (
       <>
         Press <Kbd>⌘⌥N</Kbd> to launch a Claude agent in this worktree
+      </>
+    ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to launch a Claude agent in this worktree
       </>
     ),
     actionId: "agent.terminal",
@@ -142,6 +166,11 @@ const TIPS: TipEntry[] = [
         Press <Kbd>⌘⌥N</Kbd> to launch a Gemini agent in this worktree
       </>
     ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to launch a Gemini agent in this worktree
+      </>
+    ),
     actionId: "agent.terminal",
     actionLabel: "Launch Agent",
     requiredAgents: ["gemini"],
@@ -151,6 +180,11 @@ const TIPS: TipEntry[] = [
     message: (
       <>
         Press <Kbd>⌘⇧I</Kbd> to inject the project file tree into the focused terminal
+      </>
+    ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to inject the project file tree into the focused terminal
       </>
     ),
     actionId: "terminal.inject",
@@ -163,6 +197,11 @@ const TIPS: TipEntry[] = [
         Press <Kbd>⌘⇧P</Kbd> to open the action palette and search all available commands
       </>
     ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to open the action palette and search all available commands
+      </>
+    ),
     actionId: "action.palette.open",
     actionLabel: "Open Action Palette",
   },
@@ -171,6 +210,11 @@ const TIPS: TipEntry[] = [
     message: (
       <>
         Press <Kbd>⌘K</Kbd> then <Kbd>W</Kbd> to open the worktree palette and switch branches
+      </>
+    ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to open the worktree palette and switch branches
       </>
     ),
     actionId: "worktree.openPalette",
@@ -183,7 +227,13 @@ const TIPS: TipEntry[] = [
         Press <Kbd>⌘⇧O</Kbd> to open the worktrees overview and manage all your branches
       </>
     ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to open the worktrees overview and manage all your branches
+      </>
+    ),
     actionId: "worktree.overview.open",
+    shortcutActionId: "worktree.overview",
     actionLabel: "Open Worktrees Overview",
   },
   {
@@ -191,6 +241,11 @@ const TIPS: TipEntry[] = [
     message: (
       <>
         Press <Kbd>⌘⇧A</Kbd> to quickly switch between available AI agents
+      </>
+    ),
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to quickly switch between available AI agents
       </>
     ),
     actionId: "agent.palette",
@@ -205,10 +260,24 @@ const TIPS: TipEntry[] = [
   {
     id: "new-worktree",
     message: <>Create a new worktree to isolate each task on its own branch</>,
+    messageWithShortcut: (shortcut) => (
+      <>
+        Press <Kbd>{shortcut}</Kbd> to create a new worktree
+      </>
+    ),
     actionId: "worktree.createDialog.open",
     actionLabel: "New Worktree",
   },
 ];
+
+function LiveTipMessage({ tip }: { tip: TipEntry }) {
+  const lookupId = tip.shortcutActionId ?? tip.actionId ?? "";
+  const shortcut = useKeybindingDisplay(lookupId);
+  if (tip.messageWithShortcut && shortcut) {
+    return <>{tip.messageWithShortcut(shortcut)}</>;
+  }
+  return <>{tip.message}</>;
+}
 
 let tipMountCount = 0;
 
@@ -231,7 +300,9 @@ function RotatingTip() {
 
   return (
     <div className="flex flex-col items-center gap-2 animate-in fade-in duration-200">
-      <p className="text-xs text-daintree-text/70 text-center">Tip: {tip.message}</p>
+      <p className="text-xs text-daintree-text/70 text-center">
+        Tip: <LiveTipMessage tip={tip} />
+      </p>
       {tip.actionId && tip.actionLabel && (
         <button
           type="button"

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -26,3 +26,72 @@ describe("ContentGrid EmptyState — RecipeRunner integration", () => {
     expect(content).not.toContain("handleRunRecipe");
   });
 });
+
+describe("ContentGrid TIPS live shortcut migration — issue #6437", () => {
+  it("imports useKeybindingDisplay so tip shortcuts react to remaps", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    expect(content).toMatch(/import \{ useKeybindingDisplay \} from "@\/hooks\/useKeybinding"/);
+  });
+
+  it("declares a messageWithShortcut field on TipEntry", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    expect(content).toMatch(/messageWithShortcut\?: \(shortcut: string\) => React\.ReactNode/);
+  });
+
+  it("defines a LiveTipMessage component that calls useKeybindingDisplay", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    expect(content).toContain("function LiveTipMessage");
+    const liveTipMatch = content.match(/function LiveTipMessage\([\s\S]*?\n\}/);
+    expect(liveTipMatch).not.toBeNull();
+    expect(liveTipMatch![0]).toContain("useKeybindingDisplay(lookupId)");
+    expect(liveTipMatch![0]).toContain("tip.messageWithShortcut");
+  });
+
+  it("falls back to the static tip.message when no shortcut is bound", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    const liveTipMatch = content.match(/function LiveTipMessage\([\s\S]*?\n\}/);
+    expect(liveTipMatch).not.toBeNull();
+    // The component must render `tip.message` when shortcut is empty so unbound
+    // tips degrade gracefully instead of rendering "Press  to ..." with a blank
+    // <Kbd>.
+    expect(liveTipMatch![0]).toMatch(/return <>\{tip\.message\}<\/>/);
+  });
+
+  it("RotatingTip renders <LiveTipMessage tip={tip} /> instead of {tip.message} directly", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    expect(content).toContain("<LiveTipMessage tip={tip} />");
+    // The previous direct-render pattern should be gone from the RotatingTip JSX
+    // (the static `message` field is still referenced inside LiveTipMessage as
+    // the fallback path, which is fine).
+    expect(content).not.toMatch(/Tip: \{tip\.message\}/);
+  });
+
+  it("shortcut-driven tips supply messageWithShortcut so the live combo renders inline", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    // Spot-check a few representative keybinding-driven tips. Each should
+    // declare a messageWithShortcut function so the live combo replaces the
+    // hardcoded glyph when the action is bound.
+    const tipIds = [
+      "quick-switcher",
+      "panel-palette",
+      "action-palette",
+      "worktree-overview",
+      "new-worktree",
+    ];
+    for (const id of tipIds) {
+      const tipBlock = content.match(new RegExp(`id: "${id}",[\\s\\S]*?(?=\\n  \\},)`));
+      expect(tipBlock, `Expected tip block for ${id}`).not.toBeNull();
+      expect(tipBlock![0]).toContain("messageWithShortcut:");
+    }
+  });
+
+  it("worktree-overview tip uses worktree.overview (the toggle action) for shortcut display", async () => {
+    const content = await readFile(GRID_PATH, "utf-8");
+    // The toggle is what owns the Cmd+Shift+O default binding; the .open
+    // variant has no binding registered, so we must look up the toggle to get
+    // a non-empty display combo.
+    const tipBlock = content.match(/id: "worktree-overview",[\s\S]*?(?=\n  \},)/);
+    expect(tipBlock).not.toBeNull();
+    expect(tipBlock![0]).toContain('shortcutActionId: "worktree.overview"');
+  });
+});

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -79,7 +79,7 @@ describe("ContentGrid TIPS live shortcut migration — issue #6437", () => {
       "new-worktree",
     ];
     for (const id of tipIds) {
-      const tipBlock = content.match(new RegExp(`id: "${id}",[\\s\\S]*?(?=\\n  \\},)`));
+      const tipBlock = content.match(new RegExp(`id: "${id}",[\\s\\S]*?(?=\\n {2}\\},)`));
       expect(tipBlock, `Expected tip block for ${id}`).not.toBeNull();
       expect(tipBlock![0]).toContain("messageWithShortcut:");
     }
@@ -90,7 +90,7 @@ describe("ContentGrid TIPS live shortcut migration — issue #6437", () => {
     // The toggle is what owns the Cmd+Shift+O default binding; the .open
     // variant has no binding registered, so we must look up the toggle to get
     // a non-empty display combo.
-    const tipBlock = content.match(/id: "worktree-overview",[\s\S]*?(?=\n  \},)/);
+    const tipBlock = content.match(/id: "worktree-overview",[\s\S]*?(?=\n {2}\},)/);
     expect(tipBlock).not.toBeNull();
     expect(tipBlock![0]).toContain('shortcutActionId: "worktree.overview"');
   });

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -525,5 +525,13 @@ describe("KeybindingService", () => {
       expect(display.toUpperCase()).toContain("K");
       expect(display.toUpperCase()).toContain("N");
     });
+
+    it("registers worktree.createDialog.open in the BuiltInKeyAction value set", async () => {
+      // Registry completeness: every action with a default binding should
+      // appear in KEY_ACTION_VALUES so introspection (settings UI, conflict
+      // detection, etc.) sees it.
+      const { KEY_ACTION_VALUES } = await import("@shared/types/keymap");
+      expect(KEY_ACTION_VALUES.has("worktree.createDialog.open")).toBe(true);
+    });
   });
 });

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -487,4 +487,43 @@ describe("KeybindingService", () => {
       warnSpy.mockRestore();
     });
   });
+
+  describe("worktree empty-state shortcut defaults — issue #6437", () => {
+    it("registers Cmd+K N as the default for worktree.createDialog.open", () => {
+      const binding = DEFAULT_KEYBINDINGS.find((b) => b.actionId === "worktree.createDialog.open");
+      expect(binding).toBeDefined();
+      expect(binding?.combo).toBe("Cmd+K N");
+      expect(binding?.scope).toBe("global");
+      expect(binding?.category).toBe("Worktrees");
+    });
+
+    it("does not collide with the existing Cmd+K W worktree-palette chord", () => {
+      const createDialog = DEFAULT_KEYBINDINGS.find(
+        (b) => b.actionId === "worktree.createDialog.open"
+      );
+      const palette = DEFAULT_KEYBINDINGS.find((b) => b.actionId === "worktree.openPalette");
+      expect(createDialog?.combo).toBe("Cmd+K N");
+      expect(palette?.combo).toBe("Cmd+K W");
+      expect(createDialog?.combo).not.toBe(palette?.combo);
+    });
+
+    it("makes the chord resolvable via getChordCompletions for the Cmd+K prefix", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const completions = service.getChordCompletions("Cmd+K");
+      expect(completions).toContainEqual(
+        expect.objectContaining({ actionId: "worktree.createDialog.open" })
+      );
+    });
+
+    it("returns the display combo for worktree.createDialog.open via getDisplayCombo", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const display = service.getDisplayCombo("worktree.createDialog.open");
+      expect(display).not.toBe("");
+      expect(display).toContain("⌘");
+      expect(display.toUpperCase()).toContain("K");
+      expect(display.toUpperCase()).toContain("N");
+    });
+  });
 });

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -756,6 +756,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Worktrees",
   },
   {
+    actionId: "worktree.createDialog.open",
+    combo: "Cmd+K N",
+    scope: "global",
+    priority: 0,
+    description: "Create a new worktree",
+    category: "Worktrees",
+  },
+  {
     actionId: "worktree.overview",
     combo: "Cmd+Shift+O",
     scope: "global",


### PR DESCRIPTION
## Summary

- Converts the sidebar zero-worktrees state and the `ContentGrid` tips section into shortcut-teaching moments — each surface now shows a `<Kbd>`-rendered hint for the relevant action binding
- Hint display goes through `useKeybindingDisplay` so it tracks whatever the user has mapped, not a hardcoded glyph
- Registers `worktree.createDialog.open` with a default of `Cmd+K N` in `defaultKeybindings.ts` and adds it to `BuiltInKeyAction` / `KEY_ACTION_VALUES`

Resolves #6437

## Changes

- `defaultKeybindings.ts` — registers `worktree.createDialog.open` (`Cmd+K N` default)
- `shared/types/keymap.ts` — adds `worktree.createDialog.open` to `BuiltInKeyAction` union and `KEY_ACTION_VALUES`
- `SidebarContent.tsx` — adds hint line to zero-worktrees branch; hoists `NewWorktreeDialog` mount before all early returns so the advertised shortcut actually resolves to an open dialog
- `ContentGrid.tsx` — introduces `LiveTipMessage` component that swaps hardcoded glyphs for live combos via `useKeybindingDisplay`, with a static fallback when the action is unbound; adds `shortcutActionId` field for the worktree-overview tip
- `SidebarContent.emptyState.test.ts` — regression tests for hint rendering and dialog mount correctness
- `contentGridEmptyState.test.ts` — tests for `LiveTipMessage` binding/unbound/fallback paths
- `KeybindingService.test.ts` — covers `worktree.createDialog.open` registration; ESLint `no-regex-spaces` fix on `{2}` quantifier

## Testing

- Vitest: 143+ unit tests pass, including new coverage for the hint rendering, dialog mount fix, and binding lookup paths
- `tsc --noEmit` clean
- Production build clean
- Lint and format clean