### PR TITLE
fix(fleet): make filtered arming additive when fleet is non-empty

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/DragDrop/SortableWorktreeCard";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useShallow } from "zustand/react/shallow";
 import type { RecipeTerminal } from "@/types";
 import { systemClient } from "@/clients";
@@ -381,6 +382,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const [isFleetArmingDialogOpen, setIsFleetArmingDialogOpen] = useState(false);
   const openFleetArmingDialog = useCallback(() => setIsFleetArmingDialogOpen(true), []);
   const closeFleetArmingDialog = useCallback(() => setIsFleetArmingDialogOpen(false), []);
+  const armedSize = useFleetArmingStore((s) => s.armedIds.size);
 
   // Filter/sort state - destructured for stable memoization
   const {
@@ -1133,14 +1135,22 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   )
                 }
                 className="w-full flex items-center justify-center gap-1.5 text-xs px-2 py-1 text-text-secondary hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                aria-label={`Arm ${filteredWorktrees.length} matching worktrees`}
+                aria-label={
+                  armedSize > 0
+                    ? `Arm ${filteredWorktrees.length} more matching worktrees`
+                    : `Arm ${filteredWorktrees.length} matching worktrees`
+                }
               >
                 <Zap className="w-3 h-3" />
-                Arm {filteredWorktrees.length} matching
+                {armedSize > 0
+                  ? `Arm ${filteredWorktrees.length} more matching`
+                  : `Arm ${filteredWorktrees.length} matching`}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              Arm all eligible terminals in the {filteredWorktrees.length} worktrees visible below
+              {armedSize > 0
+                ? `Add eligible terminals in the ${filteredWorktrees.length} worktrees visible below to the existing armed selection`
+                : `Arm all eligible terminals in the ${filteredWorktrees.length} worktrees visible below`}
             </TooltipContent>
           </Tooltip>
         </div>

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -353,12 +353,19 @@ describe("fleet.armMatchingFilter", () => {
     expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
   });
 
