### PR TITLE
feat(mcp): enforce per-tier authorization at dispatch time

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -48,12 +48,144 @@ const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "system",
 ]);
 
-// Curated set of action IDs advertised over MCP by default. Keeps the tool
-// surface small enough for `tool_choice: "auto"` reliability and bounded
-// token cost while still covering the agent-facing introspection,
-// query, and command actions. Power users opt into the full surface via
-// `mcpServer.fullToolSurface = true`. Dispatch is not gated by this list —
-// callers that already know an ID can still invoke it.
+/**
+ * Source-tier classification for an authenticated MCP connection. Each
+ * connection is stamped with a tier at session-creation time and that tier
+ * gates every `CallTool` and `ListTools` request for the session's
+ * lifetime. Tiers are strictly nested: `workbench ⊂ action ⊂ system`, with
+ * `external` carrying its own legacy curated allowlist for backward
+ * compatibility with the pre-tier user-facing server.
+ *
+ * - `workbench` — read-only Daintree introspection (queries, file/diff
+ *   reads, listings). The default for project agents that opt in.
+ * - `action` — workbench plus non-destructive mutations (create worktree,
+ *   run recipe, inject text into a terminal, panel manipulation). Default
+ *   for the help assistant.
+ * - `system` — action plus destructive operations (delete worktree, send
+ *   raw terminal commands, git mutations, agent.launch). Reserved for
+ *   "skip permissions" or explicitly-elevated external clients.
+ * - `external` — today's curated allowlist, tied to the global apiKey.
+ */
+export type McpTier = "workbench" | "action" | "system" | "external";
+
+/**
+ * Workbench tier — read-only introspection and queries. No mutations, no
+ * external network side effects. Walks of the action manifest filtered by
+ * `kind: "query"` plus a small set of safe-to-read commands.
+ */
+const WORKBENCH_TOOLS: ReadonlySet<string> = new Set([
+  "actions.list",
+  "actions.getContext",
+
+  "project.getAll",
+  "project.getCurrent",
+  "project.getSettings",
+  "project.getStats",
+  "project.detectRunners",
+
+  "worktree.list",
+  "worktree.getCurrent",
+  "worktree.listBranches",
+  "worktree.getDefaultPath",
+  "worktree.getAvailableBranch",
+  "worktree.resource.status",
+
+  "files.search",
+  "file.view",
+
+  "copyTree.isAvailable",
+  "copyTree.generate",
+
+  "terminal.list",
+  "terminal.getOutput",
+
+  "slashCommands.list",
+
+  "git.getProjectPulse",
+  "git.getFileDiff",
+  "git.listCommits",
+  "git.getStagingStatus",
+  "git.snapshotGet",
+  "git.snapshotList",
+
+  "github.checkCli",
+  "github.getRepoStats",
+  "github.listIssues",
+  "github.listPullRequests",
+
+  "system.checkCommand",
+  "system.checkDirectory",
+]);
+
+/**
+ * Action tier additions — non-destructive mutations layered on top of
+ * workbench. Creates resources and injects context into existing terminals,
+ * but does not delete, send raw input, or commit/push git state.
+ */
+const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
+  "worktree.create",
+  "worktree.createWithRecipe",
+  "worktree.setActive",
+  "worktree.refresh",
+
+  "terminal.inject",
+  "terminal.new",
+
+  "recipe.list",
+  "recipe.run",
+
+  "copyTree.injectToTerminal",
+  "copyTree.generateAndCopyFile",
+
+  "file.openInEditor",
+
+  "agent.focusNextWaiting",
+  "agent.focusNextWorking",
+]);
+
+/**
+ * System tier additions — destructive or privileged operations layered on
+ * top of action. Includes deleting worktrees, raw terminal input, git
+ * mutations, and launching new agents.
+ */
+const SYSTEM_TIER_ADDONS: ReadonlySet<string> = new Set([
+  "worktree.delete",
+
+  "terminal.sendCommand",
+  "terminal.bulkCommand",
+
+  "git.stageFile",
+  "git.unstageFile",
+  "git.stageAll",
+  "git.unstageAll",
+  "git.commit",
+  "git.push",
+  "git.snapshotRevert",
+  "git.snapshotDelete",
+
+  "github.openIssue",
+  "github.openPR",
+
+  "agent.launch",
+  "agent.terminal",
+]);
+
+function unionSet(...sets: ReadonlySet<string>[]): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const set of sets) {
+    for (const value of set) out.add(value);
+  }
+  return out;
+}
+
+// External tier — curated set of action IDs advertised over MCP for the
+// legacy user-facing server. Keeps the tool surface small enough for
+// `tool_choice: "auto"` reliability and bounded token cost while still
+// covering the agent-facing introspection, query, and command actions.
+// Power users opt into the full surface via `mcpServer.fullToolSurface =
+// true`. Tier-gated dispatch enforces this list at CallTool time — a
+// caller that knows an action ID outside this set will receive a
+// `TIER_NOT_PERMITTED` rejection.
 const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "actions.list",
   "actions.getContext",
