### PR TITLE
feat(workspace): add background git fetch for accurate ahead/behind counts

### DIFF
--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -18,6 +18,7 @@ import {
   validateCwd,
   createHardenedGit,
   createAuthenticatedGit,
+  createBackgroundFetchGit,
   createWslHardenedGit,
   getGitLocaleEnv,
   HARDENED_GIT_CONFIG,
@@ -424,6 +425,81 @@ describe("createAuthenticatedGit", () => {
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("transfer.bundleURI=false");
+  });
+});
+
+describe("createBackgroundFetchGit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("layers background-fetch config on top of authenticated config", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.config).toContain("core.packedRefsTimeout=5000");
+    expect(options.config).toContain("http.lowSpeedLimit=1000");
+    expect(options.config).toContain("http.lowSpeedTime=30");
+    expect(options.config).toContain("gc.auto=0");
+    // Inherits authenticated base — no credential-blocking entries.
+    expect(options.config).not.toContain("credential.helper=");
+    expect(options.config).not.toContain("core.askpass=");
+  });
+
+  it("forwards the abort signal to simple-git", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.abort).toBe(controller.signal);
+  });
+
+  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", {
+      signal: controller.signal,
+      platform: "darwin",
+    });
+
+    // Last env() call wins — the POSIX askpass override is applied second.
+    const lastEnv = mockGitInstance.env.mock.calls[mockGitInstance.env.mock.calls.length - 1][0];
+    expect(lastEnv.GIT_ASKPASS).toBe("true");
+    expect(lastEnv.GIT_TERMINAL_PROMPT).toBe("0");
+  });
+
+  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", {
+      signal: controller.signal,
+      platform: "win32",
+    });
+
+    // The base authenticated env() call doesn't set GIT_ASKPASS, and the
+    // POSIX-only override is skipped. Only one env() call should happen.
+    expect(mockGitInstance.env.mock.calls).toHaveLength(1);
+    const env = mockGitInstance.env.mock.calls[0][0];
+    expect(env.GIT_ASKPASS).toBeUndefined();
+  });
+
+  it("appends caller-supplied extraConfig after background-fetch config", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", {
+      signal: controller.signal,
+      extraConfig: ["transfer.bundleURI=false"],
+    });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.config).toContain("transfer.bundleURI=false");
+    expect(options.config).toContain("core.packedRefsTimeout=5000");
+  });
+
+  it("inherits block timeout 0 from authenticated profile", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+
+    const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(options.timeout).toEqual({ block: 0 });
   });
 });
 

--- a/electron/utils/gitUtils.ts
+++ b/electron/utils/gitUtils.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join as pathJoin } from "path";
 import { logWarn } from "./logger.js";
 
 const gitDirCache = new Map<string, string | null>();
+const gitCommonDirCache = new Map<string, string | null>();
 
 export interface GitDirOptions {
   cache?: boolean;
@@ -49,11 +50,66 @@ export function getGitDir(worktreePath: string, options: GitDirOptions = {}): st
   }
 }
 
+/**
+ * Resolve `--git-common-dir` for a worktree. Linked worktrees share the main
+ * repo's `.git` directory; common-dir returns that shared path, while
+ * `--git-dir` returns the per-worktree `.git/worktrees/<name>` location.
+ *
+ * The shared path is the correct serialization key for any operation that
+ * touches `.git/objects` or `packed-refs` — most importantly background
+ * fetches across sibling worktrees.
+ */
+export function getGitCommonDir(worktreePath: string, options: GitDirOptions = {}): string | null {
+  const { cache = true, timeout = 5000, logErrors = false, cacheErrors = true } = options;
+
+  if (cache && gitCommonDirCache.has(worktreePath)) {
+    return gitCommonDirCache.get(worktreePath)!;
+  }
+
+  try {
+    const result = execSync("git rev-parse --git-common-dir", {
+      cwd: worktreePath,
+      encoding: "utf-8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+
+    const resolved = isAbsolute(result) ? result : pathJoin(worktreePath, result);
+
+    if (cache) {
+      gitCommonDirCache.set(worktreePath, resolved);
+    }
+
+    return resolved;
+  } catch (error) {
+    if (logErrors) {
+      logWarn("Failed to resolve git common directory", {
+        path: worktreePath,
+        error: (error as Error).message,
+      });
+    }
+
+    if (cache && cacheErrors) {
+      gitCommonDirCache.set(worktreePath, null);
+    }
+
+    return null;
+  }
+}
+
 export function clearGitDirCache(worktreePath?: string): void {
   if (worktreePath) {
     gitDirCache.delete(worktreePath);
   } else {
     gitDirCache.clear();
+  }
+}
+
+export function clearGitCommonDirCache(worktreePath?: string): void {
+  if (worktreePath) {
+    gitCommonDirCache.delete(worktreePath);
+  } else {
+    gitCommonDirCache.clear();
   }
 }
 

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -195,3 +195,65 @@ export function createAuthenticatedGit(cwd: string, opts: AuthenticatedGitOption
       "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
   });
 }
