### PR TITLE
feat(worktree): add input-time receipt overlay to dashboard rows

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -32,6 +32,7 @@ import {
   MainWorktreeSummaryRows,
   type AggregateCounts,
 } from "./WorktreeCard/MainWorktreeSummaryRows";
+import { useInputReceiptKey } from "./WorktreeCard/hooks/useInputReceiptKey";
 import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
@@ -214,6 +215,17 @@ export function WorktreeCard({
       }
     }
   }, [dominantAgentState]);
+
+  // Input-time receipt — fires the moment a row terminal is pinged (well
+  // before the polled `dominantAgentState` border-flash). Acknowledges the
+  // input itself, not its outcome, so any agent-state staleness is irrelevant.
+  const pingedId = usePanelStore((state) => state.pingedId);
+  const worktreeTerminalIds = useMemo(
+    () => worktreeTerminals.map((t) => t.id),
+    [worktreeTerminals]
+  );
+  const receiptKey = useInputReceiptKey(pingedId, worktreeTerminalIds);
+
   const setFocused = usePanelStore((state) => state.setFocused);
   const pingTerminal = usePanelStore((state) => state.pingTerminal);
   const openDockTerminal = usePanelStore((state) => state.openDockTerminal);
@@ -587,6 +599,18 @@ export function WorktreeCard({
                 isActive && "mix-blend-screen dark:mix-blend-plus-lighter"
               )}
               aria-hidden="true"
