### PR TITLE
feat(fleet): add FleetSmartArmBar suggestion pill

### DIFF
--- a/src/components/Fleet/FleetSmartArmBar.tsx
+++ b/src/components/Fleet/FleetSmartArmBar.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useAgentClusters, type ClusterType } from "@/hooks/useAgentClusters";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useUIStore } from "@/store";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -49,6 +50,12 @@ function tooltipLabel(type: ClusterType, count: number): string {
 export function FleetSmartArmBar(): ReactElement | null {
   const cluster = useAgentClusters();
   const reduceMotion = useReducedMotion();
+  // Suppress while a blocking overlay (e.g. ThemeBrowser) is open. The Toolbar
+  // and FleetArmingRibbon get this for free via an `inert` ancestor in
+  // AppLayout, but body-portaled surfaces sit outside that subtree and have to
+  // gate themselves explicitly.
+  const themeBrowserOpen = useUIStore((s) => s.overlayClaims.has("theme-browser"));
+  const showCluster = cluster && !themeBrowserOpen ? cluster : null;
 
   const motionProps = reduceMotion
     ? {
@@ -69,8 +76,8 @@ export function FleetSmartArmBar(): ReactElement | null {
       };
 
   const handleArm = (): void => {
-    if (!cluster) return;
-    useFleetArmingStore.getState().armIds(cluster.memberIds);
+    if (!showCluster) return;
+    useFleetArmingStore.getState().armIds(showCluster.memberIds);
   };
 
   return createPortal(
@@ -79,7 +86,7 @@ export function FleetSmartArmBar(): ReactElement | null {
       data-testid="fleet-smart-arm-bar-root"
     >
       <AnimatePresence initial={false}>
-        {cluster && (
+        {showCluster && (
           <m.div key="fleet-smart-arm-bar" {...motionProps}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -87,9 +94,9 @@ export function FleetSmartArmBar(): ReactElement | null {
                   type="button"
                   onClick={handleArm}
                   data-testid="fleet-smart-arm-bar"
-                  data-cluster-type={cluster.type}
-                  data-cluster-count={cluster.count}
-                  aria-label={buttonLabel(cluster.type, cluster.count)}
+                  data-cluster-type={showCluster.type}
+                  data-cluster-count={showCluster.count}
+                  aria-label={buttonLabel(showCluster.type, showCluster.count)}
                   className={cn(
                     "pointer-events-auto inline-flex items-center gap-2 rounded-full px-4 py-2 text-[12px] text-daintree-text",
                     "bg-overlay-subtle shadow-[var(--theme-shadow-floating)] ring-1 ring-border-default",
@@ -97,14 +104,13 @@ export function FleetSmartArmBar(): ReactElement | null {
                   )}
                 >
                   <AnimatedLabel
-                    label={buttonLabel(cluster.type, cluster.count)}
-                    animateKey={cluster.type}
+                    label={buttonLabel(showCluster.type, showCluster.count)}
                     textClassName="font-medium tabular-nums"
                   />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={6}>
-                {tooltipLabel(cluster.type, cluster.count)}
+                {tooltipLabel(showCluster.type, showCluster.count)}
               </TooltipContent>
             </Tooltip>
           </m.div>

--- a/src/components/Fleet/FleetSmartArmBar.tsx
+++ b/src/components/Fleet/FleetSmartArmBar.tsx
@@ -100,7 +100,7 @@ export function FleetSmartArmBar(): ReactElement | null {
                   className={cn(
                     "pointer-events-auto inline-flex items-center gap-2 rounded-full px-4 py-2 text-[12px] text-daintree-text",
                     "bg-overlay-subtle shadow-[var(--theme-shadow-floating)] ring-1 ring-border-default",
-                    "transition-colors hover:bg-overlay-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-border-strong"
+                    "transition-colors hover:bg-overlay-medium focus:outline-hidden focus-visible:ring-2 focus-visible:ring-border-strong"
                   )}
                 >
                   <AnimatedLabel

--- a/src/components/Fleet/FleetSmartArmBar.tsx
+++ b/src/components/Fleet/FleetSmartArmBar.tsx
@@ -1,0 +1,116 @@
+import { type ReactElement } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, m, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { useAgentClusters, type ClusterType } from "@/hooks/useAgentClusters";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+function buttonLabel(type: ClusterType, count: number): string {
+  switch (type) {
+    case "prompt":
+      return `Arm ${count} waiting`;
+    case "error":
+      return `Arm ${count} with errors`;
+    case "completion":
+      return `Arm ${count} finished`;
+  }
+}
+
+function tooltipLabel(type: ClusterType, count: number): string {
+  const noun = count === 1 ? "terminal" : "terminals";
+  switch (type) {
+    case "prompt":
+      return `${count} ${noun} waiting for input`;
+    case "error":
+      return `${count} ${noun} exited with errors`;
+    case "completion":
+      return `${count} ${noun} just finished`;
+  }
+}
+
+/**
+ * State-driven arming suggestion. Surfaces a sticky pill at the bottom of the
+ * viewport whenever the highest-priority active cluster (≥2 panes) crosses
+ * threshold — prompt > error > completion. Click arms exactly the cluster's
+ * members and lets the user broadcast a shared response.
+ *
+ * Mounting: body-portaled so position:fixed anchors to the viewport regardless
+ * of any ancestor that creates a containing block via backdrop-filter or
+ * transform (#2574). Always-mounted wrapper carries `pointer-events-none` so
+ * mouse events pass through to terminals beneath; only the interactive button
+ * itself takes `pointer-events-auto` (#3826).
+ *
+ * Animation: entry/exit fires only when the cluster toggles between null and
+ * non-null — count or type updates swap text in place via AnimatedLabel so the
+ * pill never re-enters during normal panel state churn.
+ */
+export function FleetSmartArmBar(): ReactElement | null {
+  const cluster = useAgentClusters();
+  const reduceMotion = useReducedMotion();
+
+  const motionProps = reduceMotion
+    ? {
+        initial: { opacity: 0 },
+        animate: { opacity: 1 },
+        exit: { opacity: 0, transition: { duration: 0.12 } },
+        transition: { duration: 0.12 },
+      }
+    : {
+        initial: { y: 12, opacity: 0 },
+        animate: { y: 0, opacity: 1 },
+        exit: {
+          y: 12,
+          opacity: 0,
+          transition: { duration: 0.12, ease: [0.4, 0, 0.2, 1] as const },
+        },
+        transition: { type: "spring" as const, duration: 0.2, bounce: 0.12 },
+      };
+
+  const handleArm = (): void => {
+    if (!cluster) return;
+    useFleetArmingStore.getState().armIds(cluster.memberIds);
+  };
+
+  return createPortal(
+    <div
+      className="pointer-events-none fixed bottom-4 left-1/2 z-[var(--z-modal)] flex -translate-x-1/2 items-center justify-center"
+      data-testid="fleet-smart-arm-bar-root"
+    >
+      <AnimatePresence initial={false}>
+        {cluster && (
+          <m.div key="fleet-smart-arm-bar" {...motionProps}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleArm}
+                  data-testid="fleet-smart-arm-bar"
+                  data-cluster-type={cluster.type}
+                  data-cluster-count={cluster.count}
+                  aria-label={buttonLabel(cluster.type, cluster.count)}
+                  className={cn(
+                    "pointer-events-auto inline-flex items-center gap-2 rounded-full px-4 py-2 text-[12px] text-daintree-text",
+                    "bg-overlay-subtle shadow-[var(--theme-shadow-floating)] ring-1 ring-border-default",
+                    "transition-colors hover:bg-overlay-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-border-strong"
+                  )}
+                >
+                  <AnimatedLabel
+                    label={buttonLabel(cluster.type, cluster.count)}
+                    animateKey={cluster.type}
+                    textClassName="font-medium tabular-nums"
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6}>
+                {tooltipLabel(cluster.type, cluster.count)}
+              </TooltipContent>
+            </Tooltip>
+          </m.div>
+        )}
+      </AnimatePresence>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/Fleet/__tests__/FleetSmartArmBar.test.tsx
+++ b/src/components/Fleet/__tests__/FleetSmartArmBar.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@/components/ui/tooltip", () => ({
 
 import { FleetSmartArmBar } from "../FleetSmartArmBar";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useUIStore } from "@/store";
 import type { ClusterGroup, ClusterType } from "@/hooks/useAgentClusters";
 
 function makeCluster(overrides: Partial<ClusterGroup> = {}): ClusterGroup {
@@ -71,6 +72,7 @@ function resetStore() {
     armOrderById: {},
     lastArmedId: null,
   });
+  useUIStore.setState({ overlayClaims: new Set<string>() });
 }
 
 describe("FleetSmartArmBar", () => {
@@ -178,6 +180,52 @@ describe("FleetSmartArmBar", () => {
     render(<FleetSmartArmBar />);
     const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
     expect(button?.className).toContain("pointer-events-auto");
+    cleanup();
+  });
+
+  it("suppresses the pill when ThemeBrowser overlay is open (matches FleetArmingRibbon's inert gate)", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    useUIStore.setState({ overlayClaims: new Set<string>(["theme-browser"]) });
+    render(<FleetSmartArmBar />);
+    expect(document.body.querySelector('[data-testid="fleet-smart-arm-bar"]')).toBeNull();
+    // Root wrapper still mounts so portal stays stable; only the pill is gated.
+    expect(document.body.querySelector('[data-testid="fleet-smart-arm-bar-root"]')).not.toBeNull();
+    cleanup();
+  });
+
+  it("re-renders the count text on rerender so AnimatedLabel can crossfade", () => {
+    // The component reads `cluster.count` on every render; verifies that a
+    // count change updates the visible label (regression for the previous
+    // animateKey={cluster.type} behavior that suppressed crossfades on count
+    // changes by keeping the AnimatedLabel key stable).
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    const { rerender } = render(<FleetSmartArmBar />);
+    expect(
+      document.body.querySelector('[data-testid="fleet-smart-arm-bar"]')?.getAttribute("aria-label")
+    ).toBe("Arm 2 waiting");
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "prompt", memberIds: ["a", "b", "c"] })
+    );
+    rerender(<FleetSmartArmBar />);
+    expect(
+      document.body.querySelector('[data-testid="fleet-smart-arm-bar"]')?.getAttribute("aria-label")
+    ).toBe("Arm 3 waiting");
+    cleanup();
+  });
+
+  it("clicks an updated cluster's memberIds (not stale ones) after rerender", () => {
+    const armIdsSpy = vi.spyOn(useFleetArmingStore.getState(), "armIds");
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    const { rerender } = render(<FleetSmartArmBar />);
+
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "prompt", memberIds: ["a", "b", "c"] })
+    );
+    rerender(<FleetSmartArmBar />);
+
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    fireEvent.click(button!);
+    expect(armIdsSpy).toHaveBeenCalledWith(["a", "b", "c"]);
     cleanup();
   });
 });

--- a/src/components/Fleet/__tests__/FleetSmartArmBar.test.tsx
+++ b/src/components/Fleet/__tests__/FleetSmartArmBar.test.tsx
@@ -1,0 +1,183 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+    useReducedMotion: () => false,
+  };
+});
+
+const { useAgentClustersMock } = vi.hoisted(() => ({
+  useAgentClustersMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAgentClusters", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useAgentClusters")>(
+    "@/hooks/useAgentClusters"
+  );
+  return {
+    ...actual,
+    useAgentClusters: useAgentClustersMock,
+  };
+});
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <>{children}</>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="fleet-smart-arm-bar-tooltip">{children}</div>
+  ),
+}));
+
+import { FleetSmartArmBar } from "../FleetSmartArmBar";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import type { ClusterGroup, ClusterType } from "@/hooks/useAgentClusters";
+
+function makeCluster(overrides: Partial<ClusterGroup> = {}): ClusterGroup {
+  const type: ClusterType = overrides.type ?? "prompt";
+  const memberIds = overrides.memberIds ?? ["a", "b"];
+  return {
+    type,
+    memberIds,
+    count: overrides.count ?? memberIds.length,
+    headline: overrides.headline ?? `${memberIds.length} agents need input`,
+    priority: overrides.priority ?? 1,
+    latestStateChange: overrides.latestStateChange ?? 1,
+    signature: overrides.signature ?? `${type}:${memberIds.join(",")}:1`,
+  };
+}
+
+function resetStore() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+}
+
+describe("FleetSmartArmBar", () => {
+  beforeEach(() => {
+    resetStore();
+    useAgentClustersMock.mockReset();
+    document.body.innerHTML = "";
+  });
+
+  it("renders nothing when no cluster is active", () => {
+    useAgentClustersMock.mockReturnValue(null);
+    render(<FleetSmartArmBar />);
+    expect(document.querySelector('[data-testid="fleet-smart-arm-bar"]')).toBeNull();
+  });
+
+  it("portals the pill to document.body when a cluster is active", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    const { container } = render(<FleetSmartArmBar />);
+    // Component is portaled — its pill should not appear inside the renderer's container.
+    expect(container.querySelector('[data-testid="fleet-smart-arm-bar"]')).toBeNull();
+    // It should appear inside document.body.
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button).not.toBeNull();
+    cleanup();
+  });
+
+  it("uses 'Arm N waiting' label for prompt clusters", () => {
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "prompt", memberIds: ["a", "b", "c"] })
+    );
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button?.getAttribute("aria-label")).toBe("Arm 3 waiting");
+    expect(button?.textContent).toContain("Arm 3 waiting");
+    cleanup();
+  });
+
+  it("uses 'Arm N with errors' label for error clusters", () => {
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "error", memberIds: ["a", "b"], priority: 2 })
+    );
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button?.getAttribute("aria-label")).toBe("Arm 2 with errors");
+    cleanup();
+  });
+
+  it("uses 'Arm N finished' label for completion clusters", () => {
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "completion", memberIds: ["a", "b"], priority: 3 })
+    );
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button?.getAttribute("aria-label")).toBe("Arm 2 finished");
+    cleanup();
+  });
+
+  it("calls armIds with exactly the cluster member ids on click (does not arm-all)", () => {
+    const armIdsSpy = vi.spyOn(useFleetArmingStore.getState(), "armIds");
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "prompt", memberIds: ["pane-1", "pane-2", "pane-3"] })
+    );
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+    expect(armIdsSpy).toHaveBeenCalledTimes(1);
+    expect(armIdsSpy).toHaveBeenCalledWith(["pane-1", "pane-2", "pane-3"]);
+    expect(useFleetArmingStore.getState().armedIds).toEqual(
+      new Set(["pane-1", "pane-2", "pane-3"])
+    );
+    cleanup();
+  });
+
+  it("renders tooltip content describing the heuristic", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    render(<FleetSmartArmBar />);
+    const tooltip = document.body.querySelector('[data-testid="fleet-smart-arm-bar-tooltip"]');
+    expect(tooltip?.textContent).toBe("2 terminals waiting for input");
+    cleanup();
+  });
+
+  it("exposes cluster type and count as data attributes", () => {
+    useAgentClustersMock.mockReturnValue(
+      makeCluster({ type: "error", memberIds: ["a", "b", "c"], priority: 2 })
+    );
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button?.getAttribute("data-cluster-type")).toBe("error");
+    expect(button?.getAttribute("data-cluster-count")).toBe("3");
+    cleanup();
+  });
+
+  it("the always-mounted root has pointer-events disabled to let terminal clicks pass through", () => {
+    useAgentClustersMock.mockReturnValue(null);
+    render(<FleetSmartArmBar />);
+    const root = document.body.querySelector('[data-testid="fleet-smart-arm-bar-root"]');
+    expect(root).not.toBeNull();
+    expect(root?.className).toContain("pointer-events-none");
+    cleanup();
+  });
+
+  it("the pill button restores pointer-events so it remains clickable", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "prompt", memberIds: ["a", "b"] }));
+    render(<FleetSmartArmBar />);
+    const button = document.body.querySelector('[data-testid="fleet-smart-arm-bar"]');
+    expect(button?.className).toContain("pointer-events-auto");
+    cleanup();
+  });
+});

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,5 +1,6 @@
 export { FleetArmingRibbon } from "./FleetArmingRibbon";
 export { FleetArmingDialog } from "./FleetArmingDialog";
