### PR TITLE
feat(fleet): save and recall named fleets

### DIFF
--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -10,7 +10,11 @@ import { sanitizeSvg } from "../../shared/utils/svgSanitizer.js";
 import { isSensitiveEnvKey } from "../../shared/utils/envVars.js";
 import { projectEnvSecureStorage } from "./ProjectEnvSecureStorage.js";
 import { getProjectStateDir, settingsFilePath } from "./projectStorePaths.js";
-import { parseTerminalSettings, parseNotificationOverrides } from "./projectSettingsParsers.js";
+import {
+  parseFleetSavedScopes,
+  parseNotificationOverrides,
+  parseTerminalSettings,
+} from "./projectSettingsParsers.js";
 import { Cache } from "../utils/cache.js";
 
 export class ProjectSettingsManager {
@@ -209,6 +213,7 @@ export class ProjectSettingsManager {
             : undefined,
         terminalSettings: parseTerminalSettings(parsed.terminalSettings),
         notificationOverrides: parseNotificationOverrides(parsed.notificationOverrides),
+        fleetSavedScopes: parseFleetSavedScopes(parsed.fleetSavedScopes),
         resourceEnvironments:
           parsed.resourceEnvironments &&
           typeof parsed.resourceEnvironments === "object" &&

--- a/electron/services/__tests__/projectSettingsParsers.test.ts
+++ b/electron/services/__tests__/projectSettingsParsers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseTerminalSettings, parseNotificationOverrides } from "../projectSettingsParsers.js";
+import {
+  parseFleetSavedScopes,
+  parseNotificationOverrides,
+  parseTerminalSettings,
+} from "../projectSettingsParsers.js";
 
 describe("parseTerminalSettings", () => {
   it("returns undefined for null/undefined/non-object", () => {
@@ -104,6 +108,104 @@ describe("parseNotificationOverrides", () => {
       completedEnabled: "yes" as unknown,
       waitingEnabled: 1 as unknown,
     });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("parseFleetSavedScopes", () => {
+  it("returns undefined for non-array input", () => {
+    expect(parseFleetSavedScopes(null)).toBeUndefined();
+    expect(parseFleetSavedScopes(undefined)).toBeUndefined();
+    expect(parseFleetSavedScopes("string")).toBeUndefined();
+    expect(parseFleetSavedScopes({})).toBeUndefined();
+  });
+
+  it("parses a snapshot scope", () => {
+    const result = parseFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Sprint",
+        terminalIds: ["a", "b"],
+        createdAt: 1700000000000,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Sprint",
+        terminalIds: ["a", "b"],
+        createdAt: 1700000000000,
+      },
+    ]);
+  });
+
+  it("parses a predicate scope", () => {
+    const result = parseFleetSavedScopes([
+      {
+        kind: "predicate",
+        id: "p1",
+        name: "Waiting",
+        scope: "all",
+        stateFilter: "waiting",
+        createdAt: 1700000000000,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        kind: "predicate",
+        id: "p1",
+        name: "Waiting",
+        scope: "all",
+        stateFilter: "waiting",
+        createdAt: 1700000000000,
+      },
+    ]);
+  });
+
+  it("drops entries with unknown kind, missing fields, or invalid enum values", () => {
+    const result = parseFleetSavedScopes([
+      { kind: "snapshot", id: "ok", name: "Good", terminalIds: [], createdAt: 1 },
+      // Drop: missing id
+      { kind: "snapshot", name: "x", terminalIds: [], createdAt: 1 },
+      // Drop: empty name
+      { kind: "snapshot", id: "x", name: "", terminalIds: [], createdAt: 1 },
+      // Drop: unknown kind
+      { kind: "rule", id: "x", name: "x", createdAt: 1 },
+      // Drop: predicate with bogus stateFilter
+      { kind: "predicate", id: "x", name: "x", scope: "all", stateFilter: "bogus", createdAt: 1 },
+      // Drop: predicate with bogus scope
+      {
+        kind: "predicate",
+        id: "x",
+        name: "x",
+        scope: "global",
+        stateFilter: "all",
+        createdAt: 1,
+      },
+      // Drop: snapshot with non-array terminalIds
+      { kind: "snapshot", id: "x", name: "x", terminalIds: "a,b", createdAt: 1 },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result![0]).toMatchObject({ id: "ok" });
+  });
+
+  it("filters non-string entries from snapshot terminalIds", () => {
+    const result = parseFleetSavedScopes([
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "Sprint",
+        terminalIds: ["a", 42, null, "b"],
+        createdAt: 1,
+      },
+    ]);
+    expect(result![0]).toMatchObject({ kind: "snapshot", terminalIds: ["a", "b"] });
+  });
+
+  it("returns undefined when every entry is invalid", () => {
+    const result = parseFleetSavedScopes([{ garbage: true }, { kind: "unknown" }]);
     expect(result).toBeUndefined();
   });
 });

--- a/electron/services/projectSettingsParsers.ts
+++ b/electron/services/projectSettingsParsers.ts
@@ -1,4 +1,5 @@
 import type { ProjectTerminalSettings } from "../types/index.js";
+import type { FleetSavedScope } from "../../shared/types/project.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
 import path from "path";
 import { normalizeScrollbackLines } from "../../shared/config/scrollback.js";
@@ -88,4 +89,42 @@ export function parseNotificationOverrides(
   }
 
   return Object.keys(result).length > 0 ? result : undefined;
+}
+
+const VALID_PREDICATE_SCOPES = new Set(["current", "all"]);
+const VALID_PREDICATE_STATES = new Set(["all", "working", "waiting", "finished"]);
+
+export function parseFleetSavedScopes(raw: unknown): FleetSavedScope[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: FleetSavedScope[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const o = entry as Record<string, unknown>;
+    if (typeof o.id !== "string" || !o.id.trim()) continue;
+    if (typeof o.name !== "string" || !o.name.trim()) continue;
+    if (typeof o.createdAt !== "number" || !Number.isFinite(o.createdAt)) continue;
+    if (o.kind === "snapshot") {
+      if (!Array.isArray(o.terminalIds)) continue;
+      const terminalIds = o.terminalIds.filter((t): t is string => typeof t === "string");
+      out.push({
+        kind: "snapshot",
+        id: o.id,
+        name: o.name,
+        terminalIds,
+        createdAt: o.createdAt,
+      });
+    } else if (o.kind === "predicate") {
+      if (typeof o.scope !== "string" || !VALID_PREDICATE_SCOPES.has(o.scope)) continue;
+      if (typeof o.stateFilter !== "string" || !VALID_PREDICATE_STATES.has(o.stateFilter)) continue;
+      out.push({
+        kind: "predicate",
+        id: o.id,
+        name: o.name,
+        scope: o.scope as "current" | "all",
+        stateFilter: o.stateFilter as "all" | "working" | "waiting" | "finished",
+        createdAt: o.createdAt,
+      });
+    }
+  }
+  return out.length > 0 ? out : undefined;
 }

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -300,7 +300,10 @@ export type BuiltInActionId =
   | "fleet.scope.enter"
   | "fleet.scope.exit"
   | "fleet.armMatchingFilter"
-  | "fleet.retryFailures";
+  | "fleet.retryFailures"
+  | "fleet.saveNamedFleet"
+  | "fleet.recallNamedFleet"
+  | "fleet.deleteNamedFleet";
 
 export type ActionId = BuiltInActionId | (string & {});
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -86,6 +86,9 @@ export type {
   ProjectSettings,
   ProjectTerminalSettings,
   CopyTreeSettings,
+  FleetSavedScope,
+  SnapshotFleetSavedScope,
+  PredicateFleetSavedScope,
 } from "./project.js";
 
 // IPC types - communication payloads

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -284,16 +284,28 @@ export type ResourceEnvironment = {
   icon?: string;
 };
 
-/** A saved fleet scope — a named selection of terminal IDs or filter preset */
-export interface FleetSavedScope {
+/** Snapshot fleet scope: stores the exact pane IDs at save time. Missing IDs are silently dropped on recall. */
+export interface SnapshotFleetSavedScope {
+  kind: "snapshot";
   id: string;
   name: string;
-  /** Explicit terminal IDs — takes precedence over filter when present */
-  terminalIds?: string[];
-  /** Filter-based scope that is re-evaluated against current panels on recall */
-  filter?: { scope: "current" | "all"; stateFilter: string };
+  terminalIds: string[];
   createdAt: number;
 }
+
+/** Predicate fleet scope: stores a filter rule that is re-evaluated against the current panel set on recall. */
+export interface PredicateFleetSavedScope {
+  kind: "predicate";
+  id: string;
+  name: string;
+  scope: "current" | "all";
+  /** "all" maps to armAll(scope); "working"/"waiting"/"finished" map to armByState(preset, scope, false). */
+  stateFilter: "all" | "working" | "waiting" | "finished";
+  createdAt: number;
+}
+
+/** A saved fleet scope — a named selection persisted per-project for quick recall. */
+export type FleetSavedScope = SnapshotFleetSavedScope | PredicateFleetSavedScope;
 
 /** Per-project terminal configuration overrides */
 export interface ProjectTerminalSettings {

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1172,7 +1172,7 @@ function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement {
                 : "Arm panes first…"
               : "Name…"
           }
-          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-daintree-text/40 outline-none focus:bg-tint/[0.14]"
+          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-daintree-text/40 outline-hidden focus:bg-tint/[0.14]"
           data-testid="fleet-save-form-name"
         />
         <button

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
-import { MoreHorizontal, X } from "lucide-react";
+import { MoreHorizontal, Save, Trash2, X } from "lucide-react";
 import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
@@ -21,7 +21,9 @@ import {
 } from "@/store/fleetPendingActionStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { actionService } from "@/services/ActionService";
+import { computeSavedScopePaneCount } from "@/services/actions/definitions/fleetActions";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import {
@@ -32,6 +34,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import type { FleetSavedScope } from "@shared/types";
 
 const DOUBLE_ESC_WINDOW_MS = 350;
 
@@ -536,6 +539,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           </DropdownMenuItem>
         </>
       ) : null}
+      <SavedFleetsSection />
     </>
   );
 
@@ -943,5 +947,248 @@ function FleetWorktreeDots({ scope }: { scope: FleetWorktreeScope }): ReactEleme
         />
       ))}
     </span>
