### PR TITLE
fix(input-bar): float hint legend and fleet pill above shell to stop layout jump

### DIFF
--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -27,7 +27,7 @@ export function FleetDraftingPill(): ReactElement | null {
   };
 
   return (
-    <div data-testid="fleet-drafting-pill" className="mb-1.5 flex items-center text-[11px]">
+    <div data-testid="fleet-drafting-pill" className="flex items-center text-[11px]">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <button
@@ -54,7 +54,7 @@ export function FleetDraftingPill(): ReactElement | null {
         </PopoverTrigger>
         <PopoverContent
           side="bottom"
-          align="start"
+          align="end"
           sideOffset={4}
           data-testid="fleet-resolution-popover"
           className="max-h-[320px] w-[360px] overflow-y-auto p-1"

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -40,7 +40,6 @@ import { useCommandStore } from "@/store/commandStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore, useVoiceRecordingStore } from "@/store";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
-import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { tryFleetBroadcastFromEditor } from "@/components/Fleet/fleetEnterBroadcast";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -1322,7 +1321,6 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         className="group cursor-text px-3.5 pb-2.5 pt-2.5"
         style={{ backgroundColor: inputBarColors.background, ...shellVars }}
       >
-        {isFleetPrimary && <FleetDraftingPill />}
         <div className="flex items-end gap-2">
           <div
             ref={inputShellRef}

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -40,6 +40,7 @@ import { useCommandStore } from "@/store/commandStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore, useVoiceRecordingStore } from "@/store";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { tryFleetBroadcastFromEditor } from "@/components/Fleet/fleetEnterBroadcast";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -1318,9 +1319,26 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
 
     const barContent = (
       <div
-        className="group cursor-text px-3.5 pb-2.5 pt-2.5"
+        className="relative group cursor-text px-3.5 pb-2.5 pt-2.5"
         style={{ backgroundColor: inputBarColors.background, ...shellVars }}
       >
+        {(showLegend || isFleetPrimary) && (
+          <div className="pointer-events-none absolute bottom-full right-3.5 mb-1 flex items-center gap-2">
+            {showLegend && (
+              <p
+                aria-hidden={!showLegend}
+                className="text-[11px] text-daintree-text/40 select-none"
+              >
+                @ files · @diff · @terminal · / commands
+              </p>
+            )}
+            {isFleetPrimary && (
+              <div className="pointer-events-auto">
+                <FleetDraftingPill />
+              </div>
+            )}
+          </div>
+        )}
         <div className="flex items-end gap-2">
           <div
             ref={inputShellRef}
@@ -1433,17 +1451,6 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               />
             </div>
           </div>
-        </div>
-        <div
-          aria-hidden={!showLegend}
-          className={cn(
-            "overflow-hidden transition-[max-height,opacity] duration-150 ease-out",
-            showLegend ? "max-h-6 opacity-100" : "max-h-0 opacity-0"
-          )}
-        >
-          <p className="pt-1 text-[11px] text-daintree-text/40 select-none">
-            @ files · @diff · @terminal · / commands
-          </p>
         </div>
       </div>
     );

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1071,14 +1071,9 @@ function TerminalPaneComponent({
               )}
             </div>
 
-            {showHybridInputBar && (
+            {isFleetPrimary && (
               <div className="relative h-0 shrink-0 z-10 pointer-events-none">
-                <div
-                  className={cn(
-                    "absolute right-3.5 bottom-2 pointer-events-auto transition-opacity duration-150 ease-out",
-                    isFleetPrimary ? "opacity-100 visible" : "opacity-0 invisible"
-                  )}
-                >
+                <div className="absolute right-3.5 bottom-2 pointer-events-auto">
                   <FleetDraftingPill />
                 </div>
               </div>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -53,7 +53,6 @@ import type { HybridInputBarHandle } from "./HybridInputBar";
 const LazyHybridInputBar = lazy(() =>
   import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
 );
-import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import {
   getTerminalFocusTarget,
   shouldShowHybridInputBar,
@@ -255,7 +254,6 @@ function TerminalPaneComponent({
   // is suppressed on a single-armed seed selection because nothing fans out
   // until a second pane joins.
   const isFleetFollower = isArmed && !isFocused && armedIds.size >= 2;
-  const isFleetPrimary = isArmed && isFocused && armedIds.size >= 2;
 
   // Consolidate terminal state selectors to avoid multiple scans and ensure consistent snapshots
   const terminalState = usePanelStore(
@@ -1070,14 +1068,6 @@ function TerminalPaneComponent({
                 </div>
               )}
             </div>
-
-            {isFleetPrimary && (
-              <div className="relative h-0 shrink-0 z-10 pointer-events-none">
-                <div className="absolute right-3.5 bottom-2 pointer-events-auto">
-                  <FleetDraftingPill />
-                </div>
-              </div>
-            )}
 
             {showHybridInputBar && (
               <Suspense fallback={null}>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -53,6 +53,7 @@ import type { HybridInputBarHandle } from "./HybridInputBar";
 const LazyHybridInputBar = lazy(() =>
   import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
 );
+import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import {
   getTerminalFocusTarget,
   shouldShowHybridInputBar,
@@ -254,6 +255,7 @@ function TerminalPaneComponent({
   // is suppressed on a single-armed seed selection because nothing fans out
   // until a second pane joins.
   const isFleetFollower = isArmed && !isFocused && armedIds.size >= 2;
+  const isFleetPrimary = isArmed && isFocused && armedIds.size >= 2;
 
   // Consolidate terminal state selectors to avoid multiple scans and ensure consistent snapshots
   const terminalState = usePanelStore(
@@ -1068,6 +1070,19 @@ function TerminalPaneComponent({
                 </div>
               )}
             </div>
+
+            {showHybridInputBar && (
+              <div className="relative h-0 shrink-0 z-10 pointer-events-none">
+                <div
+                  className={cn(
+                    "absolute right-3.5 bottom-2 pointer-events-auto transition-opacity duration-150 ease-out",
+                    isFleetPrimary ? "opacity-100 visible" : "opacity-0 invisible"
+                  )}
+                >
+                  <FleetDraftingPill />
+                </div>
+              </div>
+            )}
 
             {showHybridInputBar && (
               <Suspense fallback={null}>


### PR DESCRIPTION
## Summary

- The hint legend (`@ files · @diff · @terminal · / commands`) underneath the input sat inside a `max-h-6` ↔ `max-h-0` opacity transition. Every focus change between empty terminals flipped that `max-h` and shifted the input bar by ~24px, flickering the terminal output above.
- Replaced the `max-h` transition with a single floating overlay above the input shell. The same overlay holds the fleet drafting pill (which had a similar layout-jump pattern but only triggered in fleet mode).
- Both indicators now live in one absolute-positioned, right-aligned container with no transitions. Showing or hiding either no longer affects input bar height.

Resolves #6491

## Changes

- `HybridInputBar.tsx`: added a floating absolute container above the input shell, right-aligned, holding both the legend (gated on `showLegend`) and the `FleetDraftingPill` (gated on `isFleetPrimary`); removed the old bottom legend wrapper and its `max-h` transition
- `FleetDraftingPill.tsx`: dropped `mb-1.5` (no longer needed in the floating context); switched popover `align` from `start` to `end` so the popover anchors under the right-aligned trigger

## Testing

- Clicked between empty terminals repeatedly: input bar height stays constant, no terminal flicker above
- Verified fleet primary pill still appears with correct popover behaviour
- 21 `fleetResolutionPreview` unit tests passing; typecheck and prettier clean