### PR TITLE
fix(github): hydrate from warm cache on filter tab switch

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -507,8 +507,17 @@ export function GitHubResourceList({
     // existing clear-and-skeleton behavior so genuine first views still
     // signal "loading".
     if (!isFirstMount) {
-      const targetCached = getCache(cacheKey);
+      // Search isn't part of `cacheKey`, so the warm slot only describes
+      // the unsearched view. Falling through to the cold path while a
+      // search is active flashes unfiltered cached rows before the
+      // searched fetch lands; gate hydration to non-search transitions.
+      const targetCached = !debouncedSearch ? getCache(cacheKey) : undefined;
       if (targetCached) {
+        // A previous cold fetch may have set `loading=true` and then been
+        // aborted by this effect's cleanup, which skips its `setLoading(false)`
+        // because the abort signal fired. Clear it explicitly so an empty
+        // warm slot doesn't render the skeleton via `loading && !data.length`.
+        setLoading(false);
         setData(targetCached.items);
         setCursor(targetCached.endCursor);
         setHasMore(targetCached.hasNextPage);

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -501,10 +501,28 @@ export function GitHubResourceList({
     }
 
     // Filter/sort changed while mounted (or projectPath changed via the
-    // keepMounted body): clear and refetch with skeleton. First-mount cache
-    // miss skips the explicit clear (data is already [] from the useState
-    // initializer) so no spurious setState/render churn.
+    // keepMounted body). If the target slot is warm in cache, hydrate
+    // synchronously and run the silent SWR revalidate path — no skeleton
+    // flash on Open → Closed → Open round-trips. Cold target slot keeps the
+    // existing clear-and-skeleton behavior so genuine first views still
+    // signal "loading".
     if (!isFirstMount) {
+      const targetCached = getCache(cacheKey);
+      if (targetCached) {
+        setData(targetCached.items);
+        setCursor(targetCached.endCursor);
+        setHasMore(targetCached.hasNextPage);
+        setLastUpdatedAt(targetCached.timestamp);
+        setExactNumberNotFound(null);
+        setError(null);
+        fetchData(null, false, abortController.signal, {
+          revalidating: true,
+          generation: gen,
+          cacheKey,
+        });
+        lastLoadedEffectKeyRef.current = effectKey;
+        return () => abortController.abort();
+      }
       setCursor(null);
       setHasMore(false);
       setExactNumberNotFound(null);

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1246,6 +1246,75 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
     expect(screen.getByTestId("item-70")).toBeTruthy();
   });
 
+  it("does not flash unsearched cached rows when a search query becomes active", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(81), makeIssue(82), makeIssue(83)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Mount-time revalidate resolves quickly; the searched fetch hangs so the
+    // transitional UI (post-debounce) is observable.
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(81), makeIssue(82), makeIssue(83)]))
+      .mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("item-81")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      useGitHubFilterStore.getState().setIssueSearchQuery("foo");
+    });
+
+    // After the 300ms debounce fires, the effect re-runs. The cacheKey
+    // doesn't include the search, so naively reading the warm slot would
+    // re-show the unfiltered list. Verify the cold path runs instead.
+    await waitFor(() => {
+      expect(screen.queryByTestId("item-81")).toBeNull();
+    });
+    expect(screen.getByTestId("skeleton")).toBeTruthy();
+  });
+
+  it("clears stranded loading state when switching from a cold pending filter to a warm empty slot", async () => {
+    const closedKey = buildCacheKey("/test/proj", "issue", "closed", "created");
+    setCache(closedKey, {
+      items: [],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Initial open-filter fetch hangs so loading sticks at true; the closed
+    // revalidate resolves to the cached empty page.
+    mockListIssues.mockImplementation(
+      ({ state }: { state: "open" | "closed" | "merged" | "all" }) => {
+        if (state === "closed") return Promise.resolve(makeResponse([]));
+        return new Promise(() => {});
+      }
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("skeleton")).toBeTruthy();
+
+    act(() => {
+      useGitHubFilterStore.getState().setIssueFilter("closed");
+    });
+
+    // Warm closed cache is empty — the skeleton must clear (loading reset),
+    // exposing the empty state instead.
+    await waitFor(() => {
+      expect(screen.queryByTestId("skeleton")).toBeNull();
+    });
+    expect(screen.getByText("No issues in this view")).toBeTruthy();
+  });
+
   it("clears rows and shows the skeleton when the filter changes while keepMounted", async () => {
     const openKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(openKey, {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1156,6 +1156,96 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
     });
   });
 
+  it("hydrates from warm cache without flashing the skeleton on filter switch", async () => {
+    const openKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    const closedKey = buildCacheKey("/test/proj", "issue", "closed", "created");
+    setCache(openKey, {
+      items: [makeIssue(60)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    setCache(closedKey, {
+      items: [makeIssue(61), makeIssue(62)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Mount-time revalidate for "open", then closed-filter revalidate after switch.
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(60)]))
+      .mockResolvedValueOnce(makeResponse([makeIssue(61), makeIssue(62)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("item-60")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      useGitHubFilterStore.getState().setIssueFilter("closed");
+    });
+
+    // Warm closed cache → rows swap synchronously, no skeleton flash.
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.getByTestId("item-61")).toBeTruthy();
+    expect(screen.getByTestId("item-62")).toBeTruthy();
+    expect(screen.queryByTestId("item-60")).toBeNull();
+
+    // Background revalidate for the closed slot uses the bypass-cache path.
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+    expect(mockListIssues.mock.calls[1]?.[0]).toMatchObject({
+      state: "closed",
+      bypassCache: true,
+    });
+  });
+
+  it("survives Open → Closed → Open round-trip with no skeleton on the second Open", async () => {
+    const openKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    const closedKey = buildCacheKey("/test/proj", "issue", "closed", "created");
+    setCache(openKey, {
+      items: [makeIssue(70)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    setCache(closedKey, {
+      items: [makeIssue(71)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockImplementation(
+      ({ state }: { state: "open" | "closed" | "merged" | "all" }) => {
+        if (state === "closed") return Promise.resolve(makeResponse([makeIssue(71)]));
+        return Promise.resolve(makeResponse([makeIssue(70)]));
+      }
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("item-70")).toBeTruthy();
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+
+    act(() => {
+      useGitHubFilterStore.getState().setIssueFilter("closed");
+    });
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.getByTestId("item-71")).toBeTruthy();
+
+    act(() => {
+      useGitHubFilterStore.getState().setIssueFilter("open");
+    });
+    // Warm Open cache still present — second Open shows item-70 with no flash.
+    expect(screen.queryByTestId("skeleton")).toBeNull();
+    expect(screen.getByTestId("item-70")).toBeTruthy();
+  });
+
   it("clears rows and shows the skeleton when the filter changes while keepMounted", async () => {
     const openKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(openKey, {

--- a/src/lib/__tests__/githubResourceCache.test.ts
+++ b/src/lib/__tests__/githubResourceCache.test.ts
@@ -5,8 +5,21 @@ import {
   setCache,
   nextGeneration,
   getGeneration,
+  mutateCacheEntries,
   _resetForTests,
 } from "../githubResourceCache";
+import type { GitHubIssue } from "@shared/types/github";
+
+const makeIssue = (n: number, state: "OPEN" | "CLOSED" = "OPEN"): GitHubIssue => ({
+  number: n,
+  title: `Issue #${n}`,
+  url: `https://example.test/${n}`,
+  state,
+  updatedAt: "",
+  author: { login: "u", avatarUrl: "" },
+  assignees: [],
+  commentCount: 0,
+});
 
 describe("githubResourceCache", () => {
   beforeEach(() => {
@@ -158,6 +171,110 @@ describe("githubResourceCache", () => {
       nextGeneration("gen-key-20");
       expect(getGeneration("gen-key-0")).toBe(0);
       expect(getGeneration("gen-key-20")).toBe(1);
+    });
+  });
+
+  describe("mutateCacheEntries", () => {
+    const seedSlot = (
+      projectPath: string,
+      type: string,
+      filter: string,
+      sort: string,
+      items: GitHubIssue[]
+    ): string => {
+      const key = buildCacheKey(projectPath, type, filter, sort);
+      setCache(key, {
+        items,
+        endCursor: null,
+        hasNextPage: false,
+        timestamp: 1,
+      });
+      return key;
+    };
+
+    it("applies the transform across every (filter, sort) slot for the matching project + type", () => {
+      const openCreated = seedSlot("/proj", "issue", "open", "created", [
+        makeIssue(1),
+        makeIssue(2),
+      ]);
+      const closedCreated = seedSlot("/proj", "issue", "closed", "created", [makeIssue(3)]);
+      const openUpdated = seedSlot("/proj", "issue", "open", "updated", [
+        makeIssue(1),
+        makeIssue(2),
+      ]);
+
+      mutateCacheEntries("/proj", "issue", (entry) => ({
+        ...entry,
+        items: entry.items.filter((item) => item.number !== 2),
+      }));
+
+      expect(getCache(openCreated)?.items.map((i) => i.number)).toEqual([1]);
+      expect(getCache(closedCreated)?.items.map((i) => i.number)).toEqual([3]);
+      expect(getCache(openUpdated)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("does not touch slots from a different project", () => {
+      const sameProj = seedSlot("/proj-a", "issue", "open", "created", [makeIssue(1)]);
+      const otherProj = seedSlot("/proj-b", "issue", "open", "created", [makeIssue(1)]);
+
+      mutateCacheEntries("/proj-a", "issue", (entry) => ({
+        ...entry,
+        items: [],
+      }));
+
+      expect(getCache(sameProj)?.items).toEqual([]);
+      expect(getCache(otherProj)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("does not touch slots from a different resource type", () => {
+      const issueSlot = seedSlot("/proj", "issue", "open", "created", [makeIssue(1)]);
+      const prSlot = seedSlot("/proj", "pr", "open", "created", [makeIssue(1)]);
+
+      mutateCacheEntries("/proj", "issue", (entry) => ({ ...entry, items: [] }));
+
+      expect(getCache(issueSlot)?.items).toEqual([]);
+      expect(getCache(prSlot)?.items.map((i) => i.number)).toEqual([1]);
+    });
+
+    it("bumps the generation counter only for changed slots", () => {
+      const changedKey = seedSlot("/proj", "issue", "open", "created", [
+        makeIssue(1),
+        makeIssue(2),
+      ]);
+      const skippedKey = seedSlot("/proj", "issue", "closed", "created", [makeIssue(3)]);
+      const changedGenBefore = getGeneration(changedKey);
+      const skippedGenBefore = getGeneration(skippedKey);
+
+      mutateCacheEntries("/proj", "issue", (entry) => {
+        if (entry.items.some((item) => item.number === 1)) {
+          return { ...entry, items: entry.items.filter((item) => item.number !== 1) };
+        }
+        return null;
+      });
+
+      expect(getGeneration(changedKey)).toBe(changedGenBefore + 1);
+      expect(getGeneration(skippedKey)).toBe(skippedGenBefore);
+    });
+
+    it("is a no-op on an empty cache", () => {
+      expect(() =>
+        mutateCacheEntries("/proj", "issue", (entry) => ({ ...entry, items: [] }))
+      ).not.toThrow();
+    });
+
+    it("handles project paths that contain colons (Windows-style)", () => {
+      const windowsKey = seedSlot("C:\\projects\\repo", "issue", "open", "created", [
+        makeIssue(10),
+      ]);
+      const otherKey = seedSlot("C:\\projects\\other", "issue", "open", "created", [makeIssue(10)]);
+
+      mutateCacheEntries("C:\\projects\\repo", "issue", (entry) => ({
+        ...entry,
+        items: [],
+      }));
+
+      expect(getCache(windowsKey)?.items).toEqual([]);
+      expect(getCache(otherKey)?.items.map((i) => i.number)).toEqual([10]);
     });
   });
 });

--- a/src/lib/githubResourceCache.ts
+++ b/src/lib/githubResourceCache.ts
@@ -47,6 +47,33 @@ export function getGeneration(key: string): number {
   return generationMap.get(key) ?? 0;
 }
 
+/**
+ * Apply a transform across every cached slot for a given (projectPath, type)
+ * pair, regardless of filter or sort. Use after a mutation (close, merge,
+ * reopen) so sibling filter slots don't serve stale rows on the next switch.
+ *
+ * The transform receives each entry and returns either a new entry (write
+ * back + bump generation to discard any concurrent in-flight SWR for that
+ * slot) or null (leave untouched, no generation bump).
+ *
+ * Prefix-matches on `${projectPath}:${type}:` rather than splitting on `:`
+ * because `projectPath` can contain colons on Windows (e.g., `C:\projects`).
+ */
+export function mutateCacheEntries(
+  projectPath: string,
+  type: string,
+  transform: (entry: GitHubResourceCacheEntry) => GitHubResourceCacheEntry | null
+): void {
+  const prefix = `${projectPath}:${type}:`;
+  for (const [key, entry] of cache.entries()) {
+    if (!key.startsWith(prefix)) continue;
+    const next = transform(entry);
+    if (next === null) continue;
+    setCache(key, next);
+    nextGeneration(key);
+  }
+}
+
 export function _resetForTests(): void {
   cache.clear();
   generationMap.clear();

--- a/src/utils/__tests__/ttlCache.test.ts
+++ b/src/utils/__tests__/ttlCache.test.ts
@@ -89,4 +89,38 @@ describe("TtlCache", () => {
     expect(cache.get("d")).toBe(4);
     expect(cache.size).toBe(2);
   });
+
+  describe("entries()", () => {
+    it("yields every non-expired entry in insertion order", () => {
+      const cache = new TtlCache<string, number>(10, 60_000);
+      cache.set("a", 1);
+      cache.set("b", 2);
+      cache.set("c", 3);
+
+      expect(Array.from(cache.entries())).toEqual([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
+    });
+
+    it("skips and evicts expired entries during iteration", () => {
+      const cache = new TtlCache<string, number>(10, 5_000);
+      cache.set("a", 1);
+      vi.advanceTimersByTime(3_000);
+      cache.set("b", 2);
+      vi.advanceTimersByTime(3_000);
+      // "a" is now expired, "b" is still alive.
+
+      expect(Array.from(cache.entries())).toEqual([["b", 2]]);
+      // Iteration removed the expired entry.
+      expect(cache.size).toBe(1);
+      expect(cache.get("a")).toBeUndefined();
+    });
+
+    it("returns nothing on an empty cache", () => {
+      const cache = new TtlCache<string, number>(10, 60_000);
+      expect(Array.from(cache.entries())).toEqual([]);
+    });
+  });
 });

--- a/src/utils/ttlCache.ts
+++ b/src/utils/ttlCache.ts
@@ -31,4 +31,15 @@ export class TtlCache<K, V> {
   get size(): number {
     return this.store.size;
   }
+
+  *entries(): IterableIterator<[K, V]> {
+    const now = Date.now();
+    for (const [key, entry] of this.store) {
+      if (now > entry.expiresAt) {
+        this.store.delete(key);
+        continue;
+      }
+      yield [key, entry.value];
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Filter tab switches in the GitHub dropdown now render synchronously from warm cache when data is already available, eliminating the skeleton flash on Open → Closed → Open and similar transitions.
- Guards added for active search and stranded loading edge cases so the warm-cache path doesn't interfere with in-progress fetches or typed queries.
- `entries()` iterator added to `TtlCache` and a `mutateCacheEntries` helper added to `githubResourceCache` as infrastructure for future close/merge mutation propagation (no call sites yet).

Resolves #6539

## What changed

- **`GitHubResourceList.tsx`** — the filter/sort change effect now checks the warm cache before clearing `data` to `[]`. If a matching cache slot exists and no search is active, it hydrates immediately; a background SWR revalidate still runs behind the rendered rows. Stranded-loading guard clears the spinner when switching away mid-fetch.
- **`ttlCache.ts` / `githubResourceCache.ts`** — `TtlCache.entries()` exposes the underlying map for iteration; `mutateCacheEntries` wraps it to apply a transform across all slots matching a predicate. Covered by new unit tests in both `__tests__` files.
- **`GitHubResourceList.swr.test.tsx`** — new regression tests for the warm-switch path, Open → Closed → Open round-trip, search-active guard, and stranded-loading guard.

## Testing

- Vitest: 81 unit tests pass (new: warm-switch, round-trip, search guard, stranded-loading guard).
- `npm run check` passes, lint warning count -7 vs baseline, build clean.
- Manual: Open → Closed → Open shows no skeleton on the second Open. Search input still shows the skeleton transition. Cold filter switch (never-fetched slot) unchanged.