### PR TITLE
fix(fleet): surface eligibility drift in fleet arming dialog

### DIFF
--- a/src/components/Fleet/FleetArmingDialog.tsx
+++ b/src/components/Fleet/FleetArmingDialog.tsx
@@ -406,8 +406,17 @@ export function FleetArmingDialog({
   const confirmLabel =
     confirmedIds.length === 0 ? "Arm selected" : `Arm ${confirmedIds.length} selected`;
 
+  const driftCount = selectedIds.size - confirmedIds.length;
+
   const footerHint = useMemo(() => {
-    if (visibleIds.length === 0) return null;
+    const driftNotice =
+      driftCount > 0 ? (
+        <span className="text-daintree-text/45 tabular-nums">{driftCount} became ineligible</span>
+      ) : null;
+
+    if (visibleIds.length === 0) {
+      return driftNotice;
+    }
     return (
       <>
         <span className="inline-flex items-center gap-1">
@@ -424,9 +433,15 @@ export function FleetArmingDialog({
           <Kbd>{isMac() ? "⌘⇧I" : "Ctrl+Shift+I"}</Kbd>
           <span>Invert</span>
         </span>
+        {driftNotice && (
+          <>
+            <span className="text-daintree-text/30">·</span>
+            {driftNotice}
+          </>
+        )}
       </>
     );
-  }, [visibleIds.length]);
+  }, [visibleIds.length, driftCount]);
 
   return (
     <AppDialog

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -322,6 +322,32 @@ describe("FleetArmingDialog", () => {
     expect(useFleetArmingStore.getState().armOrder).toEqual(["a"]);
   });
 
+  it("shows drift count when a selected terminal becomes ineligible while the dialog is open", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    // Drop beta from the panel store — simulates terminal closing while dialog is open.
+    act(() => {
+      const state = usePanelStore.getState();
+      const next = { ...state.panelsById };
+      delete next.b;
+      usePanelStore.setState({ panelsById: next, panelIds: ["a"] });
+    });
+    expect(screen.getByText("1 became ineligible")).toBeTruthy();
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+  });
+
+  it("hides drift notice when no eligibility change has occurred", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    expect(screen.queryByText("became ineligible")).toBeNull();
+  });
+
   it("confirm replaces (not extends) the existing armed set", () => {
     seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
     useFleetArmingStore.getState().armIds(["old"]);

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -345,7 +345,59 @@ describe("FleetArmingDialog", () => {
     fireEvent.click(screen.getByLabelText("Select alpha"));
     fireEvent.click(screen.getByLabelText("Select beta"));
     expect(screen.getByText("Arm 2 selected")).toBeTruthy();
-    expect(screen.queryByText("became ineligible")).toBeNull();
+    expect(screen.queryByText(/became ineligible/)).toBeNull();
+  });
+
+  it("shows drift when selected terminal's runtimeStatus changes to exited", () => {
+    seedTerminals([
+      makeTerminal("a", { title: "alpha" }),
+      makeTerminal("b", { title: "beta", runtimeStatus: "running" }),
+    ]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    act(() => {
+      const state = usePanelStore.getState();
+      usePanelStore.setState({
+        panelsById: {
+          ...state.panelsById,
+          b: { ...state.panelsById.b, runtimeStatus: "error" },
+        },
+      });
+    });
+    expect(screen.getByText("1 became ineligible")).toBeTruthy();
+    expect(screen.getByText("Arm 1 selected")).toBeTruthy();
+  });
+
+  it("shows drift and disables confirm when all selected terminals become ineligible", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    const onClose = vi.fn();
+    renderDialog([makeWorktreeSnap("wt-1", "Main")], true, onClose);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    act(() => {
+      usePanelStore.setState({ panelsById: {}, panelIds: [] });
+    });
+    expect(screen.getByText("2 became ineligible")).toBeTruthy();
+    const confirmBtn = screen.getByText("Arm selected").closest("button") as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(true);
+    fireEvent.click(confirmBtn);
+    expect(useFleetArmingStore.getState().armOrder).toEqual([]);
+  });
+
+  it("does not count search-filtered terminals as drift", () => {
+    seedTerminals([makeTerminal("a", { title: "alpha" }), makeTerminal("b", { title: "beta" })]);
+    renderDialog([makeWorktreeSnap("wt-1", "Main")]);
+    fireEvent.click(screen.getByLabelText("Select alpha"));
+    fireEvent.click(screen.getByLabelText("Select beta"));
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
+    // Filter to alpha only — beta is still eligible, just hidden.
+    fireEvent.change(screen.getByTestId("fleet-arming-dialog-search"), {
+      target: { value: "alpha" },
+    });
+    expect(screen.queryByText(/became ineligible/)).toBeNull();
+    expect(screen.getByText("Arm 2 selected")).toBeTruthy();
   });
 
   it("confirm replaces (not extends) the existing armed set", () => {

--- a/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingDialog.test.tsx
@@ -362,7 +362,7 @@ describe("FleetArmingDialog", () => {
       usePanelStore.setState({
         panelsById: {
           ...state.panelsById,
-          b: { ...state.panelsById.b, runtimeStatus: "error" },
+          b: { ...(state.panelsById.b as TerminalInstance), runtimeStatus: "error" },
         },
       });
     });


### PR DESCRIPTION
## Summary

When terminals become ineligible while the fleet arming dialog is open, the dialog now surfaces an inline drift notice in the footer rather than silently dropping the selection count. Before this change, the CTA would flip from "Arm 7 selected" to "Arm 6 selected" with no indication of why -- the user had to guess which terminal disappeared.

The drift count (`N became ineligible`) is displayed alongside the existing keyboard shortcut hints in the `AppDialog` footer. The data was already computed by the `confirmedIds` memo; this just surfaces it.

Resolves #6472

## Changes

- `src/components/Fleet/FleetArmingDialog.tsx` -- computes `driftCount` from `selectedIds` vs `confirmedIds` and threads it into the footer hint slot
- `src/components/Fleet/__tests__/FleetArmingDialog.test.tsx` -- 5 new test cases covering drift visibility, drift absence, status-change drift, all-terminals-ineligible edge case, and search-filter non-interference

## Testing

All drift notice assertions pass -- visible when a terminal loses eligibility, absent when nothing has changed, triggered by `runtimeStatus` transitions, disabled confirm when everything drops out, and unaffected by search filtering.