### PR TITLE
fix(worktree): replace count-pill DOM remount with Framer Motion useAnimate

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -91,6 +91,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   const [countScope, animate] = useAnimate<HTMLSpanElement>();
   const prefersReducedMotion = useReducedMotion();
   const didMountRef = useRef(false);
+  const prevCountRef = useRef(changedFileCount);
   const lastBumpTimeRef = useRef(0);
 
   useEffect(() => {
@@ -98,8 +99,16 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
       didMountRef.current = true;
       return;
     }
+    if (changedFileCount === prevCountRef.current) return;
+    prevCountRef.current = changedFileCount;
+
     if (prefersReducedMotion) return;
-    if (Date.now() - lastBumpTimeRef.current < DURATION_200) return;
+    if (countScope.current == null) return;
+    if (
+      document.body.dataset.performanceMode === "true" ||
+      Date.now() - lastBumpTimeRef.current < DURATION_200
+    )
+      return;
 
     lastBumpTimeRef.current = Date.now();
     animate(

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -1,8 +1,10 @@
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { WorktreeState } from "@/types";
 import type { RetryAction } from "@/store";
 import type { ErrorRecord } from "@/store/errorStore";
+import { useAnimate, useReducedMotion } from "framer-motion";
+import { DURATION_200 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { ActivityLight } from "../ActivityLight";
 import { LiveTimeAgo } from "../LiveTimeAgo";
@@ -85,21 +87,27 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   const detailsId = `worktree-${worktree.id}-details`;
   const detailsPanelId = `worktree-${worktree.id}-details-panel`;
 
-  // One-shot bump on file-count change. Counter increments on every change
-  // and is used as a `key` on the count span so back-to-back updates remount
-  // the node and restart the animation (a plain boolean latch would silently
-  // drop a second update arriving inside the 200ms animation window).
-  // prevRef seeded to current value so mount produces no bump.
   const changedFileCount = worktree.worktreeChanges?.changedFileCount ?? 0;
-  const prevCountRef = useRef(changedFileCount);
-  const [bumpKey, setBumpKey] = useState(0);
+  const [countScope, animate] = useAnimate<HTMLSpanElement>();
+  const prefersReducedMotion = useReducedMotion();
+  const didMountRef = useRef(false);
+  const lastBumpTimeRef = useRef(0);
 
   useEffect(() => {
-    if (prevCountRef.current !== changedFileCount) {
-      prevCountRef.current = changedFileCount;
-      setBumpKey((k) => k + 1);
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
     }
-  }, [changedFileCount]);
+    if (prefersReducedMotion) return;
+    if (Date.now() - lastBumpTimeRef.current < DURATION_200) return;
+
+    lastBumpTimeRef.current = Date.now();
+    animate(
+      countScope.current,
+      { scale: [1, 1.06, 1] },
+      { duration: DURATION_200 / 1000, ease: [0.4, 0, 0.2, 1] }
+    );
+  }, [changedFileCount, prefersReducedMotion, animate]);
 
   const rsLower = resourceStatus?.toLowerCase();
   const showResourceResume =
@@ -190,10 +198,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                 <span className="text-status-error">{lifecycleLabel}</span>
               ) : hasChanges && worktree.worktreeChanges ? (
                 <span className="flex items-center gap-1.5 text-text-secondary">
-                  <span
-                    key={bumpKey}
-                    className={cn("inline-block", bumpKey > 0 && "animate-badge-bump")}
-                  >
+                  <span ref={countScope} className="inline-block">
                     {worktree.worktreeChanges.changedFileCount} file
                     {worktree.worktreeChanges.changedFileCount !== 1 ? "s" : ""}
                   </span>

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -116,7 +116,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
       { scale: [1, 1.06, 1] },
       { duration: DURATION_200 / 1000, ease: [0.4, 0, 0.2, 1] }
     );
-  }, [changedFileCount, prefersReducedMotion, animate]);
+  }, [changedFileCount, prefersReducedMotion, animate, countScope]);
 
   const rsLower = resourceStatus?.toLowerCase();
   const showResourceResume =

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -56,7 +56,7 @@ const baseWorktree: WorktreeState = {
   branch: "feature/test",
   isCurrent: false,
   isMainWorktree: false,
-  worktreeChanges: { changedFileCount: 3, insertions: 5, deletions: 2 },
+  worktreeChanges: { changedFileCount: 3, insertions: 5, deletions: 2, changes: [], rootPath: "" },
   lastActivityTimestamp: null,
 };
 
