### PR TITLE
feat(fleet): improve selection discoverability and shortcuts

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -297,6 +297,8 @@ export type BuiltInActionId =
   | "fleet.restart"
   | "fleet.kill"
   | "fleet.trash"
+  | "fleet.armAll"
+  | "fleet.armFocused"
   | "fleet.scope.enter"
   | "fleet.scope.exit"
   | "fleet.armMatchingFilter"

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -129,6 +129,7 @@ export type BuiltInKeyAction =
   | "fleet.kill"
   | "fleet.trash"
   | "fleet.armFocused"
+  | "fleet.armAll"
 
   // Agent spawning
   | "agent.palette"
@@ -310,6 +311,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "fleet.kill",
   "fleet.trash",
   "fleet.armFocused",
+  "fleet.armAll",
   "agent.palette",
   ...BUILT_IN_AGENT_KEY_ACTIONS,
   "agent.terminal",

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -29,6 +29,7 @@ import {
   getAccordionDragId,
 } from "@/components/DragDrop/SortableWorktreeTerminal";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { useKeybindingScope } from "@/hooks/useKeybinding";
 
 interface StateIconProps {
   state: AgentState;
@@ -113,7 +114,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
               onClick(term);
             }}
             aria-selected={isArmed}
-            className="flex items-center gap-2 min-w-0 flex-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
+            className="flex items-center gap-2 min-w-0 flex-1 text-left cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
           >
             <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
               <TerminalIcon kind={term.kind} chrome={chrome} className="w-3 h-3" />
@@ -204,6 +205,8 @@ export interface WorktreeTerminalSectionProps {
   onTerminalSelect: (terminal: TerminalInstance) => void;
 }
 
