### PR TITLE
fix(setup): pause CLI poll when agent setup wizard is hidden

### DIFF
--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -13,6 +13,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
 import { logError } from "@/utils/logger";
 import type { CliAvailability } from "@shared/types";
+import { useAgentSetupPoll } from "./useAgentSetupPoll";
 import { isAgentInstalled, isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, Check, Sun, Moon } from "lucide-react";
 import { AnimatePresence, m, useReducedMotion, type Variants } from "framer-motion";
@@ -27,7 +28,6 @@ import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
-const POLL_INTERVAL = 3000;
 
 const daintreeScheme = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
 const bondiScheme = BUILT_IN_APP_SCHEMES.find((s) => s.id === "bondi")!;
@@ -347,7 +347,6 @@ export function AgentSetupWizard({
   const [telemetryEnabled, setTelemetryEnabled] = useState(false);
   const telemetryCommittedRef = useRef(false);
 
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isOpenRef = useRef(isOpen);
   const initRef = useRef(false);
   const directionRef = useRef<1 | -1>(1);
@@ -375,31 +374,10 @@ export function AgentSetupWizard({
     prevIsOpenRef.current = isOpen;
   }, [isOpen, initialAvailability]);
 
-  // Poll availability
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const poll = () => {
-      cliAvailabilityClient
-        .refresh()
-        .then((result) => {
-          if (isOpenRef.current) {
-            dispatch({ type: "SET_AVAILABILITY", payload: result });
-          }
-        })
-        .catch((err) => logError("Failed to refresh CLI availability", err));
-    };
-
-    poll();
-    pollRef.current = setInterval(poll, POLL_INTERVAL);
-
-    return () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-    };
-  }, [isOpen]);
+  // Poll availability — paused when document is hidden
+  useAgentSetupPoll(isOpen, (result) => {
+    dispatch({ type: "SET_AVAILABILITY", payload: result });
+  });
 
   // Initialize selections once when availability is ready
   useEffect(() => {

--- a/src/components/Setup/__tests__/useAgentSetupPoll.test.ts
+++ b/src/components/Setup/__tests__/useAgentSetupPoll.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAgentSetupPoll } from "../useAgentSetupPoll";
+
+vi.mock("@/clients", () => ({
+  cliAvailabilityClient: {
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+import { cliAvailabilityClient } from "@/clients";
+
+const mockRefresh = cliAvailabilityClient.refresh as ReturnType<typeof vi.fn>;
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useAgentSetupPoll", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockRefresh.mockReset();
+    mockRefresh.mockResolvedValue({});
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls refresh immediately when open while visible", () => {
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call refresh when dialog is closed", () => {
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(false, setAvailability));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls refresh at the poll interval when visible", () => {
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    mockRefresh.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops polling when document becomes hidden", () => {
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    mockRefresh.mockClear();
+
+    act(() => {
+      setHidden(true);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(mockRefresh).toHaveBeenCalledTimes(0);
+  });
+
+  it("resumes polling with an immediate refresh when document becomes visible", () => {
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    act(() => {
+      setHidden(true);
+    });
+
+    mockRefresh.mockClear();
+
+    act(() => {
+      setHidden(false);
+    });
+
+    // Immediate refresh on regain
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+
+    // Then interval resumes
+    mockRefresh.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start polling when open while hidden", () => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    expect(mockRefresh).toHaveBeenCalledTimes(0);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(mockRefresh).toHaveBeenCalledTimes(0);
+  });
+
+  it("starts polling when document becomes visible after opening while hidden", () => {
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    mockRefresh.mockClear();
+
+    act(() => {
+      setHidden(false);
+    });
+
+    // Immediate refresh on regain
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up interval and listener on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+    const setAvailability = vi.fn();
+    const { unmount } = renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    // Advancing time should not trigger more calls
+    mockRefresh.mockClear();
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(mockRefresh).toHaveBeenCalledTimes(0);
+
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it("dispatches result to setAvailability when refresh resolves", async () => {
+    const result = { claude: "ready" as const };
+    mockRefresh.mockResolvedValueOnce(result);
+
+    const setAvailability = vi.fn();
+    renderHook(() => useAgentSetupPoll(true, setAvailability));
+
+    // Flush microtasks without triggering the interval (which would loop forever)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(setAvailability).toHaveBeenCalledWith(result);
+  });
+
+  it("does not dispatch if dialog closed while refresh was in flight", async () => {
+    // refresh is slow — dialog closes before it resolves
+    let resolveRefresh: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      resolveRefresh = resolve;
+    });
+    mockRefresh.mockReturnValueOnce(pending);
+
+    const setAvailability = vi.fn();
+    const { rerender } = renderHook(({ isOpen }) => useAgentSetupPoll(isOpen, setAvailability), {
+      initialProps: { isOpen: true },
+    });
+
+    // Close the dialog while refresh is in flight
+    rerender({ isOpen: false });
+
+    // Now the refresh resolves
+    resolveRefresh!({ claude: "ready" });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(setAvailability).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/components/Setup/useAgentSetupPoll.ts
+++ b/src/components/Setup/useAgentSetupPoll.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { cliAvailabilityClient } from "@/clients";
+import { logError } from "@/utils/logger";
+
+const POLL_INTERVAL = 3000;
+
+export type SetAvailability = (
+  result: Awaited<ReturnType<typeof cliAvailabilityClient.refresh>>
+) => void;
+
+export function useAgentSetupPoll(isOpen: boolean, setAvailability: SetAvailability) {
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isOpenRef = useRef(isOpen);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const poll = () => {
+      cliAvailabilityClient
+        .refresh()
+        .then((result) => {
+          if (isOpenRef.current) {
+            setAvailability(result);
+          }
+        })
+        .catch((err) => logError("Failed to refresh CLI availability", err));
+    };
+
+    const stopPolling = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+
+    const startPolling = () => {
+      stopPolling();
+      pollRef.current = setInterval(poll, POLL_INTERVAL);
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else if (isOpenRef.current) {
+        poll();
+        startPolling();
+      }
+    };
+
+    if (document.hidden) {
+      // Defer to visibilitychange — fires one refresh on regain
+    } else {
+      poll();
+      startPolling();
+    }
+
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stopPolling();
+    };
+  }, [isOpen]);
+}


### PR DESCRIPTION
## Summary
The agent setup wizard's CLI availability poll kept running even when the browser tab or window was hidden. Now it pauses while hidden and runs a single immediate refresh when the tab becomes visible again, so we're not paying for repeated IPC pings doing nothing useful.

Extracted all the polling logic out of `AgentSetupWizard.tsx` into a dedicated `useAgentSetupPoll` hook that listens for `visibilitychange`. This also guards against dispatching stale results if the user closes the wizard while a refresh is in flight.

Resolves #6501

## Changes
- Added `useAgentSetupPoll` hook with visibility-aware polling (`src/components/Setup/useAgentSetupPoll.ts`)
- Replaced the inline polling `useEffect` in `AgentSetupWizard.tsx` with the new hook
- Added unit tests covering open/closed, visible/hidden transitions, in-flight guard, and cleanup

## Testing
Unit tests cover all edge cases: polling starts immediately when visible, skips when hidden on open, stops on hide/resumes on show with an immediate refresh, drops stale results if closed mid-flight, and cleans up on unmount.