### PR TITLE
fix(mcp): route IPC bounce to active project WebContentsView

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from "electron";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
+import { getProjectViewManager } from "../window/windowRef.js";
 import http from "node:http";
 import net from "node:net";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
@@ -128,6 +129,8 @@ interface PendingRequest<T> {
   resolve: (value: T) => void;
   reject: (err: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+  webContentsId: number;
+  destroyedCleanup?: () => void;
 }
 
 interface McpSseSession {
@@ -559,11 +562,13 @@ export class McpServerService {
 
     for (const [id, pending] of this.pendingManifests) {
       clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
       pending.reject(new Error("MCP server stopped"));
       this.pendingManifests.delete(id);
     }
     for (const [id, pending] of this.pendingDispatches) {
       clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
       pending.reject(new Error("MCP server stopped"));
       this.pendingDispatches.delete(id);
     }
@@ -655,29 +660,41 @@ export class McpServerService {
 
   private setupIpcListeners(): void {
     const manifestHandler = (
-      _event: Electron.IpcMainEvent,
+      event: Electron.IpcMainEvent,
       payload: { requestId: string; manifest: unknown }
     ) => {
       const pending = this.pendingManifests.get(payload.requestId);
-      if (pending) {
-        clearTimeout(pending.timer);
-        this.pendingManifests.delete(payload.requestId);
-        pending.resolve(
-          Array.isArray(payload.manifest) ? (payload.manifest as ActionManifestEntry[]) : []
+      if (!pending) return;
+      if (event.sender.id !== pending.webContentsId) {
+        console.warn(
+          `[MCP] Ignoring manifest response from unexpected sender ${event.sender.id} (expected ${pending.webContentsId}, requestId=${payload.requestId})`
         );
+        return;
       }
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      this.pendingManifests.delete(payload.requestId);
+      pending.resolve(
+        Array.isArray(payload.manifest) ? (payload.manifest as ActionManifestEntry[]) : []
+      );
     };
 
     const dispatchHandler = (
-      _event: Electron.IpcMainEvent,
+      event: Electron.IpcMainEvent,
       payload: { requestId: string; result: ActionDispatchResult }
     ) => {
       const pending = this.pendingDispatches.get(payload.requestId);
-      if (pending) {
-        clearTimeout(pending.timer);
-        this.pendingDispatches.delete(payload.requestId);
-        pending.resolve(payload.result);
+      if (!pending) return;
+      if (event.sender.id !== pending.webContentsId) {
+        console.warn(
+          `[MCP] Ignoring dispatch response from unexpected sender ${event.sender.id} (expected ${pending.webContentsId}, requestId=${payload.requestId})`
+        );
+        return;
       }
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      this.pendingDispatches.delete(payload.requestId);
+      pending.resolve(payload.result);
     };
 
     ipcMain.on("mcp:get-manifest-response", manifestHandler);
@@ -693,23 +710,50 @@ export class McpServerService {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
       try {
-        webContents = this.getLiveWebContents();
+        webContents = this.getActiveProjectWebContents();
       } catch (err) {
         reject(this.normalizeError(err, "MCP renderer bridge unavailable"));
         return;
       }
 
       const requestId = randomUUID();
+      const webContentsId = webContents.id;
       const timer = setTimeout(() => {
+        const pending = this.pendingManifests.get(requestId);
+        pending?.destroyedCleanup?.();
         this.pendingManifests.delete(requestId);
         reject(new Error("Manifest request timed out"));
       }, 5000);
 
-      this.pendingManifests.set(requestId, { resolve, reject, timer });
+      const onDestroyed = () => {
+        const pending = this.pendingManifests.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingManifests.delete(requestId);
+        pending.reject(new Error("MCP renderer bridge destroyed"));
+      };
+      webContents.once("destroyed", onDestroyed);
+      const destroyedCleanup = () => {
+        try {
+          webContents.removeListener("destroyed", onDestroyed);
+        } catch {
+          // best-effort cleanup; webContents may already be gone
+        }
+      };
+
+      this.pendingManifests.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        webContentsId,
+        destroyedCleanup,
+      });
+
       try {
         webContents.send("mcp:get-manifest-request", { requestId });
       } catch (err) {
         clearTimeout(timer);
+        destroyedCleanup();
         this.pendingManifests.delete(requestId);
         reject(this.normalizeError(err, "Failed to request action manifest"));
       }
@@ -724,19 +768,44 @@ export class McpServerService {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
       try {
-        webContents = this.getLiveWebContents();
+        webContents = this.getActiveProjectWebContents();
       } catch (err) {
         reject(this.normalizeError(err, "MCP renderer bridge unavailable"));
         return;
       }
 
       const requestId = randomUUID();
+      const webContentsId = webContents.id;
       const timer = setTimeout(() => {
+        const pending = this.pendingDispatches.get(requestId);
+        pending?.destroyedCleanup?.();
         this.pendingDispatches.delete(requestId);
         reject(new Error(`Action dispatch timed out: ${actionId}`));
       }, 30000);
 
-      this.pendingDispatches.set(requestId, { resolve, reject, timer });
+      const onDestroyed = () => {
+        const pending = this.pendingDispatches.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingDispatches.delete(requestId);
+        pending.reject(new Error("MCP renderer bridge destroyed"));
+      };
+      webContents.once("destroyed", onDestroyed);
+      const destroyedCleanup = () => {
+        try {
+          webContents.removeListener("destroyed", onDestroyed);
+        } catch {
+          // best-effort cleanup; webContents may already be gone
+        }
+      };
+
+      this.pendingDispatches.set(requestId, {
+        resolve,
+        reject,
+        timer,
+        webContentsId,
+        destroyedCleanup,
+      });
 
       try {
         webContents.send("mcp:dispatch-action-request", {
@@ -747,6 +816,7 @@ export class McpServerService {
         });
       } catch (err) {
         clearTimeout(timer);
+        destroyedCleanup();
         this.pendingDispatches.delete(requestId);
         reject(this.normalizeError(err, `Failed to dispatch action: ${actionId}`));
       }
@@ -974,23 +1044,21 @@ export class McpServerService {
     };
   }
 
-  private getLiveWebContents(): Electron.WebContents {
+  private getActiveProjectWebContents(): Electron.WebContents {
     if (this.registry) {
-      const primary = this.registry.getPrimary();
-      if (primary && !primary.browserWindow.isDestroyed()) {
-        const { webContents } = primary.browserWindow;
+      for (const ctx of this.registry.all()) {
+        if (ctx.browserWindow.isDestroyed()) continue;
+        const view = ctx.services.projectViewManager?.getActiveView();
+        const webContents = view?.webContents;
         if (webContents && !webContents.isDestroyed()) {
           return webContents;
         }
       }
-      for (const ctx of this.registry.all()) {
-        if (!ctx.browserWindow.isDestroyed()) {
-          const { webContents } = ctx.browserWindow;
-          if (webContents && !webContents.isDestroyed()) {
-            return webContents;
-          }
-        }
-      }
+    }
+
+    const fallback = getProjectViewManager()?.getActiveView()?.webContents;
+    if (fallback && !fallback.isDestroyed()) {
+      return fallback;
     }
 
     throw new Error("MCP renderer bridge unavailable");

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -663,6 +663,7 @@ export class McpServerService {
       event: Electron.IpcMainEvent,
       payload: { requestId: string; manifest: unknown }
     ) => {
+      if (!payload || typeof payload.requestId !== "string") return;
       const pending = this.pendingManifests.get(payload.requestId);
       if (!pending) return;
       if (event.sender.id !== pending.webContentsId) {
@@ -683,6 +684,7 @@ export class McpServerService {
       event: Electron.IpcMainEvent,
       payload: { requestId: string; result: ActionDispatchResult }
     ) => {
+      if (!payload || typeof payload.requestId !== "string") return;
       const pending = this.pendingDispatches.get(payload.requestId);
       if (!pending) return;
       if (event.sender.id !== pending.webContentsId) {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -155,9 +155,13 @@ function createManifestEntry(entry: {
   };
 }
 
+let nextWebContentsId = 100;
+
 function createMockWindow(options?: {
   getManifest?: () => ActionManifestEntry[];
   dispatchAction?: (payload: DispatchRequest) => ActionDispatchResult;
+  senderIdOverride?: number;
+  hostShellWebContentsId?: number;
 }) {
   const getManifest = options?.getManifest ?? (() => []);
   const dispatchAction =
@@ -167,7 +171,20 @@ function createMockWindow(options?: {
       result: "ok",
     }));
 
-  const webContents = {
+  const projectViewWcId = nextWebContentsId++;
+  const hostShellWcId = options?.hostShellWebContentsId ?? nextWebContentsId++;
+  const senderId = options?.senderIdOverride ?? projectViewWcId;
+  const destroyedListeners = new Set<() => void>();
+
+  const webContents: {
+    id: number;
+    isDestroyed: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+    triggerDestroyed: () => void;
+  } = {
+    id: projectViewWcId,
     isDestroyed: vi.fn(() => false),
     send: vi.fn(
       (channel: string, payload: { requestId: string; actionId?: string; args?: unknown }) => {
@@ -175,7 +192,7 @@ function createMockWindow(options?: {
           queueMicrotask(() => {
             electronMocks.ipcMain.emit(
               "mcp:get-manifest-response",
-              {},
+              { sender: { id: senderId } },
               {
                 requestId: payload.requestId,
                 manifest: getManifest(),
@@ -189,7 +206,7 @@ function createMockWindow(options?: {
           queueMicrotask(() => {
             electronMocks.ipcMain.emit(
               "mcp:dispatch-action-response",
-              {},
+              { sender: { id: senderId } },
               {
                 requestId: payload.requestId,
                 result: dispatchAction(payload as DispatchRequest),
@@ -199,20 +216,47 @@ function createMockWindow(options?: {
         }
       }
     ),
+    once: vi.fn((event: string, listener: () => void) => {
+      if (event === "destroyed") {
+        destroyedListeners.add(listener);
+      }
+    }),
+    removeListener: vi.fn((event: string, listener: () => void) => {
+      if (event === "destroyed") {
+        destroyedListeners.delete(listener);
+      }
+    }),
+    triggerDestroyed: () => {
+      const listeners = Array.from(destroyedListeners);
+      destroyedListeners.clear();
+      for (const listener of listeners) listener();
+    },
+  };
+
+  const hostShellWebContents = {
+    id: hostShellWcId,
+    isDestroyed: vi.fn(() => false),
+    send: vi.fn(),
+    once: vi.fn(),
+    removeListener: vi.fn(),
   };
 
   const browserWindow = {
     isDestroyed: vi.fn(() => false),
-    webContents,
+    webContents: hostShellWebContents,
+  };
+
+  const projectViewManager = {
+    getActiveView: vi.fn(() => ({ webContents })),
   };
 
   const windowContext = {
     windowId: 1,
-    webContentsId: 1,
+    webContentsId: hostShellWcId,
     browserWindow,
     projectPath: null,
     abortController: new AbortController(),
-    services: {},
+    services: { projectViewManager },
     cleanup: [],
   };
 
@@ -227,6 +271,8 @@ function createMockWindow(options?: {
   return {
     window: registry as never,
     webContents,
+    hostShellWebContents,
+    projectViewManager,
   };
 }
 
@@ -1420,5 +1466,108 @@ describe("McpServerService", () => {
 
     expect(result.isError).not.toBe(true);
     expect(result.content[0].text).toContain('"self": "[Circular]"');
+  });
+
+  it("routes IPC bounce to the active project view, not the host shell", async () => {
+    const { window, webContents, hostShellWebContents } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const requestManifest = (
+      service as never as { requestManifest: () => Promise<ActionManifestEntry[]> }
+    ).requestManifest.bind(service);
+
+    await requestManifest();
+
+    expect(webContents.send).toHaveBeenCalledWith(
+      "mcp:get-manifest-request",
+      expect.objectContaining({ requestId: expect.any(String) })
+    );
+    expect(hostShellWebContents.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects IPC responses from a sender that did not originate the request", async () => {
+    const { window, webContents } = createMockWindow({
+      senderIdOverride: 99999, // simulate a response coming from the wrong webContents
+    });
+
+    await service.start(window);
+    const requestManifest = (
+      service as never as { requestManifest: () => Promise<ActionManifestEntry[]> }
+    ).requestManifest.bind(service);
+
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    try {
+      const promise = requestManifest();
+      // Attach the rejection assertion synchronously so the eventual reject
+      // is not flagged as an unhandled rejection when the timer fires below.
+      const assertion = expect(promise).rejects.toThrow("Manifest request timed out");
+      // Flush the queueMicrotask in send() so the wrong-sender response lands.
+      await Promise.resolve();
+      // Advance past the 5s manifest timeout.
+      await vi.advanceTimersByTimeAsync(5_001);
+      await assertion;
+      expect(webContents.send).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected sender 99999")
+      );
+    } finally {
+      vi.useRealTimers();
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("fails closed when no project view is active", async () => {
+    const { window, webContents, projectViewManager } = createMockWindow();
+    projectViewManager.getActiveView.mockReturnValue(null);
+
+    await service.start(window);
+    const requestManifest = (
+      service as never as { requestManifest: () => Promise<unknown> }
+    ).requestManifest.bind(service);
+    const dispatchAction = (
+      service as never as {
+        dispatchAction: (actionId: string, args: unknown, confirmed?: boolean) => Promise<unknown>;
+      }
+    ).dispatchAction.bind(service);
+
+    await expect(requestManifest()).rejects.toThrow("MCP renderer bridge unavailable");
+    await expect(dispatchAction("actions.list", {}, false)).rejects.toThrow(
+      "MCP renderer bridge unavailable"
+    );
+    expect(webContents.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects pending requests when the target webContents is destroyed mid-flight", async () => {
+    const { window, webContents } = createMockWindow({
+      // Manifest mock won't fire — we simulate a destroy before the response arrives.
+      getManifest: () => {
+        throw new Error("should not be called");
+      },
+    });
+    // Override send to a no-op so the destroyed event has time to land.
+    webContents.send.mockImplementation(() => {});
+
+    await service.start(window);
+    const requestManifest = (
+      service as never as { requestManifest: () => Promise<unknown> }
+    ).requestManifest.bind(service);
+
+    const promise = requestManifest();
+
+    // Trigger the once("destroyed") listener that the service registered.
+    webContents.triggerDestroyed();
+
+    await expect(promise).rejects.toThrow("MCP renderer bridge destroyed");
   });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -247,7 +247,7 @@ function createMockWindow(options?: {
   };
 
   const projectViewManager = {
-    getActiveView: vi.fn(() => ({ webContents })),
+    getActiveView: vi.fn((): { webContents: typeof webContents } | null => ({ webContents })),
   };
 
   const windowContext = {


### PR DESCRIPTION
## Summary

- MCP IPC bounce calls were targeting `BrowserWindow.webContents` (the host shell) instead of the active `WebContentsView` for the current project. Tools like `worktree.list` and `terminal.list` were resolving against host state, not the project's Zustand stores.
- Response handlers had no sender validation -- any renderer knowing a request ID could resolve a pending promise.
- Stale or destroyed views now fail closed: `webContents.once("destroyed")` rejects in-flight requests immediately rather than silently hanging.

Resolves #6518

## Changes

- `getLiveWebContents` replaced with routing through `ProjectViewManager.getActiveView()` (singleton fallback for external clients with no window context)
- `mcp:get-manifest-response` and `mcp:dispatch-action-response` handlers now pin `event.sender.id` against the originating `webContentsId` -- warn and drop on mismatch
- Null-guard on IPC payload in both handlers
- `webContents.once("destroyed", ...)` wired up per-request to reject mid-flight
- Rejects immediately with a structured error when no active project view exists

## Testing

4 new tests in `McpServerService.test.ts`:
- Routing target -- bounce goes to the active `WebContentsView`, not the host shell
- Sender validation -- mismatched `sender.id` is warned and dropped
- No-active-view rejection -- promise rejects with a descriptive error when `getActiveView()` returns null
- Mid-flight destroy -- `destroyed` event rejects the pending promise before a response arrives