### PR TITLE
fix(workspace): drop redundant rev-list, surface ahead/behind from git status

### DIFF
--- a/electron/schemas/external.ts
+++ b/electron/schemas/external.ts
@@ -67,6 +67,9 @@ export const WorktreeChangesSchema = z.object({
   deletions: z.number().int().nonnegative().optional(),
   latestFileMtime: z.number().nonnegative().optional(),
   lastUpdated: z.number().nonnegative().optional(),
+  ahead: z.number().int().nonnegative().optional(),
+  behind: z.number().int().nonnegative().optional(),
+  tracking: z.string().nullable().optional(),
 });
 
 export const GitWorktreeEntrySchema = z.object({

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -170,6 +170,91 @@ describe("getWorktreeChangesWithStats --no-ext-diff", () => {
   });
 });
 
+describe("getWorktreeChangesWithStats upstream tracking normalization", () => {
+  const baseStatus = {
+    modified: [],
+    created: [],
+    deleted: [],
+    renamed: [],
+    staged: [],
+    conflicted: [],
+    not_added: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (fs.access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    mockGit.revparse.mockResolvedValue("/test/path\n");
+    mockGit.raw.mockResolvedValue("100\t0\tsome msg");
+    mockGit.diff.mockResolvedValue("");
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000 });
+  });
+
+  it("preserves zero ahead/behind when tracking is configured (in-sync branch)", async () => {
+    mockGit.status.mockResolvedValue({
+      ...baseStatus,
+      tracking: "origin/main",
+      ahead: 0,
+      behind: 0,
+    });
+
+    const cwd = "/upstream-test/" + Math.random();
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.tracking).toBe("origin/main");
+    expect(result.ahead).toBe(0);
+    expect(result.behind).toBe(0);
+  });
+
+  it("surfaces non-zero ahead/behind from a tracked branch", async () => {
+    mockGit.status.mockResolvedValue({
+      ...baseStatus,
+      tracking: "origin/feature",
+      ahead: 3,
+      behind: 1,
+    });
+
+    const cwd = "/upstream-test/" + Math.random();
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.tracking).toBe("origin/feature");
+    expect(result.ahead).toBe(3);
+    expect(result.behind).toBe(1);
+  });
+
+  it("normalizes null tracking to undefined ahead/behind", async () => {
+    mockGit.status.mockResolvedValue({
+      ...baseStatus,
+      tracking: null,
+      ahead: 0,
+      behind: 0,
+    });
+
+    const cwd = "/upstream-test/" + Math.random();
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.tracking).toBeNull();
+    expect(result.ahead).toBeUndefined();
+    expect(result.behind).toBeUndefined();
+  });
+
+  it("normalizes empty-string tracking to null + undefined counts", async () => {
+    mockGit.status.mockResolvedValue({
+      ...baseStatus,
+      tracking: "",
+      ahead: 0,
+      behind: 0,
+    });
+
+    const cwd = "/upstream-test/" + Math.random();
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.tracking).toBeNull();
+    expect(result.ahead).toBeUndefined();
+    expect(result.behind).toBeUndefined();
+  });
+});
+
 describe("getWorktreeChangesWithStats in-flight deduplication", () => {
   const emptyStatus = {
     modified: [],

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -117,7 +117,7 @@ describe("GitFileWatcher", () => {
     expect(dotGitCallback).toBeDefined();
 
     // Unrelated file in .git directory should not trigger
-    dotGitCallback?.("rename", "config");
+    dotGitCallback?.("rename", "description");
     await vi.advanceTimersByTimeAsync(250);
     expect(onChange).not.toHaveBeenCalled();
 
@@ -133,6 +133,31 @@ describe("GitFileWatcher", () => {
     dotGitCallback?.("rename", "packed-refs");
     await vi.advanceTimersByTimeAsync(200);
     expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("triggers onChange when .git/config changes (catches `git push -u`)", async () => {
+    const gitDir = pathJoin("/repo", ".git");
+    const onChange = vi.fn();
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 150,
+      onChange,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
+      | [unknown, unknown, unknown]
+      | undefined;
+    expect(dotGitCall).toBeDefined();
+    const dotGitCallback = dotGitCall?.[2] as
+      | ((eventType: string, filename: string | Buffer | null) => void)
+      | undefined;
+
+    dotGitCallback?.("rename", "config");
+    await vi.advanceTimersByTimeAsync(150);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it("detects commits via reflog changes", async () => {

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -442,6 +442,7 @@ export async function getWorktreeChangesWithStats(
       const totalDeletions = changes.reduce((sum, change) => sum + (change.deletions ?? 0), 0);
       const latestFileMtime = mtimes.length > 0 ? Math.max(...mtimes) : 0;
 
+      const tracking = status.tracking && status.tracking.length > 0 ? status.tracking : null;
       const result: WorktreeChanges = {
         worktreeId: realpathSync(cwd),
         rootPath: gitRoot,
@@ -455,6 +456,9 @@ export async function getWorktreeChangesWithStats(
         lastUpdated: Date.now(),
         lastCommitMessage,
         lastCommitTimestampMs,
+        ahead: tracking ? status.ahead : undefined,
+        behind: tracking ? status.behind : undefined,
+        tracking,
       };
 
       GIT_WORKTREE_CHANGES_CACHE.set(cwd, result, cacheTTL);

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -88,6 +88,10 @@ export class GitFileWatcher {
       this.watchFile(headPath);
       this.watchFile(pathJoin(commonDir, "packed-refs"));
       this.watchFile(pathJoin(commonDir, "logs", "HEAD"));
+      // Watch .git/config so `git push -u` / `git branch --set-upstream-to`
+      // triggers a poll deterministically — without this the new tracking
+      // info from `git status` only surfaces on the next timed poll.
+      this.watchFile(pathJoin(commonDir, "config"));
 
       // For linked worktrees, the per-worktree reflog lives under gitDir, not commonDir.
       // Watch it so branch changes in linked worktrees trigger the onChange callback.

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -21,12 +21,9 @@ import { ensureSerializable } from "../../shared/utils/serialization.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitFileWatcher } from "../utils/gitFileWatcher.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
-import { Cache } from "../utils/cache.js";
 
 const GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS = 1000;
 const WATCHER_FALLBACK_POLL_INTERVAL_MS = 30_000;
-const NO_UPSTREAM_CACHE_TTL_MS = 5 * 60 * 1000;
-const UPSTREAM_NOT_FOUND_CACHE_TTL_MS = 2 * 60 * 1000;
 const WATCHER_RETRY_INTERVAL_MS = 30_000;
 const WATCHER_MAX_RETRIES = 5;
 const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 150;
@@ -88,7 +85,6 @@ export class WorktreeMonitor {
   // Upstream tracking state
   private aheadCount: number | undefined;
   private behindCount: number | undefined;
-  private upstreamFailureCache = new Cache<string, string>();
 
   // Issue/PR state
   private _issueNumber: number | undefined;
@@ -248,9 +244,6 @@ export class WorktreeMonitor {
   }
 
   set branch(value: string | undefined) {
-    if (value !== this._branch && this._branch) {
-      this.upstreamFailureCache.invalidate(`${this.path}:${this._branch}`);
-    }
     this._branch = value;
   }
 
@@ -1071,11 +1064,7 @@ export class WorktreeMonitor {
       const currentBranch = await this.readCurrentBranch();
       const branchChanged = currentBranch !== undefined && currentBranch !== this._branch;
       if (branchChanged) {
-        const oldCacheKey = this._branch ? `${this.path}:${this._branch}` : undefined;
         this._branch = currentBranch;
-        const newCacheKey = `${this.path}:${this._branch}`;
-        if (oldCacheKey) this.upstreamFailureCache.invalidate(oldCacheKey);
-        this.upstreamFailureCache.invalidate(newCacheKey);
         const hadPendingRefresh = this.gitWatchRefreshPending;
         this.updateWatcher();
         if (hadPendingRefresh) {
@@ -1094,7 +1083,9 @@ export class WorktreeMonitor {
 
       const noteData = await this.noteReader.read();
 
-      const upstreamCounts = await this.fetchUpstreamCounts(forceRefresh);
+      const hasUpstream = !!newChanges.tracking;
+      const nextAheadCount = hasUpstream ? (newChanges.ahead ?? 0) : undefined;
+      const nextBehindCount = hasUpstream ? (newChanges.behind ?? 0) : undefined;
 
       const detectedPlanFile = PLAN_FILE_CANDIDATES.find((candidate) =>
         existsSync(pathJoin(this.path, candidate))
@@ -1109,7 +1100,7 @@ export class WorktreeMonitor {
       const planChanged =
         nextHasPlanFile !== this.hasPlanFile || nextPlanFilePath !== this.planFilePath;
       const upstreamChanged =
-        upstreamCounts.ahead !== this.aheadCount || upstreamCounts.behind !== this.behindCount;
+        nextAheadCount !== this.aheadCount || nextBehindCount !== this.behindCount;
 
       if (
         !stateChanged &&
@@ -1170,8 +1161,8 @@ export class WorktreeMonitor {
       this.aiNoteTimestamp = noteData?.timestamp;
       this.hasPlanFile = nextHasPlanFile;
       this.planFilePath = nextPlanFilePath;
-      this.aheadCount = upstreamCounts.ahead;
-      this.behindCount = upstreamCounts.behind;
+      this.aheadCount = nextAheadCount;
+      this.behindCount = nextBehindCount;
       this._hasInitialStatus = true;
 
       this.emitUpdate();
@@ -1235,62 +1226,6 @@ export class WorktreeMonitor {
     } catch {
       // Silently ignore extraction errors
     }
-  }
-
-  private async fetchUpstreamCounts(force: boolean = false): Promise<{
-    ahead: number | undefined;
-    behind: number | undefined;
-  }> {
-    if (!this._branch) {
-      return { ahead: undefined, behind: undefined };
-    }
-
-    const cacheKey = `${this.path}:${this._branch}`;
-    if (!force && this.upstreamFailureCache.get(cacheKey)) {
-      return { ahead: undefined, behind: undefined };
-    }
-
-    try {
-      const wsl = this.wslInvocation;
-      const git = wsl
-        ? createWslHardenedGit(wsl, this._pollAbortController.signal)
-        : createHardenedGit(this.path, this._pollAbortController.signal);
-      const output = await git.raw(["rev-list", "--left-right", "--count", "HEAD...@{u}"]);
-      const [aheadStr, behindStr] = output.trim().split(/\s+/);
-
-      this.upstreamFailureCache.invalidate(cacheKey);
-
-      return {
-        ahead: parseInt(aheadStr, 10) || 0,
-        behind: parseInt(behindStr, 10) || 0,
-      };
-    } catch (error) {
-      const classification = this.classifyUpstreamError(error);
-      if (classification) {
-        const ttl =
-          classification === "no-upstream"
-            ? NO_UPSTREAM_CACHE_TTL_MS
-            : UPSTREAM_NOT_FOUND_CACHE_TTL_MS;
-        this.upstreamFailureCache.set(cacheKey, classification, ttl);
-      }
-      return { ahead: undefined, behind: undefined };
-    }
-  }
-
-  private classifyUpstreamError(error: unknown): string | undefined {
-    if (!(error instanceof Error)) return undefined;
-    const msg = error.message;
-    if (
-      msg.includes("no upstream configured") ||
-      msg.includes("bad revision '@{u}'") ||
-      msg.includes("ambiguous argument '@{u}'")
-    ) {
-      return "no-upstream";
-    }
-    if (msg.includes("upstream branch") && msg.includes("not found")) {
-      return "upstream-not-found";
-    }
-    return undefined;
   }
 
   private calculateStateHash(changes: WorktreeChanges): string {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -307,17 +307,23 @@ describe("WorktreeMonitor", () => {
   });
 
   describe("ahead/behind upstream tracking", () => {
-    const CLEAN_CHANGES = {
+    const cleanChangesWith = (overrides: {
+      ahead?: number;
+      behind?: number;
+      tracking?: string | null;
+    }) => ({
       worktreeId: "/test/worktree",
       rootPath: "/test",
       changes: [],
       changedFileCount: 0,
       lastUpdated: Date.now(),
-    };
+      ...overrides,
+    });
 
     it("includes aheadCount and behindCount in snapshot when upstream is configured", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockResolvedValue("3\t1\n");
+      mockGetWorktreeChangesWithStats.mockResolvedValue(
+        cleanChangesWith({ tracking: "origin/main", ahead: 3, behind: 1 })
+      );
 
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
@@ -331,10 +337,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("leaves counts undefined when no upstream is configured", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error("fatal: no upstream configured for branch 'test-branch'")
-      );
+      mockGetWorktreeChangesWithStats.mockResolvedValue(cleanChangesWith({ tracking: null }));
 
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
@@ -347,30 +350,25 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("leaves counts undefined on detached HEAD (no branch)", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockResolvedValue("0\t0\n");
-
-      const detachedWorktree: Worktree = {
-        ...TEST_WORKTREE,
-        branch: undefined,
-      };
+    it("never spawns rev-list — counts come from the existing git status call", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(
+        cleanChangesWith({ tracking: "origin/main", ahead: 2, behind: 0 })
+      );
 
       const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(detachedWorktree, TEST_CONFIG, callbacks, "main");
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
       await monitor.start();
+      await monitor.updateGitStatus(false);
 
-      const snapshot = monitor.getSnapshot();
-      expect(snapshot.aheadCount).toBeUndefined();
-      expect(snapshot.behindCount).toBeUndefined();
       expect(mockGitRaw).not.toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
 
       monitor.stop();
     });
 
     it("reports zero counts when branch is in sync with upstream", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockResolvedValue("0\t0\n");
+      mockGetWorktreeChangesWithStats.mockResolvedValue(
+        cleanChangesWith({ tracking: "origin/main", ahead: 0, behind: 0 })
+      );
 
       const callbacks = makeCallbacks();
       const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
@@ -383,213 +381,9 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("caches 'no upstream' verdict and skips repeat git spawns", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error("fatal: no upstream configured for branch 'test-branch'")
-      );
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      expect(mockGitRaw).toHaveBeenCalledTimes(1);
-      expect(mockGitRaw).toHaveBeenCalledWith(expect.arrayContaining(["rev-list"]));
-
-      const snapshot1 = monitor.getSnapshot();
-      expect(snapshot1.aheadCount).toBeUndefined();
-      expect(snapshot1.behindCount).toBeUndefined();
-
-      // Second poll without forceRefresh — should hit the cache, no new git spawn
-      await monitor.updateGitStatus(false);
-
-      expect(mockGitRaw).toHaveBeenCalledTimes(1);
-
-      const snapshot2 = monitor.getSnapshot();
-      expect(snapshot2.aheadCount).toBeUndefined();
-      expect(snapshot2.behindCount).toBeUndefined();
-
-      monitor.stop();
-    });
-
-    it("retries rev-list after 'no upstream' cache TTL expires", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error("fatal: no upstream configured for branch 'test-branch'")
-      );
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      const callsAfterStart = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterStart).toBe(1);
-
-      // Pause polling so scheduled polls don't interfere with time advance
-      monitor.pausePolling();
-
-      // Advance just under TTL — cache still valid
-      await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
-      await monitor.updateGitStatus(false);
-      const callsWithinTTL = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsWithinTTL).toBe(1);
-
-      // Advance past TTL — cache expired
-      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
-      await monitor.updateGitStatus(false);
-      const callsAfterTTL = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterTTL).toBe(2);
-
-      monitor.stop();
-    });
-
-    it("uses shorter TTL for 'upstream branch not found'", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error("fatal: upstream branch 'origin/test-branch' not found")
-      );
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      const callsAfterStart = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterStart).toBe(1);
-
-      monitor.pausePolling();
-
-      // Within short TTL — cached
-      await vi.advanceTimersByTimeAsync(60 * 1000);
-      await monitor.updateGitStatus(false);
-      const callsWithinShortTTL = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsWithinShortTTL).toBe(1);
-
-      // Past 2-min TTL — retries
-      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
-      await monitor.updateGitStatus(false);
-      const callsAfterTTL = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterTTL).toBe(2);
-
-      monitor.stop();
-    });
-
-    it("invalidates failure cache when upstream becomes available", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-
-      // First call: no upstream
-      mockGitRaw.mockRejectedValueOnce(
-        new Error("fatal: no upstream configured for branch 'test-branch'")
-      );
-      // Second call (after TTL): upstream is now configured
-      mockGitRaw.mockResolvedValueOnce("2\t1\n");
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      const revListCallsAfterStart = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(revListCallsAfterStart).toBe(1);
-      expect(monitor.getSnapshot().aheadCount).toBeUndefined();
-
-      // Pause polling so scheduled polls don't fire during time advance
-      monitor.pausePolling();
-      await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-
-      // Cache expired — refresh should call git and succeed
-      await monitor.refresh();
-
-      const revListCallsAfterRefresh = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(revListCallsAfterRefresh).toBe(2);
-      expect(monitor.getSnapshot().aheadCount).toBe(2);
-      expect(monitor.getSnapshot().behindCount).toBe(1);
-
-      // Success should have invalidated cache — next call also hits git
-      mockGitRaw.mockResolvedValueOnce("3\t2\n");
-      await monitor.refresh();
-
-      const revListCallsFinal = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(revListCallsFinal).toBe(3);
-      expect(monitor.getSnapshot().aheadCount).toBe(3);
-
-      monitor.stop();
-    });
-
-    it("does not cache unclassified git failures", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(new Error("fatal: ambiguous argument 'HEAD'"));
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      expect(mockGitRaw).toHaveBeenCalledTimes(1);
-
-      await monitor.refresh();
-      // Unclassified errors should retry every poll
-      expect(mockGitRaw).toHaveBeenCalledTimes(2);
-
-      monitor.stop();
-    });
-
-    it("force-refresh bypasses the negative cache", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error("fatal: no upstream configured for branch 'test-branch'")
-      );
-
-      const callbacks = makeCallbacks();
-      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
-      await monitor.start();
-
-      // Cache should be populated — first call from start
-      const callsAfterStart = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterStart).toBe(1);
-
-      monitor.pausePolling();
-
-      // Non-force call within TTL — cache hit
-      await monitor.updateGitStatus(false);
-      const callsAfterNonForce = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterNonForce).toBe(1);
-
-      // Force-refresh bypasses cache
-      await monitor.refresh();
-      const callsAfterForce = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(callsAfterForce).toBe(2);
-
-      monitor.stop();
-    });
-
-    it("classifies ambiguous argument @{u} as no-upstream", async () => {
-      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
-      mockGitRaw.mockRejectedValue(
-        new Error(
-          "fatal: ambiguous argument '@{u}': unknown revision or path not in the working tree."
-        )
+    it("treats empty-string tracking as no upstream", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(
+        cleanChangesWith({ tracking: "", ahead: 0, behind: 0 })
       );
 
       const callbacks = makeCallbacks();
@@ -599,14 +393,6 @@ describe("WorktreeMonitor", () => {
       const snapshot = monitor.getSnapshot();
       expect(snapshot.aheadCount).toBeUndefined();
       expect(snapshot.behindCount).toBeUndefined();
-
-      // Should be cached, so second call doesn't spawn git
-      monitor.pausePolling();
-      await monitor.updateGitStatus(false);
-      const revListCalls = mockGitRaw.mock.calls.filter(
-        (c: unknown[]) => Array.isArray(c[0]) && (c[0] as string[]).includes("rev-list")
-      ).length;
-      expect(revListCalls).toBe(1);
 
       monitor.stop();
     });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -381,6 +381,26 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("clears stale counts when upstream is removed between polls", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValueOnce(
+        cleanChangesWith({ tracking: "origin/main", ahead: 2, behind: 1 })
+      );
+      mockGetWorktreeChangesWithStats.mockResolvedValueOnce(cleanChangesWith({ tracking: null }));
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+      expect(monitor.getSnapshot().aheadCount).toBe(2);
+      expect(monitor.getSnapshot().behindCount).toBe(1);
+
+      await monitor.refresh();
+
+      expect(monitor.getSnapshot().aheadCount).toBeUndefined();
+      expect(monitor.getSnapshot().behindCount).toBeUndefined();
+
+      monitor.stop();
+    });
+
     it("treats empty-string tracking as no upstream", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(
         cleanChangesWith({ tracking: "", ahead: 0, behind: 0 })

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -51,6 +51,12 @@ export interface WorktreeChanges {
   lastCommitMessage?: string;
   /** Last commit time (ms since epoch, committer date) */
   lastCommitTimestampMs?: number;
+  /** Commits ahead of upstream from `git status --porcelain -b` (undefined when no upstream). */
+  ahead?: number;
+  /** Commits behind upstream from `git status --porcelain -b` (undefined when no upstream). */
+  behind?: number;
+  /** Upstream branch name (e.g. "origin/main"); `null` when no upstream is configured. */
+  tracking?: string | null;
 }
 
 export interface StagingFileEntry {


### PR DESCRIPTION
## Summary

- Every worktree poll was running a separate `git rev-list --left-right --count HEAD...@{u}` subprocess, even though the `git status` call a few milliseconds earlier already returned ahead/behind counts — they were just being discarded. This threads those values through `WorktreeChanges` instead.
- Adds `.git/config` to `GitFileWatcher` so `git push -u` / `git branch --set-upstream-to` triggers a poll immediately, rather than waiting up to 5 minutes for the old TTL cache to expire.
- Removes `fetchUpstreamCounts`, `classifyUpstreamError`, the `upstreamFailureCache`, and the `NO_UPSTREAM_CACHE_TTL_MS` / `UPSTREAM_NOT_FOUND_CACHE_TTL_MS` constants entirely.

Resolves #6504

## Changes

- `electron/workspace-host/WorktreeMonitor.ts` — delete `fetchUpstreamCounts` and all failure-cache machinery; read `ahead`/`behind`/`tracking` from `StatusResult` directly
- `electron/utils/git.ts` — surface `ahead`, `behind`, `tracking` from `getWorktreeChangesWithStats`
- `electron/utils/gitFileWatcher.ts` — watch `.git/config` in addition to existing paths
- `electron/schemas/external.ts` — add optional `ahead`, `behind`, `tracking` fields to `WorktreeChanges` Zod schema
- `shared/types/git.ts` — thread the same optional fields through the `WorktreeChanges` type; `tracking === null` is the "no upstream" sentinel
- Tests updated: normalization unit tests in `git.test.ts`, watcher test in `gitFileWatcher.test.ts`, upstream-tracking transition tests in `WorktreeMonitor.test.ts`

## Testing

- 114 targeted vitest tests pass
- Full `npm run check` (typecheck + lint + format + build) clean
- Lint warnings down by 8 (deleted dead code paths)
- Net: −309 / +177 lines