+  );
+}
+
+/**
+ * Saved-fleets section of the selection-menu dropdown — recall list + inline
+ * save form. Sourced from `useProjectSettingsStore.fleetSavedScopes`. The list
+ * is omitted when empty; the save form is always visible.
+ *
+ * The save flow is intentionally explicit: pick a flavor (snapshot vs predicate),
+ * type a name, press Save. Snapshot freezes current `armOrder`; predicate stores
+ * a state filter that re-evaluates on recall (Apple Music "live updating" idiom).
+ */
+function SavedFleetsSection(): ReactElement {
+  const armedCount = useFleetArmingStore((s) => s.armedIds.size);
+  const savedScopes = useProjectSettingsStore(
+    useShallow((s) => s.settings?.fleetSavedScopes ?? [])
+  );
+  return (
+    <>
+      <DropdownMenuSeparator />
+      {savedScopes.length > 0 ? (
+        <>
+          <DropdownMenuLabel>Saved fleets</DropdownMenuLabel>
+          {savedScopes.map((scope) => (
+            <SavedFleetRow key={scope.id} scope={scope} />
+          ))}
+        </>
+      ) : null}
+      <SaveFleetForm armedCount={armedCount} />
+    </>
+  );
+}
+
+interface SavedFleetRowProps {
+  scope: FleetSavedScope;
+}
+
+function SavedFleetRow({ scope }: SavedFleetRowProps): ReactElement {
+  // Counts are computed at render time — the dropdown opens fresh each time,
+  // so re-running this on every paint of the open menu is fine and there's no
+  // need for a panelStore subscription that would burn cycles while closed.
+  const count = computeSavedScopePaneCount(scope);
+  const flavorLabel = scope.kind === "snapshot" ? "Snapshot" : "Live";
+  return (
+    <DropdownMenuItem
+      onSelect={() => {
+        void actionService.dispatch("fleet.recallNamedFleet", { id: scope.id }, { source: "user" });
+      }}
+      data-testid="fleet-saved-row"
+      className="flex items-center gap-2"
+    >
+      <span className="flex-1 truncate">{scope.name}</span>
+      <span className="text-[10px] text-daintree-text/50 tabular-nums">
+        {count} · {flavorLabel}
+      </span>
+      <button
+        type="button"
+        aria-label={`Delete fleet "${scope.name}"`}
+        data-testid="fleet-saved-row-delete"
+        onClick={(e) => {
+          // Stop the parent DropdownMenuItem's onSelect from firing the recall
+          // when the user clicks the trash icon.
+          e.preventDefault();
+          e.stopPropagation();
+          void actionService.dispatch(
+            "fleet.deleteNamedFleet",
+            { id: scope.id },
+            { source: "user" }
+          );
+        }}
+        onPointerDown={(e) => {
+          // Radix DropdownMenuItem also commits on pointerdown — guard the
+          // delete from triggering recall by stopping propagation early.
+          e.stopPropagation();
+        }}
+        className="inline-flex shrink-0 items-center rounded p-0.5 text-daintree-text/50 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+      >
+        <Trash2 className="h-3 w-3" />
+      </button>
+    </DropdownMenuItem>
+  );
+}
+
+interface SaveFleetFormProps {
+  armedCount: number;
+}
+
+function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement {
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<"snapshot" | "predicate">("snapshot");
+  const [predicateScope, setPredicateScope] = useState<"current" | "all">("all");
+  const [predicateState, setPredicateState] = useState<"all" | "working" | "waiting" | "finished">(
+    "waiting"
+  );
+
+  const trimmed = name.trim();
+  const canSave = trimmed.length > 0 && (kind !== "snapshot" || armedCount > 0);
+
+  const submit = useCallback(() => {
+    if (!canSave) return;
+    const args =
+      kind === "snapshot"
+        ? { kind: "snapshot" as const, name: trimmed }
+        : {
+            kind: "predicate" as const,
+            name: trimmed,
+            scope: predicateScope,
+            stateFilter: predicateState,
+          };
+    void actionService.dispatch("fleet.saveNamedFleet", args, { source: "user" });
+    setName("");
+  }, [canSave, kind, trimmed, predicateScope, predicateState]);
+
+  return (
+    <DropdownMenuItem
+      // Hosting an inline form inside a Radix DropdownMenuItem requires both
+      // preventing the default select (which would close the menu on every
+      // click inside) and giving the item an empty `textValue` so Radix's
+      // typeahead doesn't intercept characters as the user types the name.
+      onSelect={(e) => e.preventDefault()}
+      textValue=""
+      className="flex flex-col items-stretch gap-1.5 py-2"
+      data-testid="fleet-save-form"
+    >
+      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-daintree-text/50">
+        <Save className="h-3 w-3" />
+        <span>Save current as…</span>
+      </div>
+      <div className="flex gap-1 text-[11px]" role="radiogroup" aria-label="Save fleet flavor">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={kind === "snapshot"}
+          onClick={(e) => {
+            e.stopPropagation();
+            setKind("snapshot");
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "flex-1 rounded px-2 py-1 transition-colors",
+            kind === "snapshot"
+              ? "bg-tint/[0.14] text-daintree-text"
+              : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
+          )}
+        >
+          Snapshot
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={kind === "predicate"}
+          onClick={(e) => {
+            e.stopPropagation();
+            setKind("predicate");
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "flex-1 rounded px-2 py-1 transition-colors",
+            kind === "predicate"
+              ? "bg-tint/[0.14] text-daintree-text"
+              : "bg-tint/[0.04] text-daintree-text/70 hover:bg-tint/[0.08]"
+          )}
+        >
+          Live rule
+        </button>
+      </div>
+      {kind === "predicate" ? (
+        <div className="flex gap-1 text-[11px]">
+          <select
+            aria-label="Predicate scope"
+            value={predicateScope}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "current" || v === "all") setPredicateScope(v);
+            }}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="flex-1 rounded bg-tint/[0.08] px-1.5 py-1 text-daintree-text"
+          >
+            <option value="current">This worktree</option>
+            <option value="all">All worktrees</option>
+          </select>
+          <select
+            aria-label="Predicate state"
+            value={predicateState}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (v === "all" || v === "working" || v === "waiting" || v === "finished") {
+                setPredicateState(v);
+              }
+            }}
+            onClick={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+            className="flex-1 rounded bg-tint/[0.08] px-1.5 py-1 text-daintree-text"
+          >
+            <option value="all">All</option>
+            <option value="waiting">Waiting</option>
+            <option value="working">Working</option>
+            <option value="finished">Finished</option>
+          </select>
+        </div>
+      ) : null}
+      <div className="flex gap-1">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          // Without these stop-propagation guards Radix's DropdownMenu eats
+          // Space (toggles), arrow keys (navigates), and Enter (commits the
+          // focused item) before they reach the input.
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          placeholder={
+            kind === "snapshot"
+              ? armedCount > 0
+                ? `Name (${armedCount} pane${armedCount === 1 ? "" : "s"})`
+                : "Arm panes first…"
+              : "Name…"
+          }
+          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-daintree-text/40 outline-none focus:bg-tint/[0.14]"
+          data-testid="fleet-save-form-name"
+        />
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            submit();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          disabled={!canSave}
+          data-testid="fleet-save-form-submit"
+          className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-1 text-[11px] text-category-amber-text transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Save
+        </button>
+      </div>
+    </DropdownMenuItem>
   );
 }

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -1,0 +1,443 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { FleetSavedScope, TerminalInstance } from "@shared/types";
+
+const getSettingsMock = vi.hoisted(() => vi.fn());
+const saveSettingsMock = vi.hoisted(() => vi.fn());
+const notifyMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn().mockResolvedValue("test-id"),
+    write: vi.fn(),
+    resize: vi.fn(),
+    trash: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn(),
+    sendKey: vi.fn(),
+    batchDoubleEscape: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+  projectClient: {
+    getSettings: getSettingsMock,
+    saveSettings: saveSettingsMock,
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    destroy: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+  },
+}));
+
+vi.mock("@/store/persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+const { usePanelStore } = await import("@/store/panelStore");
+const { useProjectStore } = await import("@/store/projectStore");
+const { registerFleetActions } = await import("../fleetActions");
+
+type ActionRegistry = Awaited<
+  ReturnType<typeof import("@/services/actions/actionDefinitions").createActionDefinitions>
+>;
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    kind: "terminal",
+    detectedAgentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "waiting",
+    hasPty: true,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
+    panelIds: terminals.map((t) => t.id),
+  });
+}
+
+function setCurrentProject(id: string | null): void {
+  useProjectStore.setState({
+    currentProject: id ? ({ id, name: id } as never) : null,
+  });
+}
+
+function resetState(): void {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+    focusedId: null,
+    maximizedId: null,
+    commandQueue: [],
+  });
+  setCurrentProject("proj-1");
+}
+
+async function buildRegistry(): Promise<ActionRegistry> {
+  const registry: ActionRegistry = new Map();
+  registerFleetActions(registry);
+  return registry;
+}
+
+async function run(registry: ActionRegistry, id: string, args?: unknown): Promise<void> {
+  const factory = registry.get(id);
+  if (!factory) throw new Error(`action ${id} not registered`);
+  const def = factory();
+  await def.run(args as never, {} as never);
+}
+
+describe("fleet.saveNamedFleet", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("saves the current armed set as a snapshot scope", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    getSettingsMock.mockResolvedValue({ runCommands: [] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
+    const [projectId, settings] = saveSettingsMock.mock.calls[0]!;
+    expect(projectId).toBe("proj-1");
+    expect(settings.fleetSavedScopes).toHaveLength(1);
+    const saved = settings.fleetSavedScopes[0] as FleetSavedScope;
+    expect(saved.kind).toBe("snapshot");
+    expect(saved.name).toBe("My Fleet");
+    expect(saved.kind === "snapshot" ? saved.terminalIds : []).toEqual(["a", "b"]);
+  });
+
+  it("trims whitespace from the name and refuses an empty name", async () => {
+    useFleetArmingStore.getState().armIds(["a"]);
+    seedPanels([makeAgent("a")]);
+    getSettingsMock.mockResolvedValue({ runCommands: [] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "   " });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("saves a predicate scope without reading the current armed set", async () => {
+    // Predicate save must work even when nothing is armed — the rule is
+    // independent of the current selection.
+    seedPanels([]);
+    getSettingsMock.mockResolvedValue({ runCommands: [] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", {
+      kind: "predicate",
+      name: "All waiting",
+      scope: "all",
+      stateFilter: "waiting",
+    });
+
+    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
+    const saved = saveSettingsMock.mock.calls[0]![1].fleetSavedScopes[0] as FleetSavedScope;
+    expect(saved.kind).toBe("predicate");
+    if (saved.kind === "predicate") {
+      expect(saved.scope).toBe("all");
+      expect(saved.stateFilter).toBe("waiting");
+    }
+  });
+
+  it("appends to existing scopes without clobbering them", async () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    const existing: FleetSavedScope = {
+      kind: "predicate",
+      id: "old",
+      name: "Old",
+      scope: "all",
+      stateFilter: "working",
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [existing] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "New" });
+
+    const saved = saveSettingsMock.mock.calls[0]![1].fleetSavedScopes;
+    expect(saved).toHaveLength(2);
+    expect(saved[0]).toMatchObject({ id: "old" });
+    expect(saved[1].name).toBe("New");
+  });
+
+  it("aborts when the project switches mid-IPC (does not write)", async () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    getSettingsMock.mockImplementation(async () => {
+      // Simulate the project switching before getSettings resolves.
+      setCurrentProject("proj-2");
+      return { runCommands: [] };
+    });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when no project is active", async () => {
+    setCurrentProject(null);
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    expect(getSettingsMock).not.toHaveBeenCalled();
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error notification when saveSettings rejects", async () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    getSettingsMock.mockResolvedValue({ runCommands: [] });
+    saveSettingsMock.mockRejectedValue(new Error("disk full"));
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Couldn't save fleet" })
+    );
+  });
+});
+
+describe("fleet.recallNamedFleet", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("arms the saved snapshot terminal IDs that are still eligible", async () => {
+    seedPanels([makeAgent("a"), makeAgent("c")]);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      // "b" is no longer in panelsById — should be silently dropped on recall.
+      terminalIds: ["a", "b", "c"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["a", "c"]);
+  });
+
+  it("preserves saved order on snapshot recall", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    const scope: FleetSavedScope = {
+      kind: "snapshot",
+      id: "s1",
+      name: "Snap",
+      terminalIds: ["c", "a", "b"],
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "s1" });
+
+    expect(useFleetArmingStore.getState().armOrder).toEqual(["c", "a", "b"]);
+  });
+
+  it("recalls a predicate scope by re-evaluating against the current panels", async () => {
+    seedPanels([
+      makeAgent("a", { agentState: "waiting" }),
+      makeAgent("b", { agentState: "working" }),
+      makeAgent("c", { agentState: "waiting" }),
+    ]);
+    const scope: FleetSavedScope = {
+      kind: "predicate",
+      id: "p1",
+      name: "Waiting",
+      scope: "all",
+      stateFilter: "waiting",
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "p1" });
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect(armed.size).toBe(2);
+    expect(armed.has("a")).toBe(true);
+    expect(armed.has("c")).toBe(true);
+  });
+
+  it("predicate recall ends with zero armed when nothing matches (does not auto-delete)", async () => {
+    // No agents in the "waiting" state — a predicate fleet that resolves to
+    // zero panes must NOT be auto-deleted (Apple Music live-rule precedent).
+    seedPanels([makeAgent("a", { agentState: "working" })]);
+    const scope: FleetSavedScope = {
+      kind: "predicate",
+      id: "p1",
+      name: "Waiting",
+      scope: "all",
+      stateFilter: "waiting",
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "p1" });
+
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    // Saved scopes were never modified by recall — only save/delete may write.
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("predicate stateFilter='all' calls armAll(scope)", async () => {
+    seedPanels([makeAgent("a", { worktreeId: "wt-1" }), makeAgent("b", { worktreeId: "wt-2" })]);
+    const scope: FleetSavedScope = {
+      kind: "predicate",
+      id: "p1",
+      name: "Everyone",
+      scope: "all",
+      stateFilter: "all",
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "p1" });
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect(armed.has("a")).toBe(true);
+    expect(armed.has("b")).toBe(true);
+  });
+
+  it("is a no-op when the saved id is not found", async () => {
+    seedPanels([makeAgent("a")]);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "missing" });
+
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+  });
+});
+
+describe("fleet.deleteNamedFleet", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  it("removes the matching scope and persists the new array", async () => {
+    const scopes: FleetSavedScope[] = [
+      {
+        kind: "snapshot",
+        id: "s1",
+        name: "A",
+        terminalIds: [],
+        createdAt: 1,
+      },
+      {
+        kind: "snapshot",
+        id: "s2",
+        name: "B",
+        terminalIds: [],
+        createdAt: 2,
+      },
+    ];
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: scopes });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.deleteNamedFleet", { id: "s1" });
+
+    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
+    const saved = saveSettingsMock.mock.calls[0]![1].fleetSavedScopes;
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({ id: "s2" });
+  });
+
+  it("is idempotent — unknown id does not call saveSettings", async () => {
+    getSettingsMock.mockResolvedValue({
+      runCommands: [],
+      fleetSavedScopes: [
+        {
+          kind: "snapshot",
+          id: "s1",
+          name: "A",
+          terminalIds: [],
+          createdAt: 1,
+        } satisfies FleetSavedScope,
+      ],
+    });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.deleteNamedFleet", { id: "missing" });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts the write when the project switches mid-IPC", async () => {
+    getSettingsMock.mockImplementation(async () => {
+      setCurrentProject("proj-2");
+      return {
+        runCommands: [],
+        fleetSavedScopes: [
+          {
+            kind: "snapshot",
+            id: "s1",
+            name: "A",
+            terminalIds: [],
+            createdAt: 1,
+          } satisfies FleetSavedScope,
+        ],
+      };
+    });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.deleteNamedFleet", { id: "s1" });
+
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -55,6 +55,8 @@ vi.mock("@/lib/notify", () => ({
 const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
 const { usePanelStore } = await import("@/store/panelStore");
 const { useProjectStore } = await import("@/store/projectStore");
+const { useProjectSettingsStore } = await import("@/store/projectSettingsStore");
+const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
 const { registerFleetActions } = await import("../fleetActions");
 
 type ActionRegistry = Awaited<
@@ -103,6 +105,15 @@ function resetState(): void {
     maximizedId: null,
     commandQueue: [],
   });
+  useProjectSettingsStore.setState({
+    settings: null,
+    projectId: null,
+    detectedRunners: [],
+    allDetectedRunners: [],
+    isLoading: false,
+    error: null,
+  });
+  useWorktreeSelectionStore.setState({ activeWorktreeId: null });
   setCurrentProject("proj-1");
 }
 
@@ -227,6 +238,46 @@ describe("fleet.saveNamedFleet", () => {
 
     expect(getSettingsMock).not.toHaveBeenCalled();
     expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("writes the new scope through to useProjectSettingsStore so the UI updates", async () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    useProjectSettingsStore.setState({
+      projectId: "proj-1",
+      settings: { runCommands: [] },
+    });
+    getSettingsMock.mockResolvedValue({ runCommands: [] });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    const stored = useProjectSettingsStore.getState().settings?.fleetSavedScopes;
+    expect(stored).toHaveLength(1);
+    expect(stored?.[0]).toMatchObject({ kind: "snapshot", name: "My Fleet" });
+  });
+
+  it("captures the snapshot armOrder before the IPC round-trip", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    getSettingsMock.mockImplementation(async () => {
+      // The user disarms all panes during the IPC round-trip. The persisted
+      // snapshot must still reflect what they clicked Save on.
+      useFleetArmingStore.getState().clear();
+      return { runCommands: [] };
+    });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "My Fleet" });
+
+    const saved = saveSettingsMock.mock.calls[0]![1].fleetSavedScopes[0] as FleetSavedScope;
+    if (saved.kind === "snapshot") {
+      expect(saved.terminalIds).toEqual(["a", "b"]);
+    } else {
+      throw new Error("expected snapshot kind");
+    }
   });
 
   it("surfaces an error notification when saveSettings rejects", async () => {
@@ -361,6 +412,45 @@ describe("fleet.recallNamedFleet", () => {
 
     expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
   });
+
+  it("missing-id recall preserves the existing armed set (does not clear)", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "missing" });
+
+    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
+    expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("predicate scope='current' restricts to the active worktree", async () => {
+    seedPanels([
+      makeAgent("a", { worktreeId: "wt-1" }),
+      makeAgent("b", { worktreeId: "wt-2" }),
+      makeAgent("c", { worktreeId: "wt-1" }),
+    ]);
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const scope: FleetSavedScope = {
+      kind: "predicate",
+      id: "p1",
+      name: "Current",
+      scope: "current",
+      stateFilter: "all",
+      createdAt: 1,
+    };
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [scope] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "p1" });
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect(armed.size).toBe(2);
+    expect(armed.has("a")).toBe(true);
+    expect(armed.has("c")).toBe(true);
+    expect(armed.has("b")).toBe(false);
+  });
 });
 
 describe("fleet.deleteNamedFleet", () => {
@@ -416,6 +506,31 @@ describe("fleet.deleteNamedFleet", () => {
     await run(registry, "fleet.deleteNamedFleet", { id: "missing" });
 
     expect(saveSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("writes the trimmed scopes through to useProjectSettingsStore", async () => {
+    useProjectSettingsStore.setState({
+      projectId: "proj-1",
+      settings: { runCommands: [] },
+    });
+    getSettingsMock.mockResolvedValue({
+      runCommands: [],
+      fleetSavedScopes: [
+        {
+          kind: "snapshot",
+          id: "s1",
+          name: "A",
+          terminalIds: [],
+          createdAt: 1,
+        } satisfies FleetSavedScope,
+      ],
+    });
+    saveSettingsMock.mockResolvedValue(undefined);
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.deleteNamedFleet", { id: "s1" });
+
+    expect(useProjectSettingsStore.getState().settings?.fleetSavedScopes).toEqual([]);
   });
 
   it("aborts the write when the project switches mid-IPC", async () => {

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -19,6 +19,7 @@ import {
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { projectClient, terminalClient } from "@/clients";
 import { broadcastFleetLiteralPaste } from "@/components/Fleet/fleetExecution";
 import { notify } from "@/lib/notify";
@@ -371,15 +372,24 @@ export function registerFleetActions(actions: ActionRegistry): void {
       if (name.length === 0) return;
       const projectId = useProjectStore.getState().currentProject?.id ?? null;
       if (!projectId) return;
+      // Capture the snapshot's terminal IDs BEFORE the IPC round-trip so a
+      // user changing the armed set during the await doesn't end up saving a
+      // different selection than the one they clicked Save on.
+      const newScope = buildSavedScope(parsed);
+      if (!newScope) return;
       try {
         const current = await projectClient.getSettings(projectId);
-        // Re-check the project hasn't switched while the IPC was in flight —
-        // otherwise we'd persist this fleet into the wrong project's settings.
         if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        const newScope = buildSavedScope(parsed);
-        if (!newScope) return;
         const next: FleetSavedScope[] = [...(current.fleetSavedScopes ?? []), newScope];
-        await projectClient.saveSettings(projectId, { ...current, fleetSavedScopes: next });
+        const nextSettings = { ...current, fleetSavedScopes: next };
+        await projectClient.saveSettings(projectId, nextSettings);
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        // Write-through: the SavedFleetsSection reads from useProjectSettingsStore,
+        // so the row only appears if the in-memory cache is updated. Without
+        // this the user clicks Save, the disk write succeeds, but no row shows.
+        if (useProjectSettingsStore.getState().projectId === projectId) {
+          useProjectSettingsStore.getState().setSettings(nextSettings);
+        }
         notify({
           type: "success",
           message: `Saved fleet "${newScope.name}"`,
@@ -446,7 +456,12 @@ export function registerFleetActions(actions: ActionRegistry): void {
         const existing = current.fleetSavedScopes ?? [];
         const next = existing.filter((s) => s.id !== id);
         if (next.length === existing.length) return;
-        await projectClient.saveSettings(projectId, { ...current, fleetSavedScopes: next });
+        const nextSettings = { ...current, fleetSavedScopes: next };
+        await projectClient.saveSettings(projectId, nextSettings);
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        if (useProjectSettingsStore.getState().projectId === projectId) {
+          useProjectSettingsStore.getState().setSettings(nextSettings);
+        }
       } catch (error) {
         notify({
           type: "error",
@@ -509,7 +524,8 @@ function applySavedScope(scope: FleetSavedScope): void {
   if (scope.kind === "snapshot") {
     const { panelsById } = usePanelStore.getState();
     const validIds: string[] = [];
-    for (const id of scope.terminalIds) {
+    const ids = Array.isArray(scope.terminalIds) ? scope.terminalIds : [];
+    for (const id of ids) {
       if (isFleetArmEligible(panelsById[id])) validIds.push(id);
     }
     fleet.armIds(validIds);
@@ -535,8 +551,9 @@ function generateScopeId(): string {
 export function computeSavedScopePaneCount(scope: FleetSavedScope): number {
   if (scope.kind === "snapshot") {
     const { panelsById } = usePanelStore.getState();
+    const ids = Array.isArray(scope.terminalIds) ? scope.terminalIds : [];
     let n = 0;
-    for (const id of scope.terminalIds) {
+    for (const id of ids) {
       if (isFleetArmEligible(panelsById[id])) n++;
     }
     return n;

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -7,6 +7,9 @@ import {
   isFleetInterruptAgentEligible,
   isFleetRestartAgentEligible,
   isFleetWaitingAgentEligible,
+  collectEligibleIds,
+  computeArmByStateIds,
+  type FleetArmStatePreset,
 } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import {
@@ -15,9 +18,12 @@ import {
 } from "@/store/fleetPendingActionStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { terminalClient } from "@/clients";
+import { useProjectStore } from "@/store/projectStore";
+import { projectClient, terminalClient } from "@/clients";
 import { broadcastFleetLiteralPaste } from "@/components/Fleet/fleetExecution";
-import type { TerminalInstance } from "@shared/types";
+import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { FleetSavedScope, TerminalInstance } from "@shared/types";
 
 interface ArmedSnapshot {
   terminalTargets: TerminalInstance[];
@@ -348,4 +354,200 @@ export function registerFleetActions(actions: ActionRegistry): void {
       useFleetArmingStore.getState().toggleId(focusedId);
     },
   }));
+
+  actions.set("fleet.saveNamedFleet", () => ({
+    id: "fleet.saveNamedFleet",
+    title: "Fleet: Save named fleet",
+    description:
+      "Persist the current fleet selection (snapshot) or a state filter (predicate) under a name for later recall.",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: saveNamedFleetSchema,
+    run: async (args: unknown) => {
+      const parsed = saveNamedFleetSchema.parse(args);
+      const name = parsed.name.trim();
+      if (name.length === 0) return;
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      if (!projectId) return;
+      try {
+        const current = await projectClient.getSettings(projectId);
+        // Re-check the project hasn't switched while the IPC was in flight —
+        // otherwise we'd persist this fleet into the wrong project's settings.
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        const newScope = buildSavedScope(parsed);
+        if (!newScope) return;
+        const next: FleetSavedScope[] = [...(current.fleetSavedScopes ?? []), newScope];
+        await projectClient.saveSettings(projectId, { ...current, fleetSavedScopes: next });
+        notify({
+          type: "success",
+          message: `Saved fleet "${newScope.name}"`,
+          priority: "low",
+        });
+      } catch (error) {
+        notify({
+          type: "error",
+          title: "Couldn't save fleet",
+          message: formatErrorMessage(error, "Couldn't save the fleet to project settings"),
+          duration: 5000,
+        });
+      }
+    },
+  }));
+
+  actions.set("fleet.recallNamedFleet", () => ({
+    id: "fleet.recallNamedFleet",
+    title: "Fleet: Recall named fleet",
+    description:
+      "Arm panes from a saved fleet. Snapshot fleets drop missing IDs silently; predicate fleets re-evaluate against current panes.",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: idArgSchema,
+    run: async (args: unknown) => {
+      const { id } = idArgSchema.parse(args);
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      if (!projectId) return;
+      try {
+        const current = await projectClient.getSettings(projectId);
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        const scope = (current.fleetSavedScopes ?? []).find((s) => s.id === id);
+        if (!scope) return;
+        applySavedScope(scope);
+      } catch (error) {
+        notify({
+          type: "error",
+          title: "Couldn't recall fleet",
+          message: formatErrorMessage(error, "Couldn't read project settings to recall the fleet"),
+          duration: 5000,
+        });
+      }
+    },
+  }));
+
+  actions.set("fleet.deleteNamedFleet", () => ({
+    id: "fleet.deleteNamedFleet",
+    title: "Fleet: Delete named fleet",
+    description: "Remove a saved fleet by id. Idempotent — unknown ids are silently ignored.",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: idArgSchema,
+    run: async (args: unknown) => {
+      const { id } = idArgSchema.parse(args);
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      if (!projectId) return;
+      try {
+        const current = await projectClient.getSettings(projectId);
+        if (useProjectStore.getState().currentProject?.id !== projectId) return;
+        const existing = current.fleetSavedScopes ?? [];
+        const next = existing.filter((s) => s.id !== id);
+        if (next.length === existing.length) return;
+        await projectClient.saveSettings(projectId, { ...current, fleetSavedScopes: next });
+      } catch (error) {
+        notify({
+          type: "error",
+          title: "Couldn't delete fleet",
+          message: formatErrorMessage(error, "Couldn't update project settings"),
+          duration: 5000,
+        });
+      }
+    },
+  }));
+}
+
+const saveNamedFleetSchema = z.object({ name: z.string().min(1) }).and(
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("snapshot"),
+      terminalIds: z.array(z.string()).optional(),
+    }),
+    z.object({
+      kind: z.literal("predicate"),
+      scope: z.enum(["current", "all"]),
+      stateFilter: z.enum(["all", "working", "waiting", "finished"]),
+    }),
+  ])
+);
+
+const idArgSchema = z.object({ id: z.string().min(1) });
+
+type SaveNamedFleetArgs = z.infer<typeof saveNamedFleetSchema>;
+
+/**
+ * Build the persisted scope object. For snapshots without an explicit terminalIds
+ * argument, we read armOrder live so the UI doesn't have to pass IDs around — but
+ * if the caller did pass an empty array on purpose we still honor it (zero-pane
+ * snapshot is allowed; recall will arm nothing).
+ */
+function buildSavedScope(args: SaveNamedFleetArgs): FleetSavedScope | null {
+  const id = generateScopeId();
+  const createdAt = Date.now();
+  const name = args.name.trim();
+  if (args.kind === "snapshot") {
+    const terminalIds =
+      args.terminalIds !== undefined
+        ? [...args.terminalIds]
+        : [...useFleetArmingStore.getState().armOrder];
+    return { kind: "snapshot", id, name, terminalIds, createdAt };
+  }
+  return {
+    kind: "predicate",
+    id,
+    name,
+    scope: args.scope,
+    stateFilter: args.stateFilter,
+    createdAt,
+  };
+}
+
+function applySavedScope(scope: FleetSavedScope): void {
+  const fleet = useFleetArmingStore.getState();
+  if (scope.kind === "snapshot") {
+    const { panelsById } = usePanelStore.getState();
+    const validIds: string[] = [];
+    for (const id of scope.terminalIds) {
+      if (isFleetArmEligible(panelsById[id])) validIds.push(id);
+    }
+    fleet.armIds(validIds);
+    return;
+  }
+  if (scope.stateFilter === "all") {
+    fleet.armAll(scope.scope);
+    return;
+  }
+  fleet.armByState(scope.stateFilter as FleetArmStatePreset, scope.scope, false);
+}
+
+function generateScopeId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Compute how many panes a saved scope would currently arm. Used by the UI to
+ * render live counts on saved-fleet rows. Predicate scopes re-evaluate against
+ * the current panel state; snapshot scopes return the count of still-eligible
+ * stored IDs (silent drop semantics).
+ */
+export function computeSavedScopePaneCount(scope: FleetSavedScope): number {
+  if (scope.kind === "snapshot") {
+    const { panelsById } = usePanelStore.getState();
+    let n = 0;
+    for (const id of scope.terminalIds) {
+      if (isFleetArmEligible(panelsById[id])) n++;
+    }
+    return n;
+  }
+  const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId ?? null;
+  if (scope.stateFilter === "all") {
+    return collectEligibleIds(scope.scope, activeWorktreeId).length;
+  }
+  return computeArmByStateIds(
+    scope.stateFilter as FleetArmStatePreset,
+    scope.scope,
+    activeWorktreeId
+  ).length;
 }

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -410,7 +410,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     id: "fleet.recallNamedFleet",
     title: "Fleet: Recall named fleet",
     description:
-      "Arm panes from a saved fleet. Snapshot fleets drop missing IDs silently; predicate fleets re-evaluate against current panes.",
+      "Apply panes from a saved fleet. Snapshots drop missing IDs; predicates re-evaluate against current panes.",
     category: "terminal",
     kind: "command",
     danger: "safe",


### PR DESCRIPTION
## Summary

- Adds three new actions (`fleet.saveNamedFleet`, `fleet.recallNamedFleet`, `fleet.deleteNamedFleet`) backed by the existing `ProjectSettings.fleetSavedScopes` field. Two fleet kinds: snapshot (freezes `armOrder` at save time, silently drops missing IDs on recall) and predicate (state filter re-evaluated on recall, never auto-deletes on zero matches).
- UI extends the `FleetArmingRibbon` dropdown with a "Saved fleets" section: live-counted recall list with per-row delete, plus an inline save form (name input, snapshot/predicate toggle, predicate scope/state selects). Inline form uses `onSelect={preventDefault}` + `textValue=""` + key-event `stopPropagation` to stay inside the Radix `DropdownMenuItem` without breaking menu navigation.
- `FleetSavedScope` is refined from a hybrid interface to a discriminated union (safe — zero consumers before this PR). Adds a `parseFleetSavedScopes` validator on the Electron side since `ProjectSettingsManager.getProjectSettings` rebuilds settings field-by-field and needs explicit coercion. Project-switch race guard re-checks `currentProject.id` after each `getSettings`/`saveSettings` IPC resolves.

Resolves #6473

## Changes

- `shared/types/project.ts` — `FleetSavedScope` discriminated union (`snapshot` | `predicate` kinds)
- `shared/types/actions.ts` — three new action IDs
- `electron/services/projectSettingsParsers.ts` — `parseFleetSavedScopes` (kind discriminant + enum bounds checks)
- `electron/services/ProjectSettingsManager.ts` — wire parser into settings read path
- `src/services/actions/definitions/fleetActions.ts` — `saveNamedFleet`, `recallNamedFleet`, `deleteNamedFleet` implementations with race guard
- `src/components/Fleet/FleetArmingRibbon.tsx` — saved-fleets UI section in the selection dropdown
- Unit tests: `savedFleetActions.test.ts` (save/recall/delete happy paths, snapshot drop semantics, predicate zero-match no-auto-delete, race guards, store write-through, snapshot `armOrder` captured pre-IPC) and `projectSettingsParsers.test.ts` (parser drops malformed entries, validates kind + enum bounds)

## Testing

Unit tests cover the core logic. Manual verification still needed: open ribbon with 2+ panes armed, save a snapshot and a predicate fleet, recall each, delete. Confirm inline save form doesn't break dropdown keyboard navigation.

**Known v1 limitation:** recall is only reachable through the ribbon, which only renders when `armedCount >= 2`. A cold-start with 0–1 panes armed has no UI affordance — the actions are still dispatchable from the command palette and from automation. A follow-up could add a worktree-sidebar or empty-state recall affordance.