### PR TITLE
fix(terminal): unify close confirmation across Cmd+W and close button

### DIFF
--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -8,6 +8,14 @@ export const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set([
   "directing",
 ]);
 
+/**
+ * Agent states that should trigger a close-confirmation dialog. Narrower than
+ * ACTIVE_AGENT_STATES: only "working" represents in-flight computation that
+ * would be lost on close. "waiting"/"directing" are agent-paused states where
+ * stopping is not disruptive, so closing should not require confirmation.
+ */
+export const CLOSE_CONFIRM_AGENT_STATES: ReadonlySet<AgentState> = new Set(["working"]);
+
 const CANONICAL_AGENT_STATES: ReadonlySet<AgentState> = new Set([
   "idle",
   "working",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ import { WorktreePalette, WorktreeOverviewModal, QuickCreatePalette } from "./co
 import { CrossWorktreeDiff } from "./components/Worktree/CrossWorktreeDiff";
 
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
+import { TerminalCloseConfirmHost } from "./components/Terminal/TerminalCloseConfirmHost";
 import { FileViewerModalHost } from "./components/FileViewer/FileViewerModalHost";
 import { NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
@@ -816,6 +817,7 @@ function App() {
             />
 
             <TerminalInfoDialogHost />
+            <TerminalCloseConfirmHost />
             <FileViewerModalHost />
 
             {gitInitDirectoryPath && (

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -59,7 +59,7 @@ import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopove
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 
 interface DockedTabGroupProps {
   group: TabGroup;
@@ -265,7 +265,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const handleTabClose = useCallback(
     (tabId: string) => {
       const panel = panels.find((p) => p.id === tabId);
-      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+      if (panel?.agentState && CLOSE_CONFIRM_AGENT_STATES.has(panel.agentState)) {
         closeDockTerminal();
         setPendingCloseTabId(tabId);
         return;

--- a/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 /**
- * DockedTabGroup — confirm-before-close guard for active-agent tabs (#6330).
+ * DockedTabGroup — confirm-before-close guard for working-agent tabs (#6330, #6513).
  *
  * Mirrors the GridTabGroup guard with one wrinkle: the dock popover collapses
  * when a body-portalled dialog mounts (Radix's onInteractOutside reads the
  * focus shift), so the close handler must call closeDockTerminal() before
  * showing the ConfirmDialog. Otherwise canceling leaves the user with no
  * popover to return to and the dialog backdrop drops onto a half-broken state.
+ * The guard fires only for "working" tabs; "waiting"/"directing" close
+ * immediately (#6513).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
@@ -286,25 +288,42 @@ describe("DockedTabGroup close guard (#6330)", () => {
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
   });
 
-  it.each(["working", "waiting", "directing"] as const)(
-    "shows the confirm dialog and closes the popover for a %s agent tab",
+  it("shows the confirm dialog and closes the popover for a working agent tab", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", agentState: "working" as AgentState }),
+    ];
+
+    const { getByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-2"));
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+    expect(getByTestId("confirm-dialog")).toBeTruthy();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+  });
+
+  it.each(["waiting", "directing"] as const)(
+    "closes a %s agent tab immediately without confirmation (#6513)",
     (state) => {
       const panels = [
         makePanel({ id: "t-1", agentState: "idle" as AgentState }),
         makePanel({ id: "t-2", agentState: state as AgentState }),
       ];
 
-      const { getByTestId } = render(
+      const { getByTestId, queryByTestId } = render(
         <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
       );
 
       fireEvent.click(getByTestId("close-t-2"));
 
-      expect(trashPanelMock).not.toHaveBeenCalled();
-      expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
-      expect(getByTestId("confirm-dialog")).toBeTruthy();
-      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
-      expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+      expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+      expect(queryByTestId("confirm-dialog")).toBeNull();
+      expect(closeDockTerminalMock).not.toHaveBeenCalled();
     }
   );
 

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -15,7 +15,7 @@ import { buildPanelProps } from "@/utils/panelProps";
 import type { AgentState } from "@/types";
 import { terminalChromeDescriptorsEqual } from "@/utils/terminalChrome";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 
 export interface GridPanelProps {
   terminal: TerminalInstance;
@@ -168,7 +168,7 @@ export const GridPanel = React.memo(function GridPanel({
       }
       const candidates = tabs?.length ? tabs.map((t) => t.agentState) : [terminal.agentState];
       const hasActiveAgent = candidates.some(
-        (state) => state !== undefined && ACTIVE_AGENT_STATES.has(state)
+        (state) => state !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(state)
       );
       if (hasActiveAgent) {
         setPendingGroupClose(true);

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -13,7 +13,7 @@ import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 
 export interface GridTabGroupProps {
   group: TabGroup;
@@ -300,7 +300,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const handleTabClose = useCallback(
     (tabId: string) => {
       const panel = panels.find((p) => p.id === tabId);
-      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+      if (panel?.agentState && CLOSE_CONFIRM_AGENT_STATES.has(panel.agentState)) {
         setPendingCloseTabId(tabId);
         return;
       }

--- a/src/components/Terminal/TerminalCloseConfirmHost.tsx
+++ b/src/components/Terminal/TerminalCloseConfirmHost.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+import { usePanelStore } from "@/store/panelStore";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+/**
+ * Bridges the keyboard-driven `terminal.close` action to the same close
+ * confirmation dialog the per-tab and header X buttons render inline. The
+ * action dispatches `daintree:close-confirm` when the target is a "working"
+ * agent; this host listens for that event and shows the dialog.
+ */
+export function TerminalCloseConfirmHost() {
+  const [pendingTerminalId, setPendingTerminalId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleConfirm = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as { terminalId?: unknown } | undefined;
+      const id = typeof detail?.terminalId === "string" ? detail.terminalId : null;
+      if (!id) return;
+      setPendingTerminalId(id);
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:close-confirm", handleConfirm, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setPendingTerminalId(null);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    const id = pendingTerminalId;
+    setPendingTerminalId(null);
+    if (id) usePanelStore.getState().trashPanel(id);
+  }, [pendingTerminalId]);
+
+  return (
+    <ConfirmDialog
+      isOpen={pendingTerminalId !== null}
+      onClose={handleClose}
+      title="Stop this agent?"
+      description="The agent is currently working. Closing this tab will stop it."
+      confirmLabel="Stop and close"
+      onConfirm={handleConfirm}
+      variant="destructive"
+    />
+  );
+}

--- a/src/components/Terminal/TerminalCloseConfirmHost.tsx
+++ b/src/components/Terminal/TerminalCloseConfirmHost.tsx
@@ -17,7 +17,11 @@ export function TerminalCloseConfirmHost() {
       const detail = e.detail as { terminalId?: unknown } | undefined;
       const id = typeof detail?.terminalId === "string" ? detail.terminalId : null;
       if (!id) return;
-      setPendingTerminalId(id);
+      // If a dialog is already open for another terminal, ignore the new
+      // event rather than silently swapping target — the user is staring at
+      // a dialog naming one terminal and clicking confirm should not close a
+      // different one. Rapid Cmd+W or agent-driven dispatches land here.
+      setPendingTerminalId((prev) => prev ?? id);
     };
 
     const controller = new AbortController();

--- a/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 /**
- * GridPanel — header-X close guard for active-agent groups (#6330).
+ * GridPanel — header-X close guard for working-agent groups (#6330, #6513).
  *
  * The per-tab guard in GridTabGroup only intercepts the per-tab X buttons.
  * The panel-header X button calls handleClose(false) → trashPanelGroup,
  * which silently kills the entire group — including single-tab groups whose
  * only close affordance IS that header button. This test pins the parallel
- * guard at the GridPanel layer.
+ * guard at the GridPanel layer. The guard fires only for "working" tabs;
+ * "waiting"/"directing" close immediately (#6513).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
@@ -159,10 +160,26 @@ describe("GridPanel header-close guard (#6330)", () => {
     );
   });
 
-  it.each(["working", "waiting", "directing"] as const)(
-    "shows the confirm dialog when single-tab group has a %s terminal",
+  it("shows the confirm dialog when single-tab group has a working terminal", () => {
+    const { getByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "working" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+
+    expect(getByTestId("confirm-dialog")).toBeTruthy();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["waiting", "directing"] as const)(
+    "closes immediately when single-tab group has a %s terminal (#6513)",
     (state) => {
-      const { getByTestId } = render(
+      const { getByTestId, queryByTestId } = render(
         <GridPanel
           terminal={makeTerminal({ agentState: state as AgentState })}
           isFocused={false}
@@ -172,9 +189,13 @@ describe("GridPanel header-close guard (#6330)", () => {
 
       fireEvent.click(getByTestId("header-close"));
 
-      expect(getByTestId("confirm-dialog")).toBeTruthy();
-      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
-      expect(trashPanelGroupMock).not.toHaveBeenCalled();
+      expect(queryByTestId("confirm-dialog")).toBeNull();
+      return new Promise<void>((resolve) =>
+        setTimeout(() => {
+          expect(trashPanelGroupMock).toHaveBeenCalledWith("t-1");
+          resolve();
+        }, 0)
+      );
     }
   );
 

--- a/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 /**
- * GridTabGroup — confirm-before-close guard for active-agent tabs (#6330).
+ * GridTabGroup — confirm-before-close guard for working-agent tabs (#6330, #6513).
  *
- * Closing a tab whose agent is mid-task (working/waiting/directing) routes
- * through a destructive ConfirmDialog. Idle/completed/exited tabs close
- * immediately as before. Alt+Click force-close on PanelHeader bypasses
- * handleTabClose entirely (it goes through usePanelHandlers → removePanel)
- * so it doesn't need to be exercised here.
+ * Closing a tab whose agent is "working" (in-flight computation) routes through
+ * a destructive ConfirmDialog. Idle/waiting/directing/completed/exited tabs
+ * close immediately — "waiting" and "directing" represent agent-paused states
+ * where stopping is not disruptive (#6513). Alt+Click force-close on
+ * PanelHeader bypasses handleTabClose entirely.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
@@ -195,29 +195,45 @@ describe("GridTabGroup close guard (#6330)", () => {
     expect(queryByTestId("confirm-dialog")).toBeNull();
   });
 
-  it.each(["working", "waiting", "directing"] as const)(
-    "shows the confirm dialog when closing a %s agent tab",
+  it("shows the confirm dialog when closing a working agent tab", () => {
+    const panels = [
+      makePanel({ id: "t-1", agentState: "idle" as AgentState }),
+      makePanel({ id: "t-2", agentState: "working" as AgentState }),
+    ];
+
+    const { getByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-2"));
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    const dialog = getByTestId("confirm-dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute("data-variant")).toBe("destructive");
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(getByTestId("dialog-description").textContent).toBe(
+      "The agent is currently working. Closing this tab will stop it."
+    );
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+  });
+
+  it.each(["waiting", "directing"] as const)(
+    "closes a %s agent tab immediately without confirmation (#6513)",
     (state) => {
       const panels = [
         makePanel({ id: "t-1", agentState: "idle" as AgentState }),
         makePanel({ id: "t-2", agentState: state as AgentState }),
       ];
 
-      const { getByTestId } = render(
+      const { getByTestId, queryByTestId } = render(
         <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
       );
 
       fireEvent.click(getByTestId("close-t-2"));
 
-      expect(trashPanelMock).not.toHaveBeenCalled();
-      const dialog = getByTestId("confirm-dialog");
-      expect(dialog).toBeTruthy();
-      expect(dialog.getAttribute("data-variant")).toBe("destructive");
-      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
-      expect(getByTestId("dialog-description").textContent).toBe(
-        "The agent is currently working. Closing this tab will stop it."
-      );
-      expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+      expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+      expect(queryByTestId("confirm-dialog")).toBeNull();
     }
   );
 

--- a/src/components/Terminal/__tests__/TerminalCloseConfirmHost.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCloseConfirmHost.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * TerminalCloseConfirmHost — bridges `terminal.close` (Cmd+W) to the same
+ * confirmation dialog the per-tab/header X buttons render inline (#6513).
+ *
+ * The host listens for `daintree:close-confirm` CustomEvents, captures the
+ * terminalId from event.detail, and renders ConfirmDialog. Confirm calls
+ * panelStore.trashPanel; cancel does nothing.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+
+const trashPanelMock = vi.fn();
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: () => ({ trashPanel: trashPanelMock }) },
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    cancelLabel = "Cancel",
+    onConfirm,
+    onClose,
+    variant,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    confirmLabel: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onClose?: () => void;
+    variant: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog" data-variant={variant}>
+        <h2 data-testid="dialog-title">{title}</h2>
+        <p data-testid="dialog-description">{description}</p>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          {cancelLabel}
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { TerminalCloseConfirmHost } from "../TerminalCloseConfirmHost";
+
+function dispatchCloseConfirm(detail: unknown) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent("daintree:close-confirm", { detail }));
+  });
+}
+
+describe("TerminalCloseConfirmHost (#6513)", () => {
+  beforeEach(() => {
+    trashPanelMock.mockClear();
+  });
+
+  it("renders nothing until a daintree:close-confirm event arrives", () => {
+    const { queryByTestId } = render(<TerminalCloseConfirmHost />);
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("opens the dialog with destructive copy when an event arrives", () => {
+    const { queryByTestId, getByTestId } = render(<TerminalCloseConfirmHost />);
+
+    dispatchCloseConfirm({ terminalId: "term-1" });
+
+    const dialog = queryByTestId("confirm-dialog");
+    expect(dialog).toBeTruthy();
+    expect(dialog!.getAttribute("data-variant")).toBe("destructive");
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(getByTestId("dialog-description").textContent).toBe(
+      "The agent is currently working. Closing this tab will stop it."
+    );
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+  });
+
+  it("trashes the panel when the user confirms", () => {
+    const { getByTestId, queryByTestId } = render(<TerminalCloseConfirmHost />);
+
+    dispatchCloseConfirm({ terminalId: "term-7" });
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("term-7");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("does not trash when the user cancels", () => {
+    const { getByTestId, queryByTestId } = render(<TerminalCloseConfirmHost />);
+
+    dispatchCloseConfirm({ terminalId: "term-7" });
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("ignores events without a string terminalId", () => {
+    const { queryByTestId } = render(<TerminalCloseConfirmHost />);
+
+    dispatchCloseConfirm({});
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+
+    dispatchCloseConfirm({ terminalId: 42 });
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+
+    dispatchCloseConfirm(undefined);
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("removes the event listener on unmount", () => {
+    const { unmount, queryByTestId } = render(<TerminalCloseConfirmHost />);
+    unmount();
+
+    dispatchCloseConfirm({ terminalId: "term-after-unmount" });
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(trashPanelMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalCloseConfirmHost.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCloseConfirmHost.test.tsx
@@ -116,6 +116,18 @@ describe("TerminalCloseConfirmHost (#6513)", () => {
     expect(queryByTestId("confirm-dialog")).toBeNull();
   });
 
+  it("ignores a second event while a dialog is already open (target stays the first id)", () => {
+    const { getByTestId } = render(<TerminalCloseConfirmHost />);
+
+    dispatchCloseConfirm({ terminalId: "term-first" });
+    dispatchCloseConfirm({ terminalId: "term-second" });
+
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(trashPanelMock).toHaveBeenCalledTimes(1);
+    expect(trashPanelMock).toHaveBeenCalledWith("term-first");
+  });
+
   it("removes the event listener on unmount", () => {
     const { unmount, queryByTestId } = render(<TerminalCloseConfirmHost />);
     unmount();

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -485,6 +485,75 @@ describe("terminal action hardening", () => {
     expect(mocks.appClient.quit).not.toHaveBeenCalled();
   });
 
+  // #6513: Cmd+W (terminal.close action) must match the per-tab/header X-button
+  // guards — prompt before closing a "working" agent, but close idle/waiting/
+  // directing terminals immediately.
+  it("dispatches daintree:close-confirm and skips trash when target agent is working", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const closeTerminal = actions.get("terminal.close")!();
+
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": createTerminal({
+          id: "term-1",
+          location: "grid",
+          agentState: "working",
+        }),
+      },
+      panelIds: ["term-1"],
+      focusedId: "term-1",
+    });
+
+    await closeTerminal.run(undefined, {} as never);
+
+    expect(usePanelStore.getState().panelsById["term-1"]?.location).toBe("grid");
+    const confirmEvents = dispatchSpy.mock.calls
+      .map(([event]) => event)
+      .filter(
+        (e): e is CustomEvent => e instanceof CustomEvent && e.type === "daintree:close-confirm"
+      );
+    expect(confirmEvents).toHaveLength(1);
+    expect((confirmEvents[0]!.detail as { terminalId: string }).terminalId).toBe("term-1");
+
+    dispatchSpy.mockRestore();
+  });
+
+  it.each(["idle", "waiting", "directing", "completed", "exited"] as const)(
+    "trashes a %s agent terminal immediately on terminal.close (no confirm event)",
+    async (state) => {
+      const actions = buildRegistry(registerTerminalActions);
+      const closeTerminal = actions.get("terminal.close")!();
+
+      const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+      usePanelStore.setState({
+        panelsById: {
+          "term-1": createTerminal({
+            id: "term-1",
+            location: "grid",
+            agentState: state,
+          }),
+        },
+        panelIds: ["term-1"],
+        focusedId: "term-1",
+      });
+
+      await closeTerminal.run(undefined, {} as never);
+
+      expect(usePanelStore.getState().panelsById["term-1"]?.location).toBe("trash");
+      const confirmEvents = dispatchSpy.mock.calls
+        .map(([event]) => event)
+        .filter(
+          (e): e is CustomEvent => e instanceof CustomEvent && e.type === "daintree:close-confirm"
+        );
+      expect(confirmEvents).toHaveLength(0);
+
+      dispatchSpy.mockRestore();
+    }
+  );
+
   it("duplicates trashed terminals back into the grid with a copied title", async () => {
     const actions = buildRegistry(registerTerminalActions);
     const duplicate = actions.get("terminal.duplicate")!();

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -26,9 +26,17 @@ export function registerTerminalLifecycleActions(
         terminalId ??
         state.focusedId ??
         state.panelIds.find((id) => state.panelsById[id]?.location !== "trash");
-      if (targetId) {
-        state.trashPanel(targetId);
+      if (!targetId) return;
+      // Match the per-tab/header X-button guards: prompt before closing a
+      // terminal whose agent is mid-task. The host listens via CustomEvent
+      // and renders the same ConfirmDialog the buttons render inline.
+      if (state.panelsById[targetId]?.agentState === "working") {
+        window.dispatchEvent(
+          new CustomEvent("daintree:close-confirm", { detail: { terminalId: targetId } })
+        );
+        return;
       }
+      state.trashPanel(targetId);
     },
   }));
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -4,6 +4,7 @@ import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 export function registerTerminalLifecycleActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -30,7 +31,8 @@ export function registerTerminalLifecycleActions(
       // Match the per-tab/header X-button guards: prompt before closing a
       // terminal whose agent is mid-task. The host listens via CustomEvent
       // and renders the same ConfirmDialog the buttons render inline.
-      if (state.panelsById[targetId]?.agentState === "working") {
+      const targetAgentState = state.panelsById[targetId]?.agentState;
+      if (targetAgentState && CLOSE_CONFIRM_AGENT_STATES.has(targetAgentState)) {
         window.dispatchEvent(
           new CustomEvent("daintree:close-confirm", { detail: { terminalId: targetId } })
         );


### PR DESCRIPTION
## Summary

- Close confirmation was inconsistent: clicking the close button on a terminal tab showed a confirmation dialog when an agent was in `waiting` or `directing` state, but Cmd+W bypassed it entirely
- `waiting` and `directing` are recoverable states, so they no longer trigger confirmation -- only `working` does; this is codified in a new `CLOSE_CONFIRM_AGENT_STATES` constant in `shared/types/agent.ts`
- The `terminal.close` action (Cmd+W) now routes through the same dialog via a `CustomEvent("daintree:close-confirm")`, handled by a new `TerminalCloseConfirmHost` component mounted in `App.tsx`

Resolves #6513

## Changes

- `shared/types/agent.ts` -- adds `CLOSE_CONFIRM_AGENT_STATES = { "working" }`, narrower than `ACTIVE_AGENT_STATES`
- `GridTabGroup.tsx`, `GridPanel.tsx`, `DockedTabGroup.tsx` -- swap close-guard predicate to use the new constant
- `TerminalCloseConfirmHost.tsx` -- new component that listens for `daintree:close-confirm` and renders the confirmation dialog
- `App.tsx` -- mounts `TerminalCloseConfirmHost`
- `terminalLifecycleActions.ts` -- `terminal.close` dispatches `daintree:close-confirm` when the agent is in a confirm state
- Updated `closeGuard` tests; added `TerminalCloseConfirmHost.test.tsx` and `terminal.close` guard cases in `actionDefinitions.adversarial.test.ts`

## Testing

72 tests pass. Full check suite (typecheck, lint, format, channel drift) green. ESLint baseline improved by 4.