### PR TITLE
feat(github-toolbar): add +N since opened badge to toolbar counts

### DIFF
--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -31,6 +31,10 @@ import { GitHubStatusIndicator, type GitHubStatusIndicatorStatus } from "./GitHu
 import { githubClient } from "@/clients/githubClient";
 import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
+import {
+  useGitHubSeenAnchorsStore,
+  deriveBadgeLabel,
+} from "@/store/githubSeenAnchorsStore";
 import type { Project } from "@shared/types";
 import type { GitHubRateLimitDetails, RepositoryStats } from "@shared/types";
 
@@ -462,12 +466,35 @@ export const GitHubStatsToolbarButton = memo(
     // request that could overwrite fresh mount-fetch data in the cache.
     const issuesOpenRef = useRef(issuesOpen);
     const prsOpenRef = useRef(prsOpen);
+    const commitsOpenRef = useRef(commitsOpen);
     useEffect(() => {
       issuesOpenRef.current = issuesOpen;
     }, [issuesOpen]);
     useEffect(() => {
       prsOpenRef.current = prsOpen;
     }, [prsOpen]);
+    useEffect(() => {
+      commitsOpenRef.current = commitsOpen;
+    }, [commitsOpen]);
+
+    // Per-project, per-category "+N since opened" anchors. Read-only selectors
+    // here; writes go through `useGitHubSeenAnchorsStore.getState().recordOpen`
+    // synchronously inside each click/imperative handler so the anchor is
+    // captured at the precise moment of intent — not after an async refresh
+    // races in with a newer count.
+    const projectPath = currentProject?.path;
+    const issuesAnchor = useGitHubSeenAnchorsStore((s) =>
+      projectPath ? s.anchors[projectPath]?.issues : undefined
+    );
+    const prsAnchor = useGitHubSeenAnchorsStore((s) =>
+      projectPath ? s.anchors[projectPath]?.prs : undefined
+    );
+    const commitsAnchor = useGitHubSeenAnchorsStore((s) =>
+      projectPath ? s.anchors[projectPath]?.commits : undefined
+    );
+    const issuesDeltaLabel = deriveBadgeLabel(issuesAnchor, issueCount, issuesOpen, now);
+    const prsDeltaLabel = deriveBadgeLabel(prsAnchor, prCount, prsOpen, now);
+    const commitsDeltaLabel = deriveBadgeLabel(commitsAnchor, commitCount, commitsOpen, now);
 
     useEffect(() => {
       return () => {
@@ -700,6 +727,14 @@ export const GitHubStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          // Only anchor on the open transition — toggling closed should not
+          // re-record. `issuesOpenRef` is mirrored from state via useEffect
+          // and is current at imperative-call time.
+          if (!issuesOpenRef.current && currentProject && issueCount != null) {
+            useGitHubSeenAnchorsStore
+              .getState()
+              .recordOpen(currentProject.path, "issues", issueCount);
+          }
           setIssuesOpen((p) => !p);
         },
         openPrs: () => {
@@ -707,12 +742,24 @@ export const GitHubStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
+          if (!prsOpenRef.current && currentProject && prCount != null) {
+            useGitHubSeenAnchorsStore
+              .getState()
+              .recordOpen(currentProject.path, "prs", prCount);
+          }
           setPrsOpen((p) => !p);
         },
-        openCommits: () => setCommitsOpen((p) => !p),
+        openCommits: () => {
+          if (!commitsOpenRef.current && currentProject && commitCount != null) {
+            useGitHubSeenAnchorsStore
+              .getState()
+              .recordOpen(currentProject.path, "commits", commitCount);
+          }
+          setCommitsOpen((p) => !p);
+        },
         stats,
       }),
-      [stats, isTokenError, openSettingsForToken]
+      [stats, isTokenError, openSettingsForToken, currentProject, issueCount, prCount, commitCount]
     );
 
     if (!currentProject) return null;
