### PR TITLE
feat(mcp): migrate API key storage to safeStorage with Linux fallback

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { ipcMain, safeStorage } from "electron";
 import type { WindowRegistry } from "../window/WindowRegistry.js";
 import http from "node:http";
 import net from "node:net";
@@ -220,6 +220,53 @@ export class McpServerService {
     return this.getConfig().enabled;
   }
 
+  /**
+   * Returns the OS-level encryption posture for the bearer token. `keychain`
+   * means a real OS secret store is in use (macOS Keychain, Windows DPAPI, or a
+   * Linux libsecret/KWallet daemon). `basic_text` means Linux fell back to a
+   * hardcoded-password backend — encrypted at rest in name only. `unavailable`
+   * means `safeStorage.isEncryptionAvailable()` returned false (extremely rare
+   * post-`app.ready` on supported platforms).
+   */
+  getEncryptionBackend(): "keychain" | "basic_text" | "unavailable" {
+    if (!safeStorage.isEncryptionAvailable()) return "unavailable";
+    if (process.platform === "linux") {
+      const backend = safeStorage.getSelectedStorageBackend();
+      if (backend === "basic_text") return "basic_text";
+    }
+    return "keychain";
+  }
+
+  /**
+   * Decrypt the persisted bearer token. Returns "" when no key is stored. On
+   * decryption failure (OS keychain reset, app bundle id change, cross-machine
+   * config copy), the corrupted ciphertext is cleared and "" is returned so
+   * the auto-keygen path in `start()` can recover on next run.
+   */
+  private getApiKey(): string {
+    const config = this.getConfig();
+    const encrypted = config.apiKeyEncrypted;
+    if (!encrypted) return "";
+    try {
+      return safeStorage.decryptString(Buffer.from(encrypted, "base64"));
+    } catch (err) {
+      console.warn("[MCP] Failed to decrypt API key, clearing corrupted ciphertext:", err);
+      const { apiKeyEncrypted: _drop, ...rest } = config;
+      store.set("mcpServer", rest);
+      return "";
+    }
+  }
+
+  /**
+   * Encrypt a bearer token for persistence. Returns `undefined` for an empty
+   * key so callers can drop the field from the store. Throws if `safeStorage`
+   * is unavailable (caller decides whether to surface or swallow).
+   */
+  private encryptApiKey(apiKey: string): string | undefined {
+    if (!apiKey) return undefined;
+    return safeStorage.encryptString(apiKey).toString("base64");
+  }
+
   async setEnabled(enabled: boolean): Promise<void> {
     store.set("mcpServer", { ...this.getConfig(), enabled });
     if (enabled && this.registry && !this.isRunning) {
@@ -239,7 +286,13 @@ export class McpServerService {
   }
 
   async setApiKey(apiKey: string): Promise<void> {
-    store.set("mcpServer", { ...this.getConfig(), apiKey });
+    const config = this.getConfig();
+    const { apiKeyEncrypted: _previous, ...rest } = config;
+    const encrypted = this.encryptApiKey(apiKey);
+    store.set(
+      "mcpServer",
+      encrypted === undefined ? rest : { ...rest, apiKeyEncrypted: encrypted }
+    );
     if (this.isRunning) {
       await this.writeDiscoveryFile();
     }
@@ -247,10 +300,7 @@ export class McpServerService {
 
   async generateApiKey(): Promise<string> {
     const key = `daintree_${randomUUID().replace(/-/g, "")}`;
-    store.set("mcpServer", { ...this.getConfig(), apiKey: key });
-    if (this.isRunning) {
-      await this.writeDiscoveryFile();
-    }
+    await this.setApiKey(key);
     return key;
   }
 
@@ -268,7 +318,7 @@ export class McpServerService {
 
     this.starting = true;
     try {
-      if (!this.getConfig().apiKey) {
+      if (!this.getApiKey()) {
         await this.generateApiKey();
       }
 
@@ -356,22 +406,24 @@ export class McpServerService {
     port: number | null;
     configuredPort: number | null;
     apiKey: string;
+    encryptionBackend: "keychain" | "basic_text" | "unavailable";
   } {
     const config = this.getConfig();
     return {
       enabled: config.enabled,
       port: this.port,
       configuredPort: config.port,
-      apiKey: config.apiKey,
+      apiKey: this.getApiKey(),
+      encryptionBackend: this.getEncryptionBackend(),
     };
   }
 
   getConfigSnippet(): string {
-    const config = this.getConfig();
+    const apiKey = this.getApiKey();
     const url = this.port ? `http://127.0.0.1:${this.port}/sse` : "http://127.0.0.1:<port>/sse";
     const entry: Record<string, unknown> = { type: "sse", url };
-    if (config.apiKey) {
-      entry.headers = { Authorization: `Bearer ${config.apiKey}` };
+    if (apiKey) {
+      entry.headers = { Authorization: `Bearer ${apiKey}` };
     }
     return JSON.stringify({ mcpServers: { [MCP_SERVER_KEY]: entry } }, null, 2);
   }
@@ -592,7 +644,7 @@ export class McpServerService {
   }
 
   private isAuthorized(req: http.IncomingMessage): boolean {
-    const apiKey = this.getConfig().apiKey;
+    const apiKey = this.getApiKey();
     if (!apiKey) return true;
     const auth = req.headers.authorization ?? "";
     const expected = `Bearer ${apiKey}`;
@@ -835,7 +887,7 @@ export class McpServerService {
         type: "sse",
         url: `http://127.0.0.1:${this.port}/sse`,
       };
-      const apiKey = this.getConfig().apiKey;
+      const apiKey = this.getApiKey();
       if (apiKey) {
         entry.headers = { Authorization: `Bearer ${apiKey}` };
       }

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -170,6 +170,21 @@ function safeSerializeToolResult(value: unknown): string {
   }
 }
 
+/**
+ * Cached state of the decrypted bearer token.
+ * - `kind: "unread"` — not yet read this session.
+ * - `kind: "absent"` — no `apiKeyEncrypted` field present on the store.
+ * - `kind: "ok"` — decrypted successfully; `value` holds the plaintext.
+ * - `kind: "undecryptable"` — `decryptString` threw (corrupted ciphertext, OS
+ *   keychain reset, bundle id change). The configured key cannot be recovered;
+ *   `isAuthorized` must deny instead of opening access.
+ */
+type DecryptedKeyState =
+  | { kind: "unread" }
+  | { kind: "absent" }
+  | { kind: "ok"; value: string }
+  | { kind: "undecryptable" };
+
 export class McpServerService {
   private httpServer: http.Server | null = null;
   private port: number | null = null;
@@ -180,6 +195,7 @@ export class McpServerService {
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
   private statusListeners = new Set<(running: boolean) => void>();
+  private decryptedKey: DecryptedKeyState = { kind: "unread" };
 
   get isRunning(): boolean {
     return this.httpServer !== null && this.port !== null;
@@ -238,29 +254,45 @@ export class McpServerService {
   }
 
   /**
-   * Decrypt the persisted bearer token. Returns "" when no key is stored. On
-   * decryption failure (OS keychain reset, app bundle id change, cross-machine
-   * config copy), the corrupted ciphertext is cleared and "" is returned so
-   * the auto-keygen path in `start()` can recover on next run.
+   * Resolve and memoize the decrypted bearer token for this session. The cache
+   * is invalidated by `setApiKey`/`generateApiKey` (writes update the cache
+   * directly) and by an explicit `invalidateDecryptedKey()` call. We never
+   * mutate the persisted ciphertext from a read path — clearing the field on
+   * decrypt failure would let `isAuthorized` interpret the next request as
+   * "no key configured → open access," silently dropping authentication.
    */
-  private getApiKey(): string {
-    const config = this.getConfig();
-    const encrypted = config.apiKeyEncrypted;
-    if (!encrypted) return "";
-    try {
-      return safeStorage.decryptString(Buffer.from(encrypted, "base64"));
-    } catch (err) {
-      console.warn("[MCP] Failed to decrypt API key, clearing corrupted ciphertext:", err);
-      const { apiKeyEncrypted: _drop, ...rest } = config;
-      store.set("mcpServer", rest);
-      return "";
+  private resolveDecryptedKey(): DecryptedKeyState {
+    if (this.decryptedKey.kind !== "unread") {
+      return this.decryptedKey;
     }
+    const encrypted = this.getConfig().apiKeyEncrypted;
+    if (!encrypted) {
+      this.decryptedKey = { kind: "absent" };
+      return this.decryptedKey;
+    }
+    try {
+      const value = safeStorage.decryptString(Buffer.from(encrypted, "base64"));
+      this.decryptedKey = { kind: "ok", value };
+    } catch (err) {
+      console.warn(
+        "[MCP] Failed to decrypt API key — server will deny all requests until the key is regenerated:",
+        err
+      );
+      this.decryptedKey = { kind: "undecryptable" };
+    }
+    return this.decryptedKey;
+  }
+
+  private getApiKey(): string {
+    const state = this.resolveDecryptedKey();
+    return state.kind === "ok" ? state.value : "";
   }
 
   /**
    * Encrypt a bearer token for persistence. Returns `undefined` for an empty
    * key so callers can drop the field from the store. Throws if `safeStorage`
-   * is unavailable (caller decides whether to surface or swallow).
+   * is unavailable; callers that need graceful degradation must handle the
+   * throw themselves (e.g., the auto-keygen path in `start()`).
    */
   private encryptApiKey(apiKey: string): string | undefined {
     if (!apiKey) return undefined;
@@ -287,12 +319,14 @@ export class McpServerService {
 
   async setApiKey(apiKey: string): Promise<void> {
     const config = this.getConfig();
-    const { apiKeyEncrypted: _previous, ...rest } = config;
+    const { apiKeyEncrypted: _previous, apiKey: _legacy, ...rest } = config;
     const encrypted = this.encryptApiKey(apiKey);
     store.set(
       "mcpServer",
       encrypted === undefined ? rest : { ...rest, apiKeyEncrypted: encrypted }
     );
+    this.decryptedKey =
+      encrypted === undefined ? { kind: "absent" } : { kind: "ok", value: apiKey };
     if (this.isRunning) {
       await this.writeDiscoveryFile();
     }
@@ -319,7 +353,18 @@ export class McpServerService {
     this.starting = true;
     try {
       if (!this.getApiKey()) {
-        await this.generateApiKey();
+        try {
+          await this.generateApiKey();
+        } catch (err) {
+          // Encryption can throw when safeStorage is unavailable. Don't abort
+          // startup — the encryption-backend banner already surfaces the
+          // unprotected state to the user, and the server can still bind
+          // (open access on loopback, like a fresh install with no key set).
+          console.warn(
+            "[MCP] Could not auto-generate API key — starting without authentication:",
+            err
+          );
+        }
       }
 
       this.setupIpcListeners();
@@ -644,10 +689,15 @@ export class McpServerService {
   }
 
   private isAuthorized(req: http.IncomingMessage): boolean {
-    const apiKey = this.getApiKey();
-    if (!apiKey) return true;
+    const state = this.resolveDecryptedKey();
+    // No key was ever configured — the server runs with open access by design.
+    if (state.kind === "absent") return true;
+    // A key is on disk but couldn't be decrypted. Opening access here would
+    // silently downgrade to no-auth on a transient keychain failure, so we
+    // fail closed until the user regenerates the key.
+    if (state.kind === "undecryptable") return false;
     const auth = req.headers.authorization ?? "";
-    const expected = `Bearer ${apiKey}`;
+    const expected = `Bearer ${state.value}`;
     const actualHash = createHash("sha256").update(auth).digest();
     const expectedHash = createHash("sha256").update(expected).digest();
     return timingSafeEqual(actualHash, expectedHash);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -254,33 +254,37 @@ export class McpServerService {
   }
 
   /**
-   * Resolve and memoize the decrypted bearer token for this session. The cache
-   * is invalidated by `setApiKey`/`generateApiKey` (writes update the cache
-   * directly) and by an explicit `invalidateDecryptedKey()` call. We never
-   * mutate the persisted ciphertext from a read path — clearing the field on
-   * decrypt failure would let `isAuthorized` interpret the next request as
-   * "no key configured → open access," silently dropping authentication.
+   * Resolve and memoize the decrypted bearer token for this session. Writes
+   * (`setApiKey`/`generateApiKey`) update the cache directly. We never mutate
+   * the persisted ciphertext from a read path — clearing the field on decrypt
+   * failure would let `isAuthorized` interpret the next request as "no key
+   * configured → open access," silently dropping authentication.
    */
-  private resolveDecryptedKey(): DecryptedKeyState {
-    if (this.decryptedKey.kind !== "unread") {
-      return this.decryptedKey;
+  private resolveDecryptedKey(): Exclude<DecryptedKeyState, { kind: "unread" }> {
+    const cached = this.decryptedKey;
+    if (cached.kind !== "unread") {
+      return cached;
     }
     const encrypted = this.getConfig().apiKeyEncrypted;
+    let next: Exclude<DecryptedKeyState, { kind: "unread" }>;
     if (!encrypted) {
-      this.decryptedKey = { kind: "absent" };
-      return this.decryptedKey;
+      next = { kind: "absent" };
+    } else {
+      try {
+        next = {
+          kind: "ok",
+          value: safeStorage.decryptString(Buffer.from(encrypted, "base64")),
+        };
+      } catch (err) {
+        console.warn(
+          "[MCP] Failed to decrypt API key — server will deny all requests until the key is regenerated:",
+          err
+        );
+        next = { kind: "undecryptable" };
+      }
     }
-    try {
-      const value = safeStorage.decryptString(Buffer.from(encrypted, "base64"));
-      this.decryptedKey = { kind: "ok", value };
-    } catch (err) {
-      console.warn(
-        "[MCP] Failed to decrypt API key — server will deny all requests until the key is regenerated:",
-        err
-      );
-      this.decryptedKey = { kind: "undecryptable" };
-    }
-    return this.decryptedKey;
+    this.decryptedKey = next;
+    return next;
   }
 
   private getApiKey(): string {

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
-export const LATEST_SCHEMA_VERSION = 20;
+export const LATEST_SCHEMA_VERSION = 21;
 
 export interface Migration {
   version: number;

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -60,14 +60,22 @@ const electronMocks = vi.hoisted(() => {
   };
 });
 
-const storeState = vi.hoisted(() => ({
-  mcpServer: {
+interface McpServerStoreState {
+  enabled: boolean;
+  port: number;
+  apiKeyEncrypted?: string;
+  fullToolSurface: boolean;
+}
+
+const storeState = vi.hoisted(() => {
+  const initial: McpServerStoreState = {
     enabled: true,
     port: 0,
-    apiKey: "",
+    apiKeyEncrypted: undefined,
     fullToolSurface: false,
-  },
-}));
+  };
+  return { mcpServer: initial };
+});
 
 const storeMocks = vi.hoisted(() => ({
   get: vi.fn((key: string) => {
@@ -76,13 +84,31 @@ const storeMocks = vi.hoisted(() => ({
     }
     return storeState.mcpServer;
   }),
-  set: vi.fn((key: string, value: typeof storeState.mcpServer) => {
+  set: vi.fn((key: string, value: McpServerStoreState) => {
     if (key !== "mcpServer") {
       throw new Error(`Unexpected store key: ${key}`);
     }
     storeState.mcpServer = value;
   }),
 }));
+
+const safeStorageMock = vi.hoisted(() => ({
+  isEncryptionAvailable: vi.fn(() => true),
+  getSelectedStorageBackend: vi.fn(() => "gnome_libsecret"),
+  encryptString: vi.fn((s: string) => Buffer.from(s, "utf8")),
+  decryptString: vi.fn((b: Buffer) => b.toString("utf8")),
+}));
+
+function getStoredApiKey(): string {
+  const encoded = storeState.mcpServer.apiKeyEncrypted;
+  if (!encoded) return "";
+  return safeStorageMock.decryptString(Buffer.from(encoded, "base64"));
+}
+
+function setStoredApiKey(plaintext: string): void {
+  storeState.mcpServer.apiKeyEncrypted =
+    plaintext === "" ? undefined : safeStorageMock.encryptString(plaintext).toString("base64");
+}
 
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
@@ -99,6 +125,7 @@ vi.mock("node:os", async (importOriginal) => {
 vi.mock("electron", () => ({
   ipcMain: electronMocks.ipcMain,
   BrowserWindow: class BrowserWindow {},
+  safeStorage: safeStorageMock,
 }));
 
 vi.mock("../../store.js", () => ({
@@ -231,7 +258,7 @@ async function connectClient(
   port: number,
   headers?: Record<string, string>
 ): Promise<{ client: Client; transport: SSEClientTransport }> {
-  const apiKey = storeState.mcpServer.apiKey;
+  const apiKey = getStoredApiKey();
   const mergedHeaders: Record<string, string> = {
     ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     ...(headers ?? {}),
@@ -289,11 +316,19 @@ describe("McpServerService", () => {
     storeState.mcpServer = {
       enabled: true,
       port: 0,
-      apiKey: "",
+      apiKeyEncrypted: undefined,
       fullToolSurface: false,
     };
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
+    safeStorageMock.isEncryptionAvailable.mockClear();
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
+    safeStorageMock.getSelectedStorageBackend.mockClear();
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue("gnome_libsecret");
+    safeStorageMock.encryptString.mockClear();
+    safeStorageMock.encryptString.mockImplementation((s: string) => Buffer.from(s, "utf8"));
+    safeStorageMock.decryptString.mockClear();
+    safeStorageMock.decryptString.mockImplementation((b: Buffer) => b.toString("utf8"));
     electronMocks.ipcMain.removeAllListeners();
     electronMocks.ipcMain.handle.mockClear();
     electronMocks.ipcMain.removeHandler.mockClear();
@@ -526,7 +561,7 @@ describe("McpServerService", () => {
     const initial = JSON.parse(await fs.readFile(discoveryFile, "utf8")) as {
       mcpServers: Record<string, { headers?: { Authorization: string } }>;
     };
-    const initialKey = storeState.mcpServer.apiKey;
+    const initialKey = getStoredApiKey();
     expect(initialKey).toMatch(/^daintree_[a-f0-9]+$/);
     expect(initial.mcpServers.daintree.headers).toEqual({
       Authorization: `Bearer ${initialKey}`,
@@ -551,16 +586,16 @@ describe("McpServerService", () => {
   it("auto-generates a bearer token on first start and persists it across restarts", async () => {
     const { window } = createMockWindow();
 
-    expect(storeState.mcpServer.apiKey).toBe("");
+    expect(getStoredApiKey()).toBe("");
 
     await service.start(window);
-    const generatedKey = storeState.mcpServer.apiKey;
+    const generatedKey = getStoredApiKey();
     expect(generatedKey).toMatch(/^daintree_[a-f0-9]+$/);
 
     await service.stop();
 
     await service.start(window);
-    expect(storeState.mcpServer.apiKey).toBe(generatedKey);
+    expect(getStoredApiKey()).toBe(generatedKey);
   });
 
   it("rejects requests with a non-loopback Origin header", async () => {
@@ -568,7 +603,7 @@ describe("McpServerService", () => {
     await service.start(window);
 
     const evil = await requestSse(service.currentPort!, {
-      Authorization: `Bearer ${storeState.mcpServer.apiKey}`,
+      Authorization: `Bearer ${getStoredApiKey()}`,
       Origin: "https://evil.example",
     });
     expect(evil.status).toBe(403);
@@ -580,7 +615,7 @@ describe("McpServerService", () => {
     await service.start(window);
 
     const port = service.currentPort!;
-    const auth = `Bearer ${storeState.mcpServer.apiKey}`;
+    const auth = `Bearer ${getStoredApiKey()}`;
 
     // Helper that aborts the SSE GET as soon as the response status is known.
     const peekStatus = async (extraHeaders: Record<string, string>): Promise<number> =>
@@ -612,7 +647,7 @@ describe("McpServerService", () => {
   });
 
   it("uses constant-time comparison that does not short-circuit on length mismatch", async () => {
-    storeState.mcpServer.apiKey = "secret";
+    setStoredApiKey("secret");
     const { window } = createMockWindow();
     await service.start(window);
 
@@ -685,7 +720,7 @@ describe("McpServerService", () => {
     const { window } = createMockWindow();
     await service.start(window);
 
-    const oldKey = storeState.mcpServer.apiKey;
+    const oldKey = getStoredApiKey();
     const newKey = await service.generateApiKey();
     expect(newKey).not.toBe(oldKey);
 
@@ -725,7 +760,7 @@ describe("McpServerService", () => {
     await service.start(window);
 
     const port = service.currentPort!;
-    const auth = `Bearer ${storeState.mcpServer.apiKey}`;
+    const auth = `Bearer ${getStoredApiKey()}`;
 
     const status = await new Promise<number>((resolve, reject) => {
       const req = http.request(
@@ -835,7 +870,7 @@ describe("McpServerService", () => {
   });
 
   it("rejects unauthorized requests and invalid host headers", async () => {
-    storeState.mcpServer.apiKey = "secret";
+    setStoredApiKey("secret");
     const { window } = createMockWindow();
 
     await service.start(window);
@@ -1036,5 +1071,62 @@ describe("McpServerService", () => {
 
     expect(result.isError).not.toBe(true);
     expect(result.content[0].text).toContain('"self": "[Circular]"');
+  });
+
+  it("decrypts the persisted bearer for status queries and Authorization checks", async () => {
+    setStoredApiKey("plaintext-bearer");
+
+    const status = service.getStatus();
+    expect(status.apiKey).toBe("plaintext-bearer");
+    expect(safeStorageMock.decryptString).toHaveBeenCalled();
+  });
+
+  it("reports encryptionBackend=keychain on macOS/Windows", async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue("");
+    expect(service.getStatus().encryptionBackend).toBe("keychain");
+  });
+
+  it("reports encryptionBackend=basic_text on Linux fallback", async () => {
+    if (process.platform !== "linux") {
+      // The platform branch only triggers on Linux; skip outside that environment.
+      return;
+    }
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue("basic_text");
+    expect(service.getStatus().encryptionBackend).toBe("basic_text");
+  });
+
+  it("reports encryptionBackend=unavailable when safeStorage is disabled", async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false);
+    expect(service.getStatus().encryptionBackend).toBe("unavailable");
+  });
+
+  it("clears corrupted ciphertext and returns empty key on decrypt failure", async () => {
+    storeState.mcpServer.apiKeyEncrypted = "not-real-base64-ciphertext";
+    safeStorageMock.decryptString.mockImplementationOnce(() => {
+      throw new Error("decryption failed");
+    });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const status = service.getStatus();
+      expect(status.apiKey).toBe("");
+      expect(storeState.mcpServer.apiKeyEncrypted).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to decrypt"),
+        expect.any(Error)
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("setApiKey('') drops apiKeyEncrypted from the store", async () => {
+    setStoredApiKey("existing");
+    expect(storeState.mcpServer.apiKeyEncrypted).toBeDefined();
+
+    await service.setApiKey("");
+    expect(storeState.mcpServer.apiKeyEncrypted).toBeUndefined();
   });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1088,13 +1088,18 @@ describe("McpServerService", () => {
   });
 
   it("reports encryptionBackend=basic_text on Linux fallback", async () => {
-    if (process.platform !== "linux") {
-      // The platform branch only triggers on Linux; skip outside that environment.
-      return;
-    }
     safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
     safeStorageMock.getSelectedStorageBackend.mockReturnValue("basic_text");
-    expect(service.getStatus().encryptionBackend).toBe("basic_text");
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      expect(service.getStatus().encryptionBackend).toBe("basic_text");
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
   });
 
   it("reports encryptionBackend=unavailable when safeStorage is disabled", async () => {
@@ -1102,7 +1107,7 @@ describe("McpServerService", () => {
     expect(service.getStatus().encryptionBackend).toBe("unavailable");
   });
 
-  it("clears corrupted ciphertext and returns empty key on decrypt failure", async () => {
+  it("returns empty key on decrypt failure but preserves the corrupted ciphertext on disk", async () => {
     storeState.mcpServer.apiKeyEncrypted = "not-real-base64-ciphertext";
     safeStorageMock.decryptString.mockImplementationOnce(() => {
       throw new Error("decryption failed");
@@ -1112,9 +1117,64 @@ describe("McpServerService", () => {
     try {
       const status = service.getStatus();
       expect(status.apiKey).toBe("");
-      expect(storeState.mcpServer.apiKeyEncrypted).toBeUndefined();
+      // Field is intentionally not cleared — `isAuthorized` needs to see it on
+      // the next request to deny instead of silently opening access.
+      expect(storeState.mcpServer.apiKeyEncrypted).toBe("not-real-base64-ciphertext");
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining("Failed to decrypt"),
+        expect.any(Error)
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("denies all requests when the persisted key cannot be decrypted (no silent auth bypass)", async () => {
+    storeState.mcpServer.apiKeyEncrypted = "ciphertext-from-another-machine";
+    safeStorageMock.decryptString.mockImplementation(() => {
+      throw new Error("keychain access denied");
+    });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { window } = createMockWindow();
+      // Block the auto-keygen in start() so the configured-but-undecryptable
+      // state survives into the request-handling phase. (In real life the user
+      // would not see this — the test simulates a transient keychain failure
+      // that the user hasn't recovered from yet.)
+      safeStorageMock.encryptString.mockImplementationOnce(() => {
+        throw new Error("keychain unavailable");
+      });
+      await service.start(window);
+
+      const noCredentials = await requestSse(service.currentPort!);
+      const wrongCredentials = await requestSse(service.currentPort!, {
+        Authorization: "Bearer anything",
+      });
+
+      expect(noCredentials.status).toBe(401);
+      expect(wrongCredentials.status).toBe(401);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+
+  it("starts without authentication when safeStorage is unavailable instead of crashing", async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false);
+    safeStorageMock.encryptString.mockImplementation(() => {
+      throw new Error("encryption is not available");
+    });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const { window } = createMockWindow();
+      await service.start(window);
+      expect(service.isRunning).toBe(true);
+      // No key was generated — server runs open-access.
+      expect(storeState.mcpServer.apiKeyEncrypted).toBeUndefined();
+      expect(service.getStatus().encryptionBackend).toBe("unavailable");
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Could not auto-generate API key"),
         expect.any(Error)
       );
     } finally {

--- a/electron/services/migrations/021-mcp-api-key-safestorage.ts
+++ b/electron/services/migrations/021-mcp-api-key-safestorage.ts
@@ -1,0 +1,48 @@
+import { safeStorage } from "electron";
+import type { Migration } from "../StoreMigrations.js";
+
+interface LegacyMcpServerConfig {
+  enabled?: boolean;
+  port?: number | null;
+  apiKey?: string;
+  apiKeyEncrypted?: string;
+  fullToolSurface?: boolean;
+}
+
+export const migration021: Migration = {
+  version: 21,
+  description: "Migrate MCP server API key from plaintext to safeStorage-encrypted",
+  up: (store) => {
+    const config = (store.get("mcpServer") ?? {}) as LegacyMcpServerConfig;
+    const { apiKey: plaintext, ...rest } = config;
+
+    // Already migrated, no plaintext to drop, or no key to migrate.
+    if (!plaintext) {
+      if ("apiKey" in config) {
+        store.set("mcpServer", rest);
+      }
+      return;
+    }
+
+    if (!safeStorage.isEncryptionAvailable()) {
+      // Encryption not available — never leave plaintext on disk. The auto-keygen
+      // path in McpServerService.start() regenerates a key on next launch.
+      console.warn(
+        "[Migrations v21] safeStorage unavailable; dropping plaintext MCP API key without encrypting (auto-regenerates on next start)"
+      );
+      store.set("mcpServer", rest);
+      return;
+    }
+
+    try {
+      const encrypted = safeStorage.encryptString(plaintext).toString("base64");
+      store.set("mcpServer", { ...rest, apiKeyEncrypted: encrypted });
+    } catch (err) {
+      console.warn(
+        "[Migrations v21] Failed to encrypt MCP API key; dropping plaintext (auto-regenerates on next start):",
+        err
+      );
+      store.set("mcpServer", rest);
+    }
+  },
+};

--- a/electron/services/migrations/__tests__/021-mcp-api-key-safestorage.test.ts
+++ b/electron/services/migrations/__tests__/021-mcp-api-key-safestorage.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const safeStorageMock = vi.hoisted(() => ({
+  isEncryptionAvailable: vi.fn(() => true),
+  encryptString: vi.fn((s: string) => Buffer.from(`enc:${s}`, "utf8")),
+}));
+
+vi.mock("electron", () => ({
+  safeStorage: safeStorageMock,
+}));
+
+import { migration021 } from "../021-mcp-api-key-safestorage.js";
+
+interface McpServerSnapshot {
+  enabled?: boolean;
+  port?: number | null;
+  apiKey?: string;
+  apiKeyEncrypted?: string;
+  fullToolSurface?: boolean;
+}
+
+function makeStoreMock(initial: { mcpServer?: McpServerSnapshot } = {}) {
+  const data: Record<string, unknown> = { ...initial };
+  return {
+    data,
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+  } as unknown as Parameters<typeof migration021.up>[0] & {
+    data: Record<string, unknown>;
+  };
+}
+
+describe("migration021 — migrate MCP API key to safeStorage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true);
+    safeStorageMock.encryptString.mockImplementation((s: string) =>
+      Buffer.from(`enc:${s}`, "utf8")
+    );
+  });
+
+  it("encrypts a plaintext apiKey into apiKeyEncrypted and removes the legacy field", () => {
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKey: "daintree_abc123",
+        fullToolSurface: false,
+      },
+    });
+
+    migration021.up(store);
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKey).toBeUndefined();
+    expect(result.apiKeyEncrypted).toBe(
+      Buffer.from("enc:daintree_abc123", "utf8").toString("base64")
+    );
+    expect(result.enabled).toBe(true);
+    expect(result.port).toBe(45454);
+    expect(result.fullToolSurface).toBe(false);
+    expect(safeStorageMock.encryptString).toHaveBeenCalledWith("daintree_abc123");
+  });
+
+  it("removes an empty plaintext apiKey field without writing apiKeyEncrypted", () => {
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: false,
+        port: null,
+        apiKey: "",
+        fullToolSurface: false,
+      },
+    });
+
+    migration021.up(store);
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKey).toBeUndefined();
+    expect(result.apiKeyEncrypted).toBeUndefined();
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when neither apiKey nor apiKeyEncrypted are present", () => {
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: false,
+        port: null,
+        fullToolSurface: false,
+      },
+    });
+
+    migration021.up(store);
+
+    expect(store.set).not.toHaveBeenCalled();
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when apiKeyEncrypted already exists and no plaintext is left", () => {
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKeyEncrypted: "preexisting-base64",
+        fullToolSurface: false,
+      },
+    });
+
+    migration021.up(store);
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKeyEncrypted).toBe("preexisting-base64");
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
+  });
+
+  it("drops plaintext (no encryption) when safeStorage is unavailable", () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKey: "daintree_abc123",
+        fullToolSurface: false,
+      },
+    });
+
+    try {
+      migration021.up(store);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKey).toBeUndefined();
+    expect(result.apiKeyEncrypted).toBeUndefined();
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
+  });
+
+  it("drops plaintext when encryptString throws", () => {
+    safeStorageMock.encryptString.mockImplementationOnce(() => {
+      throw new Error("encryption failed");
+    });
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKey: "daintree_abc123",
+        fullToolSurface: false,
+      },
+    });
+
+    try {
+      migration021.up(store);
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKey).toBeUndefined();
+    expect(result.apiKeyEncrypted).toBeUndefined();
+  });
+
+  it("handles a missing mcpServer config (fresh installs)", () => {
+    const store = makeStoreMock({});
+
+    migration021.up(store);
+
+    expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("has version 21", () => {
+    expect(migration021.version).toBe(21);
+  });
+});

--- a/electron/services/migrations/__tests__/021-mcp-api-key-safestorage.test.ts
+++ b/electron/services/migrations/__tests__/021-mcp-api-key-safestorage.test.ts
@@ -100,6 +100,28 @@ describe("migration021 — migrate MCP API key to safeStorage", () => {
     expect(safeStorageMock.encryptString).not.toHaveBeenCalled();
   });
 
+  it("re-encrypts plaintext as the source of truth when both fields are present", () => {
+    const store = makeStoreMock({
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKey: "fresh_plaintext",
+        apiKeyEncrypted: "stale-base64-from-a-different-machine",
+        fullToolSurface: false,
+      },
+    });
+
+    migration021.up(store);
+
+    const result = store.data.mcpServer as McpServerSnapshot;
+    expect(result.apiKey).toBeUndefined();
+    expect(result.apiKeyEncrypted).toBe(
+      Buffer.from("enc:fresh_plaintext", "utf8").toString("base64")
+    );
+    expect(safeStorageMock.encryptString).toHaveBeenCalledTimes(1);
+    expect(safeStorageMock.encryptString).toHaveBeenCalledWith("fresh_plaintext");
+  });
+
   it("is idempotent when apiKeyEncrypted already exists and no plaintext is left", () => {
     const store = makeStoreMock({
       mcpServer: {

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -17,6 +17,7 @@ import { migration017 } from "./017-add-notification-quiet-hours.js";
 import { migration018 } from "./018-archive-notes.js";
 import { migration019 } from "./019-remove-fleet-deck-open.js";
 import { migration020 } from "./020-window-states-store.js";
+import { migration021 } from "./021-mcp-api-key-safestorage.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -37,4 +38,5 @@ export const migrations: Migration[] = [
   migration018,
   migration019,
   migration020,
+  migration021,
 ];

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -187,7 +187,19 @@ export interface StoreSchema {
   mcpServer: {
     enabled: boolean;
     port: number | null;
-    apiKey: string;
+    /**
+     * @deprecated Legacy plaintext field. Migration 021 reads this once on
+     * upgrade, encrypts the value into `apiKeyEncrypted`, and deletes the
+     * field. New installs never write it. Kept on the schema only so the
+     * migration can still see the field on disk before removing it.
+     */
+    apiKey?: string;
+    /**
+     * Base64-encoded ciphertext from `safeStorage.encryptString`. Set by
+     * `McpServerService.setApiKey` / migration 021. Decrypted on demand via
+     * `McpServerService.getApiKey`.
+     */
+    apiKeyEncrypted?: string;
     fullToolSurface: boolean;
   };
   pendingErrors: ErrorRecord[];
@@ -325,7 +337,6 @@ const storeOptions = {
     mcpServer: {
       enabled: false,
       port: 45454,
-      apiKey: "",
       fullToolSurface: false,
     },
     pendingErrors: [],

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -180,6 +180,20 @@ export interface NotificationSettings {
   quietHoursWeekdays: number[];
 }
 
+/**
+ * MCP server status returned to the renderer. `encryptionBackend` reflects how
+ * the bearer token is protected at rest: `keychain` (real OS secret store),
+ * `basic_text` (Linux fallback — encrypted with a hardcoded password), or
+ * `unavailable` (no encryption).
+ */
+export interface McpServerStatus {
+  enabled: boolean;
+  port: number | null;
+  configuredPort: number | null;
+  apiKey: string;
+  encryptionBackend: "keychain" | "basic_text" | "unavailable";
+}
+
 // ElectronAPI Type (exposed via preload)
 
 /** Complete Electron API exposed to renderer */
@@ -1238,33 +1252,13 @@ export interface ElectronAPI {
   };
   mcpServer: {
     /** Get current MCP server status and configuration */
-    getStatus(): Promise<{
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    }>;
+    getStatus(): Promise<McpServerStatus>;
     /** Enable or disable the MCP server */
-    setEnabled(enabled: boolean): Promise<{
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    }>;
+    setEnabled(enabled: boolean): Promise<McpServerStatus>;
     /** Set a fixed port (null = auto-assign ephemeral port) */
-    setPort(port: number | null): Promise<{
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    }>;
+    setPort(port: number | null): Promise<McpServerStatus>;
     /** Set the API key for bearer token authentication (empty string = no auth) */
-    setApiKey(apiKey: string): Promise<{
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    }>;
+    setApiKey(apiKey: string): Promise<McpServerStatus>;
     /** Generate a random API key and persist it */
     generateApiKey(): Promise<string>;
     /** Get the JSON config snippet to paste into an MCP client config */

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -9,13 +9,7 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
-
-interface McpServerStatus {
-  enabled: boolean;
-  port: number | null;
-  configuredPort: number | null;
-  apiKey: string;
-}
+import type { McpServerStatus } from "@shared/types/ipc/api.js";
 
 export function McpServerSettingsTab() {
   const [status, setStatus] = useState<McpServerStatus>({
@@ -23,6 +17,7 @@ export function McpServerSettingsTab() {
     port: null,
     configuredPort: null,
     apiKey: "",
+    encryptionBackend: "keychain",
   });
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState(false);
@@ -308,6 +303,24 @@ export function McpServerSettingsTab() {
             title="Authentication"
             description="Optionally require a bearer token for MCP connections. Recommended if other users share this machine. Not needed for typical local-only use."
           >
+            {status.encryptionBackend === "basic_text" && (
+              <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
+                <AlertCircle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
+                <p className="text-xs text-status-warning leading-relaxed">
+                  API key isn't protected by your system keychain — no secret store (GNOME Keyring,
+                  KWallet) is available. The key is encrypted with a fallback password built into
+                  Electron and offers limited protection.
+                </p>
+              </div>
+            )}
+            {status.encryptionBackend === "unavailable" && (
+              <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
+                <AlertCircle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
+                <p className="text-xs text-status-warning leading-relaxed">
+                  Encryption isn't available on this system. Your API key is stored unprotected.
+                </p>
+              </div>
+            )}
             {status.apiKey ? (
               <div className="contents">
                 <div className="flex items-center gap-1.5 text-xs text-status-success">

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -317,7 +317,8 @@ export function McpServerSettingsTab() {
               <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
                 <AlertCircle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
                 <p className="text-xs text-status-warning leading-relaxed">
-                  Encryption isn't available on this system. Your API key is stored unprotected.
+                  Encryption isn't available on this system — the MCP server can't generate or save
+                  an API key. Connections won't require authentication.
                 </p>
               </div>
             )}


### PR DESCRIPTION
## Summary

- Migrates the MCP server API key from plaintext `electron-store` to Electron `safeStorage` (Keychain on macOS, DPAPI on Windows, libsecret on Linux when available).
- Migration 021 runs on first launch: encrypts any existing plaintext key into the new `apiKeyEncrypted` field and removes the legacy `apiKey` field. On Linux without a secret store, it drops the key cleanly so the auto-keygen path can recover rather than leaving plaintext behind.
- The decrypted key is cached per session in a tagged-union (`unread` / `absent` / `ok` / `undecryptable`) so `isAuthorized` can correctly deny access when a key is configured but unreadable, rather than failing open.

Resolves #6519

## Changes

- `electron/store.ts` — new `apiKeyEncrypted` field (base64 `Buffer`), legacy `apiKey` field removed from schema.
- `electron/services/McpServerService.ts` — `resolveDecryptedKey()` returns tagged-union state; `isAuthorized` denies on `undecryptable`; `start()` catches encryption failures from auto-keygen and proceeds open-access rather than crashing; `getStatus()` exposes `encryptionBackend` (`'keychain'` | `'basic_text'` | `'unavailable'`).
- `electron/services/migrations/021-mcp-api-key-safestorage.ts` — new migration with both-fields edge case handling.
- `src/components/Settings/McpServerSettingsTab.tsx` — warning banner when `encryptionBackend` is `basic_text` or `unavailable`; silence is the positive signal.

## Testing

38 test cases pass. New coverage includes:

- `safeStorage` unavailable at startup (open-access path, no crash)
- Mid-session auth-bypass denial on `undecryptable` key
- `encryptionBackend` branches including a `process.platform` stub for the Linux `basic_text` path
- Corrupted-ciphertext recovery
- Migration with both legacy and new fields present