+            />
+          )}
+          {receiptKey > 0 && (
+            <div
+              key={receiptKey}
+              className={cn(
+                "absolute inset-0 z-20 pointer-events-none animate-input-receipt-flash",
+                variant === "grid" && "rounded-lg"
+              )}
+              style={{ background: "color-mix(in oklch, currentColor 10%, transparent)" }}
+              aria-hidden="true"
+              data-testid="worktree-card-input-receipt"
             />
           )}
           {chipState !== null && (

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -219,12 +219,16 @@ export function WorktreeCard({
   // Input-time receipt — fires the moment a row terminal is pinged (well
   // before the polled `dominantAgentState` border-flash). Acknowledges the
   // input itself, not its outcome, so any agent-state staleness is irrelevant.
+  // `pingSeq` is the authoritative trigger so back-to-back taps of the same
+  // terminal both produce a receipt (Zustand `Object.is` would suppress the
+  // re-render if we keyed off `pingedId` alone).
   const pingedId = usePanelStore((state) => state.pingedId);
+  const pingSeq = usePanelStore((state) => state.pingSeq);
   const worktreeTerminalIds = useMemo(
     () => worktreeTerminals.map((t) => t.id),
     [worktreeTerminals]
   );
-  const receiptKey = useInputReceiptKey(pingedId, worktreeTerminalIds);
+  const receiptKey = useInputReceiptKey(pingedId, pingSeq, worktreeTerminalIds);
 
   const setFocused = usePanelStore((state) => state.setFocused);
   const pingTerminal = usePanelStore((state) => state.pingTerminal);

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useInputReceiptKey.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useInputReceiptKey.test.tsx
@@ -1,0 +1,130 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useInputReceiptKey } from "../useInputReceiptKey";
+
+describe("useInputReceiptKey", () => {
+  it("starts at 0 with no ping", () => {
+    const { result } = renderHook(() => useInputReceiptKey(null, ["t-1", "t-2"]));
+    expect(result.current).toBe(0);
+  });
+
+  it("starts at 0 even when initial pingedId belongs to the card (mount is not a ping)", () => {
+    // The hook still increments on the initial effect run when the dependency
+    // is non-null and matches — that's intentional: a card mounting while a
+    // ping is live should display the receipt for that ping.
+    const { result } = renderHook(() => useInputReceiptKey("t-1", ["t-1"]));
+    expect(result.current).toBe(1);
+  });
+
+  it("increments when pingedId transitions to a card-owned terminal", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: null as string | null, ids: ["t-1", "t-2"] } }
+    );
+    expect(result.current).toBe(0);
+
+    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+  });
+
+  it("does not increment when pingedId belongs to a different card", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
+    );
+    rerender({ pinged: "other-terminal", ids: ["t-1"] });
+    expect(result.current).toBe(0);
+  });
+
+  it("does not increment on null clears (1.6s timeout end)", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
+    );
+
+    rerender({ pinged: "t-1", ids: ["t-1"] });
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: null, ids: ["t-1"] });
+    expect(result.current).toBe(1);
+  });
+
+  it("re-keys on back-to-back pings of distinct terminals in the same card", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: null as string | null, ids: ["t-1", "t-2"] } }
+    );
+
+    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: "t-2", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(2);
+  });
+
+  it("re-keys when the same terminal pings twice (transition through null)", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
+    );
+
+    rerender({ pinged: "t-1", ids: ["t-1"] });
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: null, ids: ["t-1"] });
+    rerender({ pinged: "t-1", ids: ["t-1"] });
+    expect(result.current).toBe(2);
+  });
+
+  it("does not re-fire when terminalIds array reference changes but contents do not", () => {
+    // Without the join("\0") hashing, a new `worktreeTerminals` array reference
+    // each render would re-trigger the effect spuriously.
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: "t-1" as string | null, ids: ["t-1", "t-2"] } }
+    );
+    expect(result.current).toBe(1);
+
+    // New array reference, same contents — no re-fire.
+    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+  });
+
+  it("does not re-fire when terminalIds change but pingedId is unchanged", () => {
+    // A new terminal is added to this card while the same pingedId is still
+    // live (the original receipt is still animating or the 1.6s timeout
+    // hasn't fired yet). Re-firing here would double-flash for one logical
+    // input event — the prev-pingedId guard prevents that.
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: "t-1" as string | null, ids: ["t-1"] } }
+    );
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+  });
+
+  it("does not re-fire when an unrelated terminal is added", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
+        useInputReceiptKey(pinged, ids),
+      { initialProps: { pinged: "other" as string | null, ids: ["t-1"] } }
+    );
+    expect(result.current).toBe(0);
+
+    rerender({ pinged: "other", ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(0);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useInputReceiptKey.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useInputReceiptKey.test.tsx
@@ -3,128 +3,145 @@ import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useInputReceiptKey } from "../useInputReceiptKey";
 
+type Props = { pinged: string | null; seq: number; ids: string[] };
+
 describe("useInputReceiptKey", () => {
   it("starts at 0 with no ping", () => {
-    const { result } = renderHook(() => useInputReceiptKey(null, ["t-1", "t-2"]));
+    const { result } = renderHook(() => useInputReceiptKey(null, 0, ["t-1", "t-2"]));
     expect(result.current).toBe(0);
   });
 
-  it("starts at 0 even when initial pingedId belongs to the card (mount is not a ping)", () => {
-    // The hook still increments on the initial effect run when the dependency
-    // is non-null and matches — that's intentional: a card mounting while a
-    // ping is live should display the receipt for that ping.
-    const { result } = renderHook(() => useInputReceiptKey("t-1", ["t-1"]));
-    expect(result.current).toBe(1);
-  });
-
-  it("increments when pingedId transitions to a card-owned terminal", () => {
-    const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: null as string | null, ids: ["t-1", "t-2"] } }
-    );
-    expect(result.current).toBe(0);
-
-    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
-    expect(result.current).toBe(1);
-  });
-
-  it("does not increment when pingedId belongs to a different card", () => {
-    const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
-    );
-    rerender({ pinged: "other-terminal", ids: ["t-1"] });
+  it("does not increment on initial mount even when seq > 0 and id matches", () => {
+    // Mount snapshots the current seq into the ref; only subsequent advances
+    // count as pings. This avoids flashing every card when a card mounts mid
+    // session with a stale (but still-live) `pingedId`.
+    const { result } = renderHook(() => useInputReceiptKey("t-1", 5, ["t-1"]));
     expect(result.current).toBe(0);
   });
 
-  it("does not increment on null clears (1.6s timeout end)", () => {
+  it("increments when seq advances and pingedId matches a card terminal", () => {
     const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1", "t-2"] } as Props }
+    );
+    expect(result.current).toBe(0);
+
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(1);
+  });
+
+  it("does not increment when seq advances but pingedId belongs to another card", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1"] } as Props }
+    );
+    rerender({ pinged: "other-terminal", seq: 1, ids: ["t-1"] });
+    expect(result.current).toBe(0);
+  });
+
+  it("does not increment on the 1.6s null clear (seq does not advance)", () => {
+    const { result, rerender } = renderHook(
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1"] } as Props }
     );
 
-    rerender({ pinged: "t-1", ids: ["t-1"] });
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1"] });
     expect(result.current).toBe(1);
 
-    rerender({ pinged: null, ids: ["t-1"] });
+    // The 1.6s clear in `pingTerminal` does NOT advance `pingSeq` — the
+    // clearing path is `set({ pingedId: null })` only.
+    rerender({ pinged: null, seq: 1, ids: ["t-1"] });
     expect(result.current).toBe(1);
+  });
+
+  it("re-keys on back-to-back pings of the SAME terminal (the gap fix)", () => {
+    // Without the seq counter, `pingTerminal` calling `set({ pingedId: id })`
+    // twice with the same id would be `Object.is`-equal and emit no update,
+    // dropping the second receipt.
+    const { result, rerender } = renderHook(
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1"] } as Props }
+    );
+
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1"] });
+    expect(result.current).toBe(1);
+
+    rerender({ pinged: "t-1", seq: 2, ids: ["t-1"] });
+    expect(result.current).toBe(2);
   });
 
   it("re-keys on back-to-back pings of distinct terminals in the same card", () => {
     const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: null as string | null, ids: ["t-1", "t-2"] } }
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1", "t-2"] } as Props }
     );
 
