### PR TITLE
feat(pr): focus-aware PullRequestService cadence

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -324,6 +324,15 @@ class PullRequestService {
       return;
     }
 
+    // Defensive clear: setFocusCadence and updatePollInterval can interleave
+    // such that a `pollTimer` is already armed when the catch-up's `.finally`
+    // re-enters this method. Without this clear we'd orphan the prior timer
+    // and double the polling rate until `stop()`.
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+
     if (!this.isEnabled) {
       const delay = this.nextRetryAt - Date.now();
       if (delay > 0) {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -10,7 +10,14 @@ import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
-const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
+// Focus-aware polling cadence: faster when any Daintree window is focused so
+// users see PR transitions promptly, slower when fully blurred to conserve the
+// GitHub API quota during background sessions.
+const FOCUSED_POLL_INTERVAL_MS = 30 * 1000;
+const BLURRED_POLL_INTERVAL_MS = 2 * 60 * 1000;
+// Minimum gap between blur→focus catch-up polls. Matches SWR's 5s
+// `focusThrottleInterval` convention so rapid alt-tabbing doesn't burst the API.
+const FOCUS_CATCHUP_THROTTLE_MS = 5 * 1000;
 
 const ERROR_BACKOFF_INTERVALS = [1 * 60 * 1000, 2 * 60 * 1000, 5 * 60 * 1000];
 
@@ -46,11 +53,12 @@ function isCandidateBranch(branchName: string | undefined): boolean {
 class PullRequestService {
   private pollTimer: NodeJS.Timeout | null = null;
   private revalidationTimer: NodeJS.Timeout | null = null;
-  private pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS;
+  private pollIntervalMs: number = FOCUSED_POLL_INTERVAL_MS;
   private cwd: string = "";
   private isPolling: boolean = false;
   private consecutiveErrors: number = 0;
   private nextRetryAt: number = 0;
+  private lastFocusCatchupAt: number = Number.NEGATIVE_INFINITY;
 
   get isEnabled(): boolean {
     return this.nextRetryAt === 0 || Date.now() >= this.nextRetryAt;
@@ -177,15 +185,7 @@ class PullRequestService {
     }
 
     if (intervalMs) {
-      if (intervalMs < DEFAULT_POLL_INTERVAL_MS) {
-        logWarn("PR polling interval too short - clamping to minimum 60s", {
-          requested: intervalMs,
-          clamped: DEFAULT_POLL_INTERVAL_MS,
-        });
-        this.pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
-      } else {
-        this.pollIntervalMs = intervalMs;
-      }
+      this.pollIntervalMs = intervalMs;
     }
 
     this.isPolling = true;
@@ -242,6 +242,73 @@ class PullRequestService {
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
+    this.lastFocusCatchupAt = Number.NEGATIVE_INFINITY;
+  }
+
+  /**
+   * Switch poll cadence based on global window-focus state. Focused = ~30s
+   * (snappy enough that PR transitions surface promptly), blurred = ~120s
+   * (conserves GitHub API quota during long background sessions). Called
+   * from main via the workspace-host IPC pipe; powerMonitor.ts is the focus
+   * aggregator and idempotency guard, so this method is only invoked on a
+   * real focus-state transition.
+   *
+   * On focus regain, also fires an immediate catch-up poll throttled to
+   * FOCUS_CATCHUP_THROTTLE_MS (5s) — protects against rapid alt-tabbing
+   * causing API bursts. The throttle is co-located with the rate-limited
+   * resource (this service) rather than the IPC layer to avoid a second
+   * round-trip just to decide whether to skip.
+   */
+  public setFocusCadence(focused: boolean): void {
+    const targetInterval = focused ? FOCUSED_POLL_INTERVAL_MS : BLURRED_POLL_INTERVAL_MS;
+    this.updatePollInterval(targetInterval);
+
+    if (!focused || !this.isPolling) {
+      return;
+    }
+
+    const now = Date.now();
+    if (now - this.lastFocusCatchupAt < FOCUS_CATCHUP_THROTTLE_MS) {
+      logDebug("Skipping PR focus catch-up — within throttle window", {
+        sinceLastMs: now - this.lastFocusCatchupAt,
+      });
+      return;
+    }
+
+    if (!this.hasUnresolvedCandidates() || !this.isEnabled) {
+      return;
+    }
+
+    this.lastFocusCatchupAt = now;
+
+    // Cancel the scheduled poll and run an immediate check; the .finally
+    // re-arms the timer at the new (focused) cadence. Avoids waiting up to
+    // 30s after focus regain for the next normal tick.
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    void this.checkForPRs()
+      .catch((err) => this.handleError(formatErrorMessage(err, "PR focus catch-up failed")))
+      .finally(() => this.scheduleNextPoll());
+  }
+
+  private updatePollInterval(ms: number): void {
+    if (this.pollIntervalMs === ms) {
+      return;
+    }
+    this.pollIntervalMs = ms;
+    logDebug("PR poll cadence updated", { intervalMs: ms });
+
+    if (!this.isPolling) {
+      return;
+    }
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    this.scheduleNextPoll();
   }
 
   public destroy(): void {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -899,6 +899,12 @@ export class WorkspaceClient extends EventEmitter {
     }
   }
 
+  setPRPollCadence(focused: boolean): void {
+    for (const entry of this.entries.values()) {
+      entry.host.send({ type: "set-pr-poll-cadence", focused });
+    }
+  }
+
   /**
    * Forward a per-worktree WSL git opt-in / dismissed change to every host.
    * Each host filters by worktree id internally — broadcasting is cheaper

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -701,6 +701,58 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("does not leak a duplicate timer when blur arrives mid-catchup", async () => {
+    // Regression: blur during in-flight focus catch-up used to orphan the
+    // background-cadence timer set by updatePollInterval(120s) when the
+    // catch-up's .finally re-entered scheduleNextPoll without first clearing
+    // the existing pollTimer.
+    let resolveCheck: (() => void) | null = null;
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      // Hold the catch-up promise open so blur can interleave.
+      if (callCount === 2) {
+        await new Promise<void>((resolve) => {
+          resolveCheck = resolve;
+        });
+      }
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/leak" })
+    );
+
+    await pullRequestService.start();
+    expect(callCount).toBe(1);
+
+    // Focus regain — fires catch-up that hangs awaiting `resolveCheck`.
+    pullRequestService.setFocusCadence(true);
+    await Promise.resolve();
+    expect(callCount).toBe(2);
+
+    // Blur arrives mid-catchup — sets the 120s timer.
+    pullRequestService.setFocusCadence(false);
+
+    // Resolve the in-flight catch-up; .finally calls scheduleNextPoll again.
+    resolveCheck!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Advance one full blurred cycle. With the leak, two timers would fire
+    // → callCount becomes 4. Fixed: exactly one timer fires → callCount = 3.
+    await vi.advanceTimersByTimeAsync(120 * 1000);
+    expect(callCount).toBe(3);
+
+    pullRequestService.destroy();
+  });
+
   it("polls at 30s by default after start() with no interval argument", async () => {
     let callCount = 0;
     const batchCheckLinkedPRs = vi.fn(async () => {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -313,12 +313,12 @@ describe("PullRequestService", () => {
     await pullRequestService.start();
     expect(callCount).toBe(1);
 
-    // Advance past normal poll interval — checkForPRs will throw
-    await vi.advanceTimersByTimeAsync(60 * 1000);
+    // Advance past normal poll interval (30s focused default) — checkForPRs throws
+    await vi.advanceTimersByTimeAsync(30 * 1000);
     expect(callCount).toBe(2);
 
     // The poll loop should have rescheduled despite the throw.
-    // Advance past the backoff interval (1 min for 1 error) to trigger next poll.
+    // Advance past the 1-error backoff (1 min) to trigger next poll.
     await vi.advanceTimersByTimeAsync(60 * 1000);
     expect(callCount).toBe(3);
 
@@ -557,6 +557,175 @@ describe("PullRequestService", () => {
     expect(detected[0]).toMatchObject({ worktreeId: "wt-linked", prNumber: 55 });
 
     unsubDetected();
+    pullRequestService.destroy();
+  });
+
+  it("setFocusCadence(false) lengthens the next poll to the blurred interval", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/cadence" })
+    );
+
+    await pullRequestService.start();
+    expect(callCount).toBe(1);
+
+    pullRequestService.setFocusCadence(false);
+
+    // 30s elapsed should NOT trigger a poll under the 120s blurred cadence
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(callCount).toBe(1);
+
+    // 120s total elapsed should trigger the next poll
+    await vi.advanceTimersByTimeAsync(90 * 1000);
+    expect(callCount).toBe(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("setFocusCadence(true) fires an immediate catch-up poll on focus regain", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/catchup" })
+    );
+
+    await pullRequestService.start();
+    expect(callCount).toBe(1);
+
+    // Blur, then focus — should immediately catch up
+    pullRequestService.setFocusCadence(false);
+    await vi.advanceTimersByTimeAsync(10 * 1000);
+    expect(callCount).toBe(1);
+
+    pullRequestService.setFocusCadence(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("throttles repeated focus catch-ups within 5s", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/throttle" })
+    );
+
+    await pullRequestService.start();
+    expect(callCount).toBe(1);
+
+    // First focus → catch-up fires
+    pullRequestService.setFocusCadence(false);
+    pullRequestService.setFocusCadence(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(2);
+
+    // Second blur→focus within 5s → no extra poll
+    await vi.advanceTimersByTimeAsync(2 * 1000);
+    pullRequestService.setFocusCadence(false);
+    pullRequestService.setFocusCadence(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(2);
+
+    // After 5s+ has elapsed since the last catch-up, focus regain fires again
+    await vi.advanceTimersByTimeAsync(4 * 1000);
+    pullRequestService.setFocusCadence(false);
+    pullRequestService.setFocusCadence(true);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callCount).toBe(3);
+
+    pullRequestService.destroy();
+  });
+
+  it("setFocusCadence is a no-op while not polling but still updates the stored interval", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/idle" })
+    );
+
+    pullRequestService.setFocusCadence(false);
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    await pullRequestService.start();
+    // start() preserves the blurred cadence set while idle
+    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(90 * 1000);
+    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("polls at 30s by default after start() with no interval argument", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/default" })
+    );
+
+    await pullRequestService.start();
+    expect(callCount).toBe(1);
+
+    // Under the old 60s clamp this would have required 60s
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(callCount).toBe(2);
+
     pullRequestService.destroy();
   });
 

--- a/electron/window/__tests__/windowFocusThrottle.test.ts
+++ b/electron/window/__tests__/windowFocusThrottle.test.ts
@@ -44,6 +44,7 @@ function createMockDeps() {
     updateMonitorConfig: vi.fn(),
     refresh: vi.fn().mockResolvedValue(undefined),
     setPollingEnabled: vi.fn(),
+    setPRPollCadence: vi.fn(),
   } as unknown as WorkspaceClient;
 
   const statsService = {
@@ -126,6 +127,7 @@ describe("WindowFocusThrottle", () => {
       pollIntervalBackground: 50_000,
     });
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
+    expect(workspaceClient.setPRPollCadence).toHaveBeenCalledWith(false);
     expect(statsService.updatePollInterval).toHaveBeenCalledWith(25_000);
     expect(
       vi.mocked(ptyClient as unknown as { setProcessTreePollInterval: () => void })
@@ -178,6 +180,7 @@ describe("WindowFocusThrottle", () => {
     // Reset mocks to verify unthrottle calls
     vi.mocked(workspaceClient.updateMonitorConfig).mockClear();
     vi.mocked(workspaceClient.setPollingEnabled).mockClear();
+    vi.mocked(workspaceClient.setPRPollCadence).mockClear();
     vi.mocked(statsService.updatePollInterval).mockClear();
 
     // Then unthrottle
@@ -188,6 +191,7 @@ describe("WindowFocusThrottle", () => {
       pollIntervalBackground: 10_000,
     });
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
+    expect(workspaceClient.setPRPollCadence).toHaveBeenCalledWith(true);
     expect(workspaceClient.refresh).toHaveBeenCalled();
 
     // setPollingEnabled(true) must run before refresh() so the host is

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -148,6 +148,7 @@ function applyThrottle(): void {
       pollIntervalBackground: WORKSPACE_BACKGROUND_NORMAL * THROTTLE_MULTIPLIER,
     });
     workspaceClient.setPollingEnabled(false);
+    workspaceClient.setPRPollCadence(false);
   }
 
   const statsService = focusThrottleDeps.getProjectStatsService();
@@ -172,6 +173,7 @@ function removeThrottle(): void {
       pollIntervalBackground: WORKSPACE_BACKGROUND_NORMAL,
     });
     workspaceClient.setPollingEnabled(true);
+    workspaceClient.setPRPollCadence(true);
     void workspaceClient.refresh();
   }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -426,6 +426,13 @@ port.on("message", async (rawMsg: any) => {
         workspaceService.setPollingEnabled(request.enabled);
         break;
 
+      case "set-pr-poll-cadence":
+        {
+          const { pullRequestService } = await import("./services/PullRequestService.js");
+          pullRequestService.setFocusCadence(request.focused);
+        }
+        break;
+
       case "background":
         workspaceService.pause();
         break;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -240,6 +240,8 @@ export type WorkspaceHostRequest =
     }
   // Polling control
   | { type: "set-polling-enabled"; enabled: boolean }
+  // PR polling cadence control (window-focus aware)
+  | { type: "set-pr-poll-cadence"; focused: boolean }
   // WSL-routed git opt-in / banner dismissal (Windows only)
   | {
       type: "set-wsl-opt-in";


### PR DESCRIPTION
## Summary

- Gives `PullRequestService` two polling cadences based on window focus: 30s when focused, 120s when blurred
- On blur-to-focus transition, fires an immediate catch-up poll throttled to 5s so rapid alt-tabbing doesn't burst the GitHub API
- Removes the 60s floor clamp in `start()` that was blocking the faster focused cadence from taking effect

Resolves #6540

## Changes

- `shared/types/workspace-host.ts` — added `"set-pr-poll-cadence"` IPC variant
- `electron/services/PullRequestService.ts` — new `POLL_INTERVAL_FOCUSED`/`POLL_INTERVAL_BLURRED` constants, `setFocusCadence()`, `updatePollInterval()`, defensive clear in `scheduleNextPoll()` to prevent timer leak on re-entry
- `electron/services/WorkspaceClient.ts` — `setPRPollCadence()` broadcast method
- `electron/window/powerMonitor.ts` — wired into the existing `applyThrottle`/`removeThrottle` focus hub
- `electron/workspace-host.ts` — handles the `"set-pr-poll-cadence"` switch case
- `electron/services/__tests__/PullRequestService.test.ts` — 6 new tests, 1 updated for new 30s default
- `electron/window/__tests__/windowFocusThrottle.test.ts` — `setPRPollCadence` mock + assertions

## Testing

25 tests pass. Typecheck, lint, format, and build all clean. Multi-window focus aggregation covered by existing `powerMonitor` tests; catch-up throttle and timer leak guard covered by the new unit tests.