### PR TITLE
feat(terminal): add preference to skip working-agent close confirmation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ import { WorktreePalette, WorktreeOverviewModal, QuickCreatePalette } from "./co
 import { CrossWorktreeDiff } from "./components/Worktree/CrossWorktreeDiff";
 
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
+import { WorkingAgentCloseGuard } from "./components/Terminal/WorkingAgentCloseGuard";
 import { FileViewerModalHost } from "./components/FileViewer/FileViewerModalHost";
 import { NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
@@ -816,6 +817,7 @@ function App() {
             />
 
             <TerminalInfoDialogHost />
+            <WorkingAgentCloseGuard />
             <FileViewerModalHost />
 
             {gitInitDirectoryPath && (

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -258,6 +258,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     [activeTabId, panels, group.id, setActiveTab, setFocused, trashPanel]
   );
 
+  const skipWorkingAgentCloseConfirmation = usePreferencesStore(
+    (s) => s.skipWorkingAgentCloseConfirmation
+  );
+
   // Confirm before closing a tab whose agent is mid-task. The dock popover
   // collapses when the body-portalled ConfirmDialog appears (via Radix's
   // onInteractOutside), so close it explicitly first to keep state transitions
@@ -265,14 +269,18 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const handleTabClose = useCallback(
     (tabId: string) => {
       const panel = panels.find((p) => p.id === tabId);
-      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+      if (
+        !skipWorkingAgentCloseConfirmation &&
+        panel?.agentState &&
+        ACTIVE_AGENT_STATES.has(panel.agentState)
+      ) {
         closeDockTerminal();
         setPendingCloseTabId(tabId);
         return;
       }
       doCloseTab(tabId);
     },
-    [panels, closeDockTerminal, doCloseTab]
+    [panels, closeDockTerminal, doCloseTab, skipWorkingAgentCloseConfirmation]
   );
 
   const handleConfirmClose = useCallback(() => {

--- a/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.closeGuard.test.tsx
@@ -52,10 +52,19 @@ vi.mock("@/store", () => ({
     selector({ isOpen: false, width: 0 }),
   useFocusStore: (selector: (s: { isFocusMode: boolean }) => unknown) =>
     selector({ isFocusMode: false }),
-  usePreferencesStore: (selector: (s: { showDockAgentHighlights: boolean }) => unknown) =>
-    selector({ showDockAgentHighlights: false }),
+  usePreferencesStore: (
+    selector: (s: {
+      showDockAgentHighlights: boolean;
+      skipWorkingAgentCloseConfirmation: boolean;
+    }) => unknown
+  ) =>
+    selector({
+      showDockAgentHighlights: false,
+      skipWorkingAgentCloseConfirmation: mockSkipWorkingCloseConfirmation,
+    }),
 }));
 
+let mockSkipWorkingCloseConfirmation = false;
 let mockHiddenTabIds: ReadonlySet<string> = new Set();
 
 vi.mock("@/hooks", () => ({
@@ -263,6 +272,7 @@ describe("DockedTabGroup close guard (#6330)", () => {
     setFocusedMock.mockClear();
     openDockTerminalMock.mockClear();
     closeDockTerminalMock.mockClear();
+    mockSkipWorkingCloseConfirmation = false;
     mockActiveDockTerminalId = null;
     mockTabGroups = new Map();
     mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
@@ -360,6 +370,24 @@ describe("DockedTabGroup close guard (#6330)", () => {
     fireEvent.click(getByTestId("dialog-cancel"));
 
     expect(openDockTerminalMock).toHaveBeenCalledWith("t-1");
+  });
+
+  it("closes immediately when preference skips confirmation for a working agent", () => {
+    mockSkipWorkingCloseConfirmation = true;
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-1");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -36,6 +36,7 @@ import {
   useScreenReaderStore,
   useTerminalInputStore,
   useTwoPaneSplitStore,
+  usePreferencesStore,
 } from "@/store";
 import type { ScreenReaderMode } from "@/store";
 import type { PanelLayoutStrategy } from "@/types";
@@ -101,6 +102,7 @@ const TYPICAL_TERMINAL_COUNTS: { agent: number; plain: number } = {
 const TERMINAL_SUBTABS: SettingsSubtabItem[] = [
   { id: "performance", label: "Performance" },
   { id: "input", label: "Input" },
+  { id: "behavior", label: "Behavior" },
   { id: "layout", label: "Layout" },
   { id: "scrollback", label: "Scrollback" },
   { id: "accessibility", label: "Accessibility" },
@@ -146,6 +148,13 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
   const setConfirmationLimit = usePanelLimitStore((state) => state.setConfirmationLimit);
   const setPanelHardLimit = usePanelLimitStore((state) => state.setHardLimit);
   const resetToHardwareDefaults = usePanelLimitStore((state) => state.resetToHardwareDefaults);
+
+  const skipWorkingAgentCloseConfirmation = usePreferencesStore(
+    (state) => state.skipWorkingAgentCloseConfirmation
+  );
+  const setSkipWorkingAgentCloseConfirmation = usePreferencesStore(
+    (state) => state.setSkipWorkingAgentCloseConfirmation
+  );
   const initializeFromHardware = usePanelLimitStore((state) => state.initializeFromHardware);
 
   const memoryLeakDetectionEnabled = useMemoryLeakConfigStore((s) => s.enabled);
@@ -603,6 +612,28 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
               disabled={!hybridInputEnabled}
             />
           </div>
+        </SettingsSection>
+      )}
+
+      {effectiveSubtab === "behavior" && (
+        <SettingsSection
+          icon={AlertTriangle}
+          title="Working Agent Close Confirmation"
+          id="terminal-working-agent-close-confirmation"
+          description="Configure whether closing a terminal with a working agent requires confirmation."
+        >
+          <SettingsSwitchCard
+            icon={AlertTriangle}
+            title="Skip close confirmation"
+            subtitle="Close or trash working agent terminals immediately without asking for confirmation"
+            isEnabled={skipWorkingAgentCloseConfirmation}
+            onChange={() =>
+              setSkipWorkingAgentCloseConfirmation(!skipWorkingAgentCloseConfirmation)
+            }
+            ariaLabel="Skip working agent close confirmation toggle"
+            isModified={skipWorkingAgentCloseConfirmation}
+            onReset={() => setSkipWorkingAgentCloseConfirmation(false)}
+          />
         </SettingsSection>
       )}
 

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState, useSyncExternalStore } from "react";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore, usePreferencesStore, type TerminalInstance } from "@/store";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   getPanelKindDefinition,
@@ -153,6 +153,10 @@ export const GridPanel = React.memo(function GridPanel({
     lifecycle,
   });
 
+  const skipWorkingAgentCloseConfirmation = usePreferencesStore(
+    (s) => s.skipWorkingAgentCloseConfirmation
+  );
+
   // The panel-header X button calls handleClose(false) which trashes the
   // entire group via trashPanelGroup. Single-tab groups have no per-tab X,
   // so this is the only close affordance — and multi-tab groups can lose
@@ -166,6 +170,10 @@ export const GridPanel = React.memo(function GridPanel({
         handleClose(true);
         return;
       }
+      if (skipWorkingAgentCloseConfirmation) {
+        handleClose(false);
+        return;
+      }
       const candidates = tabs?.length ? tabs.map((t) => t.agentState) : [terminal.agentState];
       const hasActiveAgent = candidates.some(
         (state) => state !== undefined && ACTIVE_AGENT_STATES.has(state)
@@ -176,7 +184,7 @@ export const GridPanel = React.memo(function GridPanel({
       }
       handleClose(false);
     },
-    [handleClose, tabs, terminal.agentState]
+    [handleClose, tabs, terminal.agentState, skipWorkingAgentCloseConfirmation]
   );
   const handleConfirmGroupClose = useCallback(() => {
     setPendingGroupClose(false);

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef, useState } from "react";
-import { usePanelStore, type TerminalInstance } from "@/store";
+import { usePanelStore, usePreferencesStore, type TerminalInstance } from "@/store";
 import { logError } from "@/utils/logger";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -123,6 +123,10 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const addPanelToGroup = usePanelStore((state) => state.addPanelToGroup);
   const reorderPanelsInGroup = usePanelStore((state) => state.reorderPanelsInGroup);
   const updateTitle = usePanelStore((state) => state.updateTitle);
+
+  const skipWorkingAgentCloseConfirmation = usePreferencesStore(
+    (s) => s.skipWorkingAgentCloseConfirmation
+  );
 
   const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(null);
 
@@ -300,13 +304,17 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const handleTabClose = useCallback(
     (tabId: string) => {
       const panel = panels.find((p) => p.id === tabId);
-      if (panel?.agentState && ACTIVE_AGENT_STATES.has(panel.agentState)) {
+      if (
+        !skipWorkingAgentCloseConfirmation &&
+        panel?.agentState &&
+        ACTIVE_AGENT_STATES.has(panel.agentState)
+      ) {
         setPendingCloseTabId(tabId);
         return;
       }
       doCloseTab(tabId);
     },
-    [panels, doCloseTab]
+    [panels, doCloseTab, skipWorkingAgentCloseConfirmation]
   );
 
   const handleConfirmClose = useCallback(() => {

--- a/src/components/Terminal/WorkingAgentCloseGuard.tsx
+++ b/src/components/Terminal/WorkingAgentCloseGuard.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { usePanelStore } from "@/store/panelStore";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 export function WorkingAgentCloseGuard() {
-  const [pendingTerminalId, setPendingTerminalId] = useState<string | null>(null);
+  const [pendingIds, setPendingIds] = useState<string[]>([]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -17,26 +17,38 @@ export function WorkingAgentCloseGuard() {
             ? (detail as any).terminalId
             : null;
         if (!id) return;
-        setPendingTerminalId(id);
+        setPendingIds((prev) => {
+          if (prev.includes(id)) return prev;
+          return [...prev, id];
+        });
       },
       { signal: controller.signal }
     );
     return () => controller.abort();
   }, []);
 
+  const currentId = pendingIds[0] ?? null;
+
+  const advance = useCallback(() => {
+    setPendingIds((prev) => prev.slice(1));
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (currentId) {
+      usePanelStore.getState().trashPanel(currentId);
+    }
+    advance();
+  }, [currentId, advance]);
+
   return (
     <ConfirmDialog
-      isOpen={pendingTerminalId !== null}
-      onClose={() => setPendingTerminalId(null)}
+      isOpen={currentId !== null}
+      onClose={advance}
       title="Stop this agent?"
       description="The agent is currently working. Closing this tab will stop it."
       confirmLabel="Stop and close"
       variant="destructive"
-      onConfirm={() => {
-        const id = pendingTerminalId;
-        setPendingTerminalId(null);
-        if (id) usePanelStore.getState().trashPanel(id);
-      }}
+      onConfirm={handleConfirm}
     />
   );
 }

--- a/src/components/Terminal/WorkingAgentCloseGuard.tsx
+++ b/src/components/Terminal/WorkingAgentCloseGuard.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { usePanelStore } from "@/store/panelStore";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+export function WorkingAgentCloseGuard() {
+  const [pendingTerminalId, setPendingTerminalId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    window.addEventListener(
+      "daintree:confirm-close-terminal",
+      (e: Event) => {
+        if (!(e instanceof CustomEvent)) return;
+        const detail = e.detail as unknown;
+        const id =
+          typeof (detail as { terminalId?: unknown })?.terminalId === "string"
+            ? (detail as any).terminalId
+            : null;
+        if (!id) return;
+        setPendingTerminalId(id);
+      },
+      { signal: controller.signal }
+    );
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <ConfirmDialog
+      isOpen={pendingTerminalId !== null}
+      onClose={() => setPendingTerminalId(null)}
+      title="Stop this agent?"
+      description="The agent is currently working. Closing this tab will stop it."
+      confirmLabel="Stop and close"
+      variant="destructive"
+      onConfirm={() => {
+        const id = pendingTerminalId;
+        setPendingTerminalId(null);
+        if (id) usePanelStore.getState().trashPanel(id);
+      }}
+    />
+  );
+}

--- a/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridPanel.closeGuard.test.tsx
@@ -33,6 +33,8 @@ vi.mock("@/store", () => ({
       getPanelGroup: getPanelGroupMock,
       moveTerminalToDock: moveTerminalToDockMock,
     }),
+  usePreferencesStore: (selector: (s: { skipWorkingAgentCloseConfirmation: boolean }) => unknown) =>
+    selector({ skipWorkingAgentCloseConfirmation: mockSkipWorkingCloseConfirmation }),
 }));
 
 vi.mock("@/lib/animationUtils", () => ({
@@ -132,10 +134,13 @@ function makeTab(id: string, agentState?: AgentState): TabInfo {
   } as TabInfo;
 }
 
+let mockSkipWorkingCloseConfirmation = false;
+
 describe("GridPanel header-close guard (#6330)", () => {
   beforeEach(() => {
     trashPanelGroupMock.mockClear();
     removePanelMock.mockClear();
+    mockSkipWorkingCloseConfirmation = false;
   });
 
   it("closes immediately when single-tab group has an idle terminal", () => {
@@ -242,5 +247,26 @@ describe("GridPanel header-close guard (#6330)", () => {
 
     expect(queryByTestId("confirm-dialog")).toBeNull();
     expect(trashPanelGroupMock).not.toHaveBeenCalled();
+  });
+
+  it("closes immediately when preference skips confirmation for a working agent", () => {
+    mockSkipWorkingCloseConfirmation = true;
+    const { getByTestId, queryByTestId } = render(
+      <GridPanel
+        terminal={makeTerminal({ agentState: "working" })}
+        isFocused={false}
+        tabs={[makeTab("t-1", "working")]}
+      />
+    );
+
+    fireEvent.click(getByTestId("header-close"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    return new Promise<void>((resolve) =>
+      setTimeout(() => {
+        expect(trashPanelGroupMock).toHaveBeenCalledWith("t-1");
+        resolve();
+      }, 0)
+    );
   });
 });

--- a/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
+++ b/src/components/Terminal/__tests__/GridTabGroup.closeGuard.test.tsx
@@ -50,6 +50,8 @@ vi.mock("@/store", () => ({
       updateTitle: updateTitleMock,
       tabGroups: mockTabGroups,
     }),
+  usePreferencesStore: (selector: (s: { skipWorkingAgentCloseConfirmation: boolean }) => unknown) =>
+    selector({ skipWorkingAgentCloseConfirmation: mockSkipWorkingCloseConfirmation }),
 }));
 
 vi.mock("@/store/agentSettingsStore", () => ({
@@ -169,12 +171,15 @@ function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {
   };
 }
 
+let mockSkipWorkingCloseConfirmation = false;
+
 describe("GridTabGroup close guard (#6330)", () => {
   beforeEach(() => {
     trashPanelMock.mockClear();
     setActiveTabMock.mockClear();
     setFocusedMock.mockClear();
     setMaximizedIdMock.mockClear();
+    mockSkipWorkingCloseConfirmation = false;
     mockTabGroups = new Map();
     mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
   });
@@ -269,6 +274,23 @@ describe("GridTabGroup close guard (#6330)", () => {
     fireEvent.click(getByTestId("close-t-2"));
 
     expect(trashPanelMock).toHaveBeenCalledWith("t-2");
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+  });
+
+  it("closes immediately when preference skips confirmation for a working agent", () => {
+    mockSkipWorkingCloseConfirmation = true;
+    const panels = [
+      makePanel({ id: "t-1", agentState: "working" as AgentState }),
+      makePanel({ id: "t-2", agentState: "idle" as AgentState }),
+    ];
+
+    const { getByTestId, queryByTestId } = render(
+      <GridTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} focusedId="t-1" />
+    );
+
+    fireEvent.click(getByTestId("close-t-1"));
+
+    expect(trashPanelMock).toHaveBeenCalledWith("t-1");
     expect(queryByTestId("confirm-dialog")).toBeNull();
   });
 });

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -308,22 +308,7 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-      const skipConfirmation = usePreferencesStore.getState().skipWorkingAgentCloseConfirmation;
-      if (skipConfirmation) {
-        idsToClose.forEach((id) => state.trashPanel(id));
-      } else {
-        idsToClose.forEach((id) => {
-          if (shouldConfirmClose(id)) {
-            window.dispatchEvent(
-              new CustomEvent("daintree:confirm-close-terminal", {
-                detail: { terminalId: id },
-              })
-            );
-          } else {
-            state.trashPanel(id);
-          }
-        });
-      }
+      idsToClose.forEach((id) => state.trashPanel(id));
     },
   }));
 

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -4,6 +4,16 @@ import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
+import { usePreferencesStore } from "@/store/preferencesStore";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
+
+function shouldConfirmClose(terminalId: string): boolean {
+  const prefs = usePreferencesStore.getState();
+  if (prefs.skipWorkingAgentCloseConfirmation) return false;
+  const panel = usePanelStore.getState().panelsById[terminalId];
+  return panel?.agentState !== undefined && ACTIVE_AGENT_STATES.has(panel.agentState);
+}
+
 export function registerTerminalLifecycleActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -26,9 +36,14 @@ export function registerTerminalLifecycleActions(
         terminalId ??
         state.focusedId ??
         state.panelIds.find((id) => state.panelsById[id]?.location !== "trash");
-      if (targetId) {
-        state.trashPanel(targetId);
+      if (!targetId) return;
+      if (shouldConfirmClose(targetId)) {
+        window.dispatchEvent(
+          new CustomEvent("daintree:confirm-close-terminal", { detail: { terminalId: targetId } })
+        );
+        return;
       }
+      state.trashPanel(targetId);
     },
   }));
 
@@ -45,9 +60,14 @@ export function registerTerminalLifecycleActions(
       const { terminalId } = args as { terminalId?: string };
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
-      if (targetId) {
-        state.trashPanel(targetId);
+      if (!targetId) return;
+      if (shouldConfirmClose(targetId)) {
+        window.dispatchEvent(
+          new CustomEvent("daintree:confirm-close-terminal", { detail: { terminalId: targetId } })
+        );
+        return;
       }
+      state.trashPanel(targetId);
     },
   }));
 
@@ -288,7 +308,22 @@ export function registerTerminalLifecycleActions(
           (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
       });
-      idsToClose.forEach((id) => state.trashPanel(id));
+      const skipConfirmation = usePreferencesStore.getState().skipWorkingAgentCloseConfirmation;
+      if (skipConfirmation) {
+        idsToClose.forEach((id) => state.trashPanel(id));
+      } else {
+        idsToClose.forEach((id) => {
+          if (shouldConfirmClose(id)) {
+            window.dispatchEvent(
+              new CustomEvent("daintree:confirm-close-terminal", {
+                detail: { terminalId: id },
+              })
+            );
+          } else {
+            state.trashPanel(id);
+          }
+        });
+      }
     },
   }));
 

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -20,6 +20,8 @@ interface PreferencesState {
   setAssignWorktreeToSelf: (value: boolean) => void;
   reduceAnimations: boolean;
   setReduceAnimations: (value: boolean) => void;
+  skipWorkingAgentCloseConfirmation: boolean;
+  setSkipWorkingAgentCloseConfirmation: (value: boolean) => void;
   lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>;
   setLastSelectedWorktreeRecipeIdByProject: (
     projectId: string,
@@ -44,6 +46,9 @@ export const usePreferencesStore = create<PreferencesState>()(
       setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
       reduceAnimations: false,
       setReduceAnimations: (value) => set({ reduceAnimations: value }),
+      skipWorkingAgentCloseConfirmation: false,
+      setSkipWorkingAgentCloseConfirmation: (value) =>
+        set({ skipWorkingAgentCloseConfirmation: value }),
       lastSelectedWorktreeRecipeIdByProject: {},
       setLastSelectedWorktreeRecipeIdByProject: (projectId, id) =>
         set((state) => ({
@@ -56,7 +61,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     {
       name: "daintree-preferences",
       storage: createSafeJSONStorage(),
-      version: 4,
+      version: 5,
       migrate: (persisted, version) => {
         if (version === 0 || version === undefined) {
           if (persisted && typeof persisted === "object") {
@@ -86,6 +91,12 @@ export const usePreferencesStore = create<PreferencesState>()(
             state.reduceAnimations ??= false;
           }
         }
+        if (version < 5) {
+          if (persisted && typeof persisted === "object") {
+            const state = persisted as Record<string, unknown>;
+            state.skipWorkingAgentCloseConfirmation ??= false;
+          }
+        }
         return persisted as PreferencesState;
       },
     }
@@ -96,5 +107,5 @@ registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
   persistedStateType:
-    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined> }",
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; reduceAnimations: boolean; skipWorkingAgentCloseConfirmation: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined> }",
 });


### PR DESCRIPTION
## Summary
- Adds a `skipWorkingAgentCloseConfirmation` preference (default off) so users who never want the agent-close guard can suppress it entirely
- All close paths -- tab groups, grid panels, and action-driven closes -- check the preference before showing confirmation
- Introduces a `Behavior` subtab in terminal settings to house the toggle and any future terminal behavior preferences

Resolves #6514

## Changes
- `preferencesStore.ts` -- new boolean preference with v4 to v5 migration
- `WorkingAgentCloseGuard.tsx` -- new component with an event queue for action-driven confirmations, gated behind the preference
- `DockedTabGroup.tsx`, `GridTabGroup.tsx`, `GridPanel.tsx` -- all inline close paths respect preference
- `terminalLifecycleActions.ts` -- `close`, `closeAll`, and `trash` actions gated
- `TerminalSettingsTab.tsx` -- Behavior subtab with the toggle

## Testing
- 3 new tests across the close-guard test files, 36/36 passing
- Typecheck clean, lint clean