### PR TITLE
fix(github): hydrate toolbar pill counts from disk cache on cold start

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -239,18 +239,48 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       if (!stat.isDirectory()) return null;
 
       const { GitHubFirstPageCache } = await import("../../services/GitHubFirstPageCache.js");
+      const { GitHubStatsCache } = await import("../../services/GitHubStatsCache.js");
       const { getRepoContext } = await import("../../services/GitHubService.js");
       const context = await getRepoContext(resolved);
       if (!context) return null;
       const repoKey = `${context.owner}/${context.repo}`;
       const entry = GitHubFirstPageCache.getInstance().get(repoKey);
-      if (!entry) return null;
+      const cachedStats = GitHubStatsCache.getInstance().getForBootstrap(repoKey);
 
+      // Neither cache has data — let the network poll populate everything.
+      if (!entry && !cachedStats) return null;
+
+      // First-page items present: attach bootstrap stats if available.
+      if (entry) {
+        const payload: GitHubFirstPageCachePayload = {
+          projectPath: resolved,
+          issues: entry.issues,
+          prs: entry.prs,
+          lastUpdated: entry.lastUpdated,
+        };
+        if (cachedStats) {
+          payload.stats = {
+            issueCount: cachedStats.issueCount,
+            prCount: cachedStats.prCount,
+            lastUpdated: cachedStats.lastUpdated,
+          };
+        }
+        return payload;
+      }
+
+      // Stats-only payload: first-page cache expired but stats are still within
+      // the 60-minute bootstrap TTL. Return empty pages so the hydration effect
+      // can seed toolbar counts without damaging the renderer items cache.
       return {
         projectPath: resolved,
-        issues: entry.issues,
-        prs: entry.prs,
-        lastUpdated: entry.lastUpdated,
+        issues: { items: [], endCursor: null, hasNextPage: false },
+        prs: { items: [], endCursor: null, hasNextPage: false },
+        lastUpdated: cachedStats.lastUpdated,
+        stats: {
+          issueCount: cachedStats.issueCount,
+          prCount: cachedStats.prCount,
+          lastUpdated: cachedStats.lastUpdated,
+        },
       };
     } catch {
       // Disk-cache reads are best-effort: a missing cache file, malformed

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -271,6 +271,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       // Stats-only payload: first-page cache expired but stats are still within
       // the 60-minute bootstrap TTL. Return empty pages so the hydration effect
       // can seed toolbar counts without damaging the renderer items cache.
+      if (!cachedStats) return null;
       return {
         projectPath: resolved,
         issues: { items: [], endCursor: null, hasNextPage: false },

--- a/electron/services/GitHubStatsCache.ts
+++ b/electron/services/GitHubStatsCache.ts
@@ -214,6 +214,28 @@ export class GitHubStatsCache {
     return normalized;
   }
 
+  /**
+   * Bootstrap read with a relaxed TTL. Same disk path as `get()` but rejects
+   * entries older than `maxAgeMs` (default 60 minutes) instead of the strict
+   * 10-minute `MAX_CACHE_AGE_MS`. Used by the cold-start hydration path so the
+   * toolbar pill shows cached counts immediately — "old number marked stale"
+   * beats an em-dash.
+   */
+  getForBootstrap(repoKey: string, maxAgeMs = 60 * 60 * 1000): CachedStats | null {
+    const cache = this.load();
+    const normalized = normalizeCachedStats((cache.projects as Record<string, unknown>)[repoKey]);
+    if (!normalized) {
+      return null;
+    }
+
+    const age = Date.now() - normalized.lastUpdated;
+    if (age > maxAgeMs || age < 0) {
+      return null;
+    }
+
+    return normalized;
+  }
+
   set(repoKey: string, stats: { issueCount: number; prCount: number }, projectPath: string): void {
     const cache = this.load();
     const normalizedProjects: Record<string, CachedStats> = {};

--- a/electron/services/__tests__/GitHubStatsCache.test.ts
+++ b/electron/services/__tests__/GitHubStatsCache.test.ts
@@ -214,6 +214,162 @@ describe("GitHubStatsCache", () => {
     expect(disk.projects).toHaveProperty("octocat/dropped");
   });
 
+  describe("getForBootstrap", () => {
+    it("returns entries 10-60 minutes old that get() rejects", async () => {
+      const elevenMinutesMs = 11 * 60 * 1000;
+      fs.writeFileSync(
+        cacheFilePath,
+        JSON.stringify(
+          {
+            version: 1,
+            projects: {
+              "octocat/repo": {
+                issueCount: 5,
+                prCount: 3,
+                lastUpdated: Date.now() - elevenMinutesMs,
+                projectPath: "/repo",
+              },
+            },
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+      GitHubStatsCache.resetInstance();
+      const cache = GitHubStatsCache.getInstance();
+
+      // get() rejects — entry is older than 10 minutes
+      expect(cache.get("octocat/repo")).toBeNull();
+      // getForBootstrap() accepts — entry is within 60 minutes
+      expect(cache.getForBootstrap("octocat/repo")).toEqual({
+        issueCount: 5,
+        prCount: 3,
+        lastUpdated: Date.now() - elevenMinutesMs,
+        projectPath: "/repo",
+      });
+    });
+
+    it("rejects entries older than 60 minutes", async () => {
+      const sixtyOneMinutesMs = 61 * 60 * 1000;
+      fs.writeFileSync(
+        cacheFilePath,
+        JSON.stringify(
+          {
+            version: 1,
+            projects: {
+              "octocat/repo": {
+                issueCount: 5,
+                prCount: 3,
+                lastUpdated: Date.now() - sixtyOneMinutesMs,
+                projectPath: "/repo",
+              },
+            },
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+      GitHubStatsCache.resetInstance();
+      const cache = GitHubStatsCache.getInstance();
+
+      expect(cache.getForBootstrap("octocat/repo")).toBeNull();
+    });
+
+    it("returns null for malformed entries (same validation as get)", async () => {
+      fs.writeFileSync(
+        cacheFilePath,
+        JSON.stringify(
+          {
+            version: 1,
+            projects: {
+              "octocat/repo": {
+                issueCount: "not-a-number",
+                prCount: 2,
+                lastUpdated: Date.now(),
+                projectPath: "/repo",
+              },
+            },
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+      GitHubStatsCache.resetInstance();
+      const cache = GitHubStatsCache.getInstance();
+
+      expect(cache.getForBootstrap("octocat/repo")).toBeNull();
+    });
+
+    it("accepts a custom maxAgeMs", async () => {
+      const twoMinutesMs = 2 * 60 * 1000;
+      fs.writeFileSync(
+        cacheFilePath,
+        JSON.stringify(
+          {
+            version: 1,
+            projects: {
+              "octocat/repo": {
+                issueCount: 5,
+                prCount: 3,
+                lastUpdated: Date.now() - twoMinutesMs,
+                projectPath: "/repo",
+              },
+            },
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+      GitHubStatsCache.resetInstance();
+      const cache = GitHubStatsCache.getInstance();
+
+      // Custom 1-minute TTL — should reject the 2-minute-old entry.
+      expect(cache.getForBootstrap("octocat/repo", 60 * 1000)).toBeNull();
+      // Custom 5-minute TTL — should accept.
+      expect(cache.getForBootstrap("octocat/repo", 5 * 60 * 1000)).not.toBeNull();
+    });
+
+    it("returns null for future-dated entries", async () => {
+      fs.writeFileSync(
+        cacheFilePath,
+        JSON.stringify(
+          {
+            version: 1,
+            projects: {
+              "octocat/repo": {
+                issueCount: 1,
+                prCount: 2,
+                lastUpdated: Date.now() + 60_000,
+                projectPath: "/repo",
+              },
+            },
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+
+      const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
+      GitHubStatsCache.resetInstance();
+      const cache = GitHubStatsCache.getInstance();
+
+      expect(cache.getForBootstrap("octocat/repo")).toBeNull();
+    });
+  });
+
   it("clear removes cached data from memory and disk", async () => {
     const { GitHubStatsCache } = await import("../GitHubStatsCache.js");
     GitHubStatsCache.resetInstance();

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -200,6 +200,14 @@ export interface GitHubFirstPageCachePayload {
   };
   /** Wall-clock timestamp (ms) when the entry was written. */
   lastUpdated: number;
+  /** Optional cached stats for cold-start toolbar hydration (60-min TTL).
+   *  Present when `GitHubStatsCache` has a bootstrap-eligible entry even if
+   *  the first-page items cache has expired. */
+  stats?: {
+    issueCount: number;
+    prCount: number;
+    lastUpdated: number;
+  };
 }
 
 /**

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -744,6 +744,111 @@ describe("useRepositoryStats", () => {
       expect(getCache(issuesKey)).toBeUndefined();
       expect(getCache(prsKey)).toBeUndefined();
     });
+
+    it("does not apply bootstrap stats from a stale project after project switch", async () => {
+      let currentProject = { id: "p", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      // Network poll for project A stays pending.
+      getRepoStatsMock.mockImplementation(() => new Promise(() => {}));
+
+      // Defer the hydration IPC response so we can switch projects mid-flight.
+      const deferred = createDeferred<{
+        projectPath: string;
+        lastUpdated: number;
+        issues: { items: GitHubIssue[]; endCursor: null; hasNextPage: false };
+        prs: { items: GitHubPR[]; endCursor: null; hasNextPage: false };
+        stats: { issueCount: number; prCount: number; lastUpdated: number };
+      }>();
+      getFirstPageCacheMock.mockReturnValueOnce(deferred.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getFirstPageCacheMock).toHaveBeenCalled();
+      });
+
+      // Switch to project B while hydration is in-flight. The onSwitch
+      // handler resets state to null and queues a fetch for B (blocked by
+      // inFlightRef since A's fetch is still pending).
+      currentProject = { id: "p", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+
+      // State was reset by the switch handler.
+      expect(result.current.stats).toBeNull();
+
+      await act(async () => {
+        // Resolve hydration with project A's cached data. The re-verify
+        // check inside the effect must detect the path mismatch against
+        // the current project (B) and bail.
+        deferred.resolve({
+          projectPath: "/repo/a",
+          lastUpdated: 1000,
+          issues: { items: [], endCursor: null, hasNextPage: false },
+          prs: { items: [], endCursor: null, hasNextPage: false },
+          stats: { issueCount: 999, prCount: 888, lastUpdated: 1000 },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Must still show null — the re-verify prevented A's stale cache
+      // from being applied after the project switch.
+      expect(result.current.stats).toBeNull();
+    });
+
+    it("does not clear an existing error when bootstrap hydration resolves", async () => {
+      const project = { id: "p", path: "/repo/err-then-cache" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+
+      // Network fetch resolves first with an error and no lastUpdated.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: null,
+        prCount: null,
+        loading: false,
+        ghError: "Network timeout",
+        // No lastUpdated field — simulates error payload from main process.
+      });
+
+      const cacheLastUpdated = Date.now() - 5_000;
+      // Hydration resolves after the error with valid cached stats.
+      getFirstPageCacheMock.mockResolvedValue({
+        projectPath: project.path,
+        lastUpdated: cacheLastUpdated,
+        issues: { items: [], endCursor: null, hasNextPage: false },
+        prs: { items: [], endCursor: null, hasNextPage: false },
+        stats: { issueCount: 5, prCount: 3, lastUpdated: cacheLastUpdated },
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      // Network fetch lands first, setting the error.
+      await waitFor(() => {
+        expect(result.current.error).toBe("Network timeout");
+      });
+
+      // Flush so hydration effect settles.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Error must persist — bootstrap MUST NOT clear it.
+      expect(result.current.error).toBe("Network timeout");
+      // Bootstrap stats (5/3) must NOT have been applied.
+      expect(result.current.stats?.issueCount).toBeNull();
+      expect(result.current.stats?.prCount).toBeNull();
+    });
   });
 
   describe("rate limits", () => {

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -637,6 +637,113 @@ describe("useRepositoryStats", () => {
       const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
       expect(getCache(issuesKey)).toBeUndefined();
     });
+
+    it("seeds toolbar stats from cached bootstrap counts on cold start", async () => {
+      const project = { id: "p", path: "/repo/bootstrap-stats" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      // Network poll never resolves — only the hydration effect writes stats.
+      getRepoStatsMock.mockImplementation(() => new Promise(() => {}));
+
+      const lastUpdated = Date.now() - 5_000;
+      getFirstPageCacheMock.mockResolvedValueOnce({
+        projectPath: project.path,
+        lastUpdated,
+        issues: { items: [], endCursor: null, hasNextPage: false },
+        prs: { items: [], endCursor: null, hasNextPage: false },
+        stats: { issueCount: 12, prCount: 7, lastUpdated },
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(12);
+        expect(result.current.stats?.prCount).toBe(7);
+        expect(result.current.isStale).toBe(true);
+        expect(result.current.stats?.stale).toBe(true);
+        expect(result.current.lastUpdated).toBe(lastUpdated);
+      });
+    });
+
+    it("does not overwrite fresher network stats with bootstrap cache", async () => {
+      const project = { id: "p", path: "/repo/race" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+
+      const networkLastUpdated = Date.now();
+      // Network poll resolves BEFORE the disk hydration effect — simulates
+      // ultra-fast network beating the async IPC cache read.
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 42,
+        issueCount: 99,
+        prCount: 88,
+        loading: false,
+        stale: false,
+        lastUpdated: networkLastUpdated,
+      });
+
+      const cachedLastUpdated = networkLastUpdated - 60_000;
+      getFirstPageCacheMock.mockResolvedValueOnce({
+        projectPath: project.path,
+        lastUpdated: cachedLastUpdated,
+        issues: { items: [], endCursor: null, hasNextPage: false },
+        prs: { items: [], endCursor: null, hasNextPage: false },
+        stats: { issueCount: 1, prCount: 2, lastUpdated: cachedLastUpdated },
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(99);
+      });
+
+      // Flush so the hydration effect settles.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Network data must not be overwritten by older cache data.
+      expect(result.current.stats?.issueCount).toBe(99);
+      expect(result.current.stats?.prCount).toBe(88);
+      expect(result.current.stats?.commitCount).toBe(42);
+      expect(result.current.isStale).toBe(false);
+      expect(result.current.lastUpdated).toBe(networkLastUpdated);
+    });
+
+    it("does not seed items cache from a stats-only payload", async () => {
+      const project = { id: "p", path: "/repo/stats-only" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockImplementation(() => new Promise(() => {}));
+
+      const lastUpdated = Date.now() - 5_000;
+      // Stats-only: empty items arrays + valid stats (simulates first-page
+      // cache expired but stats still within 60-min bootstrap TTL).
+      getFirstPageCacheMock.mockResolvedValueOnce({
+        projectPath: project.path,
+        lastUpdated,
+        issues: { items: [], endCursor: null, hasNextPage: false },
+        prs: { items: [], endCursor: null, hasNextPage: false },
+        stats: { issueCount: 5, prCount: 3, lastUpdated },
+      });
+
+      renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getFirstPageCacheMock).toHaveBeenCalled();
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
+      const prsKey = buildCacheKey(project.path, "pr", "open", "created");
+      // Items cache must NOT be seeded from empty arrays.
+      expect(getCache(issuesKey)).toBeUndefined();
+      expect(getCache(prsKey)).toBeUndefined();
+    });
   });
 
   describe("rate limits", () => {

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -366,28 +366,50 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         if (!cached || cancelled || !mountedRef.current) return;
         if (cached.projectPath !== project.path) return;
 
+        // Seed toolbar counts from bootstrap stats so the pill renders cached
+        // counts immediately instead of an em-dash. The network poll will
+        // replace these with fresh data on its next tick.
+        if (cached.stats && lastUpdatedRef.current === null) {
+          const bootstrapStats: RepositoryStats = {
+            commitCount: 0,
+            issueCount: cached.stats.issueCount,
+            prCount: cached.stats.prCount,
+            loading: false,
+            stale: true,
+            lastUpdated: cached.stats.lastUpdated,
+          };
+          applyStatsResult(bootstrapStats, { projectPath: project.path });
+        }
+
         const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
         const prsKey = buildCacheKey(project.path, "pr", "open", "created");
         // Don't downgrade a fresher entry — the broadcast push from the first
         // poll can land before this hydration resolves, and disk data is up
         // to 10 minutes old.
-        const existingIssues = getCache(issuesKey);
-        if (!existingIssues || existingIssues.timestamp < cached.lastUpdated) {
-          setCache(issuesKey, {
-            items: cached.issues.items,
-            endCursor: cached.issues.endCursor,
-            hasNextPage: cached.issues.hasNextPage,
-            timestamp: cached.lastUpdated,
-          });
+        // Only seed items when the payload has actual items — a stats-only
+        // payload (first-page cache expired but stats within bootstrap TTL)
+        // has empty arrays that must not overwrite the renderer items cache.
+        if (cached.issues.items.length > 0) {
+          const existingIssues = getCache(issuesKey);
+          if (!existingIssues || existingIssues.timestamp < cached.lastUpdated) {
+            setCache(issuesKey, {
+              items: cached.issues.items,
+              endCursor: cached.issues.endCursor,
+              hasNextPage: cached.issues.hasNextPage,
+              timestamp: cached.lastUpdated,
+            });
+          }
         }
-        const existingPRs = getCache(prsKey);
-        if (!existingPRs || existingPRs.timestamp < cached.lastUpdated) {
-          setCache(prsKey, {
-            items: cached.prs.items,
-            endCursor: cached.prs.endCursor,
-            hasNextPage: cached.prs.hasNextPage,
-            timestamp: cached.lastUpdated,
-          });
+        if (cached.prs.items.length > 0) {
+          const existingPRs = getCache(prsKey);
+          if (!existingPRs || existingPRs.timestamp < cached.lastUpdated) {
+            setCache(prsKey, {
+              items: cached.prs.items,
+              endCursor: cached.prs.endCursor,
+              hasNextPage: cached.prs.hasNextPage,
+              timestamp: cached.lastUpdated,
+            });
+          }
         }
       } catch {
         // Disk hydration is best-effort; the network poll fallback covers
@@ -397,7 +419,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applyStatsResult]);
 
   // Subscribe to the combined repo-stats-and-first-page push from the main
   // process. Whenever a poll completes successfully, main broadcasts the

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -70,6 +70,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // `fetchedAt` is older than what we've already applied.
   const lastUpdatedRef = useRef<number | null>(null);
 
+  // Tracks whether any result (success, error, or stale) has already been
+  // applied to state. Set to true by applyStatsResult on first write, reset
+  // to false on project switch. Prevents the cold-start hydration from
+  // overwriting a network fetch result (including errors) that landed first.
+  const hasAppliedResultRef = useRef(false);
+
   // Preserve last known non-zero counts to prevent empty state flash during refresh
   const lastKnownCountsRef = useRef<{
     issueCount: number | null;
@@ -96,6 +102,8 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const applyStatsResult = useCallback(
     (repoStats: RepositoryStats, opts: { projectPath: string }) => {
       if (!mountedRef.current) return;
+
+      hasAppliedResultRef.current = true;
 
       // Track current project so a stale callback from a previous project
       // can be detected by `fetchStats`'s cross-project guard.
@@ -331,6 +339,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
       // Clear preserved counts on project switch to prevent cross-contamination
       lastKnownCountsRef.current = { issueCount: null, prCount: null, projectPath: null };
+      hasAppliedResultRef.current = false;
 
       setStats(null);
       setIsStale(false);
@@ -364,12 +373,19 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         if (!project || cancelled || !mountedRef.current) return;
         const cached = await githubClient.getFirstPageCache(project.path);
         if (!cached || cancelled || !mountedRef.current) return;
-        if (cached.projectPath !== project.path) return;
+
+        // Re-verify project identity after the async cache read. A project
+        // switch may have fired while we were waiting for the IPC response.
+        const currentProject = await projectClient.getCurrent();
+        if (cancelled || !mountedRef.current) return;
+        if (!currentProject || currentProject.path !== project.path) return;
+        if (cached.projectPath !== currentProject.path) return;
 
         // Seed toolbar counts from bootstrap stats so the pill renders cached
-        // counts immediately instead of an em-dash. The network poll will
-        // replace these with fresh data on its next tick.
-        if (cached.stats && lastUpdatedRef.current === null) {
+        // counts immediately instead of an em-dash. Only apply when no other
+        // result (network fetch success, error, or stale push) has landed
+        // yet — the network poll will replace these with fresh data.
+        if (cached.stats && !hasAppliedResultRef.current) {
           const bootstrapStats: RepositoryStats = {
             commitCount: 0,
             issueCount: cached.stats.issueCount,
@@ -378,11 +394,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
             stale: true,
             lastUpdated: cached.stats.lastUpdated,
           };
-          applyStatsResult(bootstrapStats, { projectPath: project.path });
+          applyStatsResult(bootstrapStats, { projectPath: currentProject.path });
         }
 
-        const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
-        const prsKey = buildCacheKey(project.path, "pr", "open", "created");
+        const issuesKey = buildCacheKey(currentProject.path, "issue", "open", "created");
+        const prsKey = buildCacheKey(currentProject.path, "pr", "open", "created");
         // Don't downgrade a fresher entry — the broadcast push from the first
         // poll can land before this hydration resolves, and disk data is up
         // to 10 minutes old.


### PR DESCRIPTION
## Summary

The toolbar pill flashes an em-dash placeholder for issue, PR, and commit counts on every cold launch, even when valid cached data is sitting on disk. This fix hydrates those counts before the first React paint so the pill always has real numbers in hand.

A separate bootstrap cache path with a 60-minute TTL feeds the cold-start path. The strict 10-minute polling TTL remains unchanged. If the network poll completes faster than the cache hydrate, the fresher data wins and the cached values are never applied.

Also fixes a cross-project hydration race: switching projects mid-load could apply stale counts from the previous project. The project identity is re-verified after the async IPC resolves to guard against that.

Resolves #6533

## Changes

- `getForBootstrap()` on `GitHubStatsCache` with a relaxed 60-minute TTL for the cold-start path
- Extended `getFirstPageCache` IPC payload with an optional `stats` field so counts reach the renderer before the network poll lands
- Stats-only fallback: returns counts from cache even when first-page items have expired but stats are still within the bootstrap window
- `hasAppliedResultRef` guard in the renderer hook prevents older cache data from overwriting fresher poll results, and prevents cross-project staleness
- Regression tests for both the bootstrap hydration path and the project-switch race
- Unit tests for the new `getForBootstrap` cache method

## Testing

Unit tests cover the cache layer (`GitHubStatsCache.test.ts`) and the renderer hook (`useRepositoryStats.test.tsx`), including the race condition and stats-only payload paths. Manual verification confirmed the pill renders real counts on cold start with no em-dash flash.