@@ -750,6 +797,16 @@ export const GitHubStatsToolbarButton = memo(
                 const willOpen = !issuesOpen;
                 setIssuesOpen(willOpen);
                 if (!willOpen) setIssueSearchQuery("");
+                // Capture the "+N since opened" anchor synchronously here so a
+                // poll that lands during dropdown-opening can't race a newer
+                // count past the seen marker. Anchored at click intent, not
+                // poll completion. `currentProject` is guaranteed non-null by
+                // the early-return above.
+                if (willOpen && issueCount != null) {
+                  useGitHubSeenAnchorsStore
+                    .getState()
+                    .recordOpen(currentProject.path, "issues", issueCount);
+                }
                 // Only force-refresh on open if the polled stats are stale
                 // enough to be visibly out of date. Within the freshness
                 // window, the 30s poll has the cache hot and the dropdown
@@ -791,6 +848,14 @@ export const GitHubStatsToolbarButton = memo(
               >
                 {issueCount ?? "\u2014"}
               </span>
+              {!isTokenError && issuesDeltaLabel ? (
+                <span
+                  className="text-[10px] font-medium leading-none text-muted-foreground"
+                  aria-label={`${issuesDeltaLabel} since you last opened issues`}
+                >
+                  {issuesDeltaLabel}
+                </span>
+              ) : null}
               {!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
             </Button>
           </TooltipTrigger>
@@ -873,6 +938,11 @@ export const GitHubStatsToolbarButton = memo(
                 const willOpen = !prsOpen;
                 setPrsOpen(willOpen);
                 if (!willOpen) setPrSearchQuery("");
+                if (willOpen && prCount != null) {
+                  useGitHubSeenAnchorsStore
+                    .getState()
+                    .recordOpen(currentProject.path, "prs", prCount);
+                }
                 // Only force-refresh on open if the polled stats are stale
                 // enough to be visibly out of date. Within the freshness
                 // window, the 30s poll has the cache hot and the dropdown
@@ -914,6 +984,14 @@ export const GitHubStatsToolbarButton = memo(
               >
                 {prCount ?? "\u2014"}
               </span>
+              {!isTokenError && prsDeltaLabel ? (
+                <span
+                  className="text-[10px] font-medium leading-none text-muted-foreground"
+                  aria-label={`${prsDeltaLabel} since you last opened pull requests`}
+                >
+                  {prsDeltaLabel}
+                </span>
+              ) : null}
               {!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
             </Button>
           </TooltipTrigger>
@@ -979,7 +1057,13 @@ export const GitHubStatsToolbarButton = memo(
                 setIssueSearchQuery("");
                 setPrsOpen(false);
                 setPrSearchQuery("");
-                setCommitsOpen(!commitsOpen);
+                const willOpen = !commitsOpen;
+                setCommitsOpen(willOpen);
+                if (willOpen && commitCount != null) {
+                  useGitHubSeenAnchorsStore
+                    .getState()
+                    .recordOpen(currentProject.path, "commits", commitCount);
+                }
               }}
               className={cn(
                 "h-full gap-2 rounded-none px-3 text-daintree-text transition-opacity hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
@@ -1000,6 +1084,14 @@ export const GitHubStatsToolbarButton = memo(
               >
                 {commitCount ?? "\u2014"}
               </span>
+              {commitsDeltaLabel ? (
+                <span
+                  className="text-[10px] font-medium leading-none text-muted-foreground"
+                  aria-label={`${commitsDeltaLabel} since you last opened commits`}
+                >
+                  {commitsDeltaLabel}
+                </span>
+              ) : null}
               <FreshnessGlyph level={freshnessLevel} />
             </Button>
           </TooltipTrigger>

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -729,8 +729,9 @@ export const GitHubStatsToolbarButton = memo(
           }
           // Only anchor on the open transition — toggling closed should not
           // re-record. `issuesOpenRef` is mirrored from state via useEffect
-          // and is current at imperative-call time.
-          if (!issuesOpenRef.current && currentProject && issueCount != null) {
+          // and is current at imperative-call time. A null count clears any
+          // stale anchor so the next known-count open starts fresh.
+          if (!issuesOpenRef.current && currentProject) {
             useGitHubSeenAnchorsStore
               .getState()
               .recordOpen(currentProject.path, "issues", issueCount);
@@ -742,7 +743,7 @@ export const GitHubStatsToolbarButton = memo(
             openSettingsForToken();
             return;
           }
-          if (!prsOpenRef.current && currentProject && prCount != null) {
+          if (!prsOpenRef.current && currentProject) {
             useGitHubSeenAnchorsStore
               .getState()
               .recordOpen(currentProject.path, "prs", prCount);
@@ -750,7 +751,7 @@ export const GitHubStatsToolbarButton = memo(
           setPrsOpen((p) => !p);
         },
         openCommits: () => {
-          if (!commitsOpenRef.current && currentProject && commitCount != null) {
+          if (!commitsOpenRef.current && currentProject) {
             useGitHubSeenAnchorsStore
               .getState()
               .recordOpen(currentProject.path, "commits", commitCount);
@@ -801,8 +802,10 @@ export const GitHubStatsToolbarButton = memo(
                 // poll that lands during dropdown-opening can't race a newer
                 // count past the seen marker. Anchored at click intent, not
                 // poll completion. `currentProject` is guaranteed non-null by
-                // the early-return above.
-                if (willOpen && issueCount != null) {
+                // the early-return above. A null `issueCount` means stats
+                // haven't loaded yet — `recordOpen` clears any stale anchor in
+                // that case so the next open with a known count starts fresh.
+                if (willOpen) {
                   useGitHubSeenAnchorsStore
                     .getState()
                     .recordOpen(currentProject.path, "issues", issueCount);
@@ -830,7 +833,9 @@ export const GitHubStatsToolbarButton = memo(
               aria-label={
                 isTokenError
                   ? "Configure GitHub token to see issues"
-                  : `${issueCount ?? "\u2014"} open issues${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+                  : `${issueCount ?? "\u2014"} open issues${
+                      issuesDeltaLabel ? ` (${issuesDeltaLabel} since last opened)` : ""
+                    }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
             >
               <CircleDot
@@ -851,7 +856,7 @@ export const GitHubStatsToolbarButton = memo(
               {!isTokenError && issuesDeltaLabel ? (
                 <span
                   className="text-[10px] font-medium leading-none text-muted-foreground"
-                  aria-label={`${issuesDeltaLabel} since you last opened issues`}
+                  aria-hidden="true"
                 >
                   {issuesDeltaLabel}
                 </span>
@@ -938,7 +943,7 @@ export const GitHubStatsToolbarButton = memo(
                 const willOpen = !prsOpen;
                 setPrsOpen(willOpen);
                 if (!willOpen) setPrSearchQuery("");
-                if (willOpen && prCount != null) {
+                if (willOpen) {
                   useGitHubSeenAnchorsStore
                     .getState()
                     .recordOpen(currentProject.path, "prs", prCount);
@@ -966,7 +971,9 @@ export const GitHubStatsToolbarButton = memo(
               aria-label={
                 isTokenError
                   ? "Configure GitHub token to see pull requests"
-                  : `${prCount ?? "\u2014"} open pull requests${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+                  : `${prCount ?? "\u2014"} open pull requests${
+                      prsDeltaLabel ? ` (${prsDeltaLabel} since last opened)` : ""
+                    }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
               }
             >
               <GitPullRequest
@@ -987,7 +994,7 @@ export const GitHubStatsToolbarButton = memo(
               {!isTokenError && prsDeltaLabel ? (
                 <span
                   className="text-[10px] font-medium leading-none text-muted-foreground"
-                  aria-label={`${prsDeltaLabel} since you last opened pull requests`}
+                  aria-hidden="true"
                 >
                   {prsDeltaLabel}
                 </span>
@@ -1059,7 +1066,7 @@ export const GitHubStatsToolbarButton = memo(
                 setPrSearchQuery("");
                 const willOpen = !commitsOpen;
                 setCommitsOpen(willOpen);
-                if (willOpen && commitCount != null) {
+                if (willOpen) {
                   useGitHubSeenAnchorsStore
                     .getState()
                     .recordOpen(currentProject.path, "commits", commitCount);
@@ -1072,7 +1079,9 @@ export const GitHubStatsToolbarButton = memo(
                 commitsOpen &&
                   "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-border-strong"
               )}
-              aria-label={`${commitCount ?? "\u2014"} commits${freshnessSuffix(freshnessLevel, lastUpdated, now)}`}
+              aria-label={`${commitCount ?? "\u2014"} commits${
+                commitsDeltaLabel ? ` (${commitsDeltaLabel} since last opened)` : ""
+              }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`}
             >
               <GitCommit className="h-4 w-4" />
               <span
@@ -1087,7 +1096,7 @@ export const GitHubStatsToolbarButton = memo(
               {commitsDeltaLabel ? (
                 <span
                   className="text-[10px] font-medium leading-none text-muted-foreground"
-                  aria-label={`${commitsDeltaLabel} since you last opened commits`}
+                  aria-hidden="true"
                 >
                   {commitsDeltaLabel}
                 </span>

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -31,10 +31,7 @@ import { GitHubStatusIndicator, type GitHubStatusIndicatorStatus } from "./GitHu
 import { githubClient } from "@/clients/githubClient";
 import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
-import {
-  useGitHubSeenAnchorsStore,
-  deriveBadgeLabel,
-} from "@/store/githubSeenAnchorsStore";
+import { useGitHubSeenAnchorsStore, deriveBadgeLabel } from "@/store/githubSeenAnchorsStore";
 import type { Project } from "@shared/types";
 import type { GitHubRateLimitDetails, RepositoryStats } from "@shared/types";
 
@@ -744,9 +741,7 @@ export const GitHubStatsToolbarButton = memo(
             return;
           }
           if (!prsOpenRef.current && currentProject) {
-            useGitHubSeenAnchorsStore
-              .getState()
-              .recordOpen(currentProject.path, "prs", prCount);
+            useGitHubSeenAnchorsStore.getState().recordOpen(currentProject.path, "prs", prCount);
           }
           setPrsOpen((p) => !p);
         },

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -271,7 +271,9 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
     // The visual badge has aria-hidden, so the delta must reach screen
     // readers via the button's accessible name. Each of the three button
     // aria-label expressions must reference its matching delta label.
-    expect(source).toMatch(/issuesDeltaLabel\s*\?\s*` \(\$\{issuesDeltaLabel\} since last opened\)`/);
+    expect(source).toMatch(
+      /issuesDeltaLabel\s*\?\s*` \(\$\{issuesDeltaLabel\} since last opened\)`/
+    );
     expect(source).toMatch(/prsDeltaLabel\s*\?\s*` \(\$\{prsDeltaLabel\} since last opened\)`/);
     expect(source).toMatch(
       /commitsDeltaLabel\s*\?\s*` \(\$\{commitsDeltaLabel\} since last opened\)`/

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -166,3 +166,125 @@ describe("GitHubStatsToolbarButton digit pulse", () => {
     expect(slice).toMatch(/prevLastUpdatedRef\.current\s*=\s*null/);
   });
 });
+
+/**
+ * "+N since opened" badge wiring (issue #6530).
+ *
+ * Each of the three toolbar counts (issues, PRs, commits) carries a small
+ * de-emphasized adornment showing the gross delta since the user last opened
+ * that specific dropdown. The anchor is captured synchronously at click intent
+ * (not poll completion) and stored per project + per category in a persisted
+ * Zustand store. Imperative open methods must also anchor on the open
+ * transition. Badge styling must use `text-muted-foreground` (no accent).
+ */
+describe("GitHubStatsToolbarButton +N badge wiring", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(TOOLBAR_PATH, "utf-8");
+  });
+
+  it("imports the seen-anchors store and pure deriveBadgeLabel helper", () => {
+    expect(source).toMatch(/from\s+"@\/store\/githubSeenAnchorsStore"/);
+    expect(source).toContain("useGitHubSeenAnchorsStore");
+    expect(source).toContain("deriveBadgeLabel");
+  });
+
+  it("derives a delta label for each of the three categories", () => {
+    expect(source).toMatch(/issuesDeltaLabel\s*=\s*deriveBadgeLabel\(\s*issuesAnchor/);
+    expect(source).toMatch(/prsDeltaLabel\s*=\s*deriveBadgeLabel\(\s*prsAnchor/);
+    expect(source).toMatch(/commitsDeltaLabel\s*=\s*deriveBadgeLabel\(\s*commitsAnchor/);
+  });
+
+  it("calls recordOpen synchronously inside each willOpen branch", () => {
+    // Issue, PR, and commit click handlers each anchor before any async
+    // refresh fires. Three call sites, one per category.
+    const issuesCalls = source.match(
+      /recordOpen\(\s*currentProject\.path,\s*"issues"\s*,\s*issueCount\s*\)/g
+    );
+    const prsCalls = source.match(
+      /recordOpen\(\s*currentProject\.path,\s*"prs"\s*,\s*prCount\s*\)/g
+    );
+    const commitsCalls = source.match(
+      /recordOpen\(\s*currentProject\.path,\s*"commits"\s*,\s*commitCount\s*\)/g
+    );
+    // Two call sites per category — once in onClick, once in useImperativeHandle.
+    expect(issuesCalls?.length).toBe(2);
+    expect(prsCalls?.length).toBe(2);
+    expect(commitsCalls?.length).toBe(2);
+  });
+
+  it("guards imperative anchor recording on the closed→open transition only", () => {
+    // Anchor on the call itself, not the import — `useImperativeHandle,` also
+    // appears in the React import block at the top of the file.
+    const handleStart = source.indexOf("useImperativeHandle(");
+    expect(handleStart).toBeGreaterThan(0);
+    const slice = source.slice(handleStart, handleStart + 2200);
+    // openIssues / openPrs / openCommits each guard on the *Ref.current being
+    // false (i.e., currently closed) before recording an anchor — toggling to
+    // close must not re-record.
+    expect(slice).toMatch(/!issuesOpenRef\.current/);
+    expect(slice).toMatch(/!prsOpenRef\.current/);
+    expect(slice).toMatch(/!commitsOpenRef\.current/);
+  });
+
+  it("renders a muted +N badge for each category (no accent color)", () => {
+    // Three rendered badges, each conditional on the matching delta label.
+    const issuesBadge = source.match(/issuesDeltaLabel\s*\?\s*\(\s*<span/);
+    const prsBadge = source.match(/prsDeltaLabel\s*\?\s*\(\s*<span/);
+    const commitsBadge = source.match(/commitsDeltaLabel\s*\?\s*\(\s*<span/);
+    expect(issuesBadge).not.toBeNull();
+    expect(prsBadge).not.toBeNull();
+    expect(commitsBadge).not.toBeNull();
+
+    // Each badge span uses text-muted-foreground (codebase de-emphasis idiom),
+    // not text-accent-primary or any accent token. Window is generous because
+    // each block spans ~300 chars including aria-label and inner content.
+    const badgeBlocks = source.match(/DeltaLabel\s*\?\s*\([\s\S]{0,500}?<\/span>/g);
+    expect(badgeBlocks).not.toBeNull();
+    expect(badgeBlocks?.length).toBe(3);
+    for (const block of badgeBlocks ?? []) {
+      expect(block).toContain("text-muted-foreground");
+      expect(block).not.toContain("text-accent");
+      expect(block).not.toContain("accent-primary");
+    }
+  });
+
+  it("places each badge between the count digit and the FreshnessGlyph", () => {
+    // For each category, source order in the button must be:
+    //   <span ... tabular-nums>{count}</span>
+    //   {deltaLabel ? <span ...muted...> : null}
+    //   <FreshnessGlyph ...>
+    // Anchored on the unique animKey props so we don't conflate aria-label
+    // sites that happen to also reference the count value.
+
+    const issuesSpan = source.indexOf("key={issueAnimKey}");
+    const issuesBadge = source.indexOf("issuesDeltaLabel ?");
+    const issuesGlyph = source.indexOf("<FreshnessGlyph", issuesSpan);
+    expect(issuesSpan).toBeGreaterThan(0);
+    expect(issuesBadge).toBeGreaterThan(issuesSpan);
+    expect(issuesGlyph).toBeGreaterThan(issuesBadge);
+
+    const prsSpan = source.indexOf("key={prAnimKey}");
+    const prsBadge = source.indexOf("prsDeltaLabel ?");
+    const prsGlyph = source.indexOf("<FreshnessGlyph", prsSpan);
+    expect(prsSpan).toBeGreaterThan(0);
+    expect(prsBadge).toBeGreaterThan(prsSpan);
+    expect(prsGlyph).toBeGreaterThan(prsBadge);
+
+    const commitsSpan = source.indexOf("key={commitAnimKey}");
+    const commitsBadge = source.indexOf("commitsDeltaLabel ?");
+    const commitsGlyph = source.indexOf("<FreshnessGlyph", commitsSpan);
+    expect(commitsSpan).toBeGreaterThan(0);
+    expect(commitsBadge).toBeGreaterThan(commitsSpan);
+    expect(commitsGlyph).toBeGreaterThan(commitsBadge);
+  });
+
+  it("registers the seen-anchors store under a unique storage key", async () => {
+    const storePath = path.resolve(__dirname, "../../../store/githubSeenAnchorsStore.ts");
+    const storeSource = await fs.readFile(storePath, "utf-8");
+    expect(storeSource).toContain('name: "daintree-github-seen-anchors"');
+    expect(storeSource).toContain("registerPersistedStore");
+    expect(storeSource).toMatch(/SEEN_SUPPRESSION_TTL_MS\s*=\s*72\s*\*\s*60\s*\*\s*60\s*\*\s*1000/);
+  });
+});

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshFetch.test.tsx
@@ -198,7 +198,8 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
 
   it("calls recordOpen synchronously inside each willOpen branch", () => {
     // Issue, PR, and commit click handlers each anchor before any async
-    // refresh fires. Three call sites, one per category.
+    // refresh fires. recordOpen is called unconditionally on the open
+    // transition; a null count clears any stale anchor for that category.
     const issuesCalls = source.match(
       /recordOpen\(\s*currentProject\.path,\s*"issues"\s*,\s*issueCount\s*\)/g
     );
@@ -212,6 +213,16 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
     expect(issuesCalls?.length).toBe(2);
     expect(prsCalls?.length).toBe(2);
     expect(commitsCalls?.length).toBe(2);
+  });
+
+  it("does not gate recordOpen on a non-null count (null clears the anchor)", () => {
+    // Earlier drafts gated `recordOpen` on `issueCount != null` etc., which
+    // left a stale anchor when the user opened before the first stats fetch
+    // completed. The store now treats `null` as a clear-anchor signal, so the
+    // call sites must NOT include the count-not-null guard.
+    expect(source).not.toMatch(/willOpen\s*&&\s*issueCount\s*!=\s*null/);
+    expect(source).not.toMatch(/willOpen\s*&&\s*prCount\s*!=\s*null/);
+    expect(source).not.toMatch(/willOpen\s*&&\s*commitCount\s*!=\s*null/);
   });
 
   it("guards imperative anchor recording on the closed→open transition only", () => {
@@ -239,7 +250,7 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
 
     // Each badge span uses text-muted-foreground (codebase de-emphasis idiom),
     // not text-accent-primary or any accent token. Window is generous because
-    // each block spans ~300 chars including aria-label and inner content.
+    // each block spans ~300 chars including aria attribute and inner content.
     const badgeBlocks = source.match(/DeltaLabel\s*\?\s*\([\s\S]{0,500}?<\/span>/g);
     expect(badgeBlocks).not.toBeNull();
     expect(badgeBlocks?.length).toBe(3);
@@ -247,7 +258,24 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
       expect(block).toContain("text-muted-foreground");
       expect(block).not.toContain("text-accent");
       expect(block).not.toContain("accent-primary");
+      // Child <span> aria-label inside a button with explicit aria-label is
+      // ignored by ARIA — the delta is announced via the button's aria-label
+      // instead. Badge spans must use aria-hidden so screen readers don't
+      // double-announce the visual digits.
+      expect(block).toContain('aria-hidden="true"');
+      expect(block).not.toContain("aria-label");
     }
+  });
+
+  it("folds the delta label into each button's aria-label for screen readers", () => {
+    // The visual badge has aria-hidden, so the delta must reach screen
+    // readers via the button's accessible name. Each of the three button
+    // aria-label expressions must reference its matching delta label.
+    expect(source).toMatch(/issuesDeltaLabel\s*\?\s*` \(\$\{issuesDeltaLabel\} since last opened\)`/);
+    expect(source).toMatch(/prsDeltaLabel\s*\?\s*` \(\$\{prsDeltaLabel\} since last opened\)`/);
+    expect(source).toMatch(
+      /commitsDeltaLabel\s*\?\s*` \(\$\{commitsDeltaLabel\} since last opened\)`/
+    );
   });
 
   it("places each badge between the count digit and the FreshnessGlyph", () => {
@@ -255,25 +283,26 @@ describe("GitHubStatsToolbarButton +N badge wiring", () => {
     //   <span ... tabular-nums>{count}</span>
     //   {deltaLabel ? <span ...muted...> : null}
     //   <FreshnessGlyph ...>
-    // Anchored on the unique animKey props so we don't conflate aria-label
-    // sites that happen to also reference the count value.
+    // The badge-render anchor is `<category>DeltaLabel ? (` — distinct from
+    // the aria-label form `<category>DeltaLabel ? \`...\`` which also
+    // appears earlier in the button props.
 
     const issuesSpan = source.indexOf("key={issueAnimKey}");
-    const issuesBadge = source.indexOf("issuesDeltaLabel ?");
+    const issuesBadge = source.indexOf("issuesDeltaLabel ? (", issuesSpan);
     const issuesGlyph = source.indexOf("<FreshnessGlyph", issuesSpan);
     expect(issuesSpan).toBeGreaterThan(0);
     expect(issuesBadge).toBeGreaterThan(issuesSpan);
     expect(issuesGlyph).toBeGreaterThan(issuesBadge);
 
     const prsSpan = source.indexOf("key={prAnimKey}");
-    const prsBadge = source.indexOf("prsDeltaLabel ?");
+    const prsBadge = source.indexOf("prsDeltaLabel ? (", prsSpan);
     const prsGlyph = source.indexOf("<FreshnessGlyph", prsSpan);
     expect(prsSpan).toBeGreaterThan(0);
     expect(prsBadge).toBeGreaterThan(prsSpan);
     expect(prsGlyph).toBeGreaterThan(prsBadge);
 
     const commitsSpan = source.indexOf("key={commitAnimKey}");
-    const commitsBadge = source.indexOf("commitsDeltaLabel ?");
+    const commitsBadge = source.indexOf("commitsDeltaLabel ? (", commitsSpan);
     const commitsGlyph = source.indexOf("<FreshnessGlyph", commitsSpan);
     expect(commitsSpan).toBeGreaterThan(0);
     expect(commitsBadge).toBeGreaterThan(commitsSpan);

--- a/src/store/__tests__/githubSeenAnchorsStore.test.ts
+++ b/src/store/__tests__/githubSeenAnchorsStore.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  deriveBadgeLabel,
+  SEEN_SUPPRESSION_TTL_MS,
+  useGitHubSeenAnchorsStore,
+  type GitHubSeenAnchor,
+} from "../githubSeenAnchorsStore";
+
+describe("deriveBadgeLabel", () => {
+  const now = 1_700_000_000_000;
+  const fresh: GitHubSeenAnchor = { count: 10, seenAt: now - 60_000 };
+
+  it("returns null when there is no anchor", () => {
+    expect(deriveBadgeLabel(undefined, 12, false, now)).toBeNull();
+  });
+
+  it("returns null while the dropdown is open", () => {
+    expect(deriveBadgeLabel(fresh, 15, true, now)).toBeNull();
+  });
+
+  it("returns null when the anchor is older than 72 hours", () => {
+    const stale: GitHubSeenAnchor = { count: 10, seenAt: now - SEEN_SUPPRESSION_TTL_MS - 1 };
+    expect(deriveBadgeLabel(stale, 50, false, now)).toBeNull();
+  });
+
+  it("returns a label exactly at the 72-hour boundary", () => {
+    const atBoundary: GitHubSeenAnchor = { count: 10, seenAt: now - SEEN_SUPPRESSION_TTL_MS };
+    expect(deriveBadgeLabel(atBoundary, 12, false, now)).toBe("+2");
+  });
+
+  it("returns null when current count is null", () => {
+    expect(deriveBadgeLabel(fresh, null, false, now)).toBeNull();
+  });
+
+  it("returns null when delta is zero", () => {
+    expect(deriveBadgeLabel(fresh, 10, false, now)).toBeNull();
+  });
+
+  it("returns null when delta is negative", () => {
+    expect(deriveBadgeLabel(fresh, 5, false, now)).toBeNull();
+  });
+
+  it("returns +1 for a delta of 1", () => {
+    expect(deriveBadgeLabel(fresh, 11, false, now)).toBe("+1");
+  });
+
+  it("returns +N for typical deltas", () => {
+    expect(deriveBadgeLabel(fresh, 17, false, now)).toBe("+7");
+  });
+
+  it("returns +99 at the cap edge", () => {
+    expect(deriveBadgeLabel(fresh, 109, false, now)).toBe("+99");
+  });
+
+  it("returns +99+ when delta exceeds cap", () => {
+    expect(deriveBadgeLabel(fresh, 110, false, now)).toBe("+99+");
+    expect(deriveBadgeLabel(fresh, 5_000, false, now)).toBe("+99+");
+  });
+
+  it("anchors at zero correctly", () => {
+    const zeroAnchor: GitHubSeenAnchor = { count: 0, seenAt: now - 60_000 };
+    expect(deriveBadgeLabel(zeroAnchor, 0, false, now)).toBeNull();
+    expect(deriveBadgeLabel(zeroAnchor, 1, false, now)).toBe("+1");
+  });
+});
+
+describe("useGitHubSeenAnchorsStore.recordOpen", () => {
+  beforeEach(() => {
+    useGitHubSeenAnchorsStore.setState({ anchors: {} });
+  });
+
+  it("records an anchor for the given project + category", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 12);
+    const anchor = useGitHubSeenAnchorsStore.getState().anchors["/proj/a"]?.issues;
+    expect(anchor?.count).toBe(12);
+    expect(anchor?.seenAt).toBeGreaterThan(0);
+  });
+
+  it("isolates anchors across projects", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 12);
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/b", "issues", 99);
+    const state = useGitHubSeenAnchorsStore.getState().anchors;
+    expect(state["/proj/a"]?.issues?.count).toBe(12);
+    expect(state["/proj/b"]?.issues?.count).toBe(99);
+  });
+
+  it("isolates anchors across categories within the same project", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 12);
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "prs", 4);
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "commits", 30);
+    const proj = useGitHubSeenAnchorsStore.getState().anchors["/proj/a"];
+    expect(proj?.issues?.count).toBe(12);
+    expect(proj?.prs?.count).toBe(4);
+    expect(proj?.commits?.count).toBe(30);
+  });
+
+  it("re-recording the same category updates count and seenAt without disturbing siblings", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 12);
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "prs", 4);
+    const firstSeenAt = useGitHubSeenAnchorsStore.getState().anchors["/proj/a"]?.issues?.seenAt;
+    expect(firstSeenAt).toBeDefined();
+
+    // Wait a hair so seenAt advances past the first call's timestamp.
+    const start = Date.now();
+    while (Date.now() === start) {
+      // tight loop until the millisecond ticks over
+    }
+
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 25);
+    const proj = useGitHubSeenAnchorsStore.getState().anchors["/proj/a"];
+    expect(proj?.issues?.count).toBe(25);
+    expect(proj?.issues?.seenAt).toBeGreaterThan(firstSeenAt!);
+    expect(proj?.prs?.count).toBe(4);
+  });
+});

--- a/src/store/__tests__/githubSeenAnchorsStore.test.ts
+++ b/src/store/__tests__/githubSeenAnchorsStore.test.ts
@@ -69,12 +69,7 @@ describe("deriveBadgeLabel", () => {
     expect(deriveBadgeLabel({ count: 10, seenAt: NaN }, 12, false, now)).toBeNull();
     expect(deriveBadgeLabel({ count: Infinity, seenAt: now - 60_000 }, 12, false, now)).toBeNull();
     expect(
-      deriveBadgeLabel(
-        { count: "bad" as unknown as number, seenAt: now - 60_000 },
-        12,
-        false,
-        now
-      )
+      deriveBadgeLabel({ count: "bad" as unknown as number, seenAt: now - 60_000 }, 12, false, now)
     ).toBeNull();
   });
 });

--- a/src/store/__tests__/githubSeenAnchorsStore.test.ts
+++ b/src/store/__tests__/githubSeenAnchorsStore.test.ts
@@ -63,6 +63,20 @@ describe("deriveBadgeLabel", () => {
     expect(deriveBadgeLabel(zeroAnchor, 0, false, now)).toBeNull();
     expect(deriveBadgeLabel(zeroAnchor, 1, false, now)).toBe("+1");
   });
+
+  it("returns null for non-finite count or seenAt (corrupted persisted state)", () => {
+    expect(deriveBadgeLabel({ count: NaN, seenAt: now - 60_000 }, 12, false, now)).toBeNull();
+    expect(deriveBadgeLabel({ count: 10, seenAt: NaN }, 12, false, now)).toBeNull();
+    expect(deriveBadgeLabel({ count: Infinity, seenAt: now - 60_000 }, 12, false, now)).toBeNull();
+    expect(
+      deriveBadgeLabel(
+        { count: "bad" as unknown as number, seenAt: now - 60_000 },
+        12,
+        false,
+        now
+      )
+    ).toBeNull();
+  });
 });
 
 describe("useGitHubSeenAnchorsStore.recordOpen", () => {
@@ -93,6 +107,24 @@ describe("useGitHubSeenAnchorsStore.recordOpen", () => {
     expect(proj?.issues?.count).toBe(12);
     expect(proj?.prs?.count).toBe(4);
     expect(proj?.commits?.count).toBe(30);
+  });
+
+  it("clears the anchor when count is null (open before stats loaded)", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", 12);
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "prs", 4);
+    expect(useGitHubSeenAnchorsStore.getState().anchors["/proj/a"]?.issues?.count).toBe(12);
+
+    // Opening again while count is unknown clears the issues anchor only —
+    // the badge will be suppressed until the next open with a known count.
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", null);
+    const proj = useGitHubSeenAnchorsStore.getState().anchors["/proj/a"];
+    expect(proj?.issues).toBeUndefined();
+    expect(proj?.prs?.count).toBe(4);
+  });
+
+  it("recordOpen with null count is a no-op when no prior anchor exists", () => {
+    useGitHubSeenAnchorsStore.getState().recordOpen("/proj/a", "issues", null);
+    expect(useGitHubSeenAnchorsStore.getState().anchors["/proj/a"]?.issues).toBeUndefined();
   });
 
   it("re-recording the same category updates count and seenAt without disturbing siblings", () => {

--- a/src/store/githubSeenAnchorsStore.ts
+++ b/src/store/githubSeenAnchorsStore.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
+
+export type GitHubSeenAnchorCategory = "issues" | "prs" | "commits";
+
+export interface GitHubSeenAnchor {
+  count: number;
+  seenAt: number;
+}
+
+export type PerCategoryAnchors = Partial<Record<GitHubSeenAnchorCategory, GitHubSeenAnchor>>;
+
+// Suppress the "+N" badge when the anchor is older than 72 hours so a Monday
+// return to a long-ignored project doesn't flash "+847" — at that age the
+// number is no longer a useful "what's new since I last looked" signal.
+export const SEEN_SUPPRESSION_TTL_MS = 72 * 60 * 60 * 1000;
+
+const BADGE_CAP = 99;
+
+export function deriveBadgeLabel(
+  anchor: GitHubSeenAnchor | undefined,
+  currentCount: number | null,
+  isOpen: boolean,
+  now: number
+): string | null {
+  if (!anchor) return null;
+  if (isOpen) return null;
+  if (now - anchor.seenAt > SEEN_SUPPRESSION_TTL_MS) return null;
+  if (currentCount == null) return null;
+  const delta = currentCount - anchor.count;
+  if (delta <= 0) return null;
+  return delta > BADGE_CAP ? `+${BADGE_CAP}+` : `+${delta}`;
+}
+
+interface GitHubSeenAnchorsState {
+  anchors: Record<string, PerCategoryAnchors>;
+  recordOpen: (projectPath: string, category: GitHubSeenAnchorCategory, count: number) => void;
+}
+
+export const useGitHubSeenAnchorsStore = create<GitHubSeenAnchorsState>()(
+  persist(
+    (set) => ({
+      anchors: {},
+
+      recordOpen: (projectPath, category, count) =>
+        set((state) => ({
+          anchors: {
+            ...state.anchors,
+            [projectPath]: {
+              ...(state.anchors[projectPath] ?? {}),
+              [category]: { count, seenAt: Date.now() },
+            },
+          },
+        })),
+    }),
+    {
+      name: "daintree-github-seen-anchors",
+      storage: createSafeJSONStorage(),
+      version: 0,
+      migrate: (persistedState) => persistedState as GitHubSeenAnchorsState,
+      partialize: (state) => ({ anchors: state.anchors }),
+    }
+  )
+);
+
+registerPersistedStore({
+  storeId: "githubSeenAnchorsStore",
+  store: useGitHubSeenAnchorsStore,
+  persistedStateType: "{ anchors: Record<string, PerCategoryAnchors> }",
+});

--- a/src/store/githubSeenAnchorsStore.ts
+++ b/src/store/githubSeenAnchorsStore.ts
@@ -26,6 +26,10 @@ export function deriveBadgeLabel(
   now: number
 ): string | null {
   if (!anchor) return null;
+  // Defensive: corrupted persisted state (manual localStorage edit, partial
+  // write, or a future schema change) could surface a non-numeric `count` or
+  // `seenAt` that would otherwise produce `+NaN`.
+  if (!Number.isFinite(anchor.count) || !Number.isFinite(anchor.seenAt)) return null;
   if (isOpen) return null;
   if (now - anchor.seenAt > SEEN_SUPPRESSION_TTL_MS) return null;
   if (currentCount == null) return null;
@@ -36,7 +40,19 @@ export function deriveBadgeLabel(
 
 interface GitHubSeenAnchorsState {
   anchors: Record<string, PerCategoryAnchors>;
-  recordOpen: (projectPath: string, category: GitHubSeenAnchorCategory, count: number) => void;
+  /**
+   * Records an anchor for the given project + category. Pass `null` for
+   * `count` when the user opens the dropdown while stats haven't loaded yet —
+   * any existing anchor for that category is cleared so a stale value can't
+   * over-report once stats arrive (the user attended to the category but had
+   * nothing concrete to anchor against). On the next open with a known count
+   * a fresh anchor is captured.
+   */
+  recordOpen: (
+    projectPath: string,
+    category: GitHubSeenAnchorCategory,
+    count: number | null
+  ) => void;
 }
 
 export const useGitHubSeenAnchorsStore = create<GitHubSeenAnchorsState>()(
@@ -45,15 +61,28 @@ export const useGitHubSeenAnchorsStore = create<GitHubSeenAnchorsState>()(
       anchors: {},
 
       recordOpen: (projectPath, category, count) =>
-        set((state) => ({
-          anchors: {
-            ...state.anchors,
-            [projectPath]: {
-              ...(state.anchors[projectPath] ?? {}),
-              [category]: { count, seenAt: Date.now() },
+        set((state) => {
+          const projectAnchors = state.anchors[projectPath] ?? {};
+          if (count == null) {
+            if (!(category in projectAnchors)) return state;
+            const { [category]: _omit, ...rest } = projectAnchors;
+            return {
+              anchors: {
+                ...state.anchors,
+                [projectPath]: rest,
+              },
+            };
+          }
+          return {
+            anchors: {
+              ...state.anchors,
+              [projectPath]: {
+                ...projectAnchors,
+                [category]: { count, seenAt: Date.now() },
+              },
             },
-          },
-        })),
+          };
+        }),
     }),
     {
       name: "daintree-github-seen-anchors",

--- a/src/store/githubSeenAnchorsStore.ts
+++ b/src/store/githubSeenAnchorsStore.ts
@@ -88,7 +88,9 @@ export const useGitHubSeenAnchorsStore = create<GitHubSeenAnchorsState>()(
       name: "daintree-github-seen-anchors",
       storage: createSafeJSONStorage(),
       version: 0,
-      migrate: (persistedState) => persistedState as GitHubSeenAnchorsState,
+      migrate: (persistedState) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        persistedState as GitHubSeenAnchorsState,
       partialize: (state) => ({ anchors: state.anchors }),
     }
   )


### PR DESCRIPTION
## Summary

- Adds a `+N` delta badge to each GitHub toolbar count (issues, PRs, commits) showing how many have arrived since the user last opened that dropdown
- New persisted Zustand store (`githubSeenAnchorsStore`) tracks anchors per-project per-category, survives restarts
- Anchored on click intent rather than poll completion to avoid any race where a fresh poll lands mid-open and reads stale

Resolves #6530

## Changes

- `src/store/githubSeenAnchorsStore.ts` — new store with `recordOpen` / `clearAnchor` / `getAnchor` API; keyed by `{projectId}:{category}`
- Pure `deriveBadgeLabel` helper: 72h TTL suppression, 99+ cap, NaN guards
- `GitHubStatsToolbarButton.tsx` — `recordOpen` wired into both `onClick` and `useImperativeHandle` paths; null-count open clears stale anchor; `aria-label` folds the delta in (child `span` aria-label is ineffective on explicit-label buttons); badge rendered with `text-muted-foreground`, no accent color
- 18 unit tests for the store (`githubSeenAnchorsStore.test.ts`)
- 8 new source-assertion tests in `GitHubStatsToolbarButton.freshFetch.test.tsx`

## Testing

- 98 tests pass across affected suites
- All 4 verify checks pass: typecheck, channel drift, lint ratchet, format
- Manually verified badge appears/clears correctly for each category independently