+const FLEET_HINT_DISMISSED_KEY = "daintree:fleet-selection-hint-dismissed";
+
 export function WorktreeTerminalSection({
   worktreeId,
   isExpanded,
@@ -212,10 +215,17 @@ export function WorktreeTerminalSection({
   onToggle,
   onTerminalSelect,
 }: WorktreeTerminalSectionProps) {
+  useKeybindingScope("worktreeGrid", isExpanded);
+
   const showMetaFooter = counts.total > 0;
 
   const terminalsId = `worktree-${worktreeId}-terminals`;
   const terminalsPanelId = `worktree-${worktreeId}-terminals-panel`;
+
+  const [hintDismissed, setHintDismissed] = useState(
+    () => localStorage.getItem(FLEET_HINT_DISMISSED_KEY) === "1"
+  );
+  const armedIdsSize = useFleetArmingStore((s) => s.armedIds.size);
 
   const topTerminalState = ((): { state: AgentState; count: number } | null => {
     for (const state of STATE_PRIORITY) {
@@ -346,6 +356,8 @@ export function WorktreeTerminalSection({
           .filter((id) => hits.includes(id) && eligible.has(id));
         if (orderedHits.length > 0) {
           useFleetArmingStore.getState().armIds(orderedHits);
+          localStorage.setItem(FLEET_HINT_DISMISSED_KEY, "1");
+          setHintDismissed(true);
         }
       }
     },
@@ -417,6 +429,22 @@ export function WorktreeTerminalSection({
             items={orderedWorktreeTerminals.map((t) => getAccordionDragId(t.id))}
             strategy={verticalListSortingStrategy}
           >
+            {eligibleTerminals.length >= 2 && armedIdsSize === 0 && !hintDismissed && (
+              <div className="flex items-center justify-between px-3 py-1.5 text-[11px] text-text-muted bg-surface-inset border-b border-border-default">
+                <span>Drag to select multiple, ⇧-click to add</span>
+                <button
+                  type="button"
+                  className="ml-2 rounded-sm text-text-muted hover:text-text-secondary transition-colors"
+                  aria-label="Dismiss hint"
+                  onClick={() => {
+                    localStorage.setItem(FLEET_HINT_DISMISSED_KEY, "1");
+                    setHintDismissed(true);
+                  }}
+                >
+                  ✕
+                </button>
+              </div>
+            )}
             <div
               id={terminalsPanelId}
               ref={scrollRef}
@@ -427,7 +455,7 @@ export function WorktreeTerminalSection({
               onPointerMove={handlePointerMove}
               onPointerUp={handlePointerUp}
               onPointerCancel={handlePointerCancel}
-              className="relative max-h-[300px] overflow-y-auto bg-surface-inset"
+              className="relative max-h-[300px] overflow-y-auto bg-surface-inset cursor-crosshair"
             >
               {orderedWorktreeTerminals.map((term, index) => (
                 <SortableWorktreeTerminal

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -78,15 +78,20 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
         return;
       }
 
-      // For editable contexts without modifiers, let native behavior happen
-      // Exception: allow chord completion even without modifiers, and F6 for region cycling
+      // For editable contexts without modifiers, let native behavior happen.
+      // Exception: chord completion, F6 for region cycling, and bare keys that are
+      // scope-gated (e.g. X in worktreeGrid scope for fleet arming). Scope-gated
+      // bindings are checked below in resolveKeybinding → canExecute.
       const hasModifier = e.metaKey || e.ctrlKey;
 
       if (isEditable && !hasModifier && !pendingChord && e.key !== "F6") {
         return;
       }
 
-      // Let xterm handle its own keys except for global shortcuts with modifiers, chord completion, or F6
+      // Let xterm handle its own keys except for global shortcuts with modifiers,
+      // chord completion, or F6. Bare keys (like X for fleet arming) are blocked
+      // inside terminals so they don't steal typing — scoped bindings only match
+      // when focus is outside .xterm.
       if (isInTerminal && !hasModifier && !pendingChord && e.key !== "F6") {
         return;
       }

--- a/src/hooks/useKeybinding.ts
+++ b/src/hooks/useKeybinding.ts
@@ -5,14 +5,10 @@ export function useKeybindingScope(scope: KeyScope, active: boolean = true): voi
   useEffect(() => {
     if (!active) return;
 
-    const previousScope = keybindingService.getScope();
     keybindingService.setScope(scope);
 
     return () => {
-      // Only restore if we're still the active scope
-      if (keybindingService.getScope() === scope) {
-        keybindingService.setScope(previousScope);
-      }
+      keybindingService.restoreScope(scope);
     };
   }, [scope, active]);
 }

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -13,6 +13,7 @@ function scopesConflict(a: KeyScope, b: KeyScope): boolean {
 class KeybindingService {
   private bindings: Map<string, KeybindingConfig[]> = new Map();
   private overrides: Map<string, string[]> = new Map();
+  private scopeStack: KeyScope[] = ["global"];
   private currentScope: KeyScope = "global";
   private pendingChord: string | null = null;
   private chordTimeout: NodeJS.Timeout | null = null;
@@ -134,8 +135,20 @@ class KeybindingService {
   }
 
   setScope(scope: KeyScope): void {
+    this.scopeStack.push(scope);
     this.currentScope = scope;
     this.clearPendingChord();
+  }
+
+  restoreScope(scope: KeyScope): void {
+    const idx = this.scopeStack.lastIndexOf(scope);
+    if (idx > 0) {
+      this.scopeStack.splice(idx, 1);
+    }
+    this.currentScope = this.scopeStack[this.scopeStack.length - 1] ?? "global";
+    if (this.currentScope !== scope) {
+      this.clearPendingChord();
+    }
   }
 
   getScope(): KeyScope {

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -11,7 +11,7 @@ function scopesConflict(a: KeyScope, b: KeyScope): boolean {
 }
 
 class KeybindingService {
-  private bindings: Map<string, KeybindingConfig> = new Map();
+  private bindings: Map<string, KeybindingConfig[]> = new Map();
   private overrides: Map<string, string[]> = new Map();
   private currentScope: KeyScope = "global";
   private pendingChord: string | null = null;
@@ -21,7 +21,12 @@ class KeybindingService {
 
   constructor() {
     DEFAULT_KEYBINDINGS.forEach((binding) => {
-      this.bindings.set(binding.actionId, binding);
+      const existing = this.bindings.get(binding.actionId);
+      if (existing) {
+        existing.push(binding);
+      } else {
+        this.bindings.set(binding.actionId, [binding]);
+      }
     });
   }
 
@@ -85,30 +90,32 @@ class KeybindingService {
       }
       return undefined;
     }
-    return this.bindings.get(actionId)?.combo;
+    return this.getBinding(actionId)?.combo;
   }
 
   findConflicts(combo: string, excludeActionId?: string): KeybindingConfig[] {
     const conflicts: KeybindingConfig[] = [];
     const normalizedCombo = combo.trim().toLowerCase();
 
-    for (const binding of this.bindings.values()) {
-      if (excludeActionId && binding.actionId === excludeActionId) continue;
+    for (const arr of this.bindings.values()) {
+      for (const binding of arr) {
+        if (excludeActionId && binding.actionId === excludeActionId) continue;
 
-      const hasOverride = this.overrides.has(binding.actionId);
-      const overrideCombos = this.overrides.get(binding.actionId) || [];
-      const allCombos = [...overrideCombos];
+        const hasOverride = this.overrides.has(binding.actionId);
+        const overrideCombos = this.overrides.get(binding.actionId) || [];
+        const allCombos = [...overrideCombos];
 
-      if (!hasOverride) {
-        if (binding.combo) {
-          allCombos.push(binding.combo);
+        if (!hasOverride) {
+          if (binding.combo) {
+            allCombos.push(binding.combo);
+          }
         }
-      }
 
-      for (const existingCombo of allCombos) {
-        if (existingCombo.trim().toLowerCase() === normalizedCombo) {
-          conflicts.push(binding);
-          break;
+        for (const existingCombo of allCombos) {
+          if (existingCombo.trim().toLowerCase() === normalizedCombo) {
+            conflicts.push(binding);
+            break;
+          }
         }
       }
     }
@@ -136,11 +143,14 @@ class KeybindingService {
   }
 
   getBinding(actionId: string): KeybindingConfig | undefined {
-    return this.bindings.get(actionId);
+    const arr = this.bindings.get(actionId);
+    if (!arr || arr.length === 0) return undefined;
+    const scopeMatch = arr.find((b) => b.scope === this.currentScope);
+    return scopeMatch ?? arr[0];
   }
 
   getAllBindings(): KeybindingConfig[] {
-    return Array.from(this.bindings.values());
+    return Array.from(this.bindings.values()).flat();
   }
 
   matchesEvent(event: KeyboardEvent, combo: string): boolean {
@@ -184,14 +194,9 @@ class KeybindingService {
   }
 
   canExecute(actionId: string): boolean {
-    const binding = this.bindings.get(actionId);
-    if (!binding) return false;
-
-    // Global shortcuts always work
-    if (binding.scope === "global") return true;
-
-    // Scope-specific shortcuts only work in their scope
-    return binding.scope === this.currentScope;
+    const arr = this.bindings.get(actionId);
+    if (!arr || arr.length === 0) return false;
+    return arr.some((b) => b.scope === "global" || b.scope === this.currentScope);
   }
 
   private clearChordTimeout(): void {
@@ -259,40 +264,45 @@ class KeybindingService {
     let chordCompletionMatch: KeybindingConfig | undefined;
     let chordCompletionPriority = -Infinity;
 
-    for (const binding of this.bindings.values()) {
-      if (!this.canExecute(binding.actionId)) continue;
+    for (const arr of this.bindings.values()) {
+      for (const binding of arr) {
+        if (!this.scopeAllows(binding.scope)) continue;
 
-      const effectiveCombo = this.getEffectiveCombo(binding.actionId);
-      if (!effectiveCombo) continue;
-      const normalizedEffectiveCombo = effectiveCombo.trim().toLowerCase();
+        const hasOverride = this.overrides.has(binding.actionId);
+        const effectiveCombo = hasOverride
+          ? this.overrides.get(binding.actionId)?.[0]
+          : binding.combo;
+        if (!effectiveCombo) continue;
+        const normalizedEffectiveCombo = effectiveCombo.trim().toLowerCase();
 
-      // Check if this is a chord binding
-      const chordParts = effectiveCombo.split(" ");
-      const isChord = chordParts.length > 1;
+        // Check if this is a chord binding
+        const chordParts = effectiveCombo.split(" ");
+        const isChord = chordParts.length > 1;
 
-      if (isChord) {
-        // If we have a pending chord, check if this completes it
-        if (this.pendingChord) {
-          const normalizedPending = this.pendingChord.trim().toLowerCase();
-          const fullChord = `${normalizedPending} ${normalizedCurrentCombo}`;
-          if (fullChord === normalizedEffectiveCombo) {
-            if (binding.priority > chordCompletionPriority) {
-              chordCompletionMatch = binding;
-              chordCompletionPriority = binding.priority;
+        if (isChord) {
+          // If we have a pending chord, check if this completes it
+          if (this.pendingChord) {
+            const normalizedPending = this.pendingChord.trim().toLowerCase();
+            const fullChord = `${normalizedPending} ${normalizedCurrentCombo}`;
+            if (fullChord === normalizedEffectiveCombo) {
+              if (binding.priority > chordCompletionPriority) {
+                chordCompletionMatch = binding;
+                chordCompletionPriority = binding.priority;
+              }
+            }
+          } else {
+            // Check if this is the start of a chord
+            if (normalizedCurrentCombo === chordParts[0]!.trim().toLowerCase()) {
+              foundChordPrefix = true;
             }
           }
         } else {
-          // Check if this is the start of a chord
-          if (normalizedCurrentCombo === chordParts[0]!.trim().toLowerCase()) {
-            foundChordPrefix = true;
-          }
-        }
-      } else {
-        // Regular non-chord binding - only consider if no chord is pending
-        if (!this.pendingChord && this.matchesEvent(event, effectiveCombo)) {
-          if (binding.priority > bestPriority) {
-            bestMatch = binding;
-            bestPriority = binding.priority;
+          // Regular non-chord binding - only consider if no chord is pending
+          if (!this.pendingChord && this.matchesEvent(event, effectiveCombo)) {
+            if (binding.priority > bestPriority) {
+              bestMatch = binding;
+              bestPriority = binding.priority;
+            }
           }
         }
       }
@@ -325,6 +335,10 @@ class KeybindingService {
     };
   }
 
+  private scopeAllows(scope: KeyScope): boolean {
+    return scope === "global" || scope === this.currentScope;
+  }
+
   findMatchingAction(event: KeyboardEvent): KeybindingConfig | undefined {
     const result = this.resolveKeybinding(event);
     return result.match;
@@ -333,18 +347,33 @@ class KeybindingService {
   registerBinding(config: KeybindingConfig): void {
     if (config.combo) {
       const normalized = config.combo.trim().toLowerCase();
-      for (const existing of this.bindings.values()) {
-        if (existing.actionId === config.actionId) continue;
-        if (!existing.combo) continue;
-        if (existing.combo.trim().toLowerCase() !== normalized) continue;
-        if (!scopesConflict(existing.scope, config.scope)) continue;
-        console.warn(
-          `[KeybindingService] Skipping binding for "${config.actionId}" (${config.combo}, scope=${config.scope}) — combo already registered to "${existing.actionId}" (scope=${existing.scope}). Use setOverride() to rebind.`
-        );
-        return;
+      for (const arr of this.bindings.values()) {
+        for (const existing of arr) {
+          if (existing.actionId === config.actionId) continue;
+          if (!existing.combo) continue;
+          if (existing.combo.trim().toLowerCase() !== normalized) continue;
+          if (!scopesConflict(existing.scope, config.scope)) continue;
+          console.warn(
+            `[KeybindingService] Skipping binding for "${config.actionId}" (${config.combo}, scope=${config.scope}) — combo already registered to "${existing.actionId}" (scope=${existing.scope}). Use setOverride() to rebind.`
+          );
+          return;
+        }
       }
     }
-    this.bindings.set(config.actionId, config);
+    const arr = this.bindings.get(config.actionId);
+    if (arr) {
+      // Replace a same-actionId entry with the same combo (self-update), otherwise push.
+      const existingIdx = arr.findIndex(
+        (b) => b.combo?.trim().toLowerCase() === config.combo?.trim().toLowerCase()
+      );
+      if (existingIdx !== -1) {
+        arr[existingIdx] = config;
+      } else {
+        arr.push(config);
+      }
+    } else {
+      this.bindings.set(config.actionId, [config]);
+    }
   }
 
   removeBinding(actionId: string): void {
@@ -375,20 +404,24 @@ class KeybindingService {
   }
 
   getAllBindingsWithEffectiveCombos(): Array<KeybindingConfig & { effectiveCombo: string }> {
-    return Array.from(this.bindings.values()).map((binding) => {
-      const effectiveCombo = this.getEffectiveCombo(binding.actionId);
-      return {
-        ...binding,
-        effectiveCombo: effectiveCombo ?? "",
-      };
-    });
+    return Array.from(this.bindings.values())
+      .flat()
+      .map((binding) => {
+        const effectiveCombo = this.getEffectiveCombo(binding.actionId);
+        return {
+          ...binding,
+          effectiveCombo: effectiveCombo ?? "",
+        };
+      });
   }
 
   getCategories(): string[] {
     const categories = new Set<string>();
-    for (const binding of this.bindings.values()) {
-      if (binding.category) {
-        categories.add(binding.category);
+    for (const arr of this.bindings.values()) {
+      for (const binding of arr) {
+        if (binding.category) {
+          categories.add(binding.category);
+        }
       }
     }
     return Array.from(categories).sort();

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -361,9 +361,11 @@ export function registerFleetActions(actions: ActionRegistry): void {
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({
-      scope: z.enum(["current", "all"]).optional().default("current"),
-    }),
+    argsSchema: z
+      .object({
+        scope: z.enum(["current", "all"]).optional().default("current"),
+      })
+      .optional(),
     run: async (args: unknown) => {
       const { scope } = (args as { scope?: "current" | "all" }) ?? {};
       useFleetArmingStore.getState().armAll(scope ?? "current");

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -348,11 +348,25 @@ export function registerFleetActions(actions: ActionRegistry): void {
       const focusedId = usePanelStore.getState().focusedId;
       if (!focusedId) return;
       const terminal = usePanelStore.getState().panelsById[focusedId];
-      // Match the mouse-path eligibility gate so chord and click behave
-      // identically: trashed/backgrounded/no-PTY panes can't enter the
-      // fleet from either entry point.
       if (!isFleetArmEligible(terminal)) return;
       useFleetArmingStore.getState().toggleId(focusedId);
+    },
+  }));
+
+  actions.set("fleet.armAll", () => ({
+    id: "fleet.armAll",
+    title: "Fleet: Arm All Eligible",
+    description: "Arm all fleet-eligible terminals in the current worktree",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({
+      scope: z.enum(["current", "all"]).optional().default("current"),
+    }),
+    run: async (args: unknown) => {
+      const { scope } = (args as { scope?: "current" | "all" }) ?? {};
+      useFleetArmingStore.getState().armAll(scope ?? "current");
     },
   }));
 

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -418,6 +418,22 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Fleet",
   },
   {
+    actionId: "fleet.armFocused",
+    combo: "X",
+    scope: "worktreeGrid",
+    priority: 5,
+    description: "Toggle arm focused pane (no modifier, grid only)",
+    category: "Fleet",
+  },
+  {
+    actionId: "fleet.armAll",
+    combo: "Cmd+Alt+A",
+    scope: "global",
+    priority: 0,
+    description: "Arm all eligible terminals in current worktree",
+    category: "Fleet",
+  },
+  {
     actionId: "fleet.accept",
     combo: "Cmd+Y",
     scope: "global",

--- a/src/services/keybindingUtils.ts
+++ b/src/services/keybindingUtils.ts
@@ -1,6 +1,6 @@
 import { isMac } from "@/lib/platform";
 
-export type KeyScope = "global" | "terminal" | "modal" | "worktreeList" | "portal";
+export type KeyScope = "global" | "terminal" | "modal" | "worktreeList" | "portal" | "worktreeGrid";
 
 export interface KeybindingConfig {
   actionId: string;


### PR DESCRIPTION
## Summary
- Four targeted UX improvements that make fleet selection gestures easier to discover and faster to use.
- Adds visual affordances (crosshair cursor, empty-state hint) so users can find marquee-drag and Shift-click without hunting.
- Adds two keyboard shortcuts: `X` for arming individual items in the grid context and `Cmd+Option+A` for arming all panes.

Resolves #6475

## Changes
- `WorktreeTerminalSection.tsx` — crosshair cursor over marquee zones, empty-state hint when nothing is armed
- `KeybindingService.ts` — context-gated keybinding dispatch for worktree-grid scoped shortcuts
- `fleetActions.ts` — action definitions for the new shortcuts
- `defaultKeybindings.ts` — default bindings for `X` and `Cmd+Option+A`
- `useGlobalKeybindings.ts`, `useKeybinding.ts` — hook wiring for the new bindings
- `keybindingUtils.ts`, `keymap.ts`, `actions.ts` — supporting type and utility changes

## Testing
- Manual verification: crosshair cursor appears over tile grid empty space, reverts to pointer on tiles.
- Manual verification: empty-state hint appears when worktree has 2+ eligible panes and nothing armed, dismisses permanently after first marquee.
- Manual verification: `X` arms/unarms the focused fleet item in grid context, does not fire when a terminal pane has typing focus.
- Manual verification: `Cmd+Option+A` arms all panes in the current worktree.