+
+/**
+ * Background-fetch config additions on top of the authenticated profile:
+ *   - `core.packedRefsTimeout=5000`: when a foreground git operation holds
+ *     `.git/packed-refs.lock`, wait up to 5s instead of failing immediately.
+ *   - `http.lowSpeedLimit=1000` + `http.lowSpeedTime=30`: abort fetches that
+ *     stall under 1 KB/s for 30s, so a half-open TCP connection doesn't sit
+ *     against the 60s AbortSignal timeout.
+ *   - `gc.auto=0`: belt-and-braces — `--no-auto-gc` is also passed at the
+ *     fetch call site, but pinning the config too prevents any sub-invocation
+ *     (e.g., a fetch hook) from racing a gc against foreground git CLI.
+ */
+const BACKGROUND_FETCH_CONFIG = [
+  "core.packedRefsTimeout=5000",
+  "http.lowSpeedLimit=1000",
+  "http.lowSpeedTime=30",
+  "gc.auto=0",
+] as const;
+
+export interface BackgroundFetchGitOptions {
+  signal: AbortSignal;
+  progress?: (data: SimpleGitProgressEvent) => void;
+  extraConfig?: string[];
+  /** Override platform detection — test-only. */
+  platform?: NodeJS.Platform;
+}
+
+/**
+ * SimpleGit instance for background `git fetch` invocations. Wraps
+ * `createAuthenticatedGit` so the system credential helper still works for
+ * HTTPS remotes, but layers on:
+ *   - lock-friendly config (see `BACKGROUND_FETCH_CONFIG`)
+ *   - `GIT_ASKPASS=true` on POSIX so credential helpers that ignore
+ *     `GIT_TERMINAL_PROMPT=0` fail fast instead of hanging on a TTY prompt
+ *     (Windows omits this — `true` is not on PATH there, and
+ *     `GIT_TERMINAL_PROMPT=0` blocks Windows credential dialogs)
+ *
+ * The signal is required: every background fetch must carry an
+ * AbortController so a stalled connection can be cancelled.
+ */
+export function createBackgroundFetchGit(cwd: string, opts: BackgroundFetchGitOptions): SimpleGit {
+  const { signal, progress, extraConfig, platform = process.platform } = opts;
+  const git = createAuthenticatedGit(cwd, {
+    signal,
+    progress,
+    extraConfig: [...BACKGROUND_FETCH_CONFIG, ...(extraConfig ?? [])],
+  });
+  if (platform !== "win32") {
+    return git.env({
+      ...process.env,
+      ...getGitLocaleEnv(platform),
+      LC_ALL: "",
+      LC_MESSAGES: "C",
+      LANGUAGE: "",
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_SSH_COMMAND:
+        "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
+      GIT_ASKPASS: "true",
+    });
+  }
+  return git;
+}

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -1,0 +1,272 @@
+import { createBackgroundFetchGit } from "../utils/hardenedGit.js";
+import { getGitCommonDir } from "../utils/gitUtils.js";
+import { classifyGitError, extractGitErrorMessage } from "../../shared/utils/gitOperationErrors.js";
+import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
+
+const FETCH_ABORT_TIMEOUT_MS = 60_000;
+
+const NETWORK_FAILURE_TTL_MS = 60_000;
+const NETWORK_FAILURE_JITTER_MS = 30_000;
+const REPO_NOT_FOUND_FIRST_FETCH_TTL_MS = 5 * 60_000;
+const TRANSIENT_FAILURE_TTL_MS = 60_000;
+const TRANSIENT_FAILURE_JITTER_MS = 30_000;
+const AUTH_FAILURE_TTL_MS = Number.POSITIVE_INFINITY;
+
+/** Failure categories with distinct retry semantics. */
+type FetchFailureKind = "auth" | "network" | "repo-not-found-first" | "transient";
+
+interface FetchFailureEntry {
+  kind: FetchFailureKind;
+  reason: GitOperationReason;
+  retryAt: number;
+}
+
+interface RepoState {
+  /** In-flight chain — every fetch awaits the prior one for the same commondir. */
+  chain: Promise<void>;
+  failure: FetchFailureEntry | null;
+  lastSuccessfulFetch: number | null;
+  /** Bumped when the repo's monitors are torn down so stale completions discard. */
+  generation: number;
+}
+
+export interface RepoFetchCoordinatorCallbacks {
+  onFetchSuccess?: (worktreeId: string) => void;
+}
+
+export interface FetchOptions {
+  worktreeId: string;
+  worktreePath: string;
+  /** When true, ignore the failure cache (manual user-triggered refresh). */
+  force?: boolean;
+}
+
+export interface FetchResult {
+  status: "success" | "skipped" | "failed";
+  /** Present when status === "failed". */
+  reason?: GitOperationReason;
+  /** Why we skipped — for logging / diagnostics. */
+  skipReason?: "no-common-dir" | "in-failure-window" | "auth-suspended" | "stale-generation";
+}
+
+/**
+ * Per-repo coordinator for background `git fetch` calls.
+ *
+ * Why this exists:
+ *   - Linked worktrees share the same `.git/objects` and `packed-refs`. If
+ *     N worktrees fetch concurrently they race on `packed-refs.lock` and
+ *     produce sporadic failures. Solution: per-commondir promise chain.
+ *   - `git fetch` has no native timeout. A stalled connection can sit forever
+ *     even with the lowSpeedLimit/lowSpeedTime config. Solution: an
+ *     AbortController armed with a 60s timeout per fetch.
+ *   - Auth failures must NOT auto-retry — repeated bad-token attempts trigger
+ *     GitHub secondary rate limits. Solution: indefinite suspension cleared
+ *     only by `clearAuthFailures()` (called when the user signs in / rotates
+ *     a token).
+ *   - Network blips and "repository-not-found-on-first-fetch" should retry
+ *     after a short window. After at least one prior success, a 404 is more
+ *     likely a permission revocation masked as 404 (GitHub does this) — treat
+ *     it as auth-failed.
+ */
+export class RepoFetchCoordinator {
+  private readonly states = new Map<string, RepoState>();
+
+  constructor(private readonly callbacks: RepoFetchCoordinatorCallbacks = {}) {}
+
+  /**
+   * Schedule a fetch for the given worktree. Resolves with a status describing
+   * what happened. Multiple worktrees that share a `git common-dir` are
+   * serialized on a single per-repo promise chain.
+   */
+  async fetchForWorktree(opts: FetchOptions): Promise<FetchResult> {
+    const commonDir = getGitCommonDir(opts.worktreePath, { logErrors: false });
+    if (!commonDir) {
+      return { status: "skipped", skipReason: "no-common-dir" };
+    }
+
+    const state = this.getOrCreateState(commonDir);
+
+    if (!opts.force && state.failure) {
+      const failure = state.failure;
+      if (failure.kind === "auth") {
+        return {
+          status: "skipped",
+          skipReason: "auth-suspended",
+          reason: failure.reason,
+        };
+      }
+      if (Date.now() < failure.retryAt) {
+        return {
+          status: "skipped",
+          skipReason: "in-failure-window",
+          reason: failure.reason,
+        };
+      }
+    }
+
+    const generationAtStart = state.generation;
+    const result = state.chain.then(() => this.runFetch(commonDir, generationAtStart, opts));
+    state.chain = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  /**
+   * Drop network-class failures so the next fetch attempt is allowed
+   * immediately. Called on OS wake / network reconnect.
+   */
+  clearNetworkFailures(): void {
+    for (const state of this.states.values()) {
+      if (
+        state.failure &&
+        (state.failure.kind === "network" || state.failure.kind === "transient")
+      ) {
+        state.failure = null;
+      }
+    }
+  }
+
+  /**
+   * Drop auth-suspension entries. Called when the user signs in / refreshes
+   * GitHub credentials so previously-failing repos can fetch again.
+   */
+  clearAuthFailures(): void {
+    for (const state of this.states.values()) {
+      if (state.failure?.kind === "auth") {
+        state.failure = null;
+      }
+    }
+  }
+
+  /** Force-clear all failure entries (e.g. on project switch). */
+  clearAllFailures(): void {
+    for (const state of this.states.values()) {
+      state.failure = null;
+    }
+  }
+
+  /**
+   * Mark every known repo's generation as invalidated, dropping in-flight
+   * results before they mutate state. Called on shutdown / project switch.
+   */
+  destroy(): void {
+    for (const state of this.states.values()) {
+      state.generation += 1;
+      state.failure = null;
+    }
+    this.states.clear();
+  }
+
+  /** Test/diagnostic accessor. */
+  hasFailureFor(commonDir: string): boolean {
+    return this.states.get(commonDir)?.failure != null;
+  }
+
+  /** Test/diagnostic accessor. */
+  getLastSuccessfulFetch(commonDir: string): number | null {
+    return this.states.get(commonDir)?.lastSuccessfulFetch ?? null;
+  }
+
+  private getOrCreateState(commonDir: string): RepoState {
+    let state = this.states.get(commonDir);
+    if (!state) {
+      state = {
+        chain: Promise.resolve(),
+        failure: null,
+        lastSuccessfulFetch: null,
+        generation: 0,
+      };
+      this.states.set(commonDir, state);
+    }
+    return state;
+  }
+
+  private async runFetch(
+    commonDir: string,
+    generationAtStart: number,
+    opts: FetchOptions
+  ): Promise<FetchResult> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_ABORT_TIMEOUT_MS);
+    try {
+      const git = createBackgroundFetchGit(opts.worktreePath, {
+        signal: controller.signal,
+      });
+      await git.raw(["fetch", "origin", "--no-auto-gc", "--prune"]);
+
+      const state = this.states.get(commonDir);
+      if (!state || state.generation !== generationAtStart) {
+        return { status: "skipped", skipReason: "stale-generation" };
+      }
+      state.failure = null;
+      state.lastSuccessfulFetch = Date.now();
+      this.callbacks.onFetchSuccess?.(opts.worktreeId);
+      return { status: "success" };
+    } catch (error) {
+      const reason = classifyGitError(error);
+      const state = this.states.get(commonDir);
+      if (!state || state.generation !== generationAtStart) {
+        return { status: "skipped", skipReason: "stale-generation" };
+      }
+      state.failure = this.classifyForCache(reason, state.lastSuccessfulFetch, error);
+      return { status: "failed", reason };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private classifyForCache(
+    reason: GitOperationReason,
+    lastSuccessfulFetch: number | null,
+    error: unknown
+  ): FetchFailureEntry {
+    const now = Date.now();
+    if (reason === "auth-failed") {
+      return { kind: "auth", reason, retryAt: now + AUTH_FAILURE_TTL_MS };
+    }
+    if (reason === "repository-not-found") {
+      // After at least one prior success, a 404 from origin almost always
+      // indicates GitHub's "404 instead of 403" permission masking. Treat as
+      // auth-failed so we don't hammer with retries.
+      if (lastSuccessfulFetch !== null) {
+        return { kind: "auth", reason, retryAt: now + AUTH_FAILURE_TTL_MS };
+      }
+      return {
+        kind: "repo-not-found-first",
+        reason,
+        retryAt: now + REPO_NOT_FOUND_FIRST_FETCH_TTL_MS,
+      };
+    }
+    if (reason === "network-unavailable") {
+      const jitter = Math.random() * NETWORK_FAILURE_JITTER_MS;
+      return {
+        kind: "network",
+        reason,
+        retryAt: now + NETWORK_FAILURE_TTL_MS + jitter,
+      };
+    }
+    // Aborts (the 60s timeout firing) look like generic errors; bucket them
+    // with transient so they retry on a short window.
+    if (this.isAbortError(error)) {
+      const jitter = Math.random() * TRANSIENT_FAILURE_JITTER_MS;
+      return {
+        kind: "transient",
+        reason,
+        retryAt: now + TRANSIENT_FAILURE_TTL_MS + jitter,
+      };
+    }
+    const jitter = Math.random() * TRANSIENT_FAILURE_JITTER_MS;
+    return {
+      kind: "transient",
+      reason,
+      retryAt: now + TRANSIENT_FAILURE_TTL_MS + jitter,
+    };
+  }
+
+  private isAbortError(error: unknown): boolean {
+    const msg = extractGitErrorMessage(error);
+    return /aborted|operation was aborted|AbortError/i.test(msg);
+  }
+}

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -70,6 +70,15 @@ export interface FetchResult {
  */
 export class RepoFetchCoordinator {
   private readonly states = new Map<string, RepoState>();
+  /**
+   * Coordinator-wide generation baseline. Bumped by `destroy()` so any new
+   * `RepoState` created after a project switch (e.g. when reopening the same
+   * repo path on a fresh project) starts at a higher generation than any
+   * still-in-flight pre-destroy fetch. Without this, a stale completion that
+   * captured `generationAtStart=0` could pass the guard against a fresh
+   * `state.generation=0` and corrupt the new project's failure cache.
+   */
+  private baseGeneration = 0;
 
   constructor(private readonly callbacks: RepoFetchCoordinatorCallbacks = {}) {}
 
@@ -150,6 +159,9 @@ export class RepoFetchCoordinator {
   /**
    * Mark every known repo's generation as invalidated, dropping in-flight
    * results before they mutate state. Called on shutdown / project switch.
+   * Bumps the coordinator-wide baseline too so freshly-created states (e.g.
+   * after reopening the same repo on a different project) start above any
+   * still-in-flight pre-destroy fetch's captured generation.
    */
   destroy(): void {
     for (const state of this.states.values()) {
@@ -157,6 +169,7 @@ export class RepoFetchCoordinator {
       state.failure = null;
     }
     this.states.clear();
+    this.baseGeneration += 1;
   }
 
   /** Test/diagnostic accessor. */
@@ -176,7 +189,7 @@ export class RepoFetchCoordinator {
         chain: Promise.resolve(),
         failure: null,
         lastSuccessfulFetch: null,
-        generation: 0,
+        generation: this.baseGeneration,
       };
       this.states.set(commonDir, state);
     }
@@ -190,6 +203,7 @@ export class RepoFetchCoordinator {
   ): Promise<FetchResult> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_ABORT_TIMEOUT_MS);
+    let succeeded = false;
     try {
       const git = createBackgroundFetchGit(opts.worktreePath, {
         signal: controller.signal,
@@ -202,7 +216,7 @@ export class RepoFetchCoordinator {
       }
       state.failure = null;
       state.lastSuccessfulFetch = Date.now();
-      this.callbacks.onFetchSuccess?.(opts.worktreeId);
+      succeeded = true;
       return { status: "success" };
     } catch (error) {
       const reason = classifyGitError(error);
@@ -214,6 +228,15 @@ export class RepoFetchCoordinator {
       return { status: "failed", reason };
     } finally {
       clearTimeout(timeout);
+      // Notify outside the try/catch so a throwing observer can't poison the
+      // failure cache. Wrapped defensively — `onFetchSuccess` is fire-and-forget.
+      if (succeeded) {
+        try {
+          this.callbacks.onFetchSuccess?.(opts.worktreeId);
+        } catch {
+          // Observer threw — silently swallow; fetch itself succeeded.
+        }
+      }
     }
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -32,6 +32,7 @@ import { WorktreeLifecycleService } from "./WorktreeLifecycleService.js";
 import { WorktreeMonitor } from "./WorktreeMonitor.js";
 import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService } from "./PRIntegrationService.js";
+import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
 import { waitForPathExists } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -176,6 +177,7 @@ export class WorkspaceService {
   private lifecycleService = new WorktreeLifecycleService();
   private listService = new WorktreeListService();
   private prService: PRIntegrationService;
+  private fetchCoordinator: RepoFetchCoordinator;
   private _shutdownController = new AbortController();
   private resourceActionQueues = new Map<string, PQueue>();
   private resourceActionAbortControllers = new Map<string, AbortController>();
@@ -192,6 +194,17 @@ export class WorkspaceService {
   private wslDefaultDistroPromise: Promise<string | null> | null = null;
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
+    this.fetchCoordinator = new RepoFetchCoordinator({
+      onFetchSuccess: (worktreeId) => {
+        const monitor = this.monitors.get(worktreeId);
+        if (!monitor || !monitor.isRunning) return;
+        // A successful fetch updated remote refs, so the next `rev-list` for
+        // ahead/behind will return fresh counts. Trigger a status refresh
+        // immediately rather than waiting for the next poll tick — but
+        // fire-and-forget; fetch success must never block.
+        monitor.triggerRefreshIfUpdating();
+      },
+    });
     this.prService = new PRIntegrationService(pullRequestService, events, {
       onPRDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
@@ -552,6 +565,15 @@ export class WorkspaceService {
         },
         onInotifyLimitReached: () => this.handleInotifyLimitReached(),
         onEmfileLimitReached: () => this.handleEmfileLimitReached(),
+        onScheduleFetch: async (worktreeId, _isCurrent, force) => {
+          const target = this.monitors.get(worktreeId);
+          if (!target || !target.isRunning) return;
+          await this.fetchCoordinator.fetchForWorktree({
+            worktreeId,
+            worktreePath: target.path,
+            force,
+          });
+        },
       },
       this.mainBranch,
       this.pollQueue
@@ -840,6 +862,10 @@ export class WorkspaceService {
    */
   async refreshOnWake(requestId: string): Promise<void> {
     try {
+      // Drop network/transient fetch failures so the post-wake fetch attempt
+      // is allowed to run even if the network was down before sleep. Auth
+      // suspensions stay sticky — they require explicit re-auth.
+      this.fetchCoordinator.clearNetworkFailures();
       for (const monitor of this.monitors.values()) {
         monitor.resetPollingStrategy();
       }
@@ -856,6 +882,15 @@ export class WorkspaceService {
         })
       );
       await Promise.all(promises);
+      // Kick off background fetches across all worktrees so ahead/behind
+      // counts catch up against the network state we just reconnected to.
+      // Fire-and-forget — the fetch coordinator serializes per-repo and
+      // failures don't block the wake refresh result.
+      for (const monitor of this.monitors.values()) {
+        if (monitor.isRunning) {
+          void monitor.triggerFetchNow();
+        }
+      }
       await pullRequestService.refresh();
       this.sendEvent({ type: "refresh-result", requestId, success: true });
     } catch (error) {
@@ -1821,6 +1856,17 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   updateGitHubToken(token: string | null): void {
     GitHubAuth.setMemoryToken(token);
     if (token) {
+      // A new token may resolve previously-failing auth — drop suspensions so
+      // the next scheduled fetch retries. Network/transient entries stay so we
+      // don't immediately re-storm an offline remote.
+      this.fetchCoordinator.clearAuthFailures();
+      // Trigger an opportunistic fetch on every worktree so the user sees
+      // refreshed counts shortly after sign-in / token rotation.
+      for (const monitor of this.monitors.values()) {
+        if (monitor.isRunning) {
+          void monitor.triggerFetchNow();
+        }
+      }
       pullRequestService.refresh();
     } else {
       pullRequestService.reset();
@@ -1862,6 +1908,10 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       monitor.stop();
     }
     this.monitors.clear();
+    // Drop in-flight fetch chains and per-repo failure state — the next
+    // project's monitors get a clean coordinator and stale completions are
+    // discarded by the generation guard.
+    this.fetchCoordinator.destroy();
 
     this.activeWorktreeId = null;
     this.mainBranch = "main";

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -22,7 +22,7 @@ import type {
 } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { detectWslPath, listFirstWslDistro } from "../utils/wsl.js";
-import { getGitDir, clearGitDirCache } from "../utils/gitUtils.js";
+import { getGitDir, clearGitDirCache, clearGitCommonDirCache } from "../utils/gitUtils.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { pullRequestService } from "../services/PullRequestService.js";
@@ -1920,6 +1920,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.projectEnvVars = {};
 
     clearGitDirCache();
+    clearGitCommonDirCache();
     this.listService.invalidateCache();
     this.listService.setGit(null, null);
 

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -36,6 +36,26 @@ const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 120_000;
 const HEARTBEAT_GAP_MULTIPLIER = 3;
 const HEARTBEAT_GAP_FLOOR_MS = 30_000;
 
+// Background fetch cadence — independent from the local-status poll. Focused
+// (current) worktrees fetch frequently so ahead/behind counts stay fresh while
+// the user is looking at them; everything else falls back to a low-rate
+// background tier to avoid hammering remotes for repos the user isn't viewing.
+// Jitter is applied at the call site to avoid thundering-herd alignment when
+// multiple worktrees were started together.
+const FETCH_INTERVAL_FOCUSED_MIN_MS = 30_000;
+const FETCH_INTERVAL_FOCUSED_MAX_MS = 45_000;
+const FETCH_INTERVAL_BACKGROUND_MIN_MS = 5 * 60_000;
+const FETCH_INTERVAL_BACKGROUND_MAX_MS = 10 * 60_000;
+// Initial fetch fires shortly after start so users don't wait a full cadence
+// window for fresh ahead/behind on app launch.
+const FETCH_INITIAL_DELAY_MIN_MS = 2_000;
+const FETCH_INITIAL_DELAY_MAX_MS = 5_000;
+
+function randomBetween(minMs: number, maxMs: number): number {
+  if (maxMs <= minMs) return minMs;
+  return minMs + Math.floor(Math.random() * (maxMs - minMs));
+}
+
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
   adaptiveBackoff: boolean;
@@ -54,6 +74,17 @@ export interface WorktreeMonitorCallbacks {
   onResourceStatusPoll?: (worktreeId: string) => Promise<unknown> | void;
   onInotifyLimitReached?: (worktreeId: string) => void;
   onEmfileLimitReached?: (worktreeId: string) => void;
+  /**
+   * Schedule a background `git fetch` for this worktree's repo. Routed through
+   * `WorkspaceService` so per-repo serialization and failure-cache state are
+   * shared across sibling monitors. Resolves regardless of fetch outcome.
+   * `force` bypasses the per-repo failure cache (manual user-triggered refresh).
+   */
+  onScheduleFetch?: (
+    worktreeId: string,
+    isCurrent: boolean,
+    force: boolean
+  ) => Promise<void> | void;
 }
 
 export class WorktreeMonitor {
@@ -140,6 +171,12 @@ export class WorktreeMonitor {
   // Resource status auto-polling
   private resourcePollTimer: NodeJS.Timeout | null = null;
   private resourcePollIntervalMs: number = 0; // 0 = disabled
+
+  // Background fetch timer — separate from the local-status poll so a stuck
+  // remote can't poison local-status updates. Cadence flips based on
+  // `_isCurrent`; rescheduling happens in the `isCurrent` setter.
+  private fetchTimer: NodeJS.Timeout | null = null;
+  private _pendingFetchPromise: Promise<void> | null = null;
 
   // Poll queue concurrency
   private _pendingPollPromise: Promise<void> | null = null;
@@ -285,6 +322,14 @@ export class WorktreeMonitor {
           this.scheduleNextPoll();
         }
       }
+    }
+    // Fetch cadence flips between focused (~30-45s) and background (5-10min)
+    // based on `isCurrent`. Reschedule from the new tier the moment focus
+    // changes so the user sees fresh counts shortly after switching to a
+    // worktree that hadn't been actively fetched.
+    if (changed && this._isRunning) {
+      this.clearFetchTimer();
+      this.scheduleNextFetch(true);
     }
   }
 
@@ -560,6 +605,7 @@ export class WorktreeMonitor {
 
     if (this._isRunning && this.pollingEnabled) {
       this.scheduleNextPoll();
+      this.scheduleNextFetch(true);
     }
   }
 
@@ -589,6 +635,7 @@ export class WorktreeMonitor {
 
     if (this._isRunning && this.pollingEnabled) {
       this.scheduleNextPoll();
+      this.scheduleNextFetch(true);
     }
   }
 
@@ -598,6 +645,15 @@ export class WorktreeMonitor {
     this._pollAbortController = new AbortController();
     this.clearTimers();
     this.stopWatcher();
+  }
+
+  /**
+   * Trigger an immediate background fetch, bypassing the per-repo failure
+   * cache. Used by wake handlers and explicit user refresh paths. The
+   * coordinator still serializes against any in-flight fetch on the same repo.
+   */
+  triggerFetchNow(): Promise<void> {
+    return this.runFetch(true);
   }
 
   async refresh(): Promise<void> {
@@ -629,6 +685,7 @@ export class WorktreeMonitor {
     }
 
     this.scheduleResourcePoll();
+    this.scheduleNextFetch(true);
   }
 
   getSnapshot(): WorktreeSnapshot {
@@ -966,6 +1023,52 @@ export class WorktreeMonitor {
       this.watcherRetryTimer = null;
     }
     this.clearResourcePollTimer();
+    this.clearFetchTimer();
+  }
+
+  private clearFetchTimer(): void {
+    if (this.fetchTimer) {
+      clearTimeout(this.fetchTimer);
+      this.fetchTimer = null;
+    }
+  }
+
+  private scheduleNextFetch(initial: boolean = false): void {
+    if (!this._isRunning) return;
+    if (!this.callbacks.onScheduleFetch) return;
+    if (this.fetchTimer) return;
+
+    const delay = initial
+      ? randomBetween(FETCH_INITIAL_DELAY_MIN_MS, FETCH_INITIAL_DELAY_MAX_MS)
+      : this._isCurrent
+        ? randomBetween(FETCH_INTERVAL_FOCUSED_MIN_MS, FETCH_INTERVAL_FOCUSED_MAX_MS)
+        : randomBetween(FETCH_INTERVAL_BACKGROUND_MIN_MS, FETCH_INTERVAL_BACKGROUND_MAX_MS);
+
+    this.fetchTimer = setTimeout(() => {
+      this.fetchTimer = null;
+      if (!this._isRunning) return;
+      void this.runFetch(false);
+    }, delay);
+  }
+
+  private async runFetch(force: boolean): Promise<void> {
+    if (!this._isRunning) return;
+    if (!this.callbacks.onScheduleFetch) return;
+    if (this._pendingFetchPromise) return;
+
+    const run = Promise.resolve(this.callbacks.onScheduleFetch(this.id, this._isCurrent, force))
+      .catch(() => {
+        // Coordinator handles classification; monitor doesn't surface fetch
+        // errors directly — they don't block local-status updates.
+      })
+      .finally(() => {
+        this._pendingFetchPromise = null;
+        if (this._isRunning) {
+          this.scheduleNextFetch(false);
+        }
+      });
+    this._pendingFetchPromise = run;
+    await run;
   }
 
   private scheduleCircuitBreakerRetry(): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -177,6 +177,13 @@ export class WorktreeMonitor {
   // `_isCurrent`; rescheduling happens in the `isCurrent` setter.
   private fetchTimer: NodeJS.Timeout | null = null;
   private _pendingFetchPromise: Promise<void> | null = null;
+  /**
+   * When `triggerFetchNow()` is called while a non-force fetch is in-flight,
+   * we can't drop the force request — wake / auth-rotation hooks rely on it
+   * bypassing the failure cache. Defer it: set this flag, let the in-flight
+   * call complete, then run a forced fetch in the post-pending hook.
+   */
+  private _pendingForceFetch: boolean = false;
 
   // Poll queue concurrency
   private _pendingPollPromise: Promise<void> | null = null;
@@ -1054,7 +1061,16 @@ export class WorktreeMonitor {
   private async runFetch(force: boolean): Promise<void> {
     if (!this._isRunning) return;
     if (!this.callbacks.onScheduleFetch) return;
-    if (this._pendingFetchPromise) return;
+    if (this._pendingFetchPromise) {
+      // A fetch is already in-flight. Drop non-force duplicates, but defer a
+      // force request so wake / auth-rotation can still bypass the failure
+      // cache once the current fetch lands.
+      if (force) {
+        this._pendingForceFetch = true;
+        await this._pendingFetchPromise;
+      }
+      return;
+    }
 
     const run = Promise.resolve(this.callbacks.onScheduleFetch(this.id, this._isCurrent, force))
       .catch(() => {
@@ -1063,8 +1079,14 @@ export class WorktreeMonitor {
       })
       .finally(() => {
         this._pendingFetchPromise = null;
+        const queuedForce = this._pendingForceFetch;
+        this._pendingForceFetch = false;
         if (this._isRunning) {
-          this.scheduleNextFetch(false);
+          if (queuedForce) {
+            void this.runFetch(true);
+          } else {
+            this.scheduleNextFetch(false);
+          }
         }
       });
     this._pendingFetchPromise = run;

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetGitCommonDir = vi.fn();
+const mockCreateBackgroundFetchGit = vi.fn();
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitCommonDir: (...args: unknown[]) => mockGetGitCommonDir(...args),
+  // Other exports referenced by the coordinator's import surface but not used.
+  getGitDir: vi.fn().mockReturnValue(null),
+  clearGitDirCache: vi.fn(),
+  clearGitCommonDirCache: vi.fn(),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createBackgroundFetchGit: (...args: unknown[]) => mockCreateBackgroundFetchGit(...args),
+}));
+
+import { RepoFetchCoordinator } from "../RepoFetchCoordinator.js";
+
+interface MockGit {
+  raw: ReturnType<typeof vi.fn>;
+}
+
+function makeMockGit(rawImpl: () => Promise<unknown>): MockGit {
+  return { raw: vi.fn().mockImplementation(rawImpl) };
+}
+
+describe("RepoFetchCoordinator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns success on a clean fetch and records lastSuccessfulFetch", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+    const onFetchSuccess = vi.fn();
+    const coord = new RepoFetchCoordinator({ onFetchSuccess });
+
+    const result = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+
+    expect(result.status).toBe("success");
+    expect(onFetchSuccess).toHaveBeenCalledWith("wt1");
+    expect(coord.getLastSuccessfulFetch("/repo/.git")).not.toBeNull();
+  });
+
+  it("skips when commondir cannot be resolved", async () => {
+    mockGetGitCommonDir.mockReturnValue(null);
+
+    const coord = new RepoFetchCoordinator();
+    const result = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/no/such/repo",
+    });
+
+    expect(result.status).toBe("skipped");
+    expect(result.skipReason).toBe("no-common-dir");
+    expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+  });
+
+  it("serializes fetches for sibling worktrees sharing a commondir", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        await Promise.resolve();
+        inFlight--;
+      })
+    );
+
+    const coord = new RepoFetchCoordinator();
+    const a = coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repo/a" });
+    const b = coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repo/b" });
+    const c = coord.fetchForWorktree({ worktreeId: "wtC", worktreePath: "/repo/c" });
+
+    await Promise.all([a, b, c]);
+
+    expect(maxInFlight).toBe(1);
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(3);
+  });
+
+  it("allows concurrent fetches for distinct commondirs", async () => {
+    let invocations = 0;
+    mockGetGitCommonDir.mockImplementation((path: string) => `${path}/.git`);
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(async () => {
+        invocations++;
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        await Promise.resolve();
+        inFlight--;
+      })
+    );
+
+    const coord = new RepoFetchCoordinator();
+    const a = coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repoA" });
+    const b = coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repoB" });
+
+    await Promise.all([a, b]);
+
+    expect(invocations).toBe(2);
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+
+  it("classifies auth failures and suspends future fetches indefinitely", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() =>
+        Promise.reject(new Error("Authentication failed for 'https://example.com'"))
+      )
+    );
+
+    const coord = new RepoFetchCoordinator();
+    const first = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(first.status).toBe("failed");
+    expect(first.reason).toBe("auth-failed");
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    // Second attempt should skip without invoking git.
+    mockCreateBackgroundFetchGit.mockClear();
+    const second = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(second.status).toBe("skipped");
+    expect(second.skipReason).toBe("auth-suspended");
+    expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+  });
+
+  it("clears auth suspensions on demand", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed")))
+    );
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    coord.clearAuthFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
+  });
+
+  it("classifies network failures with a short retry window", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() =>
+        Promise.reject(
+          new Error(
+            "fatal: unable to access 'https://github.com/x.git/': Could not resolve host: github.com"
+          )
+        )
+      )
+    );
+
+    const coord = new RepoFetchCoordinator();
+    const result = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(result.reason).toBe("network-unavailable");
+
+    // Within the network failure TTL, subsequent attempts skip.
+    mockCreateBackgroundFetchGit.mockClear();
+    const blocked = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(blocked.status).toBe("skipped");
+    expect(blocked.skipReason).toBe("in-failure-window");
+  });
+
+  it("clears network failures on demand (wake hook)", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Could not resolve host: github.com")))
+    );
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    coord.clearNetworkFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
+  });
+
+  it("treats repo-not-found AFTER a prior success as auth-failed (404 masking)", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let attempt = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => {
+        attempt++;
+        if (attempt === 1) return Promise.resolve();
+        return Promise.reject(new Error("ERROR: Repository not found."));
+      })
+    );
+
+    const coord = new RepoFetchCoordinator();
+    // First fetch succeeds.
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(coord.getLastSuccessfulFetch("/repo/.git")).not.toBeNull();
+
+    // Second fetch fails with 404 — now treated as auth-failed.
+    const second = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(second.status).toBe("failed");
+    expect(second.reason).toBe("repository-not-found");
+
+    // clearNetworkFailures should NOT clear it — auth-suspensions stay.
+    coord.clearNetworkFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    // clearAuthFailures should clear it.
+    coord.clearAuthFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
+  });
+
+  it("treats first-fetch repo-not-found as a short retry window (typo / race)", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("ERROR: Repository not found.")))
+    );
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    // clearAuthFailures must NOT clear it — first-fetch 404 is not auth.
+    coord.clearAuthFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+  });
+
+  it("force=true bypasses the failure cache", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let attempt = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => {
+        attempt++;
+        if (attempt === 1) return Promise.reject(new Error("Could not resolve host"));
+        return Promise.resolve();
+      })
+    );
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+
+    // Without force, would skip; with force, retries and succeeds.
+    const result = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+      force: true,
+    });
+    expect(result.status).toBe("success");
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
+  });
+
+  it("destroy() bumps the generation so in-flight completions are discarded", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let resolveFetch: (() => void) | undefined;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(
+        () =>
+          new Promise<void>((res) => {
+            resolveFetch = res;
+          })
+      )
+    );
+
+    const onFetchSuccess = vi.fn();
+    const coord = new RepoFetchCoordinator({ onFetchSuccess });
+
+    const inFlight = coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+
+    // Drain microtasks so runFetch starts and captures resolveFetch.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(resolveFetch).toBeDefined();
+
+    // Tear down before the fetch completes, then resolve.
+    coord.destroy();
+    resolveFetch?.();
+
+    const result = await inFlight;
+    expect(result.status).toBe("skipped");
+    expect(result.skipReason).toBe("stale-generation");
+    expect(onFetchSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -276,6 +276,52 @@ describe("RepoFetchCoordinator", () => {
     expect(coord.hasFailureFor("/repo/.git")).toBe(false);
   });
 
+  it("destroy() isolates generations across same-repo re-entry", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let resolveFirst: (() => void) | undefined;
+    let rawCalls = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => {
+        rawCalls++;
+        if (rawCalls === 1) {
+          return new Promise<void>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve();
+      })
+    );
+
+    const onFetchSuccess = vi.fn();
+    const coord = new RepoFetchCoordinator({ onFetchSuccess });
+
+    // First fetch: starts but doesn't resolve.
+    const inFlight = coord.fetchForWorktree({
+      worktreeId: "wtA",
+      worktreePath: "/repo",
+    });
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(resolveFirst).toBeDefined();
+
+    // Project switch: destroy + reopen same repo path.
+    coord.destroy();
+    const second = await coord.fetchForWorktree({
+      worktreeId: "wtB",
+      worktreePath: "/repo",
+    });
+    expect(second.status).toBe("success");
+    // onFetchSuccess fired exactly once for wtB; not for wtA.
+    expect(onFetchSuccess).toHaveBeenCalledTimes(1);
+    expect(onFetchSuccess).toHaveBeenCalledWith("wtB");
+
+    // Now resolve the original fetch — its completion must NOT fire onFetchSuccess
+    // for wtA, because its captured generation is older than the post-destroy
+    // baseline assigned to the new state.
+    resolveFirst?.();
+    await inFlight;
+    expect(onFetchSuccess).toHaveBeenCalledTimes(1);
+  });
+
   it("destroy() bumps the generation so in-flight completions are discarded", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     let resolveFetch: (() => void) | undefined;

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1726,4 +1726,73 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
   });