@@ -87,6 +87,11 @@ describe("WorktreeDetailsSection count pill bump", () => {
   beforeEach(() => {
     mockAnimate.mockClear();
     mockReducedMotion = false;
+    delete document.body.dataset.performanceMode;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders file count without calling animate on initial mount", () => {
@@ -100,7 +105,12 @@ describe("WorktreeDetailsSection count pill bump", () => {
 
     const updated = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
     };
 
     rerender(
@@ -118,15 +128,30 @@ describe("WorktreeDetailsSection count pill bump", () => {
 
     const first = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
     };
     const second = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 7, insertions: 12, deletions: 5 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 7,
+        insertions: 12,
+        deletions: 5,
+      },
     };
     const third = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 9, insertions: 15, deletions: 8 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 9,
+        insertions: 15,
+        deletions: 8,
+      },
     };
 
     rerender(
@@ -149,37 +174,50 @@ describe("WorktreeDetailsSection count pill bump", () => {
     expect(screen.getByText(/9 files/)).toBeDefined();
   });
 
-  it("re-arms bump after throttle window expires", async () => {
+  it("re-arms bump after throttle window expires", () => {
     vi.useFakeTimers();
-    const { rerender } = renderSection();
+    try {
+      const { rerender } = renderSection();
 
-    const first = {
-      ...baseWorktree,
-      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
-    };
+      const first = {
+        ...baseWorktree,
+        worktreeChanges: {
+          ...baseWorktree.worktreeChanges,
+          changedFileCount: 5,
+          insertions: 10,
+          deletions: 3,
+        },
+      };
 
-    rerender(
-      <TooltipProvider>
-        <WorktreeDetailsSection {...baseProps} worktree={first} />
-      </TooltipProvider>
-    );
-    expect(mockAnimate).toHaveBeenCalledTimes(1);
+      rerender(
+        <TooltipProvider>
+          <WorktreeDetailsSection {...baseProps} worktree={first} />
+        </TooltipProvider>
+      );
+      expect(mockAnimate).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(250);
+      vi.advanceTimersByTime(250);
 
-    const second = {
-      ...baseWorktree,
-      worktreeChanges: { changedFileCount: 7, insertions: 12, deletions: 5 },
-    };
+      const second = {
+        ...baseWorktree,
+        worktreeChanges: {
+          ...baseWorktree.worktreeChanges,
+          changedFileCount: 7,
+          insertions: 12,
+          deletions: 5,
+        },
+      };
 
-    rerender(
-      <TooltipProvider>
-        <WorktreeDetailsSection {...baseProps} worktree={second} />
-      </TooltipProvider>
-    );
+      rerender(
+        <TooltipProvider>
+          <WorktreeDetailsSection {...baseProps} worktree={second} />
+        </TooltipProvider>
+      );
 
-    expect(mockAnimate).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
+      expect(mockAnimate).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("skips animation when reduced motion is preferred", () => {
@@ -188,7 +226,12 @@ describe("WorktreeDetailsSection count pill bump", () => {
 
     const updated = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
     };
 
     rerender(
@@ -201,13 +244,32 @@ describe("WorktreeDetailsSection count pill bump", () => {
     expect(screen.getByText(/5 files/)).toBeDefined();
   });
 
+  it("does not bump when reduced motion toggles off without a count change", () => {
+    mockReducedMotion = true;
+    const { rerender } = renderSection();
+
+    mockReducedMotion = false;
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+
   it("keeps the count span DOM node stable across changes", () => {
     const { rerender } = renderSection();
     const firstNode = screen.getByText(/3 files/);
 
     const updated = {
       ...baseWorktree,
-      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
     };
 
     rerender(
@@ -231,5 +293,73 @@ describe("WorktreeDetailsSection count pill bump", () => {
     );
 
     expect(mockAnimate).not.toHaveBeenCalled();
+  });
+
+  it("does not animate when expanded (count span not rendered)", () => {
+    const { rerender } = renderSection({ isExpanded: false });
+
+    const updated = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} isExpanded={true} worktree={updated} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+
+  it("does not animate when count span not rendered, then allows bump after collapse", () => {
+    const { rerender } = renderSection({ isExpanded: true });
+
+    const collapsed = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} isExpanded={false} worktree={collapsed} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips animation in performance mode", () => {
+    document.body.dataset.performanceMode = "true";
+    const { rerender } = renderSection();
+
+    const updated = {
+      ...baseWorktree,
+      worktreeChanges: {
+        ...baseWorktree.worktreeChanges,
+        changedFileCount: 5,
+        insertions: 10,
+        deletions: 3,
+      },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={updated} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).not.toHaveBeenCalled();
+    expect(screen.getByText(/5 files/)).toBeDefined();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { WorktreeState } from "@/types";
+import type { WorktreeChanges } from "@shared/types/git";
 import type { ComputedSubtitle } from "../hooks/useWorktreeStatus";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
@@ -31,7 +32,7 @@ vi.mock("framer-motion", () => {
     domMax: {},
     m: { div: MotionDiv },
     motion: { div: MotionDiv },
-    useAnimate: () => [{ current: null } as React.RefObject<HTMLElement>, mockAnimate],
+    useAnimate: () => [{ current: null } as unknown as React.RefObject<HTMLElement>, mockAnimate],
     useReducedMotion: () => mockReducedMotion,
   };
 });
@@ -56,7 +57,14 @@ const baseWorktree: WorktreeState = {
   branch: "feature/test",
   isCurrent: false,
   isMainWorktree: false,
-  worktreeChanges: { changedFileCount: 3, insertions: 5, deletions: 2, changes: [], rootPath: "" },
+  worktreeChanges: {
+    worktreeId: "test-wt",
+    changedFileCount: 3,
+    insertions: 5,
+    deletions: 2,
+    changes: [],
+    rootPath: "",
+  },
   lastActivityTimestamp: null,
 };
 
@@ -74,6 +82,13 @@ const baseProps: WorktreeDetailsSectionProps = {
   onDismissError: noop,
   onRetryError: noopAsync,
 };
+
+function withChanges(overrides: Partial<WorktreeChanges>): WorktreeState {
+  return {
+    ...baseWorktree,
+    worktreeChanges: { ...baseWorktree.worktreeChanges, ...overrides } as WorktreeChanges,
+  };
+}
 
 function renderSection(overrides: Partial<WorktreeDetailsSectionProps> = {}) {
   return render(
@@ -103,15 +118,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
   it("calls animate when changedFileCount changes after mount", () => {
     const { rerender } = renderSection();
 
-    const updated = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const updated = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>
@@ -126,33 +133,9 @@ describe("WorktreeDetailsSection count pill bump", () => {
   it("coalesces rapid changes within 200ms gate", () => {
     const { rerender } = renderSection();
 
-    const first = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
-    const second = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 7,
-        insertions: 12,
-        deletions: 5,
-      },
-    };
-    const third = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 9,
-        insertions: 15,
-        deletions: 8,
-      },
-    };
+    const first = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
+    const second = withChanges({ changedFileCount: 7, insertions: 12, deletions: 5 });
+    const third = withChanges({ changedFileCount: 9, insertions: 15, deletions: 8 });
 
     rerender(
       <TooltipProvider>
@@ -179,15 +162,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
     try {
       const { rerender } = renderSection();
 
-      const first = {
-        ...baseWorktree,
-        worktreeChanges: {
-          ...baseWorktree.worktreeChanges,
-          changedFileCount: 5,
-          insertions: 10,
-          deletions: 3,
-        },
-      };
+      const first = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
       rerender(
         <TooltipProvider>
@@ -198,15 +173,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
 
       vi.advanceTimersByTime(250);
 
-      const second = {
-        ...baseWorktree,
-        worktreeChanges: {
-          ...baseWorktree.worktreeChanges,
-          changedFileCount: 7,
-          insertions: 12,
-          deletions: 5,
-        },
-      };
+      const second = withChanges({ changedFileCount: 7, insertions: 12, deletions: 5 });
 
       rerender(
         <TooltipProvider>
@@ -224,15 +191,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
     mockReducedMotion = true;
     const { rerender } = renderSection();
 
-    const updated = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const updated = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>
@@ -262,15 +221,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
     const { rerender } = renderSection();
     const firstNode = screen.getByText(/3 files/);
 
-    const updated = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const updated = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>
@@ -298,15 +249,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
   it("does not animate when expanded (count span not rendered)", () => {
     const { rerender } = renderSection({ isExpanded: false });
 
-    const updated = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const updated = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>
@@ -320,15 +263,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
   it("does not animate when count span not rendered, then allows bump after collapse", () => {
     const { rerender } = renderSection({ isExpanded: true });
 
-    const collapsed = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const collapsed = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>
@@ -343,15 +278,7 @@ describe("WorktreeDetailsSection count pill bump", () => {
     document.body.dataset.performanceMode = "true";
     const { rerender } = renderSection();
 
-    const updated = {
-      ...baseWorktree,
-      worktreeChanges: {
-        ...baseWorktree.worktreeChanges,
-        changedFileCount: 5,
-        insertions: 10,
-        deletions: 3,
-      },
-    };
+    const updated = withChanges({ changedFileCount: 5, insertions: 10, deletions: 3 });
 
     rerender(
       <TooltipProvider>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { WorktreeState } from "@/types";
+import type { ComputedSubtitle } from "../hooks/useWorktreeStatus";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  WorktreeDetailsSection,
+  type WorktreeDetailsSectionProps,
+} from "../WorktreeDetailsSection";
+
+const mockAnimate = vi.fn();
+let mockReducedMotion = false;
+
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ children, ...props }, ref) => (
+      <div ref={ref} {...props}>
+        {children}
+      </div>
+    )
+  );
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+    useAnimate: () => [{ current: null } as React.RefObject<HTMLElement>, mockAnimate],
+    useReducedMotion: () => mockReducedMotion,
+  };
+});
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+const noop = () => {};
+const noopAsync = async () => {};
+
+const baseWorktree: WorktreeState = {
+  id: "test-wt",
+  worktreeId: "test-wt",
+  path: "/tmp/test-wt",
+  name: "test-branch",
+  branch: "feature/test",
+  isCurrent: false,
+  isMainWorktree: false,
+  worktreeChanges: { changedFileCount: 3, insertions: 5, deletions: 2 },
+  lastActivityTimestamp: null,
+};
+
+const baseSubtitle: ComputedSubtitle = { text: "3 files changed", tone: "muted" };
+
+const baseProps: WorktreeDetailsSectionProps = {
+  worktree: baseWorktree,
+  isExpanded: false,
+  hasChanges: true,
+  computedSubtitle: baseSubtitle,
+  worktreeErrors: [],
+  isFocused: false,
+  onToggleExpand: noop,
+  onPathClick: noop,
+  onDismissError: noop,
+  onRetryError: noopAsync,
+};
+
+function renderSection(overrides: Partial<WorktreeDetailsSectionProps> = {}) {
+  return render(
+    <TooltipProvider>
+      <WorktreeDetailsSection {...baseProps} {...overrides} />
+    </TooltipProvider>
+  );
+}
+
+describe("WorktreeDetailsSection count pill bump", () => {
+  beforeEach(() => {
+    mockAnimate.mockClear();
+    mockReducedMotion = false;
+  });
+
+  it("renders file count without calling animate on initial mount", () => {
+    renderSection();
+    expect(screen.getByText(/3 files/)).toBeDefined();
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+
+  it("calls animate when changedFileCount changes after mount", () => {
+    const { rerender } = renderSection();
+
+    const updated = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={updated} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/5 files/)).toBeDefined();
+  });
+
+  it("coalesces rapid changes within 200ms gate", () => {
+    const { rerender } = renderSection();
+
+    const first = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+    };
+    const second = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 7, insertions: 12, deletions: 5 },
+    };
+    const third = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 9, insertions: 15, deletions: 8 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={first} />
+      </TooltipProvider>
+    );
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={second} />
+      </TooltipProvider>
+    );
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={third} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/9 files/)).toBeDefined();
+  });
+
+  it("re-arms bump after throttle window expires", async () => {
+    vi.useFakeTimers();
+    const { rerender } = renderSection();
+
+    const first = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={first} />
+      </TooltipProvider>
+    );
+    expect(mockAnimate).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(250);
+
+    const second = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 7, insertions: 12, deletions: 5 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={second} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("skips animation when reduced motion is preferred", () => {
+    mockReducedMotion = true;
+    const { rerender } = renderSection();
+
+    const updated = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={updated} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).not.toHaveBeenCalled();
+    expect(screen.getByText(/5 files/)).toBeDefined();
+  });
+
+  it("keeps the count span DOM node stable across changes", () => {
+    const { rerender } = renderSection();
+    const firstNode = screen.getByText(/3 files/);
+
+    const updated = {
+      ...baseWorktree,
+      worktreeChanges: { changedFileCount: 5, insertions: 10, deletions: 3 },
+    };
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} worktree={updated} />
+      </TooltipProvider>
+    );
+
+    const secondNode = screen.getByText(/5 files/);
+    expect(firstNode).toBe(secondNode);
+  });
+
+  it("does not bump when changedFileCount stays the same", () => {
+    const { rerender } = renderSection();
+    expect(mockAnimate).not.toHaveBeenCalled();
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeDetailsSection {...baseProps} />
+      </TooltipProvider>
+    );
+
+    expect(mockAnimate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced the DOM remount trick on the worktree card count pill with an imperative useAnimate call, keeping the element in the DOM across count changes.
- Coalesces rapid count changes within a window so multiple saves in quick succession produce a single visible bump.
- Eliminates focus loss and potential screen-reader double-announce that the remount approach caused.

Resolves #6537

## Changes
- WorktreeDetailsSection.tsx -- swapped key={bumpKey} remount for a useAnimate ref and a cooldown window that suppresses redundant bumps.
- WorktreeDetailsSection.test.tsx -- added test coverage for bump coalescing, the render-branch guard, and the performance-mode bypass.

## Testing
- Unit tests pass covering coalesced bumps, the render-branch guard, and the performance-mode bypass.
- Manually verified collapsed worktree card: rapid formatter saves now produce a single clean bump instead of a series of them.