### PR TITLE
fix(worktree): remove redundant green border from overview cards

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -586,9 +586,7 @@ export function WorktreeOverviewModal({
                           "border border-divider",
                           "bg-daintree-sidebar/50",
                           "transition duration-150",
-                          "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
-                          worktree.id === activeWorktreeId &&
-                            "border-[var(--color-state-active)]/70 shadow-md"
+                          "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5"
                         )}
                       >
                         <OverviewWorktreeCard
@@ -633,9 +631,7 @@ export function WorktreeOverviewModal({
                     "border border-divider",
                     "bg-daintree-sidebar/50",
                     "transition duration-150",
-                    "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5",
-                    worktree.id === activeWorktreeId &&
-                      "border-[var(--color-state-active)]/70 shadow-md"
+                    "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5"
                   )}
                 >
                   <OverviewWorktreeCard


### PR DESCRIPTION
## Summary
When a worktree is selected in the overview modal, the green bar on the left side of the card already handles selection. The additional green border tint and shadow around the whole card just adds noise, so this drops it.

Resolves #6496.

## Changes
- Removes `border-[var(--color-state-active)]/70 shadow-md` from selected worktree cards in both grouped and ungrouped sections of `WorktreeOverviewModal.tsx`
- The left green bar on `WorktreeCard` (the `before:bg-daintree-accent` pseudo-element) is untouched and remains the sole selection indicator

## Testing
- Visual check: confirmed the overview modal no longer double-highlights selected worktrees