### PR TITLE
perf(git): cache per-file insertion/deletion counts

### DIFF
--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -20,7 +20,7 @@ vi.mock("fs", async (importOriginal) => {
     promises: {
       ...(actual as { promises: Record<string, unknown> }).promises,
       access: vi.fn().mockResolvedValue(undefined),
-      stat: vi.fn().mockResolvedValue({ mtimeMs: 1000 }),
+      stat: vi.fn().mockResolvedValue({ mtimeMs: 1000, size: 512 }),
     },
   };
 });
@@ -35,6 +35,7 @@ import {
   getWorktreeChangesWithStats,
   listCommits,
   invalidateWorktreeCache,
+  __clearPerFileDiffStatCacheForTesting,
 } from "../git.js";
 import { createHardenedGit } from "../hardenedGit.js";
 import { promises as fs } from "fs";
@@ -158,7 +159,7 @@ describe("getWorktreeChangesWithStats --no-ext-diff", () => {
     mockGit.revparse.mockResolvedValue("/test/path\n");
     mockGit.raw.mockResolvedValue("100\t0\tsome msg");
     mockGit.diff.mockResolvedValue("1\t0\tsrc/app.ts");
-    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000 });
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000, size: 512 });
   });
 
   it("passes --no-ext-diff in numstat diff call", async () => {
@@ -499,6 +500,7 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __clearPerFileDiffStatCacheForTesting();
     (fs.access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
     mockGit.raw.mockResolvedValue("");
   });
@@ -583,6 +585,35 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     // stable.ts comes from cache (3/1); dirty.ts from fresh diff (8/3).
     expect(result.totalInsertions).toBe(3 + 8);
     expect(result.totalDeletions).toBe(1 + 3);
+  });
+
+  it("invalidates cache when only the file size changes", async () => {
+    const cwd = "/per-file-cache-sizeonly/" + Math.random();
+    setupRevparse(cwd, "head-oid-sizeonly");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/grow.ts"],
+    });
+    mockGit.diff.mockResolvedValue("3\t1\tsrc/grow.ts");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 7000, size: 100 });
+
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+
+    // Same mtime, same path, same HEAD — but size changed. Must miss cache.
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 7000, size: 200 });
+    mockGit.diff.mockReset();
+    mockGit.diff.mockResolvedValue("5\t2\tsrc/grow.ts");
+
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+    expect(mockGit.diff).toHaveBeenCalledWith([
+      "--no-ext-diff",
+      "--numstat",
+      "HEAD",
+      "--",
+      "src/grow.ts",
+    ]);
   });
 
   it("invalidates cache when HEAD OID changes", async () => {

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -477,6 +477,167 @@ describe("getWorktreeChangesWithStats concurrent worktree isolation", () => {
   });
 });
 