@@ -126,6 +258,23 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "system.checkDirectory",
 ]);
 
+/**
+ * Per-tier allowlist of action IDs. Tiers are additive: `action` is the
+ * union of `workbench` plus its addons; `system` adds further on top of
+ * `action`. Callers should treat these as the authoritative gate for both
+ * `ListTools` filtering and `CallTool` dispatch. `external` is intentionally
+ * NOT a superset of `system` — it tracks the legacy curated allowlist so
+ * existing apiKey clients keep seeing the same tools they always have.
+ */
+const TIER_ALLOWLISTS: Readonly<Record<McpTier, ReadonlySet<string>>> = {
+  workbench: WORKBENCH_TOOLS,
+  action: unionSet(WORKBENCH_TOOLS, ACTION_TIER_ADDONS),
+  system: unionSet(WORKBENCH_TOOLS, ACTION_TIER_ADDONS, SYSTEM_TIER_ADDONS),
+  external: MCP_TOOL_ALLOWLIST,
+};
+
+const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
+
 interface PendingRequest<T> {
   resolve: (value: T) => void;
   reject: (err: Error) => void;
@@ -137,12 +286,6 @@ interface PendingRequest<T> {
 interface McpSseSession {
   transport: SSEServerTransport;
   idleTimer: ReturnType<typeof setTimeout>;
-  /**
-   * Source-tier classification for the SSE peer. Will be populated by the
-   * tier-policy work in #6517; until then every record is tagged
-   * `"unknown"`.
-   */
-  tier?: string;
 }
 
 interface McpHttpSession {
@@ -206,6 +349,14 @@ export class McpServerService {
   private starting = false;
   private sessions = new Map<string, McpSseSession>();
   private httpSessions = new Map<string, McpHttpSession>();
+  /**
+   * Authoritative session-id → tier map used by both transports. Written
+   * when a new SSE or HTTP session is created (after the request has
+   * already passed `isAuthorized`) and read inside the `CallTool` /
+   * `ListTools` handlers via `getSessionTier`. Cleared in the matching
+   * `transport.onclose` and idle-eviction paths.
+   */
+  private sessionTierMap = new Map<string, McpTier>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
   private cleanupListeners: Array<() => void> = [];
@@ -378,10 +529,16 @@ export class McpServerService {
   }
 
   private classifyDispatchResult(
-    outcome: { kind: "result"; value: ActionDispatchResult } | { kind: "throw"; error: unknown }
+    outcome:
+      | { kind: "result"; value: ActionDispatchResult }
+      | { kind: "throw"; error: unknown }
+      | { kind: "unauthorized" }
   ): { result: McpAuditResult; errorCode?: string } {
     if (outcome.kind === "throw") {
       return { result: "error", errorCode: "DISPATCH_THREW" };
+    }
+    if (outcome.kind === "unauthorized") {
+      return { result: "unauthorized", errorCode: TIER_NOT_PERMITTED_CODE };
     }
     const value = outcome.value;
     if (value.ok) return { result: "success" };
@@ -394,10 +551,13 @@ export class McpServerService {
   private appendAuditRecord(input: {
     toolId: string;
     sessionId: string;
-    tier: string | undefined;
+    tier: McpTier;
     args: unknown;
     durationMs: number;
-    outcome: { kind: "result"; value: ActionDispatchResult } | { kind: "throw"; error: unknown };
+    outcome:
+      | { kind: "result"; value: ActionDispatchResult }
+      | { kind: "throw"; error: unknown }
+      | { kind: "unauthorized" };
   }): void {
     // `=== false` so legacy persisted configs (undefined) default to enabled,
     // matching `getAuditConfig()`. A bare `!auditEnabled` would silently drop
@@ -411,7 +571,7 @@ export class McpServerService {
       timestamp: Date.now(),
       toolId: input.toolId,
       sessionId: input.sessionId,
-      tier: input.tier ?? "unknown",
+      tier: input.tier,
       argsSummary: this.redactArgsSummary(input.args),
       result: classification.result,
       durationMs: Math.max(0, Math.round(input.durationMs)),
@@ -574,6 +734,7 @@ export class McpServerService {
       }
     }
     this.httpSessions.clear();
+    this.sessionTierMap.clear();
 
     for (const cleanup of this.cleanupListeners) {
       cleanup();
@@ -853,9 +1014,10 @@ export class McpServerService {
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
       const manifest = await this.requestManifest();
+      const tier = this.getSessionTier(sessionId);
       return {
         tools: manifest
-          .filter((entry) => this.shouldExposeTool(entry))
+          .filter((entry) => this.shouldExposeTool(entry, tier))
           .map((entry) => ({
             name: entry.id,
             description: this.buildToolDescription(entry),
@@ -869,7 +1031,32 @@ export class McpServerService {
       const actionId = request.params.name;
       const { args, confirmed } = this.parseToolArguments(request.params.arguments);
       const startedAt = Date.now();
-      const tier = this.sessions.get(sessionId)?.tier;
+      const tier = this.getSessionTier(sessionId);
+
+      if (!this.isTierPermitted(tier, actionId)) {
+        try {
+          this.appendAuditRecord({
+            toolId: actionId,
+            sessionId,
+            tier,
+            args,
+            durationMs: Date.now() - startedAt,
+            outcome: { kind: "unauthorized" },
+          });
+        } catch (err) {
+          console.error("[MCP] Failed to append audit record:", err);
+        }
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error [${TIER_NOT_PERMITTED_CODE}]: action '${actionId}' is not permitted for the '${tier}' tier.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
       let outcome:
         | { kind: "result"; value: ActionDispatchResult }
         | { kind: "throw"; error: unknown };
@@ -967,14 +1154,67 @@ export class McpServerService {
     return origin === `http://127.0.0.1:${this.port}` || origin === `http://localhost:${this.port}`;
   }
 
-  private shouldExposeTool(entry: ActionManifestEntry): boolean {
+  /**
+   * Returns true if the entry should be advertised to a session at the
+   * given tier. `restricted` actions are never advertised regardless of
+   * tier. `fullToolSurface` widens the surface only for the `external`
+   * tier — tier allowlists are security boundaries for the other tiers,
+   * not convenience filters that can be opted out of.
+   */
+  private shouldExposeTool(entry: ActionManifestEntry, tier: McpTier): boolean {
     if (entry.danger === "restricted") {
       return false;
     }
-    if (this.getConfig().fullToolSurface === true) {
+    if (tier === "external" && this.getConfig().fullToolSurface === true) {
       return true;
     }
-    return MCP_TOOL_ALLOWLIST.has(entry.id);
+    return TIER_ALLOWLISTS[tier].has(entry.id);
+  }
+
+  /** Hard gate consulted before every CallTool dispatch. */
+  private isTierPermitted(tier: McpTier, actionId: string): boolean {
+    return TIER_ALLOWLISTS[tier].has(actionId);
+  }
+
+  /**
+   * Read the tier stamped on the session by the connection-time auth
+   * resolver. Falls back to `"workbench"` — the most restrictive tier — so
+   * a session that somehow escaped tier stamping cannot elevate access by
+   * default.
+   */
+  private getSessionTier(sessionId: string): McpTier {
+    return this.sessionTierMap.get(sessionId) ?? "workbench";
+  }
+
+  /**
+   * Resolve the source-tier classification for an authenticated request.
+   * Mirrors the three branches of `isAuthorized`:
+   *   1. Bearer matches the global apiKey → `"external"` (legacy server).
+   *   2. Bearer matches a per-pane token → `"workbench"` (project agents).
+   *   3. No `Authorization` header and no apiKey configured → `"external"`
+   *      (legacy permissive path; preserves pre-auth behavior).
+   * Falls back to `"workbench"` for anything that slipped through but
+   * isn't recognized.
+   */
+  private resolveTokenTier(req: http.IncomingMessage): McpTier {
+    const apiKey = this.getConfig().apiKey;
+    const auth = req.headers.authorization ?? "";
+
+    if (apiKey) {
+      const expected = `Bearer ${apiKey}`;
+      const actualHash = createHash("sha256").update(auth).digest();
+      const expectedHash = createHash("sha256").update(expected).digest();
+      if (timingSafeEqual(actualHash, expectedHash)) return "external";
+    } else if (auth.length === 0) {
+      return "external";
+    }
+
+    if (auth.startsWith("Bearer ")) {
+      const token = auth.slice("Bearer ".length);
+      if (mcpPaneConfigService.isValidPaneToken(token)) return "workbench";
+    }
+
+    return "workbench";
   }
 
   private buildToolDescription(entry: ActionManifestEntry): string {
@@ -1120,6 +1360,8 @@ export class McpServerService {
         allowedOrigins,
       });
       const sessionId = transport.sessionId;
+      const tier = this.resolveTokenTier(req);
+      this.sessionTierMap.set(sessionId, tier);
       const server = this.createSessionServer(sessionId);
 
       const idleTimer = this.createIdleTimer(sessionId);
@@ -1130,6 +1372,7 @@ export class McpServerService {
           clearTimeout(session.idleTimer);
           this.sessions.delete(sessionId);
         }
+        this.sessionTierMap.delete(sessionId);
       };
 
       await server.connect(transport);
@@ -1190,6 +1433,12 @@ export class McpServerService {
     // id via `sessionIdGenerator`, keeping the audit log keyed consistently
     // with the entry in `httpSessions`.
     const newSessionId = randomUUID();
+    // Resolve the tier from the initialize request's Authorization header
+    // and stamp it eagerly. The token is stable for the lifetime of the
+    // transport, so resolving once at connection time avoids re-hashing
+    // on every CallTool.
+    const tier = this.resolveTokenTier(req);
+    this.sessionTierMap.set(newSessionId, tier);
     const server = this.createSessionServer(newSessionId);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => newSessionId,
@@ -1207,6 +1456,7 @@ export class McpServerService {
         clearTimeout(session.idleTimer);
         this.httpSessions.delete(id);
       }
+      this.sessionTierMap.delete(id);
     };
 
     try {
@@ -1221,6 +1471,9 @@ export class McpServerService {
           clearTimeout(session.idleTimer);
           this.httpSessions.delete(id);
         }
+        this.sessionTierMap.delete(id);
+      } else {
+        this.sessionTierMap.delete(newSessionId);
       }
       await transport.close().catch(() => {});
       if (!res.headersSent) {
@@ -1235,6 +1488,7 @@ export class McpServerService {
       const session = this.httpSessions.get(sessionId);
       if (!session) return;
       this.httpSessions.delete(sessionId);
+      this.sessionTierMap.delete(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
       });
@@ -1255,6 +1509,7 @@ export class McpServerService {
       const session = this.sessions.get(sessionId);
       if (!session) return;
       this.sessions.delete(sessionId);
+      this.sessionTierMap.delete(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
       });

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1171,8 +1171,17 @@ export class McpServerService {
     return TIER_ALLOWLISTS[tier].has(entry.id);
   }
 
-  /** Hard gate consulted before every CallTool dispatch. */
+  /**
+   * Hard gate consulted before every CallTool dispatch. Mirrors
+   * `shouldExposeTool` so a tool that appears in `ListTools` is always
+   * callable — `fullToolSurface=true` widens the external tier for both
+   * listing and dispatch in lockstep. The non-external tiers ignore the
+   * flag because their allowlists are security boundaries.
+   */
   private isTierPermitted(tier: McpTier, actionId: string): boolean {
+    if (tier === "external" && this.getConfig().fullToolSurface === true) {
+      return true;
+    }
     return TIER_ALLOWLISTS[tier].has(actionId);
   }
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -112,6 +112,14 @@ vi.mock("../../store.js", () => ({
   },
 }));
 
+const paneTokens = vi.hoisted(() => new Set<string>());
+
+vi.mock("../McpPaneConfigService.js", () => ({
+  mcpPaneConfigService: {
+    isValidPaneToken: (token: string) => paneTokens.has(token),
+  },
+}));
+
 import { McpServerService } from "../McpServerService.js";
 
 type DispatchRequest = {
@@ -405,6 +413,7 @@ describe("McpServerService", () => {
     };
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
+    paneTokens.clear();
     electronMocks.ipcMain.removeAllListeners();
     electronMocks.ipcMain.handle.mockClear();
     electronMocks.ipcMain.removeHandler.mockClear();
@@ -1084,7 +1093,7 @@ describe("McpServerService", () => {
     expect(ids).not.toContain("panel.gridLayout.setStrategy");
   });
 
-  it("dispatches non-allowlisted actions even in curated mode", async () => {
+  it("denies non-allowlisted actions for the external tier (dispatch never reached)", async () => {
     const dispatchMock = vi.fn(
       (payload: DispatchRequest): ActionDispatchResult => ({
         ok: true,
@@ -1118,11 +1127,241 @@ describe("McpServerService", () => {
       })
     );
 
-    expect(result.isError).not.toBe(true);
-    expect(result.content[0].text).toContain('"dispatched": "panel.gridLayout.setStrategy"');
-    expect(dispatchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ actionId: "panel.gridLayout.setStrategy" })
-    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("TIER_NOT_PERMITTED");
+    expect(result.content[0].text).toContain("panel.gridLayout.setStrategy");
+    expect(result.content[0].text).toContain("external");
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  describe("tier authorization", () => {
+    type AuditRecord = {
+      id: string;
+      timestamp: number;
+      toolId: string;
+      sessionId: string;
+      tier: string;
+      argsSummary: string;
+      result: "success" | "error" | "confirmation-pending" | "unauthorized";
+      errorCode?: string;
+      durationMs: number;
+    };
+
+    function getAuditRecords(svc: McpServerService): AuditRecord[] {
+      return (svc as unknown as { getAuditRecords: () => AuditRecord[] }).getAuditRecords();
+    }
+
+    async function connectWorkbench(
+      port: number
+    ): Promise<{ client: Client; transport: SSEClientTransport; token: string }> {
+      const token = `pane-token-${Math.random().toString(36).slice(2)}`;
+      paneTokens.add(token);
+      const client = new Client({ name: "mcp-pane-client", version: "1.0.0" });
+      const headers = { Authorization: `Bearer ${token}` };
+      const transport = new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`), {
+        eventSourceInit: { headers } as never,
+        requestInit: { headers },
+      });
+      await client.connect(transport);
+      return { client, transport, token };
+    }
+
+    function manifestForAllAllowlistedTools(): ActionManifestEntry[] {
+      const ids = [
+        "actions.list",
+        "worktree.list",
+        "worktree.create",
+        "worktree.delete",
+        "terminal.list",
+        "terminal.inject",
+        "terminal.sendCommand",
+        "recipe.run",
+        "git.commit",
+      ];
+      return ids.map((id) =>
+        createManifestEntry({
+          id: id as ActionId,
+          title: id,
+          description: id,
+        })
+      );
+    }
+
+    it("workbench tier: allows queries, denies mutations, and never reaches dispatch on denial", async () => {
+      const dispatchMock = vi.fn(
+        (payload: DispatchRequest): ActionDispatchResult => ({
+          ok: true,
+          result: { dispatched: payload.actionId },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectWorkbench(service.currentPort!);
+      transports.push(transport);
+
+      // Query allowed
+      const allowed = getTextResult(
+        await client.callTool({ name: "actions.list", arguments: {} })
+      );
+      expect(allowed.isError).not.toBe(true);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ actionId: "actions.list" })
+      );
+      dispatchMock.mockClear();
+
+      // Mutation denied — workbench cannot create worktrees
+      const denied = getTextResult(
+        await client.callTool({ name: "worktree.create", arguments: { name: "x" } })
+      );
+      expect(denied.isError).toBe(true);
+      expect(denied.content[0].text).toContain("TIER_NOT_PERMITTED");
+      expect(denied.content[0].text).toContain("workbench");
+      expect(dispatchMock).not.toHaveBeenCalled();
+
+      // Destructive denied
+      const destructiveDenied = getTextResult(
+        await client.callTool({ name: "terminal.sendCommand", arguments: { id: "t", text: "x" } })
+      );
+      expect(destructiveDenied.isError).toBe(true);
+      expect(destructiveDenied.content[0].text).toContain("TIER_NOT_PERMITTED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("workbench tier: listTools advertises only the workbench surface", async () => {
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectWorkbench(service.currentPort!);
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((t) => t.name);
+      expect(ids).toContain("actions.list");
+      expect(ids).toContain("worktree.list");
+      expect(ids).toContain("terminal.list");
+      // Mutations and destructive operations are absent.
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).not.toContain("worktree.delete");
+      expect(ids).not.toContain("terminal.inject");
+      expect(ids).not.toContain("terminal.sendCommand");
+      expect(ids).not.toContain("recipe.run");
+      expect(ids).not.toContain("git.commit");
+    });
+
+    it("external tier: backward compatibility for the apiKey-authenticated server", async () => {
+      const dispatchMock = vi.fn(
+        (payload: DispatchRequest): ActionDispatchResult => ({
+          ok: true,
+          result: { dispatched: payload.actionId },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      // External tier inherits the legacy MCP_TOOL_ALLOWLIST — destructive
+      // actions in that list (e.g. terminal.sendCommand, worktree.delete)
+      // remain callable so existing user-facing clients keep working.
+      const result = getTextResult(
+        await client.callTool({
+          name: "terminal.sendCommand",
+          arguments: { id: "t", text: "ls" },
+        })
+      );
+      expect(result.isError).not.toBe(true);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ actionId: "terminal.sendCommand" })
+      );
+    });
+
+    it("audit records carry the resolved tier and unauthorized denials are classified", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectWorkbench(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "actions.list", arguments: {} });
+      await client.callTool({ name: "worktree.delete", arguments: { id: "wt" } });
+
+      const records = getAuditRecords(service);
+      // newest first: worktree.delete (denied), then actions.list (allowed)
+      expect(records).toHaveLength(2);
+      const denied = records.find((r) => r.toolId === "worktree.delete");
+      const allowed = records.find((r) => r.toolId === "actions.list");
+      expect(denied?.tier).toBe("workbench");
+      expect(denied?.result).toBe("unauthorized");
+      expect(denied?.errorCode).toBe("TIER_NOT_PERMITTED");
+      expect(allowed?.tier).toBe("workbench");
+      expect(allowed?.result).toBe("success");
+    });
+
+    it("fullToolSurface widens external tier only — workbench remains tightly scoped", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+            kind: "query",
+          }),
+          createManifestEntry({
+            id: "panel.gridLayout.setStrategy" as ActionId,
+            title: "Set grid layout",
+            description: "UI plumbing",
+          }),
+        ],
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectWorkbench(service.currentPort!);
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((t) => t.name);
+      expect(ids).toContain("actions.list");
+      // panel.gridLayout.setStrategy is NOT in the workbench allowlist —
+      // fullToolSurface must not widen anything for non-external tiers.
+      expect(ids).not.toContain("panel.gridLayout.setStrategy");
+    });
+
+    it("Streamable HTTP transport stamps the resolved tier on the session", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectHttpClient(service.currentPort!);
+      httpTransports.push(transport);
+
+      await client.callTool({ name: "actions.list", arguments: {} });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      // connectHttpClient sends the global apiKey header → external tier.
+      expect(records[0].tier).toBe("external");
+      expect(records[0].result).toBe("success");
+    });
   });
 
   describe("audit log", () => {
@@ -1133,7 +1372,7 @@ describe("McpServerService", () => {
       sessionId: string;
       tier: string;
       argsSummary: string;
-      result: "success" | "error" | "confirmation-pending";
+      result: "success" | "error" | "confirmation-pending" | "unauthorized";
       errorCode?: string;
       durationMs: number;
     };
@@ -1175,7 +1414,8 @@ describe("McpServerService", () => {
       const [record] = records;
       expect(record.toolId).toBe("actions.list");
       expect(record.result).toBe("success");
-      expect(record.tier).toBe("unknown");
+      // connectClient passes the global apiKey by default, mapping to external tier.
+      expect(record.tier).toBe("external");
       expect(record.sessionId.length).toBeGreaterThan(0);
       expect(record.argsSummary).toContain("<string: 120 chars>");
       expect(record.argsSummary).toContain('"limit":10');

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1241,9 +1241,7 @@ describe("McpServerService", () => {
       transports.push(transport);
 
       // Query allowed
-      const allowed = getTextResult(
-        await client.callTool({ name: "actions.list", arguments: {} })
-      );
+      const allowed = getTextResult(await client.callTool({ name: "actions.list", arguments: {} }));
       expect(allowed.isError).not.toBe(true);
       expect(dispatchMock).toHaveBeenCalledWith(
         expect.objectContaining({ actionId: "actions.list" })
@@ -1322,9 +1320,7 @@ describe("McpServerService", () => {
     });
 
     it("audit records carry the resolved tier and unauthorized denials are classified", async () => {
-      const dispatchMock = vi.fn(
-        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
-      );
+      const dispatchMock = vi.fn((): ActionDispatchResult => ({ ok: true, result: { ok: true } }));
       const { window } = createMockWindow({
         getManifest: manifestForAllAllowlistedTools,
         dispatchAction: dispatchMock,
@@ -1379,9 +1375,7 @@ describe("McpServerService", () => {
     });
 
     it("Streamable HTTP transport stamps the resolved tier on the session", async () => {
-      const dispatchMock = vi.fn(
-        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
-      );
+      const dispatchMock = vi.fn((): ActionDispatchResult => ({ ok: true, result: { ok: true } }));
       const { window } = createMockWindow({
         getManifest: manifestForAllAllowlistedTools,
         dispatchAction: dispatchMock,
@@ -1401,9 +1395,7 @@ describe("McpServerService", () => {
     });
 
     it("Streamable HTTP transport with a pane token stamps workbench tier and gates dispatch", async () => {
-      const dispatchMock = vi.fn(
-        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
-      );
+      const dispatchMock = vi.fn((): ActionDispatchResult => ({ ok: true, result: { ok: true } }));
       const { window } = createMockWindow({
         getManifest: manifestForAllAllowlistedTools,
         dispatchAction: dispatchMock,
@@ -1422,9 +1414,7 @@ describe("McpServerService", () => {
       httpTransports.push(transport);
 
       // Query allowed
-      const allowed = getTextResult(
-        await client.callTool({ name: "actions.list", arguments: {} })
-      );
+      const allowed = getTextResult(await client.callTool({ name: "actions.list", arguments: {} }));
       expect(allowed.isError).not.toBe(true);
 
       // Destructive denied at dispatch time

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1066,6 +1066,43 @@ describe("McpServerService", () => {
     expect(ids).not.toContain("internal.dangerous");
   });
 
+  it("dispatches fullToolSurface external tools that are outside the curated allowlist", async () => {
+    storeState.mcpServer.fullToolSurface = true;
+    const dispatchMock = vi.fn(
+      (payload: DispatchRequest): ActionDispatchResult => ({
+        ok: true,
+        result: { dispatched: payload.actionId },
+      })
+    );
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "panel.gridLayout.setStrategy" as ActionId,
+          title: "Set grid layout",
+          description: "Power-user UI plumbing",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = getTextResult(
+      await client.callTool({
+        name: "panel.gridLayout.setStrategy",
+        arguments: { strategy: "automatic" },
+      })
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content[0].text).toContain('"dispatched": "panel.gridLayout.setStrategy"');
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ actionId: "panel.gridLayout.setStrategy" })
+    );
+  });
+
   it("treats non-true fullToolSurface values as curated (fail-closed)", async () => {
     (storeState.mcpServer as { fullToolSurface: unknown }).fullToolSurface = "false";
     const { window } = createMockWindow({
@@ -1361,6 +1398,49 @@ describe("McpServerService", () => {
       // connectHttpClient sends the global apiKey header → external tier.
       expect(records[0].tier).toBe("external");
       expect(records[0].result).toBe("success");
+    });
+
+    it("Streamable HTTP transport with a pane token stamps workbench tier and gates dispatch", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: { ok: true } })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForAllAllowlistedTools,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+
+      const token = `pane-token-${Math.random().toString(36).slice(2)}`;
+      paneTokens.add(token);
+      const client = new Client({ name: "mcp-pane-http-client", version: "1.0.0" });
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`http://127.0.0.1:${service.currentPort}/mcp`),
+        { requestInit: { headers: { Authorization: `Bearer ${token}` } } }
+      );
+      await client.connect(transport);
+      httpTransports.push(transport);
+
+      // Query allowed
+      const allowed = getTextResult(
+        await client.callTool({ name: "actions.list", arguments: {} })
+      );
+      expect(allowed.isError).not.toBe(true);
+
+      // Destructive denied at dispatch time
+      const denied = getTextResult(
+        await client.callTool({ name: "worktree.delete", arguments: { id: "x" } })
+      );
+      expect(denied.isError).toBe(true);
+      expect(denied.content[0].text).toContain("TIER_NOT_PERMITTED");
+      expect(denied.content[0].text).toContain("workbench");
+
+      const records = getAuditRecords(service);
+      const denyRecord = records.find((r) => r.toolId === "worktree.delete");
+      const allowRecord = records.find((r) => r.toolId === "actions.list");
+      expect(denyRecord?.tier).toBe("workbench");
+      expect(denyRecord?.result).toBe("unauthorized");
+      expect(allowRecord?.tier).toBe("workbench");
     });
   });
 

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -8,8 +8,11 @@
  *   `CONFIRMATION_REQUIRED` error code — surfaced separately so audit
  *   readers can distinguish "agent forgot `_meta.confirmed`" from a real
  *   failure.
+ * - `unauthorized`: the session's tier was not permitted to invoke the
+ *   action — the dispatch was rejected before reaching the renderer. Carries
+ *   `errorCode: "TIER_NOT_PERMITTED"`.
  */
-export type McpAuditResult = "success" | "error" | "confirmation-pending";
+export type McpAuditResult = "success" | "error" | "confirmation-pending" | "unauthorized";
 
 /**
  * Persisted audit record for a single MCP tool dispatch. Written once per
@@ -21,9 +24,10 @@ export type McpAuditResult = "success" | "error" | "confirmation-pending";
  * persisted because tool args may carry terminal output, file content, or
  * prompt text.
  *
- * `tier` carries a placeholder of `"unknown"` until the tier-policy work
- * (issue #6517) lands. The field exists on the record so downstream readers
- * (incident reports, support exports) can rely on a stable schema.
+ * `tier` records the source-tier classification of the connection that
+ * issued the call (`workbench`, `action`, `system`, `external`). Sessions
+ * that are not yet stamped fall back to `"workbench"` — the most
+ * restrictive tier — so an unstamped session can never elevate access.
  */
 export interface McpAuditRecord {
   id: string;

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -41,12 +41,14 @@ const RESULT_LABEL: Record<McpAuditResult, string> = {
   success: "Success",
   error: "Error",
   "confirmation-pending": "Awaiting confirmation",
+  unauthorized: "Unauthorized",
 };
 
 const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   success: "bg-status-success",
   error: "bg-status-danger",
   "confirmation-pending": "bg-status-warning",
+  unauthorized: "bg-status-danger",
 };
 
 function formatRelativeTimestamp(ts: number): string {


### PR DESCRIPTION
## Summary

- The MCP `MCP_TOOL_ALLOWLIST` was filtering tools at `listTools` time but not enforcing anything at dispatch — any client that already knew an action ID could invoke it. This PR closes that gap.
- Adds a 4-tier authorization model (`workbench` / `action` / `system` / `external`) with strictly nested allowlists. Each connection resolves its tier from the `Authorization` header at connect time, stored in a `sessionTierMap` shared across SSE and HTTP transports.
- Dispatch gates on tier before forwarding to IPC; unauthorized calls get a proper MCP error envelope and are audit-logged. `listTools` filters per the same tier boundaries. The `fullToolSurface` flag widens the `external` tier consistently for both list and dispatch.

Resolves #6517

## Changes

- `electron/services/McpServerService.ts` — `sessionTierMap`, `resolveTokenTier()`, tier-gated `CallTool` and `ListTools` handlers, 4 allowlist constants (`WORKBENCH_TOOLS`, `ACTION_TOOLS`, `SYSTEM_TOOLS`, `EXTERNAL_TOOLS`)
- `electron/services/__tests__/McpServerService.test.ts` — 52 tests covering per-tier dispatch gates, `listTools` filtering, `fullToolSurface` behavior, and backward-compat legacy `apiKey` → `external` mapping
- `shared/types/ipc/mcpServer.ts` — `McpTier` type and updated `McpAuthConfig`
- `src/components/Settings/McpServerSettingsTab.tsx` — minor display update for tier label

## Testing

All 52 unit tests pass. Verified that legacy `apiKey` clients continue to connect and dispatch under the `external` tier without any config changes. Verified that a `workbench`-tier token is rejected when attempting to call a `system`-tier action.