### PR TITLE
feat(project): per-project Daintree MCP tier selection

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -17,6 +17,7 @@ import { mcpServerService } from "../../../services/McpServerService.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import type { HandlerDependencies } from "../../types.js";
 import { TerminalSpawnOptionsSchema } from "../../../schemas/ipc.js";
+import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
 import {
@@ -220,12 +221,14 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     ) {
       try {
         const projSettings = await projectStore.getProjectSettings(projectId);
-        if (projSettings.exposeDaintreeMcpToAgents) {
+        const tier = resolveDaintreeMcpTier(projSettings);
+        if (tier !== "off") {
           const port = mcpServerService.currentPort;
           if (port) {
             const { configPath, token } = await mcpPaneConfigService.preparePaneConfig({
               paneId: id,
               port,
+              tier,
             });
             safeCommand = `${safeCommand} --mcp-config ${shellQuote(configPath)}`;
             spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_MCP_TOKEN: token };

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 import { app } from "electron";
 import { resilientAtomicWriteFile, resilientUnlink } from "../utils/fs.js";
+import type { DaintreeMcpTier } from "../../shared/types/project.js";
 
 const PANE_CONFIG_DIR_NAME = "mcp-pane-configs";
 const MCP_SERVER_KEY = "daintree";
@@ -10,11 +11,18 @@ const MCP_SERVER_KEY = "daintree";
 interface PaneRecord {
   configPath: string;
   token: string;
+  tier: DaintreeMcpTier;
+}
+
+interface TokenRecord {
+  paneId: string;
+  tier: DaintreeMcpTier;
 }
 
 export interface PreparePaneConfigParams {
   paneId: string;
   port: number;
+  tier: DaintreeMcpTier;
 }
 
 export interface PreparedPaneConfig {
@@ -24,7 +32,7 @@ export interface PreparedPaneConfig {
 
 export class McpPaneConfigService {
   private records = new Map<string, PaneRecord>();
-  private tokens = new Map<string, string>();
+  private tokens = new Map<string, TokenRecord>();
 
   private get baseDir(): string {
     return path.join(app.getPath("userData"), PANE_CONFIG_DIR_NAME);
@@ -43,12 +51,19 @@ export class McpPaneConfigService {
     return candidate;
   }
 
-  async preparePaneConfig({ paneId, port }: PreparePaneConfigParams): Promise<PreparedPaneConfig> {
+  async preparePaneConfig({
+    paneId,
+    port,
+    tier,
+  }: PreparePaneConfigParams): Promise<PreparedPaneConfig> {
     if (!paneId) {
       throw new Error("paneId is required");
     }
     if (!Number.isInteger(port) || port <= 0 || port > 65535) {
       throw new Error(`Invalid MCP port: ${port}`);
+    }
+    if (tier === "off") {
+      throw new Error('preparePaneConfig should not be called with tier "off"');
     }
     // Validate paneId early — configPathFor throws on traversal attempts.
     const configPath = this.configPathFor(paneId);
@@ -80,8 +95,8 @@ export class McpPaneConfigService {
       mode: 0o600,
     });
 
-    this.records.set(paneId, { configPath, token });
-    this.tokens.set(token, paneId);
+    this.records.set(paneId, { configPath, token, tier });
+    this.tokens.set(token, { paneId, tier });
 
     return { configPath, token };
   }
@@ -124,6 +139,11 @@ export class McpPaneConfigService {
   isValidPaneToken(token: string): boolean {
     if (!token) return false;
     return this.tokens.has(token);
+  }
+
+  getTierForToken(token: string): DaintreeMcpTier | undefined {
+    if (!token) return undefined;
+    return this.tokens.get(token)?.tier;
   }
 }
 

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1199,7 +1199,10 @@ export class McpServerService {
    * Resolve the source-tier classification for an authenticated request.
    * Mirrors the three branches of `isAuthorized`:
    *   1. Bearer matches the global apiKey → `"external"` (legacy server).
-   *   2. Bearer matches a per-pane token → `"workbench"` (project agents).
+   *   2. Bearer matches a per-pane token → the per-pane configured tier
+   *      (`"workbench"`, `"action"`, or `"system"` from the project's
+   *      `daintreeMcpTier` setting). Pane configs with tier `"off"` are
+   *      never written, so this branch returns one of the active tiers.
    *   3. No `Authorization` header and no apiKey configured → `"external"`
    *      (legacy permissive path; preserves pre-auth behavior).
    * Falls back to `"workbench"` for anything that slipped through but
@@ -1220,7 +1223,10 @@ export class McpServerService {
 
     if (auth.startsWith("Bearer ")) {
       const token = auth.slice("Bearer ".length);
-      if (mcpPaneConfigService.isValidPaneToken(token)) return "workbench";
+      const paneTier = mcpPaneConfigService.getTierForToken(token);
+      if (paneTier === "workbench" || paneTier === "action" || paneTier === "system") {
+        return paneTier;
+      }
     }
 
     return "workbench";

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -222,6 +222,17 @@ export class ProjectSettingsManager {
             : undefined,
         defaultWorktreeMode:
           typeof parsed.defaultWorktreeMode === "string" ? parsed.defaultWorktreeMode : undefined,
+        daintreeMcpTier:
+          parsed.daintreeMcpTier === "off" ||
+          parsed.daintreeMcpTier === "workbench" ||
+          parsed.daintreeMcpTier === "action" ||
+          parsed.daintreeMcpTier === "system"
+            ? parsed.daintreeMcpTier
+            : undefined,
+        exposeDaintreeMcpToAgents:
+          typeof parsed.exposeDaintreeMcpToAgents === "boolean"
+            ? parsed.exposeDaintreeMcpToAgents
+            : undefined,
       };
 
       this.notificationOverridesCache.set(projectId, settings.notificationOverrides);

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -36,6 +36,7 @@ describe("McpPaneConfigService", () => {
     const { configPath, token } = await service.preparePaneConfig({
       paneId: "pane-001",
       port: 45454,
+      tier: "workbench",
     });
 
     expect(configPath).toBe(path.join(testUserData, "mcp-pane-configs", "pane-001.json"));
@@ -54,7 +55,7 @@ describe("McpPaneConfigService", () => {
   it("creates the pane config directory with mode 0700 on POSIX", async () => {
     if (process.platform === "win32") return;
 
-    await service.preparePaneConfig({ paneId: "pane-002", port: 45454 });
+    await service.preparePaneConfig({ paneId: "pane-002", port: 45454, tier: "workbench" });
     const stat = await fs.stat(path.join(testUserData, "mcp-pane-configs"));
     expect(stat.mode & 0o777).toBe(0o700);
   });
@@ -62,13 +63,21 @@ describe("McpPaneConfigService", () => {
   it("creates the config file with mode 0600 on POSIX", async () => {
     if (process.platform === "win32") return;
 
-    const { configPath } = await service.preparePaneConfig({ paneId: "pane-003", port: 45454 });
+    const { configPath } = await service.preparePaneConfig({
+      paneId: "pane-003",
+      port: 45454,
+      tier: "workbench",
+    });
     const stat = await fs.stat(configPath);
     expect(stat.mode & 0o777).toBe(0o600);
   });
 
   it("registers the token as valid and rejects unknown tokens", async () => {
-    const { token } = await service.preparePaneConfig({ paneId: "pane-004", port: 45454 });
+    const { token } = await service.preparePaneConfig({
+      paneId: "pane-004",
+      port: 45454,
+      tier: "workbench",
+    });
 
     expect(service.isValidPaneToken(token)).toBe(true);
     expect(service.isValidPaneToken("not-a-real-token")).toBe(false);
@@ -79,6 +88,7 @@ describe("McpPaneConfigService", () => {
     const { configPath, token } = await service.preparePaneConfig({
       paneId: "pane-005",
       port: 45454,
+      tier: "action",
     });
 
     expect(service.isValidPaneToken(token)).toBe(true);
@@ -91,15 +101,23 @@ describe("McpPaneConfigService", () => {
   it("is idempotent — revokePaneConfig tolerates missing files and unknown panes", async () => {
     await expect(service.revokePaneConfig("never-existed")).resolves.toBeUndefined();
 
-    await service.preparePaneConfig({ paneId: "pane-006", port: 45454 });
+    await service.preparePaneConfig({ paneId: "pane-006", port: 45454, tier: "workbench" });
     await service.revokePaneConfig("pane-006");
     // second call against an already-revoked pane must not throw
     await expect(service.revokePaneConfig("pane-006")).resolves.toBeUndefined();
   });
 
   it("re-preparing the same paneId rotates the token and overwrites the file", async () => {
-    const first = await service.preparePaneConfig({ paneId: "pane-007", port: 45454 });
-    const second = await service.preparePaneConfig({ paneId: "pane-007", port: 45454 });
+    const first = await service.preparePaneConfig({
+      paneId: "pane-007",
+      port: 45454,
+      tier: "workbench",
+    });
+    const second = await service.preparePaneConfig({
+      paneId: "pane-007",
+      port: 45454,
+      tier: "system",
+    });
 
     expect(second.token).not.toBe(first.token);
     expect(service.isValidPaneToken(first.token)).toBe(false);
@@ -111,42 +129,99 @@ describe("McpPaneConfigService", () => {
   });
 
   it("rejects invalid ports", async () => {
-    await expect(service.preparePaneConfig({ paneId: "pane-008", port: 0 })).rejects.toThrow(
-      /Invalid MCP port/
-    );
-    await expect(service.preparePaneConfig({ paneId: "pane-009", port: 70000 })).rejects.toThrow(
-      /Invalid MCP port/
-    );
     await expect(
-      service.preparePaneConfig({ paneId: "pane-010", port: -1 as unknown as number })
+      service.preparePaneConfig({ paneId: "pane-008", port: 0, tier: "workbench" })
+    ).rejects.toThrow(/Invalid MCP port/);
+    await expect(
+      service.preparePaneConfig({ paneId: "pane-009", port: 70000, tier: "workbench" })
+    ).rejects.toThrow(/Invalid MCP port/);
+    await expect(
+      service.preparePaneConfig({
+        paneId: "pane-010",
+        port: -1 as unknown as number,
+        tier: "workbench",
+      })
     ).rejects.toThrow(/Invalid MCP port/);
   });
 
   it("rejects empty pane IDs", async () => {
-    await expect(service.preparePaneConfig({ paneId: "", port: 45454 })).rejects.toThrow(
-      /paneId is required/
-    );
+    await expect(
+      service.preparePaneConfig({ paneId: "", port: 45454, tier: "workbench" })
+    ).rejects.toThrow(/paneId is required/);
+  });
+
+  it('rejects tier "off" — caller must skip preparePaneConfig instead', async () => {
+    await expect(
+      service.preparePaneConfig({ paneId: "pane-off", port: 45454, tier: "off" })
+    ).rejects.toThrow(/should not be called with tier "off"/);
   });
 
   it("rejects path-traversal pane IDs", async () => {
-    await expect(service.preparePaneConfig({ paneId: "../escape", port: 45454 })).rejects.toThrow(
-      /Invalid paneId/
-    );
     await expect(
-      service.preparePaneConfig({ paneId: "../../etc/passwd", port: 45454 })
+      service.preparePaneConfig({ paneId: "../escape", port: 45454, tier: "workbench" })
     ).rejects.toThrow(/Invalid paneId/);
-    await expect(service.preparePaneConfig({ paneId: "subdir/leak", port: 45454 })).rejects.toThrow(
-      /Invalid paneId/
-    );
+    await expect(
+      service.preparePaneConfig({
+        paneId: "../../etc/passwd",
+        port: 45454,
+        tier: "workbench",
+      })
+    ).rejects.toThrow(/Invalid paneId/);
+    await expect(
+      service.preparePaneConfig({ paneId: "subdir/leak", port: 45454, tier: "workbench" })
+    ).rejects.toThrow(/Invalid paneId/);
 
     // Confirm no file was written outside the base directory.
     const escapeCandidate = path.join(testUserData, "escape.json");
     await expect(fs.stat(escapeCandidate)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("getTierForToken returns the tier the token was minted at", async () => {
+    const wb = await service.preparePaneConfig({
+      paneId: "pane-wb",
+      port: 45454,
+      tier: "workbench",
+    });
+    const action = await service.preparePaneConfig({
+      paneId: "pane-action",
+      port: 45454,
+      tier: "action",
+    });
+    const sys = await service.preparePaneConfig({
+      paneId: "pane-sys",
+      port: 45454,
+      tier: "system",
+    });
+
+    expect(service.getTierForToken(wb.token)).toBe("workbench");
+    expect(service.getTierForToken(action.token)).toBe("action");
+    expect(service.getTierForToken(sys.token)).toBe("system");
+    expect(service.getTierForToken("not-a-real-token")).toBeUndefined();
+    expect(service.getTierForToken("")).toBeUndefined();
+  });
+
+  it("revokePaneConfig clears the tier mapping", async () => {
+    const { token } = await service.preparePaneConfig({
+      paneId: "pane-revoke-tier",
+      port: 45454,
+      tier: "system",
+    });
+    expect(service.getTierForToken(token)).toBe("system");
+    await service.revokePaneConfig("pane-revoke-tier");
+    expect(service.getTierForToken(token)).toBeUndefined();
+  });
+
   it("revokeAll clears all tokens and files", async () => {
-    const a = await service.preparePaneConfig({ paneId: "pane-a", port: 45454 });
-    const b = await service.preparePaneConfig({ paneId: "pane-b", port: 45454 });
+    const a = await service.preparePaneConfig({
+      paneId: "pane-a",
+      port: 45454,
+      tier: "workbench",
+    });
+    const b = await service.preparePaneConfig({
+      paneId: "pane-b",
+      port: 45454,
+      tier: "system",
+    });
 
     expect(service.isValidPaneToken(a.token)).toBe(true);
     expect(service.isValidPaneToken(b.token)).toBe(true);

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -112,11 +112,12 @@ vi.mock("../../store.js", () => ({
   },
 }));
 
-const paneTokens = vi.hoisted(() => new Set<string>());
+const paneTokenTiers = vi.hoisted(() => new Map<string, "workbench" | "action" | "system">());
 
 vi.mock("../McpPaneConfigService.js", () => ({
   mcpPaneConfigService: {
-    isValidPaneToken: (token: string) => paneTokens.has(token),
+    isValidPaneToken: (token: string) => paneTokenTiers.has(token),
+    getTierForToken: (token: string) => paneTokenTiers.get(token),
   },
 }));
 
@@ -413,7 +414,7 @@ describe("McpServerService", () => {
     };
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
-    paneTokens.clear();
+    paneTokenTiers.clear();
     electronMocks.ipcMain.removeAllListeners();
     electronMocks.ipcMain.handle.mockClear();
     electronMocks.ipcMain.removeHandler.mockClear();
@@ -1192,7 +1193,7 @@ describe("McpServerService", () => {
       port: number
     ): Promise<{ client: Client; transport: SSEClientTransport; token: string }> {
       const token = `pane-token-${Math.random().toString(36).slice(2)}`;
-      paneTokens.add(token);
+      paneTokenTiers.set(token, "workbench");
       const client = new Client({ name: "mcp-pane-client", version: "1.0.0" });
       const headers = { Authorization: `Bearer ${token}` };
       const transport = new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`), {
@@ -1404,7 +1405,7 @@ describe("McpServerService", () => {
       await service.start(window);
 
       const token = `pane-token-${Math.random().toString(36).slice(2)}`;
-      paneTokens.add(token);
+      paneTokenTiers.set(token, "workbench");
       const client = new Client({ name: "mcp-pane-http-client", version: "1.0.0" });
       const transport = new StreamableHTTPClientTransport(
         new URL(`http://127.0.0.1:${service.currentPort}/mcp`),
@@ -1431,6 +1432,132 @@ describe("McpServerService", () => {
       expect(denyRecord?.tier).toBe("workbench");
       expect(denyRecord?.result).toBe("unauthorized");
       expect(allowRecord?.tier).toBe("workbench");
+    });
+  });
+
+  describe("per-pane MCP tier", () => {
+    const tierManifest = () => [
+      createManifestEntry({
+        id: "actions.list" as ActionId,
+        title: "List Actions",
+        description: "Read the action registry",
+        kind: "query",
+      }),
+      createManifestEntry({
+        id: "worktree.list" as ActionId,
+        title: "List Worktrees",
+        description: "Read worktree state",
+        kind: "query",
+      }),
+      createManifestEntry({
+        id: "worktree.create" as ActionId,
+        title: "Create Worktree",
+        description: "Create a new worktree",
+      }),
+      createManifestEntry({
+        id: "git.commit" as ActionId,
+        title: "Commit",
+        description: "Create a git commit",
+      }),
+    ];
+
+    it("workbench tier exposes only read-only introspection tools", async () => {
+      paneTokenTiers.set("token-wb", "workbench");
+      const { window } = createMockWindow({ getManifest: tierManifest });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wb",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("actions.list");
+      expect(ids).toContain("worktree.list");
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).not.toContain("git.commit");
+    });
+
+    it("action tier adds non-destructive mutations but excludes irreversible ones", async () => {
+      paneTokenTiers.set("token-action", "action");
+      const { window } = createMockWindow({ getManifest: tierManifest });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-action",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("worktree.list");
+      expect(ids).toContain("worktree.create");
+      expect(ids).not.toContain("git.commit");
+    });
+
+    it("system tier exposes the full curated allowlist including irreversible mutations", async () => {
+      paneTokenTiers.set("token-sys", "system");
+      const { window } = createMockWindow({ getManifest: tierManifest });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-sys",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("worktree.list");
+      expect(ids).toContain("worktree.create");
+      expect(ids).toContain("git.commit");
+    });
+
+    it("rejects callTool for actions outside the session tier with MethodNotFound", async () => {
+      paneTokenTiers.set("token-wb", "workbench");
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: "should-not-run" })
+      );
+      const { window } = createMockWindow({
+        getManifest: tierManifest,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wb",
+      });
+      transports.push(transport);
+
+      await expect(
+        client.callTool({ name: "git.commit", arguments: { message: "x" } })
+      ).rejects.toMatchObject({ code: -32601 });
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("tier filtering takes precedence over fullToolSurface for pane-scoped sessions", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      paneTokenTiers.set("token-wb", "workbench");
+      const { window } = createMockWindow({
+        getManifest: () => [
+          ...tierManifest(),
+          createManifestEntry({
+            id: "panel.gridLayout.setStrategy" as ActionId,
+            title: "Set grid layout",
+            description: "Power-user UI plumbing",
+          }),
+        ],
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wb",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("worktree.list");
+      // workbench excludes these even with fullToolSurface enabled.
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).not.toContain("git.commit");
+      expect(ids).not.toContain("panel.gridLayout.setStrategy");
     });
   });
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1454,12 +1454,41 @@ describe("McpServerService", () => {
         title: "Create Worktree",
         description: "Create a new worktree",
       }),
+      // System-only tools — irreversible or externally-visible mutations.
       createManifestEntry({
         id: "git.commit" as ActionId,
         title: "Commit",
         description: "Create a git commit",
       }),
+      createManifestEntry({
+        id: "git.push" as ActionId,
+        title: "Push",
+        description: "Push commits to a remote",
+      }),
+      createManifestEntry({
+        id: "worktree.delete" as ActionId,
+        title: "Delete Worktree",
+        description: "Permanently remove a worktree",
+      }),
+      createManifestEntry({
+        id: "terminal.sendCommand" as ActionId,
+        title: "Send Terminal Command",
+        description: "Run an arbitrary command in a terminal",
+      }),
+      createManifestEntry({
+        id: "agent.terminal" as ActionId,
+        title: "Agent Terminal",
+        description: "Drive a running agent",
+      }),
     ];
+
+    const SYSTEM_ONLY_TOOLS = [
+      "git.commit",
+      "git.push",
+      "worktree.delete",
+      "terminal.sendCommand",
+      "agent.terminal",
+    ] as const;
 
     it("workbench tier exposes only read-only introspection tools", async () => {
       paneTokenTiers.set("token-wb", "workbench");
@@ -1491,7 +1520,9 @@ describe("McpServerService", () => {
       const ids = (await client.listTools()).tools.map((tool) => tool.name);
       expect(ids).toContain("worktree.list");
       expect(ids).toContain("worktree.create");
-      expect(ids).not.toContain("git.commit");
+      for (const id of SYSTEM_ONLY_TOOLS) {
+        expect(ids).not.toContain(id);
+      }
     });
 
     it("system tier exposes the full curated allowlist including irreversible mutations", async () => {
@@ -1507,7 +1538,9 @@ describe("McpServerService", () => {
       const ids = (await client.listTools()).tools.map((tool) => tool.name);
       expect(ids).toContain("worktree.list");
       expect(ids).toContain("worktree.create");
-      expect(ids).toContain("git.commit");
+      for (const id of SYSTEM_ONLY_TOOLS) {
+        expect(ids).toContain(id);
+      }
     });
 
     it("rejects callTool for actions outside the session tier with MethodNotFound", async () => {
@@ -1528,6 +1561,33 @@ describe("McpServerService", () => {
 
       await expect(
         client.callTool({ name: "git.commit", arguments: { message: "x" } })
+      ).rejects.toMatchObject({ code: -32601 });
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("filters listTools and rejects callTool over the Streamable HTTP transport", async () => {
+      paneTokenTiers.set("token-wb-http", "workbench");
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: "should-not-run" })
+      );
+      const { window } = createMockWindow({
+        getManifest: tierManifest,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectHttpClient(service.currentPort!, {
+        Authorization: "Bearer token-wb-http",
+      });
+      httpTransports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      expect(ids).toContain("worktree.list");
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).not.toContain("git.commit");
+
+      await expect(
+        client.callTool({ name: "worktree.create", arguments: {} })
       ).rejects.toMatchObject({ code: -32601 });
       expect(dispatchMock).not.toHaveBeenCalled();
     });

--- a/electron/services/__tests__/ProjectSettingsManager.test.ts
+++ b/electron/services/__tests__/ProjectSettingsManager.test.ts
@@ -183,4 +183,43 @@ describe("ProjectSettingsManager caching", () => {
     const loaded = await manager.getProjectSettings(projectId);
     expect(loaded.turbopackEnabled).toBeUndefined();
   });
+
+  it.each(["off", "workbench", "action", "system"] as const)(
+    "round-trips daintreeMcpTier=%s through save/load",
+    async (tier) => {
+      await manager.saveProjectSettings(projectId, {
+        runCommands: [],
+        daintreeMcpTier: tier,
+      });
+
+      const freshManager = new ProjectSettingsManager(tempDir, createMockStore());
+      const loaded = await freshManager.getProjectSettings(projectId);
+      expect(loaded.daintreeMcpTier).toBe(tier);
+    }
+  );
+
+  it("rejects unknown daintreeMcpTier values from disk", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], daintreeMcpTier: "godmode" }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.daintreeMcpTier).toBeUndefined();
+  });
+
+  it("preserves the deprecated exposeDaintreeMcpToAgents flag for migration", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], exposeDaintreeMcpToAgents: true }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.exposeDaintreeMcpToAgents).toBe(true);
+    expect(loaded.daintreeMcpTier).toBeUndefined();
+  });
 });

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -396,6 +396,32 @@ export interface ProjectSettings {
   defaultWorktreeMode?: string;
   /** Hostnames the user approved for the browser panel beyond the implicit local/private allow-list */
   browserAllowedHosts?: string[];
-  /** Expose the Daintree MCP server to Claude Code agents launched in this project's worktrees */
+  /**
+   * Tier of Daintree MCP access exposed to agents launched in this project's worktrees.
+   * - `off` (default): no MCP server injected
+   * - `workbench`: read-only introspection (worktree/files/terminal output, project state, history)
+   * - `action`: workbench + non-destructive operations (create worktrees, inject context, stage changes)
+   * - `system`: action + destructive/irreversible operations (delete worktrees, commit/push, send terminal commands)
+   */
+  daintreeMcpTier?: DaintreeMcpTier;
+  /**
+   * @deprecated Use `daintreeMcpTier` instead. Kept for one-cycle migration of existing project files.
+   * `true` migrates to `workbench` on read; `false`/undefined migrates to `off`.
+   */
   exposeDaintreeMcpToAgents?: boolean;
+}
+
+/** Tier of Daintree MCP access exposed to agents in a project. */
+export type DaintreeMcpTier = "off" | "workbench" | "action" | "system";
+
+/** Resolve the legacy boolean field into the new tier enum. */
+export function resolveDaintreeMcpTier(settings: {
+  daintreeMcpTier?: DaintreeMcpTier;
+  exposeDaintreeMcpToAgents?: boolean;
+}): DaintreeMcpTier {
+  const tier = settings.daintreeMcpTier;
+  if (tier === "workbench" || tier === "action" || tier === "system") return tier;
+  if (tier === "off") return "off";
+  if (settings.exposeDaintreeMcpToAgents === true) return "workbench";
+  return "off";
 }

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -1,16 +1,50 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { Image, Upload, X, Rocket, Check, FolderOpen, Copy, Palette } from "lucide-react";
+import {
+  Image,
+  Upload,
+  X,
+  Rocket,
+  Check,
+  FolderOpen,
+  Copy,
+  Palette,
+  AlertTriangle,
+} from "lucide-react";
 import { FolderGit2, McpServerIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { EmojiPicker } from "@/components/ui/emoji-picker";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
+import { SettingsChoicebox, type ChoiceboxOption } from "@/components/Settings/SettingsChoicebox";
 import { getProjectGradient, isValidHexColor } from "@/lib/colorUtils";
 import { cn } from "@/lib/utils";
 import { sanitizeSvg, svgToDataUrl } from "@/lib/svg";
 import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { Project } from "@shared/types/project";
+import type { DaintreeMcpTier, Project } from "@shared/types/project";
+
+const DAINTREE_MCP_TIER_OPTIONS: readonly ChoiceboxOption<DaintreeMcpTier>[] = [
+  {
+    value: "off",
+    label: "Off",
+    description: "No Daintree MCP access. Default for new projects.",
+  },
+  {
+    value: "workbench",
+    label: "Workbench",
+    description: "Read-only: worktree status, terminal output, file search, project history.",
+  },
+  {
+    value: "action",
+    label: "Action",
+    description: "Workbench + create worktrees, inject context, stage changes.",
+  },
+  {
+    value: "system",
+    label: "System",
+    description: "Action + commit, push, delete, send terminal commands.",
+  },
+];
 
 const PRESET_SWATCHES = [
   { label: "Blue", cssVar: "--theme-category-blue" },
@@ -54,8 +88,8 @@ interface GeneralTabProps {
   onDevServerLoadTimeoutChange: (value: number | undefined) => void;
   turbopackEnabled: boolean;
   onTurbopackEnabledChange: (value: boolean) => void;
-  exposeDaintreeMcpToAgents: boolean;
-  onExposeDaintreeMcpToAgentsChange: (value: boolean) => void;
+  daintreeMcpTier: DaintreeMcpTier;
+  onDaintreeMcpTierChange: (value: DaintreeMcpTier) => void;
   projectIconSvg: string | undefined;
   onProjectIconSvgChange: (value: string | undefined) => void;
   enableInRepoSettings: (projectId: string) => Promise<Project>;
@@ -78,8 +112,8 @@ export function GeneralTab({
   onDevServerLoadTimeoutChange,
   turbopackEnabled,
   onTurbopackEnabledChange,
-  exposeDaintreeMcpToAgents,
-  onExposeDaintreeMcpToAgentsChange,
+  daintreeMcpTier,
+  onDaintreeMcpTierChange,
   projectIconSvg,
   onProjectIconSvgChange,
   enableInRepoSettings,
@@ -462,18 +496,34 @@ export function GeneralTab({
           Agent integrations
         </h3>
         <p className="text-xs text-daintree-text/60 mb-4">
-          Connect Claude Code agents launched in this project's worktrees to the Daintree MCP
-          server. Agents can read worktree status, terminal output, and run safe project actions.
+          Choose how much of Daintree the Claude Code agents launched in this project's worktrees
+          can reach. Each tier expands what's available — newly launched agents pick up the change.
         </p>
 
-        <SettingsSwitchCard
-          icon={McpServerIcon}
-          title="Expose Daintree MCP to Claude Code agents"
-          subtitle="Injects --mcp-config with a per-pane bearer token on agent launch"
-          isEnabled={exposeDaintreeMcpToAgents}
-          onChange={() => onExposeDaintreeMcpToAgentsChange(!exposeDaintreeMcpToAgents)}
-          ariaLabel="Expose Daintree MCP to Claude Code agents"
-        />
+        <div className="flex flex-col gap-3">
+          <SettingsChoicebox<DaintreeMcpTier>
+            value={daintreeMcpTier}
+            onChange={onDaintreeMcpTierChange}
+            options={DAINTREE_MCP_TIER_OPTIONS}
+            columns={2}
+            aria-label="Daintree MCP access tier"
+          />
+          {daintreeMcpTier === "system" && (
+            <div
+              className={cn(
+                "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
+                "bg-overlay-subtle border border-daintree-border"
+              )}
+            >
+              <AlertTriangle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
+              <div className="text-xs text-daintree-text/70 leading-relaxed select-text">
+                System tier lets agents commit, push, delete worktrees, and send terminal commands —
+                some of these are irreversible or visible to teammates. Only enable it for projects
+                where you trust the agent to take that kind of action.
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="mb-6">

--- a/src/components/Project/projectSettingsDirty.ts
+++ b/src/components/Project/projectSettingsDirty.ts
@@ -1,6 +1,7 @@
 import type { CommandOverride } from "@shared/types/commands";
 import type {
   CopyTreeSettings,
+  DaintreeMcpTier,
   ProjectTerminalSettings,
   ResourceEnvironment,
 } from "@shared/types/project";
@@ -12,7 +13,7 @@ export interface ProjectSettingsSnapshot {
   devServerCommand: string;
   devServerLoadTimeout: number | undefined;
   turbopackEnabled: boolean;
-  exposeDaintreeMcpToAgents: boolean;
+  daintreeMcpTier: DaintreeMcpTier;
   projectIconSvg: string | undefined;
   excludedPaths: string[];
   environmentVariables: Record<string, string>;
@@ -78,7 +79,7 @@ export function createProjectSettingsSnapshot(
   activeResourceEnvironment: string | undefined = undefined,
   defaultWorktreeMode: string | undefined = undefined,
   turbopackEnabled: boolean = true,
-  exposeDaintreeMcpToAgents: boolean = false
+  daintreeMcpTier: DaintreeMcpTier = "off"
 ): ProjectSettingsSnapshot {
   const envVarRecord: Record<string, string> = {};
   const seenKeys = new Map<string, number>();
@@ -147,7 +148,7 @@ export function createProjectSettingsSnapshot(
     devServerCommand: devServerCommand.trim(),
     devServerLoadTimeout,
     turbopackEnabled,
-    exposeDaintreeMcpToAgents,
+    daintreeMcpTier,
     projectIconSvg,
     excludedPaths: sanitizedPaths,
     environmentVariables: sortedEnvVars,
@@ -220,7 +221,7 @@ export function areSnapshotsEqual(a: ProjectSettingsSnapshot, b: ProjectSettings
   if (a.devServerCommand !== b.devServerCommand) return false;
   if (a.devServerLoadTimeout !== b.devServerLoadTimeout) return false;
   if (a.turbopackEnabled !== b.turbopackEnabled) return false;
-  if (a.exposeDaintreeMcpToAgents !== b.exposeDaintreeMcpToAgents) return false;
+  if (a.daintreeMcpTier !== b.daintreeMcpTier) return false;
   if (a.projectIconSvg !== b.projectIconSvg) return false;
   if (a.defaultWorktreeRecipeId !== b.defaultWorktreeRecipeId) return false;
 

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1434,10 +1434,8 @@ function SettingsDialogInner({
                               onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
                               turbopackEnabled={projectForm.turbopackEnabled}
                               onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
-                              exposeDaintreeMcpToAgents={projectForm.exposeDaintreeMcpToAgents}
-                              onExposeDaintreeMcpToAgentsChange={
-                                projectForm.setExposeDaintreeMcpToAgents
-                              }
+                              daintreeMcpTier={projectForm.daintreeMcpTier}
+                              onDaintreeMcpTierChange={projectForm.setDaintreeMcpTier}
                               projectIconSvg={projectForm.projectIconSvg}
                               onProjectIconSvgChange={projectForm.setProjectIconSvg}
                               enableInRepoSettings={projectForm.enableInRepoSettings}

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -12,7 +12,12 @@ import {
 } from "@/components/Project/projectSettingsDirty";
 import { validatePathPattern } from "@shared/utils/pathPattern";
 import type { RunCommand, CopyTreeSettings } from "@/types";
-import type { ProjectTerminalSettings, ResourceEnvironment } from "@shared/types/project";
+import type {
+  DaintreeMcpTier,
+  ProjectTerminalSettings,
+  ResourceEnvironment,
+} from "@shared/types/project";
+import { resolveDaintreeMcpTier } from "@shared/types/project";
 import type { CommandOverride } from "@shared/types/commands";
 import type { NotificationSettings } from "@shared/types/ipc/api";
 import { SCROLLBACK_MIN, SCROLLBACK_MAX } from "@shared/config/scrollback";
@@ -51,7 +56,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
   const [devServerCommand, setDevServerCommand] = useState<string>("");
   const [devServerLoadTimeout, setDevServerLoadTimeout] = useState<number | undefined>(undefined);
   const [turbopackEnabled, setTurbopackEnabled] = useState<boolean>(true);
-  const [exposeDaintreeMcpToAgents, setExposeDaintreeMcpToAgents] = useState<boolean>(false);
+  const [daintreeMcpTier, setDaintreeMcpTier] = useState<DaintreeMcpTier>("off");
   const [commandOverrides, setCommandOverrides] = useState<CommandOverride[]>([]);
   const [copyTreeSettings, setCopyTreeSettings] = useState<CopyTreeSettings>({});
   const [branchPrefixMode, setBranchPrefixMode] = useState<"none" | "username" | "custom">("none");
@@ -135,7 +140,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       activeResourceEnvironment,
       defaultWorktreeMode,
       turbopackEnabled,
-      exposeDaintreeMcpToAgents
+      daintreeMcpTier
     );
   }, [
     projectName,
@@ -161,7 +166,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     activeResourceEnvironment,
     defaultWorktreeMode,
     turbopackEnabled,
-    exposeDaintreeMcpToAgents,
+    daintreeMcpTier,
   ]);
   useEffect(() => {
     currentProjectSnapshotRef.current = currentProjectSnapshot;
@@ -184,7 +189,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       setDevServerCommand("");
       setDevServerLoadTimeout(undefined);
       setTurbopackEnabled(true);
-      setExposeDaintreeMcpToAgents(false);
+      setDaintreeMcpTier("off");
       setCommandOverrides([]);
       setCopyTreeSettings({});
       setProjectAutoSaveError(null);
@@ -221,7 +226,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     const initialDevServerCommand = projectSettings.devServerCommand || "";
     const initialDevServerLoadTimeout = projectSettings.devServerLoadTimeout;
     const initialTurbopackEnabled = projectSettings.turbopackEnabled ?? true;
-    const initialExposeDaintreeMcpToAgents = projectSettings.exposeDaintreeMcpToAgents ?? false;
+    const initialDaintreeMcpTier = resolveDaintreeMcpTier(projectSettings);
     const initialCommandOverrides = projectSettings.commandOverrides || [];
     const initialCopyTreeSettings = projectSettings.copyTreeSettings || {};
     const initialBranchPrefixMode = projectSettings.branchPrefixMode ?? "none";
@@ -261,7 +266,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDevServerCommand(initialDevServerCommand);
     setDevServerLoadTimeout(initialDevServerLoadTimeout);
     setTurbopackEnabled(initialTurbopackEnabled);
-    setExposeDaintreeMcpToAgents(initialExposeDaintreeMcpToAgents);
+    setDaintreeMcpTier(initialDaintreeMcpTier);
     setCommandOverrides(initialCommandOverrides);
     setCopyTreeSettings(initialCopyTreeSettings);
     setBranchPrefixMode(initialBranchPrefixMode);
@@ -304,7 +309,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       initialActiveResourceEnvironment,
       initialDefaultWorktreeMode,
       initialTurbopackEnabled,
-      initialExposeDaintreeMcpToAgents
+      initialDaintreeMcpTier
     );
     setProjectIsInitialized(true);
   }, [projectSettings, isOpen, projectIsInitialized, currentProject, projectIsLoading, projectId]);
@@ -390,7 +395,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
         devServerCommand: devServerCommand.trim() || undefined,
         devServerLoadTimeout,
         turbopackEnabled: turbopackEnabled === true ? undefined : false,
-        exposeDaintreeMcpToAgents: exposeDaintreeMcpToAgents ? true : undefined,
+        daintreeMcpTier: daintreeMcpTier !== "off" ? daintreeMcpTier : undefined,
+        exposeDaintreeMcpToAgents: undefined,
         commandOverrides: commandOverrides.length > 0 ? commandOverrides : undefined,
         copyTreeSettings: hasCopyTreeSettings ? sanitizedCopyTreeSettings : undefined,
         branchPrefixMode: effectivePrefixMode !== "none" ? effectivePrefixMode : undefined,
@@ -468,8 +474,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDevServerLoadTimeout,
     turbopackEnabled,
     setTurbopackEnabled,
-    exposeDaintreeMcpToAgents,
-    setExposeDaintreeMcpToAgents,
+    daintreeMcpTier,
+    setDaintreeMcpTier,
     commandOverrides,
     setCommandOverrides,
     copyTreeSettings,


### PR DESCRIPTION
## Summary

- Adds a \"Daintree MCP access\" control to Project Settings with four tiers: `off`, `workbench`, `action`, and `system`
- The `system` tier requires explicit user acknowledgement before enabling, with a clear warning about destructive capabilities
- Setting persists per-project via `ProjectSettingsManager`; `McpServerService` filters exposed tools based on the active tier

Resolves #6528

## Changes

- `shared/types/project.ts` — `DainTreeMcpTier` type and project settings field
- `electron/services/McpServerService.ts` — tool filtering by tier
- `electron/services/McpPaneConfigService.ts` — tier-aware pane config
- `electron/services/ProjectSettingsManager.ts` — persist and read `daintreeMcpTier`
- `src/components/Project/GeneralTab.tsx` — tier selector UI with system-tier warning
- `src/hooks/useProjectSettingsForm.ts` — form state for tier field
- Tests across `McpServerService`, `McpPaneConfigService`, and `ProjectSettingsManager`

## Testing

- Unit tests added for tier filtering in `McpServerService` and config generation in `McpPaneConfigService`
- `ProjectSettingsManager` tests cover read/write round-trip for the new field
- Manually verified the tier selector renders correctly in Project Settings and that the system-tier acknowledgement gate works