### PR TITLE
fix(keyboard): consume shared chord parser in ShortcutReferenceDialog

### DIFF
--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -2,6 +2,8 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { useOverlayState } from "@/hooks";
+import { KbdChord } from "@/components/ui/Kbd";
+import { MODIFIER_SEARCH_MAP, isChordPrefix, normalizeQuery } from "@/lib/kbdShortcut";
 import { keybindingService } from "../../services/KeybindingService";
 import type { KeybindingConfig } from "../../services/KeybindingService";
 
@@ -15,82 +17,6 @@ interface ShortcutSearchItem extends KeybindingConfig {
   displayCombo: string;
   normalizedCombo: string;
   keywords?: string[];
-}
-
-const MODIFIER_MAP: Record<string, string> = {
-  cmd: "cmd",
-  command: "cmd",
-  meta: "cmd",
-  ctrl: "ctrl",
-  control: "ctrl",
-  alt: "alt",
-  option: "alt",
-  shift: "shift",
-  "⌘": "cmd",
-  "⌃": "ctrl",
-  "⌥": "alt",
-  "⇧": "shift",
-};
-
-// Valid key characters for chord detection (letters, digits, punctuation keys)
-const VALID_KEY_PATTERN = /^[a-z0-9`~!@#$%^&*()_\-=[\]{}\\|;:'",.<>/?]$/i;
-
-function isChordPrefix(query: string): boolean {
-  const trimmed = query.toLowerCase().trim();
-  if (!trimmed) return false;
-
-  // Look for modifier symbols (⌘, ⌥, ⌃, ⇧) or modifier text with separator
-  const hasModifierSymbol = /[⌘⌥⌃⇧]/.test(trimmed);
-  const hasModifierText = /^(cmd|command|meta|ctrl|control|alt|option|shift)[+\s]/i.test(trimmed);
-
-  if (!hasModifierSymbol && !hasModifierText) return false;
-
-  // Normalize for validation
-  let normalized = trimmed.replace(/\s*\+\s*/g, "+").replace(/\s+/g, "+");
-
-  // Replace unicode symbols with text equivalents
-  for (const [symbol, text] of Object.entries(MODIFIER_MAP)) {
-    if (symbol !== text) {
-      normalized = normalized.replace(new RegExp(symbol, "g"), text);
-    }
-  }
-
-  // Find the modifier at the start
-  const modifierMatch = Object.values(MODIFIER_MAP).find((m) => normalized.startsWith(m));
-  if (!modifierMatch) return false;
-
-  // Must have more than just the modifier
-  if (normalized.length <= modifierMatch.length) return false;
-
-  // Split by + and check we have at least 2 parts
-  const parts = normalized.split("+").filter(Boolean);
-  if (parts.length >= 2) {
-    // All parts should be valid: either a modifier or a valid key
-    return parts.every((p) => {
-      if (Object.values(MODIFIER_MAP).includes(p)) return true;
-      // Check it's a valid key character, not just empty or another modifier word
-      return p.length > 0 && VALID_KEY_PATTERN.test(p);
-    });
-  }
-
-  // Handle cases without separator (e.g., "cmdk" or "⌘k")
-  const remaining = normalized.slice(modifierMatch.length);
-  // The remaining part must be a valid key, not empty or modifier-like
-  return remaining.length > 0 && VALID_KEY_PATTERN.test(remaining);
-}
-
-function normalizeQuery(query: string): string {
-  let normalized = query.toLowerCase().trim();
-  normalized = normalized.replace(/\s*\+\s*/g, "+").replace(/\s+/g, "+");
-
-  // Replace unicode symbols with text equivalents
-  for (const [symbol, text] of Object.entries(MODIFIER_MAP)) {
-    if (symbol !== text) {
-      normalized = normalized.replace(new RegExp(symbol, "g"), text);
-    }
-  }
-
-  return normalized;
 }
 
 export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDialogProps) {
@@ -115,7 +41,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
     return allBindings.map((binding) => {
       const displayCombo = keybindingService.getDisplayCombo(binding.actionId);
       let normalizedCombo = displayCombo.toLowerCase().replace(/[\s+]+/g, "");
-      for (const [symbol, text] of Object.entries(MODIFIER_MAP)) {
+      for (const [symbol, text] of Object.entries(MODIFIER_SEARCH_MAP)) {
         normalizedCombo = normalizedCombo.replace(new RegExp(symbol, "g"), text);
       }
       return {
@@ -251,9 +177,9 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
                         )}
                       </div>
                       <div className="ml-4">
-                        <kbd className="px-3 py-1.5 bg-daintree-bg border border-daintree-border rounded text-sm font-mono text-daintree-text shadow-[var(--theme-shadow-ambient)]">
-                          {binding.displayCombo}
-                        </kbd>
+                        {binding.effectiveCombo ? (
+                          <KbdChord shortcut={binding.effectiveCombo} />
+                        ) : null}
                       </div>
                     </div>
                   ))}

--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseChord } from "../kbdShortcut";
+import {
+  parseChord,
+  MODIFIER_SEARCH_MAP,
+  VALID_KEY_PATTERN,
+  isChordPrefix,
+  normalizeQuery,
+} from "../kbdShortcut";
 
 describe("parseChord — macOS glyphs", () => {
   it("maps Cmd/Option/Shift/Ctrl to glyphs", () => {
@@ -139,5 +145,117 @@ describe("parseChord — edge cases", () => {
   it("preserves casing of unknown multi-char tokens (PageUp)", () => {
     expect(parseChord("PageUp", false)).toEqual([["PageUp"]]);
     expect(parseChord("Cmd+NumpadEnter", true)).toEqual([["⌘", "NumpadEnter"]]);
+  });
+});
+
+describe("MODIFIER_SEARCH_MAP", () => {
+  it("maps text aliases to canonical IDs", () => {
+    expect(MODIFIER_SEARCH_MAP["cmd"]).toBe("cmd");
+    expect(MODIFIER_SEARCH_MAP["command"]).toBe("cmd");
+    expect(MODIFIER_SEARCH_MAP["meta"]).toBe("cmd");
+    expect(MODIFIER_SEARCH_MAP["ctrl"]).toBe("ctrl");
+    expect(MODIFIER_SEARCH_MAP["control"]).toBe("ctrl");
+    expect(MODIFIER_SEARCH_MAP["alt"]).toBe("alt");
+    expect(MODIFIER_SEARCH_MAP["option"]).toBe("alt");
+    expect(MODIFIER_SEARCH_MAP["shift"]).toBe("shift");
+  });
+
+  it("maps unicode symbols to canonical IDs", () => {
+    expect(MODIFIER_SEARCH_MAP["⌘"]).toBe("cmd");
+    expect(MODIFIER_SEARCH_MAP["⌃"]).toBe("ctrl");
+    expect(MODIFIER_SEARCH_MAP["⌥"]).toBe("alt");
+    expect(MODIFIER_SEARCH_MAP["⇧"]).toBe("shift");
+  });
+});
+
+describe("VALID_KEY_PATTERN", () => {
+  it("matches single letters, digits, and punctuation", () => {
+    expect(VALID_KEY_PATTERN.test("a")).toBe(true);
+    expect(VALID_KEY_PATTERN.test("Z")).toBe(true);
+    expect(VALID_KEY_PATTERN.test("0")).toBe(true);
+    expect(VALID_KEY_PATTERN.test("`")).toBe(true);
+    expect(VALID_KEY_PATTERN.test(",")).toBe(true);
+    expect(VALID_KEY_PATTERN.test("/")).toBe(true);
+  });
+
+  it("rejects multi-character tokens", () => {
+    expect(VALID_KEY_PATTERN.test("ab")).toBe(false);
+    expect(VALID_KEY_PATTERN.test("F1")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(VALID_KEY_PATTERN.test("")).toBe(false);
+  });
+});
+
+describe("isChordPrefix", () => {
+  it("returns true for text modifier + key (cmd+k)", () => {
+    expect(isChordPrefix("cmd+k")).toBe(true);
+  });
+
+  it("returns true for unicode symbol + key (⌘k)", () => {
+    expect(isChordPrefix("⌘k")).toBe(true);
+  });
+
+  it("returns true for multiple modifiers (cmd+shift+p)", () => {
+    expect(isChordPrefix("cmd+shift+p")).toBe(true);
+  });
+
+  it("returns false for unicode multiple modifiers without separator (⌘⇧p)", () => {
+    // Falls back to fuzzy search — separators are required for multi-modifier detection
+    expect(isChordPrefix("⌘⇧p")).toBe(false);
+  });
+
+  it("returns true for space-separated chord (cmd k)", () => {
+    expect(isChordPrefix("cmd k")).toBe(true);
+  });
+
+  it("returns false for bare modifier (cmd)", () => {
+    expect(isChordPrefix("cmd")).toBe(false);
+  });
+
+  it("returns false for bare unicode modifier (⌘)", () => {
+    expect(isChordPrefix("⌘")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isChordPrefix("")).toBe(false);
+  });
+
+  it("returns false for non-modifier word (toggle)", () => {
+    expect(isChordPrefix("toggle")).toBe(false);
+  });
+
+  it("returns false for modifier-like word without separator (commander)", () => {
+    expect(isChordPrefix("commander")).toBe(false);
+  });
+
+  it("returns false for trailing separator without key (cmd+)", () => {
+    expect(isChordPrefix("cmd+")).toBe(false);
+  });
+
+  it("is case insensitive (CMD+K)", () => {
+    expect(isChordPrefix("CMD+K")).toBe(true);
+  });
+});
+
+describe("normalizeQuery", () => {
+  it("replaces unicode symbols with text equivalents", () => {
+    expect(normalizeQuery("⌘k")).toBe("cmdk");
+    expect(normalizeQuery("⌘+k")).toBe("cmd+k");
+    expect(normalizeQuery("⌘⇧p")).toBe("cmdshiftp");
+  });
+
+  it("collapses whitespace and normalizes separators", () => {
+    expect(normalizeQuery("cmd + k")).toBe("cmd+k");
+    expect(normalizeQuery("cmd   k")).toBe("cmd+k");
+  });
+
+  it("returns already-canonical input unchanged", () => {
+    expect(normalizeQuery("cmd+shift+p")).toBe("cmd+shift+p");
+  });
+
+  it("lowercases input", () => {
+    expect(normalizeQuery("CMD+K")).toBe("cmd+k");
   });
 });

