### PR TITLE
fix(startup): smooth cold-start skeleton handoff via View Transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,11 +59,20 @@
         flex-direction: column;
         background: var(--theme-surface-grid, #0e0e0d);
         animation: skeleton-safety-fade 10s forwards;
-        transition: opacity 250ms ease-out;
+        transition: opacity 120ms ease-out;
       }
       #startup-skeleton.fade-out {
         opacity: 0;
         pointer-events: none;
+      }
+
+      /* View Transitions API: GPU-snapshot crossfade tuned to UI_EXIT_DURATION
+         (Tier 2 exit, 120ms). Used by removeStartupSkeleton.ts when the API is
+         available. The reduced-motion media query below short-circuits this. */
+      ::view-transition-old(root),
+      ::view-transition-new(root) {
+        animation-duration: 120ms;
+        animation-timing-function: ease-out;
       }
 
       /* ── Progressive reveal delays ── */

--- a/index.html
+++ b/index.html
@@ -66,15 +66,6 @@
         pointer-events: none;
       }
 
-      /* View Transitions API: GPU-snapshot crossfade tuned to UI_EXIT_DURATION
-         (Tier 2 exit, 120ms). Used by removeStartupSkeleton.ts when the API is
-         available. The reduced-motion media query below short-circuits this. */
-      ::view-transition-old(root),
-      ::view-transition-new(root) {
-        animation-duration: 120ms;
-        animation-timing-function: ease-out;
-      }
-
       /* ── Progressive reveal delays ── */
       .skel-reveal {
         opacity: 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -496,7 +496,32 @@ function App() {
   }
 
   if (!crashResolved || !isStateLoaded) {
-    return <div className="h-screen w-screen bg-daintree-bg" />;
+    // Render the structural chrome (toolbar, dock) behind the HTML skeleton so
+    // the cold-start handoff has positionally-stable surfaces underneath when
+    // the skeleton fades out. AppLayout's `isHydrated={false}` mode skips the
+    // focus-mode persistence and renders no sidebar/main content.
+    return (
+      <LazyMotion strict features={loadMotionFeatures}>
+        <MotionConfig reducedMotion={reduceAnimations ? "always" : "user"}>
+          <ErrorBoundary variant="fullscreen" componentName="App">
+            <TooltipProvider
+              delayDuration={UI_TOOLTIP_DELAY_DURATION}
+              skipDelayDuration={UI_TOOLTIP_SKIP_DELAY_DURATION}
+            >
+              <AppLayout
+                onLaunchAgent={handleLaunchAgent}
+                onSettings={handleSettings}
+                onPreloadSettings={handlePreloadSettings}
+                agentAvailability={availability}
+                agentSettings={agentSettings}
+                isHydrated={false}
+                projectSwitcherPalette={projectSwitcherPalette}
+              />
+            </TooltipProvider>
+          </ErrorBoundary>
+        </MotionConfig>
+      </LazyMotion>
+    );
   }
 
   return (

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -131,6 +131,10 @@ export function AppLayout({
 
   useEffect(() => {
     if (layout.isFocusMode) return;
+    // Skip until hydration completes — the pre-hydration mount uses the
+    // default 350px and would otherwise overwrite the persisted value before
+    // restoreState() reads it back.
+    if (!isHydrated) return;
 
     const persistSidebarWidth = async () => {
       try {
@@ -142,7 +146,7 @@ export function AppLayout({
 
     const timer = setTimeout(persistSidebarWidth, 300);
     return () => clearTimeout(timer);
-  }, [sidebarWidth, layout.isFocusMode]);
+  }, [sidebarWidth, layout.isFocusMode, isHydrated]);
 
   useEffect(() => {
     // Gate persistence until hydration completes and project switching ends

--- a/src/utils/__tests__/removeStartupSkeleton.test.ts
+++ b/src/utils/__tests__/removeStartupSkeleton.test.ts
@@ -116,6 +116,47 @@ describe("removeStartupSkeleton", () => {
     expect(document.getElementById("startup-skeleton")).toBeNull();
   });
 
+  it("animates ::view-transition-old(root) opacity over UI_EXIT_DURATION on transition.ready", async () => {
+    const startViewTransition = vi.fn(() => ({
+      ready: Promise.resolve(),
+      finished: Promise.resolve(),
+    }));
+    (
+      document as unknown as { startViewTransition: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+
+    const animate = vi.fn();
+    const originalAnimate = (document.documentElement as unknown as { animate?: unknown }).animate;
+    (document.documentElement as unknown as { animate: typeof animate }).animate = animate;
+
+    try {
+      const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+      addSkeleton();
+      removeStartupSkeleton();
+
+      flushRaf();
+      flushRaf();
+
+      // transition.ready resolves microtask-async; flush the queue so the
+      // .then handler that drives the WAAPI animation runs before assertions.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(animate).toHaveBeenCalledTimes(1);
+      const call = animate.mock.calls[0];
+      expect(call).toBeDefined();
+      const [keyframes, options] = call!;
+      expect(keyframes).toEqual({ opacity: [1, 0] });
+      expect(options).toMatchObject({
+        duration: UI_EXIT_DURATION,
+        pseudoElement: "::view-transition-old(root)",
+        fill: "forwards",
+      });
+    } finally {
+      (document.documentElement as unknown as { animate?: unknown }).animate = originalAnimate;
+    }
+  });
+
   it("skips the View Transitions path when prefers-reduced-motion is set", async () => {
     matchesReducedMotion = true;
     const startViewTransition = vi.fn();

--- a/src/utils/__tests__/removeStartupSkeleton.test.ts
+++ b/src/utils/__tests__/removeStartupSkeleton.test.ts
@@ -1,19 +1,33 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UI_EXIT_DURATION } from "../../lib/animationUtils";
 
 describe("removeStartupSkeleton", () => {
   let rafQueue: FrameRequestCallback[];
   let notifyFirstInteractive: ReturnType<typeof vi.fn>;
+  let matchesReducedMotion: boolean;
 
   beforeEach(async () => {
     vi.resetModules();
     rafQueue = [];
     notifyFirstInteractive = vi.fn(() => Promise.resolve());
+    matchesReducedMotion = false;
 
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
+
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? matchesReducedMotion : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
 
     (
       window as unknown as { electron: { app: { notifyFirstInteractive: () => Promise<void> } } }
@@ -22,10 +36,17 @@ describe("removeStartupSkeleton", () => {
     };
 
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
   });
 
   afterEach(() => {
     document.getElementById("startup-skeleton")?.remove();
+    delete (document as { startViewTransition?: unknown }).startViewTransition;
+    delete document.body.dataset.performanceMode;
     vi.unstubAllGlobals();
     vi.useRealTimers();
     delete (window as unknown as { electron?: unknown }).electron;
@@ -43,7 +64,7 @@ describe("removeStartupSkeleton", () => {
     for (const cb of batch) cb(performance.now());
   }
 
-  it("adds fade-out class after two RAF ticks and removes element after timeout", async () => {
+  it("falls back to fade-out class + UI_EXIT_DURATION setTimeout when startViewTransition is unavailable", async () => {
     const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
     const el = addSkeleton();
     removeStartupSkeleton();
@@ -61,7 +82,77 @@ describe("removeStartupSkeleton", () => {
     expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
     expect(document.getElementById("startup-skeleton")).toBe(el);
 
-    vi.advanceTimersByTime(250);
+    vi.advanceTimersByTime(UI_EXIT_DURATION);
+    expect(document.getElementById("startup-skeleton")).toBeNull();
+  });
+
+  it("uses startViewTransition and removes the skeleton inside its callback when available", async () => {
+    let capturedCallback: (() => void) | null = null;
+    const startViewTransition = vi.fn((cb: () => void) => {
+      capturedCallback = cb;
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    });
+    (
+      document as unknown as { startViewTransition: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    const el = addSkeleton();
+    removeStartupSkeleton();
+
+    flushRaf();
+    flushRaf();
+
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
+    expect(el.getAttribute("aria-busy")).toBe("false");
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(document.getElementById("startup-skeleton")).toBe(el);
+    // No fallback setTimeout was scheduled — advancing the timer is a no-op
+    vi.advanceTimersByTime(UI_EXIT_DURATION);
+    expect(document.getElementById("startup-skeleton")).toBe(el);
+
+    expect(capturedCallback).toBeTypeOf("function");
+    capturedCallback!();
+    expect(document.getElementById("startup-skeleton")).toBeNull();
+  });
+
+  it("skips the View Transitions path when prefers-reduced-motion is set", async () => {
+    matchesReducedMotion = true;
+    const startViewTransition = vi.fn();
+    (
+      document as unknown as { startViewTransition: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    const el = addSkeleton();
+    removeStartupSkeleton();
+
+    flushRaf();
+    flushRaf();
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(el.classList.contains("fade-out")).toBe(true);
+    vi.advanceTimersByTime(UI_EXIT_DURATION);
+    expect(document.getElementById("startup-skeleton")).toBeNull();
+  });
+
+  it("skips the View Transitions path when performance mode is enabled", async () => {
+    document.body.dataset.performanceMode = "true";
+    const startViewTransition = vi.fn();
+    (
+      document as unknown as { startViewTransition: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    const el = addSkeleton();
+    removeStartupSkeleton();
+
+    flushRaf();
+    flushRaf();
+
+    expect(startViewTransition).not.toHaveBeenCalled();
+    expect(el.classList.contains("fade-out")).toBe(true);
+    vi.advanceTimersByTime(UI_EXIT_DURATION);
     expect(document.getElementById("startup-skeleton")).toBeNull();
   });
 
@@ -83,7 +174,7 @@ describe("removeStartupSkeleton", () => {
 
     expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(250);
+    vi.advanceTimersByTime(UI_EXIT_DURATION);
     expect(document.getElementById("startup-skeleton")).toBeNull();
 
     removeStartupSkeleton(); // no-op, should not throw

--- a/src/utils/removeStartupSkeleton.ts
+++ b/src/utils/removeStartupSkeleton.ts
@@ -1,5 +1,14 @@
+import { UI_EXIT_DURATION } from "../lib/animationUtils";
+import { prefersReducedMotion } from "../lib/appThemeViewTransition";
+
 const SKELETON_ID = "startup-skeleton";
-const FADE_DURATION_MS = 250;
+
+type ViewTransitionDocument = Document & {
+  startViewTransition?: (callback: () => void) => {
+    ready: Promise<void>;
+    finished: Promise<void>;
+  };
+};
 
 let firstInteractiveNotified = false;
 
@@ -19,7 +28,10 @@ function notifyFirstInteractive(): void {
  * Fade out and remove the startup skeleton overlay, and signal the main
  * process that the renderer is interactive so it can drain its deferred
  * service queue. Uses requestAnimationFrame to ensure React has painted
- * real content before both the fade and the signal fire.
+ * real content before both the fade and the signal fire, then prefers
+ * the View Transitions API for a GPU-snapshot crossfade — falling back
+ * to a plain CSS opacity transition under reduced-motion / performance
+ * mode / older runtimes.
  */
 export function removeStartupSkeleton(): void {
   const el = document.getElementById(SKELETON_ID);
@@ -31,13 +43,25 @@ export function removeStartupSkeleton(): void {
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       notifyFirstInteractive();
-
       el.setAttribute("aria-busy", "false");
-      el.classList.add("fade-out");
 
+      const doc = document as ViewTransitionDocument;
+      const canViewTransition =
+        typeof doc.startViewTransition === "function" &&
+        doc.visibilityState === "visible" &&
+        !prefersReducedMotion();
+
+      if (canViewTransition) {
+        doc.startViewTransition!(() => {
+          el.remove();
+        });
+        return;
+      }
+
+      el.classList.add("fade-out");
       setTimeout(() => {
         el.remove();
-      }, FADE_DURATION_MS);
+      }, UI_EXIT_DURATION);
     });
   });
 }

--- a/src/utils/removeStartupSkeleton.ts
+++ b/src/utils/removeStartupSkeleton.ts
@@ -52,9 +52,29 @@ export function removeStartupSkeleton(): void {
         !prefersReducedMotion();
 
       if (canViewTransition) {
-        doc.startViewTransition!(() => {
+        const transition = doc.startViewTransition!(() => {
           el.remove();
         });
+        // The shared `::view-transition-old(root)` / `::view-transition-new(root)`
+        // rules in src/index.css set `animation: none` so the theme-reveal can
+        // drive its own clip-path animation via WAAPI. We follow the same
+        // pattern: fade the old root snapshot out over UI_EXIT_DURATION.
+        transition.ready
+          .then(() => {
+            document.documentElement.animate(
+              { opacity: [1, 0] },
+              {
+                duration: UI_EXIT_DURATION,
+                easing: "ease-out",
+                pseudoElement: "::view-transition-old(root)",
+                fill: "forwards",
+              }
+            );
+          })
+          .catch(() => {
+            // Transition aborted (e.g. another startViewTransition started)
+            // — the callback already removed the skeleton, nothing else to do.
+          });
         return;
       }
 


### PR DESCRIPTION
## Summary

- The hardcoded 250ms skeleton-fade timeout was a non-standard outlier — replaced with `UI_EXIT_DURATION` (120ms) to match the project's Tier 2 motion tokens.
- Skeleton removal is now wrapped in `document.startViewTransition`, giving a GPU-snapshot crossfade between the HTML overlay and the React tree. The transition opacity is driven via WAAPI on `transition.ready` to sidestep the `animation: none` reset in `src/index.css`. `prefers-reduced-motion` and `data-performance-mode` both bypass the View Transitions path and fall back to the CSS fade, using the existing `prefersReducedMotion()` helper.
- Replaced the structureless `<div>` pre-hydration placeholder in `App.tsx` with `LazyMotion → MotionConfig → ErrorBoundary → TooltipProvider → AppLayout(isHydrated={false})`, so the toolbar chrome is positionally stable behind the skeleton during the fade rather than popping in afterwards.
- Gated the sidebar-width persistence effect on `isHydrated` to prevent a premature 350px write before `restoreState()` reads the persisted value back.

Resolves #6509

## Changes

- `index.html` — opacity transition duration 250ms → 120ms
- `src/utils/removeStartupSkeleton.ts` — `document.startViewTransition` wrapper, `UI_EXIT_DURATION` import, WAAPI animation on `transition.ready`
- `src/utils/__tests__/removeStartupSkeleton.test.ts` — 8 tests covering the View Transitions path (including the WAAPI call), reduced-motion/performance-mode bypasses, and the legacy fallback
- `src/App.tsx` — pre-hydration render replaced with real `AppLayout` chrome
- `src/components/Layout/AppLayout.tsx` — sidebar-width persistence gated on `isHydrated`

## Testing

- vitest 969/969 pass; targeted skeleton tests 8/8 pass
- Typecheck clean across renderer, electron, and preload
- Lint clean (warning count 2442 → 2441); prettier clean
- Production build successful

Manual:
- [ ] Cold-start with a hydrated project: skeleton fades smoothly into React UI with no visible blank frame
- [ ] Cold-start with `prefers-reduced-motion` or `data-performance-mode`: fallback CSS fade still applies
- [ ] Cold-start on a browser without the View Transitions API: fallback path active, skeleton removed after 120ms
- [ ] Sidebar width persists correctly after hydration (no premature 350px overwrite)