### PR TITLE
feat(notifications): surface toast eviction with overflow pill and bell animation

### DIFF
--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -140,6 +140,17 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     }
   }, [evictedToInboxCount, isDndActive]);
 
+  // Strip the animation class shortly after the blip plays so its
+  // `will-change: transform, opacity` layer-promotion hint does not linger
+  // on a long-lived toolbar element. The 320ms timer covers the 260ms
+  // animation plus a small buffer; further bumps reset the timer via the
+  // dependency array.
+  useEffect(() => {
+    if (bellBumpKey === 0) return;
+    const t = setTimeout(() => setBellBumpKey(0), 320);
+    return () => clearTimeout(t);
+  }, [bellBumpKey]);
+
   if (!notificationsEnabled) return null;
 
   const label = (() => {

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -12,6 +12,11 @@ import { isScheduledQuietNow } from "@shared/utils/quietHours";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text transition-colors";
 
+// Strip the bell `animate-activity-blip` class shortly after it plays so the
+// CSS `will-change: transform, opacity` layer-promotion hint does not linger
+// on a long-lived toolbar element. Covers the 260ms animation plus a buffer.
+const BELL_BLIP_CLEANUP_MS = 320;
+
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
   minute: "2-digit",
@@ -140,14 +145,12 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     }
   }, [evictedToInboxCount, isDndActive]);
 
-  // Strip the animation class shortly after the blip plays so its
-  // `will-change: transform, opacity` layer-promotion hint does not linger
-  // on a long-lived toolbar element. The 320ms timer covers the 260ms
-  // animation plus a small buffer; further bumps reset the timer via the
-  // dependency array.
+  // Reset bumpKey shortly after each blip so the animation class drops off
+  // and `will-change` is no longer applied. Further bumps cancel the pending
+  // timer via the dependency array.
   useEffect(() => {
     if (bellBumpKey === 0) return;
-    const t = setTimeout(() => setBellBumpKey(0), 320);
+    const t = setTimeout(() => setBellBumpKey(0), BELL_BLIP_CLEANUP_MS);
     return () => clearTimeout(t);
   }, [bellBumpKey]);
 

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -31,6 +31,7 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
   );
   const notificationCenterButtonRef = useRef<HTMLButtonElement>(null);
   const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
+  const evictedToInboxCount = useNotificationHistoryStore((s) => s.evictedToInboxCount);
   const {
     enabled: notificationsEnabled,
     quietUntil,
@@ -124,6 +125,21 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     if (!notificationsEnabled && notificationCenterOpen) closeNotificationCenter();
   }, [notificationsEnabled, notificationCenterOpen, closeNotificationCenter]);
 