-    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] });
     expect(result.current).toBe(1);
 
-    rerender({ pinged: "t-2", ids: ["t-1", "t-2"] });
+    rerender({ pinged: "t-2", seq: 2, ids: ["t-1", "t-2"] });
     expect(result.current).toBe(2);
   });
 
-  it("re-keys when the same terminal pings twice (transition through null)", () => {
+  it("does not re-fire when terminalIds reference changes but seq is unchanged", () => {
+    // Without seq-based gating, an unstable `worktreeTerminals` array would
+    // re-trigger the effect spuriously every render.
     const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: null as string | null, ids: ["t-1"] } }
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] } as Props }
     );
+    // Initial mount snapshots seq=1 into ref → no increment yet.
+    expect(result.current).toBe(0);
 
-    rerender({ pinged: "t-1", ids: ["t-1"] });
-    expect(result.current).toBe(1);
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(0);
 
-    rerender({ pinged: null, ids: ["t-1"] });
-    rerender({ pinged: "t-1", ids: ["t-1"] });
-    expect(result.current).toBe(2);
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] });
+    expect(result.current).toBe(0);
   });
 
-  it("does not re-fire when terminalIds array reference changes but contents do not", () => {
-    // Without the join("\0") hashing, a new `worktreeTerminals` array reference
-    // each render would re-trigger the effect spuriously.
+  it("does not re-fire when terminalIds change but seq is unchanged", () => {
     const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: "t-1" as string | null, ids: ["t-1", "t-2"] } }
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: ["t-1"] } as Props }
     );
+
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1"] });
     expect(result.current).toBe(1);
 
-    // New array reference, same contents — no re-fire.
-    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
-    expect(result.current).toBe(1);
-
-    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
-    expect(result.current).toBe(1);
-  });
-
-  it("does not re-fire when terminalIds change but pingedId is unchanged", () => {
-    // A new terminal is added to this card while the same pingedId is still
-    // live (the original receipt is still animating or the 1.6s timeout
-    // hasn't fired yet). Re-firing here would double-flash for one logical
-    // input event — the prev-pingedId guard prevents that.
-    const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: "t-1" as string | null, ids: ["t-1"] } }
-    );
-    expect(result.current).toBe(1);
-
-    rerender({ pinged: "t-1", ids: ["t-1", "t-2"] });
+    // Terminal added; same ping still live. The receipt must NOT double-flash
+    // for one logical input event.
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1", "t-2"] });
     expect(result.current).toBe(1);
   });
 
-  it("does not re-fire when an unrelated terminal is added", () => {
+  it("does not increment when terminalIds is empty even on a seq advance", () => {
     const { result, rerender } = renderHook(
-      ({ pinged, ids }: { pinged: string | null; ids: string[] }) =>
-        useInputReceiptKey(pinged, ids),
-      { initialProps: { pinged: "other" as string | null, ids: ["t-1"] } }
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: null, seq: 0, ids: [] } as Props }
+    );
+
+    rerender({ pinged: "t-1", seq: 1, ids: [] });
+    expect(result.current).toBe(0);
+  });
+
+  it("fires when an already-live ping's target terminal joins this card mid-flight", () => {
+    // Race scenario: a ping fires before the card sees the terminal in its
+    // membership list. The seq is still the latest, and the terminal is now a
+    // member, but seq hasn't advanced — so the receipt does NOT fire on the
+    // late join. This is intentional: we acknowledge inputs at their moment,
+    // not after-the-fact when the structural state catches up.
+    const { result, rerender } = renderHook(
+      ({ pinged, seq, ids }: Props) => useInputReceiptKey(pinged, seq, ids),
+      { initialProps: { pinged: "t-1", seq: 1, ids: [] } as Props }
     );
     expect(result.current).toBe(0);
 
-    rerender({ pinged: "other", ids: ["t-1", "t-2"] });
+    rerender({ pinged: "t-1", seq: 1, ids: ["t-1"] });
     expect(result.current).toBe(0);
+
+    // A NEW ping (seq advances) on the now-known terminal does fire.
+    rerender({ pinged: "t-1", seq: 2, ids: ["t-1"] });
+    expect(result.current).toBe(1);
   });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Tracks input-time pings against a card's terminals and emits a monotonically
