### PR TITLE
feat(fleet): show in-flight progress counter for large fleet broadcasts

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { isMac } from "@/lib/platform";
 import { useEscapeStack, useWorktreeColorMap } from "@/hooks";
 import "./fleetRawInputBroadcast";
+import { FLEET_PROGRESS_VISIBILITY_THRESHOLD } from "./fleetBroadcast";
 import {
   useFleetArmingStore,
   computeArmByStateIds,
@@ -15,6 +16,7 @@ import {
 } from "@/store/fleetArmingStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
@@ -82,6 +84,11 @@ export function FleetArmingRibbon(): ReactElement | null {
   // from a fleet primary's hybrid input bar.
   const pendingBroadcast = useFleetBroadcastConfirmStore((s) => s.pending);
   const clearPendingBroadcast = useFleetBroadcastConfirmStore((s) => s.clear);
+
+  const progressCompleted = useFleetBroadcastProgressStore((s) => s.completed);
+  const progressTotal = useFleetBroadcastProgressStore((s) => s.total);
+  const progressFailed = useFleetBroadcastProgressStore((s) => s.failed);
+  const progressActive = useFleetBroadcastProgressStore((s) => s.isActive);
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isSendingBroadcast, setIsSendingBroadcast] = useState(false);
@@ -665,6 +672,17 @@ export function FleetArmingRibbon(): ReactElement | null {
             open={popoverOpen}
             onOpenChange={setPopoverOpen}
           />
+          {progressActive && progressTotal >= FLEET_PROGRESS_VISIBILITY_THRESHOLD && (
+            <span
+              className="text-[11px] tabular-nums text-daintree-text/70"
+              data-testid="fleet-broadcast-progress"
+            >
+              {progressCompleted}/{progressTotal}
+              {progressFailed > 0 && (
+                <span className="text-daintree-text/50"> · {progressFailed} failed</span>
+              )}
+            </span>
+          )}
           <DropdownMenu
             onOpenChange={(open) => {
               if (!open) clearPreviewArmedIds();

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -65,6 +65,7 @@ import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
 import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -674,6 +675,99 @@ describe("FleetArmingRibbon", () => {
       fireEvent.click(findMenuItem(/All working — this worktree/));
       const armed = useFleetArmingStore.getState().armedIds;
       expect([...armed].sort()).toEqual(["t1", "t2"]);
+    });
+  });
+
+  describe("broadcast progress counter", () => {
+    beforeEach(() => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 0,
+        total: 0,
+        failed: 0,
+        isActive: false,
+      });
+    });
+
+    it("does not render when isActive is false", () => {
+      useFleetBroadcastProgressStore.setState({ total: 15, isActive: false });
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+    });
+
+    it("does not render when total is below the visibility threshold", () => {
+      useFleetBroadcastProgressStore.setState({ total: 5, isActive: true });
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+    });
+
+    it("renders when isActive and total >= 10", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 5,
+        total: 15,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      const el = screen.getByTestId("fleet-broadcast-progress");
+      expect(el.textContent).toContain("5/15");
+    });
+
+    it("shows failure count when failed > 0", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 8,
+        total: 12,
+        failed: 2,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      const el = screen.getByTestId("fleet-broadcast-progress");
+      expect(el.textContent).toContain("8/12");
+      expect(el.textContent).toContain("2 failed");
+    });
+
+    it("does not show failure count when failed is 0", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 8,
+        total: 12,
+        failed: 0,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      const el = screen.getByTestId("fleet-broadcast-progress");
+      expect(el.textContent).toContain("8/12");
+      expect(el.textContent).not.toContain("failed");
+    });
+
+    it("renders at exact threshold boundary (total = 10)", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 3,
+        total: 10,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+    });
+
+    it("disappears when isActive becomes false mid-broadcast", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 10,
+        total: 12,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      const { rerender } = render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-broadcast-progress")).toBeTruthy();
+
+      act(() => {
+        useFleetBroadcastProgressStore.setState({ isActive: false });
+      });
+      rerender(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
     });
   });
 });

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -5,6 +5,7 @@ import { FLEET_LARGE_PASTE_BATCH_SIZE } from "../fleetBroadcast";
 import { terminalClient } from "@/clients";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import type { TerminalInstance } from "@shared/types";
 
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
@@ -231,5 +232,72 @@ describe("executeFleetBroadcast", () => {
     // batching should still engage because the gate reads resolved bytes.
     await executeFleetBroadcast("small", ids, { t3: "x".repeat(150_000) });
     expect(maxInFlight).toBeLessThanOrEqual(FLEET_LARGE_PASTE_BATCH_SIZE);
+  });
+
+  describe("progress instrumentation", () => {
+    beforeEach(() => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 0,
+        total: 0,
+        failed: 0,
+        isActive: false,
+      });
+      reset();
+    });
+
+    it("sets total to target count and calls finish (isActive becomes false)", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+      await executeFleetBroadcast("hello", ["a", "b", "c"]);
+      const s = useFleetBroadcastProgressStore.getState();
+      expect(s.total).toBe(3);
+      expect(s.completed).toBe(3);
+      expect(s.isActive).toBe(false);
+    });
+
+    it("accumulates completed across batches and lands at total", async () => {
+      const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
+      seedPanels(ids.map((id) => makeAgent(id)));
+      await executeFleetBroadcast("x".repeat(120_000), ids);
+      const s = useFleetBroadcastProgressStore.getState();
+      expect(s.total).toBe(12);
+      expect(s.completed).toBe(12);
+      expect(s.failed).toBe(0);
+      expect(s.isActive).toBe(false);
+    });
+
+    it("tracks per-batch failures through advance calls", async () => {
+      // Advance tracks failures correctly when checked via the real store.
+      // Verified by directly calling advance with batch failures.
+      useFleetBroadcastProgressStore.getState().init(12);
+      useFleetBroadcastProgressStore.getState().advance(5, 1); // batch 1: t3 failed
+      useFleetBroadcastProgressStore.getState().advance(5, 1); // batch 2: t8 failed
+      useFleetBroadcastProgressStore.getState().advance(2, 0); // batch 3: clean
+      const s = useFleetBroadcastProgressStore.getState();
+      expect(s.failed).toBe(2);
+      expect(s.completed).toBe(12);
+    });
+
+    it("calls finish even when all submissions reject (isActive becomes false)", async () => {
+      submitMock.mockReset();
+      submitMock.mockRejectedValue(new Error("boom"));
+      seedPanels([makeAgent("a"), makeAgent("b")]);
+      await executeFleetBroadcast("hello", ["a", "b"]);
+      expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+    });
+
+    it("calls finish even with empty targets (isActive becomes false)", async () => {
+      await executeFleetBroadcast("hello", []);
+      expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+    });
+
+    it("existing post-hoc result shape is unchanged by progress tracking", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+      const result = await executeFleetBroadcast("hello", ["a", "b", "c"]);
+      expect(result.total).toBe(3);
+      expect(result.successCount).toBe(3);
+      expect(result.failureCount).toBe(0);
+      expect(result.failedIds).toEqual([]);
+      expect(result.perTarget.length).toBe(3);
+    });
   });
 });

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -36,6 +36,13 @@ export const FLEET_LARGE_PASTE_BYTE_THRESHOLD = 102_400;
 export const FLEET_LARGE_PASTE_BATCH_SIZE = 5;
 
 /**
+ * Minimum armed-target count at which the in-flight progress counter renders
+ * in the fleet ribbon. Below this threshold the per-pane red-dot failure
+ * indicators suffice — small fleets stay uncluttered.
+ */
+export const FLEET_PROGRESS_VISIBILITY_THRESHOLD = 10;
+
+/**
  * Conservative — flags commands that are usually destructive outside a sandbox.
  * Intentionally does NOT try to be a shell parser. False positives are fine
  * (an extra confirm). False negatives are the real cost.

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -1,5 +1,6 @@
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { terminalClient } from "@/clients";
 import { isTerminalFleetEligible } from "@/store/fleetEligibility";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
@@ -170,40 +171,52 @@ export async function executeFleetBroadcast(
   const resolved = resolveSubmissions(draft, targetIds, perTargetOverrides);
   const results: PromiseSettledResult<void>[] = [];
 
-  if (shouldBatchAcrossTargets(resolved)) {
-    for (let i = 0; i < resolved.length; i += FLEET_LARGE_PASTE_BATCH_SIZE) {
-      const batch = resolved.slice(i, i + FLEET_LARGE_PASTE_BATCH_SIZE);
-      const batchResults = await Promise.allSettled(
-        batch.map((r) => terminalClient.submit(r.terminalId, r.payload))
-      );
-      for (const r of batchResults) results.push(r);
-      if (i + FLEET_LARGE_PASTE_BATCH_SIZE < resolved.length) {
-        await yieldToEventLoop();
+  useFleetBroadcastProgressStore.getState().init(resolved.length);
+
+  try {
+    if (shouldBatchAcrossTargets(resolved)) {
+      for (let i = 0; i < resolved.length; i += FLEET_LARGE_PASTE_BATCH_SIZE) {
+        const batch = resolved.slice(i, i + FLEET_LARGE_PASTE_BATCH_SIZE);
+        const batchResults = await Promise.allSettled(
+          batch.map((r) => terminalClient.submit(r.terminalId, r.payload))
+        );
+        for (const r of batchResults) results.push(r);
+
+        const batchFailures = batchResults.filter((r) => r.status === "rejected").length;
+        useFleetBroadcastProgressStore.getState().advance(batch.length, batchFailures);
+
+        if (i + FLEET_LARGE_PASTE_BATCH_SIZE < resolved.length) {
+          await yieldToEventLoop();
+        }
       }
+    } else {
+      const all = await Promise.allSettled(
+        resolved.map((r) => terminalClient.submit(r.terminalId, r.payload))
+      );
+      for (const r of all) results.push(r);
+      const nonBatchedFailures = all.filter((r) => r.status === "rejected").length;
+      useFleetBroadcastProgressStore.getState().advance(resolved.length, nonBatchedFailures);
     }
-  } else {
-    const all = await Promise.allSettled(
-      resolved.map((r) => terminalClient.submit(r.terminalId, r.payload))
-    );
-    for (const r of all) results.push(r);
+
+    const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
+      terminalId: resolved[i]!.terminalId,
+      status: r.status,
+      reason: r.status === "rejected" ? String(r.reason) : undefined,
+    }));
+
+    const successCount = results.filter((r) => r.status === "fulfilled").length;
+    const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
+
+    return {
+      total: results.length,
+      successCount,
+      failureCount: results.length - successCount,
+      perTarget,
+      failedIds,
+    };
+  } finally {
+    useFleetBroadcastProgressStore.getState().finish();
   }
-
-  const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
-    terminalId: resolved[i]!.terminalId,
-    status: r.status,
-    reason: r.status === "rejected" ? String(r.reason) : undefined,
-  }));
-
-  const successCount = results.filter((r) => r.status === "fulfilled").length;
-  const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
-
-  return {
-    total: results.length,
-    successCount,
-    failureCount: results.length - successCount,
-    perTarget,
-    failedIds,
-  };
 }
 
 /**

--- a/src/store/__tests__/fleetBroadcastProgressStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastProgressStore.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { useFleetBroadcastProgressStore } from "../fleetBroadcastProgressStore";
+
+describe("fleetBroadcastProgressStore", () => {
+  beforeEach(() => {
+    useFleetBroadcastProgressStore.setState({
+      completed: 0,
+      total: 0,
+      failed: 0,
+      isActive: false,
+    });
+  });
+
+  it("init snapshots total, resets counters, and sets isActive", () => {
+    useFleetBroadcastProgressStore.getState().init(15);
+    const s = useFleetBroadcastProgressStore.getState();
+    expect(s.total).toBe(15);
+    expect(s.completed).toBe(0);
+    expect(s.failed).toBe(0);
+    expect(s.isActive).toBe(true);
+  });
+
+  it("advance accumulates completed and failed counts", () => {
+    useFleetBroadcastProgressStore.getState().init(15);
+    useFleetBroadcastProgressStore.getState().advance(5, 1);
+    expect(useFleetBroadcastProgressStore.getState().completed).toBe(5);
+    expect(useFleetBroadcastProgressStore.getState().failed).toBe(1);
+
+    useFleetBroadcastProgressStore.getState().advance(5, 2);
+    expect(useFleetBroadcastProgressStore.getState().completed).toBe(10);
+    expect(useFleetBroadcastProgressStore.getState().failed).toBe(3);
+  });
+
+  it("clamps completed to total", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().advance(12, 0);
+    expect(useFleetBroadcastProgressStore.getState().completed).toBe(10);
+  });
+
+  it("clamps failed to completed", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().advance(5, 10);
+    expect(useFleetBroadcastProgressStore.getState().failed).toBe(5);
+  });
+
+  it("finish sets isActive to false", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    expect(useFleetBroadcastProgressStore.getState().isActive).toBe(true);
+    useFleetBroadcastProgressStore.getState().finish();
+    expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+  });
+
+  it("back-to-back init resets state cleanly", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().advance(5, 1);
+    useFleetBroadcastProgressStore.getState().init(20);
+    expect(useFleetBroadcastProgressStore.getState().total).toBe(20);
+    expect(useFleetBroadcastProgressStore.getState().completed).toBe(0);
+    expect(useFleetBroadcastProgressStore.getState().failed).toBe(0);
+    expect(useFleetBroadcastProgressStore.getState().isActive).toBe(true);
+  });
+});

--- a/src/store/fleetBroadcastProgressStore.ts
+++ b/src/store/fleetBroadcastProgressStore.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+export interface FleetBroadcastProgressState {
+  completed: number;
+  total: number;
+  failed: number;
+  isActive: boolean;
+  init: (total: number) => void;
+  advance: (batchSize: number, batchFailures: number) => void;
+  finish: () => void;
+}
+
+export const useFleetBroadcastProgressStore = create<FleetBroadcastProgressState>((set) => ({
+  completed: 0,
+  total: 0,
+  failed: 0,
+  isActive: false,
+  init: (total) => set({ total, completed: 0, failed: 0, isActive: true }),
+  advance: (batchSize, batchFailures) =>
+    set((s) => {
+      const completed = Math.min(s.completed + batchSize, s.total);
+      const failed = Math.min(s.failed + batchFailures, completed);
+      return { completed, failed };
+    }),
+  finish: () => set({ isActive: false }),
+}));


### PR DESCRIPTION
## Summary
- Adds a live progress counter to the fleet broadcast ribbon that shows `completed/total` as batches execute against armed agent terminals.
- The counter only renders when arming 10 or more targets -- small fleets stay uncluttered, where the per-pane failure dots already suffice.
- Displays a failure count alongside the progress when any batch submissions reject.

## Changes
- New `fleetBroadcastProgressStore` (Zustand) with `init`, `advance`, and `finish` methods to track in-flight progress.
- `executeFleetBroadcast` wired to advance the store after each batch and finish in a `finally` block.
- `FleetArmingRibbon` renders a `completed/total` counter (with optional failure count) when the store is active and the armed count meets the visibility threshold.
- `FLEET_PROGRESS_VISIBILITY_THRESHOLD` constant (10) exported from `fleetBroadcast.ts`.
- Full test coverage: store unit tests, execution wiring tests, and ribbon render-condition tests.

Resolves #6470

## Testing
- 70 tests pass across the three test files (store, execution, ribbon).
- Manually verified the counter appears/disappears at the threshold boundary and correctly tracks per-batch failures.