### PR TITLE
feat(github): use REST + ETag for branch-to-PR discovery

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1055,6 +1055,9 @@ async function probeBranchPRListChange(
         return "unknown";
       }
       if (!Array.isArray(body)) {
+        // Pathological 200 with a non-array body — drop the cached validator
+        // so the next cycle does not revalidate against an unparseable shape.
+        branchListETagCache.delete(cacheKey);
         return "unknown";
       }
       return body.length === 0 ? "unchanged" : "changed";
@@ -1138,32 +1141,49 @@ export async function batchCheckLinkedPRs(
     }
   }
 
-  // Discovery-path optimization: for each unresolved candidate (no
-  // knownPRNumber) with a branchName, run a conditional REST probe against
-  // the filtered pulls list. A 304 or empty 200 means "still no PR for this
-  // branch" — that candidate is dropped from the GraphQL batch entirely.
-  // 200-with-results and probe errors keep the candidate so GraphQL provides
-  // full enrichment (issue title, draft state, merge state, etc.).
+  // Discovery-path optimization: for each branch-only candidate (no
+  // knownPRNumber AND no issueNumber, branchName is the sole discovery
+  // signal), run a conditional REST probe against the filtered pulls list.
+  // A 304 or empty 200 means "still no PR for this branch" — that candidate
+  // is dropped from the GraphQL batch entirely. 200-with-results and probe
+  // errors keep the candidate so GraphQL provides full enrichment.
+  //
+  // Candidates with an issueNumber must always pass through to GraphQL: the
+  // PR may be linked via the issue's timeline (CrossReferencedEvent /
+  // ConnectedEvent) on a different head ref than the local branchName, in
+  // which case the branch-list filter would falsely report "no PR."
   let candidatesForGraphQL = candidates;
   if (token !== undefined && !allRevalidation) {
-    const probeable: Array<{ index: number; branchName: string }> = [];
+    const probeableIndicesByBranch = new Map<string, number[]>();
     for (let i = 0; i < candidates.length; i++) {
       const c = candidates[i];
       const branch = c.branchName?.trim();
-      if (typeof c.knownPRNumber !== "number" && branch) {
-        probeable.push({ index: i, branchName: branch });
+      if (
+        typeof c.knownPRNumber !== "number" &&
+        typeof c.issueNumber !== "number" &&
+        branch
+      ) {
+        const existing = probeableIndicesByBranch.get(branch);
+        if (existing) {
+          existing.push(i);
+        } else {
+          probeableIndicesByBranch.set(branch, [i]);
+        }
       }
     }
-    if (probeable.length > 0) {
+    if (probeableIndicesByBranch.size > 0) {
+      const uniqueBranches = Array.from(probeableIndicesByBranch.keys());
       const probeResults = await Promise.all(
-        probeable.map((p) =>
-          probeBranchPRListChange(context.owner, context.repo, p.branchName, token)
+        uniqueBranches.map((branch) =>
+          probeBranchPRListChange(context.owner, context.repo, branch, token)
         )
       );
       const skip = new Set<number>();
-      for (let i = 0; i < probeable.length; i++) {
+      for (let i = 0; i < uniqueBranches.length; i++) {
         if (probeResults[i] === "unchanged") {
-          skip.add(probeable[i].index);
+          for (const idx of probeableIndicesByBranch.get(uniqueBranches[i])!) {
+            skip.add(idx);
+          }
         }
       }
       if (skip.size === candidates.length) {

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -77,6 +77,11 @@ const prTooltipCache = new Cache<string, PRTooltipData>({ defaultTTL: 300000 });
 // Cleared on token rotation via clearGitHubCaches (ETags are token-scoped).
 const prETagCache = new Map<string, string>();
 
+// ETag cache for branch-to-PR list conditional probes used by the discovery
+// path. Key: `owner/repo@branchName`. Cleared atomically with `prETagCache`
+// in `clearGitHubCaches` because ETags are token-scoped.
+const branchListETagCache = new Map<string, string>();
+
 interface PRRequiredStatusEntry {
   ciStatus: GitHubPRCIStatus | undefined;
   ciSummary: GitHubPRCISummary | undefined;
@@ -988,6 +993,79 @@ async function probePRChange(
 }
 
 /**
+ * Conditional REST probe against `/repos/{owner}/{repo}/pulls?head=...&state=all`
+ * used by the discovery path to detect "still no PR for this branch" without
+ * paying the GraphQL cost. The `head` filter requires `{owner}:{branch}` —
+ * omitting the owner prefix silently bypasses the filter and returns the
+ * whole-repo list ETag. Returns:
+ *   - "unchanged" on 304, or 200 with an empty array (refreshes ETag)
+ *   - "changed"   on 200 with one or more PRs (refreshes ETag; caller falls
+ *     through to GraphQL for full enrichment)
+ *   - "unknown"   on any other outcome (network error, non-200/304 status,
+ *     malformed body) — caller treats as a cue to fall through to GraphQL
+ */
+async function probeBranchPRListChange(
+  owner: string,
+  repo: string,
+  branchName: string,
+  token: string
+): Promise<"changed" | "unchanged" | "unknown"> {
+  const cacheKey = `${owner}/${repo}@${branchName}`;
+  const cachedETag = branchListETagCache.get(cacheKey);
+  const headFilter = `${owner}:${encodeURIComponent(branchName)}`;
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls?head=${headFilter}&state=all`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (cachedETag) {
+    headers["If-None-Match"] = cachedETag;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+
+    try {
+      gitHubRateLimitService.update(response.headers, response.status);
+    } catch {
+      // Rate-limit bookkeeping must never break the probe.
+    }
+
+    if (response.status === 304) {
+      return "unchanged";
+    }
+    if (response.status === 200) {
+      const etag = response.headers.get("etag");
+      if (etag) {
+        branchListETagCache.set(cacheKey, etag);
+      } else {
+        branchListETagCache.delete(cacheKey);
+      }
+      let body: unknown;
+      try {
+        body = await response.json();
+      } catch {
+        // Malformed body — drop the ETag we just stored (it cannot be trusted
+        // to revalidate against an unparseable response) and fall through.
+        branchListETagCache.delete(cacheKey);
+        return "unknown";
+      }
+      if (!Array.isArray(body)) {
+        return "unknown";
+      }
+      return body.length === 0 ? "unchanged" : "changed";
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * When every candidate has a `knownPRNumber` (the revalidation path), probe
  * each unique PR via REST conditional requests. If the entire batch is
  * unchanged, the caller can skip the GraphQL query — the dominant per-cycle
@@ -1060,13 +1138,61 @@ export async function batchCheckLinkedPRs(
     }
   }
 
+  // Discovery-path optimization: for each unresolved candidate (no
+  // knownPRNumber) with a branchName, run a conditional REST probe against
+  // the filtered pulls list. A 304 or empty 200 means "still no PR for this
+  // branch" — that candidate is dropped from the GraphQL batch entirely.
+  // 200-with-results and probe errors keep the candidate so GraphQL provides
+  // full enrichment (issue title, draft state, merge state, etc.).
+  let candidatesForGraphQL = candidates;
+  if (token !== undefined && !allRevalidation) {
+    const probeable: Array<{ index: number; branchName: string }> = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const c = candidates[i];
+      const branch = c.branchName?.trim();
+      if (typeof c.knownPRNumber !== "number" && branch) {
+        probeable.push({ index: i, branchName: branch });
+      }
+    }
+    if (probeable.length > 0) {
+      const probeResults = await Promise.all(
+        probeable.map((p) =>
+          probeBranchPRListChange(context.owner, context.repo, p.branchName, token)
+        )
+      );
+      const skip = new Set<number>();
+      for (let i = 0; i < probeable.length; i++) {
+        if (probeResults[i] === "unchanged") {
+          skip.add(probeable[i].index);
+        }
+      }
+      if (skip.size === candidates.length) {
+        return { results: new Map() };
+      }
+      if (skip.size > 0) {
+        candidatesForGraphQL = candidates.filter((_, idx) => !skip.has(idx));
+      }
+      // A probe may itself have observed a 403/429 and updated the rate-limit
+      // service. Re-check before falling through to GraphQL so we do not burn
+      // an attempt while a known pause is already in effect.
+      const postProbeBlock = gitHubRateLimitService.shouldBlockRequest();
+      if (postProbeBlock.blocked && postProbeBlock.reason && postProbeBlock.resumeAt) {
+        return {
+          results: new Map(),
+          error: rateLimitMessage(postProbeBlock.reason, postProbeBlock.resumeAt),
+          rateLimit: { kind: postProbeBlock.reason, resumeAt: postProbeBlock.resumeAt },
+        };
+      }
+    }
+  }
+
   try {
-    const query = buildBatchPRQuery(context.owner, context.repo, candidates);
+    const query = buildBatchPRQuery(context.owner, context.repo, candidatesForGraphQL);
     const response = (await client(query, {
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as Record<string, unknown>;
 
-    const results = parseBatchPRResponse(response, candidates);
+    const results = parseBatchPRResponse(response, candidatesForGraphQL);
     return { results };
   } catch (error) {
     if (isRepoNotFoundError(error)) {
@@ -1077,11 +1203,15 @@ export async function batchCheckLinkedPRs(
         (freshContext.owner !== context.owner || freshContext.repo !== context.repo)
       ) {
         try {
-          const retryQuery = buildBatchPRQuery(freshContext.owner, freshContext.repo, candidates);
+          const retryQuery = buildBatchPRQuery(
+            freshContext.owner,
+            freshContext.repo,
+            candidatesForGraphQL
+          );
           const retryResponse = (await client(retryQuery, {
             request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
           })) as Record<string, unknown>;
-          return { results: parseBatchPRResponse(retryResponse, candidates) };
+          return { results: parseBatchPRResponse(retryResponse, candidatesForGraphQL) };
         } catch (retryError) {
           return { results: new Map(), error: parseGitHubError(retryError), ...rateLimitMeta() };
         }
@@ -1361,6 +1491,7 @@ export function clearGitHubCaches(): void {
   issueTooltipCache.clear();
   prTooltipCache.clear();
   prETagCache.clear();
+  branchListETagCache.clear();
   prRequiredStatusCache.clear();
   // Token rotation invalidates persisted first-page data — a different
   // identity may have access to a different repo set.

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1158,11 +1158,7 @@ export async function batchCheckLinkedPRs(
     for (let i = 0; i < candidates.length; i++) {
       const c = candidates[i];
       const branch = c.branchName?.trim();
-      if (
-        typeof c.knownPRNumber !== "number" &&
-        typeof c.issueNumber !== "number" &&
-        branch
-      ) {
+      if (typeof c.knownPRNumber !== "number" && typeof c.issueNumber !== "number" && branch) {
         const existing = probeableIndicesByBranch.get(branch);
         if (existing) {
           existing.push(i);

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -679,6 +679,71 @@ describe("GitHubService adversarial", () => {
     ]);
   });
 
+  it("BATCHCHECK_DISCOVERY_BRANCH_EMPTY_DOES_NOT_SKIP_ISSUE_LOOKUP", async () => {
+    // Candidate with both issueNumber and branchName: a PR may be linked via
+    // the issue timeline on a different head ref. The branch-list probe must
+    // NOT skip GraphQL for this candidate even on an empty 200, otherwise
+    // cross-referenced PRs would never be discovered.
+    const fetchMock = vi.mocked(global.fetch);
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", issueNumber: 6541, branchName: "feature/x" },
+    ]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+    expect(result.results.size).toBe(1);
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_NONARRAY_200_CLEARS_ETAG", async () => {
+    // Pathological response: 200 + ETag + non-array body (e.g., an error
+    // object). The probe must not retain the ETag, so the next cycle issues
+    // an unconditional GET rather than revalidating against an unparseable
+    // shape.
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({ etag: 'W/"poison"' }),
+      json: () => Promise.resolve({ message: "not an array" }),
+    } as unknown as Response);
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createBranchListResponse(200, { etag: 'W/"fresh"', body: [] });
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
+  });
+
+  it("BATCHCHECK_DISCOVERY_DUPLICATE_BRANCHES_PROBED_ONCE", async () => {
+    // Two candidates with identical branchName must dedupe to a single REST
+    // probe — avoids wasteful concurrent requests for the same resource.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, { etag: 'W/"shared"', body: [] })
+    );
+
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/shared" },
+      { worktreeId: "wt-2", branchName: "feature/shared" },
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("BATCHCHECK_DISCOVERY_BRANCH_ETAG_CLEARED_ON_TOKEN_ROTATION", async () => {
     // Cycle 1: seed branch-list ETag.
     vi.mocked(global.fetch).mockResolvedValueOnce(

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -133,6 +133,22 @@ function createETagResponse(status: number, etag?: string): Response {
   } as unknown as Response;
 }
 
+function createBranchListResponse(
+  status: number,
+  options: { etag?: string; body?: unknown } = {}
+): Response {
+  const headers = new Headers();
+  if (options.etag) headers.set("etag", options.etag);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 304 ? "Not Modified" : "OK",
+    headers,
+    json: () =>
+      options.body === undefined ? Promise.resolve([]) : Promise.resolve(options.body),
+  } as unknown as Response;
+}
+
 function buildIssueNode(
   overrides?: Partial<{ assignees: Array<{ login: string; avatarUrl: string }> }>
 ) {
@@ -483,15 +499,14 @@ describe("GitHubService adversarial", () => {
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
   });
 
-  it("BATCHCHECK_DISCOVERY_WITHOUT_KNOWNPR_SKIPS_ETAG_PROBE", async () => {
-    // Discovery path: no knownPRNumber → ETag probe must not run.
+  it("BATCHCHECK_DISCOVERY_WITHOUT_BRANCHNAME_SKIPS_PROBE", async () => {
+    // Discovery candidate without a branchName cannot be probed via the REST
+    // pulls list — the helper falls straight through to GraphQL.
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
 
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/discovery" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1" }]);
     expect(global.fetch).not.toHaveBeenCalled();
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
   });
@@ -524,8 +539,15 @@ describe("GitHubService adversarial", () => {
   });
 
   it("BATCHCHECK_MIXED_DISCOVERY_AND_REVALIDATION_BYPASSES_FAST_PATH", async () => {
-    // One candidate with knownPRNumber, one without → fast path must be
-    // skipped and GraphQL must run for both.
+    // One candidate with knownPRNumber, one without → all-revalidation fast
+    // path must be skipped. The discovery candidate's branch-list probe
+    // returns a PR (changed), so GraphQL runs for the full batch.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, {
+        etag: 'W/"branch-etag"',
+        body: [{ number: 99 }],
+      })
+    );
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
       wt_1_branch: { pullRequests: { nodes: [] } },
@@ -536,9 +558,150 @@ describe("GitHubService adversarial", () => {
       { worktreeId: "wt-2", branchName: "feature/discovery" },
     ]);
 
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
     expect(result.results.size).toBe(2);
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_304_SKIPS_GRAPHQL", async () => {
+    // Cycle 1: 200 with empty array seeds the ETag and skips GraphQL.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, { etag: 'W/"seed"', body: [] })
+    );
+    const cycleOne = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/discovery" },
+    ]);
+    expect(cycleOne.results.size).toBe(0);
+    expect(shared.graphqlClient).not.toHaveBeenCalled();
+
+    // Cycle 2: 304 — must still skip GraphQL, no quota burned.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createBranchListResponse(304));
+    const cycleTwo = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/discovery" },
+    ]);
+    expect(cycleTwo.results.size).toBe(0);
+    expect(shared.graphqlClient).not.toHaveBeenCalled();
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_200_WITH_PRS_FALLS_THROUGH", async () => {
+    // 200 with one or more PRs in the body → caller falls through to GraphQL
+    // for full enrichment.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, {
+        etag: 'W/"discovered"',
+        body: [{ number: 7 }],
+      })
+    );
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/has-pr" },
+    ]);
+    expect(result.results.size).toBe(1);
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_PROBE_SENDS_IF_NONE_MATCH", async () => {
+    // Cycle 1 seeds the branch-list ETag.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, { etag: 'W/"seed-2"', body: [] })
+    );
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    // Cycle 2 must send If-None-Match and target the filtered pulls URL.
+    let capturedUrl: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (url, init) => {
+      capturedUrl = typeof url === "string" ? url : String(url);
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createBranchListResponse(304);
+    });
+
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    expect(capturedUrl).toBe(
+      "https://api.github.com/repos/owner/repo/pulls?head=owner:feature%2Fx&state=all"
+    );
+    expect(capturedHeaders?.["If-None-Match"]).toBe('W/"seed-2"');
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_PROBE_ERROR_FALLS_THROUGH", async () => {
+    // A network failure on the branch-list probe must not block discovery —
+    // GraphQL still runs as the authoritative source.
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("network down"));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+    expect(result.results.size).toBe(1);
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_PARTIAL_SKIP_FILTERS_GRAPHQL", async () => {
+    // Mixed discovery batch: one branch has no PR (skip), the other has a PR
+    // (fall through). Only the changed candidate should be queried via GraphQL.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createBranchListResponse(200, { etag: 'W/"a"', body: [] }))
+      .mockResolvedValueOnce(
+        createBranchListResponse(200, { etag: 'W/"b"', body: [{ number: 11 }] })
+      );
+    let capturedCandidates: unknown;
+    const githubIndex = await import("../github/index.js");
+    const buildBatch = vi.mocked(githubIndex.buildBatchPRQuery);
+    buildBatch.mockImplementationOnce((_owner, _repo, candidates) => {
+      capturedCandidates = candidates;
+      return "FILTERED_QUERY";
+    });
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/empty" },
+      { worktreeId: "wt-2", branchName: "feature/has-pr" },
+    ]);
+
+    expect(result.results.size).toBe(1);
+    expect(result.results.has("wt-2")).toBe(true);
+    expect(result.results.has("wt-1")).toBe(false);
+    expect(Array.isArray(capturedCandidates)).toBe(true);
+    expect((capturedCandidates as Array<{ worktreeId: string }>).map((c) => c.worktreeId)).toEqual([
+      "wt-2",
+    ]);
+  });
+
+  it("BATCHCHECK_DISCOVERY_BRANCH_ETAG_CLEARED_ON_TOKEN_ROTATION", async () => {
+    // Cycle 1: seed branch-list ETag.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, { etag: 'W/"v1"', body: [] })
+    );
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    // Rotate token — branch-list ETag cache must be cleared atomically.
+    github.setGitHubToken("ghp_rotated");
+
+    // Cycle 2: probe must send no If-None-Match because the cache was cleared.
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createBranchListResponse(200, { etag: 'W/"v2"', body: [] });
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x" },
+    ]);
+
+    expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
   });
 
   it("BATCHCHECK_DUPLICATE_PR_NUMBERS_PROBED_ONCE", async () => {

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -144,8 +144,7 @@ function createBranchListResponse(
     status,
     statusText: status === 304 ? "Not Modified" : "OK",
     headers,
-    json: () =>
-      options.body === undefined ? Promise.resolve([]) : Promise.resolve(options.body),
+    json: () => (options.body === undefined ? Promise.resolve([]) : Promise.resolve(options.body)),
   } as unknown as Response;
 }
 
@@ -608,9 +607,7 @@ describe("GitHubService adversarial", () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       createBranchListResponse(200, { etag: 'W/"seed-2"', body: [] })
     );
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     // Cycle 2 must send If-None-Match and target the filtered pulls URL.
     let capturedUrl: string | undefined;
@@ -621,9 +618,7 @@ describe("GitHubService adversarial", () => {
       return createBranchListResponse(304);
     });
 
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     expect(capturedUrl).toBe(
       "https://api.github.com/repos/owner/repo/pulls?head=owner:feature%2Fx&state=all"
@@ -713,18 +708,14 @@ describe("GitHubService adversarial", () => {
     shared.graphqlClient.mockResolvedValueOnce({
       wt_0_branch: { pullRequests: { nodes: [] } },
     });
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     let capturedHeaders: Record<string, string> | undefined;
     vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
       capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
       return createBranchListResponse(200, { etag: 'W/"fresh"', body: [] });
     });
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
   });
@@ -749,9 +740,7 @@ describe("GitHubService adversarial", () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       createBranchListResponse(200, { etag: 'W/"v1"', body: [] })
     );
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     // Rotate token — branch-list ETag cache must be cleared atomically.
     github.setGitHubToken("ghp_rotated");
@@ -762,9 +751,7 @@ describe("GitHubService adversarial", () => {
       capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
       return createBranchListResponse(200, { etag: 'W/"v2"', body: [] });
     });
-    await github.batchCheckLinkedPRs("/repo", [
-      { worktreeId: "wt-1", branchName: "feature/x" },
-    ]);
+    await github.batchCheckLinkedPRs("/repo", [{ worktreeId: "wt-1", branchName: "feature/x" }]);
 
     expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Adds a REST + ETag conditional probe to the branch-to-PR discovery loop in `GitHubService` — every unresolved candidate was hitting GraphQL on every cycle; now a cheap probe runs first
- 304 skips GraphQL entirely; 200 with empty array skips GraphQL and refreshes the ETag; 200 with results triggers the existing rich GraphQL fetch
- New `branchListETagCache` keyed by `owner/repo@branch`; clears atomically with `prETagCache` on token rotation so nothing goes stale after credential changes

Resolves #6541

## Changes

- `probeBranchPRListChange` helper hits `/repos/{owner}/{repo}/pulls?head={owner}:{branch}&state=all` with `If-None-Match`
- `batchCheckLinkedPRs` discovery lane: per-candidate branch probe for branch-only candidates (no `knownPRNumber` and no `issueNumber`); probes deduplicated by branch name; non-array bodies clear stale ETag
- `clearPRCaches` extended to clear `branchListETagCache` alongside `prETagCache`

## Testing

32 adversarial tests passing, including 8 new `BATCHCHECK_DISCOVERY_BRANCH_*` tests covering: 304 skip, 200-with-PRs fallthrough, `If-None-Match` header, probe error fallthrough, partial skip filtering, issue-linked candidates bypassing probe, non-array body clearing ETag, duplicate branches probed once, and token rotation invalidation.