### PR TITLE
fix(sidebar): roving tabindex for worktree list (#6422)

### DIFF
--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -96,22 +96,31 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
     }),
   };
 
-  const { role: _role, "aria-roledescription": _ariaRoleDesc, ...filteredAttributes } = attributes;
+  const {
+    role: _role,
+    "aria-roledescription": _ariaRoleDesc,
+    tabIndex: _tabIndex,
+    ...filteredAttributes
+  } = attributes;
 
   return (
     <div
       ref={setNodeRef}
       style={style}
       className={cn(isDragging && "opacity-40")}
-      role="listitem"
+      role="row"
       aria-roledescription="sortable worktree"
+      data-worktree-row={worktreeId}
+      tabIndex={-1}
       {...filteredAttributes}
     >
-      {children({
-        isDraggingSort: isDragging,
-        dragHandleListeners: listeners,
-        dragHandleActivatorRef: setActivatorNodeRef,
-      })}
+      <div role="gridcell">
+        {children({
+          isDraggingSort: isDragging,
+          dragHandleListeners: listeners,
+          dragHandleActivatorRef: setActivatorNodeRef,
+        })}
+      </div>
     </div>
   );
 }, sortableWorktreeCardPropsAreEqual);

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -67,6 +67,7 @@ import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { logError } from "@/utils/logger";
+import { useWorktreeGridRovingFocus } from "./useWorktreeGridRovingFocus";
 
 export function preloadNewWorktreeDialog() {
   return import("@/components/Worktree/NewWorktreeDialog");
@@ -306,29 +307,33 @@ const StaticWorktreeRow = React.memo(function StaticWorktreeRow({
   if (!worktree) return null;
 
   return (
-    <ErrorBoundary
-      variant="component"
-      componentName="WorktreeCard"
-      fallback={WorktreeCardErrorFallback}
-      resetKeys={[worktreeId]}
-      context={{ worktreeId }}
-    >
-      <WorktreeCard
-        worktree={worktree}
-        isActive={worktreeId === activeWorktreeId}
-        isFocused={worktreeId === focusedWorktreeId}
-        isSingleWorktree={totalWorktreeCount === 1}
-        aggregateCounts={aggregateCounts}
-        onSelect={onSelect}
-        onCopyTree={onCopyTree}
-        onOpenEditor={onOpenEditor}
-        onSaveLayout={onSaveLayout}
-        onLaunchAgent={onLaunchAgent}
-        agentAvailability={availability}
-        agentSettings={agentSettings}
-        homeDir={homeDir}
-      />
-    </ErrorBoundary>
+    <div role="row" data-worktree-row={worktreeId} tabIndex={-1}>
+      <div role="gridcell">
+        <ErrorBoundary
+          variant="component"
+          componentName="WorktreeCard"
+          fallback={WorktreeCardErrorFallback}
+          resetKeys={[worktreeId]}
+          context={{ worktreeId }}
+        >
+          <WorktreeCard
+            worktree={worktree}
+            isActive={worktreeId === activeWorktreeId}
+            isFocused={worktreeId === focusedWorktreeId}
+            isSingleWorktree={totalWorktreeCount === 1}
+            aggregateCounts={aggregateCounts}
+            onSelect={onSelect}
+            onCopyTree={onCopyTree}
+            onOpenEditor={onOpenEditor}
+            onSaveLayout={onSaveLayout}
+            onLaunchAgent={onLaunchAgent}
+            agentAvailability={availability}
+            agentSettings={agentSettings}
+            homeDir={homeDir}
+          />
+        </ErrorBoundary>
+      </div>
+    </div>
   );
 });
 
@@ -341,6 +346,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const armFocusedShortcut = useKeybindingDisplay("fleet.armFocused");
   const refreshShortcut = useKeybindingDisplay("worktree.refresh");
   const createWorktreeShortcut = useKeybindingDisplay("worktree.createDialog.open");
+  const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus();
   const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
@@ -1140,135 +1146,145 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         </div>
       )}
 