+ * increasing key whenever `pingedId` transitions to one of `terminalIds`.
+ * Consumers mount a keyed overlay element on the returned key so each ping
+ * replays the one-shot CSS animation. Null clears (the 1.6s timeout end) are
+ * intentionally ignored — the receipt acknowledges input, not its absence.
+ *
+ * `terminalIds` reference instability is tolerated: the prev-pingedId guard
+ * means re-runs of the effect with the same `pingedId` are no-ops.
+ */
+export function useInputReceiptKey(
+  pingedId: string | null,
+  terminalIds: readonly string[]
+): number {
+  const [receiptKey, setReceiptKey] = useState(0);
+  const prevPingedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const prev = prevPingedRef.current;
+    prevPingedRef.current = pingedId;
+    if (pingedId && pingedId !== prev && terminalIds.includes(pingedId)) {
+      setReceiptKey((k) => k + 1);
+    }
+  }, [pingedId, terminalIds]);
+
+  return receiptKey;
+}

--- a/src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts
@@ -2,28 +2,32 @@ import { useEffect, useRef, useState } from "react";
 
 /**
  * Tracks input-time pings against a card's terminals and emits a monotonically
- * increasing key whenever `pingedId` transitions to one of `terminalIds`.
- * Consumers mount a keyed overlay element on the returned key so each ping
- * replays the one-shot CSS animation. Null clears (the 1.6s timeout end) are
- * intentionally ignored — the receipt acknowledges input, not its absence.
+ * increasing key whenever a new ping (`pingSeq` advanced) targets one of
+ * `terminalIds`. Consumers mount a keyed overlay element on the returned key
+ * so each ping replays the one-shot CSS animation. Null clears (the 1.6s
+ * timeout end) are intentionally ignored — the receipt acknowledges input,
+ * not its absence.
  *
- * `terminalIds` reference instability is tolerated: the prev-pingedId guard
- * means re-runs of the effect with the same `pingedId` are no-ops.
+ * `pingSeq` (rather than `pingedId` alone) is the authoritative trigger:
+ * tapping the same row twice within the live window holds `pingedId` constant
+ * but advances `pingSeq`, so both taps produce a receipt. `terminalIds`
+ * reference instability is tolerated — only the seq drives an increment.
  */
 export function useInputReceiptKey(
   pingedId: string | null,
+  pingSeq: number,
   terminalIds: readonly string[]
 ): number {
   const [receiptKey, setReceiptKey] = useState(0);
-  const prevPingedRef = useRef<string | null>(null);
+  const prevSeqRef = useRef(pingSeq);
 
   useEffect(() => {
-    const prev = prevPingedRef.current;
-    prevPingedRef.current = pingedId;
-    if (pingedId && pingedId !== prev && terminalIds.includes(pingedId)) {
+    const prev = prevSeqRef.current;
+    prevSeqRef.current = pingSeq;
+    if (pingSeq !== prev && pingedId && terminalIds.includes(pingedId)) {
       setReceiptKey((k) => k + 1);
     }
-  }, [pingedId, terminalIds]);
+  }, [pingSeq, pingedId, terminalIds]);
 
   return receiptKey;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1337,6 +1337,29 @@ body,
   will-change: opacity;
 }
 
