### PR TITLE
feat(mcp): expose Daintree MCP to project Claude Code agents via --mcp-config

### DIFF
--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -5,6 +5,7 @@
 import { CHANNELS } from "../../channels.js";
 import { broadcastToRenderer } from "../../utils.js";
 import { events, type DaintreeEventMap } from "../../../services/events.js";
+import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import type {
   SpawnResult,
   BroadcastWriteResultPayload,
@@ -28,6 +29,11 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   handlers.push(() => ptyClient.off("data", handlePtyData));
 
   const handlePtyExit = (id: string, exitCode: number) => {
+    // Best-effort: revoke any per-pane MCP token + delete the managed config
+    // file. Idempotent — no-ops if no pane config was minted for this terminal.
+    mcpPaneConfigService.revokePaneConfig(id).catch((err) => {
+      console.error("[MCP] Failed to revoke pane config on exit:", err);
+    });
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "terminal:exit",
       payload: [id, exitCode],

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -50,6 +50,14 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
 
   // Spawn result events (success or failure)
   const handleSpawnResult = (id: string, result: SpawnResult) => {
+    if (!result.success) {
+      // Async pty-host spawn rejection (PENDING_SPAWNS_CAPPED, bad shell path,
+      // etc.) doesn't throw from ptyClient.spawn(). Revoke any minted pane
+      // config so the token doesn't outlive the never-running PTY.
+      mcpPaneConfigService.revokePaneConfig(id).catch((err) => {
+        console.error("[MCP] Failed to revoke pane config on spawn failure:", err);
+      });
+    }
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "terminal:spawn-result",
       payload: [id, result],

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -13,6 +13,8 @@ import {
   typedHandleValidated,
 } from "../../utils.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import { mcpServerService } from "../../../services/McpServerService.js";
+import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import type { HandlerDependencies } from "../../types.js";
 import { TerminalSpawnOptionsSchema } from "../../../schemas/ipc.js";
 
@@ -203,7 +205,39 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     if (hasMultilineCommand) {
       console.error("Multi-line commands not allowed for security, ignoring");
     }
-    const safeCommand = hasMultilineCommand ? "" : trimmedCommand;
+    let safeCommand = hasMultilineCommand ? "" : trimmedCommand;
+    let spawnEnv: Record<string, string> | undefined = validatedOptions.env;
+
+    // Daintree MCP injection for Claude Code agent launches.
+    // Mints a per-pane bearer token, writes a managed --mcp-config JSON under
+    // userData, and injects the flag into the command + the token into env.
+    // Token is revoked and the file deleted on PTY exit (see registerTerminalEventHandlers).
+    if (
+      launchAgentId === "claude" &&
+      safeCommand.length > 0 &&
+      projectId &&
+      mcpServerService.isRunning
+    ) {
+      try {
+        const projSettings = await projectStore.getProjectSettings(projectId);
+        if (projSettings.exposeDaintreeMcpToAgents) {
+          const port = mcpServerService.currentPort;
+          if (port) {
+            const { configPath, token } = await mcpPaneConfigService.preparePaneConfig({
+              paneId: id,
+              port,
+            });
+            safeCommand = `${safeCommand} --mcp-config ${shellQuote(configPath)}`;
+            spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_MCP_TOKEN: token };
+          }
+        }
+      } catch (mcpErr) {
+        console.error(
+          "[TerminalSpawn] Failed to prepare Daintree MCP config; continuing without MCP injection:",
+          mcpErr
+        );
+      }
+    }
 
     // Resolve shell and args: project overrides > spawn options > defaults.
     // For command launches on POSIX, run the command through the shell's
@@ -226,7 +260,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         cols,
         rows,
         command: safeCommand || undefined,
-        env: validatedOptions.env,
+        env: spawnEnv,
         kind,
         launchAgentId,
         title,
@@ -254,6 +288,11 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
       return id;
     } catch (error) {
+      // If we minted an MCP pane config above and the PTY spawn never landed,
+      // revoke it now so we don't leak per-pane tokens or config files.
+      mcpPaneConfigService.revokePaneConfig(id).catch(() => {
+        // best-effort cleanup
+      });
       const errorMessage = formatErrorMessage(error, "Failed to spawn terminal");
       throw new Error(`Failed to spawn terminal: ${errorMessage}`);
     }

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { app } from "electron";
+import { resilientAtomicWriteFile, resilientUnlink } from "../utils/fs.js";
+
+const PANE_CONFIG_DIR_NAME = "mcp-pane-configs";
+const MCP_SERVER_KEY = "daintree";
+
+interface PaneRecord {
+  configPath: string;
+  token: string;
+}
+
+export interface PreparePaneConfigParams {
+  paneId: string;
+  port: number;
+}
+
+export interface PreparedPaneConfig {
+  configPath: string;
+  token: string;
+}
+
+export class McpPaneConfigService {
+  private records = new Map<string, PaneRecord>();
+  private tokens = new Map<string, string>();
+
+  private get baseDir(): string {
+    return path.join(app.getPath("userData"), PANE_CONFIG_DIR_NAME);
+  }
+
+  private configPathFor(paneId: string): string {
+    return path.join(this.baseDir, `${paneId}.json`);
+  }
+
+  async preparePaneConfig({ paneId, port }: PreparePaneConfigParams): Promise<PreparedPaneConfig> {
+    if (!paneId) {
+      throw new Error("paneId is required");
+    }
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+      throw new Error(`Invalid MCP port: ${port}`);
+    }
+
+    await this.revokePaneConfig(paneId);
+
+    await fs.mkdir(this.baseDir, { recursive: true });
+    if (process.platform !== "win32") {
+      await fs.chmod(this.baseDir, 0o700).catch((err) => {
+        console.error("[MCP] Failed to chmod pane config directory:", err);
+      });
+    }
+
+    const token = randomUUID();
+    const configPath = this.configPathFor(paneId);
+
+    // Bake the token literal into the file rather than using ${VAR} substitution.
+    // Claude Code's env substitution in `headers` has an active bug; literal value is reliable.
+    const payload = {
+      mcpServers: {
+        [MCP_SERVER_KEY]: {
+          type: "sse",
+          url: `http://127.0.0.1:${port}/sse`,
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      },
+    };
+
+    await resilientAtomicWriteFile(configPath, JSON.stringify(payload, null, 2) + "\n", "utf-8", {
+      mode: 0o600,
+    });
+
+    this.records.set(paneId, { configPath, token });
+    this.tokens.set(token, paneId);
+
+    return { configPath, token };
+  }
+
+  async revokePaneConfig(paneId: string): Promise<void> {
+    const record = this.records.get(paneId);
+    if (!record) {
+      // Defensive: try to remove a stale file even if no record exists.
+      try {
+        await resilientUnlink(this.configPathFor(paneId));
+      } catch {
+        // best-effort cleanup
+      }
+      return;
+    }
+
+    this.records.delete(paneId);
+    this.tokens.delete(record.token);
+
+    try {
+      await resilientUnlink(record.configPath);
+    } catch (err) {
+      const code =
+        err != null && typeof err === "object" && "code" in err
+          ? (err as NodeJS.ErrnoException).code
+          : undefined;
+      if (code !== "ENOENT") {
+        console.error("[MCP] Failed to delete pane config:", err);
+      }
+    }
+  }
+
+  async revokeAll(): Promise<void> {
+    const ids = Array.from(this.records.keys());
+    for (const id of ids) {
+      await this.revokePaneConfig(id);
+    }
+  }
+
+  isValidPaneToken(token: string): boolean {
+    if (!token) return false;
+    return this.tokens.has(token);
+  }
+}
+
+export const mcpPaneConfigService = new McpPaneConfigService();

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -31,7 +31,16 @@ export class McpPaneConfigService {
   }
 
   private configPathFor(paneId: string): string {
-    return path.join(this.baseDir, `${paneId}.json`);
+    const baseDir = this.baseDir;
+    const candidate = path.join(baseDir, `${paneId}.json`);
+    // Defense in depth: paneIds are normally crypto.randomUUID(), but the
+    // callers' schemas allow arbitrary strings. Require the resulting file to
+    // be a direct child of the base dir — rejects `../escape`, `subdir/leak`,
+    // and similar.
+    if (path.dirname(candidate) !== baseDir) {
+      throw new Error(`Invalid paneId: ${paneId}`);
+    }
+    return candidate;
   }
 
   async preparePaneConfig({ paneId, port }: PreparePaneConfigParams): Promise<PreparedPaneConfig> {
@@ -41,6 +50,8 @@ export class McpPaneConfigService {
     if (!Number.isInteger(port) || port <= 0 || port > 65535) {
       throw new Error(`Invalid MCP port: ${port}`);
     }
+    // Validate paneId early — configPathFor throws on traversal attempts.
+    const configPath = this.configPathFor(paneId);
 
     await this.revokePaneConfig(paneId);
 
@@ -52,7 +63,6 @@ export class McpPaneConfigService {
     }
 
     const token = randomUUID();
-    const configPath = this.configPathFor(paneId);
 
     // Bake the token literal into the file rather than using ${VAR} substitution.
     // Claude Code's env substitution in `headers` has an active bug; literal value is reliable.

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -15,6 +15,7 @@ import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/typ
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { mcpPaneConfigService } from "./McpPaneConfigService.js";
 
 const DISCOVERY_DIR = path.join(os.homedir(), ".daintree");
 const DISCOVERY_FILE = path.join(DISCOVERY_DIR, "mcp.json");
@@ -593,12 +594,25 @@ export class McpServerService {
 
   private isAuthorized(req: http.IncomingMessage): boolean {
     const apiKey = this.getConfig().apiKey;
-    if (!apiKey) return true;
     const auth = req.headers.authorization ?? "";
-    const expected = `Bearer ${apiKey}`;
-    const actualHash = createHash("sha256").update(auth).digest();
-    const expectedHash = createHash("sha256").update(expected).digest();
-    return timingSafeEqual(actualHash, expectedHash);
+
+    if (apiKey) {
+      const expected = `Bearer ${apiKey}`;
+      const actualHash = createHash("sha256").update(auth).digest();
+      const expectedHash = createHash("sha256").update(expected).digest();
+      if (timingSafeEqual(actualHash, expectedHash)) return true;
+    } else if (auth.length === 0) {
+      // No global key configured and no Authorization header sent — legacy permissive path.
+      return true;
+    }
+
+    // Per-pane bearer token (minted at PTY spawn, revoked on exit).
+    if (auth.startsWith("Bearer ")) {
+      const token = auth.slice("Bearer ".length);
+      if (mcpPaneConfigService.isValidPaneToken(token)) return true;
+    }
+
+    return false;
   }
 
   private isValidOrigin(req: http.IncomingMessage): boolean {

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testUserData = vi.hoisted(
+  () => `${process.cwd()}/.vitest-mcp-pane-${Math.random().toString(36).slice(2)}`
+);
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name !== "userData") {
+        throw new Error(`Unexpected getPath: ${name}`);
+      }
+      return testUserData;
+    },
+  },
+}));
+
+import { McpPaneConfigService } from "../McpPaneConfigService.js";
+
+describe("McpPaneConfigService", () => {
+  let service: McpPaneConfigService;
+
+  beforeEach(async () => {
+    await fs.rm(testUserData, { recursive: true, force: true });
+    service = new McpPaneConfigService();
+  });
+
+  afterEach(async () => {
+    await service.revokeAll();
+    await fs.rm(testUserData, { recursive: true, force: true });
+  });
+
+  it("writes a per-pane MCP config file with the literal token in the Authorization header", async () => {
+    const { configPath, token } = await service.preparePaneConfig({
+      paneId: "pane-001",
+      port: 45454,
+    });
+
+    expect(configPath).toBe(path.join(testUserData, "mcp-pane-configs", "pane-001.json"));
+    expect(token).toMatch(/^[0-9a-f-]{36}$/);
+
+    const raw = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+
+    expect(parsed.mcpServers.daintree.type).toBe("sse");
+    expect(parsed.mcpServers.daintree.url).toBe("http://127.0.0.1:45454/sse");
+    expect(parsed.mcpServers.daintree.headers.Authorization).toBe(`Bearer ${token}`);
+    // Token must NOT be ${VAR}-style — Claude's env substitution is buggy.
+    expect(parsed.mcpServers.daintree.headers.Authorization).not.toContain("${");
+  });
+
+  it("creates the pane config directory with mode 0700 on POSIX", async () => {
+    if (process.platform === "win32") return;
+
+    await service.preparePaneConfig({ paneId: "pane-002", port: 45454 });
+    const stat = await fs.stat(path.join(testUserData, "mcp-pane-configs"));
+    expect(stat.mode & 0o777).toBe(0o700);
+  });
+
+  it("creates the config file with mode 0600 on POSIX", async () => {
+    if (process.platform === "win32") return;
+
+    const { configPath } = await service.preparePaneConfig({ paneId: "pane-003", port: 45454 });
+    const stat = await fs.stat(configPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("registers the token as valid and rejects unknown tokens", async () => {
+    const { token } = await service.preparePaneConfig({ paneId: "pane-004", port: 45454 });
+
+    expect(service.isValidPaneToken(token)).toBe(true);
+    expect(service.isValidPaneToken("not-a-real-token")).toBe(false);
+    expect(service.isValidPaneToken("")).toBe(false);
+  });
+
+  it("revokes the token and deletes the config file on revokePaneConfig", async () => {
+    const { configPath, token } = await service.preparePaneConfig({
+      paneId: "pane-005",
+      port: 45454,
+    });
+
+    expect(service.isValidPaneToken(token)).toBe(true);
+    await service.revokePaneConfig("pane-005");
+
+    expect(service.isValidPaneToken(token)).toBe(false);
+    await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("is idempotent — revokePaneConfig tolerates missing files and unknown panes", async () => {
+    await expect(service.revokePaneConfig("never-existed")).resolves.toBeUndefined();
+
+    await service.preparePaneConfig({ paneId: "pane-006", port: 45454 });
+    await service.revokePaneConfig("pane-006");
+    // second call against an already-revoked pane must not throw
+    await expect(service.revokePaneConfig("pane-006")).resolves.toBeUndefined();
+  });
+
+  it("re-preparing the same paneId rotates the token and overwrites the file", async () => {
+    const first = await service.preparePaneConfig({ paneId: "pane-007", port: 45454 });
+    const second = await service.preparePaneConfig({ paneId: "pane-007", port: 45454 });
+
+    expect(second.token).not.toBe(first.token);
+    expect(service.isValidPaneToken(first.token)).toBe(false);
+    expect(service.isValidPaneToken(second.token)).toBe(true);
+
+    const raw = await fs.readFile(second.configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.mcpServers.daintree.headers.Authorization).toBe(`Bearer ${second.token}`);
+  });
+
+  it("rejects invalid ports", async () => {
+    await expect(service.preparePaneConfig({ paneId: "pane-008", port: 0 })).rejects.toThrow(
+      /Invalid MCP port/
+    );
+    await expect(service.preparePaneConfig({ paneId: "pane-009", port: 70000 })).rejects.toThrow(
+      /Invalid MCP port/
+    );
+    await expect(
+      service.preparePaneConfig({ paneId: "pane-010", port: -1 as unknown as number })
+    ).rejects.toThrow(/Invalid MCP port/);
+  });
+
+  it("rejects empty pane IDs", async () => {
+    await expect(service.preparePaneConfig({ paneId: "", port: 45454 })).rejects.toThrow(
+      /paneId is required/
+    );
+  });
+
+  it("revokeAll clears all tokens and files", async () => {
+    const a = await service.preparePaneConfig({ paneId: "pane-a", port: 45454 });
+    const b = await service.preparePaneConfig({ paneId: "pane-b", port: 45454 });
+
+    expect(service.isValidPaneToken(a.token)).toBe(true);
+    expect(service.isValidPaneToken(b.token)).toBe(true);
+
+    await service.revokeAll();
+
+    expect(service.isValidPaneToken(a.token)).toBe(false);
+    expect(service.isValidPaneToken(b.token)).toBe(false);
+    await expect(fs.stat(a.configPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(b.configPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -128,6 +128,22 @@ describe("McpPaneConfigService", () => {
     );
   });
 
+  it("rejects path-traversal pane IDs", async () => {
+    await expect(service.preparePaneConfig({ paneId: "../escape", port: 45454 })).rejects.toThrow(
+      /Invalid paneId/
+    );
+    await expect(
+      service.preparePaneConfig({ paneId: "../../etc/passwd", port: 45454 })
+    ).rejects.toThrow(/Invalid paneId/);
+    await expect(service.preparePaneConfig({ paneId: "subdir/leak", port: 45454 })).rejects.toThrow(
+      /Invalid paneId/
+    );
+
+    // Confirm no file was written outside the base directory.
+    const escapeCandidate = path.join(testUserData, "escape.json");
+    await expect(fs.stat(escapeCandidate)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("revokeAll clears all tokens and files", async () => {
     const a = await service.preparePaneConfig({ paneId: "pane-a", port: 45454 });
     const b = await service.preparePaneConfig({ paneId: "pane-b", port: 45454 });

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -398,4 +398,6 @@ export interface ProjectSettings {
   defaultWorktreeMode?: string;
   /** Hostnames the user approved for the browser panel beyond the implicit local/private allow-list */
   browserAllowedHosts?: string[];
+  /** Expose the Daintree MCP server to Claude Code agents launched in this project's worktrees */
+  exposeDaintreeMcpToAgents?: boolean;
 }

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Image, Upload, X, Rocket, Check, FolderOpen, Copy, Palette } from "lucide-react";
-import { FolderGit2 } from "@/components/icons";
+import { FolderGit2, McpServerIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { EmojiPicker } from "@/components/ui/emoji-picker";
@@ -54,6 +54,8 @@ interface GeneralTabProps {
   onDevServerLoadTimeoutChange: (value: number | undefined) => void;
   turbopackEnabled: boolean;
   onTurbopackEnabledChange: (value: boolean) => void;
+  exposeDaintreeMcpToAgents: boolean;
+  onExposeDaintreeMcpToAgentsChange: (value: boolean) => void;
   projectIconSvg: string | undefined;
   onProjectIconSvgChange: (value: string | undefined) => void;
   enableInRepoSettings: (projectId: string) => Promise<Project>;
@@ -76,6 +78,8 @@ export function GeneralTab({
   onDevServerLoadTimeoutChange,
   turbopackEnabled,
   onTurbopackEnabledChange,
+  exposeDaintreeMcpToAgents,
+  onExposeDaintreeMcpToAgentsChange,
   projectIconSvg,
   onProjectIconSvgChange,
   enableInRepoSettings,
@@ -450,6 +454,26 @@ export function GeneralTab({
             Auto-inject <code className="font-mono">--turbopack</code> for Next.js 15+ projects
           </label>
         </div>
+      </div>
+
+      <div className="mb-6 pb-6 border-b border-daintree-border">
+        <h3 className="text-sm font-semibold text-daintree-text/80 mb-2 flex items-center gap-2">
+          <McpServerIcon className="h-4 w-4" />
+          Agent integrations
+        </h3>
+        <p className="text-xs text-daintree-text/60 mb-4">
+          Connect Claude Code agents launched in this project's worktrees to the Daintree MCP
+          server. Agents can read worktree status, terminal output, and run safe project actions.
+        </p>
+
+        <SettingsSwitchCard
+          icon={McpServerIcon}
+          title="Expose Daintree MCP to Claude Code agents"
+          subtitle="Injects --mcp-config with a per-pane bearer token on agent launch"
+          isEnabled={exposeDaintreeMcpToAgents}
+          onChange={() => onExposeDaintreeMcpToAgentsChange(!exposeDaintreeMcpToAgents)}
+          ariaLabel="Expose Daintree MCP to Claude Code agents"
+        />
       </div>
 
       <div className="mb-6">

--- a/src/components/Project/projectSettingsDirty.ts
+++ b/src/components/Project/projectSettingsDirty.ts
@@ -12,6 +12,7 @@ export interface ProjectSettingsSnapshot {
   devServerCommand: string;
   devServerLoadTimeout: number | undefined;
   turbopackEnabled: boolean;
+  exposeDaintreeMcpToAgents: boolean;
   projectIconSvg: string | undefined;
   excludedPaths: string[];
   environmentVariables: Record<string, string>;
@@ -76,7 +77,8 @@ export function createProjectSettingsSnapshot(
   resourceEnvironments: Record<string, ResourceEnvironment> | undefined = undefined,
   activeResourceEnvironment: string | undefined = undefined,
   defaultWorktreeMode: string | undefined = undefined,
-  turbopackEnabled: boolean = true
+  turbopackEnabled: boolean = true,
+  exposeDaintreeMcpToAgents: boolean = false
 ): ProjectSettingsSnapshot {
   const envVarRecord: Record<string, string> = {};
   const seenKeys = new Map<string, number>();
@@ -145,6 +147,7 @@ export function createProjectSettingsSnapshot(
     devServerCommand: devServerCommand.trim(),
     devServerLoadTimeout,
     turbopackEnabled,
+    exposeDaintreeMcpToAgents,
     projectIconSvg,
     excludedPaths: sanitizedPaths,
     environmentVariables: sortedEnvVars,
@@ -217,6 +220,7 @@ export function areSnapshotsEqual(a: ProjectSettingsSnapshot, b: ProjectSettings
   if (a.devServerCommand !== b.devServerCommand) return false;
   if (a.devServerLoadTimeout !== b.devServerLoadTimeout) return false;
   if (a.turbopackEnabled !== b.turbopackEnabled) return false;
+  if (a.exposeDaintreeMcpToAgents !== b.exposeDaintreeMcpToAgents) return false;
   if (a.projectIconSvg !== b.projectIconSvg) return false;
   if (a.defaultWorktreeRecipeId !== b.defaultWorktreeRecipeId) return false;
 

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1400,6 +1400,10 @@ function SettingsDialogInner({
                               onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
                               turbopackEnabled={projectForm.turbopackEnabled}
                               onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
+                              exposeDaintreeMcpToAgents={projectForm.exposeDaintreeMcpToAgents}
+                              onExposeDaintreeMcpToAgentsChange={
+                                projectForm.setExposeDaintreeMcpToAgents
+                              }
                               projectIconSvg={projectForm.projectIconSvg}
                               onProjectIconSvgChange={projectForm.setProjectIconSvg}
                               enableInRepoSettings={projectForm.enableInRepoSettings}

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -51,6 +51,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
   const [devServerCommand, setDevServerCommand] = useState<string>("");
   const [devServerLoadTimeout, setDevServerLoadTimeout] = useState<number | undefined>(undefined);
   const [turbopackEnabled, setTurbopackEnabled] = useState<boolean>(true);
+  const [exposeDaintreeMcpToAgents, setExposeDaintreeMcpToAgents] = useState<boolean>(false);
   const [commandOverrides, setCommandOverrides] = useState<CommandOverride[]>([]);
   const [copyTreeSettings, setCopyTreeSettings] = useState<CopyTreeSettings>({});
   const [branchPrefixMode, setBranchPrefixMode] = useState<"none" | "username" | "custom">("none");
@@ -133,7 +134,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       resourceEnvironments,
       activeResourceEnvironment,
       defaultWorktreeMode,
-      turbopackEnabled
+      turbopackEnabled,
+      exposeDaintreeMcpToAgents
     );
   }, [
     projectName,
@@ -159,6 +161,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     activeResourceEnvironment,
     defaultWorktreeMode,
     turbopackEnabled,
+    exposeDaintreeMcpToAgents,
   ]);
   useEffect(() => {
     currentProjectSnapshotRef.current = currentProjectSnapshot;
@@ -181,6 +184,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       setDevServerCommand("");
       setDevServerLoadTimeout(undefined);
       setTurbopackEnabled(true);
+      setExposeDaintreeMcpToAgents(false);
       setCommandOverrides([]);
       setCopyTreeSettings({});
       setProjectAutoSaveError(null);
@@ -217,6 +221,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     const initialDevServerCommand = projectSettings.devServerCommand || "";
     const initialDevServerLoadTimeout = projectSettings.devServerLoadTimeout;
     const initialTurbopackEnabled = projectSettings.turbopackEnabled ?? true;
+    const initialExposeDaintreeMcpToAgents = projectSettings.exposeDaintreeMcpToAgents ?? false;
     const initialCommandOverrides = projectSettings.commandOverrides || [];
     const initialCopyTreeSettings = projectSettings.copyTreeSettings || {};
     const initialBranchPrefixMode = projectSettings.branchPrefixMode ?? "none";
@@ -256,6 +261,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDevServerCommand(initialDevServerCommand);
     setDevServerLoadTimeout(initialDevServerLoadTimeout);
     setTurbopackEnabled(initialTurbopackEnabled);
+    setExposeDaintreeMcpToAgents(initialExposeDaintreeMcpToAgents);
     setCommandOverrides(initialCommandOverrides);
     setCopyTreeSettings(initialCopyTreeSettings);
     setBranchPrefixMode(initialBranchPrefixMode);
@@ -297,7 +303,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       initialResourceEnvironments,
       initialActiveResourceEnvironment,
       initialDefaultWorktreeMode,
-      initialTurbopackEnabled
+      initialTurbopackEnabled,
+      initialExposeDaintreeMcpToAgents
     );
     setProjectIsInitialized(true);
   }, [projectSettings, isOpen, projectIsInitialized, currentProject, projectIsLoading, projectId]);
@@ -383,6 +390,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
         devServerCommand: devServerCommand.trim() || undefined,
         devServerLoadTimeout,
         turbopackEnabled: turbopackEnabled === true ? undefined : false,
+        exposeDaintreeMcpToAgents: exposeDaintreeMcpToAgents ? true : undefined,
         commandOverrides: commandOverrides.length > 0 ? commandOverrides : undefined,
         copyTreeSettings: hasCopyTreeSettings ? sanitizedCopyTreeSettings : undefined,
         branchPrefixMode: effectivePrefixMode !== "none" ? effectivePrefixMode : undefined,
@@ -460,6 +468,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDevServerLoadTimeout,
     turbopackEnabled,
     setTurbopackEnabled,
+    exposeDaintreeMcpToAgents,
+    setExposeDaintreeMcpToAgents,
     commandOverrides,
     setCommandOverrides,
     copyTreeSettings,


### PR DESCRIPTION
## Summary

- Adds a per-project toggle ("Expose Daintree MCP to my agents") that routes through to the Claude Code launcher — off by default, no changes to user-owned config files.
- New `McpPaneConfigService` mints a per-pane bearer token at spawn time, writes a managed `--mcp-config` JSON under `userData/mcp-pane-configs/{paneId}.json` (mode 0600), and revokes it on PTY exit, spawn failure, or async rejection.
- `McpServerService.isAuthorized()` extended to accept per-pane tokens; terminal lifecycle handler appends `--mcp-config <path>` and injects `DAINTREE_MCP_TOKEN` into the env for qualifying Claude Code launches.

Resolves #6527

## Changes

- `shared/types/project.ts` — `exposeDaintreeMcpToAgents` field on `ProjectSettings`
- `electron/services/McpPaneConfigService.ts` — new service: token minting, config file writes (0600), path-traversal guard, revocation
- `electron/services/McpServerService.ts` — `isAuthorized()` extended for per-pane tokens
- `electron/ipc/handlers/terminal/lifecycle.ts` — appends `--mcp-config` on Claude Code launches when toggle is on and MCP server is running
- `electron/ipc/handlers/terminal/events.ts` — revokes pane config on PTY exit and spawn-result rejection
- `src/components/Project/GeneralTab.tsx` — "Agent integrations" section with `SettingsSwitchCard`
- `src/components/Project/projectSettingsDirty.ts`, `src/hooks/useProjectSettingsForm.ts` — wired up new field
- `electron/services/__tests__/McpPaneConfigService.test.ts` — 11 unit tests covering token lifecycle and revocation

## Out of scope (tracked separately)

Streamable HTTP (#6516), tier policy (#6528), per-project WebContents routing (#6518), safeStorage (#6519), Codex/Gemini injection — Phase 1 is Claude Code only.

## Testing

- 11 new unit tests pass (`McpPaneConfigService` — token mint/revoke, file write, path-traversal guard)
- Full suite: 16,543 tests pass
- `tsc --noEmit` clean, lint baseline improved by 8 warnings