### PR TITLE
feat(fleet): keyboard navigation in FleetArmingDialog

### DIFF
--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -102,6 +103,11 @@ export function FleetArmingDialog({
   // number and is dropped if the counter has since advanced.
   const searchRequestRef = useRef(0);
   const rangeAnchorRef = useRef<string | null>(null);
+  // Roving-tabindex target — the id of the row that owns `tabIndex={0}`.
+  // Driven by arrow keys, Space, and click; reset by the clamping effect
+  // below when the visible list changes.
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const rowRefs = useRef<Map<string, HTMLLabelElement>>(new Map());
 
   // Reset all dialog-local state on each open/close transition. Single
   // useEffect keyed on [isOpen] per lesson #4958.
@@ -261,6 +267,31 @@ export function FleetArmingDialog({
     return out;
   }, [groupedVisible]);
 
+  // Stable callback-ref factory bound per row id. Keeps memoized children
+  // stable across renders — calling `setRowRef(id)` returns the same
+  // callback identity for the same id (memoized inside TerminalRow).
+  const setRowRef = useCallback(
+    (id: string) => (el: HTMLLabelElement | null) => {
+      if (el) rowRefs.current.set(id, el);
+      else rowRefs.current.delete(id);
+    },
+    []
+  );
+
+  // Keep `focusedId` valid as the visible list changes (search/filter/open).
+  // Clamps to the first visible id when the focused row is filtered out, or
+  // resets to null when the list is empty. Also drives initial focus on open.
+  useEffect(() => {
+    if (flatVisibleIds.length === 0) {
+      setFocusedId(null);
+      return;
+    }
+    setFocusedId((prev) => {
+      if (prev !== null && flatVisibleIds.includes(prev)) return prev;
+      return flatVisibleIds[0]!;
+    });
+  }, [flatVisibleIds]);
+
   // Counts derived from full eligible set, not visibleTerminals — chip
   // labels show project-wide totals so the user can see what's available
   // even after filtering.
@@ -332,6 +363,7 @@ export function FleetArmingDialog({
             return next;
           });
           rangeAnchorRef.current = id;
+          setFocusedId(id);
           return;
         }
       }
@@ -346,6 +378,7 @@ export function FleetArmingDialog({
         return next;
       });
       rangeAnchorRef.current = id;
+      setFocusedId(id);
     },
     [flatVisibleIds]
   );
@@ -371,6 +404,64 @@ export function FleetArmingDialog({
 
   const handleListKeyDown = useCallback(
     (e: ReactKeyboardEvent<HTMLDivElement>) => {
+      // Arrow navigation — handled before mod-required Cmd+A / Cmd+Shift+I
+      // since plain Arrow / Shift+Arrow / Ctrl+Arrow have no Meta requirement.
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        // Don't override macOS Cmd+Up/Down (page-jump); let the system handle.
+        if (e.metaKey) return;
+        if (flatVisibleIds.length === 0) return;
+        e.preventDefault();
+        const currentIdx = focusedId !== null ? flatVisibleIds.indexOf(focusedId) : -1;
+        const baseIdx = currentIdx === -1 ? 0 : currentIdx;
+        const nextIdx =
+          e.key === "ArrowDown"
+            ? Math.min(baseIdx + 1, flatVisibleIds.length - 1)
+            : Math.max(baseIdx - 1, 0);
+        const nextId = flatVisibleIds[nextIdx];
+        if (!nextId) return;
+        const moved = nextId !== focusedId;
+        if (moved) {
+          setFocusedId(nextId);
+          rowRefs.current.get(nextId)?.focus();
+        }
+        // Shift extends the range from the anchor to `nextIdx`. Plain Arrow
+        // and Ctrl+Arrow are focus-only — no selection change, no anchor
+        // update. If the anchor is null or filtered out, fall back to focus
+        // only (do not silently corrupt the user's intended range).
+        if (e.shiftKey && moved && rangeAnchorRef.current !== null) {
+          const anchorIdx = flatVisibleIds.indexOf(rangeAnchorRef.current);
+          if (anchorIdx !== -1) {
+            const lo = Math.min(anchorIdx, nextIdx);
+            const hi = Math.max(anchorIdx, nextIdx);
+            setSelectedIds((prev) => {
+              const next = new Set(prev);
+              for (let i = lo; i <= hi; i++) {
+                const id = flatVisibleIds[i];
+                if (id) next.add(id);
+              }
+              return next;
+            });
+          }
+        }
+        return;
+      }
+
+      // Space toggles the focused row and resets the anchor to it (matches
+      // VS Code QuickPick canSelectMany; subsequent Shift+Arrow extends from
+      // the just-toggled row).
+      if (e.key === " ") {
+        if (focusedId === null) return;
+        e.preventDefault();
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          if (next.has(focusedId)) next.delete(focusedId);
+          else next.add(focusedId);
+          return next;
+        });
+        rangeAnchorRef.current = focusedId;
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
       const key = e.key.toLowerCase();
@@ -394,7 +485,7 @@ export function FleetArmingDialog({
         });
       }
     },
