### PR TITLE
chore(terminal): remove obsolete xterm 6 DECRQM workarounds and add regression guard

### DIFF
--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -102,24 +102,6 @@ export class TerminalParserHandler {
     );
     this.disposables.push(altScreenSetHandler);
 
-    // Block DECRQM (Request Mode) queries: CSI ? Pm $ p
-    // xterm.js 6.0 has a bug in its minified requestMode handler that throws
-    // "i is not defined", crashing the parser and dropping all subsequent output.
-    // OpenCode (Bubble Tea) sends these during startup for capability detection.
-    // Silently consuming them is safe — the app doesn't need DECRQM responses.
-    const decrqmHandler = terminal.parser.registerCsiHandler(
-      { prefix: "?", intermediates: "$", final: "p" },
-      () => true // Consume and discard
-    );
-    this.disposables.push(decrqmHandler);
-
-    // Also block the non-private DECRQM variant: CSI Pm $ p
-    const decrqmNonPrivateHandler = terminal.parser.registerCsiHandler(
-      { intermediates: "$", final: "p" },
-      () => true
-    );
-    this.disposables.push(decrqmNonPrivateHandler);
-
     // Block mouse reporting mode toggles (enables programs to capture mouse events).
     // We block this for agent terminals to avoid surprising interactions inside the app.
     const mouseModeParams = new Set([1000, 1002, 1003, 1005, 1006, 1015]);

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -25,15 +25,17 @@ interface XtermCoreRenderDimensions {
 /**
  * Returns the CSS pixel dimensions of a single terminal cell.
  *
- * xterm.js 6.0 does not expose a public API for per-cell pixel dimensions.
- * The official @xterm/addon-fit (0.11) accesses the same private path
- * (`_core._renderService.dimensions`) — see its proposeDimensions() source.
- * Upstream tracking: xtermjs/xterm.js#702 (closed; no public API in 6.0).
+ * xterm 6.0 has no public cell-dimension API (verified against installed
+ * `@xterm/xterm` typings). The only available path is the private
+ * `_core._renderService.dimensions.css.cell` property — the same approach
+ * `@xterm/addon-fit` 0.11 uses in its `proposeDimensions()` method.
  *
- * This helper uses a narrow structural type instead of `any` and rejects
- * non-finite, zero, or negative values. Returns `null` on any failure so
- * callers can fall back to fitAddon.fit().
- * Replace with a public API when one is available in our xterm version.
+ * Uses a narrow structural type instead of `any` and rejects non-finite,
+ * zero, or negative values. Returns `null` on any failure so callers can
+ * fall back to fitAddon.fit().
+ *
+ * Upstream tracking: xtermjs/xterm.js#702 (no public API in 6.0).
+ * Replace with a public API when one becomes available.
  */
 export function getXtermCellDimensions(
   terminal: Terminal

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -100,8 +100,8 @@ describe("TerminalParserHandler", () => {
 
     new TerminalParserHandler(mockManaged);
     expect(escHandlers).toHaveLength(0);
-    // 1 alt screen exit (?l) + 2 dynamic agent blockers (?h) + 2 DECRQM blockers.
-    expect(csiHandlers).toHaveLength(5);
+    // 1 alt screen exit (?l) + 2 dynamic agent blockers (?h).
+    expect(csiHandlers).toHaveLength(3);
     const dynamicBlockers = csiHandlers.filter(
       (h) => h.opts.prefix === "?" && h.opts.final === "h"
     );
@@ -110,26 +110,6 @@ describe("TerminalParserHandler", () => {
     // OSC 52 clipboard block applies unconditionally to all terminal kinds
     expect(oscHandlers).toHaveLength(1);
     expect(oscHandlers[0].ident).toBe(52);
-  });
-
-  it("should block DECRQM queries to prevent xterm.js parser crash", () => {
-    mockManaged.kind = "terminal";
-    mockManaged.launchAgentId = undefined;
-    mockManaged.runtimeAgentId = undefined;
-
-    new TerminalParserHandler(mockManaged);
-
-    const privateDecrqm = csiHandlers.find(
-      (h) => h.opts.prefix === "?" && h.opts.intermediates === "$" && h.opts.final === "p"
-    );
-    const nonPrivateDecrqm = csiHandlers.find(
-      (h) => !h.opts.prefix && h.opts.intermediates === "$" && h.opts.final === "p"
-    );
-    expect(privateDecrqm).toBeDefined();
-    expect(nonPrivateDecrqm).toBeDefined();
-    // Handlers should consume (return true)
-    expect(privateDecrqm.handler()).toBe(true);
-    expect(nonPrivateDecrqm.handler()).toBe(true);
   });
 
   it("should NOT block alt screen for OpenCode agent", () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,28 @@ function cspTransformPlugin(): Plugin {
   };
 }
 
+// Build-time invariant guard: esbuild.minifyIdentifiers must stay false.
+// xterm 6.0 ships pre-minified code with a closure in `requestMode` that
+// captures a mangled parameter name. If esbuild re-minifies the bundle, it
+// renames the parameter but not the closure reference, producing
+// `ReferenceError: i is not defined` and crashing the parser silently.
+// This guard fails the build if the config is accidentally changed.
+function xtermMinifyIdentifiersGuardPlugin(): Plugin {
+  return {
+    name: "xterm-minify-identifiers-guard",
+    apply: "build",
+    configResolved(config) {
+      const esbuildConfig = config.esbuild;
+      if (!esbuildConfig || esbuildConfig.minifyIdentifiers !== false) {
+        throw new Error(
+          "esbuild.minifyIdentifiers must be false to prevent xterm 6.0 parser crash. " +
+            "See https://github.com/daintreehq/daintree/blob/develop/vite.config.ts#L215-L221"
+        );
+      }
+    },
+  };
+}
+
 // Emits dist/renderer-bundle-size-report.json after the build completes with
 // per-chunk and total JS/CSS sizes (raw + gzip). Used by the CI bundle size
 // budget gate to catch silent regressions from dependency upgrades or
@@ -238,6 +260,7 @@ export default defineConfig(({ command, mode }) => {
       cspTransformPlugin(),
       compilerReportPlugin,
       rendererBundleSizePlugin(),
+      xtermMinifyIdentifiersGuardPlugin(),
     ],
     base: "./",
     build: {


### PR DESCRIPTION
## Summary
- Removes two DECRQM CSI handlers in `TerminalParserHandler` that became redundant after the bundler config in `vite.config.ts` started preventing the underlying minification bug at the source.
- Updates the `getXtermCellDimensions` comment to match what the installed `@xterm/xterm` typings actually expose -- xterm 6 still has no public cell-dimension API.
- Adds `xtermMinifyIdentifiersGuardPlugin`, a build-time invariant that fails the build if `esbuild.minifyIdentifiers` is accidentally turned back on.

Resolves #6502

## Changes
- **`TerminalParserHandler.ts`** -- Removed the `CSI ? Pm $ p` and `CSI Pm $ p` DECRQM consume-and-discard handlers.
- **`TerminalResizeController.ts`** -- Simplified the `getXtermCellDimensions` JSDoc; old wording was speculative, now confirmed against the installed typings.
- **`vite.config.ts`** -- Added `xtermMinifyIdentifiersGuardPlugin` that throws during `configResolved` if `esbuild.minifyIdentifiers` isn't `false`.
- **`TerminalParserHandler.test.ts`** -- Removed the DECRQM blocker test case; updated the CSI handler count assertion from 5 to 3.

## Testing
- Existing terminal parser tests pass with the updated handler count.
- Build-time guard verified by temporarily removing the config and confirming the build fails.