--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -258,4 +258,15 @@ describe("normalizeQuery", () => {
   it("lowercases input", () => {
     expect(normalizeQuery("CMD+K")).toBe("cmd+k");
   });
+
+  it("preserves plain-text words containing modifier substrings", () => {
+    expect(normalizeQuery("metadata")).toBe("metadata");
+    expect(normalizeQuery("optional")).toBe("optional");
+    expect(normalizeQuery("toggle")).toBe("toggle");
+  });
+
+  it("canonicalizes whole-token modifier aliases", () => {
+    expect(normalizeQuery("command+shift+p")).toBe("cmd+shift+p");
+    expect(normalizeQuery("command palette")).toBe("cmd+palette");
+  });
 });

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -120,3 +120,72 @@ export function parseChord(shortcut: string, isMac: boolean): string[][] {
 
   return steps.map((tokens) => tokens.map((token) => mapToken(token, isMac)));
 }
+
+// ── Search utilities ──────────────────────────────────────────────────────
+// Reverse-lookup map: display symbols/text → canonical modifier IDs.
+// The inverse of MODIFIER_GLYPH_MAP / MODIFIER_TEXT_MAP, used by chord-prefix
+// search to normalize user queries into the canonical token space.
+
+export const MODIFIER_SEARCH_MAP: Record<string, string> = {
+  cmd: "cmd",
+  command: "cmd",
+  meta: "cmd",
+  ctrl: "ctrl",
+  control: "ctrl",
+  alt: "alt",
+  option: "alt",
+  shift: "shift",
+  "⌘": "cmd",
+  "⌃": "ctrl",
+  "⌥": "alt",
+  "⇧": "shift",
+};
+
+export const VALID_KEY_PATTERN = /^[a-z0-9`~!@#$%^&*()_\-=[\]{}\\|;:'",.<>/?]$/i;
+
+export function isChordPrefix(query: string): boolean {
+  const trimmed = query.toLowerCase().trim();
+  if (!trimmed) return false;
+
+  const hasModifierSymbol = /[⌘⌥⌃⇧]/.test(trimmed);
+  const hasModifierText = /^(cmd|command|meta|ctrl|control|alt|option|shift)[+\s]/i.test(trimmed);
+
+  if (!hasModifierSymbol && !hasModifierText) return false;
+
+  let normalized = trimmed.replace(/\s*\+\s*/g, "+").replace(/\s+/g, "+");
+
+  for (const [symbol, text] of Object.entries(MODIFIER_SEARCH_MAP)) {
+    if (symbol !== text) {
+      normalized = normalized.replace(new RegExp(symbol, "g"), text);
+    }
+  }
+
+  const modifierMatch = Object.values(MODIFIER_SEARCH_MAP).find((m) => normalized.startsWith(m));
+  if (!modifierMatch) return false;
+
+  if (normalized.length <= modifierMatch.length) return false;
+
+  const parts = normalized.split("+").filter(Boolean);
+  if (parts.length >= 2) {
+    return parts.every((p) => {
+      if (Object.values(MODIFIER_SEARCH_MAP).includes(p)) return true;
+      return p.length > 0 && VALID_KEY_PATTERN.test(p);
+    });
+  }
+
+  const remaining = normalized.slice(modifierMatch.length);
+  return remaining.length > 0 && VALID_KEY_PATTERN.test(remaining);
+}
+
+export function normalizeQuery(query: string): string {
+  let normalized = query.toLowerCase().trim();
+  normalized = normalized.replace(/\s*\+\s*/g, "+").replace(/\s+/g, "+");
+
+  for (const [symbol, text] of Object.entries(MODIFIER_SEARCH_MAP)) {
+    if (symbol !== text) {
+      normalized = normalized.replace(new RegExp(symbol, "g"), text);
+    }
+  }
+
+  return normalized;
+}

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -181,11 +181,19 @@ export function normalizeQuery(query: string): string {
   let normalized = query.toLowerCase().trim();
   normalized = normalized.replace(/\s*\+\s*/g, "+").replace(/\s+/g, "+");
 
+  // Replace unicode modifier symbols globally (safe — these glyphs don't appear
+  // in plain-English text, so there are no false positives).
   for (const [symbol, text] of Object.entries(MODIFIER_SEARCH_MAP)) {
-    if (symbol !== text) {
+    if (symbol !== text && /[⌘⌥⌃⇧]/.test(symbol)) {
       normalized = normalized.replace(new RegExp(symbol, "g"), text);
     }
   }
 
-  return normalized;
+  // Map each +-separated token through the search map individually so modifier
+  // aliases are only replaced when they appear as whole tokens, not as substrings
+  // of unrelated words ("metadata" stays "metadata", not "cmddata").
+  return normalized
+    .split("+")
+    .map((token) => MODIFIER_SEARCH_MAP[token] ?? token)
+    .join("+");
 }


### PR DESCRIPTION
## Summary
- Removes duplicate chord-parsing code from `ShortcutReferenceDialog.tsx` — `MODIFIER_MAP`, `isChordPrefix`, `normalizeQuery` — replacing them with imports from the shared `kbdShortcut` utility.
- Replaces the single-`<kbd>` element with the `<KbdChord>` pill component so the reference dialog matches the chord rendering used everywhere else.
- Adds unit tests for the exported search utilities (`MODIFIER_SEARCH_MAP`, `VALID_KEY_PATTERN`, `isChordPrefix`, `normalizeQuery`).

Resolves #6435

## Changes
- `src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx` — ~80 lines of duplicate code removed, imports from `@/lib/kbdShortcut`, renders `<KbdChord>` instead of bare `<kbd>`
- `src/lib/kbdShortcut.ts` — new exports: `MODIFIER_SEARCH_MAP`, `VALID_KEY_PATTERN`, `isChordPrefix`, `normalizeQuery`
- `src/lib/__tests__/kbdShortcut.test.ts` — tests for all four exports

## Testing
Unit tests pass. Manual verification that the reference dialog renders chord pills correctly and chord-prefix search still works.