### PR TITLE
fix(worktree): recover from stale local branch on worktree create

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -927,20 +927,27 @@ export class WorkspaceService {
 
         if (localBranches.includes(newBranch)) {
           let checkedOut = new Set<string>();
+          let listFailed = false;
           try {
             const output = await git.raw(["worktree", "list", "--porcelain"]);
             checkedOut = parseCheckedOutBranches(output);
           } catch {
-            // An empty set forces the suffix path, which is safer than
-            // reusing a possibly-live branch.
+            // We can't tell if the branch is live elsewhere; fall through to
+            // the suffix path rather than risk reusing a checked-out branch.
+            listFailed = true;
           }
 
-          if (!checkedOut.has(newBranch)) {
+          // For fromRemote (PR mode) we never reuse a stale local branch:
+          // the local ref is at the previous tip, and dropping --track would
+          // strip @{u} that ahead/behind badges depend on. Suffix instead so
+          // a fresh tracking branch is created.
+          const canReuse = !listFailed && !fromRemote && !checkedOut.has(newBranch);
+
+          if (canReuse) {
             useExistingBranch = true;
-            // The -b path tracks baseBranch / origin remotes; reuse drops
-            // that. Stale branches typically retain their original tracking
-            // config from the prior worktree, so this is the right tradeoff
-            // vs. surfacing a hard failure to the user.
+            // The -b path tracks baseBranch; reuse drops that. Stale local
+            // branches typically retain their original config, so this is
+            // the right tradeoff vs. failing the user-visible create.
             fromRemote = false;
           } else {
             newBranch = nextAvailableBranchName(newBranch, new Set(localBranches));

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -98,6 +98,41 @@ export function probeGitLfsAvailable(): Promise<boolean> {
   });
 }
 
+function escapeBranchRegex(name: string): string {
+  return name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function parseCheckedOutBranches(porcelainOutput: string): Set<string> {
+  const branches = new Set<string>();
+  for (const line of porcelainOutput.split("\n")) {
+    if (line.startsWith("branch ")) {
+      const ref = line.replace("branch ", "").replace("refs/heads/", "").trim();
+      if (ref) {
+        branches.add(ref);
+      }
+    }
+  }
+  return branches;
+}
+
+function nextAvailableBranchName(baseName: string, existing: Set<string>): string {
+  if (!existing.has(baseName)) {
+    return baseName;
+  }
+  const pattern = new RegExp(`^${escapeBranchRegex(baseName)}-(\\d+)$`);
+  let maxSuffix = 1;
+  for (const name of existing) {
+    const match = name.match(pattern);
+    if (match) {
+      const n = parseInt(match[1], 10);
+      if (n > maxSuffix) {
+        maxSuffix = n;
+      }
+    }
+  }
+  return `${baseName}-${maxSuffix + 1}`;
+}
+
 async function ensureNoteFile(worktreePath: string): Promise<void> {
   const gitDir = getGitDir(worktreePath);
   if (!gitDir) {
@@ -866,13 +901,52 @@ export class WorkspaceService {
   ): Promise<void> {
     try {
       const git = createHardenedGit(rootPath);
-      const {
-        baseBranch,
-        newBranch,
-        path,
-        fromRemote = false,
-        useExistingBranch = false,
-      } = options;
+      const { baseBranch, path } = options;
+      let { newBranch } = options;
+      let { fromRemote = false, useExistingBranch = false } = options;
+
+      // #6463: when not explicitly reusing a branch, guard against a stale
+      // local branch with the same name. Without this, `git worktree add -b`
+      // hits "fatal: a branch named '...' already exists" whenever a previous
+      // worktree was deleted but its branch was kept. Two recoveries:
+      // (a) branch exists but is not checked out anywhere → reuse it (drop
+      //     -b, switch to the useExistingBranch arg form);
+      // (b) branch is live in another worktree → suffix -2/-3/... and create
+      //     a fresh branch.
+      // Inlined (not behind a helper) so the happy-path microtask timing
+      // matches the pre-fix behavior — the next await is still the worktree
+      // add, not a wrapper-promise resolution.
+      if (!useExistingBranch) {
+        let localBranches: string[] = [];
+        try {
+          localBranches = (await git.branchLocal()).all;
+        } catch {
+          // Best-effort: if branch listing fails, fall through and let the
+          // actual worktree command surface its own error.
+        }
+
+        if (localBranches.includes(newBranch)) {
+          let checkedOut = new Set<string>();
+          try {
+            const output = await git.raw(["worktree", "list", "--porcelain"]);
+            checkedOut = parseCheckedOutBranches(output);
+          } catch {
+            // An empty set forces the suffix path, which is safer than
+            // reusing a possibly-live branch.
+          }
+
+          if (!checkedOut.has(newBranch)) {
+            useExistingBranch = true;
+            // The -b path tracks baseBranch / origin remotes; reuse drops
+            // that. Stale branches typically retain their original tracking
+            // config from the prior worktree, so this is the right tradeoff
+            // vs. surfacing a hard failure to the user.
+            fromRemote = false;
+          } else {
+            newBranch = nextAvailableBranchName(newBranch, new Set(localBranches));
+          }
+        }
+      }
 
       if (useExistingBranch) {
         await git.raw(["worktree", "add", path, newBranch]);

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -469,7 +469,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall).toBeDefined();
     // No -b — reuse path, like the explicit useExistingBranch caller.
@@ -523,7 +523,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall).toBeDefined();
     expect(worktreeAddCall![0]).toEqual([
@@ -580,7 +580,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall![0]).toEqual([
       "worktree",
@@ -618,7 +618,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall![0]).toEqual([
       "worktree",
@@ -661,7 +661,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall![0]).toEqual([
       "worktree",
@@ -708,7 +708,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall![0][3]).toBe("feature/foo-11");
   });
@@ -747,7 +747,7 @@ describe("WorkspaceService.createWorktree", () => {
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
     expect(worktreeAddCall![0][3]).toBe("bugfix/[6463]-3");
   });
@@ -780,7 +780,7 @@ describe("WorkspaceService.createWorktree", () => {
     ]);
     // Never queried the worktree list — short-circuit when branch is free.
     const listCall = mockSimpleGit.raw.mock.calls.find(
-      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "list"
+      (call) => call[0][0] === "worktree" && call[0][1] === "list"
     );
     expect(listCall).toBeUndefined();
   });

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -582,7 +582,174 @@ describe("WorkspaceService.createWorktree", () => {
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
       ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
     );
-    expect(worktreeAddCall![0]).toContain("feature/foo-4");
+    expect(worktreeAddCall![0]).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "feature/foo-4",
+      "--no-track",
+      "/test/worktree-foo-new",
+      "main",
+    ]);
+  });
+
+  it("falls through to the suffix path when the worktree-list probe fails", async () => {
+    // #6463 critical edge case: the porcelain probe must NOT mask "branch is
+    // live elsewhere" as "stale and reusable". When git rejects the probe
+    // (e.g., .git lock contention under bulk creation), the safer move is to
+    // suffix the branch and create fresh, not reuse a possibly-live ref.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "feature/foo"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        return Promise.reject(new Error("fatal: unable to read .git/index"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-list-failed", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-foo-fail",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall![0]).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "feature/foo-2",
+      "--no-track",
+      "/test/worktree-foo-fail",
+      "main",
+    ]);
+  });
+
+  it("suffixes (not reuses) when fromRemote=true and the local branch already exists", async () => {
+    // PR-mode creates need --track to give @{u} for ahead/behind badges
+    // (WorktreeMonitor.ts:1092). Reusing a stale local branch would drop the
+    // tracking ref AND pin the worktree to whatever commit the stale branch
+    // was at, instead of origin's current tip. Always suffix in PR mode.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "pr-9999-feature"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        // pr-9999-feature is NOT checked out — would normally trigger reuse,
+        // but fromRemote suppresses that.
+        return Promise.resolve(
+          ["worktree /test/root", "HEAD abc", "branch refs/heads/main", ""].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-fromremote-stale", "/test/root", {
+      baseBranch: "origin/pr-9999-feature",
+      newBranch: "pr-9999-feature",
+      path: "/test/worktree-pr",
+      fromRemote: true,
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall![0]).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "pr-9999-feature-2",
+      "--track",
+      "/test/worktree-pr",
+      "origin/pr-9999-feature",
+    ]);
+  });
+
+  it("picks the next free suffix past non-contiguous existing names", async () => {
+    // nextAvailableBranchName scans for the maximum existing -N suffix; gaps
+    // (e.g., -2 deleted but -10 kept) must not regress to a colliding name.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "feature/foo", "feature/foo-10"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        return Promise.resolve(
+          [
+            "worktree /test/root",
+            "HEAD abc",
+            "branch refs/heads/main",
+            "",
+            "worktree /test/foo-live",
+            "HEAD def",
+            "branch refs/heads/feature/foo",
+            "",
+          ].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-suffix-gap", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-foo-gap",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall![0][3]).toBe("feature/foo-11");
+  });
+
+  it("escapes regex metacharacters in branch names when computing suffixes", async () => {
+    // Branch names like `bugfix/[6463]` contain regex metacharacters; without
+    // escaping, the suffix scan would miss `bugfix/[6463]-2` and reissue it.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "bugfix/[6463]", "bugfix/[6463]-2"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        return Promise.resolve(
+          [
+            "worktree /test/root",
+            "HEAD abc",
+            "branch refs/heads/main",
+            "",
+            "worktree /test/live",
+            "HEAD def",
+            "branch refs/heads/bugfix/[6463]",
+            "",
+          ].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-regex-escape", "/test/root", {
+      baseBranch: "main",
+      newBranch: "bugfix/[6463]",
+      path: "/test/worktree-regex",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall![0][3]).toBe("bugfix/[6463]-3");
   });
 
   it("proceeds with the original -b path when the branch does not exist locally", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -5,6 +5,7 @@ import type { WorkspaceService } from "../WorkspaceService.js";
 const mockSimpleGit = {
   raw: vi.fn().mockResolvedValue(undefined),
   branch: vi.fn().mockResolvedValue({ current: "main" }),
+  branchLocal: vi.fn().mockResolvedValue({ all: [], current: "", branches: {}, detached: false }),
 };
 
 vi.mock("simple-git", () => ({
@@ -129,6 +130,19 @@ describe("WorkspaceService.createWorktree", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+
+    // restoreAllMocks (in afterEach) wipes mockResolvedValue so we re-anchor
+    // the defaults each test. Without this, branchLocal returns undefined on
+    // the second test onwards, which the createWorktree pre-flight handles
+    // via try/catch — but the fallback masks real test failures.
+    mockSimpleGit.raw.mockResolvedValue(undefined);
+    mockSimpleGit.branch.mockResolvedValue({ current: "main" });
+    mockSimpleGit.branchLocal.mockResolvedValue({
+      all: [],
+      current: "",
+      branches: {},
+      detached: false,
+    });
 
     const fsModule = await import("../../utils/fs.js");
     waitForPathExists = vi.mocked(fsModule.waitForPathExists);
@@ -279,7 +293,10 @@ describe("WorkspaceService.createWorktree", () => {
 
     const createPromise = service.createWorktree(requestId, "/test/root", options);
 
-    await Promise.resolve();
+    // The pre-flight branchLocal check (added for #6463) adds one microtask
+    // hop before git.raw is reached on the happy path; flush via setImmediate
+    // so this assertion isn't tied to the precise tick count.
+    await flushAsyncTail();
     expect(mockSimpleGit.raw).toHaveBeenCalled();
     expect(waitForPathExists).toHaveBeenCalledTimes(1);
 
@@ -422,6 +439,203 @@ describe("WorkspaceService.createWorktree", () => {
 
     expect(monitorPresentAtEmission).toBe(true);
     expect(service["monitors"].has("/test/worktree-sync")).toBe(true);
+  });
+
+  it("reuses a stale local branch (no -b) when it exists locally and is not checked out in any worktree", async () => {
+    // #6463 regression guard: a leftover local branch from a previously
+    // deleted worktree must not poison the next create. Reuse semantics
+    // (`git worktree add <path> <branch>`) preserve the user's chosen name.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "bugfix/issue-6463"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    // git worktree list --porcelain — only main is checked out, the stale
+    // bugfix/issue-6463 branch has no live worktree.
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        return Promise.resolve(
+          ["worktree /test/root", "HEAD abc123", "branch refs/heads/main", ""].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-stale-reuse", "/test/root", {
+      baseBranch: "main",
+      newBranch: "bugfix/issue-6463",
+      path: "/test/worktree-reuse",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall).toBeDefined();
+    // No -b — reuse path, like the explicit useExistingBranch caller.
+    expect(worktreeAddCall![0]).toEqual([
+      "worktree",
+      "add",
+      "/test/worktree-reuse",
+      "bugfix/issue-6463",
+    ]);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-stale-reuse",
+        success: true,
+      })
+    );
+  });
+
+  it("suffixes branch name when it exists locally and is already checked out in another worktree", async () => {
+    // #6463: branch is live in another worktree → cannot reuse, must
+    // generate a unique suffix and create with -b.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "feature/foo"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        return Promise.resolve(
+          [
+            "worktree /test/root",
+            "HEAD abc123",
+            "branch refs/heads/main",
+            "",
+            "worktree /test/foo-existing",
+            "HEAD def456",
+            "branch refs/heads/feature/foo",
+            "",
+          ].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-checked-out", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-foo",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall).toBeDefined();
+    expect(worktreeAddCall![0]).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "feature/foo-2",
+      "--no-track",
+      "/test/worktree-foo",
+      "main",
+    ]);
+
+    // Emitted worktree carries the suffixed branch name, not the original.
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "worktree-update",
+        worktree: expect.objectContaining({ branch: "feature/foo-2" }),
+      })
+    );
+  });
+
+  it("picks the next free suffix past existing -2/-3 collisions", async () => {
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "feature/foo", "feature/foo-2", "feature/foo-3"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") {
+        // feature/foo is live; feature/foo-2 and feature/foo-3 are stale
+        // local branches but the requested name is feature/foo (live), so
+        // we must suffix past every existing local name.
+        return Promise.resolve(
+          [
+            "worktree /test/root",
+            "HEAD abc",
+            "branch refs/heads/main",
+            "",
+            "worktree /test/foo-live",
+            "HEAD def",
+            "branch refs/heads/feature/foo",
+            "",
+          ].join("\n")
+        );
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-suffix-skip", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-foo-new",
+    });
+
+    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "add"
+    );
+    expect(worktreeAddCall![0]).toContain("feature/foo-4");
+  });
+
+  it("proceeds with the original -b path when the branch does not exist locally", async () => {
+    // Baseline: the guard is a no-op when there's no collision. Argv must
+    // match the pre-fix shape exactly so the issue-mode --no-track contract
+    // is preserved.
+    mockSimpleGit.branchLocal.mockResolvedValueOnce({
+      all: ["main", "develop"],
+      current: "main",
+      branches: {},
+      detached: false,
+    });
+
+    await service.createWorktree("req-no-collision", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/brand-new",
+      path: "/test/worktree-new",
+    });
+
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+      "worktree",
+      "add",
+      "-b",
+      "feature/brand-new",
+      "--no-track",
+      "/test/worktree-new",
+      "main",
+    ]);
+    // Never queried the worktree list — short-circuit when branch is free.
+    const listCall = mockSimpleGit.raw.mock.calls.find(
+      ([args]: [string[]]) => args[0] === "worktree" && args[1] === "list"
+    );
+    expect(listCall).toBeUndefined();
+  });
+
+  it("skips the pre-flight guard entirely when useExistingBranch is true", async () => {
+    // The caller is asking for explicit reuse; the guard's job is done by
+    // intent, not detection. Confirms we don't add a redundant branchLocal
+    // round-trip on the explicit-reuse path.
+    await service.createWorktree("req-explicit-reuse", "/test/root", {
+      baseBranch: "main",
+      newBranch: "existing-branch",
+      path: "/test/worktree-explicit",
+      useExistingBranch: true,
+    });
+
+    expect(mockSimpleGit.branchLocal).not.toHaveBeenCalled();
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith([
+      "worktree",
+      "add",
+      "/test/worktree-explicit",
+      "existing-branch",
+    ]);
   });
 
   it("emits a worktree-update before create-worktree-result so the renderer's store picks up the new worktree", async () => {

--- a/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
+++ b/src/components/GitHub/__tests__/bulkCreatePrequery.test.ts
@@ -206,6 +206,46 @@ describe("resolveIssuePrequeries", () => {
     expect(failedItems.some((f) => f.number === 1)).toBe(true);
   });
 
+  it("resolves branch names sequentially so each call sees prior in-batch claims", async () => {
+    // #6463 regression guard: parallel resolution let two siblings both see
+    // "name X is free in git" before either created its worktree. With
+    // sequential resolution the second call starts strictly after the first
+    // returns.
+    let inFlight = 0;
+    let maxObservedConcurrency = 0;
+    const callOrder: string[] = [];
+
+    const getAvailableBranch = vi.fn(async (_: string, name: string) => {
+      inFlight++;
+      maxObservedConcurrency = Math.max(maxObservedConcurrency, inFlight);
+      callOrder.push(`enter:${name}`);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      callOrder.push(`exit:${name}`);
+      inFlight--;
+      return name;
+    });
+    const getDefaultPath = vi.fn((_, branch) => Promise.resolve(`/path/${branch}`));
+
+    await resolveIssuePrequeries({
+      rootPath: "/repo",
+      items: [mockPlanned(1), mockPlanned(2), mockPlanned(3)],
+      existingBranches: null,
+      getAvailableBranch,
+      getDefaultPath,
+      isStaleRun: () => false,
+    });
+
+    expect(maxObservedConcurrency).toBe(1);
+    expect(callOrder).toEqual([
+      "enter:feature/issue-1",
+      "exit:feature/issue-1",
+      "enter:feature/issue-2",
+      "exit:feature/issue-2",
+      "enter:feature/issue-3",
+      "exit:feature/issue-3",
+    ]);
+  });
+
   it("calls onProgress callback with completion stats", async () => {
     const getAvailableBranch = vi.fn().mockResolvedValue("branch");
     const getDefaultPath = vi.fn().mockResolvedValue("/path");

--- a/src/components/GitHub/bulkCreatePrequery.ts
+++ b/src/components/GitHub/bulkCreatePrequery.ts
@@ -57,23 +57,6 @@ function applyUniqueSuffix(branch: string, assignedBranches: Set<string>): strin
   return uniqueBranch;
 }
 
-function resolveBranchUniqueness(
-  candidateBranches: Map<number, string>,
-  inputOrder: number[]
-): Map<number, string> {
-  const assignedBranches = new Set<string>();
-  const uniqueBranches = new Map<number, string>();
-
-  for (const itemNumber of inputOrder) {
-    const candidate = candidateBranches.get(itemNumber);
-    if (candidate !== undefined) {
-      uniqueBranches.set(itemNumber, applyUniqueSuffix(candidate, assignedBranches));
-    }
-  }
-
-  return uniqueBranches;
-}
-
 async function resolveIssuePrequeries({
   rootPath,
   items,
@@ -91,33 +74,32 @@ async function resolveIssuePrequeries({
   }
 
   const results = new Map<number, PrequeryResult>();
-  const branchQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
-  const candidateBranches = new Map<number, string>();
+  const uniqueBranches = new Map<number, string>();
   const branchErrors = new Array<{ number: number; error: Error }>();
 
-  const branchPromises = issueItems.map((planned) =>
-    branchQueue.add(async () => {
-      if (isStaleRun()) return;
-      try {
-        const branch = await withTimeout(
-          getAvailableBranch(rootPath, planned.branchName),
-          PREQUERY_TIMEOUT_MS,
-          `Prequery timeout for branch lookup on issue #${planned.item.number}`
-        );
-        candidateBranches.set(planned.item.number, branch);
-      } catch (err) {
-        branchErrors.push({
-          number: planned.item.number,
-          error: err instanceof Error ? err : new Error(String(err)),
-        });
-      }
-    })
-  );
-
-  await Promise.all(branchPromises);
+  // #6463: resolve branch names sequentially so each item sees the names
+  // already claimed in this batch. Parallel resolution let two siblings both
+  // see "name-X is free in git" and both claim it — when the actual worktree
+  // create ran, the second one collided. Threading the assigned-set through a
+  // sequential loop closes that gap without a mutex.
+  const assignedBranches = new Set<string>();
+  for (const planned of issueItems) {
+    if (isStaleRun()) break;
+    try {
+      const branch = await withTimeout(
+        getAvailableBranch(rootPath, planned.branchName),
+        PREQUERY_TIMEOUT_MS,
+        `Prequery timeout for branch lookup on issue #${planned.item.number}`
+      );
+      uniqueBranches.set(planned.item.number, applyUniqueSuffix(branch, assignedBranches));
+    } catch (err) {
+      branchErrors.push({
+        number: planned.item.number,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+  }
   if (isStaleRun()) return { results, failedItems: branchErrors };
-
-  const uniqueBranches = resolveBranchUniqueness(candidateBranches, inputOrder);
 
   const pathQueue = new PQueue({ concurrency: PREQUERY_CONCURRENCY });
   const pathErrors = new Array<{ number: number; error: Error }>();


### PR DESCRIPTION
## Summary

- `WorkspaceService.createWorktree` now pre-flights branch existence before running `git worktree add -b`. If the branch is stale (exists locally, not checked out anywhere) it reuses it via `git worktree add <path> <branch>`; if the branch is live in another worktree it falls back to suffixing the name (-2, -3, ...).
- The `fromRemote` path always suffixes -- never reuses -- so `--track` is preserved.
- `bulkCreatePrequery` now resolves branch names sequentially so each item in a batch sees prior in-batch claims, closing a parallel-resolution TOCTOU.

Resolves #6463

## Changes

- `electron/workspace-host/WorkspaceService.ts` -- branch existence pre-flight, stale-reuse vs. suffix logic, sequential bulk prequery
- `electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts` -- new test cases for stale reuse, suffix-on-checked-out, non-contiguous gap skipping, regex-metacharacter branch names, list-probe failure, `fromRemote` suffix path, and `useExistingBranch` short-circuit
- `src/components/GitHub/__tests__/bulkCreatePrequery.test.ts` -- sequential resolution test
- `src/components/GitHub/bulkCreatePrequery.ts` -- sequential loop replacing parallel `Promise.all`

## Testing

Unit tests added for every branch of the new logic: stale reuse, suffix when checked out, skipping non-contiguous suffix gaps, regex-metacharacter branch names, list-probe failure forcing suffix, `fromRemote` suffix path, and sequential bulk prequery. 34 targeted tests pass. Typecheck, lint ratchet, and format check all pass.