+  // Bump the bell key whenever a new notification lands in the inbox while
+  // DND is inactive. Remounting the wrapped <Icon /> (Pattern A from
+  // WorktreeDetailsSection) restarts the CSS `animate-activity-blip`
+  // animation cleanly without an imperative classList reflow. A ref-tracked
+  // baseline avoids firing on the first render or on resets to zero.
+  const prevEvictedRef = useRef(evictedToInboxCount);
+  const [bellBumpKey, setBellBumpKey] = useState(0);
+  useEffect(() => {
+    const prev = prevEvictedRef.current;
+    prevEvictedRef.current = evictedToInboxCount;
+    if (evictedToInboxCount > prev && !isDndActive) {
+      setBellBumpKey((k) => k + 1);
+    }
+  }, [evictedToInboxCount, isDndActive]);
+
   if (!notificationsEnabled) return null;
 
   const label = (() => {
@@ -154,7 +170,13 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
             aria-expanded={notificationCenterOpen}
             aria-haspopup="dialog"
           >
-            <Icon />
+            <span
+              key={bellBumpKey}
+              data-testid="notification-bell-icon"
+              className={bellBumpKey > 0 ? "inline-flex animate-activity-blip" : "inline-flex"}
+            >
+              <Icon />
+            </span>
             {notificationUnreadCount > 0 && (
               <span
                 data-testid="notification-unread-dot"

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -12,7 +12,7 @@
  *  - aria-label / tooltip describes the muted state with a time-of-day when known
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render, act } from "@testing-library/react";
+import { render, act, fireEvent } from "@testing-library/react";
 import { NotificationCenterToolbarButton } from "../NotificationCenterToolbarButton";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -501,6 +501,39 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
     });
 
+    it("toggling the center open resets the eviction counter; closing does not", async () => {
+      // Seed the counter as if two toasts had been evicted into the inbox.
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 2 });
+      const { container } = render(<NotificationCenterToolbarButton />);
+      const button = container.querySelector("button")!;
+
+      // First click: closed → open. Reset must fire.
+      await act(async () => {
+        button.click();
+      });
+      expect(useUIStore.getState().notificationCenterOpen).toBe(true);
+      expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
+
+      // Second click: open → closed. Closing must NOT silently zero a fresh
+      // counter that arrives after the user has already opened the center.
+      await act(async () => {
+        button.click();
+      });
+      expect(useUIStore.getState().notificationCenterOpen).toBe(false);
+      // Simulate a fresh eviction landing while the center is closed.
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(1);
+
+      // Third click: closed → open again. Reset must fire on every entry to
+      // the open state, not just the first.
+      await act(async () => {
+        button.click();
+      });
+      expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
+    });
+
     it("animation class persists across multiple subsequent increments", async () => {
       const { getByTestId } = render(<NotificationCenterToolbarButton />);
       await act(async () => {
@@ -515,6 +548,26 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
         useNotificationHistoryStore.setState({ evictedToInboxCount: 3 });
       });
       expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+    });
+
+    it("strips the animation class shortly after the blip so will-change does not linger", async () => {
+      vi.useFakeTimers();
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+
+      // Advance past the 320ms cleanup timer (260ms blip + buffer).
+      await act(async () => {
+        vi.advanceTimersByTime(320);
+      });
+
+      // After cleanup, the wrapper falls back to the no-animation className —
+      // the will-change layer-promotion hint is no longer applied.
+      expect(getByTestId("notification-bell-icon").className).not.toContain(
+        "animate-activity-blip"
+      );
     });
   });
 });

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -56,7 +56,11 @@ vi.mock("lucide-react", () => ({
 }));
 
 function resetStores() {
-  useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+  useNotificationHistoryStore.setState({
+    entries: [],
+    unreadCount: 0,
+    evictedToInboxCount: 0,
+  });
   useNotificationSettingsStore.setState({
     enabled: true,
     hydrated: true,
@@ -432,6 +436,85 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
 
       unmount();
       expect(visibilityListeners.length).toBe(0);
+    });
+  });
+
+  // Issue #6424 — when a notification lands in the inbox (toast eviction or
+  // priority:"low" direct-to-inbox), the bell should play a brief one-shot
+  // arrival animation. The animation must not fire during DND/quiet hours
+  // and must not fire on the initial mount baseline.
+  describe("inbox arrival animation (issue #6424)", () => {
+    it("does not animate on the initial render", () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 0 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const wrapper = getByTestId("notification-bell-icon");
+      expect(wrapper.className).not.toContain("animate-activity-blip");
+    });
+
+    it("does not animate when mounted with a non-zero baseline (e.g. fast-refresh)", () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 5 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const wrapper = getByTestId("notification-bell-icon");
+      expect(wrapper.className).not.toContain("animate-activity-blip");
+    });
+
+    it("animates the bell when evictedToInboxCount increases and DND is inactive", async () => {
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      const wrapper = getByTestId("notification-bell-icon");
+      expect(wrapper.className).toContain("animate-activity-blip");
+    });
+
+    it("does not animate when DND is active", async () => {
+      useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60 * 60 * 1000 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      const wrapper = getByTestId("notification-bell-icon");
+      expect(wrapper.className).not.toContain("animate-activity-blip");
+    });
+
+    it("does not re-animate when the count drops back to zero (no new arrival)", async () => {
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      const firstWrapper = getByTestId("notification-bell-icon");
+      expect(firstWrapper.className).toContain("animate-activity-blip");
+
+      // Reset — count drops 1 → 0. evictedToInboxCount > prev is false, so the
+      // bumpKey does not increment and the bell wrapper is not remounted.
+      // (The CSS animation is `both`-fill at scale(1)/opacity(0.9), so a
+      // residual class on the existing wrapper is visually inert.)
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 0 });
+      });
+      // Sanity: the count drop alone did not trigger another bump cycle.
+      // (We can't directly observe React's internal key, but a fresh
+      // increment from 0 → 1 below confirms the bumpKey path still works.)
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+    });
+
+    it("animation class persists across multiple subsequent increments", async () => {
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+      });
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 2 });
+      });
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+      await act(async () => {
+        useNotificationHistoryStore.setState({ evictedToInboxCount: 3 });
+      });
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
     });
   });
 });

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -12,7 +12,7 @@
  *  - aria-label / tooltip describes the muted state with a time-of-day when known
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render, act, fireEvent } from "@testing-library/react";
+import { render, act } from "@testing-library/react";
 import { NotificationCenterToolbarButton } from "../NotificationCenterToolbarButton";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