-    [visibleIds]
+    [flatVisibleIds, focusedId, visibleIds]
   );
 
   const handleConfirm = useCallback(() => {
@@ -419,6 +510,17 @@ export function FleetArmingDialog({
     }
     return (
       <>
+        <span className="inline-flex items-center gap-1">
+          <Kbd>↑</Kbd>
+          <Kbd>↓</Kbd>
+          <span>Move</span>
+        </span>
+        <span className="text-daintree-text/30">·</span>
+        <span className="inline-flex items-center gap-1">
+          <Kbd>Space</Kbd>
+          <span>Toggle</span>
+        </span>
+        <span className="text-daintree-text/30">·</span>
         <span className="inline-flex items-center gap-1">
           <Kbd>{isMac() ? "⌘A" : "Ctrl+A"}</Kbd>
           <span>Select all</span>
@@ -580,6 +682,9 @@ export function FleetArmingDialog({
           ref={listContainerRef}
           onKeyDown={handleListKeyDown}
           tabIndex={-1}
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label="Terminals"
           className="flex-1 min-h-0 overflow-y-auto px-2 py-2 outline-hidden"
           data-testid="fleet-arming-dialog-list"
         >
@@ -599,10 +704,12 @@ export function FleetArmingDialog({
                 key={group.worktreeId}
                 group={group}
                 selectedIds={selectedIds}
+                focusedId={focusedId}
                 hideHeader={isSingleWorktree}
                 snippetMap={snippetMap}
                 onToggleId={handleToggleId}
                 onToggleGroup={handleGroupHeaderToggle}
+                registerRow={setRowRef}
               />
             ))
           )}
@@ -675,19 +782,23 @@ function EmptyState({ title, hint }: EmptyStateProps): ReactElement {
 interface WorktreeGroupSectionProps {
   group: WorktreeGroup;
   selectedIds: ReadonlySet<string>;
+  focusedId: string | null;
   hideHeader: boolean;
   snippetMap: ReadonlyMap<string, SemanticSearchMatch>;
   onToggleId: (id: string, event?: React.MouseEvent) => void;
   onToggleGroup: (group: WorktreeGroup) => void;
+  registerRow: (id: string) => (el: HTMLLabelElement | null) => void;
 }
 
 function WorktreeGroupSection({
   group,
   selectedIds,
+  focusedId,
   hideHeader,
   snippetMap,
   onToggleId,
   onToggleGroup,
+  registerRow,
 }: WorktreeGroupSectionProps): ReactElement {
   const groupIds = useMemo(() => group.terminals.map((t) => t.id), [group.terminals]);
   const groupState = useMemo(
@@ -724,14 +835,20 @@ function WorktreeGroupSection({
           </button>
         </header>
       )}
-      <ul className="flex flex-col">
+      {/* role="presentation" suppresses the implicit <ul> list role so the
+          listbox container's role="option" children aren't nested inside a
+          redundant list landmark (screen readers would otherwise announce a
+          list-within-listbox). */}
+      <ul className="flex flex-col" role="presentation">
         {group.terminals.map((t) => (
           <TerminalRow
             key={t.id}
             terminal={t}
             checked={selectedIds.has(t.id)}
             snippet={snippetMap.get(t.id)}
-            onToggle={(e) => onToggleId(t.id, e)}
+            isFocused={focusedId === t.id}
+            onToggleId={onToggleId}
+            registerRow={registerRow}
           />
         ))}
       </ul>
@@ -743,25 +860,48 @@ interface TerminalRowProps {
   terminal: DialogTerminal;
   checked: boolean;
   snippet?: SemanticSearchMatch;
-  onToggle: (event?: React.MouseEvent) => void;
+  isFocused: boolean;
+  onToggleId: (id: string, event?: React.MouseEvent) => void;
+  registerRow: (id: string) => (el: HTMLLabelElement | null) => void;
 }
 
-function TerminalRow({ terminal, checked, snippet, onToggle }: TerminalRowProps): ReactElement {
+const TerminalRow = memo(function TerminalRow({
+  terminal,
+  checked,
+  snippet,
+  isFocused,
+  onToggleId,
+  registerRow,
+}: TerminalRowProps): ReactElement {
   const stateBadge = renderStateBadge(terminal.agentState);
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => onToggleId(terminal.id, e),
+    [onToggleId, terminal.id]
+  );
+  const handleCheckedChange = useCallback(() => onToggleId(terminal.id), [onToggleId, terminal.id]);
+  // Memoize the bound ref-callback so React doesn't unmount/remount the ref
+  // entry on every render (would cause Map churn for N rows).
+  const rowRefCallback = useMemo(() => registerRow(terminal.id), [registerRow, terminal.id]);
   return (
     <li className="flex items-stretch">
       <label
+        ref={rowRefCallback}
+        tabIndex={isFocused ? 0 : -1}
+        role="option"
+        aria-selected={checked}
         className={cn(
-          "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer",
-          "hover:bg-tint/[0.06]"
+          "flex flex-1 items-start gap-2 pl-5 pr-2 py-1.5 rounded text-[13px] text-daintree-text cursor-pointer outline-hidden",
+          "hover:bg-tint/[0.06]",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
         )}
-        onClick={onToggle}
+        onClick={handleClick}
       >
         <DialogCheckbox
           checked={checked}
-          onCheckedChange={() => onToggle()}
+          onCheckedChange={handleCheckedChange}
           ariaLabel={`Select ${terminal.title}`}
           enableShiftBubble
+          tabIndex={-1}
         />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
@@ -773,7 +913,7 @@ function TerminalRow({ terminal, checked, snippet, onToggle }: TerminalRowProps)
       </label>
     </li>
   );
-}
+});
 
 function SnippetLine({ snippet }: { snippet: SemanticSearchMatch }): ReactElement {
   // Truncate from the left so the matched range stays in the visible window
@@ -828,6 +968,11 @@ interface DialogCheckboxProps {
   // Group-header checkboxes (no parent label) leave this off so the original
   // always-stopPropagation behavior is preserved.
   enableShiftBubble?: boolean;
+  // Row checkboxes pass -1 so the roving tabindex on the parent <label>
+  // (role="option") owns keyboard focus exclusively. Without this Radix
+  // defaults to tabIndex={0}, which would let Tab land on every checkbox
+  // and bypass the listbox roving system.
+  tabIndex?: number;
 }
 
 function DialogCheckbox({
@@ -835,12 +980,14 @@ function DialogCheckbox({
   onCheckedChange,
   ariaLabel,
   enableShiftBubble = false,
+  tabIndex,
 }: DialogCheckboxProps): ReactElement {
   return (
     <Checkbox.Root
       checked={checked}
       onCheckedChange={onCheckedChange}
       aria-label={ariaLabel}
+      tabIndex={tabIndex}
       onClick={(e) => {
         if (enableShiftBubble && e.shiftKey) {
           // Suppress Radix's internal onCheckedChange (composed via

--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -812,7 +812,11 @@ function WorktreeGroupSection({
   }, [groupIds, selectedIds]);
 
   return (
-    <section className="mb-1">
+    // role="group" satisfies WAI-ARIA listbox structural rules — children of
+    // role="listbox" must be option or group elements. The header controls
+    // (group-toggle checkbox + name button) live inside the group; AT will
+    // announce them as buttons within the group.
+    <section className="mb-1" role="group" aria-label={group.worktreeName}>
       {!hideHeader && (
         <header
           className="flex items-center gap-2 px-2 py-1.5 sticky top-0 bg-surface-panel z-[1]"

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -977,6 +977,265 @@ describe("FleetArmingDialog", () => {
     });
   });
 
+  describe("keyboard navigation", () => {
+    function getRowLabel(title: string): HTMLLabelElement {
+      const el = screen.getByText(title).closest("label");
+      if (!el) throw new Error(`No label found for ${title}`);
+      return el as HTMLLabelElement;
+    }
+
+    it("first visible row label has tabIndex=0 on open; others -1", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(getRowLabel("alpha").getAttribute("tabindex")).toBe("0");
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("-1");
+      expect(getRowLabel("gamma").getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("row checkboxes carry tabIndex=-1 so Tab cannot bypass roving system", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(screen.getByLabelText("Select alpha").getAttribute("tabindex")).toBe("-1");
+      expect(screen.getByLabelText("Select beta").getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("list container exposes role=listbox aria-multiselectable=true", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      expect(list.getAttribute("role")).toBe("listbox");
+      expect(list.getAttribute("aria-multiselectable")).toBe("true");
+    });
+
+    it("rows expose role=option and reflect aria-selected from checked state", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      expect(getRowLabel("alpha").getAttribute("role")).toBe("option");
+      expect(getRowLabel("alpha").getAttribute("aria-selected")).toBe("false");
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      expect(getRowLabel("alpha").getAttribute("aria-selected")).toBe("true");
+      expect(getRowLabel("beta").getAttribute("aria-selected")).toBe("false");
+    });
+
+    it("ArrowDown moves focus to next row without changing selection", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      expect(getRowLabel("alpha").getAttribute("tabindex")).toBe("-1");
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("0");
+      // Selection unchanged.
+      expect(screen.getByText("Arm selected")).toBeTruthy();
+    });
+
+    it("ArrowUp moves focus to previous row without changing selection", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      fireEvent.keyDown(list, { key: "ArrowUp" });
+      expect(getRowLabel("alpha").getAttribute("tabindex")).toBe("0");
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("ArrowDown clamps at last row", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      fireEvent.keyDown(list, { key: "ArrowDown" }); // already at end
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("0");
+    });
+
+    it("ArrowUp clamps at first row", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowUp" });
+      expect(getRowLabel("alpha").getAttribute("tabindex")).toBe("0");
+    });
+
+    it("Space toggles the focused row", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: " " });
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+      // Toggle off.
+      fireEvent.keyDown(list, { key: " " });
+      expect(screen.getByText("Arm selected")).toBeTruthy();
+    });
+
+    it("Space updates the range anchor — subsequent Shift+ArrowDown extends from it", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // Space on alpha → anchor = alpha, alpha selected.
+      fireEvent.keyDown(list, { key: " " });
+      // Shift+ArrowDown twice → focus = gamma; range alpha..gamma.
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
+    it("Shift+ArrowDown extends selection from anchor downward", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Plain click sets anchor = a.
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
+    it("Shift+ArrowUp extends selection from anchor upward", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Set anchor = c by plain-clicking gamma.
+      fireEvent.click(screen.getByLabelText("Select gamma"));
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowUp", shiftKey: true });
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+      fireEvent.keyDown(list, { key: "ArrowUp", shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
+    it("Shift+Arrow at boundary does not change selection", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // alpha is focused (just clicked) and is at index 0; ArrowUp stays.
+      fireEvent.keyDown(list, { key: "ArrowUp", shiftKey: true });
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    });
+
+    it("Shift+Arrow falls back to focus-only when anchor is filtered out", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha", agentState: "waiting" }),
+        makeTerminal("b", { title: "beta", agentState: "working" }),
+        makeTerminal("c", { title: "gamma", agentState: "working" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Click alpha → anchor = alpha, alpha selected.
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      // Filter to working — alpha is now hidden, anchor filtered out.
+      fireEvent.click(screen.getByTestId("fleet-arming-dialog-chip-working"));
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // Shift+ArrowDown — should move focus only, not extend (anchor invalid).
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      // Selection unchanged: only alpha (still selected though hidden).
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    });
+
+    it("Ctrl+ArrowDown moves focus without changing selection", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown", ctrlKey: true });
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("0");
+      expect(screen.getByText("Arm selected")).toBeTruthy();
+    });
+
+    it("Cmd+ArrowDown does not consume the event (system shortcut passthrough)", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // metaKey is the Cmd key on macOS; we should NOT preventDefault so the
+      // OS can still do its page-jump.
+      const event = fireEvent.keyDown(list, { key: "ArrowDown", metaKey: true });
+      expect(event).toBe(true); // event was not preventDefaulted (returns true)
+      // Focus did not move.
+      expect(getRowLabel("alpha").getAttribute("tabindex")).toBe("0");
+    });
+
+    it("focused row clamps to first visible when search filter removes it", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // Move focus to beta (index 1).
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("0");
+      // Filter out beta via search.
+      fireEvent.change(screen.getByTestId("fleet-arming-dialog-search"), {
+        target: { value: "gamma" },
+      });
+      // Only gamma is now visible; it should own focus.
+      expect(getRowLabel("gamma").getAttribute("tabindex")).toBe("0");
+    });
+
+    it("mouse click updates focusedId so subsequent ArrowDown continues from clicked row", () => {
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      // Click gamma (index 2).
+      fireEvent.click(screen.getByLabelText("Select gamma"));
+      expect(getRowLabel("gamma").getAttribute("tabindex")).toBe("0");
+      // ArrowDown from gamma should clamp at gamma (already last).
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      expect(getRowLabel("gamma").getAttribute("tabindex")).toBe("0");
+      // ArrowUp moves to beta.
+      fireEvent.keyDown(list, { key: "ArrowUp" });
+      expect(getRowLabel("beta").getAttribute("tabindex")).toBe("0");
+    });
+
+    it("Space on empty list (no eligible terminals) is a no-op", () => {
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // No focused id — Space should not crash and selection stays empty.
+      fireEvent.keyDown(list, { key: " " });
+      expect(screen.queryByText(/Arm \d/)).toBeNull();
+    });
+
+    it("keyboard navigation does not break Cmd+A select-all", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: "ArrowDown" });
+      fireEvent.keyDown(list, { key: "a", metaKey: true });
+      expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    });
+
+    it("keyboard navigation does not break Cmd+Shift+I invert", () => {
+      seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      fireEvent.keyDown(list, { key: " " }); // Select alpha
+      fireEvent.keyDown(list, { key: "i", metaKey: true, shiftKey: true });
+      expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+    });
+  });
+
   describe("quick-select rows", () => {
     it("'Select waiting' button selects only visible waiting terminals", () => {
       seedTerminals([

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -1106,6 +1106,28 @@ describe("FleetArmingDialog", () => {
       expect(screen.getByText("Arm 3 selected")).toBeTruthy();
     });
 
+    it("Shift+Arrow is additive — direction reversal does not contract the range", () => {
+      // Documents the additive-only contract per WAI-APG and VS Code QuickPick
+      // canSelectMany: anchor never moves on Shift+Arrow, and reversing
+      // direction grows (does not shrink) the selection.
+      seedTerminals([
+        makeTerminal("a", { title: "alpha" }),
+        makeTerminal("b", { title: "beta" }),
+        makeTerminal("c", { title: "gamma" }),
+      ]);
+      renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+      fireEvent.click(screen.getByLabelText("Select alpha"));
+      const list = screen.getByTestId("fleet-arming-dialog-list");
+      // Shift+Down twice → anchor=a, focus=c, range a..c (3 selected).
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      fireEvent.keyDown(list, { key: "ArrowDown", shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+      // Shift+Up reverses direction → focus=b, but range is still
+      // additive (anchor a..b adds nothing new since b was already in).
+      fireEvent.keyDown(list, { key: "ArrowUp", shiftKey: true });
+      expect(screen.getByText("Arm 3 selected")).toBeTruthy();
+    });
+
     it("Shift+ArrowUp extends selection from anchor upward", () => {
       seedTerminals([
         makeTerminal("a", { title: "alpha" }),


### PR DESCRIPTION
## Summary

- Adds WAI-ARIA listbox keyboard navigation to the fleet arming dialog: Up/Down move row focus via roving tabindex, Space toggles the focused row and resets the range anchor, Shift+Arrow extends selection from the anchor, Ctrl+Arrow moves focus only
- Full ARIA markup: `role=listbox aria-multiselectable=true` on the container, `role=option aria-selected` on each row, `role=group` on section headers; Radix `Checkbox` gets `tabIndex={-1}` so the listbox owns Tab
- `TerminalRow` wrapped in `React.memo` with an `isFocused` boolean prop to keep focus changes O(1) rather than O(N); mouse click syncs `focusedId` so keyboard nav always resumes from the last clicked row

Resolves #6471

## Changes

- `FleetArmingDialog.tsx`: roving tabindex state, keyboard handler, ARIA roles, `React.memo` on `TerminalRow`, `isFocused` prop, mouse click sync, footer hint update
- `FleetArmingDialog.test.tsx`: 22 new tests covering arrow navigation, Space toggle, anchor reset, Shift+Arrow extension and reversal, Ctrl/Cmd+Arrow, search-filter clamping, ARIA roles, Radix `tabIndex` pinning, and regressions on Cmd+A and Cmd+Shift+I

## Testing

Existing `Cmd+A` and `Cmd+Shift+I` shortcuts preserved and covered by regression tests. All 22 new tests pass locally alongside the existing suite.