### PR TITLE
feat(mcp): audit log for every tool dispatch

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -498,6 +498,11 @@ export const CHANNELS = {
   MCP_SERVER_SET_API_KEY: "mcp-server:set-api-key",
   MCP_SERVER_GENERATE_API_KEY: "mcp-server:generate-api-key",
   MCP_SERVER_GET_CONFIG_SNIPPET: "mcp-server:get-config-snippet",
+  MCP_SERVER_GET_AUDIT_RECORDS: "mcp-server:get-audit-records",
+  MCP_SERVER_CLEAR_AUDIT_LOG: "mcp-server:clear-audit-log",
+  MCP_SERVER_SET_AUDIT_ENABLED: "mcp-server:set-audit-enabled",
+  MCP_SERVER_SET_AUDIT_MAX_RECORDS: "mcp-server:set-audit-max-records",
+  MCP_SERVER_GET_AUDIT_CONFIG: "mcp-server:get-audit-config",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -17,6 +17,11 @@ const serviceMock = vi.hoisted(() => ({
   setApiKey: vi.fn().mockResolvedValue(undefined),
   generateApiKey: vi.fn().mockResolvedValue("k-new"),
   getConfigSnippet: vi.fn(() => "snippet"),
+  getAuditRecords: vi.fn(() => []),
+  getAuditConfig: vi.fn(() => ({ enabled: true, maxRecords: 500 })),
+  clearAuditLog: vi.fn(),
+  setAuditEnabled: vi.fn(() => ({ enabled: true, maxRecords: 500 })),
+  setAuditMaxRecords: vi.fn(() => ({ enabled: true, maxRecords: 500 })),
 }));
 
 vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
@@ -131,8 +136,66 @@ describe("mcpServer IPC adversarial", () => {
     expect(result).toBe("new-secret-123");
   });
 
-  it("cleanup removes all six registered handlers", () => {
-    expect(ipcHandlers.size).toBe(6);
+  it("setAuditEnabled rejects non-boolean values", async () => {
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED)(fakeEvent(), "true")
+    ).rejects.toThrow(/boolean/);
+    await expect(getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED)(fakeEvent(), 1)).rejects.toThrow(
+      /boolean/
+    );
+    expect(serviceMock.setAuditEnabled).not.toHaveBeenCalled();
+  });
+
+  it("setAuditMaxRecords rejects non-integer or out-of-range values", async () => {
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), 49)
+    ).rejects.toThrow(/between/);
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), 10001)
+    ).rejects.toThrow(/between/);
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), 1.5)
+    ).rejects.toThrow(/integer/);
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), Number.NaN)
+    ).rejects.toThrow();
+    await expect(
+      getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), "500")
+    ).rejects.toThrow(/integer/);
+    expect(serviceMock.setAuditMaxRecords).not.toHaveBeenCalled();
+  });
+
+  it("setAuditMaxRecords accepts boundary values", async () => {
+    await getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), 50);
+    await getHandler(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS)(fakeEvent(), 10000);
+    expect(serviceMock.setAuditMaxRecords).toHaveBeenCalledTimes(2);
+  });
+
+  it("getAuditRecords passes through service result", async () => {
+    serviceMock.getAuditRecords.mockReturnValueOnce([
+      {
+        id: "x",
+        timestamp: 1,
+        toolId: "t",
+        sessionId: "s",
+        tier: "unknown",
+        argsSummary: "{}",
+        result: "success",
+        durationMs: 0,
+      },
+    ] as never);
+    const result = await getHandler(CHANNELS.MCP_SERVER_GET_AUDIT_RECORDS)(fakeEvent());
+    expect(Array.isArray(result)).toBe(true);
+    expect((result as unknown[]).length).toBe(1);
+  });
+
+  it("clearAuditLog calls service clear", async () => {
+    await getHandler(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG)(fakeEvent());
+    expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleanup removes all eleven registered handlers", () => {
+    expect(ipcHandlers.size).toBe(11);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -69,5 +69,47 @@ export function registerMcpServerHandlers(): () => void {
     })
   );
 
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GET_AUDIT_RECORDS, async () => {
+      const svc = await getMcpServerService();
+      return svc.getAuditRecords();
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GET_AUDIT_CONFIG, async () => {
+      const svc = await getMcpServerService();
+      return svc.getAuditConfig();
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG, async () => {
+      const svc = await getMcpServerService();
+      svc.clearAuditLog();
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED, async (enabled: boolean) => {
+      if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean");
+      const svc = await getMcpServerService();
+      return svc.setAuditEnabled(enabled);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS, async (max: number) => {
+      if (typeof max !== "number" || !Number.isFinite(max) || !Number.isInteger(max)) {
+        throw new Error("max must be a finite integer");
+      }
+      if (max < 50 || max > 10000) {
+        throw new Error("max must be between 50 and 10000");
+      }
+      const svc = await getMcpServerService();
+      return svc.setAuditMaxRecords(max);
+    })
+  );
+
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2333,6 +2333,13 @@ const api: ElectronAPI = {
     setApiKey: (apiKey: string) => _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_API_KEY, apiKey),
     generateApiKey: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GENERATE_API_KEY),
     getConfigSnippet: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_CONFIG_SNIPPET),