-  it("replaces any prior armed set that falls outside the filter", async () => {
+  it("replaces when armed set is empty", async () => {
+    seedPanels([makeAgent("a1", { worktreeId: "wt-1" }), makeAgent("a2", { worktreeId: "wt-2" })]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1"] });
+    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+  });
+
+  it("unions with existing armed set when non-empty", async () => {
     seedPanels([makeAgent("a1", { worktreeId: "wt-1" }), makeAgent("a2", { worktreeId: "wt-2" })]);
     useFleetArmingStore.getState().armIds(["a2"]);
     const registry = await buildRegistry();
     await run(registry, "fleet.armMatchingFilter", { worktreeIds: ["wt-1"] });
-    expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
   });
 });
 

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -360,6 +360,22 @@ describe("fleetArmingStore", () => {
       expect(s.armOrder).toEqual(["a2", "a1"]);
     });
 
+    it("preserves existing armOrder and appends new matches in panel order", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+        makeAgentTerminal("a3", { worktreeId: "wt-1" }),
+      ]);
+      useFleetArmingStore.getState().armIds(["a2"]);
+      // a2 already armed. a1 and a3 match the filter — both are new.
+      // a1 appears before a3 in panel order, so a2,a1,a3 is the expected result.
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a2", "a1", "a3"]);
+      expect(s.armOrderById).toEqual({ a2: 1, a1: 2, a3: 3 });
+      expect(s.lastArmedId).toBe("a3");
+    });
+
     it("no-op when all filter matches are already armed (additive path)", () => {
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -336,14 +336,47 @@ describe("fleetArmingStore", () => {
       expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
     });
 
-    it("replaces the existing armed set rather than merging", () => {
+    it("replaces the existing armed set when armed set is empty", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-2" }),
+      ]);
+      // Armed set starts empty — armMatchingFilter replaces it with matches
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+
+    it("unions with existing armed set when non-empty", () => {
       seedPanels([
         makeAgentTerminal("a1", { worktreeId: "wt-1" }),
         makeAgentTerminal("a2", { worktreeId: "wt-2" }),
       ]);
       useFleetArmingStore.getState().armIds(["a2"]);
+      // Non-empty armed set → armMatchingFilter adds matches without removing existing
       useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
-      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["a1", "a2"]);
+      // Existing armed entries keep their position; new ones are appended
+      expect(s.armOrder).toEqual(["a2", "a1"]);
+    });
+
+    it("no-op when all filter matches are already armed (additive path)", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a2", { worktreeId: "wt-1" }),
+        makeAgentTerminal("a3", { worktreeId: "wt-2" }),
+      ]);
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      // Add a3 from wt-2 — additive since a1,a2 are already armed
+      useFleetArmingStore.getState().armMatchingFilter(["wt-2"]);
+      // Now a1,a2,a3 are all armed. Call armMatchingFilter with wt-1 — a1 and a2
+      // are already armed, so the additive path should be a no-op.
+      const preState = useFleetArmingStore.getState();
+      useFleetArmingStore.getState().armMatchingFilter(["wt-1"]);
+      const postState = useFleetArmingStore.getState();
+      expect(postState.armOrder).toEqual(preState.armOrder);
+      expect(postState.armOrderById).toEqual(preState.armOrderById);
+      expect(postState.lastArmedId).toBe(preState.lastArmedId);
     });
 
     it("preserves panel iteration order, not worktreeIds input order", () => {

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -234,7 +234,29 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
     // worktrees match the filter; clicking it must not destroy the user's
     // prior selection when the filtered subset has no arm-eligible terminals.
     if (ids.length === 0) return;
-    get().armIds(ids);
+    if (get().armedIds.size === 0) {
+      get().armIds(ids);
+    } else {
+      set((s) => {
+        const nextArmed = new Set(s.armedIds);
+        const nextOrder = [...s.armOrder];
+        let lastAdded: string | null = null;
+        for (const id of ids) {
+          if (!nextArmed.has(id)) {
+            nextArmed.add(id);
+            nextOrder.push(id);
+            lastAdded = id;
+          }
+        }
+        if (lastAdded === null) return {};
+        return {
+          armedIds: nextArmed,
+          armOrder: nextOrder,
+          armOrderById: rebuildOrderById(nextOrder),
+          lastArmedId: lastAdded,
+        };
+      });
+    }
   },
 
   clear: () =>


### PR DESCRIPTION
## Summary
- The Sidebar "Arm N matching" button used to replace the armed fleet every time it was clicked. If someone harvested matches across a few filter changes and clicked to arm again, the prior set was destroyed.
- `armMatchingFilter` now unions filter matches into the existing armed set when the fleet is non-empty. An empty fleet still replaces outright.
- The button label changes to reflect the mode: "Arm N more matching" when adding to an existing fleet, "Arm N matching" when starting fresh.

Resolves #6476

## Changes
- **`src/store/fleetArmingStore.ts`** — `armMatchingFilter` takes the additive path when `armedIds` is non-empty, appending only new matches and preserving existing `armOrder`. No-op when all matches are already armed.
- **`src/components/Sidebar/SidebarContent.tsx`** — button label, aria-label, and tooltip switch between additive and replacement copy based on whether there is an existing armed set.
- **`src/store/__tests__/fleetArmingStore.test.ts`** — expanded from 1 to 5 test cases: additive union, armOrder preservation, no-op when all already armed, panel-order ordering with partial overlap, and the existing replace-when-empty case.
- **`src/services/actions/definitions/__tests__/fleetActions.test.ts`** — split the old "replaces any prior armed set" test into "replaces when armed set is empty" and a new "unions with existing armed set when non-empty" case.

## Testing
- Unit tests cover empty-fleet replacement, additive union with partial overlap, armOrder preservation, no-op when all matches are already armed, and panel-order iteration.
- Full fleet arming store and fleet actions test suites pass.