+export { FleetSmartArmBar } from "./FleetSmartArmBar";
 export {
   buildFleetTargetPreviews,
   executeFleetBroadcast,

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -9,7 +9,7 @@ import { PortalDock, PortalVisibilityController } from "../Portal";
 import { HelpPanel } from "../HelpPanel";
 import { ThemeBrowser } from "../ThemeBrowser";
 import { ProjectSwitchOverlay } from "@/components/Project";
-import { FleetArmingRibbon } from "@/components/Fleet";
+import { FleetArmingRibbon, FleetSmartArmBar } from "@/components/Fleet";
 import { ChordIndicator } from "./ChordIndicator";
 import { DemoCaptureBridge, DemoCursor, DemoOverlay } from "../Demo";
 
@@ -404,6 +404,7 @@ export function AppLayout({
       <ChordIndicator />
 
       <AllClearOverlay />
+      <FleetSmartArmBar />
       {themeBrowserOpen &&
         createPortal(
           <>

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -250,10 +250,9 @@ describe("deriveHighestPriorityCluster", () => {
       expect(cluster).toBeNull();
     });
 
-    it("excludes terminals whose runtimeStatus is exited or error (post-exit liveness guard)", () => {
-      // `runtimeStatus` is the renderer's authoritative liveness signal — a
-      // pane preserved after PTY exit can still expose `hasPty=true` from a
-      // stale snapshot, so the cluster must defer to runtimeStatus when set.
+    it("excludes prompt/completion clusters whose runtimeStatus is exited or error", () => {
+      // For prompt and completion buckets the downstream fleet actions assume
+      // a live PTY, so the eligibility guard still rejects post-exit terminals.
       const exited = derive([
         makeAgent("a", {
           agentState: "waiting",
@@ -275,6 +274,66 @@ describe("deriveHighestPriorityCluster", () => {
         makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
       ]);
       expect(errored).toBeNull();
+    });
+
+    it("includes error-cluster terminals whose runtimeStatus is exited (the whole point)", () => {
+      // The PTY exit handler stamps `exitCode` and `runtimeStatus: "exited"`
+      // together, so production error-bucket members ALWAYS have post-exit
+      // runtime status. Filtering them out would make the error cluster
+      // unreachable in real use.
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "exited",
+          exitCode: 1,
+          lastStateChange: NOW - 10,
+          runtimeStatus: "exited",
+        }),
+        makeAgent("b", {
+          agentState: "exited",
+          exitCode: 137,
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+        }),
+      ]);
+      expect(cluster).not.toBeNull();
+      expect(cluster!.type).toBe("error");
+      expect(cluster!.count).toBe(2);
+    });
+
+    it("error-cluster eligibility still excludes trashed/background/dock and hasPty=false", () => {
+      const trashed = derive([
+        makeAgent("a", {
+          agentState: "exited",
+          exitCode: 1,
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+          location: "trash",
+        }),
+        makeAgent("b", {
+          agentState: "exited",
+          exitCode: 1,
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+        }),
+      ]);
+      expect(trashed).toBeNull();
+
+      const noPty = derive([
+        makeAgent("a", {
+          agentState: "exited",
+          exitCode: 1,
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+          hasPty: false,
+        }),
+        makeAgent("b", {
+          agentState: "exited",
+          exitCode: 1,
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+        }),
+      ]);
+      expect(noPty).toBeNull();
     });
 
     it("respects the isInTrash predicate", () => {

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -250,6 +250,33 @@ describe("deriveHighestPriorityCluster", () => {
       expect(cluster).toBeNull();
     });
 
+    it("excludes terminals whose runtimeStatus is exited or error (post-exit liveness guard)", () => {
+      // `runtimeStatus` is the renderer's authoritative liveness signal — a
+      // pane preserved after PTY exit can still expose `hasPty=true` from a
+      // stale snapshot, so the cluster must defer to runtimeStatus when set.
+      const exited = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          runtimeStatus: "exited",
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(exited).toBeNull();
+
+      const errored = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          runtimeStatus: "error",
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(errored).toBeNull();
+    });
+
     it("respects the isInTrash predicate", () => {
       const { panelsById, panelIds } = build([
         makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),

--- a/src/hooks/useAgentClusters.ts
+++ b/src/hooks/useAgentClusters.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { isFleetArmEligible } from "@/store/fleetArmingStore";
+import { isTerminalErrorClusterEligible } from "@/store/fleetEligibility";
 import { isTerminalVisible, useWorktreeIds } from "@/hooks/useTerminalSelectors";
 
 export type ClusterType = "prompt" | "error" | "completion";
@@ -81,7 +82,6 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
   for (const id of panelIds) {
     const t = panelsById[id];
     if (!t) continue;
-    if (!isFleetArmEligible(t)) continue;
     if (!isTerminalVisible(t, isInTrash, worktreeIds)) continue;
 
     const lsc =
@@ -89,12 +89,20 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
         ? t.lastStateChange
         : 0;
 
-    if (t.agentState === "waiting" && t.waitingReason === "prompt") {
+    // Per-bucket eligibility: prompt and completion need a live PTY (their
+    // downstream fleet actions assume one), but the error bucket is for
+    // post-exit terminals — the very state `isFleetArmEligible` rejects.
+    if (t.agentState === "waiting" && t.waitingReason === "prompt" && isFleetArmEligible(t)) {
       buckets.prompt.push({ id, lastStateChange: lsc });
       continue;
     }
 
-    if (t.agentState === "exited" && typeof t.exitCode === "number" && t.exitCode !== 0) {
+    if (
+      t.agentState === "exited" &&
+      typeof t.exitCode === "number" &&
+      t.exitCode !== 0 &&
+      isTerminalErrorClusterEligible(t)
+    ) {
       buckets.error.push({ id, lastStateChange: lsc });
       continue;
     }
@@ -103,7 +111,8 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
       t.agentState === "completed" &&
       typeof t.lastStateChange === "number" &&
       !Number.isNaN(t.lastStateChange) &&
-      t.lastStateChange >= now - COMPLETION_WINDOW_MS
+      t.lastStateChange >= now - COMPLETION_WINDOW_MS &&
+      isFleetArmEligible(t)
     ) {
       buckets.completion.push({ id, lastStateChange: lsc });
       continue;

--- a/src/store/fleetEligibility.ts
+++ b/src/store/fleetEligibility.ts
@@ -19,6 +19,23 @@ export function isTerminalFleetEligible(t: TerminalInstance | undefined): t is T
 }
 
 /**
+ * Cluster-error predicate: the terminal is in a valid location and not
+ * snapshot-stale, but post-exit `runtimeStatus` is *expected* — these are the
+ * terminals the error cluster is meant to surface. Used by the agent-cluster
+ * hook in place of `isTerminalFleetEligible` for the "exited with errors"
+ * bucket only; `prompt` and `completion` buckets keep the full eligibility
+ * gate because their downstream actions assume a live PTY.
+ */
+export function isTerminalErrorClusterEligible(
+  t: TerminalInstance | undefined
+): t is TerminalInstance {
+  if (!t) return false;
+  if (t.location === "trash" || t.location === "background" || t.location === "dock") return false;
+  if (t.hasPty === false) return false;
+  return true;
+}
+
+/**
  * Agent capability for agent-specific Fleet actions.
  *
  * Broadcast can target any live terminal. Accept/reject/interrupt/restart


### PR DESCRIPTION
## Summary

- Adds `FleetSmartArmBar`, a floating suggestion pill that surfaces when 2+ agent panes enter the waiting state or 2+ worktrees have unmerged commits
- Clicking the pill arms the whole cluster at once — no need to open the ribbon and pick a preset manually
- Single pill at a time; count swaps in place on change without re-firing the entry animation

Resolves #6474

## Changes

- `FleetSmartArmBar.tsx` — new component with `bg-overlay-subtle` surface, Tier 2 motion (200ms enter / 120ms exit), tooltip explaining the heuristic
- `FleetSmartArmBar.test.tsx` — full test coverage for threshold behaviour, count-swap, animation gating, and both trigger conditions
- `useAgentClusters.ts` — extended to return eligible clusters for the bar
- `fleetEligibility.ts` — new store tracking which agents and worktrees are eligible to arm
- `AppLayout.tsx` — mounts the pill at the bottom of the layout

## Testing

- Unit tests cover: threshold guard (no pill below 2), single-pill constraint, count-swap without re-animation, waiting-state trigger, unmerged-commits trigger
- Manually verified pill appearance/dismissal, count updates, and click-to-arm flow in a multi-worktree session