+describe("getWorktreeChangesWithStats per-file diff cache", () => {
+  const emptyStatus = {
+    modified: [],
+    created: [],
+    deleted: [],
+    renamed: [],
+    staged: [],
+    conflicted: [],
+    not_added: [],
+  };
+
+  function setupRevparse(cwd: string, headOid: string) {
+    mockGit.revparse.mockImplementation((args: string[]) => {
+      if (Array.isArray(args) && args[0] === "HEAD") {
+        return Promise.resolve(`${headOid}\n`) as ReturnType<typeof mockGit.revparse>;
+      }
+      return Promise.resolve(`${cwd}\n`) as ReturnType<typeof mockGit.revparse>;
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fs.access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    mockGit.raw.mockResolvedValue("");
+  });
+
+  it("scopes the numstat diff to cache-miss paths via pathspec", async () => {
+    const cwd = "/per-file-cache-scope/" + Math.random();
+    setupRevparse(cwd, "head-oid-scope");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/a.ts"],
+    });
+    mockGit.diff.mockResolvedValue("4\t2\tsrc/a.ts");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000, size: 50 });
+
+    await getWorktreeChangesWithStats(cwd, true);
+
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+    expect(mockGit.diff).toHaveBeenCalledWith([
+      "--no-ext-diff",
+      "--numstat",
+      "HEAD",
+      "--",
+      "src/a.ts",
+    ]);
+  });
+
+  it("skips git.diff when every tracked file hits the per-file cache", async () => {
+    const cwd = "/per-file-cache-allhit/" + Math.random();
+    setupRevparse(cwd, "head-oid-allhit");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/cached.ts"],
+    });
+    mockGit.diff.mockResolvedValue("9\t1\tsrc/cached.ts");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 2000, size: 75 });
+
+    // First call populates the cache.
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+
+    // Second call with identical (HEAD, path, mtime, size) should hit cache.
+    mockGit.diff.mockClear();
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(mockGit.diff).not.toHaveBeenCalled();
+    expect(result.totalInsertions).toBe(9);
+    expect(result.totalDeletions).toBe(1);
+  });
+
+  it("only diffs cache-miss files when one of two changed", async () => {
+    const cwd = "/per-file-cache-mix/" + Math.random();
+    setupRevparse(cwd, "head-oid-mix");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/stable.ts", "src/dirty.ts"],
+    });
+    mockGit.diff.mockResolvedValue("3\t1\tsrc/stable.ts\n7\t2\tsrc/dirty.ts");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1500, size: 120 });
+
+    // Prime cache for both files.
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+
+    // dirty.ts gets a new mtime; stable.ts unchanged.
+    (fs.stat as ReturnType<typeof vi.fn>).mockImplementation(async (p: string) => {
+      if (p.endsWith("dirty.ts")) return { mtimeMs: 9999, size: 130 };
+      return { mtimeMs: 1500, size: 120 };
+    });
+    mockGit.diff.mockReset();
+    mockGit.diff.mockResolvedValue("8\t3\tsrc/dirty.ts");
+
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+    expect(mockGit.diff).toHaveBeenCalledWith([
+      "--no-ext-diff",
+      "--numstat",
+      "HEAD",
+      "--",
+      "src/dirty.ts",
+    ]);
+    // stable.ts comes from cache (3/1); dirty.ts from fresh diff (8/3).
+    expect(result.totalInsertions).toBe(3 + 8);
+    expect(result.totalDeletions).toBe(1 + 3);
+  });
+
+  it("invalidates cache when HEAD OID changes", async () => {
+    const cwd = "/per-file-cache-headchange/" + Math.random();
+    setupRevparse(cwd, "head-oid-old");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/file.ts"],
+    });
+    mockGit.diff.mockResolvedValue("2\t0\tsrc/file.ts");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 4000, size: 200 });
+
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+
+    // Same path/mtime/size but a fresh HEAD OID — must miss the cache.
+    setupRevparse(cwd, "head-oid-new");
+    mockGit.diff.mockReset();
+    mockGit.diff.mockResolvedValue("2\t0\tsrc/file.ts");
+
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+    expect(mockGit.diff).toHaveBeenCalledWith([
+      "--no-ext-diff",
+      "--numstat",
+      "HEAD",
+      "--",
+      "src/file.ts",
+    ]);
+  });
+
+  it("does not cache stats when the diff command fails", async () => {
+    const cwd = "/per-file-cache-difffail/" + Math.random();
+    setupRevparse(cwd, "head-oid-fail");
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      modified: ["src/flaky.ts"],
+    });
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 5000, size: 300 });
+    mockGit.diff.mockRejectedValueOnce(new Error("transient git failure"));
+
+    await getWorktreeChangesWithStats(cwd, true);
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+
+    // Next call must rerun the diff because the prior failure was not cached.
+    mockGit.diff.mockReset();
+    mockGit.diff.mockResolvedValue("6\t4\tsrc/flaky.ts");
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(mockGit.diff).toHaveBeenCalledTimes(1);
+    expect(result.totalInsertions).toBe(6);
+    expect(result.totalDeletions).toBe(4);
+  });
+});
+
 describe("listCommits", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -27,6 +27,23 @@ interface DiffStat {
   deletions: number | null;
 }
 
+// Per-file diff stat cache: skips redundant `git diff --numstat` work for files
+// whose (HEAD OID, path, mtime, size) tuple is unchanged since last refresh.
+// HEAD OID participates in the key, so commits/resets/checkouts self-invalidate.
+const PER_FILE_DIFF_STAT_CACHE = new Cache<string, DiffStat>({
+  maxSize: 2000,
+  defaultTTL: 300_000,
+});
+
+function makeFileStatCacheKey(
+  headOid: string,
+  absolutePath: string,
+  mtimeMs: number,
+  size: number
+): string {
+  return `${headOid}:${absolutePath}:${mtimeMs}:${size}`;
+}
+
 const NUMSTAT_PATH_SPLITTERS = ["=>", "->"];
 
 function normalizeNumstatPath(rawPath: string): string {
@@ -241,18 +258,27 @@ export async function getWorktreeChangesWithStats(
     try {
       const git: SimpleGit = gitForChanges(cwd, options);
       const status: StatusResult = await git.status();
-      const gitRoot = realpathSync((await git.revparse(["--show-toplevel"])).trim());
+
+      // Parallelise revparse + log lookups; HEAD/log are non-critical and may
+      // legitimately fail (e.g. empty repo, no commits yet) — fall back gracefully.
+      const [toplevelRaw, headOid, logOutput] = await Promise.all([
+        git.revparse(["--show-toplevel"]),
+        git
+          .revparse(["HEAD"])
+          .then((s) => s.trim())
+          .catch(() => ""),
+        git.raw(["log", "-1", "--format=%ct%n%s"]).catch(() => ""),
+      ]);
+
+      const gitRoot = realpathSync(toplevelRaw.trim());
 
       let lastCommitMessage: string | undefined;
       let lastCommitTimestampMs: number | undefined;
-      try {
-        const output = await git.raw(["log", "-1", "--format=%ct%n%s"]);
-        const [tsLine, ...msgLines] = output.split("\n");
+      if (logOutput) {
+        const [tsLine, ...msgLines] = logOutput.split("\n");
         const parsed = Number.parseInt((tsLine ?? "").trim(), 10);
         lastCommitTimestampMs = Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : undefined;
         lastCommitMessage = msgLines.join("\n").trim() || undefined;
-      } catch {
-        // Silently ignore - this is a non-critical field
       }
 
       const trackedChangedFiles = [
@@ -263,14 +289,60 @@ export async function getWorktreeChangesWithStats(
         ...status.staged,
       ];
 
+      // Early stat pass: gather (mtimeMs, size) for each tracked file so we can
+      // probe the per-file cache before shelling out to `git diff`. Stat failures
+      // (e.g. deleted files) fall through to the cache-miss path, matching prior
+      // behaviour.
+      const useScopedDiff =
+        trackedChangedFiles.length > 0 &&
+        trackedChangedFiles.length <= MAX_FILES_FOR_NUMSTAT &&
+        headOid !== "";
+
+      const cacheMissPaths: string[] = [];
+      const hitStats = new Map<string, DiffStat>();
+      const fileMetaByRel = new Map<
+        string,
+        { absolutePath: string; mtimeMs: number; size: number }
+      >();
+
+      if (useScopedDiff) {
+        const statResults = await Promise.allSettled(
+          trackedChangedFiles.map((rel) => fs.stat(resolve(gitRoot, rel)))
+        );
+        for (let i = 0; i < trackedChangedFiles.length; i++) {
+          const rel = trackedChangedFiles[i];
+          const result = statResults[i];
+          if (result.status !== "fulfilled") {
+            cacheMissPaths.push(rel);
+            continue;
+          }
+          const absolutePath = resolve(gitRoot, rel);
+          const mtimeMs = result.value.mtimeMs;
+          const size = result.value.size;
+          fileMetaByRel.set(rel, { absolutePath, mtimeMs, size });
+          const cached = PER_FILE_DIFF_STAT_CACHE.get(
+            makeFileStatCacheKey(headOid, absolutePath, mtimeMs, size)
+          );
+          if (cached) {
+            hitStats.set(absolutePath, cached);
+          } else {
+            cacheMissPaths.push(rel);
+          }
+        }
+      } else {
+        for (const rel of trackedChangedFiles) cacheMissPaths.push(rel);
+      }
+
       let diffOutput = "";
+      let diffSucceeded = false;
 
       try {
-        if (trackedChangedFiles.length === 0) {
+        if (cacheMissPaths.length === 0) {
           diffOutput = "";
-        } else if (trackedChangedFiles.length <= MAX_FILES_FOR_NUMSTAT) {
-          diffOutput = await git.diff(["--no-ext-diff", "--numstat", "HEAD"]);
-        } else {
+          diffSucceeded = true;
+        } else if (trackedChangedFiles.length > MAX_FILES_FOR_NUMSTAT) {
+          // Escape hatch: skip per-file caching and run an unscoped numstat over
+          // the first 100 files to keep argv length bounded.
           const limitedFiles = trackedChangedFiles.slice(0, MAX_FILES_FOR_NUMSTAT);
           diffOutput = await git.diff([
             "--no-ext-diff",
@@ -284,6 +356,15 @@ export async function getWorktreeChangesWithStats(
             totalFiles: trackedChangedFiles.length,
             limitedTo: MAX_FILES_FOR_NUMSTAT,
           });
+        } else {
+          diffOutput = await git.diff([
+            "--no-ext-diff",
+            "--numstat",
+            "HEAD",
+            "--",
+            ...cacheMissPaths,
+          ]);
+          diffSucceeded = true;
         }
       } catch (error) {
         logWarn("Failed to read numstat diff; continuing without line stats", {
@@ -293,6 +374,29 @@ export async function getWorktreeChangesWithStats(
       }
 
       const diffStats = parseNumstat(diffOutput, gitRoot);
+
+      // Populate per-file cache with newly-computed stats from cache-miss files
+      // (only when the diff itself succeeded — never cache failure outcomes).
+      if (useScopedDiff && diffSucceeded) {
+        for (const rel of cacheMissPaths) {
+          const meta = fileMetaByRel.get(rel);
+          if (!meta) continue;
+          const stats = diffStats.get(meta.absolutePath);
+          if (!stats) continue;
+          PER_FILE_DIFF_STAT_CACHE.set(
+            makeFileStatCacheKey(headOid, meta.absolutePath, meta.mtimeMs, meta.size),
+            stats
+          );
+        }
+      }
+
+      // Merge cache hits into diffStats so addChange picks them up uniformly.
+      for (const [absolutePath, stats] of hitStats) {
+        if (!diffStats.has(absolutePath)) {
+          diffStats.set(absolutePath, stats);
+        }
+      }
+
       const changesMap = new Map<string, FileChangeDetail>();
 
       const countFileLines = async (filePath: string): Promise<number | null> => {
@@ -301,6 +405,16 @@ export async function getWorktreeChangesWithStats(
           const MAX_FILE_SIZE = 10 * 1024 * 1024;
           if (stats.size > MAX_FILE_SIZE) {
             return null;
+          }
+
+          const cacheKey = headOid
+            ? makeFileStatCacheKey(headOid, filePath, stats.mtimeMs, stats.size)
+            : "";
+          if (cacheKey) {
+            const cached = PER_FILE_DIFF_STAT_CACHE.get(cacheKey);
+            if (cached && cached.insertions !== null) {
+              return cached.insertions;
+            }
           }
 
           const buffer = await fs.readFile(filePath);
@@ -314,19 +428,20 @@ export async function getWorktreeChangesWithStats(
 
           const content = buffer.toString("utf-8");
 
-          if (content.length === 0) {
-            return 0;
-          }
-
           let lineCount = 0;
-          for (let i = 0; i < content.length; i++) {
-            if (content[i] === "\n") {
+          if (content.length > 0) {
+            for (let i = 0; i < content.length; i++) {
+              if (content[i] === "\n") {
+                lineCount++;
+              }
+            }
+            if (content[content.length - 1] !== "\n") {
               lineCount++;
             }
           }
 
-          if (content[content.length - 1] !== "\n") {
-            lineCount++;
+          if (cacheKey) {
+            PER_FILE_DIFF_STAT_CACHE.set(cacheKey, { insertions: lineCount, deletions: 0 });
           }
 
           return lineCount;

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -44,6 +44,12 @@ function makeFileStatCacheKey(
   return `${headOid}:${absolutePath}:${mtimeMs}:${size}`;
 }
 
+// Test-only: clear the per-file diff stat cache between cases. Production code
+// relies on (HEAD OID, mtime, size) self-invalidation and TTL eviction.
+export function __clearPerFileDiffStatCacheForTesting(): void {
+  PER_FILE_DIFF_STAT_CACHE.clear();
+}
+
 const NUMSTAT_PATH_SPLITTERS = ["=>", "->"];
 
 function normalizeNumstatPath(rawPath: string): string {
@@ -281,12 +287,17 @@ export async function getWorktreeChangesWithStats(
         lastCommitMessage = msgLines.join("\n").trim() || undefined;
       }
 
+      // Deduplicate: a partially-staged file appears in both `modified` and
+      // `staged`, and double-counting wastes the 100-file budget reserved for
+      // the per-file cache fast path.
       const trackedChangedFiles = [
-        ...status.modified,
-        ...status.created,
-        ...status.deleted,
-        ...status.renamed.map((r) => r.to),
-        ...status.staged,
+        ...new Set([
+          ...status.modified,
+          ...status.created,
+          ...status.deleted,
+          ...status.renamed.map((r) => r.to),
+          ...status.staged,
+        ]),
       ];
 
       // Early stat pass: gather (mtimeMs, size) for each tracked file so we can


### PR DESCRIPTION
## Summary

- Every worktree refresh was running `git diff --no-ext-diff --numstat HEAD` over the entire modified file set, even when only one file changed. With 8-30 worktrees open that's the dominant cost on every file-watcher burst.
- Adds a per-file diff stat cache in `electron/utils/git.ts` keyed on `(HEAD OID, absolute path, mtime, size)` — the same invariant Git's index-refresh heuristic uses. An early `stat()` pass partitions tracked files into hits and misses; the diff invocation is then scoped to only the misses. When everything hits, the diff is skipped entirely.
- Parallelises the three serial `git rev-parse`/`git log` calls via `Promise.all`, and memoises `countFileLines()` for untracked files using the same key tuple.

Resolves #6531

## Changes

- `electron/utils/git.ts`: per-file diff stat cache with `(HEAD OID, path, mtime, size)` key; early stat pass + scoped pathspec diff; `Promise.all` parallelisation; untracked line-count memo; deduplication of partially-staged files against the 100-file budget; cache skipped on diff failure or large changesets to preserve the existing escape hatch
- `electron/utils/__tests__/git.test.ts`: 6 new vitest cases under `getWorktreeChangesWithStats per-file diff cache` covering scoped diff, all-hit skip, mixed hit/miss, size-only invalidation, HEAD invalidation, and diff failure non-caching; `__clearPerFileDiffStatCacheForTesting` exported for test isolation

## Testing

- [ ] `npx vitest run electron/utils/__tests__/git.test.ts` — 31 tests pass
- [ ] Open a worktree with several modified files, edit one file, confirm the watcher refresh is visibly faster in a profiled run
- [ ] Edit a file, then revert it (same mtime/size as original) — cache should invalidate on size change and revalidate correctly
- [ ] Commit a change (HEAD rotates) — all cache entries for the old HEAD should miss and recompute
- [ ] Stage part of a file so it appears in both staged and unstaged sets — confirm it doesn't double-count against the 100-file budget