-      {/* Main worktree — visible unless excluded by text search */}
-      {mainMatchesQuery && (
-        <div
-          className="shrink-0"
-          style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
-        >
-          <StaticWorktreeRow
-            key={mainWorktree.id}
-            worktreeId={mainWorktree.id}
-            activeWorktreeId={activeWorktreeId}
-            focusedWorktreeId={focusedWorktreeId}
-            totalWorktreeCount={deferredWorktrees.length}
-            selectWorktree={selectWorktree}
-            worktreeActions={worktreeActions}
-            availability={availability}
-            agentSettings={agentSettings}
-            homeDir={homeDir}
-            aggregateCounts={mainWorktreeAggregateCounts}
-          />
-        </div>
-      )}
-
-      {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
-      {integrationMatchesQuery && (
-        <div
-          className="shrink-0"
-          style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
-        >
-          {renderWorktreeCard(integrationWorktree)}
-        </div>
-      )}
-
-      {/* Strong divider between pinned worktrees and scrollable list */}
-      {hasNonMainWorktrees && <div className="shrink-0 border-b border-border-default" />}
-
-      {/* Non-main worktree list */}
-      <div className="relative flex-1 min-h-0">
-        <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
-          <div ref={scrollContentRef}>
-            {hasNonMainWorktrees && (
-              <QuickStateFilterBar
-                value={quickStateFilter}
-                onChange={setQuickStateFilter}
-                counts={quickStateCounts}
-              />
-            )}
-            {showQuickStateEmptyState ? (
-              <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
-                <p className="text-sm text-daintree-text/80 mb-1">
-                  No {quickStateFilter} worktrees
-                </p>
-                <p className="text-xs text-daintree-text/50 mb-3">
-                  {hasPopoverFilters
-                    ? "Try a different state, or clear your other filters"
-                    : "Try a different state to see the rest"}
-                </p>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={clearQuickStateFilter}
-                    className="text-xs px-3 py-1.5 text-accent-primary hover:bg-overlay-soft rounded transition-colors font-medium"
-                  >
-                    Show all states
-                  </button>
-                  {hasPopoverFilters ? (
-                    <button
-                      onClick={clearAllFilters}
-                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                    >
-                      Clear all filters
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
-              <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
-                <p className="text-sm text-daintree-text/60 mb-3">
-                  No worktrees match your filters
-                </p>
-                <button
-                  onClick={clearAllFilters}
-                  className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                >
-                  Clear filters
-                </button>
-              </div>
-            ) : groupedSections ? (
-              <div className="flex flex-col">
-                {groupedSections.map((section) => (
-                  <div key={section.type}>
-                    <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide bg-daintree-sidebar border-b border-divider">
-                      {section.displayName} ({section.worktrees.length})
-                    </div>
-                    {section.worktrees.map(renderWorktreeCard)}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                <div className="flex flex-col">
-                  {filteredWorktrees.map((worktree, idx) => {
-                    const isPinned = pinnedWorktrees.includes(worktree.id);
-                    return (
-                      <SidebarWorktreeRow
-                        key={worktree.id}
-                        worktreeId={worktree.id}
-                        activeWorktreeId={activeWorktreeId}
-                        focusedWorktreeId={focusedWorktreeId}
-                        totalWorktreeCount={deferredWorktrees.length}
-                        selectWorktree={selectWorktree}
-                        worktreeActions={worktreeActions}
-                        availability={availability}
-                        agentSettings={agentSettings}
-                        homeDir={homeDir}
-                        dragStartOrder={dragStartOrder}
-                        isSortDisabled={isSortDisabled}
-                        isPinned={isPinned}
-                        rowIndex={idx}
-                      />
-                    );
-                  })}
-                </div>
-              </SortableContext>
-            )}
+      {/* Worktree list — single role="grid" with roving tab stop spans pinned + scrollable rows */}
+      <div
+        ref={gridRef}
+        role="grid"
+        aria-label="Worktrees"
+        onKeyDown={handleGridKeyDown}
+        onFocusCapture={handleGridFocusCapture}
+        className="flex flex-col flex-1 min-h-0"
+      >
+        {/* Main worktree — visible unless excluded by text search */}
+        {mainMatchesQuery && (
+          <div
+            className="shrink-0"
+            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+          >
+            <StaticWorktreeRow
+              key={mainWorktree.id}
+              worktreeId={mainWorktree.id}
+              activeWorktreeId={activeWorktreeId}
+              focusedWorktreeId={focusedWorktreeId}
+              totalWorktreeCount={deferredWorktrees.length}
+              selectWorktree={selectWorktree}
+              worktreeActions={worktreeActions}
+              availability={availability}
+              agentSettings={agentSettings}
+              homeDir={homeDir}
+              aggregateCounts={mainWorktreeAggregateCounts}
+            />
           </div>
+        )}
+
+        {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
+        {integrationMatchesQuery && (
+          <div
+            className="shrink-0"
+            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+          >
+            {renderWorktreeCard(integrationWorktree)}
+          </div>
+        )}
+
+        {/* Strong divider between pinned worktrees and scrollable list */}
+        {hasNonMainWorktrees && <div className="shrink-0 border-b border-border-default" />}
+
+        {/* Non-main worktree list */}
+        <div className="relative flex-1 min-h-0">
+          <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
+            <div ref={scrollContentRef}>
+              {hasNonMainWorktrees && (
+                <QuickStateFilterBar
+                  value={quickStateFilter}
+                  onChange={setQuickStateFilter}
+                  counts={quickStateCounts}
+                />
+              )}
+              {showQuickStateEmptyState ? (
+                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                  <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
+                  <p className="text-sm text-daintree-text/80 mb-1">
+                    No {quickStateFilter} worktrees
+                  </p>
+                  <p className="text-xs text-daintree-text/50 mb-3">
+                    {hasPopoverFilters
+                      ? "Try a different state, or clear your other filters"
+                      : "Try a different state to see the rest"}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={clearQuickStateFilter}
+                      className="text-xs px-3 py-1.5 text-accent-primary hover:bg-overlay-soft rounded transition-colors font-medium"
+                    >
+                      Show all states
+                    </button>
+                    {hasPopoverFilters ? (
+                      <button
+                        onClick={clearAllFilters}
+                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                      >
+                        Clear all filters
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
+                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                  <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
+                  <p className="text-sm text-daintree-text/60 mb-3">
+                    No worktrees match your filters
+                  </p>
+                  <button
+                    onClick={clearAllFilters}
+                    className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                  >
+                    Clear filters
+                  </button>
+                </div>
+              ) : groupedSections ? (
+                <div className="flex flex-col">
+                  {groupedSections.map((section) => (
+                    <div key={section.type}>
+                      <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide bg-daintree-sidebar border-b border-divider">
+                        {section.displayName} ({section.worktrees.length})
+                      </div>
+                      {section.worktrees.map(renderWorktreeCard)}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                  <div className="flex flex-col">
+                    {filteredWorktrees.map((worktree, idx) => {
+                      const isPinned = pinnedWorktrees.includes(worktree.id);
+                      return (
+                        <SidebarWorktreeRow
+                          key={worktree.id}
+                          worktreeId={worktree.id}
+                          activeWorktreeId={activeWorktreeId}
+                          focusedWorktreeId={focusedWorktreeId}
+                          totalWorktreeCount={deferredWorktrees.length}
+                          selectWorktree={selectWorktree}
+                          worktreeActions={worktreeActions}
+                          availability={availability}
+                          agentSettings={agentSettings}
+                          homeDir={homeDir}
+                          dragStartOrder={dragStartOrder}
+                          isSortDisabled={isSortDisabled}
+                          isPinned={isPinned}
+                          rowIndex={idx}
+                        />
+                      );
+                    })}
+                  </div>
+                </SortableContext>
+              )}
+            </div>
+          </div>
+          <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
+          <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
         </div>
-        <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
-        <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
       </div>
 
       <ErrorBoundary

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -139,5 +139,23 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     it("handles Space to select the row's primary worktree button", () => {
       expect(source).toMatch(/aria-label\^='Select worktree'/);
     });
+
+    it("demotes every native focusable inside each row so the grid is one tab stop", () => {
+      // Without this, the absolute "Select worktree" button, terminal-section
+      // collapse buttons, PR/issue links, etc. all keep their native tab
+      // stops and the keyboard-exhaustion bug is unfixed.
+      expect(source).toMatch(/ROW_DESCENDANT_SELECTOR/);
+      expect(source).toMatch(/demoteRowDescendants/);
+    });
+
+    it("repairs DOM tab stops on window blur (not just modeRef)", () => {
+      // Stale tabIndex=0 on a toolbar item would let the next Tab land back
+      // inside that toolbar instead of on the row. Blur must clear it.
+      const blurEffect = source.match(
+        /useEffect\(\(\)\s*=>\s*\{[\s\S]*?addEventListener\("blur"[\s\S]*?\}\s*,\s*\[[^\]]*\]\)/
+      );
+      expect(blurEffect).toBeTruthy();
+      expect(blurEffect?.[0]).toContain("syncRowTabStops");
+    });
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+const SORTABLE_CARD_PATH = path.resolve(__dirname, "../../DragDrop/SortableWorktreeCard.tsx");
+const WORKTREE_CARD_PATH = path.resolve(__dirname, "../../Worktree/WorktreeCard.tsx");
+const WORKTREE_HEADER_PATH = path.resolve(
+  __dirname,
+  "../../Worktree/WorktreeCard/WorktreeHeader.tsx"
+);
+const HOOK_PATH = path.resolve(__dirname, "../useWorktreeGridRovingFocus.ts");
+
+describe("Worktree list keyboard grid — issue #6422", () => {
+  describe("SortableWorktreeCard ARIA contract", () => {
+    let source: string;
+    beforeEach(async () => {
+      source = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+    });
+
+    it("strips dnd-kit's tabIndex from spread attributes so the row never gets a stray tab stop", () => {
+      // dnd-kit's useSortable returns attributes that include `tabIndex: 0`.
+      // Spreading them onto the row would defeat the single-tab-stop contract.
+      expect(source).toMatch(/tabIndex:\s*_tabIndex/);
+    });
+
+    it('uses role="row" (not listitem) so the wrapper participates in the grid', () => {
+      expect(source).toContain('role="row"');
+      expect(source).not.toContain('role="listitem"');
+    });
+
+    it("exposes data-worktree-row so the roving controller can query rows", () => {
+      expect(source).toContain("data-worktree-row={worktreeId}");
+    });
+
+    it('wraps children in role="gridcell" for valid grid > row > gridcell semantics', () => {
+      expect(source).toContain('role="gridcell"');
+    });
+
+    it("starts with tabIndex={-1}; the controller promotes one row to 0", () => {
+      expect(source).toContain("tabIndex={-1}");
+    });
+  });
+
+  describe("WorktreeCard role conditional", () => {
+    let source: string;
+    beforeEach(async () => {
+      source = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+    });
+
+    it('only applies role="group" in the overview grid variant — sidebar rows defer to the row wrapper', () => {
+      expect(source).toContain('role={variant === "grid" ? "group" : undefined}');
+    });
+  });
+
+  describe("WorktreeHeader actions toolbar", () => {
+    let source: string;
+    beforeEach(async () => {
+      source = await fs.readFile(WORKTREE_HEADER_PATH, "utf-8");
+    });
+
+    it("marks the actions wrapper with data-worktree-row-toolbar so the controller can find it", () => {
+      expect(source).toContain('data-worktree-row-toolbar=""');
+    });
+
+    it('declares role="toolbar" and an accessible label', () => {
+      expect(source).toMatch(/role="toolbar"/);
+      expect(source).toMatch(/aria-label="Worktree actions"/);
+    });
+  });
+
+  describe("SidebarContent grid wiring", () => {
+    let source: string;
+    beforeEach(async () => {
+      source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+    });
+
+    it("imports the roving-focus hook", () => {
+      expect(source).toContain('from "./useWorktreeGridRovingFocus"');
+      expect(source).toContain("useWorktreeGridRovingFocus");
+    });
+
+    it('wires gridRef + handlers from the hook into a role="grid" container', () => {
+      expect(source).toContain(
+        "const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus();"
+      );
+      expect(source).toContain('role="grid"');
+      expect(source).toContain('aria-label="Worktrees"');
+      expect(source).toContain("ref={gridRef}");
+      expect(source).toContain("onKeyDown={handleGridKeyDown}");
+      expect(source).toContain("onFocusCapture={handleGridFocusCapture}");
+    });
+
+    it('wraps StaticWorktreeRow\'s WorktreeCard in role="row" + data-worktree-row + role="gridcell"', () => {
+      // The static (pinned/grouped) rows don't go through SortableWorktreeCard,
+      // so the row + gridcell roles must be added explicitly here.
+      expect(source).toContain('<div role="row" data-worktree-row={worktreeId} tabIndex={-1}>');
+      // Ensure the static path also has a gridcell wrapper
+      const staticRowMatch = source.match(
+        /const StaticWorktreeRow[\s\S]*?<\/div>\s*\)\s*;\s*\}\s*\)\s*;/
+      );
+      expect(staticRowMatch).toBeTruthy();
+      expect(staticRowMatch?.[0]).toContain('role="gridcell"');
+    });
+  });
+
+  describe("useWorktreeGridRovingFocus hook", () => {
+    let source: string;
+    beforeEach(async () => {
+      source = await fs.readFile(HOOK_PATH, "utf-8");
+    });
+
+    it("queries rows via [data-worktree-row]", () => {
+      expect(source).toContain("[data-worktree-row]");
+    });
+
+    it("queries the per-row toolbar via [data-worktree-row-toolbar]", () => {
+      expect(source).toContain("[data-worktree-row-toolbar]");
+    });
+
+    it("syncs tab stops by mutating element.tabIndex directly (not via React state)", () => {
+      // Mirrors Toolbar.tsx's DOM-mutation pattern to avoid re-rendering 50–200
+      // worktree cards on every arrow keypress.
+      expect(source).toMatch(/\.tabIndex\s*=\s*-1/);
+      expect(source).toMatch(/\.tabIndex\s*=\s*0/);
+    });
+
+    it("resets to list mode on window blur (lesson #4591)", () => {
+      expect(source).toContain('window.addEventListener("blur"');
+      expect(source).toMatch(/modeRef\.current\s*=\s*"list"/);
+    });
+
+    it("handles Enter / ArrowRight to enter toolbar mode and Escape to return to list mode", () => {
+      expect(source).toMatch(/"Enter"/);
+      expect(source).toMatch(/"ArrowRight"/);
+      expect(source).toMatch(/"Escape"/);
+    });
+
+    it("handles Space to select the row's primary worktree button", () => {
+      expect(source).toMatch(/aria-label\^='Select worktree'/);
+    });
+  });
+});

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -225,7 +225,8 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
       if (rows.length === 0) return;
 
       const mode = modeRef.current;
-      const target = e.target as HTMLElement;
+      if (!(e.target instanceof HTMLElement)) return;
+      const target = e.target;
       const isOnRow = rows.some((row) => row === target);
 
       if (mode === "list") {

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -7,6 +7,11 @@ const ROW_SELECTOR = "[data-worktree-row]";
 const TOOLBAR_SELECTOR = "[data-worktree-row-toolbar]";
 const TOOLBAR_ITEM_SELECTOR =
   "button:not(:disabled), [role='button']:not([aria-disabled='true']), [tabindex]:not([tabindex='-1'])";
+// Every natively-focusable element inside a row that isn't the row itself.
+// These are demoted to tabIndex=-1 so the grid presents exactly one tab stop;
+// access happens via the row → toolbar mode flow or directly via mouse.
+const ROW_DESCENDANT_SELECTOR =
+  "button, a[href], input, select, textarea, [tabindex]:not([data-worktree-row])";
 
 function isElementVisible(el: HTMLElement): boolean {
   return el.offsetParent !== null || el.getClientRects().length > 0;
@@ -39,10 +44,27 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
     );
   }, []);
 
-  const syncRowTabStops = useCallback((rows: HTMLElement[], activeIdx: number) => {
-    for (const row of rows) row.tabIndex = -1;
-    if (rows[activeIdx]) rows[activeIdx].tabIndex = 0;
+  // Force every native focusable inside the row out of the tab order. Called
+  // every render and on every navigation event — without it, every per-row
+  // button (select, collapse, PR link, etc.) keeps tabIndex=0 and the user
+  // still hits hundreds of tab stops to traverse the list.
+  const demoteRowDescendants = useCallback((row: HTMLElement) => {
+    const descendants = row.querySelectorAll<HTMLElement>(ROW_DESCENDANT_SELECTOR);
+    for (const el of descendants) {
+      if (el.tabIndex !== -1) el.tabIndex = -1;
+    }
   }, []);
+
+  const syncRowTabStops = useCallback(
+    (rows: HTMLElement[], activeIdx: number) => {
+      for (const row of rows) {
+        row.tabIndex = -1;
+        demoteRowDescendants(row);
+      }
+      if (rows[activeIdx]) rows[activeIdx].tabIndex = 0;
+    },
+    [demoteRowDescendants]
+  );
 
   const syncToolbarTabStops = useCallback((items: HTMLElement[], activeIdx: number) => {
     for (const el of items) el.tabIndex = -1;
@@ -125,14 +147,27 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
   });
 
   // Reset to list mode when the window loses focus so re-entering the grid
-  // always starts on a row, never inside a toolbar (lesson #4591).
+  // always starts on a row, never inside a toolbar (lesson #4591). Repairs the
+  // DOM tab stops too — leaving stale tabIndex=0 on a toolbar item would let
+  // the next Tab land back inside that toolbar instead of on the row.
   useEffect(() => {
     const handleBlur = () => {
+      const wasInToolbar = modeRef.current === "toolbar";
       modeRef.current = "list";
+      if (!wasInToolbar) return;
+      const rows = getRows();
+      if (rows.length === 0) return;
+      const rowIdx = Math.min(activeRowIndexRef.current, rows.length - 1);
+      const row = rows[rowIdx];
+      if (row) {
+        const items = getRowToolbarItems(row);
+        for (const el of items) el.tabIndex = -1;
+      }
+      syncRowTabStops(rows, rowIdx);
     };
     window.addEventListener("blur", handleBlur);
     return () => window.removeEventListener("blur", handleBlur);
-  }, []);
+  }, [getRows, getRowToolbarItems, syncRowTabStops]);
 
   const handleGridFocusCapture = useCallback(
     (e: React.FocusEvent<HTMLDivElement>) => {
@@ -174,9 +209,10 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
         }
       }
       // Focus landed somewhere inside the row but outside the toolbar (e.g.,
-      // the underlying full-card "Select worktree" button). Stay in list mode
-      // but hand the row's tabIndex off so re-entering the grid lands here.
-      syncRowTabStops(rows, containingRowIdx);
+      // the underlying full-card "Select worktree" button, or a click into a
+      // different row while we were in toolbar mode on row A). Always reset
+      // toolbar items in the previously active row before promoting this row.
+      enterListMode(rows, containingRowIdx);
     },
     [enterListMode, getRowToolbarItems, getRows, syncRowTabStops, syncToolbarTabStops]
   );

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import type React from "react";
+
+type GridMode = "list" | "toolbar";
+
+const ROW_SELECTOR = "[data-worktree-row]";
+const TOOLBAR_SELECTOR = "[data-worktree-row-toolbar]";
+const TOOLBAR_ITEM_SELECTOR =
+  "button:not(:disabled), [role='button']:not([aria-disabled='true']), [tabindex]:not([tabindex='-1'])";
+
+function isElementVisible(el: HTMLElement): boolean {
+  return el.offsetParent !== null || el.getClientRects().length > 0;
+}
+
+export interface UseWorktreeGridRovingFocusReturn {
+  gridRef: React.RefObject<HTMLDivElement | null>;
+  handleGridKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleGridFocusCapture: (e: React.FocusEvent<HTMLDivElement>) => void;
+}
+
+export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const modeRef = useRef<GridMode>("list");
+  const activeRowIndexRef = useRef<number>(0);
+  const activeToolbarIndexRef = useRef<number>(0);
+
+  const getRows = useCallback((): HTMLElement[] => {
+    if (!gridRef.current) return [];
+    return Array.from(gridRef.current.querySelectorAll<HTMLElement>(ROW_SELECTOR)).filter(
+      isElementVisible
+    );
+  }, []);
+
+  const getRowToolbarItems = useCallback((row: HTMLElement): HTMLElement[] => {
+    const toolbar = row.querySelector<HTMLElement>(TOOLBAR_SELECTOR);
+    if (!toolbar) return [];
+    return Array.from(toolbar.querySelectorAll<HTMLElement>(TOOLBAR_ITEM_SELECTOR)).filter(
+      isElementVisible
+    );
+  }, []);
+
+  const syncRowTabStops = useCallback((rows: HTMLElement[], activeIdx: number) => {
+    for (const row of rows) row.tabIndex = -1;
+    if (rows[activeIdx]) rows[activeIdx].tabIndex = 0;
+  }, []);
+
+  const syncToolbarTabStops = useCallback((items: HTMLElement[], activeIdx: number) => {
+    for (const el of items) el.tabIndex = -1;
+    if (items[activeIdx]) items[activeIdx].tabIndex = 0;
+  }, []);
+
+  const selectRow = useCallback(
+    (row: HTMLElement | undefined, e: React.KeyboardEvent | React.SyntheticEvent) => {
+      if (!row) return;
+      const selectBtn = row.querySelector<HTMLElement>("button[aria-label^='Select worktree']");
+      if (selectBtn) {
+        e.preventDefault();
+        e.stopPropagation();
+        selectBtn.click();
+      }
+    },
+    []
+  );
+
+  const enterListMode = useCallback(
+    (rows: HTMLElement[], rowIdx: number) => {
+      modeRef.current = "list";
+      activeRowIndexRef.current = rowIdx;
+      // Reset toolbar items in the previously active row so they are no longer
+      // tab-reachable from outside the grid.
+      const previousRow = rows[rowIdx];
+      if (previousRow) {
+        const items = getRowToolbarItems(previousRow);
+        for (const el of items) el.tabIndex = -1;
+      }
+      syncRowTabStops(rows, rowIdx);
+    },
+    [getRowToolbarItems, syncRowTabStops]
+  );
+
+  const enterToolbarMode = useCallback(
+    (rows: HTMLElement[], rowIdx: number): boolean => {
+      const row = rows[rowIdx];
+      if (!row) return false;
+      const items = getRowToolbarItems(row);
+      if (items.length === 0) return false;
+      modeRef.current = "toolbar";
+      activeToolbarIndexRef.current = 0;
+      // Hand the tab stop off from the row to the first toolbar button so a
+      // re-entrant Tab still hits this row's actions.
+      row.tabIndex = -1;
+      syncToolbarTabStops(items, 0);
+      items[0]!.focus();
+      return true;
+    },
+    [getRowToolbarItems, syncToolbarTabStops]
+  );
+
+  // After every render, re-sync the tab stops so a single row owns tabIndex=0.
+  // Mirrors Toolbar.tsx's approach — survives re-renders without storing the
+  // active index in React state.
+  useLayoutEffect(() => {
+    const rows = getRows();
+    if (rows.length === 0) return;
+    const clamped = Math.min(activeRowIndexRef.current, rows.length - 1);
+    activeRowIndexRef.current = clamped;
+    if (modeRef.current === "list") {
+      syncRowTabStops(rows, clamped);
+    } else {
+      const row = rows[clamped];
+      if (row) {
+        const items = getRowToolbarItems(row);
+        if (items.length === 0) {
+          // Toolbar disappeared (e.g., row no longer hover/focus visible) —
+          // fall back to list mode.
+          enterListMode(rows, clamped);
+        } else {
+          row.tabIndex = -1;
+          const itemIdx = Math.min(activeToolbarIndexRef.current, items.length - 1);
+          activeToolbarIndexRef.current = itemIdx;
+          syncToolbarTabStops(items, itemIdx);
+        }
+      }
+    }
+  });
+
+  // Reset to list mode when the window loses focus so re-entering the grid
+  // always starts on a row, never inside a toolbar (lesson #4591).
+  useEffect(() => {
+    const handleBlur = () => {
+      modeRef.current = "list";
+    };
+    window.addEventListener("blur", handleBlur);
+    return () => window.removeEventListener("blur", handleBlur);
+  }, []);
+
+  const handleGridFocusCapture = useCallback(
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement;
+      const rows = getRows();
+      if (rows.length === 0) return;
+
+      const rowIdx = rows.findIndex((row) => row === target);
+      if (rowIdx !== -1) {
+        // Focus landed on the row wrapper itself.
+        activeRowIndexRef.current = rowIdx;
+        if (modeRef.current === "toolbar") {
+          enterListMode(rows, rowIdx);
+        } else {
+          syncRowTabStops(rows, rowIdx);
+        }
+        return;
+      }
+
+      // Focus landed inside a row — find which one.
+      const containingRowIdx = rows.findIndex((row) => row.contains(target));
+      if (containingRowIdx === -1) return;
+
+      activeRowIndexRef.current = containingRowIdx;
+      const row = rows[containingRowIdx]!;
+
+      // If the focus target is inside the per-row action toolbar, switch to
+      // toolbar mode and remember which item is active.
+      const toolbar = row.querySelector<HTMLElement>(TOOLBAR_SELECTOR);
+      if (toolbar && toolbar.contains(target)) {
+        const items = getRowToolbarItems(row);
+        const itemIdx = items.indexOf(target);
+        if (itemIdx !== -1) {
+          modeRef.current = "toolbar";
+          activeToolbarIndexRef.current = itemIdx;
+          row.tabIndex = -1;
+          syncToolbarTabStops(items, itemIdx);
+          return;
+        }
+      }
+      // Focus landed somewhere inside the row but outside the toolbar (e.g.,
+      // the underlying full-card "Select worktree" button). Stay in list mode
+      // but hand the row's tabIndex off so re-entering the grid lands here.
+      syncRowTabStops(rows, containingRowIdx);
+    },
+    [enterListMode, getRowToolbarItems, getRows, syncRowTabStops, syncToolbarTabStops]
+  );
+
+  const handleGridKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.metaKey || e.altKey || e.ctrlKey) return;
+
+      const rows = getRows();
+      if (rows.length === 0) return;
+
+      const mode = modeRef.current;
+      const target = e.target as HTMLElement;
+      const isOnRow = rows.some((row) => row === target);
+
+      if (mode === "list") {
+        // If focus isn't on a row wrapper, skip — the user is interacting with
+        // some other in-grid element (e.g., a scroll indicator).
+        if (!isOnRow) return;
+
+        const currentIdx = Math.min(activeRowIndexRef.current, rows.length - 1);
+        let newIdx: number | null = null;
+
+        if (e.key === "Enter" || e.key === "ArrowRight") {
+          // Try to enter toolbar mode. If the row has no toolbar items
+          // (e.g., the actions wrapper is hidden), fall back to selecting
+          // the row's primary worktree (the absolute "Select worktree" button).
+          if (enterToolbarMode(rows, currentIdx)) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
+          selectRow(rows[currentIdx], e);
+          return;
+        }
+
+        if (e.key === " " || e.key === "Spacebar") {
+          selectRow(rows[currentIdx], e);
+          return;
+        }
+
+        switch (e.key) {
+          case "ArrowDown":
+            newIdx = (currentIdx + 1) % rows.length;
+            break;
+          case "ArrowUp":
+            newIdx = (currentIdx - 1 + rows.length) % rows.length;
+            break;
+          case "Home":
+            newIdx = 0;
+            break;
+          case "End":
+            newIdx = rows.length - 1;
+            break;
+        }
+        if (newIdx !== null) {
+          e.preventDefault();
+          activeRowIndexRef.current = newIdx;
+          syncRowTabStops(rows, newIdx);
+          rows[newIdx]!.focus();
+        }
+        return;
+      }
+
+      // Toolbar mode
+      const rowIdx = activeRowIndexRef.current;
+      const row = rows[rowIdx];
+      if (!row) return;
+      const items = getRowToolbarItems(row);
+      if (items.length === 0) {
+        enterListMode(rows, rowIdx);
+        return;
+      }
+      const currentIdx = Math.min(activeToolbarIndexRef.current, items.length - 1);
+
+      if (e.key === "Escape") {
+        enterListMode(rows, rowIdx);
+        row.focus();
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+        // Up/Down in toolbar mode bounces back to list mode and moves rows.
+        enterListMode(rows, rowIdx);
+        const nextIdx =
+          e.key === "ArrowDown"
+            ? (rowIdx + 1) % rows.length
+            : (rowIdx - 1 + rows.length) % rows.length;
+        e.preventDefault();
+        activeRowIndexRef.current = nextIdx;
+        syncRowTabStops(rows, nextIdx);
+        rows[nextIdx]!.focus();
+        return;
+      }
+
+      let newIdx: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+          newIdx = (currentIdx + 1) % items.length;
+          break;
+        case "ArrowLeft":
+          newIdx = (currentIdx - 1 + items.length) % items.length;
+          break;
+        case "Home":
+          newIdx = 0;
+          break;
+        case "End":
+          newIdx = items.length - 1;
+          break;
+      }
+      if (newIdx !== null) {
+        e.preventDefault();
+        activeToolbarIndexRef.current = newIdx;
+        syncToolbarTabStops(items, newIdx);
+        items[newIdx]!.focus();
+      }
+    },
+    [
+      enterListMode,
+      enterToolbarMode,
+      getRowToolbarItems,
+      getRows,
+      selectRow,
+      syncRowTabStops,
+      syncToolbarTabStops,
+    ]
+  );
+
+  return { gridRef, handleGridKeyDown, handleGridFocusCapture };
+}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -709,7 +709,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
           data-worktree-branch={branchLabel}
           data-worktree-is-main={isMainWorktree ? "true" : undefined}
           data-resource-status={resourceStatusLabel ?? undefined}
