### PR TITLE
feat(github): pre-warm PR tooltip from poll and Doherty-gate the loader

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -72,6 +72,14 @@ const prListCache = new Cache<string, GitHubListResponse<GitHubPR>>({ defaultTTL
 const projectHealthCache = new Cache<string, ProjectHealth>({ defaultTTL: 60000 });
 const issueTooltipCache = new Cache<string, IssueTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
 const prTooltipCache = new Cache<string, PRTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
+// Newest-wins guard for prTooltipCache: tracks the request-start timestamp of
+// the most recent successful write per cache key. Both poll-path (pre-warm)
+// and hover-path writes capture Date.now() before awaiting the network call,
+// then only commit when their captured timestamp is >= the stored one. Without
+// this guard a slow poll resolving after a faster hover fetch would clobber
+// fresher data with staler data (lessons #2243, #1377). MUST be cleared
+// alongside prTooltipCache wherever it is cleared.
+const prTooltipWrittenAt = new Map<string, number>();
 
 // ETag cache for PR conditional revalidation. Key: `owner/repo#prNumber`.
 // Cleared on token rotation via clearGitHubCaches (ETags are token-scoped).
@@ -806,6 +814,76 @@ export async function getRepoInfo(cwd: string): Promise<RepoContext | null> {
   return getRepoContext(cwd);
 }
 
+/**
+ * Tooltip-shaped raw fields fetched alongside `LinkedPR` shape in the batch
+ * query. Mirrors the subset of `GET_PR_QUERY` fields that `getPRTooltip`
+ * reads, so the same projection logic produces a `PRTooltipData`.
+ */
+interface BatchPRTooltipFields {
+  bodyText?: string | null;
+  createdAt?: string;
+  author?: { login?: string; avatarUrl?: string } | null;
+  assignees?: { nodes?: Array<{ login?: string; avatarUrl?: string }> };
+  labels?: { nodes?: Array<{ name?: string; color?: string }> };
+}
+
+interface BatchPRRawNode extends BatchPRTooltipFields {
+  number?: number;
+  title?: string;
+  url?: string;
+  state?: string;
+  isDraft?: boolean;
+  merged?: boolean;
+}
+
+/**
+ * Build a `PRTooltipData` from the raw GraphQL node returned by the batch
+ * query. Mirrors the projection in `getPRTooltip` (single-PR path) so both
+ * write paths produce structurally identical cache entries. Returns
+ * `undefined` when required fields are missing — the batch query may degrade
+ * gracefully if a node was selected via the `LinkedPR` shape only (e.g., on
+ * a partial response).
+ */
+function buildTooltipDataFromBatchNode(node: BatchPRRawNode): PRTooltipData | undefined {
+  if (typeof node.number !== "number" || typeof node.title !== "string") {
+    return undefined;
+  }
+  if (typeof node.createdAt !== "string") {
+    // createdAt is a required scalar on PRTooltipData — without it we cannot
+    // construct a valid entry (callers format it as a date).
+    return undefined;
+  }
+
+  const merged = node.merged ?? false;
+  const rawState = (node.state ?? "OPEN").toUpperCase();
+  const state: "OPEN" | "CLOSED" | "MERGED" = merged
+    ? "MERGED"
+    : rawState === "CLOSED"
+      ? "CLOSED"
+      : "OPEN";
+
+  return {
+    number: node.number,
+    title: node.title,
+    bodyExcerpt: truncateBody(node.bodyText ?? null),
+    state,
+    isDraft: node.isDraft ?? false,
+    createdAt: node.createdAt,
+    author: {
+      login: node.author?.login ?? "unknown",
+      avatarUrl: node.author?.avatarUrl ?? "",
+    },
+    assignees: (node.assignees?.nodes ?? []).filter(Boolean).map((a) => ({
+      login: a.login ?? "unknown",
+      avatarUrl: a.avatarUrl ?? "",
+    })),
+    labels: (node.labels?.nodes ?? []).filter(Boolean).map((l) => ({
+      name: l.name ?? "",
+      color: l.color ?? "",
+    })),
+  };
+}
+
 function parseBatchPRResponse(
   data: Record<string, unknown>,
   candidates: PRCheckCandidate[]
@@ -816,6 +894,7 @@ function parseBatchPRResponse(
     const candidate = candidates[i];
     const alias = `wt_${i}`;
     let foundPR: LinkedPR | null = null;
+    let foundTooltip: PRTooltipData | undefined;
     const issueResponse = (
       data?.[`${alias}_issue`] as {
         issue?: { title?: string; timelineItems?: { nodes?: unknown[] } };
@@ -824,54 +903,46 @@ function parseBatchPRResponse(
     const issueTitle = issueResponse?.title;
     const issueData = issueResponse?.timelineItems?.nodes;
     if (issueData && Array.isArray(issueData)) {
-      const prs: LinkedPR[] = [];
+      const prs: Array<{ pr: LinkedPR; raw: BatchPRRawNode }> = [];
       const seenPRNumbers = new Set<number>();
       for (const node of issueData as Array<{
-        // CROSS_REFERENCED_EVENT uses 'source'
-        source?: {
-          number?: number;
-          title?: string;
-          url?: string;
-          state?: string;
-          isDraft?: boolean;
-          merged?: boolean;
-        };
-        // CONNECTED_EVENT uses 'subject'
-        subject?: {
-          number?: number;
-          title?: string;
-          url?: string;
-          state?: string;
-          isDraft?: boolean;
-          merged?: boolean;
-        };
+        source?: BatchPRRawNode;
+        subject?: BatchPRRawNode;
       }>) {
         // Handle both CROSS_REFERENCED_EVENT (source) and CONNECTED_EVENT (subject)
         const prData = node?.source ?? node?.subject;
         if (prData?.number && prData?.url && !seenPRNumbers.has(prData.number)) {
           seenPRNumbers.add(prData.number);
           prs.push({
-            number: prData.number,
-            title: prData.title || "",
-            url: prData.url,
-            state: prData.merged
-              ? "merged"
-              : (prData.state?.toLowerCase() as "open" | "closed") || "open",
-            isDraft: prData.isDraft ?? false,
+            pr: {
+              number: prData.number,
+              title: prData.title || "",
+              url: prData.url,
+              state: prData.merged
+                ? "merged"
+                : (prData.state?.toLowerCase() as "open" | "closed") || "open",
+              isDraft: prData.isDraft ?? false,
+            },
+            raw: prData,
           });
         }
       }
 
-      const openPRs = prs.filter((pr) => pr.state === "open");
-      const mergedPRs = prs.filter((pr) => pr.state === "merged");
-      const closedPRs = prs.filter((pr) => pr.state === "closed");
+      const openPRs = prs.filter((entry) => entry.pr.state === "open");
+      const mergedPRs = prs.filter((entry) => entry.pr.state === "merged");
+      const closedPRs = prs.filter((entry) => entry.pr.state === "closed");
 
+      let chosen: { pr: LinkedPR; raw: BatchPRRawNode } | undefined;
       if (openPRs.length > 0) {
-        foundPR = openPRs[openPRs.length - 1];
+        chosen = openPRs[openPRs.length - 1];
       } else if (mergedPRs.length > 0) {
-        foundPR = mergedPRs[mergedPRs.length - 1];
+        chosen = mergedPRs[mergedPRs.length - 1];
       } else if (closedPRs.length > 0) {
-        foundPR = closedPRs[closedPRs.length - 1];
+        chosen = closedPRs[closedPRs.length - 1];
+      }
+      if (chosen) {
+        foundPR = chosen.pr;
+        foundTooltip = buildTooltipDataFromBatchNode(chosen.raw);
       }
     }
 
@@ -880,39 +951,40 @@ function parseBatchPRResponse(
         ?.pullRequests?.nodes;
       if (branchData && Array.isArray(branchData)) {
         // Parse all PRs from branch query
-        const branchPRs: LinkedPR[] = [];
-        for (const node of branchData as Array<{
-          number?: number;
-          title?: string;
-          url?: string;
-          state?: string;
-          isDraft?: boolean;
-          merged?: boolean;
-        }>) {
+        const branchPRs: Array<{ pr: LinkedPR; raw: BatchPRRawNode }> = [];
+        for (const node of branchData as BatchPRRawNode[]) {
           if (node?.number && node?.url) {
             branchPRs.push({
-              number: node.number,
-              title: node.title || "",
-              url: node.url,
-              state: node.merged
-                ? "merged"
-                : (node.state?.toLowerCase() as "open" | "closed") || "open",
-              isDraft: node.isDraft ?? false,
+              pr: {
+                number: node.number,
+                title: node.title || "",
+                url: node.url,
+                state: node.merged
+                  ? "merged"
+                  : (node.state?.toLowerCase() as "open" | "closed") || "open",
+                isDraft: node.isDraft ?? false,
+              },
+              raw: node,
             });
           }
         }
 
         // Apply same preference: open > merged > closed
-        const openPRs = branchPRs.filter((pr) => pr.state === "open");
-        const mergedPRs = branchPRs.filter((pr) => pr.state === "merged");
-        const closedPRs = branchPRs.filter((pr) => pr.state === "closed");
+        const openPRs = branchPRs.filter((entry) => entry.pr.state === "open");
+        const mergedPRs = branchPRs.filter((entry) => entry.pr.state === "merged");
+        const closedPRs = branchPRs.filter((entry) => entry.pr.state === "closed");
 
+        let chosen: { pr: LinkedPR; raw: BatchPRRawNode } | undefined;
         if (openPRs.length > 0) {
-          foundPR = openPRs[openPRs.length - 1];
+          chosen = openPRs[openPRs.length - 1];
         } else if (mergedPRs.length > 0) {
-          foundPR = mergedPRs[mergedPRs.length - 1];
+          chosen = mergedPRs[mergedPRs.length - 1];
         } else if (closedPRs.length > 0) {
-          foundPR = closedPRs[closedPRs.length - 1];
+          chosen = closedPRs[closedPRs.length - 1];
+        }
+        if (chosen) {
+          foundPR = chosen.pr;
+          foundTooltip = buildTooltipDataFromBatchNode(chosen.raw);
         }
       }
     }
@@ -922,6 +994,7 @@ function parseBatchPRResponse(
       issueTitle,
       branchName: candidate.branchName,
       pr: foundPR,
+      ...(foundTooltip ? { tooltipData: foundTooltip } : {}),
     });
   }
 
@@ -1203,12 +1276,18 @@ export async function batchCheckLinkedPRs(
   }
 
   try {
+    // Capture timestamp BEFORE the network round-trip so the newest-wins guard
+    // orders writes by request-start time, not response-arrival time. A slow
+    // batch that starts before a fast hover but resolves after must NOT
+    // overwrite the fresher hover write.
+    const requestedAt = Date.now();
     const query = buildBatchPRQuery(context.owner, context.repo, candidatesForGraphQL);
     const response = (await client(query, {
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as Record<string, unknown>;
 
     const results = parseBatchPRResponse(response, candidatesForGraphQL);
+    prewarmPRTooltipCache(context.owner, context.repo, results, requestedAt);
     return { results };
   } catch (error) {
     if (isRepoNotFoundError(error)) {
@@ -1219,6 +1298,7 @@ export async function batchCheckLinkedPRs(
         (freshContext.owner !== context.owner || freshContext.repo !== context.repo)
       ) {
         try {
+          const retryRequestedAt = Date.now();
           const retryQuery = buildBatchPRQuery(
             freshContext.owner,
             freshContext.repo,
@@ -1227,13 +1307,45 @@ export async function batchCheckLinkedPRs(
           const retryResponse = (await client(retryQuery, {
             request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
           })) as Record<string, unknown>;
-          return { results: parseBatchPRResponse(retryResponse, candidatesForGraphQL) };
+          const retryResults = parseBatchPRResponse(retryResponse, candidatesForGraphQL);
+          prewarmPRTooltipCache(
+            freshContext.owner,
+            freshContext.repo,
+            retryResults,
+            retryRequestedAt
+          );
+          return { results: retryResults };
         } catch (retryError) {
           return { results: new Map(), error: parseGitHubError(retryError), ...rateLimitMeta() };
         }
       }
     }
     return { results: new Map(), error: parseGitHubError(error), ...rateLimitMeta() };
+  }
+}
+
+/**
+ * Write each batch result's harvested tooltip data into `prTooltipCache`
+ * subject to the newest-wins guard. Cache key matches `getPRTooltip`'s
+ * format so on-hover IPC calls hit the warm entry instead of issuing a
+ * fresh GraphQL request.
+ */
+function prewarmPRTooltipCache(
+  owner: string,
+  repo: string,
+  results: Map<string, PRCheckResult>,
+  requestedAt: number
+): void {
+  for (const result of results.values()) {
+    const prNumber = result.pr?.number;
+    const tooltipData = result.tooltipData;
+    if (typeof prNumber !== "number" || !tooltipData) continue;
+    const cacheKey = `${owner}/${repo}:${prNumber}`;
+    const existing = prTooltipWrittenAt.get(cacheKey);
+    if (existing === undefined || requestedAt >= existing) {
+      prTooltipCache.set(cacheKey, tooltipData);
+      prTooltipWrittenAt.set(cacheKey, requestedAt);
+    }
   }
 }
 
@@ -1506,6 +1618,7 @@ export function clearGitHubCaches(): void {
   prListCache.clear();
   issueTooltipCache.clear();
   prTooltipCache.clear();
+  prTooltipWrittenAt.clear();
   prETagCache.clear();
   branchListETagCache.clear();
   prRequiredStatusCache.clear();
@@ -1517,6 +1630,7 @@ export function clearGitHubCaches(): void {
 export function clearPRCaches(): void {
   prListCache.clear();
   prTooltipCache.clear();
+  prTooltipWrittenAt.clear();
   prRequiredStatusCache.clear();
 }
 
@@ -2132,6 +2246,10 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
         return cached;
       }
 
+      // Capture timestamp BEFORE the network round-trip so the newest-wins
+      // guard orders writes by request-start time. A poll batch starting
+      // later would still overwrite if we used response-arrival time here.
+      const requestedAt = Date.now();
       const response = (await client(GET_PR_QUERY, {
         owner: context.owner,
         repo: context.repo,
@@ -2178,7 +2296,11 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
         })),
       };
 
-      prTooltipCache.set(cacheKey, tooltipData);
+      const existing = prTooltipWrittenAt.get(cacheKey);
+      if (existing === undefined || requestedAt >= existing) {
+        prTooltipCache.set(cacheKey, tooltipData);
+        prTooltipWrittenAt.set(cacheKey, requestedAt);
+      }
       return tooltipData;
     });
   } catch {

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -71,15 +71,21 @@ const issueListCache = new Cache<string, GitHubListResponse<GitHubIssue>>({ defa
 const prListCache = new Cache<string, GitHubListResponse<GitHubPR>>({ defaultTTL: 60000 });
 const projectHealthCache = new Cache<string, ProjectHealth>({ defaultTTL: 60000 });
 const issueTooltipCache = new Cache<string, IssueTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
-const prTooltipCache = new Cache<string, PRTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
 // Newest-wins guard for prTooltipCache: tracks the request-start timestamp of
 // the most recent successful write per cache key. Both poll-path (pre-warm)
 // and hover-path writes capture Date.now() before awaiting the network call,
 // then only commit when their captured timestamp is >= the stored one. Without
 // this guard a slow poll resolving after a faster hover fetch would clobber
-// fresher data with staler data (lessons #2243, #1377). MUST be cleared
-// alongside prTooltipCache wherever it is cleared.
+// fresher data with staler data (lessons #2243, #1377). The Cache `onEvict`
+// hook keeps this map's lifetime tied to prTooltipCache so LRU eviction does
+// not leave orphaned timestamps; explicit clears below also reset it.
 const prTooltipWrittenAt = new Map<string, number>();
+const prTooltipCache = new Cache<string, PRTooltipData>({
+  defaultTTL: 300000, // 5 min TTL
+  onEvict: (key) => {
+    prTooltipWrittenAt.delete(key as string);
+  },
+});
 
 // ETag cache for PR conditional revalidation. Key: `owner/repo#prNumber`.
 // Cleared on token rotation via clearGitHubCaches (ETags are token-scoped).

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -450,6 +450,11 @@ export function buildBatchPRQuery(
                       state
                       isDraft
                       merged
+                      bodyText
+                      createdAt
+                      author { login avatarUrl }
+                      assignees(first: 5) { nodes { login avatarUrl } }
+                      labels(first: 10) { nodes { name color } }
                     }
                   }
                 }
@@ -462,6 +467,11 @@ export function buildBatchPRQuery(
                       state
                       isDraft
                       merged
+                      bodyText
+                      createdAt
+                      author { login avatarUrl }
+                      assignees(first: 5) { nodes { login avatarUrl } }
+                      labels(first: 10) { nodes { name color } }
                     }
                   }
                 }
@@ -486,6 +496,11 @@ export function buildBatchPRQuery(
               state
               isDraft
               merged
+              bodyText
+              createdAt
+              author { login avatarUrl }
+              assignees(first: 5) { nodes { login avatarUrl } }
+              labels(first: 10) { nodes { name color } }
             }
           }
         }

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -199,4 +199,80 @@ describe("buildBatchPRQuery", () => {
     expect(query).toContain("issue(number: 7)");
     expect(query).toContain('headRefName: "feature-branch"');
   });
+
+  describe("tooltip pre-warm fields", () => {
+    // The poll-driven batch query over-fetches PR fields that match
+    // PRTooltipData so `prTooltipCache` can be warmed without an extra
+    // round-trip on first hover. Both query paths (issue timeline + branch
+    // search) must emit the same field shape.
+
+    it("includes tooltip fields on the issue-path PR fragments", () => {
+      const query = buildBatchPRQuery("owner", "repo", [{ worktreeId: "wt-1", issueNumber: 42 }]);
+
+      // Locate the issue path slice (no branch path emitted for this candidate).
+      const issuePathStart = query.indexOf("wt_0_issue:");
+      expect(issuePathStart).toBeGreaterThanOrEqual(0);
+      const issuePath = query.slice(issuePathStart);
+
+      // Both timeline event types resolve to PullRequest fragments — both
+      // need the tooltip projection so either codepath warms the cache.
+      const sourceFragmentStart = issuePath.indexOf("source");
+      const subjectFragmentStart = issuePath.indexOf("subject");
+      expect(sourceFragmentStart).toBeGreaterThanOrEqual(0);
+      expect(subjectFragmentStart).toBeGreaterThan(sourceFragmentStart);
+
+      const sourceFragment = issuePath.slice(sourceFragmentStart, subjectFragmentStart);
+      const subjectFragment = issuePath.slice(subjectFragmentStart);
+
+      for (const fragment of [sourceFragment, subjectFragment]) {
+        expect(fragment).toContain("bodyText");
+        expect(fragment).toContain("createdAt");
+        expect(fragment).toContain("author { login avatarUrl }");
+        expect(fragment).toContain("assignees(first: 5) { nodes { login avatarUrl } }");
+        expect(fragment).toContain("labels(first: 10) { nodes { name color } }");
+      }
+    });
+
+    it("includes tooltip fields on the branch-path PR nodes", () => {
+      const query = buildBatchPRQuery("owner", "repo", [
+        { worktreeId: "wt-1", branchName: "feature-branch" },
+      ]);
+
+      const branchPathStart = query.indexOf("wt_0_branch:");
+      expect(branchPathStart).toBeGreaterThanOrEqual(0);
+      const branchPath = query.slice(branchPathStart);
+
+      expect(branchPath).toContain("bodyText");
+      expect(branchPath).toContain("createdAt");
+      expect(branchPath).toContain("author { login avatarUrl }");
+      expect(branchPath).toContain("assignees(first: 5) { nodes { login avatarUrl } }");
+      expect(branchPath).toContain("labels(first: 10) { nodes { name color } }");
+    });
+
+    it("does not add an orderBy argument to assignees or labels connections", () => {
+      // Past lesson #3339: schema-context mismatches on connection ordering
+      // produce silent failures. Neither GitHub's PR.assignees nor PR.labels
+      // accepts an order arg; keep the call sites bare.
+      const query = buildBatchPRQuery("owner", "repo", [
+        { worktreeId: "wt-1", issueNumber: 42, branchName: "feature-branch" },
+      ]);
+
+      expect(query).not.toMatch(/assignees\(first:\s*5,\s*orderBy/);
+      expect(query).not.toMatch(/labels\(first:\s*10,\s*orderBy/);
+    });
+
+    it("uses bodyText (not body) so the response carries plain-text excerpt content", () => {
+      // GraphQL has both `body` (Markdown) and `bodyText` (plain text). The
+      // tooltip excerpt is rendered as plain text; using `body` would force
+      // every consumer to strip Markdown and breaks parity with getPRTooltip.
+      const query = buildBatchPRQuery("owner", "repo", [
+        { worktreeId: "wt-1", issueNumber: 42, branchName: "feature-branch" },
+      ]);
+
+      expect(query).toContain("bodyText");
+      // `body` is not present as a standalone field on either path. Match
+      // a word boundary to avoid matching `bodyText`.
+      expect(query).not.toMatch(/\bbody\b(?!Text)/);
+    });
+  });
 });

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -1,3 +1,5 @@
+import type { PRTooltipData } from "../../../shared/types/github.js";
+
 export interface RepoContext {
   owner: string;
   repo: string;
@@ -28,6 +30,12 @@ export interface PRCheckResult {
   issueTitle?: string;
   branchName?: string;
   pr: LinkedPR | null;
+  /**
+   * Tooltip-shaped data harvested from the same batch query, used to pre-warm
+   * `prTooltipCache` so hover-time fetches hit instantly. Populated only when
+   * the batch query yielded a PR with the extended tooltip fields.
+   */
+  tooltipData?: PRTooltipData;
 }
 
 export interface PRCheckCandidate {

--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,7 +1,6 @@
 import { memo } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
 import { User, Users, Calendar, KeyRound } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 
 function formatDate(dateString: string): string {
@@ -13,15 +12,24 @@ function formatDate(dateString: string): string {
   });
 }
 
-interface TooltipLoadingProps {
-  type: "issue" | "pr";
-}
-
-export const TooltipLoading = memo(function TooltipLoading({ type }: TooltipLoadingProps) {
+export const TooltipLoading = memo(function TooltipLoading() {
+  // Doherty-gated skeleton: `animate-pulse-delayed` keeps the bars invisible
+  // for the first 400ms, so a fast cache-warm response (the common case after
+  // the poll has pre-warmed `prTooltipCache`) shows nothing rather than a
+  // flash. After 400ms the bars fade in and pulse. Layout mirrors PR/issue
+  // tooltip content: title row, body excerpt, metadata row.
   return (
-    <div className="flex items-center gap-2 text-daintree-text/70 py-1">
-      <Spinner size="xs" />
-      <span className="text-xs">Loading {type} details...</span>
+    <div className="space-y-2 max-w-[280px]" aria-hidden="true">
+      <div className="flex items-start gap-2">
+        <div className="animate-pulse-delayed h-3 w-10 rounded bg-muted" />
+        <div className="animate-pulse-delayed h-3 flex-1 rounded bg-muted" />
+      </div>
+      <div className="animate-pulse-delayed h-2.5 w-full rounded bg-muted" />
+      <div className="animate-pulse-delayed h-2.5 w-2/3 rounded bg-muted" />
+      <div className="flex items-center gap-3 pt-1">
+        <div className="animate-pulse-delayed h-2 w-16 rounded bg-muted" />
+        <div className="animate-pulse-delayed h-2 w-20 rounded bg-muted" />
+      </div>
     </div>
   );
 });

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -172,7 +172,7 @@ const IssueBadge = memo(function IssueBadge({
         {missingToken ? (
           <TokenMissingTooltip type="issue" />
         ) : loading ? (
-          <TooltipLoading type="issue" />
+          <TooltipLoading />
         ) : data ? (
           <IssueTooltipContent data={data} />
         ) : error ? (
@@ -274,7 +274,7 @@ const PRBadge = memo(function PRBadge({
         {missingToken ? (
           <TokenMissingTooltip type="pr" />
         ) : loading ? (
-          <TooltipLoading type="pr" />
+          <TooltipLoading />
         ) : data ? (
           <PRTooltipContent data={data} />
         ) : error ? (


### PR DESCRIPTION
## Summary

- Extends `buildBatchPRQuery` to over-fetch tooltip fields (`bodyText`, `createdAt`, `author`, `assignees`, `labels`) on both PR fragments, so the existing poll has everything the hover tooltip needs — cold hover becomes warm hover.
- Introduces a `prTooltipWrittenAt` timestamp map (keyed by PR node ID, captured before the network await) so a stale poll write can't overwrite a fresher on-hover fetch. Eviction from `prTooltipCache` cleans the timestamp map via `onEvict`; `clearGitHubCaches` / `clearPRCaches` reset it explicitly.
- `TooltipLoading` drops the unconditional `Spinner` in favour of `animate-pulse-delayed` skeleton bars — the 400ms opacity gate hides them entirely on cache-warm hovers and renders a structural skeleton beyond the threshold.

Resolves #6534

## Changes

- `electron/services/GitHubService.ts` — `buildBatchPRQuery` over-fetches tooltip fields; `parseBatchPRResponse` harvests them via `buildTooltipDataFromBatchNode`; `batchCheckLinkedPRs` writes to `prTooltipCache` on both the primary and repo-rename retry paths; `prTooltipWrittenAt` map guards concurrent writes; `clearGitHubCaches` / `clearPRCaches` reset the map.
- `electron/services/github/GitHubQueries.ts` — tooltip field fragments added to both issue-timeline and branch-search PR fragments.
- `electron/services/github/types.ts` — `PRCheckResult` gains an optional `tooltipData` field.
- `src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx` — `TooltipLoading` rewritten with skeleton bars; unused `type` prop removed.
- `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx` — `TooltipLoading` call sites updated to remove the `type` prop.

## Testing

28 `GitHubQueries` tests pass (4 new: tooltip field presence on both PR fragments, no `orderBy` regression, `bodyText` vs `body` field). Full GitHub-related vitest run: 3054 tests. Typecheck, lint, format, and build all clean.