@@ -558,9 +558,9 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
 
-      // Advance past the 320ms cleanup timer (260ms blip + buffer).
+      // Advance past the BELL_BLIP_CLEANUP_MS timer (260ms blip + buffer).
       await act(async () => {
-        vi.advanceTimersByTime(320);
+        vi.advanceTimersByTime(400);
       });
 
       // After cleanup, the wrapper falls back to the no-animation className —

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -948,7 +948,70 @@ describe("Toast overflow pill (issue #6424)", () => {
     expect(pill.className).not.toContain("text-accent-primary");
   });
 
-  it("renders even when no toasts are visible (e.g. priority:'low' direct-to-inbox)", async () => {
+  it("renders the pill end-to-end when MAX_VISIBLE_TOASTS evicts a real toast", async () => {
+    render(<Toaster />);
+    // Seed a history entry that's currently 'seenAsToast' (i.e., visible as a
+    // toast) and link a toast to it via historyEntryId. When the cap is hit
+    // and this toast is evicted, markUnseenAsToast fires and the eviction
+    // counter increments — the pill should appear without any direct
+    // setState fakery.
+    const evictableHistoryId = useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "first",
+      seenAsToast: true,
+    });
+
+    await act(async () => {
+      addToast({ message: "first", historyEntryId: evictableHistoryId });
+      addToast({ message: "second" });
+      addToast({ message: "third" });
+      vi.advanceTimersByTime(16);
+    });
+    expect(screen.queryByTestId("toast-overflow-pill")).toBeNull();
+
+    // The fourth toast pushes the cap and evicts 'first' (oldest non-error).
+    await act(async () => {
+      addToast({ message: "fourth" });
+      vi.advanceTimersByTime(16);
+    });
+
+    // History counter incremented through the real eviction path.
+    expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(1);
+    const pill = screen.getByTestId("toast-overflow-pill");
+    expect(pill.textContent).toBe("+1 more");
+  });
+
+  it("does NOT increment the counter when the notification center is open during eviction", async () => {
+    render(<Toaster />);
+    // Open the notification center BEFORE evicting — the user is already
+    // looking at the inbox, so signaling the arrival twice is contradictory.
+    useUIStore.setState({ notificationCenterOpen: true });
+
+    const evictableHistoryId = useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "first",
+      seenAsToast: true,
+    });
+
+    await act(async () => {
+      addToast({ message: "first", historyEntryId: evictableHistoryId });
+      addToast({ message: "second" });
+      addToast({ message: "third" });
+      addToast({ message: "fourth" });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Eviction fired (the entry is now unseen) but the cue counter did not.
+    expect(useNotificationHistoryStore.getState().entries[0]!.seenAsToast).toBe(false);
+    expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
+    expect(screen.queryByTestId("toast-overflow-pill")).toBeNull();
+  });
+
+  it("renders the pill even when no toasts are currently visible", async () => {
+    // Models the steady state after every visible toast has auto-dismissed
+    // but the eviction counter is still > 0 — the cue must persist until the
+    // user opens the notification center, otherwise the affordance vanishes
+    // before they can act on it.
     render(<Toaster />);
     await act(async () => {
       useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -6,6 +6,7 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { useUIStore } from "@/store/uiStore";
 import { notify } from "@/lib/notify";
 import { Toaster } from "../toaster";
 
@@ -868,5 +869,92 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
       expect(toasterGuardCall).toBeUndefined();
       consoleSpy.mockRestore();
     });
+  });
+});
+
+// Issue #6424 — when MAX_VISIBLE_TOASTS evicts a toast into the inbox, surface
+// a "+N more" pill below the visible stack so users can discover that
+// notifications were silently moved instead of disappearing.
+describe("Toast overflow pill (issue #6424)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().reset();
+    useNotificationHistoryStore.setState({
+      entries: [],
+      unreadCount: 0,
+      evictedToInboxCount: 0,
+    });
+    useUIStore.setState({ notificationCenterOpen: false });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("does not render the pill when nothing has been evicted", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast();
+      vi.advanceTimersByTime(16);
+    });
+    expect(screen.queryByTestId("toast-overflow-pill")).toBeNull();
+  });
+
+  it("renders +1 more after a single eviction", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+    });
+    const pill = screen.getByTestId("toast-overflow-pill");
+    expect(pill.textContent).toBe("+1 more");
+    expect(pill.getAttribute("aria-live")).toBe("polite");
+    expect(pill.getAttribute("aria-label")).toBe("1 more in notification center");
+  });
+
+  it("renders the cumulative count for multiple evictions", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 4 });
+    });
+    expect(screen.getByTestId("toast-overflow-pill").textContent).toBe("+4 more");
+  });
+
+  it("opens the notification center and clears the count when clicked", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 2 });
+    });
+
+    const pill = screen.getByTestId("toast-overflow-pill");
+    await act(async () => {
+      fireEvent.click(pill);
+    });
+
+    expect(useUIStore.getState().notificationCenterOpen).toBe(true);
+    expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
+    expect(screen.queryByTestId("toast-overflow-pill")).toBeNull();
+  });
+
+  it("uses neutral surface tokens and does not paint the accent colour", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+    });
+    const pill = screen.getByTestId("toast-overflow-pill");
+    expect(pill.className).toContain("bg-surface-panel");
+    expect(pill.className).not.toContain("bg-daintree-accent");
+    expect(pill.className).not.toContain("text-accent-primary");
+  });
+
+  it("renders even when no toasts are visible (e.g. priority:'low' direct-to-inbox)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
+    });
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByTestId("toast-overflow-pill")).toBeTruthy();
   });
 });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -22,7 +22,9 @@ import {
 } from "@/lib/animationUtils";
 import { Spinner } from "@/components/ui/Spinner";
 import { useNotificationStore, type Notification } from "@/store/notificationStore";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
 import {
   DropdownMenu,
@@ -412,8 +414,36 @@ function Toast({ notification }: { notification: Notification }) {
   );
 }
 