-          role="group"
+          role={variant === "grid" ? "group" : undefined}
           aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${isActive ? " (selected)" : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
           onClick={onSelect}
           onDoubleClick={handleDoubleClick}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -641,6 +641,9 @@ export function WorktreeHeader({
 
         <div
           data-testid="worktree-actions-wrapper"
+          data-worktree-row-toolbar=""
+          role="toolbar"
+          aria-label="Worktree actions"
           className={cn(
             "flex items-center gap-0.5 shrink-0 transition-opacity duration-150",
             isCollapsed

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -29,6 +29,40 @@
     inset 0 0 0 2px var(--sidebar-ring);
 }
 
+/* Roving-tabindex grid: when the row wrapper itself is keyboard-focused,
+   surface the same focus ring on the embedded card so the user can see
+   which row owns the tab stop. */
+[data-worktree-row]:focus-visible {
+  outline: none;
+}
+
+[data-worktree-row]:focus-visible .sidebar-worktree-card {
+  box-shadow: inset 0 0 0 2px var(--sidebar-ring);
+}
+
+[data-worktree-row]:focus-visible .sidebar-worktree-card[data-active="true"] {
+  box-shadow:
+    inset 2px 0 0 var(--theme-overlay-selected),
+    inset 0 0 0 2px var(--sidebar-ring);
+}
+
+/* Reveal the per-row action toolbar whenever the row is focused (or any
+   descendant has focus). The card-internal `group-focus-within/card`
+   reveal only fires when focus lands inside the card; this rule handles
+   focus on the row wrapper itself. */
+[data-worktree-row]:focus [data-worktree-row-toolbar],
+[data-worktree-row]:focus-within [data-worktree-row-toolbar] {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (forced-colors: active) {
+  [data-worktree-row]:focus-visible .sidebar-worktree-card {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}
+
 .sidebar-action-button:hover {
   background: var(--sidebar-action-hover-bg, var(--theme-overlay-hover));
 }


### PR DESCRIPTION
## Summary

- Replaces per-row tab stops in the worktree list with a WAI-ARIA grid roving tabindex — the entire list is now a single tab stop instead of one per button per row
- Introduces `useWorktreeGridRovingFocus` and updates the container/row ARIA roles (`role="grid"`, `role="row"`, `role="gridcell"`, `role="toolbar"`)
- Fixes a silent bug where dnd-kit was injecting `tabIndex` via the sortable spread, making every row tabbable regardless of intent

Resolves #6422

## Changes

- `useWorktreeGridRovingFocus.ts` — new hook managing two-mode navigation: list mode (Up/Down to move between rows, Enter/ArrowRight to enter the row toolbar, Space to select) and toolbar mode (Left/Right to move between actions, Escape to return to the row)
- `SidebarContent.tsx` — wires the hook; adds `role="grid"` to the container and `data-worktree-row` markers to each row
- `SortableWorktreeCard.tsx` — strips `tabIndex` from the dnd-kit sortable spread to close the silent extra-tab-stop bug
- `WorktreeCard.tsx` / `WorktreeHeader.tsx` — demotes all in-row focusables to `tabIndex={-1}` so the grid truly owns navigation
- `sidebar.css` — focus styling for the roving tabindex active row
- Window blur handler repairs DOM focus state so re-entering the sidebar lands predictably on a row
- `SidebarContent.grid.test.ts` — 19 static-source assertions covering ARIA roles, data attributes, and tabIndex hygiene

## Testing

- Tab into the sidebar from outside — should land on one row, not cycle through every button
- Arrow keys navigate between rows; Enter or ArrowRight reveals the row toolbar and focuses the first action
- Escape from the toolbar returns focus to the row
- Tab away and back — focus lands on the previously active row