### PR TITLE
feat(mcp): add Streamable HTTP transport at /mcp

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -10,6 +10,7 @@ import fs from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/types/actions.js";
@@ -144,6 +145,12 @@ interface McpSseSession {
   tier?: string;
 }
 
+interface McpHttpSession {
+  transport: StreamableHTTPServerTransport;
+  server: Server;
+  idleTimer: ReturnType<typeof setTimeout>;
+}
+
 function safeSerializeToolResult(value: unknown): string {
   const seen = new WeakSet<object>();
 
@@ -198,6 +205,7 @@ export class McpServerService {
   private registry: WindowRegistry | null = null;
   private starting = false;
   private sessions = new Map<string, McpSseSession>();
+  private httpSessions = new Map<string, McpHttpSession>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
@@ -535,7 +543,9 @@ export class McpServerService {
       this.port = boundPort;
       this.httpServer = server;
       await this.writeDiscoveryFile();
-      console.log(`[MCP] Server started on http://127.0.0.1:${this.port}/sse`);
+      console.log(
+        `[MCP] Server started on http://127.0.0.1:${this.port}/mcp (Streamable HTTP) and /sse (legacy SSE)`
+      );
       this.emitStatusChange();
     } finally {
       this.starting = false;
@@ -554,6 +564,16 @@ export class McpServerService {
       }
     }
     this.sessions.clear();
+
+    for (const session of this.httpSessions.values()) {
+      clearTimeout(session.idleTimer);
+      try {
+        await session.transport.close();
+      } catch {
+        // ignore close errors during shutdown
+      }
+    }
+    this.httpSessions.clear();
 
     for (const cleanup of this.cleanupListeners) {
       cleanup();
@@ -607,8 +627,8 @@ export class McpServerService {
 
   getConfigSnippet(): string {
     const config = this.getConfig();
-    const url = this.port ? `http://127.0.0.1:${this.port}/sse` : "http://127.0.0.1:<port>/sse";
-    const entry: Record<string, unknown> = { type: "sse", url };
+    const url = this.port ? `http://127.0.0.1:${this.port}/mcp` : "http://127.0.0.1:<port>/mcp";
+    const entry: Record<string, unknown> = { type: "http", url };
     if (config.apiKey) {
       entry.headers = { Authorization: `Bearer ${config.apiKey}` };
     }
@@ -1124,10 +1144,94 @@ export class McpServerService {
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Session not found");
       }
+    } else if (
+      url.pathname === "/mcp" &&
+      (req.method === "GET" || req.method === "POST" || req.method === "DELETE")
+    ) {
+      await this.handleStreamableHttpRequest(req, res);
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");
     }
+  }
+
+  private async handleStreamableHttpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    const headerValue = req.headers["mcp-session-id"];
+    const sessionId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (sessionId !== undefined && sessionId !== "") {
+      const session = this.httpSessions.get(sessionId);
+      if (!session) {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Session not found");
+        return;
+      }
+      this.resetHttpIdleTimer(sessionId);
+      await session.transport.handleRequest(req, res);
+      return;
+    }
+
+    const server = this.createSessionServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (newSessionId) => {
+        const idleTimer = this.createHttpIdleTimer(newSessionId);
+        this.httpSessions.set(newSessionId, { transport, server, idleTimer });
+      },
+    });
+
+    transport.onclose = () => {
+      const id = transport.sessionId;
+      if (id === undefined) return;
+      const session = this.httpSessions.get(id);
+      if (session) {
+        clearTimeout(session.idleTimer);
+        this.httpSessions.delete(id);
+      }
+    };
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (err) {
+      console.error("[MCP] Streamable HTTP request failed:", err);
+      const id = transport.sessionId;
+      if (id !== undefined) {
+        const session = this.httpSessions.get(id);
+        if (session) {
+          clearTimeout(session.idleTimer);
+          this.httpSessions.delete(id);
+        }
+      }
+      await transport.close().catch(() => {});
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end("Internal server error");
+      }
+    }
+  }
+
+  private createHttpIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
+    const timer = setTimeout(() => {
+      const session = this.httpSessions.get(sessionId);
+      if (!session) return;
+      this.httpSessions.delete(sessionId);
+      session.transport.close().catch(() => {
+        // ignore close errors during idle timeout cleanup
+      });
+    }, MCP_SSE_IDLE_TIMEOUT_MS);
+    timer.unref?.();
+    return timer;
+  }
+
+  private resetHttpIdleTimer(sessionId: string): void {
+    const session = this.httpSessions.get(sessionId);
+    if (!session) return;
+    clearTimeout(session.idleTimer);
+    session.idleTimer = this.createHttpIdleTimer(sessionId);
   }
 
   private createIdleTimer(sessionId: string): ReturnType<typeof setTimeout> {
@@ -1170,8 +1274,8 @@ export class McpServerService {
 
       const mcpServers = (existing["mcpServers"] as Record<string, unknown> | undefined) ?? {};
       const entry: Record<string, unknown> = {
-        type: "sse",
-        url: `http://127.0.0.1:${this.port}/sse`,
+        type: "http",
+        url: `http://127.0.0.1:${this.port}/mcp`,
       };
       const apiKey = this.getConfig().apiKey;
       if (apiKey) {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1144,10 +1144,15 @@ export class McpServerService {
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Session not found");
       }
-    } else if (
-      url.pathname === "/mcp" &&
-      (req.method === "GET" || req.method === "POST" || req.method === "DELETE")
-    ) {
+    } else if (url.pathname === "/mcp") {
+      if (req.method !== "GET" && req.method !== "POST" && req.method !== "DELETE") {
+        res.writeHead(405, {
+          Allow: "GET, POST, DELETE",
+          "Content-Type": "text/plain",
+        });
+        res.end("Method not allowed");
+        return;
+      }
       await this.handleStreamableHttpRequest(req, res);
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
@@ -1165,8 +1170,14 @@ export class McpServerService {
     if (sessionId !== undefined && sessionId !== "") {
       const session = this.httpSessions.get(sessionId);
       if (!session) {
-        res.writeHead(404, { "Content-Type": "text/plain" });
-        res.end("Session not found");
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            error: { code: -32001, message: "Session not found" },
+            id: null,
+          })
+        );
         return;
       }
       this.resetHttpIdleTimer(sessionId);

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   ActionDispatchResult,
   ActionManifestEntry,
@@ -295,6 +296,63 @@ async function connectClient(
   return { client, transport };
 }
 
+async function connectHttpClient(
+  port: number,
+  headers?: Record<string, string>
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+  const apiKey = storeState.mcpServer.apiKey;
+  const mergedHeaders: Record<string, string> = {
+    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    ...(headers ?? {}),
+  };
+  const hasHeaders = Object.keys(mergedHeaders).length > 0;
+  const client = new Client({ name: "mcp-test-http-client", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+    requestInit: hasHeaders ? { headers: mergedHeaders } : undefined,
+  });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+async function requestMcp(
+  port: number,
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  } = {}
+): Promise<{ status: number; body: string }> {
+  const method = options.method ?? "POST";
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/mcp",
+        method,
+        headers: options.headers ?? {},
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body });
+        });
+      }
+    );
+
+    req.on("error", reject);
+    if (options.body !== undefined) {
+      req.end(options.body);
+    } else {
+      req.end();
+    }
+  });
+}
+
 async function requestSse(
   port: number,
   headers: Record<string, string> = {}
@@ -332,6 +390,7 @@ function getTextResult(result: unknown): TextToolResult {
 describe("McpServerService", () => {
   let service: McpServerService;
   const transports: SSEClientTransport[] = [];
+  const httpTransports: StreamableHTTPClientTransport[] = [];
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
@@ -350,6 +409,7 @@ describe("McpServerService", () => {
     electronMocks.ipcMain.handle.mockClear();
     electronMocks.ipcMain.removeHandler.mockClear();
     transports.length = 0;
+    httpTransports.length = 0;
     await fs.rm(path.join(testHomeDir, ".daintree"), { recursive: true, force: true });
     await fs.mkdir(testHomeDir, { recursive: true });
     consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -358,6 +418,9 @@ describe("McpServerService", () => {
 
   afterEach(async () => {
     for (const transport of transports) {
+      await transport.close().catch(() => {});
+    }
+    for (const transport of httpTransports) {
       await transport.close().catch(() => {});
     }
     if (service.isRunning) {
@@ -576,10 +639,15 @@ describe("McpServerService", () => {
     await service.start(window);
 
     const initial = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
-      mcpServers: Record<string, { headers?: { Authorization: string } }>;
+      mcpServers: Record<
+        string,
+        { type?: string; url?: string; headers?: { Authorization: string } }
+      >;
     };
     const initialKey = storeState.mcpServer.apiKey;
     expect(initialKey).toMatch(/^daintree_[a-f0-9]+$/);
+    expect(initial.mcpServers.daintree.type).toBe("http");
+    expect(initial.mcpServers.daintree.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/);
     expect(initial.mcpServers.daintree.headers).toEqual({
       Authorization: `Bearer ${initialKey}`,
     });
@@ -1569,5 +1637,206 @@ describe("McpServerService", () => {
     webContents.triggerDestroyed();
 
     await expect(promise).rejects.toThrow("MCP renderer bridge destroyed");
+  });
+
+  it("serves the Streamable HTTP transport at /mcp and lists tools", async () => {
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectHttpClient(service.currentPort!);
+    httpTransports.push(transport);
+
+    const result = await client.listTools();
+    const ids = result.tools.map((tool) => tool.name);
+    expect(ids).toContain("actions.list");
+
+    const httpSessions = (service as unknown as { httpSessions: Map<string, unknown> })
+      .httpSessions;
+    expect(httpSessions.size).toBe(1);
+  });
+
+  it("reuses the same Streamable HTTP session for follow-up tool calls", async () => {
+    const dispatchMock = vi.fn(
+      (payload: DispatchRequest): ActionDispatchResult => ({
+        ok: true,
+        result: { dispatched: payload.actionId },
+      })
+    );
+
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectHttpClient(service.currentPort!);
+    httpTransports.push(transport);
+
+    await client.callTool({ name: "actions.list", arguments: {} });
+    await client.callTool({ name: "actions.list", arguments: {} });
+
+    const httpSessions = (service as unknown as { httpSessions: Map<string, unknown> })
+      .httpSessions;
+    expect(httpSessions.size).toBe(1);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 404 on /mcp requests with an unknown mcp-session-id header", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const port = service.currentPort!;
+    const result = await requestMcp(port, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${storeState.mcpServer.apiKey}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": "definitely-not-a-real-session",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+
+    expect(result.status).toBe(404);
+    expect(result.body).toBe("Session not found");
+  });
+
+  it("rejects /mcp requests that fail auth, host, or origin checks", async () => {
+    storeState.mcpServer.apiKey = "secret";
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const port = service.currentPort!;
+
+    const unauthorized = await requestMcp(port, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const wrongOrigin = await requestMcp(port, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret",
+        Origin: "https://evil.example",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(wrongOrigin.status).toBe(403);
+
+    const wrongHost = await requestMcp(port, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer secret",
+        Host: "evil.example",
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    expect(wrongHost.status).toBe(403);
+  });
+
+  it("closes idle Streamable HTTP sessions after the application-level timeout", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const { window } = createMockWindow();
+      await service.start(window);
+
+      const httpSessions = (
+        service as unknown as {
+          httpSessions: Map<string, { transport: { close: () => Promise<void> } }>;
+        }
+      ).httpSessions;
+
+      const transport = {
+        sessionId: "http-test-session",
+        close: vi.fn(async () => {}),
+      };
+      const createHttpIdleTimer = (
+        service as unknown as {
+          createHttpIdleTimer: (sessionId: string) => ReturnType<typeof setTimeout>;
+        }
+      ).createHttpIdleTimer.bind(service);
+
+      const idleTimer = createHttpIdleTimer("http-test-session");
+      httpSessions.set("http-test-session", {
+        transport,
+        idleTimer,
+      } as never);
+
+      expect(httpSessions.has("http-test-session")).toBe(true);
+
+      vi.advanceTimersByTime(30 * 60 * 1000 + 1);
+
+      expect(httpSessions.has("http-test-session")).toBe(false);
+      expect(transport.close).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the SSE transport functional after Streamable HTTP is in use", async () => {
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list" as ActionId,
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+    });
+
+    await service.start(window);
+
+    const { client: httpClient, transport: httpTransport } = await connectHttpClient(
+      service.currentPort!
+    );
+    httpTransports.push(httpTransport);
+    const httpResult = await httpClient.listTools();
+    expect(httpResult.tools.map((t) => t.name)).toContain("actions.list");
+
+    const { client: sseClient, transport: sseTransport } = await connectClient(
+      service.currentPort!
+    );
+    transports.push(sseTransport);
+    const sseResult = await sseClient.listTools();
+    expect(sseResult.tools.map((t) => t.name)).toContain("actions.list");
+  });
+
+  it("emits the Streamable HTTP config snippet with type 'http' and /mcp", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const snippet = JSON.parse(service.getConfigSnippet()) as {
+      mcpServers: Record<
+        string,
+        { type: string; url: string; headers?: { Authorization: string } }
+      >;
+    };
+
+    expect(snippet.mcpServers.daintree.type).toBe("http");
+    expect(snippet.mcpServers.daintree.url).toBe(`http://127.0.0.1:${service.currentPort}/mcp`);
+    expect(snippet.mcpServers.daintree.headers).toEqual({
+      Authorization: `Bearer ${storeState.mcpServer.apiKey}`,
+    });
   });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1689,11 +1689,16 @@ describe("McpServerService", () => {
     httpTransports.push(transport);
 
     await client.callTool({ name: "actions.list", arguments: {} });
-    await client.callTool({ name: "actions.list", arguments: {} });
 
     const httpSessions = (service as unknown as { httpSessions: Map<string, unknown> })
       .httpSessions;
-    expect(httpSessions.size).toBe(1);
+    const sessionIdsAfterFirst = Array.from(httpSessions.keys());
+    expect(sessionIdsAfterFirst).toHaveLength(1);
+
+    await client.callTool({ name: "actions.list", arguments: {} });
+
+    const sessionIdsAfterSecond = Array.from(httpSessions.keys());
+    expect(sessionIdsAfterSecond).toEqual(sessionIdsAfterFirst);
     expect(dispatchMock).toHaveBeenCalledTimes(2);
   });
 
@@ -1714,7 +1719,48 @@ describe("McpServerService", () => {
     });
 
     expect(result.status).toBe(404);
-    expect(result.body).toBe("Session not found");
+    const parsed = JSON.parse(result.body) as {
+      jsonrpc: string;
+      error: { code: number; message: string };
+      id: null;
+    };
+    expect(parsed.jsonrpc).toBe("2.0");
+    expect(parsed.error.code).toBe(-32001);
+    expect(parsed.error.message).toBe("Session not found");
+    expect(parsed.id).toBeNull();
+  });
+
+  it("returns 405 with an Allow header for unsupported methods on /mcp", async () => {
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    const port = service.currentPort!;
+    const result = await new Promise<{ status: number; allow: string | undefined }>(
+      (resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/mcp",
+            method: "PUT",
+            headers: { Authorization: `Bearer ${storeState.mcpServer.apiKey}` },
+          },
+          (res) => {
+            const allow = res.headers["allow"];
+            resolve({
+              status: res.statusCode ?? 0,
+              allow: Array.isArray(allow) ? allow[0] : allow,
+            });
+            res.resume();
+          }
+        );
+        req.on("error", reject);
+        req.end();
+      }
+    );
+
+    expect(result.status).toBe(405);
+    expect(result.allow).toBe("GET, POST, DELETE");
   });
 
   it("rejects /mcp requests that fail auth, host, or origin checks", async () => {


### PR DESCRIPTION
## Summary

- Adds a Streamable HTTP endpoint at `/mcp` to `McpServerService`, giving modern clients (Claude Code, Cursor, Cline) a spec-compliant transport without breaking existing SSE consumers
- Per-session lifecycle via `StreamableHTTPServerTransport` — each session gets its own transport instance, cleaned up on close; DNS-rebinding protection enabled; same bearer auth and Host/Origin validation as SSE
- Generated config snippet and `~/.daintree/mcp.json` discovery file now emit `type: "http"` pointing at `/mcp`; the `"sse"` value remains for backward compat

Resolves #6516

## Changes

- `electron/services/McpServerService.ts`: `POST /mcp` initialises a new `StreamableHTTPServerTransport` (or reuses an existing session via `mcp-session-id`), wires it to the existing `McpServer` instance, and connects the IPC dispatch path; `GET /mcp` and `DELETE /mcp` delegate to the transport; unsupported methods return 405; `getConfigSnippet` now returns `type: "http"` and the `/mcp` URL; discovery file write updated to match
- `electron/services/__tests__/McpServerService.test.ts`: tests for session init/reuse, unknown-session 404, auth and host/origin rejection, idle timeout, SSE coexistence, 405 for unsupported methods, and config snippet shape

## Testing

Unit tests cover the full surface area of the new endpoint — session lifecycle, security rejections, timeout handling, and correct coexistence with the existing `/sse` + `/messages` routes. All tests pass.