### PR TITLE
fix(diff-viewer): single horizontal scrollbar per file instead of per line

### DIFF
--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -173,16 +173,18 @@ function FileDiff({ file, viewType, language, rootPath }: FileDiffProps) {
           </div>
         </div>
       )}
-      <Diff
-        viewType={viewType}
-        diffType={diffType}
-        hunks={file.hunks ?? []}
-        tokens={tokens ?? undefined}
-      >
-        {(hunks: HunkData[]) =>
-          hunks.map((hunk) => <Hunk key={`${hunk.oldStart}-${hunk.newStart}`} hunk={hunk} />)
-        }
-      </Diff>
+      <div className="diff-file-scroll">
+        <Diff
+          viewType={viewType}
+          diffType={diffType}
+          hunks={file.hunks ?? []}
+          tokens={tokens ?? undefined}
+        >
+          {(hunks: HunkData[]) =>
+            hunks.map((hunk) => <Hunk key={`${hunk.oldStart}-${hunk.newStart}`} hunk={hunk} />)
+          }
+        </Diff>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2140,6 +2140,9 @@ body[data-performance-mode="true"] .github-status-error {
   background: var(--color-daintree-sidebar);
   color: var(--color-state-idle);
   padding: 0 8px;
+  /* width acts as a hint under table-layout:auto; min-width keeps it from
+     shrinking under content-heavy code columns. */
+  width: 50px;
   min-width: 50px;
   text-align: right;
   user-select: none;

--- a/src/index.css
+++ b/src/index.css
@@ -2130,6 +2130,9 @@ body[data-performance-mode="true"] .github-status-error {
 .diff-viewer .diff {
   background: var(--color-daintree-bg);
   color: var(--color-daintree-text);
+  table-layout: auto;
+  width: max-content;
+  min-width: 100%;
 }
 
 /* Gutter (line numbers) styling */
@@ -2148,7 +2151,6 @@ body[data-performance-mode="true"] .github-status-error {
   background: var(--color-daintree-bg);
   padding: 0 12px;
   white-space: pre;
-  overflow-x: auto;
 }
 
 /* Added lines - Tokyo Night green */
@@ -2291,9 +2293,31 @@ body[data-performance-mode="true"] .github-status-error {
 
 /* Ensure proper table layout */
 .diff-viewer table.diff {
-  width: 100%;
   border-collapse: collapse;
-  table-layout: fixed;
+}
+
+/* Per-file horizontal scroll wrapper — gives each file its own scrollbar
+   so all rows scroll together instead of each <td> scrolling independently. */
+.diff-viewer .diff-file-scroll {
+  overflow-x: auto;
+}
+
+.diff-viewer .diff-file-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.diff-viewer .diff-file-scroll::-webkit-scrollbar-track {
+  background: var(--color-daintree-bg);
+}
+
+.diff-viewer .diff-file-scroll::-webkit-scrollbar-thumb {
+  background: var(--color-state-idle);
+  border-radius: var(--radius-sm);
+}
+
+.diff-viewer .diff-file-scroll::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklab, var(--color-state-idle) 70%, var(--color-text-primary));
 }
 
 .diff-viewer table.diff td {


### PR DESCRIPTION
## Summary

- The diff viewer in the worktree panel was putting a horizontal scrollbar on every individual line. `overflow-x: auto` was set on each `td.diff-code` cell, so each row scrolled independently — reading a long diff meant scrolling each line separately.
- Moves the overflow to a per-file wrapper so the whole file's diff scrolls as a unit.
- Pins the gutter column width explicitly, which is required under `table-layout: auto`, and applies the custom scrollbar class to the new wrapper.

Resolves #6492

## Changes

- `src/components/Worktree/DiffViewer.tsx` — wraps each file's table in a scrollable container; removes `overflow-x` from the cell-level class.
- `src/index.css` — removes `overflow-x: auto` from `.diff-code`; adds per-file wrapper styles with pinned gutter width and custom scrollbar.

## Testing

- Opened diffs with long lines across multiple hunks — single scrollbar at the file level, whole content shifts together.
- Verified gutter column stays stable width when scrolling horizontally.
- Checked short diffs (no overflow) show no scrollbar.