### PR TITLE
feat(review-hub): add Doherty-gated stale cue while background refresh runs

### DIFF
--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -762,6 +762,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
           {/* Content */}
           <div
             ref={scrollContainerRef}
+            data-testid="review-hub-scroll-container"
             className={cn(
               "flex-1 overflow-y-auto min-h-0",
               isBackgroundRefreshing && "surface-stale"

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -762,7 +762,11 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
           {/* Content */}
           <div
             ref={scrollContainerRef}
-            className="flex-1 overflow-y-auto min-h-0"
+            className={cn(
+              "flex-1 overflow-y-auto min-h-0",
+              isBackgroundRefreshing && "surface-stale"
+            )}
+            aria-busy={isBackgroundRefreshing || undefined}
             onScroll={handleScrollContainer}
           >
             {diffMode === "base-branch" ? (

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
@@ -143,13 +143,7 @@ const makeWorktreeState = (path = WORKTREE_PATH): WorktreeState =>
   }) as unknown as WorktreeState;
 
 function findScrollContainer(): HTMLElement {
-  const row = screen.getByText("index.ts");
-  let el: HTMLElement | null = row;
-  while (el) {
-    if (el.classList.contains("overflow-y-auto")) return el;
-    el = el.parentElement;
-  }
-  throw new Error("scroll container not found");
+  return screen.getByTestId("review-hub-scroll-container");
 }
 
 describe("ReviewHub stale visual", () => {
@@ -252,6 +246,38 @@ describe("ReviewHub stale visual", () => {
       resolveRefresh(makeStatus());
       await Promise.resolve();
     });
+  });
+
+  it("clears surface-stale and aria-busy when the background refresh rejects", async () => {
+    render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("index.ts"));
+
+    let rejectRefresh!: (reason: unknown) => void;
+    getStagingStatusMock.mockReturnValue(
+      new Promise<StagingStatus>((_, reject) => {
+        rejectRefresh = reject;
+      })
+    );
+
+    await act(async () => {
+      capturedUpdateCallback!(makeWorktreeState());
+      await Promise.resolve();
+    });
+
+    expect(findScrollContainer().classList.contains("surface-stale")).toBe(true);
+
+    await act(async () => {
+      rejectRefresh(new Error("git fail"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const scroll = findScrollContainer();
+      expect(scroll.classList.contains("surface-stale")).toBe(false);
+      expect(scroll.getAttribute("aria-busy")).toBeNull();
+    });
+
+    screen.getByText("index.ts");
   });
 
   it("clears surface-stale and aria-busy after the background refresh resolves", async () => {

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { StagingStatus, WorktreeState } from "@shared/types";
+
+const {
+  getStagingStatusMock,
+  onUpdateMock,
+  debounceCancelSpy,
+  compareWorktreesMock,
+  openPRMock,
+  abortRepositoryOperationMock,
+  continueRepositoryOperationMock,
+  openInEditorMock,
+  stageFileMock,
+  commitMock,
+  pushMock,
+  actionDispatchMock,
+  worktreeStoreData,
+} = vi.hoisted(() => ({
+  getStagingStatusMock: vi.fn(),
+  onUpdateMock: vi.fn(),
+  debounceCancelSpy: vi.fn(),
+  compareWorktreesMock: vi.fn(),
+  openPRMock: vi.fn().mockResolvedValue(undefined),
+  abortRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  continueRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  openInEditorMock: vi.fn().mockResolvedValue(undefined),
+  stageFileMock: vi.fn().mockResolvedValue(undefined),
+  commitMock: vi.fn(),
+  pushMock: vi.fn(),
+  actionDispatchMock: vi.fn().mockResolvedValue({ ok: true }),
+  worktreeStoreData: {
+    current: new Map<string, Partial<WorktreeState>>(),
+  },
+}));
+
+vi.mock("@/utils/debounce", () => ({
+  debounce: (fn: (...args: unknown[]) => void) => {
+    const immediate = (...args: unknown[]) => fn(...args);
+    immediate.cancel = debounceCancelSpy;
+    immediate.flush = vi.fn();
+    return immediate;
+  },
+}));
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: vi.fn(),
+  useTruncationDetection: vi.fn(() => ({ ref: vi.fn(), isTruncated: false })),
+}));
+
+vi.mock("../../FileDiffModal", () => ({ FileDiffModal: () => null }));
+vi.mock("../BaseBranchDiffModal", () => ({ BaseBranchDiffModal: () => null }));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: { worktrees: Map<string, WorktreeState> }) => unknown) =>
+    selector({ worktrees: worktreeStoreData.current as Map<string, WorktreeState> }),
+}));
+
+vi.mock("@/clients/githubClient", () => ({
+  githubClient: { openPR: openPRMock },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: actionDispatchMock },
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    "aria-label": ariaLabel,
+    "data-testid": testId,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    variant?: string;
+    size?: string;
+    className?: string;
+    "aria-label"?: string;
+    "data-testid"?: string;
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      data-testid={testId}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+import { ReviewHub } from "../ReviewHub";
+
+const WORKTREE_PATH = "/home/user/project";
+
+const makeStatus = (overrides?: Partial<StagingStatus>): StagingStatus => ({
+  staged: [{ path: "src/index.ts", status: "modified", insertions: 5, deletions: 2 }],
+  unstaged: [{ path: "src/app.ts", status: "modified", insertions: 3, deletions: 1 }],
+  conflicted: [],
+  conflictedFiles: [],
+  isDetachedHead: false,
+  currentBranch: "feature/test",
+  hasRemote: false,
+  repoState: "DIRTY",
+  rebaseStep: null,
+  rebaseTotalSteps: null,
+  ...overrides,
+});
+
+const makeWorktreeState = (path = WORKTREE_PATH): WorktreeState =>
+  ({
+    id: path,
+    path,
+    worktreeId: path,
+    name: "test",
+    isCurrent: true,
+    worktreeChanges: null,
+    lastActivityTimestamp: null,
+  }) as unknown as WorktreeState;
+
+function findScrollContainer(): HTMLElement {
+  const row = screen.getByText("index.ts");
+  let el: HTMLElement | null = row;
+  while (el) {
+    if (el.classList.contains("overflow-y-auto")) return el;
+    el = el.parentElement;
+  }
+  throw new Error("scroll container not found");
+}
+
+describe("ReviewHub stale visual", () => {
+  let capturedUpdateCallback: ((state: WorktreeState) => void) | null = null;
+  const mockUnsubscribe = vi.fn();
+
+  beforeEach(() => {
+    capturedUpdateCallback = null;
+    debounceCancelSpy.mockReset();
+
+    worktreeStoreData.current = new Map([
+      [
+        "main-wt",
+        {
+          id: "main-wt",
+          path: "/home/user/project",
+          name: "main",
+          branch: "main",
+          isMainWorktree: true,
+          isCurrent: false,
+          worktreeId: "main-wt",
+          worktreeChanges: null,
+          lastActivityTimestamp: null,
+        },
+      ],
+    ]);
+
+    getStagingStatusMock.mockResolvedValue(makeStatus());
+    onUpdateMock.mockImplementation((callback: (state: WorktreeState) => void) => {
+      capturedUpdateCallback = callback;
+      return mockUnsubscribe;
+    });
+
+    compareWorktreesMock.mockResolvedValue({ branch1: "main", branch2: "feature/test", files: [] });
+
+    abortRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    continueRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    openInEditorMock.mockReset().mockResolvedValue(undefined);
+    stageFileMock.mockReset().mockResolvedValue(undefined);
+    commitMock.mockReset().mockResolvedValue({ hash: "abc123", summary: "commit" });
+    pushMock.mockReset().mockResolvedValue(undefined);
+    actionDispatchMock.mockReset().mockResolvedValue({ ok: true });
+
+    Object.defineProperty(window, "electron", {
+      value: {
+        git: {
+          getStagingStatus: getStagingStatusMock,
+          stageFile: stageFileMock,
+          unstageFile: vi.fn().mockResolvedValue(undefined),
+          stageAll: vi.fn().mockResolvedValue(undefined),
+          unstageAll: vi.fn().mockResolvedValue(undefined),
+          commit: commitMock,
+          push: pushMock,
+          compareWorktrees: compareWorktreesMock,
+          abortRepositoryOperation: abortRepositoryOperationMock,
+          continueRepositoryOperation: continueRepositoryOperationMock,
+        },
+        system: { openInEditor: openInEditorMock },
+        worktree: { onUpdate: onUpdateMock },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not apply surface-stale or aria-busy when no background refresh is in flight", async () => {
+    render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("index.ts"));
+
+    const scroll = findScrollContainer();
+    expect(scroll.classList.contains("surface-stale")).toBe(false);
+    expect(scroll.getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("applies surface-stale and aria-busy=true while a background refresh is in flight", async () => {
+    render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("index.ts"));
+
+    let resolveRefresh!: (value: StagingStatus) => void;
+    getStagingStatusMock.mockReturnValue(
+      new Promise<StagingStatus>((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+
+    await act(async () => {
+      capturedUpdateCallback!(makeWorktreeState());
+      await Promise.resolve();
+    });
+
+    const scroll = findScrollContainer();
+    expect(scroll.classList.contains("surface-stale")).toBe(true);
+    expect(scroll.getAttribute("aria-busy")).toBe("true");
+
+    await act(async () => {
+      resolveRefresh(makeStatus());
+      await Promise.resolve();
+    });
+  });
+
+  it("clears surface-stale and aria-busy after the background refresh resolves", async () => {
+    render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    await waitFor(() => screen.getByText("index.ts"));
+
+    let resolveRefresh!: (value: StagingStatus) => void;
+    getStagingStatusMock.mockReturnValue(
+      new Promise<StagingStatus>((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+
+    await act(async () => {
+      capturedUpdateCallback!(makeWorktreeState());
+      await Promise.resolve();
+    });
+
+    expect(findScrollContainer().classList.contains("surface-stale")).toBe(true);
+
+    await act(async () => {
+      resolveRefresh(makeStatus());
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      const scroll = findScrollContainer();
+      expect(scroll.classList.contains("surface-stale")).toBe(false);
+      expect(scroll.getAttribute("aria-busy")).toBeNull();
+    });
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1095,13 +1095,17 @@ body,
   will-change: opacity;
 }
 
-/* Stale-dim for palette listboxes during a deferred filter pass.
- * Driven by `useSearchablePalette`'s `isStale` flag (query !== deferredQuery).
- * The 400ms transition-delay matches the Doherty anti-flicker gate: if the
- * deferred render resolves in under one frame (typical for ~258 actions on
- * fast hardware), the dim never starts. On a genuinely overloaded render the
- * listbox fades to half opacity as a "still filtering" cue. */
-.palette-results-stale {
+/* Stale-dim for surfaces during a deferred refresh or filter pass.
+ * `palette-results-stale` is the original palette-listbox callsite (driven by
+ * `useSearchablePalette`'s `isStale` flag); `surface-stale` is the generic
+ * alias used by larger surfaces (e.g., the Review and Commit modal during a
+ * background `git status` refresh). The 400ms transition-delay matches the
+ * Doherty anti-flicker gate: if the deferred work resolves in under one frame
+ * (typical for ~258 actions on fast hardware), the dim never starts. On a
+ * genuinely overloaded render the surface fades to half opacity as a "still
+ * working" cue. */
+.palette-results-stale,
+.surface-stale {
   opacity: 0.5;
   transition: opacity 150ms ease-out 400ms;
 }
@@ -1431,9 +1435,10 @@ body,
   }
 
   /* The global `transition: none` rules below would strip the 400ms delay,
-   * letting any sub-frame stale flip flash the listbox to half opacity. Keep
-   * the listbox at full opacity instead. WCAG 2.3.3. */
-  .palette-results-stale {
+   * letting any sub-frame stale flip flash the surface to half opacity. Keep
+   * stale surfaces at full opacity instead. WCAG 2.3.3. */
+  .palette-results-stale,
+  .surface-stale {
     opacity: 1 !important;
     transition: none !important;
   }
@@ -1558,7 +1563,8 @@ body[data-reduce-animations="true"] .content-fade-in {
   opacity: 1;
 }
 
-body[data-reduce-animations="true"] .palette-results-stale {
+body[data-reduce-animations="true"] .palette-results-stale,
+body[data-reduce-animations="true"] .surface-stale {
   opacity: 1 !important;
   transition: none !important;
 }
@@ -2345,9 +2351,10 @@ body[data-performance-mode="true"] .animate-hint-fade-in {
 }
 
 /* The global wildcard above strips the 400ms transition-delay; without an
- * explicit opacity reset the listbox would stay at 0.5 if it was mid-stale
- * when performance mode kicked in. */
-body[data-performance-mode="true"] .palette-results-stale {
+ * explicit opacity reset stale surfaces would stay at 0.5 if they were
+ * mid-stale when performance mode kicked in. */
+body[data-performance-mode="true"] .palette-results-stale,
+body[data-performance-mode="true"] .surface-stale {
   opacity: 1 !important;
 }
 


### PR DESCRIPTION
## Summary

- Promotes `.palette-results-stale` to a shared `.surface-stale` utility (aliased at all four sites in `src/index.css`) so the pattern is reusable across surfaces
- Applies `.surface-stale` + `aria-busy` to the ReviewHub modal scroll container while `isBackgroundRefreshing` is true — the 400ms `transition-delay` on the class acts as a Doherty Threshold gate, so refreshes that complete under 400ms produce no visible change
- Adds `ReviewHub.stale.test.tsx` covering idle state, in-flight stale state, and rejection clearing the stale cue

Resolves #6542

## Changes

- `src/index.css` — `.palette-results-stale` now aliases `.surface-stale`; the base rule lives under `.surface-stale`
- `src/components/Worktree/ReviewHub/ReviewHub.tsx` — conditionally applies `.surface-stale` and `aria-busy` to the scroll container
- `src/components/Worktree/ReviewHub/__tests__/ReviewHub.stale.test.tsx` — 3 tests: idle, in-flight, and rejection clear

## Testing

Typecheck, lint, format, and build all pass clean. Unit tests pass. Manually confirmed that fast refreshes (under 400ms) produce no visual change and slow refreshes dim the list as expected.