+    getAuditRecords: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_RECORDS),
+    getAuditConfig: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_CONFIG),
+    clearAuditLog: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG),
+    setAuditEnabled: (enabled: boolean) =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED, enabled),
+    setAuditMaxRecords: (max: number) =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_AUDIT_MAX_RECORDS, max),
   },
 
   mcpBridge: {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -12,6 +12,13 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/types/actions.js";
+import {
+  type McpAuditRecord,
+  type McpAuditResult,
+  MCP_AUDIT_DEFAULT_MAX_RECORDS,
+  MCP_AUDIT_MAX_RECORDS,
+  MCP_AUDIT_MIN_RECORDS,
+} from "../../shared/types/ipc/mcpServer.js";
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -23,6 +30,11 @@ const MCP_SERVER_KEY = "daintree";
 const DEFAULT_PORT = 45454;
 const MAX_PORT_RETRIES = 10;
 const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+const AUDIT_FLUSH_DEBOUNCE_MS = 2000;
+const AUDIT_ARGS_INLINE_STRING_LIMIT = 50;
+const AUDIT_ARGS_SUMMARY_LIMIT = 300;
+const CONFIRMATION_REQUIRED_CODE = "CONFIRMATION_REQUIRED";
 
 const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "browser",
@@ -120,6 +132,12 @@ interface PendingRequest<T> {
 interface McpSseSession {
   transport: SSEServerTransport;
   idleTimer: ReturnType<typeof setTimeout>;
+  /**
+   * Source-tier classification for the SSE peer. Will be populated by the
+   * tier-policy work in #6517; until then every record is tagged
+   * `"unknown"`.
+   */
+  tier?: string;
 }
 
 function safeSerializeToolResult(value: unknown): string {
@@ -180,6 +198,9 @@ export class McpServerService {
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
   private statusListeners = new Set<(running: boolean) => void>();
+  private auditRecords: McpAuditRecord[] = [];
+  private auditFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private auditHydrated = false;
 
   get isRunning(): boolean {
     return this.httpServer !== null && this.port !== null;
@@ -216,12 +237,27 @@ export class McpServerService {
     return store.get("mcpServer");
   }
 
+  /**
+   * Persist a config patch without dropping the in-memory audit log. Every
+   * config-mutation method must route through here so `setEnabled`,
+   * `setPort`, etc. don't clobber `auditLog` on disk by writing back a
+   * spread of the live config minus the in-memory ring buffer.
+   */
+  private persistConfig(patch: Partial<ReturnType<typeof this.getConfig>>): void {
+    const current = this.getConfig();
+    store.set("mcpServer", {
+      ...current,
+      ...patch,
+      auditLog: this.auditHydrated ? this.auditRecords : current.auditLog,
+    });
+  }
+
   isEnabled(): boolean {
     return this.getConfig().enabled;
   }
 
   async setEnabled(enabled: boolean): Promise<void> {
-    store.set("mcpServer", { ...this.getConfig(), enabled });
+    this.persistConfig({ enabled });
     if (enabled && this.registry && !this.isRunning) {
       await this.start(this.registry);
     } else if (!enabled && this.isRunning) {
@@ -230,16 +266,16 @@ export class McpServerService {
   }
 
   async setPort(port: number | null): Promise<void> {
-    const config = this.getConfig();
-    store.set("mcpServer", { ...config, port });
-    if (config.enabled && this.isRunning) {
+    const wasEnabled = this.getConfig().enabled;
+    this.persistConfig({ port });
+    if (wasEnabled && this.isRunning) {
       await this.stop();
       if (this.registry) await this.start(this.registry);
     }
   }
 
   async setApiKey(apiKey: string): Promise<void> {
-    store.set("mcpServer", { ...this.getConfig(), apiKey });
+    this.persistConfig({ apiKey });
     if (this.isRunning) {
       await this.writeDiscoveryFile();
     }
@@ -247,11 +283,202 @@ export class McpServerService {
 
   async generateApiKey(): Promise<string> {
     const key = `daintree_${randomUUID().replace(/-/g, "")}`;
-    store.set("mcpServer", { ...this.getConfig(), apiKey: key });
+    this.persistConfig({ apiKey: key });
     if (this.isRunning) {
       await this.writeDiscoveryFile();
     }
     return key;
+  }
+
+  /**
+   * Hydrate the in-memory ring buffer from the persisted store. Idempotent —
+   * subsequent calls are no-ops so tests and callers can invoke it freely.
+   * Trims to the current `auditMaxRecords` cap on load so a shrunk cap takes
+   * effect immediately.
+   */
+  private hydrateAuditLog(): void {
+    if (this.auditHydrated) return;
+    const config = this.getConfig();
+    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
+    const cap = this.normalizeAuditMaxRecords(config.auditMaxRecords);
+    this.auditRecords =
+      persisted.length > cap ? persisted.slice(persisted.length - cap) : [...persisted];
+    this.auditHydrated = true;
+  }
+
+  private normalizeAuditMaxRecords(value: unknown): number {
+    const n = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : NaN;
+    if (!Number.isFinite(n)) return MCP_AUDIT_DEFAULT_MAX_RECORDS;
+    if (n < MCP_AUDIT_MIN_RECORDS) return MCP_AUDIT_MIN_RECORDS;
+    if (n > MCP_AUDIT_MAX_RECORDS) return MCP_AUDIT_MAX_RECORDS;
+    return n;
+  }
+
+  /**
+   * Redact a tool-call argument blob into a short summary string. Walks one
+   * level deep on top-level objects; long strings collapse to
+   * `<string: N chars>`, nested objects/arrays collapse to `<object>`.
+   * Final output is truncated to keep audit records compact and to avoid
+   * leaking pasted file contents or terminal output through the UI.
+   */
+  private redactArgsSummary(args: unknown): string {
+    const summarize = (value: unknown): unknown => {
+      if (value === null) return null;
+      if (typeof value === "string") {
+        return value.length > AUDIT_ARGS_INLINE_STRING_LIMIT
+          ? `<string: ${value.length} chars>`
+          : value;
+      }
+      if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+        return typeof value === "bigint" ? `${value.toString()}n` : value;
+      }
+      if (typeof value === "undefined") return undefined;
+      return "<object>";
+    };
+
+    let summary: unknown;
+    if (args === undefined || args === null) {
+      summary = args ?? null;
+    } else if (typeof args !== "object" || Array.isArray(args)) {
+      summary = summarize(args);
+    } else {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+        if (key === "_meta") continue;
+        const reduced = summarize(value);
+        if (reduced !== undefined) {
+          out[key] = reduced;
+        }
+      }
+      summary = out;
+    }
+
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(summary) ?? "";
+    } catch {
+      serialized = "<unserializable>";
+    }
+    if (serialized.length > AUDIT_ARGS_SUMMARY_LIMIT) {
+      return `${serialized.slice(0, AUDIT_ARGS_SUMMARY_LIMIT - 1)}…`;
+    }
+    return serialized;
+  }
+
+  private classifyDispatchResult(
+    outcome: { kind: "result"; value: ActionDispatchResult } | { kind: "throw"; error: unknown }
+  ): { result: McpAuditResult; errorCode?: string } {
+    if (outcome.kind === "throw") {
+      return { result: "error", errorCode: "DISPATCH_THREW" };
+    }
+    const value = outcome.value;
+    if (value.ok) return { result: "success" };
+    if (value.error.code === CONFIRMATION_REQUIRED_CODE) {
+      return { result: "confirmation-pending", errorCode: value.error.code };
+    }
+    return { result: "error", errorCode: value.error.code };
+  }
+
+  private appendAuditRecord(input: {
+    toolId: string;
+    sessionId: string;
+    tier: string | undefined;
+    args: unknown;
+    durationMs: number;
+    outcome: { kind: "result"; value: ActionDispatchResult } | { kind: "throw"; error: unknown };
+  }): void {
+    if (!this.getConfig().auditEnabled) return;
+    this.hydrateAuditLog();
+
+    const classification = this.classifyDispatchResult(input.outcome);
+    const record: McpAuditRecord = {
+      id: randomUUID(),
+      timestamp: Date.now(),
+      toolId: input.toolId,
+      sessionId: input.sessionId,
+      tier: input.tier ?? "unknown",
+      argsSummary: this.redactArgsSummary(input.args),
+      result: classification.result,
+      durationMs: Math.max(0, Math.round(input.durationMs)),
+    };
+    if (classification.errorCode !== undefined) {
+      record.errorCode = classification.errorCode;
+    }
+
+    this.auditRecords.push(record);
+    const cap = this.normalizeAuditMaxRecords(this.getConfig().auditMaxRecords);
+    if (this.auditRecords.length > cap) {
+      this.auditRecords.splice(0, this.auditRecords.length - cap);
+    }
+    this.scheduleAuditFlush();
+  }
+
+  private scheduleAuditFlush(): void {
+    if (this.auditFlushTimer) return;
+    this.auditFlushTimer = setTimeout(() => {
+      this.auditFlushTimer = null;
+      this.flushAuditLog();
+    }, AUDIT_FLUSH_DEBOUNCE_MS);
+    this.auditFlushTimer.unref?.();
+  }
+
+  private flushAuditLog(): void {
+    if (!this.auditHydrated) return;
+    try {
+      this.persistConfig({});
+    } catch (err) {
+      console.error("[MCP] Failed to flush audit log:", err);
+    }
+  }
+
+  /** Cancel any pending debounce and persist the buffer immediately. */
+  private flushAuditLogNow(): void {
+    if (this.auditFlushTimer) {
+      clearTimeout(this.auditFlushTimer);
+      this.auditFlushTimer = null;
+    }
+    this.flushAuditLog();
+  }
+
+  /** Read the persisted ring buffer (newest first). */
+  getAuditRecords(): McpAuditRecord[] {
+    this.hydrateAuditLog();
+    return [...this.auditRecords].reverse();
+  }
+
+  /** Read the persisted audit-log configuration as the renderer sees it. */
+  getAuditConfig(): { enabled: boolean; maxRecords: number } {
+    const config = this.getConfig();
+    return {
+      enabled: config.auditEnabled !== false,
+      maxRecords: this.normalizeAuditMaxRecords(config.auditMaxRecords),
+    };
+  }
+
+  /** Empty the buffer and persist the change synchronously. */
+  clearAuditLog(): void {
+    this.hydrateAuditLog();
+    this.auditRecords = [];
+    this.flushAuditLogNow();
+  }
+
+  /** Toggle capture without dropping existing records. */
+  setAuditEnabled(enabled: boolean): { enabled: boolean; maxRecords: number } {
+    this.hydrateAuditLog();
+    this.persistConfig({ auditEnabled: enabled });
+    return this.getAuditConfig();
+  }
+
+  /** Update the ring-buffer cap; trims and flushes immediately if it shrunk. */
+  setAuditMaxRecords(max: number): { enabled: boolean; maxRecords: number } {
+    this.hydrateAuditLog();
+    const normalized = this.normalizeAuditMaxRecords(max);
+    if (this.auditRecords.length > normalized) {
+      this.auditRecords.splice(0, this.auditRecords.length - normalized);
+    }
+    this.persistConfig({ auditMaxRecords: normalized });
+    this.flushAuditLogNow();
+    return this.getAuditConfig();
   }
 
   async start(registry: WindowRegistry): Promise<void> {
@@ -272,6 +499,7 @@ export class McpServerService {
         await this.generateApiKey();
       }
 
+      this.hydrateAuditLog();
       this.setupIpcListeners();
 
       const server = http.createServer((req, res) => {
@@ -308,6 +536,8 @@ export class McpServerService {
   }
 
   async stop(): Promise<void> {
+    this.flushAuditLogNow();
+
     for (const session of this.sessions.values()) {
       clearTimeout(session.idleTimer);
       try {
@@ -519,7 +749,7 @@ export class McpServerService {
     });
   }
 
-  private createSessionServer(): Server {
+  private createSessionServer(sessionId: string): Server {
     const server = new Server(
       { name: "Daintree", version: "1.0.0" },
       { capabilities: { tools: {} } }
@@ -542,45 +772,66 @@ export class McpServerService {
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const actionId = request.params.name;
       const { args, confirmed } = this.parseToolArguments(request.params.arguments);
+      const startedAt = Date.now();
+      const tier = this.sessions.get(sessionId)?.tier;
+      let outcome:
+        | { kind: "result"; value: ActionDispatchResult }
+        | { kind: "throw"; error: unknown };
 
-      let result: ActionDispatchResult;
       try {
-        result = await this.dispatchAction(actionId, args, confirmed);
-      } catch (err) {
+        try {
+          const value = await this.dispatchAction(actionId, args, confirmed);
+          outcome = { kind: "result", value };
+        } catch (err) {
+          outcome = { kind: "throw", error: err };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: ${formatErrorMessage(err, "Action dispatch failed")}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (outcome.value.ok) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  outcome.value.result !== undefined && outcome.value.result !== null
+                    ? safeSerializeToolResult(outcome.value.result)
+                    : "OK",
+              },
+            ],
+          };
+        }
+
         return {
           content: [
             {
               type: "text" as const,
-              text: `Error: ${formatErrorMessage(err, "Action dispatch failed")}`,
+              text: `Error [${outcome.value.error.code}]: ${outcome.value.error.message}`,
             },
           ],
           isError: true,
         };
+      } finally {
+        try {
+          this.appendAuditRecord({
+            toolId: actionId,
+            sessionId,
+            tier,
+            args,
+            durationMs: Date.now() - startedAt,
+            outcome: outcome!,
+          });
+        } catch (err) {
+          console.error("[MCP] Failed to append audit record:", err);
+        }
       }
-
-      if (result.ok) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text:
-                result.result !== undefined && result.result !== null
-                  ? safeSerializeToolResult(result.result)
-                  : "OK",
-            },
-          ],
-        };
-      }
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Error [${result.error.code}]: ${result.error.message}`,
-          },
-        ],
-        isError: true,
-      };
     });
 
     return server;
@@ -761,8 +1012,8 @@ export class McpServerService {
         allowedHosts,
         allowedOrigins,
       });
-      const server = this.createSessionServer();
       const sessionId = transport.sessionId;
+      const server = this.createSessionServer(sessionId);
 
       const idleTimer = this.createIdleTimer(sessionId);
       this.sessions.set(sessionId, { transport, idleTimer });

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -387,7 +387,10 @@ export class McpServerService {
     durationMs: number;
     outcome: { kind: "result"; value: ActionDispatchResult } | { kind: "throw"; error: unknown };
   }): void {
-    if (!this.getConfig().auditEnabled) return;
+    // `=== false` so legacy persisted configs (undefined) default to enabled,
+    // matching `getAuditConfig()`. A bare `!auditEnabled` would silently drop
+    // every record for any user whose store predates this feature.
+    if (this.getConfig().auditEnabled === false) return;
     this.hydrateAuditLog();
 
     const classification = this.classifyDispatchResult(input.outcome);

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -66,6 +66,9 @@ const storeState = vi.hoisted(() => ({
     port: 0,
     apiKey: "",
     fullToolSurface: false,
+    auditEnabled: true,
+    auditMaxRecords: 500,
+    auditLog: [] as Array<Record<string, unknown>>,
   },
 }));
 
@@ -291,6 +294,9 @@ describe("McpServerService", () => {
       port: 0,
       apiKey: "",
       fullToolSurface: false,
+      auditEnabled: true,
+      auditMaxRecords: 500,
+      auditLog: [],
     };
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
@@ -1003,6 +1009,272 @@ describe("McpServerService", () => {
     expect(dispatchMock).toHaveBeenCalledWith(
       expect.objectContaining({ actionId: "panel.gridLayout.setStrategy" })
     );
+  });
+
+  describe("audit log", () => {
+    type AuditRecord = {
+      id: string;
+      timestamp: number;
+      toolId: string;
+      sessionId: string;
+      tier: string;
+      argsSummary: string;
+      result: "success" | "error" | "confirmation-pending";
+      errorCode?: string;
+      durationMs: number;
+    };
+
+    function getAuditRecords(svc: McpServerService): AuditRecord[] {
+      return (svc as unknown as { getAuditRecords: () => AuditRecord[] }).getAuditRecords();
+    }
+
+    it("records a successful dispatch with redacted args and a non-empty session id", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({
+          ok: true,
+          result: { ok: true },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const longArg = "x".repeat(120);
+      await client.callTool({
+        name: "actions.list",
+        arguments: { query: longArg, limit: 10, force: false },
+      });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      const [record] = records;
+      expect(record.toolId).toBe("actions.list");
+      expect(record.result).toBe("success");
+      expect(record.tier).toBe("unknown");
+      expect(record.sessionId.length).toBeGreaterThan(0);
+      expect(record.argsSummary).toContain("<string: 120 chars>");
+      expect(record.argsSummary).toContain('"limit":10');
+      expect(record.argsSummary).toContain('"force":false');
+      expect(record.argsSummary).not.toContain("xxxxxxxxxx");
+      expect(record.durationMs).toBeGreaterThanOrEqual(0);
+      expect(record.errorCode).toBeUndefined();
+    });
+
+    it("records error and confirmation-pending dispatches separately", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "worktree.delete" && !payload.confirmed) {
+          return {
+            ok: false,
+            error: { code: "CONFIRMATION_REQUIRED", message: "Need confirm" },
+          };
+        }
+        return {
+          ok: false,
+          error: { code: "BOOM", message: "exploded" },
+        };
+      });
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "worktree.delete", arguments: { worktreeId: "wt" } });
+      await client.callTool({ name: "actions.list", arguments: {} });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(2);
+      const byTool = Object.fromEntries(records.map((r) => [r.toolId, r]));
+      expect(byTool["worktree.delete"].result).toBe("confirmation-pending");
+      expect(byTool["worktree.delete"].errorCode).toBe("CONFIRMATION_REQUIRED");
+      expect(byTool["actions.list"].result).toBe("error");
+      expect(byTool["actions.list"].errorCode).toBe("BOOM");
+    });
+
+    it("records dispatch throws even when no result envelope is returned", async () => {
+      const { window, webContents } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      // After start, simulate the renderer bridge dropping mid-call so dispatch
+      // throws synchronously inside the handler.
+      webContents.isDestroyed.mockReturnValue(true);
+
+      const result = (await client.callTool({
+        name: "actions.list",
+        arguments: {},
+      })) as TextToolResult;
+      expect(result.isError).toBe(true);
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].toolId).toBe("actions.list");
+      expect(records[0].result).toBe("error");
+      expect(records[0].errorCode).toBe("DISPATCH_THREW");
+    });
+
+    it("trims the ring buffer to the configured cap on append", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+
+      storeState.mcpServer.auditMaxRecords = 50; // clamped floor
+      await service.start(window);
+      (
+        service as unknown as {
+          setAuditMaxRecords: (n: number) => unknown;
+        }
+      ).setAuditMaxRecords(50);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      for (let i = 0; i < 55; i++) {
+        await client.callTool({ name: "actions.list", arguments: { i } });
+      }
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(50);
+      // newest first → first record should reference highest i (54)
+      expect(records[0].argsSummary).toContain('"i":54');
+    });
+
+    it("clearAuditLog empties the buffer and persists immediately", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+      await client.callTool({ name: "actions.list", arguments: {} });
+
+      expect(getAuditRecords(service)).toHaveLength(1);
+
+      storeMocks.set.mockClear();
+      (service as unknown as { clearAuditLog: () => void }).clearAuditLog();
+
+      expect(getAuditRecords(service)).toHaveLength(0);
+      // clearAuditLog must persist synchronously, not wait for the debounce.
+      expect(storeMocks.set).toHaveBeenCalled();
+      const lastCall = storeMocks.set.mock.calls[storeMocks.set.mock.calls.length - 1];
+      expect(lastCall[0]).toBe("mcpServer");
+      expect((lastCall[1] as { auditLog: unknown[] }).auditLog).toEqual([]);
+    });
+
+    it("does not record dispatches when capture is disabled", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+      storeState.mcpServer.auditEnabled = false;
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "actions.list", arguments: {} });
+
+      expect(getAuditRecords(service)).toHaveLength(0);
+    });
+
+    it("hydrates the buffer from persisted audit records on start", async () => {
+      const seeded: AuditRecord[] = [
+        {
+          id: "seed-1",
+          timestamp: 1,
+          toolId: "actions.list",
+          sessionId: "old",
+          tier: "unknown",
+          argsSummary: "{}",
+          result: "success",
+          durationMs: 5,
+        },
+      ];
+      storeState.mcpServer.auditLog = seeded;
+
+      const { window } = createMockWindow();
+      await service.start(window);
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].id).toBe("seed-1");
+    });
+
+    it("preserves audit log when other config writes happen", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "actions.list", arguments: {} });
+      expect(getAuditRecords(service)).toHaveLength(1);
+
+      // Mutate auth — historically this clobbered auditLog because the config
+      // setter wrote back the spread of getConfig() without the in-memory log.
+      await service.setApiKey("daintree_abcd");
+
+      expect(storeState.mcpServer.auditLog).toHaveLength(1);
+      expect(getAuditRecords(service)).toHaveLength(1);
+    });
   });
 
   it("returns safe text output for circular tool results", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1081,7 +1081,7 @@ describe("McpServerService", () => {
         }
         return {
           ok: false,
-          error: { code: "BOOM", message: "exploded" },
+          error: { code: "EXECUTION_ERROR", message: "exploded" },
         };
       });
       const { window } = createMockWindow({
@@ -1114,7 +1114,7 @@ describe("McpServerService", () => {
       expect(byTool["worktree.delete"].result).toBe("confirmation-pending");
       expect(byTool["worktree.delete"].errorCode).toBe("CONFIRMATION_REQUIRED");
       expect(byTool["actions.list"].result).toBe("error");
-      expect(byTool["actions.list"].errorCode).toBe("BOOM");
+      expect(byTool["actions.list"].errorCode).toBe("EXECUTION_ERROR");
     });
 
     it("records dispatch throws even when no result envelope is returned", async () => {
@@ -1317,10 +1317,12 @@ describe("McpServerService", () => {
         const calls = storeMocks.set.mock.calls.filter((call) => call[0] === "mcpServer");
         expect(calls.length).toBeGreaterThanOrEqual(1);
         const last = calls[calls.length - 1];
-        expect((last[1] as { auditLog: Array<{ toolId: string }> }).auditLog).toHaveLength(1);
-        expect((last[1] as { auditLog: Array<{ toolId: string }> }).auditLog[0].toolId).toBe(
-          "actions.list"
-        );
+        expect(
+          (last[1] as unknown as { auditLog: Array<{ toolId: string }> }).auditLog
+        ).toHaveLength(1);
+        expect(
+          (last[1] as unknown as { auditLog: Array<{ toolId: string }> }).auditLog[0].toolId
+        ).toBe("actions.list");
       } finally {
         vi.useRealTimers();
       }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1251,6 +1251,116 @@ describe("McpServerService", () => {
       expect(records[0].id).toBe("seed-1");
     });
 
+    it("treats a missing auditEnabled key (legacy persisted config) as enabled", async () => {
+      // Simulate a user whose config.json predates this feature: auditEnabled
+      // and auditMaxRecords are absent. A naive `!auditEnabled` guard would
+      // silently drop every record while the UI shows "Capture on".
+      delete (storeState.mcpServer as Partial<typeof storeState.mcpServer>).auditEnabled;
+      delete (storeState.mcpServer as Partial<typeof storeState.mcpServer>).auditMaxRecords;
+
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "actions.list", arguments: {} });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].toolId).toBe("actions.list");
+
+      const config = (
+        service as unknown as { getAuditConfig: () => { enabled: boolean; maxRecords: number } }
+      ).getAuditConfig();
+      expect(config.enabled).toBe(true);
+      expect(config.maxRecords).toBe(500);
+    });
+
+    it("debounced flush persists without an explicit clear or stop", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      vi.useFakeTimers({
+        toFake: ["setTimeout", "clearTimeout"],
+        shouldAdvanceTime: true,
+        advanceTimeDelta: 50,
+      });
+      try {
+        await client.callTool({ name: "actions.list", arguments: { x: 1 } });
+        storeMocks.set.mockClear();
+
+        // Before the debounce window expires, no flush.
+        vi.advanceTimersByTime(1000);
+        expect(storeMocks.set).not.toHaveBeenCalled();
+
+        // After the 2s window the debounced flush fires once.
+        vi.advanceTimersByTime(1500);
+        const calls = storeMocks.set.mock.calls.filter((call) => call[0] === "mcpServer");
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+        const last = calls[calls.length - 1];
+        expect((last[1] as { auditLog: Array<{ toolId: string }> }).auditLog).toHaveLength(1);
+        expect((last[1] as { auditLog: Array<{ toolId: string }> }).auditLog[0].toolId).toBe(
+          "actions.list"
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clearAuditLog cancels any pending debounce flush", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+          }),
+        ],
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      vi.useFakeTimers({
+        toFake: ["setTimeout", "clearTimeout"],
+        shouldAdvanceTime: true,
+        advanceTimeDelta: 50,
+      });
+      try {
+        await client.callTool({ name: "actions.list", arguments: {} });
+        // Pending debounce timer is now set with the record in the buffer.
+        (service as unknown as { clearAuditLog: () => void }).clearAuditLog();
+        storeMocks.set.mockClear();
+
+        // Advance well past the original debounce window. The cancelled
+        // timer must not fire and re-persist the cleared record.
+        vi.advanceTimersByTime(5000);
+        expect(storeMocks.set).not.toHaveBeenCalled();
+        expect(getAuditRecords(service)).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("preserves audit log when other config writes happen", async () => {
       const { window } = createMockWindow({
         getManifest: () => [

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -10,6 +10,8 @@ import type {
 } from "../shared/types/index.js";
 import type { IssueAssociation } from "../shared/types/ipc/worktree.js";
 import type { ErrorRecord } from "../shared/types/ipc/errors.js";
+import type { McpAuditRecord } from "../shared/types/ipc/mcpServer.js";
+import { MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/mcpServer.js";
 import type { BuiltInAgentId } from "../shared/config/agentIds.js";
 import type { AgentId } from "../shared/types/agent.js";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_APP_AGENT_CONFIG } from "../shared/types/index.js";
@@ -189,6 +191,9 @@ export interface StoreSchema {
     port: number | null;
     apiKey: string;
     fullToolSurface: boolean;
+    auditEnabled: boolean;
+    auditMaxRecords: number;
+    auditLog?: McpAuditRecord[];
   };
   pendingErrors: ErrorRecord[];
   gpu: {
@@ -327,6 +332,8 @@ const storeOptions = {
       port: 45454,
       apiKey: "",
       fullToolSurface: false,
+      auditEnabled: true,
+      auditMaxRecords: MCP_AUDIT_DEFAULT_MAX_RECORDS,
     },
     pendingErrors: [],
     gpu: {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -305,6 +305,14 @@ export { UserAgentConfigSchema, UserAgentRegistrySchema } from "./userAgentRegis
 // Per-service connectivity helpers
 export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";
 
+// MCP server audit log
+export type { McpAuditRecord, McpAuditResult } from "./ipc/mcpServer.js";
+export {
+  MCP_AUDIT_MIN_RECORDS,
+  MCP_AUDIT_MAX_RECORDS,
+  MCP_AUDIT_DEFAULT_MAX_RECORDS,
+} from "./ipc/mcpServer.js";
+
 // Event types - event context for correlation
 export type { EventContext } from "./events.js";
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1269,6 +1269,16 @@ export interface ElectronAPI {
     generateApiKey(): Promise<string>;
     /** Get the JSON config snippet to paste into an MCP client config */
     getConfigSnippet(): Promise<string>;
+    /** Read the audit-log ring buffer (newest first). */
+    getAuditRecords(): Promise<import("./mcpServer.js").McpAuditRecord[]>;
+    /** Get the persisted audit-log configuration. */
+    getAuditConfig(): Promise<{ enabled: boolean; maxRecords: number }>;
+    /** Clear all audit records from the ring buffer and persistence. */
+    clearAuditLog(): Promise<void>;
+    /** Toggle audit-log capture without losing existing records. */
+    setAuditEnabled(enabled: boolean): Promise<{ enabled: boolean; maxRecords: number }>;
+    /** Update the ring-buffer cap (clamped to MCP_AUDIT_MIN/MAX). */
+    setAuditMaxRecords(max: number): Promise<{ enabled: boolean; maxRecords: number }>;
   };
   mcpBridge: {
     /** Listen for manifest requests from main process */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1818,6 +1818,26 @@ export interface IpcInvokeMap {
     args: [];
     result: string;
   };
+  "mcp-server:get-audit-records": {
+    args: [];
+    result: import("./mcpServer.js").McpAuditRecord[];
+  };
+  "mcp-server:get-audit-config": {
+    args: [];
+    result: { enabled: boolean; maxRecords: number };
+  };
+  "mcp-server:clear-audit-log": {
+    args: [];
+    result: void;
+  };
+  "mcp-server:set-audit-enabled": {
+    args: [enabled: boolean];
+    result: { enabled: boolean; maxRecords: number };
+  };
+  "mcp-server:set-audit-max-records": {
+    args: [max: number];
+    result: { enabled: boolean; maxRecords: number };
+  };
 
   // Webview console capture
   "webview:start-console-capture": {

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -1,0 +1,43 @@
+/**
+ * Result classification for an MCP tool dispatch.
+ *
+ * - `success`: dispatch resolved with `{ ok: true }`.
+ * - `error`: dispatch threw, timed out, or resolved with `{ ok: false }` for
+ *   any reason other than a missing confirmation.
+ * - `confirmation-pending`: dispatch resolved with the canonical
+ *   `CONFIRMATION_REQUIRED` error code — surfaced separately so audit
+ *   readers can distinguish "agent forgot `_meta.confirmed`" from a real
+ *   failure.
+ */
+export type McpAuditResult = "success" | "error" | "confirmation-pending";
+
+/**
+ * Persisted audit record for a single MCP tool dispatch. Written once per
+ * `CallToolRequestSchema` invocation regardless of outcome.
+ *
+ * `argsSummary` is a redacted, single-level JSON-encoded view of the call
+ * arguments — long strings are replaced with `<string: N chars>` and nested
+ * objects are collapsed to `<object>`. Raw argument values are never
+ * persisted because tool args may carry terminal output, file content, or
+ * prompt text.
+ *
+ * `tier` carries a placeholder of `"unknown"` until the tier-policy work
+ * (issue #6517) lands. The field exists on the record so downstream readers
+ * (incident reports, support exports) can rely on a stable schema.
+ */
+export interface McpAuditRecord {
+  id: string;
+  timestamp: number;
+  toolId: string;
+  sessionId: string;
+  tier: string;
+  argsSummary: string;
+  result: McpAuditResult;
+  errorCode?: string;
+  durationMs: number;
+}
+
+/** Minimum and maximum values accepted for the configurable ring-buffer cap. */
+export const MCP_AUDIT_MIN_RECORDS = 50;
+export const MCP_AUDIT_MAX_RECORDS = 10000;
+export const MCP_AUDIT_DEFAULT_MAX_RECORDS = 500;

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -1,5 +1,16 @@
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Copy, Check, AlertCircle, Key, Hash, Shield, Eye, EyeOff, RefreshCw } from "lucide-react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import {
+  Copy,
+  Check,
+  AlertCircle,
+  Key,
+  Hash,
+  Shield,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  ScrollText,
+} from "lucide-react";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -9,12 +20,46 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
+import {
+  type McpAuditRecord,
+  type McpAuditResult,
+  MCP_AUDIT_DEFAULT_MAX_RECORDS,
+  MCP_AUDIT_MAX_RECORDS,
+  MCP_AUDIT_MIN_RECORDS,
+} from "@shared/types";
 
 interface McpServerStatus {
   enabled: boolean;
   port: number | null;
   configuredPort: number | null;
   apiKey: string;
+}
+
+type AuditResultFilter = "all" | McpAuditResult;
+
+const RESULT_LABEL: Record<McpAuditResult, string> = {
+  success: "Success",
+  error: "Error",
+  "confirmation-pending": "Awaiting confirmation",
+};
+
+const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
+  success: "bg-status-success",
+  error: "bg-status-danger",
+  "confirmation-pending": "bg-status-warning",
+};
+
+function formatRelativeTimestamp(ts: number): string {
+  const diffMs = Date.now() - ts;
+  if (diffMs < 0) return "just now";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
 }
 
 export function McpServerSettingsTab() {
@@ -32,6 +77,23 @@ export function McpServerSettingsTab() {
   const [copiedKey, setCopiedKey] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [auditEnabled, setAuditEnabled] = useState(true);
+  const [auditMaxRecords, setAuditMaxRecords] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS);
+  const [maxRecordsInput, setMaxRecordsInput] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS.toString());
+  const [auditLoading, setAuditLoading] = useState(true);
+  const [toolFilter, setToolFilter] = useState("");
+  const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
+
+  const refreshAuditRecords = useCallback(async (): Promise<void> => {
+    try {
+      const records = await window.electron.mcpServer.getAuditRecords();
+      setAuditRecords(records);
+    } catch (err) {
+      logError("Failed to load MCP audit log", err);
+    }
+  }, []);
+
   useEffect(() => {
     let settled = false;
     const timer = setTimeout(() => {
@@ -46,12 +108,20 @@ export function McpServerSettingsTab() {
       });
       logError("MCP status load timed out");
     }, 10_000);
-    window.electron.mcpServer
-      .getStatus()
-      .then((s) => {
+
+    Promise.all([
+      window.electron.mcpServer.getStatus(),
+      window.electron.mcpServer.getAuditConfig(),
+      window.electron.mcpServer.getAuditRecords(),
+    ])
+      .then(([s, auditCfg, records]) => {
         if (settled) return;
         setStatus(s);
         setPortInput(s.configuredPort?.toString() ?? "");
+        setAuditEnabled(auditCfg.enabled);
+        setAuditMaxRecords(auditCfg.maxRecords);
+        setMaxRecordsInput(auditCfg.maxRecords.toString());
+        setAuditRecords(records);
         setError(null);
       })
       .catch((err) => {
@@ -69,6 +139,7 @@ export function McpServerSettingsTab() {
         settled = true;
         clearTimeout(timer);
         setLoading(false);
+        setAuditLoading(false);
       });
 
     return () => {
@@ -183,6 +254,108 @@ export function McpServerSettingsTab() {
       // clipboard write failed — silently ignore
     }
   }, [status.apiKey]);
+
+  const handleAuditEnabledToggle = useCallback(async () => {
+    try {
+      const next = !auditEnabled;
+      const cfg = await window.electron.mcpServer.setAuditEnabled(next);
+      setAuditEnabled(cfg.enabled);
+      setAuditMaxRecords(cfg.maxRecords);
+    } catch (err) {
+      logError("Failed to toggle MCP audit log", err);
+      notify({
+        type: "error",
+        title: "Audit log update failed",
+        message: "Couldn't update audit logging. Try again.",
+        priority: "low",
+      });
+    }
+  }, [auditEnabled]);
+
+  const handleMaxRecordsSave = useCallback(async () => {
+    const trimmed = maxRecordsInput.trim();
+    const parsed = Number.parseInt(trimmed, 10);
+    if (
+      !Number.isFinite(parsed) ||
+      parsed < MCP_AUDIT_MIN_RECORDS ||
+      parsed > MCP_AUDIT_MAX_RECORDS
+    ) {
+      notify({
+        type: "error",
+        title: "Audit cap invalid",
+        message: `Enter a number between ${MCP_AUDIT_MIN_RECORDS} and ${MCP_AUDIT_MAX_RECORDS}.`,
+        priority: "low",
+      });
+      return;
+    }
+    try {
+      const cfg = await window.electron.mcpServer.setAuditMaxRecords(parsed);
+      setAuditEnabled(cfg.enabled);
+      setAuditMaxRecords(cfg.maxRecords);
+      setMaxRecordsInput(cfg.maxRecords.toString());
+      await refreshAuditRecords();
+    } catch (err) {
+      logError("Failed to update audit cap", err);
+      notify({
+        type: "error",
+        title: "Audit cap update failed",
+        message: "Couldn't save the audit cap. Try again.",
+        priority: "low",
+      });
+    }
+  }, [maxRecordsInput, refreshAuditRecords]);
+
+  const handleClearAuditLog = useCallback(async () => {
+    try {
+      await window.electron.mcpServer.clearAuditLog();
+      setAuditRecords([]);
+      notify({
+        type: "info",
+        title: "Audit log cleared",
+        message: "All recorded MCP tool dispatches were removed.",
+        priority: "low",
+      });
+    } catch (err) {
+      logError("Failed to clear MCP audit log", err);
+      notify({
+        type: "error",
+        title: "Couldn't clear audit log",
+        message: "The audit log wasn't cleared. Try again.",
+        priority: "low",
+      });
+    }
+  }, []);
+
+  const handleCopyAuditAsJson = useCallback(async () => {
+    try {
+      const records = await window.electron.mcpServer.getAuditRecords();
+      await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
+      setAuditRecords(records);
+      notify({
+        type: "info",
+        title: "Audit log copied",
+        message: `${records.length} record${records.length === 1 ? "" : "s"} copied as JSON.`,
+        priority: "low",
+      });
+    } catch (err) {
+      logError("Failed to copy MCP audit log", err);
+      notify({
+        type: "error",
+        title: "Couldn't copy audit log",
+        message: "Clipboard access failed. Try again.",
+        priority: "low",
+      });
+    }
+  }, []);
+
+  const filteredAuditRecords = useMemo(() => {
+    const needle = toolFilter.trim().toLowerCase();
+    return auditRecords.filter((record) => {
+      if (resultFilter !== "all" && record.result !== resultFilter) return false;
+      if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
+      return true;
+    });
+  }, [auditRecords, resultFilter, toolFilter]);
 
   const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
 
@@ -385,6 +558,178 @@ export function McpServerSettingsTab() {
                 </button>
               </div>
             )}
+          </SettingsSection>
+
+          {/* Audit Log */}
+          <SettingsSection
+            icon={ScrollText}
+            title="Audit log"
+            description="Every tool dispatched over MCP is recorded with a redacted argument summary. Use this to investigate what an agent did during a session — argument values are never stored verbatim."
+          >
+            <div className="contents">
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleAuditEnabledToggle}
+                  className={cn(
+                    "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+                    auditEnabled
+                      ? "border-status-success/30 text-status-success hover:bg-status-success/10"
+                      : "border-daintree-border text-daintree-text/60 hover:text-daintree-text"
+                  )}
+                  aria-pressed={auditEnabled}
+                >
+                  {auditEnabled ? "Capture on" : "Capture off"}
+                </button>
+                <span className="text-xs text-daintree-text/50">
+                  {auditEnabled
+                    ? "Recording every dispatch."
+                    : "New dispatches will not be recorded."}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <label htmlFor="mcp-audit-max-records" className="text-xs text-daintree-text/60">
+                  Max records
+                </label>
+                <input
+                  id="mcp-audit-max-records"
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={maxRecordsInput}
+                  onChange={(e) => setMaxRecordsInput(e.target.value.replace(/\D/g, ""))}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void handleMaxRecordsSave();
+                  }}
+                  placeholder={MCP_AUDIT_DEFAULT_MAX_RECORDS.toString()}
+                  className="w-24 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleMaxRecordsSave()}
+                  disabled={maxRecordsInput === auditMaxRecords.toString()}
+                  className={cn(
+                    "px-3 py-1 text-xs font-medium rounded-[var(--radius-md)] transition-colors",
+                    "border border-daintree-border",
+                    maxRecordsInput === auditMaxRecords.toString()
+                      ? "text-daintree-text/30 cursor-not-allowed"
+                      : "text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+                  )}
+                >
+                  Apply
+                </button>
+                <span className="text-xs text-daintree-text/40">
+                  Range {MCP_AUDIT_MIN_RECORDS}–{MCP_AUDIT_MAX_RECORDS}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  type="text"
+                  value={toolFilter}
+                  onChange={(e) => setToolFilter(e.target.value)}
+                  placeholder="Filter by tool ID"
+                  className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                />
+                <select
+                  value={resultFilter}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    if (
+                      value === "all" ||
+                      value === "success" ||
+                      value === "error" ||
+                      value === "confirmation-pending"
+                    ) {
+                      setResultFilter(value);
+                    }
+                  }}
+                  className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                >
+                  <option value="all">All results</option>
+                  <option value="success">Success</option>
+                  <option value="error">Error</option>
+                  <option value="confirmation-pending">Awaiting confirmation</option>
+                </select>
+              </div>
+
+              <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
+                {auditLoading ? (
+                  <p className="p-3 text-xs text-daintree-text/50">Loading…</p>
+                ) : filteredAuditRecords.length === 0 ? (
+                  <p className="p-3 text-xs text-daintree-text/50">
+                    {auditRecords.length === 0
+                      ? "No tool dispatches recorded yet."
+                      : "No records match the current filters."}
+                  </p>
+                ) : (
+                  <ul className="divide-y divide-daintree-border">
+                    {filteredAuditRecords.map((record) => (
+                      <li
+                        key={record.id}
+                        className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs"
+                      >
+                        <span
+                          className={cn(
+                            "mt-1 h-2 w-2 rounded-full shrink-0",
+                            RESULT_DOT_CLASS[record.result]
+                          )}
+                          aria-label={RESULT_LABEL[record.result]}
+                          title={RESULT_LABEL[record.result]}
+                        />
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-mono text-daintree-text/90 truncate">
+                              {record.toolId}
+                            </span>
+                            {record.errorCode && (
+                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                                {record.errorCode}
+                              </span>
+                            )}
+                          </div>
+                          <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
+                            {record.argsSummary || "{}"}
+                          </div>
+                        </div>
+                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                          <div>{formatRelativeTimestamp(record.timestamp)}</div>
+                          <div>{record.durationMs}ms</div>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void handleCopyAuditAsJson()}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+                >
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy as JSON
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleClearAuditLog()}
+                  disabled={auditRecords.length === 0}
+                  className={cn(
+                    "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+                    auditRecords.length === 0
+                      ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+                      : "border-daintree-border text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20"
+                  )}
+                >
+                  Clear log
+                </button>
+                <span className="ml-auto text-xs text-daintree-text/40">
+                  {auditRecords.length} of {auditMaxRecords}
+                </span>
+              </div>
+            </div>
           </SettingsSection>
         </>
       )}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -326,11 +326,9 @@ export function McpServerSettingsTab() {
     }
   }, []);
 
-  const handleCopyAuditAsJson = useCallback(async () => {
+  const handleCopyAuditAsJson = useCallback(async (records: McpAuditRecord[]) => {
     try {
-      const records = await window.electron.mcpServer.getAuditRecords();
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
-      setAuditRecords(records);
       notify({
         type: "info",
         title: "Audit log copied",
@@ -706,11 +704,27 @@ export function McpServerSettingsTab() {
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => void handleCopyAuditAsJson()}
+                  onClick={() => void refreshAuditRecords()}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+                  aria-label="Refresh audit log"
+                >
+                  <RefreshCw className="w-3.5 h-3.5" />
+                  Refresh
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void handleCopyAuditAsJson(filteredAuditRecords)}
+                  disabled={filteredAuditRecords.length === 0}
+                  className={cn(
+                    "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+                    filteredAuditRecords.length === 0
+                      ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+                      : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+                  )}
                 >
                   <Copy className="w-3.5 h-3.5" />
-                  Copy as JSON
+                  Copy {filteredAuditRecords.length === auditRecords.length ? "all" : "filtered"} as
+                  JSON
                 </button>
                 <button
                   type="button"

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -37,6 +37,11 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
       configuredPort: 9020,
       apiKey: "",
     }),
+    getAuditRecords: vi.fn().mockResolvedValue([]),
+    getAuditConfig: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
+    clearAuditLog: vi.fn().mockResolvedValue(undefined),
+    setAuditEnabled: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
+    setAuditMaxRecords: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Adds an audit log that records every MCP tool dispatch: `timestamp`, `toolId`, `sessionId`, `tier`, `argsSummary` (redacted), `result`, `errorCode`, and `durationMs`.
- Stores entries in a capped in-memory ring buffer (default 500, range 50–10,000), with a 2-second debounced flush to `electron-store` and immediate flush on clear or stop.
- Hybrid type-and-truncation redaction ensures terminal and file content never reach disk.

Resolves #6521

## Changes

- `McpServerService.ts` — ring buffer, redaction, flush logic, and `sessionId` threading into `createSessionServer`
- `electron/ipc/handlers/mcpServer.ts` — IPC handlers for `getAuditLog`, `clearAuditLog`, `updateAuditSettings`
- `electron/ipc/channels.ts` + `shared/types/ipc/` — new channel constants and type definitions
- `electron/store.ts` — persistent audit log store schema
- `src/components/Settings/McpServerSettingsTab.tsx` — settings UI: scrollable/filterable audit list, capture toggle, configurable cap, refresh, copy-as-JSON (filter-aware), clear

## Testing

- 8 new unit tests covering ring buffer capping, redaction, debounced flush, and immediate flush on clear/stop
- 5 IPC handler validation tests
- Typecheck, lint (improved 8 warnings vs baseline), and format all pass
- `tier` defaults to `"unknown"` pending #6517