### PR TITLE
feat(sidebar): add hover prefetch for new-worktree dialog

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1101,6 +1101,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     source: "user",
                   })
                 }
+                onPointerEnter={() => void preloadNewWorktreeDialog()}
                 className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
                 aria-label="Create new worktree"
               >


### PR DESCRIPTION
## Summary
One-line change in `SidebarContent.tsx` to add a hover prefetch for the new-worktree dialog. The `onPointerEnter` preloads the dialog chunk on hover, matching the existing Settings button pattern.

An idle callback preloads this dialog after boot, but there's a gap between app startup and the callback firing where the chunk isn't warm yet. This closes that gap.

Resolves #6503

## Changes
- Added `onPointerEnter={() => void preloadNewWorktreeDialog()}` to the new-worktree `+` button in `src/components/Sidebar/SidebarContent.tsx`

## Testing
- Verified the hover prefetch triggers dialog preload on pointer enter
- Confirmed no regression in button click behavior