+/* Card input-time receipt — opacity-only sibling overlay that fires the moment
+ * a row-level input lands (before any polled state change). 150ms ease-out
+ * matches the Tier 1 state-change tier so it reads as a precursor to the
+ * border-flash rather than a competing animation. The 10% peak is the MD3
+ * pressed state-layer level; using `currentColor` keeps it theme-neutral.
+ */
+@keyframes input-receipt-flash {
+  0% {
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-input-receipt-flash {
+  animation: input-receipt-flash var(--duration-150) ease-out 1 both;
+  will-change: opacity;
+}
+
 /* Fleet broadcast bar refocus pulse — when the OS window regains focus and
  * fleet is armed, breathe the bar's amber stripe so the user can re-orient
  * to the active mode without searching for it. ~800ms total, opacity-only.
@@ -1514,6 +1537,16 @@ body,
     will-change: auto;
   }
 
+  /* Card input-time receipt — strip the keyframe and keep the overlay
+   * invisible. Unlike `border-flash`, this overlay has no static-state
+   * meaning, so `opacity: 0` (not `opacity: 1`) is the correct rest state.
+   */
+  .animate-input-receipt-flash {
+    animation: none;
+    opacity: 0;
+    will-change: auto;
+  }
+
   /* Label swap under reduced motion — animation removed entirely. The swap
    * still happens (the new value renders), it just snaps into place rather
    * than crossfading. WCAG 2.3.3: remove motion, don't just speed it up.
@@ -1635,6 +1668,12 @@ body[data-reduce-animations="true"] .fleet-exit-pulse-overlay {
 }
 
 body[data-reduce-animations="true"] .file-change-row-new::before {
+  animation: none;
+  opacity: 0;
+  will-change: auto;
+}
+
+body[data-reduce-animations="true"] .animate-input-receipt-flash {
   animation: none;
   opacity: 0;
   will-change: auto;

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -86,6 +86,14 @@ export interface TerminalFocusSlice {
   maximizeTarget: MaximizeTarget;
   activeDockTerminalId: string | null;
   pingedId: string | null;
+  /**
+   * Monotonically increases on every `pingTerminal` call. Lets consumers
+   * distinguish back-to-back pings of the same terminal — a Zustand `set` with
+   * the same `pingedId` value is `Object.is`-equal and emits no update, so
+   * `pingedId` alone can't drive a one-shot animation when the same row is
+   * tapped twice within the 1.6s clear window.
+   */
+  pingSeq: number;
   preMaximizeLayout: PreMaximizeLayoutSnapshot | null;
   setFocused: (id: string | null, shouldPing?: boolean) => void;
   pingTerminal: (id: string) => void;
@@ -161,6 +169,7 @@ export const createTerminalFocusSlice =
       maximizeTarget: null,
       activeDockTerminalId: null,
       pingedId: null,
+      pingSeq: 0,
       preMaximizeLayout: null,
       setFocused: (id, shouldPing = false) => {
         if (id) {
@@ -197,7 +206,7 @@ export const createTerminalFocusSlice =
 
       pingTerminal: (id) => {
         if (pingTimeout) clearTimeout(pingTimeout);
-        set({ pingedId: id });
+        set((state) => ({ pingedId: id, pingSeq: state.pingSeq + 1 }));
         pingTimeout = setTimeout(() => {
           if (get().pingedId === id) {
             set({ pingedId: null });


### PR DESCRIPTION
## Summary

- Worktree dashboard rows had no visual acknowledgement on click. Polled state updates take 2–30 seconds, which violates the 100ms perception bound — the row read as inert until the poll caught up.
- Adds a transient opacity-only overlay that fires at input time, independent of polled state. Uses the MD3 state-layer pattern (10% on-color via `color-mix`) so it stays within accent-restraint rules and is compositor-only (no layout, no paint).
- The `pingSeq` monotonic counter in `terminalFocusSlice` ensures back-to-back same-terminal pings both produce a receipt (Zustand's `Object.is` check would otherwise deduplicate them).

Resolves #6499

## Changes

- `src/index.css` — new `animate-input-receipt-flash` class (150ms ease-out, 10% on-color state-layer via `color-mix`); reduced-motion bypass entries in both `prefers-reduced-motion` and `body[data-reduce-animations]` blocks
- `src/store/slices/terminalFocusSlice.ts` — `pingSeq` monotonic counter added to `pingTerminal` so repeated same-terminal pings are distinguishable
- `src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts` — new hook; watches `pingSeq` advances filtered by terminal membership, returns an incrementing key that drives a CSS animation restart
- `src/components/Worktree/WorktreeCard.tsx` — sibling overlay rendered next to the existing `border-flash` element (`z-20`, `pointer-events-none`, `aria-hidden`)
- `src/components/Worktree/WorktreeCard/hooks/__tests__/useInputReceiptKey.test.tsx` — 11 unit tests covering all transition scenarios

## Testing

- Unit tests cover: initial state, ping for a member terminal, ping for a non-member terminal, `pingSeq` increment on repeated same-terminal ping, and reset/cleanup behaviour.
- Manually verified the receipt fires on terminal select, agent launch, and recipe dispatch — each produces a visible flash before polled state catches up. The existing `border-flash` reads as a continuation of the receipt's envelope.
- Verified reduced-motion bypass: no animation fires under `prefers-reduced-motion: reduce` or `data-reduce-animations`.