+function OverflowPill({ count }: { count: number }) {
+  const openNotificationCenter = useUIStore((s) => s.openNotificationCenter);
+  const label = `${count} more in notification center`;
+  return (
+    <button
+      type="button"
+      onClick={openNotificationCenter}
+      aria-live="polite"
+      aria-label={label}
+      data-testid="toast-overflow-pill"
+      className={cn(
+        "pointer-events-auto self-end",
+        "inline-flex items-center gap-1 rounded-full",
+        "bg-surface-panel/85 backdrop-blur-xl",
+        "border border-tint/[0.08] ring-1 ring-inset ring-tint/[0.05]",
+        "px-2.5 py-1 text-[11px] font-medium leading-none tabular-nums",
+        "text-daintree-text/70 hover:text-daintree-text",
+        "shadow-[var(--theme-shadow-floating)]",
+        "transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+      )}
+    >
+      +{count} more
+    </button>
+  );
+}
+
 export function Toaster() {
   const notifications = useNotificationStore((state) => state.notifications);
+  const evictedToInboxCount = useNotificationHistoryStore((s) => s.evictedToInboxCount);
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -424,7 +454,7 @@ export function Toaster() {
     (notification) => notification.placement !== "grid-bar"
   );
 
-  if (!mounted || toastNotifications.length === 0) return null;
+  if (!mounted || (toastNotifications.length === 0 && evictedToInboxCount === 0)) return null;
 
   return createPortal(
     <div
@@ -434,6 +464,7 @@ export function Toaster() {
       {[...toastNotifications].reverse().map((notification) => (
         <Toast key={notification.id} notification={notification} />
       ))}
+      {evictedToInboxCount > 0 && <OverflowPill count={evictedToInboxCount} />}
     </div>,
     document.body
   );

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -421,6 +421,17 @@ describe("notificationHistorySlice", () => {
       getState().clearAll();
       expect(getState().evictedToInboxCount).toBe(0);
     });
+
+    it("does NOT increment when called with { silent: true }", () => {
+      const id = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      expect(getState().evictedToInboxCount).toBe(0);
+      getState().markUnseenAsToast(id, { silent: true });
+      // The seenAsToast flip + unreadCount update still happen — only the
+      // discoverability cue is suppressed.
+      expect(getState().entries[0]!.seenAsToast).toBe(false);
+      expect(getState().unreadCount).toBe(1);
+      expect(getState().evictedToInboxCount).toBe(0);
+    });
   });
 
   describe("dismissEntry", () => {

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -26,7 +26,11 @@ function addEntry(
 
 describe("notificationHistorySlice", () => {
   beforeEach(() => {
-    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
+    useNotificationHistoryStore.setState({
+      entries: [],
+      unreadCount: 0,
+      evictedToInboxCount: 0,
+    });
   });
 
   it("adds an entry with id and timestamp", () => {
@@ -352,6 +356,70 @@ describe("notificationHistorySlice", () => {
       const entries = getState().entries;
       expect(entries.find((e) => e.id === targetId)?.seenAsToast).toBe(false);
       expect(entries.find((e) => e.id !== targetId)?.seenAsToast).toBe(true);
+    });
+  });
+
+  describe("evictedToInboxCount", () => {
+    it("starts at 0", () => {
+      expect(getState().evictedToInboxCount).toBe(0);
+    });
+
+    it("increments when markUnseenAsToast flips a seen entry", () => {
+      const id = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      expect(getState().evictedToInboxCount).toBe(0);
+      getState().markUnseenAsToast(id);
+      expect(getState().evictedToInboxCount).toBe(1);
+    });
+
+    it("does not increment when markUnseenAsToast targets a missing id", () => {
+      addEntry({ message: "test" });
+      expect(getState().evictedToInboxCount).toBe(0);
+      getState().markUnseenAsToast("nonexistent-id");
+      expect(getState().evictedToInboxCount).toBe(0);
+    });
+
+    it("does not increment when markUnseenAsToast targets an already-unseen entry", () => {
+      const id = getState().addEntry({ type: "info", message: "missed", seenAsToast: false });
+      expect(getState().evictedToInboxCount).toBe(0);
+      getState().markUnseenAsToast(id);
+      expect(getState().evictedToInboxCount).toBe(0);
+    });
+
+    it("accumulates across multiple evictions", () => {
+      const a = getState().addEntry({ type: "info", message: "a", seenAsToast: true });
+      const b = getState().addEntry({ type: "info", message: "b", seenAsToast: true });
+      const c = getState().addEntry({ type: "info", message: "c", seenAsToast: true });
+      getState().markUnseenAsToast(a);
+      getState().markUnseenAsToast(b);
+      getState().markUnseenAsToast(c);
+      expect(getState().evictedToInboxCount).toBe(3);
+    });
+
+    it("resetEvictedCount zeroes the counter without touching entries or unreadCount", () => {
+      const id = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      getState().markUnseenAsToast(id);
+      expect(getState().evictedToInboxCount).toBe(1);
+      expect(getState().unreadCount).toBe(1);
+      getState().resetEvictedCount();
+      expect(getState().evictedToInboxCount).toBe(0);
+      expect(getState().unreadCount).toBe(1);
+      expect(getState().entries).toHaveLength(1);
+    });
+
+    it("resetEvictedCount returns the same state object when already zero", () => {
+      const before = getState();
+      getState().resetEvictedCount();
+      const after = getState();
+      // No-op set: same evictedToInboxCount value, no spurious render trigger.
+      expect(after.evictedToInboxCount).toBe(before.evictedToInboxCount);
+    });
+
+    it("clearAll resets the eviction counter", () => {
+      const id = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      getState().markUnseenAsToast(id);
+      expect(getState().evictedToInboxCount).toBe(1);
+      getState().clearAll();
+      expect(getState().evictedToInboxCount).toBe(0);
     });
   });
 

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { ReactNode } from "react";
 import type { ActionId } from "@shared/types/actions";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
+import { useUIStore } from "@/store/uiStore";
 
 const uuidv4 = () => crypto.randomUUID();
 
@@ -184,7 +185,14 @@ export const useNotificationStore = create<NotificationStore>((set) => ({
             n.id === evictCandidate.id ? { ...n, dismissed: true } : n
           );
           if (evictCandidate.historyEntryId) {
-            useNotificationHistoryStore.getState().markUnseenAsToast(evictCandidate.historyEntryId);
+            // Suppress the discoverability cue (overflow pill + bell blip)
+            // when the notification center is already open — the user can
+            // see the entry land in the inbox directly, so signaling its
+            // arrival twice would create a UX contradiction.
+            const silent = useUIStore.getState().notificationCenterOpen;
+            useNotificationHistoryStore
+              .getState()
+              .markUnseenAsToast(evictCandidate.historyEntryId, { silent });
           }
         }
       }

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -50,7 +50,13 @@ interface NotificationHistoryState {
    */
   evictedToInboxCount: number;
   addEntry: (entry: AddEntryInput) => string;
-  markUnseenAsToast: (id: string) => void;
+  /**
+   * Flips an entry's `seenAsToast` back to false (it's no longer visible as a
+   * toast). Pass `silent: true` to skip the discoverability-cue increment
+   * (`evictedToInboxCount`) — used when the notification center is already
+   * open and the user can see the entry land in the inbox directly.
+   */
+  markUnseenAsToast: (id: string, options?: { silent?: boolean }) => void;
   dismissEntry: (id: string) => void;
   clearAll: () => void;
   markAllRead: () => void;
@@ -83,7 +89,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
     });
     return newEntry.id;
   },
-  markUnseenAsToast: (id) =>
+  markUnseenAsToast: (id, options) =>
     set((state) => {
       const entry = state.entries.find((e) => e.id === id);
       if (!entry || !entry.seenAsToast) return state;
@@ -91,7 +97,9 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       return {
         entries,
         unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
-        evictedToInboxCount: state.evictedToInboxCount + 1,
+        evictedToInboxCount: options?.silent
+          ? state.evictedToInboxCount
+          : state.evictedToInboxCount + 1,
       };
     }),
   dismissEntry: (id) =>

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -43,17 +43,25 @@ const MAX_ENTRIES = 200;
 interface NotificationHistoryState {
   entries: NotificationHistoryEntry[];
   unreadCount: number;
+  /**
+   * Number of toasts that have been evicted into the inbox since the user
+   * last opened the notification center. Drives the toaster overflow pill
+   * and the toolbar bell arrival animation. Reset by `resetEvictedCount`.
+   */
+  evictedToInboxCount: number;
   addEntry: (entry: AddEntryInput) => string;
   markUnseenAsToast: (id: string) => void;
   dismissEntry: (id: string) => void;
   clearAll: () => void;
   markAllRead: () => void;
   markSummarized: (ids: string[]) => void;
+  resetEvictedCount: () => void;
 }
 
 export const useNotificationHistoryStore = create<NotificationHistoryState>((set) => ({
   entries: [],
   unreadCount: 0,
+  evictedToInboxCount: 0,
   addEntry: (entry) => {
     const seenAsToast = entry.seenAsToast ?? false;
     const countable = entry.countable ?? true;
@@ -83,6 +91,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       return {
         entries,
         unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+        evictedToInboxCount: state.evictedToInboxCount + 1,
       };
     }),
   dismissEntry: (id) =>
@@ -93,7 +102,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
         unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
       };
     }),
-  clearAll: () => set({ entries: [], unreadCount: 0 }),
+  clearAll: () => set({ entries: [], unreadCount: 0, evictedToInboxCount: 0 }),
   markAllRead: () =>
     set((state) => ({
       unreadCount: 0,
@@ -108,6 +117,8 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
         ),
       };
     }),
+  resetEvictedCount: () =>
+    set((state) => (state.evictedToInboxCount === 0 ? state : { evictedToInboxCount: 0 })),
 }));
 
 /** Returns all history entries that share the given correlationId */

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 
 interface UIState {
   overlayClaims: Set<string>;
@@ -36,8 +37,19 @@ export const useUIStore = create<UIState>((set, get) => ({
   hasOpenOverlays: () => get().overlayClaims.size > 0,
 
   notificationCenterOpen: false,
-  openNotificationCenter: () => set({ notificationCenterOpen: true }),
+  openNotificationCenter: () => {
+    useNotificationHistoryStore.getState().resetEvictedCount();
+    set({ notificationCenterOpen: true });
+  },
   closeNotificationCenter: () => set({ notificationCenterOpen: false }),
   toggleNotificationCenter: () =>
-    set((state) => ({ notificationCenterOpen: !state.notificationCenterOpen })),
+    set((state) => {
+      const next = !state.notificationCenterOpen;
+      // Reset only on the closed → open transition; closing the center
+      // should not silently zero an unread arrival counter.
+      if (next) {
+        useNotificationHistoryStore.getState().resetEvictedCount();
+      }
+      return { notificationCenterOpen: next };
+    }),
 }));


### PR DESCRIPTION
When the toast stack evicts a notification into the inbox, there's no signal to the user that this happened — the toast just disappears. This PR closes that gap with two cues that work together: a pill below the toast stack that says how many toasts moved to the inbox, and a brief bell animation on the toolbar pointing users toward where they went.

Resolves #6424

## Changes

- New `evictedToInboxCount` field and `resetEvictedCount()` action on `notificationHistorySlice`. The counter increments inside `markUnseenAsToast` when a seen entry actually flips to unseen (the eviction success branch). An optional `{ silent?: boolean }` arg suppresses the increment for cases where the cue should be skipped.
- The eviction call site in `notificationStore.ts` reads `useUIStore.getState().notificationCenterOpen` and passes `silent: true` when the center is already open, so the cue doesn't fire when the user is already looking at the inbox.
- `uiStore.openNotificationCenter` and `toggleNotificationCenter` (closed→open transition only) call `resetEvictedCount()`, so opening the center clears the pill and stops the bell.
- New `OverflowPill` in `toaster.tsx` — rendered below the toast stack when `evictedToInboxCount > 0`. It's a `<button>` with `aria-live="polite"`, neutral surface tokens (no accent), and opens the notification center on click. Pointer-events-auto since the parent portal is pointer-events-none.
- Toolbar bell in `NotificationCenterToolbarButton.tsx` is wrapped in a `<span key={bellBumpKey}>` that gets `animate-activity-blip` when `bumpKey > 0`. A `useEffect` bumps the key when `evictedToInboxCount` increases and DND isn't active. A second `useEffect` schedules a `BELL_BLIP_CLEANUP_MS` (320ms) timer to reset the key so `will-change` doesn't linger on the toolbar.

## Files changed

- `src/store/slices/notificationHistorySlice.ts`
- `src/store/uiStore.ts`
- `src/store/notificationStore.ts`
- `src/components/ui/toaster.tsx`
- `src/components/Layout/NotificationCenterToolbarButton.tsx`
- `src/store/__tests__/notificationHistoryStore.test.ts`
- `src/components/ui/__tests__/toaster.test.tsx`
- `src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx`

## Testing

20 new tests across the three test files: 8 slice tests covering `evictedToInboxCount`, `resetEvictedCount`, and the `silent` option; 6 toaster tests for pill rendering, click behavior, the end-to-end eviction path, and center-open suppression; 6 toolbar button tests for bell animation, DND gating, key persistence, cleanup timer, and toggle reset semantics.