+
+  describe("background fetch scheduling", () => {
+    const CLEAN_CHANGES = {
+      worktreeId: "/test/worktree",
+      rootPath: "/test",
+      changes: [],
+      changedFileCount: 0,
+      lastUpdated: Date.now(),
+    };
+
+    beforeEach(() => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockGitRaw.mockResolvedValue("0\t0\n");
+    });
+
+    it("invokes onScheduleFetch after the initial-delay window once running", async () => {
+      const onScheduleFetch = vi.fn().mockResolvedValue(undefined);
+      const callbacks = makeCallbacks({ onScheduleFetch });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      expect(onScheduleFetch).not.toHaveBeenCalled();
+
+      // Advance past the initial-delay max (5s) so the timer fires.
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(onScheduleFetch).toHaveBeenCalledTimes(1);
+      expect(onScheduleFetch).toHaveBeenCalledWith(TEST_WORKTREE.id, false, false);
+
+      monitor.stop();
+    });
+
+    it("clears the fetch timer in stop()", async () => {
+      const onScheduleFetch = vi.fn().mockResolvedValue(undefined);
+      const callbacks = makeCallbacks({ onScheduleFetch });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      monitor.stop();
+
+      // Advance well past the longest possible fetch interval.
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      expect(onScheduleFetch).not.toHaveBeenCalled();
+    });
+
+    it("triggerFetchNow() calls the callback with force=true", async () => {
+      const onScheduleFetch = vi.fn().mockResolvedValue(undefined);
+      const callbacks = makeCallbacks({ onScheduleFetch });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      onScheduleFetch.mockClear();
+
+      await monitor.triggerFetchNow();
+      expect(onScheduleFetch).toHaveBeenCalledWith(TEST_WORKTREE.id, false, true);
+
+      monitor.stop();
+    });
+
+    it("does not schedule fetches when onScheduleFetch is not provided", async () => {
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      // No callback registered — there should be no errors and no scheduling.
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      monitor.stop();
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1794,5 +1794,46 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("triggerFetchNow() defers behind a pending fetch and runs after it lands", async () => {
+      let resolveFirst: (() => void) | undefined;
+      const invocations: Array<{ force: boolean }> = [];
+      const onScheduleFetch = vi
+        .fn()
+        .mockImplementation((_id: string, _isCurrent: boolean, force: boolean) => {
+          invocations.push({ force });
+          if (invocations.length === 1) {
+            return new Promise<void>((res) => {
+              resolveFirst = res;
+            });
+          }
+          return Promise.resolve();
+        });
+
+      const callbacks = makeCallbacks({ onScheduleFetch });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      // Let the initial-delay timer fire so the first (non-force) fetch starts.
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(invocations).toEqual([{ force: false }]);
+      expect(resolveFirst).toBeDefined();
+
+      // Issue a force request while the first is pending. It must not be lost.
+      const triggered = monitor.triggerFetchNow();
+
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      // Still only 1 invocation — the force request is deferred.
+      expect(invocations).toHaveLength(1);
+
+      // Resolve the first; the deferred force should fire next.
+      resolveFirst?.();
+      await triggered;
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+
+      expect(invocations).toEqual([{ force: false }, { force: true }]);
+
+      monitor.stop();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- The worktree ahead/behind pipeline previously ran `git rev-list` against locally-cached refs only — counts would go stale for hours until the user manually fetched
- This adds automatic background `git fetch origin` so the dashboard stays accurate without any user intervention
- The fetch path composes with the existing focus/blur/wake hooks rather than duplicating them

Resolves #6538

## Changes

- `createBackgroundFetchGit` factory (`electron/utils/hardenedGit.ts`) — wraps `createAuthenticatedGit` with packed-refs lock timeout, HTTP low-speed thresholds, and POSIX-only `GIT_ASKPASS=true` to prevent credential prompts from hanging the process
- `RepoFetchCoordinator` (`electron/workspace-host/RepoFetchCoordinator.ts`) — serializes fetches per `gitCommonDir` so multiple worktrees sharing `.git/objects` never contend on `packed-refs.lock`; multi-tier failure cache (auth: indefinite until token refresh, network: 60s + jitter, repo-not-found: bifurcates on prior-success to handle GitHub's 404-masking of expired PATs on private repos); 60s `AbortController` per fetch; generation guard so stale post-destroy completions are silently dropped
- `WorktreeMonitor` — independent fetch timer with separate cadences (focused: 30–45s, background: 5–10min, initial: 2–5s); `force=true` requests defer behind any pending non-force fetch; `isCurrent` setter reschedules on focus flip
- `WorkspaceService` — `clearNetworkFailures()` on OS wake with immediate fetch trigger; `clearAuthFailures()` + immediate fetch trigger on GitHub token update; `coordinator.destroy()` + `clearGitCommonDirCache()` on project switch
- `getGitCommonDir` helper in `electron/utils/gitUtils.ts` for the shared-objects key

## Testing

21 new unit tests: 12 coordinator tests (including generation isolation across destroy/re-entry and force-during-pending deferred execution), 5 monitor fetch hook tests, 6 `createBackgroundFetchGit` tests