### PR TITLE
feat(worktree): surface fetch freshness on dashboard cards

### DIFF
--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -47,6 +47,21 @@ export interface FetchResult {
   reason?: GitOperationReason;
   /** Why we skipped — for logging / diagnostics. */
   skipReason?: "no-common-dir" | "in-failure-window" | "auth-suspended" | "stale-generation";
+  /**
+   * Coordinator's per-commondir `lastSuccessfulFetch` after this call settled.
+   * Set on success (the timestamp just written) and on skipped/failed
+   * outcomes (the prior timestamp, if any). Lets `WorkspaceService` propagate
+   * the freshest known value to monitors without reaching into coordinator
+   * internals.
+   */
+  lastFetchedAt?: number | null;
+  /**
+   * True when this call ended in (or remained in) an auth-class failure for
+   * this commondir. Includes the `auth-suspended` skip case so the renderer
+   * keeps showing the "Sign in to refresh" affordance instead of flashing
+   * stale counts when a sibling's force-fetch is rate-cached.
+   */
+  authFailed?: boolean;
 }
 
 /**
@@ -102,6 +117,8 @@ export class RepoFetchCoordinator {
           status: "skipped",
           skipReason: "auth-suspended",
           reason: failure.reason,
+          lastFetchedAt: state.lastSuccessfulFetch,
+          authFailed: true,
         };
       }
       if (Date.now() < failure.retryAt) {
@@ -109,6 +126,8 @@ export class RepoFetchCoordinator {
           status: "skipped",
           skipReason: "in-failure-window",
           reason: failure.reason,
+          lastFetchedAt: state.lastSuccessfulFetch,
+          authFailed: false,
         };
       }
     }
@@ -217,7 +236,11 @@ export class RepoFetchCoordinator {
       state.failure = null;
       state.lastSuccessfulFetch = Date.now();
       succeeded = true;
-      return { status: "success" };
+      return {
+        status: "success",
+        lastFetchedAt: state.lastSuccessfulFetch,
+        authFailed: false,
+      };
     } catch (error) {
       const reason = classifyGitError(error);
       const state = this.states.get(commonDir);
@@ -225,7 +248,12 @@ export class RepoFetchCoordinator {
         return { status: "skipped", skipReason: "stale-generation" };
       }
       state.failure = this.classifyForCache(reason, state.lastSuccessfulFetch, error);
-      return { status: "failed", reason };
+      return {
+        status: "failed",
+        reason,
+        lastFetchedAt: state.lastSuccessfulFetch,
+        authFailed: state.failure.kind === "auth",
+      };
     } finally {
       clearTimeout(timeout);
       // Notify outside the try/catch so a throwing observer can't poison the

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -62,6 +62,14 @@ export interface FetchResult {
    * stale counts when a sibling's force-fetch is rate-cached.
    */
   authFailed?: boolean;
+  /**
+   * True when this call ended in (or remained in) a transient (network /
+   * repo-not-found-first / generic transient) failure. Drives the
+   * "Couldn't reach origin" tooltip line on the worktree card. False on
+   * success, on auth-class failures (those use `authFailed`), and on the
+   * `no-common-dir` skip path where we have no state to report.
+   */
+  networkFailed?: boolean;
 }
 
 /**
@@ -119,6 +127,7 @@ export class RepoFetchCoordinator {
           reason: failure.reason,
           lastFetchedAt: state.lastSuccessfulFetch,
           authFailed: true,
+          networkFailed: false,
         };
       }
       if (Date.now() < failure.retryAt) {
@@ -128,6 +137,9 @@ export class RepoFetchCoordinator {
           reason: failure.reason,
           lastFetchedAt: state.lastSuccessfulFetch,
           authFailed: false,
+          // Skipping inside the retry window means a transient failure is
+          // still cached — keep the "Couldn't reach origin" tooltip up.
+          networkFailed: true,
         };
       }
     }
@@ -240,6 +252,7 @@ export class RepoFetchCoordinator {
         status: "success",
         lastFetchedAt: state.lastSuccessfulFetch,
         authFailed: false,
+        networkFailed: false,
       };
     } catch (error) {
       const reason = classifyGitError(error);
@@ -248,11 +261,15 @@ export class RepoFetchCoordinator {
         return { status: "skipped", skipReason: "stale-generation" };
       }
       state.failure = this.classifyForCache(reason, state.lastSuccessfulFetch, error);
+      const isAuth = state.failure.kind === "auth";
       return {
         status: "failed",
         reason,
         lastFetchedAt: state.lastSuccessfulFetch,
-        authFailed: state.failure.kind === "auth",
+        authFailed: isAuth,
+        // Auth-class failures use `authFailed`; everything else surfaces as
+        // a transient "Couldn't reach origin" tooltip line.
+        networkFailed: !isAuth,
       };
     } finally {
       clearTimeout(timeout);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -22,7 +22,12 @@ import type {
 } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { detectWslPath, listFirstWslDistro } from "../utils/wsl.js";
-import { getGitDir, clearGitDirCache, clearGitCommonDirCache } from "../utils/gitUtils.js";
+import {
+  getGitDir,
+  getGitCommonDir,
+  clearGitDirCache,
+  clearGitCommonDirCache,
+} from "../utils/gitUtils.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { pullRequestService } from "../services/PullRequestService.js";
@@ -101,6 +106,18 @@ export function probeGitLfsAvailable(): Promise<boolean> {
 
 function escapeBranchRegex(name: string): string {
   return name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Detect github.com remotes in either HTTPS or SSH form. Inlined here rather
+ * than imported from `../services/github/...` to keep the workspace-host's
+ * dependency direction one-way (workspace-host → utils, never → main services).
+ */
+function isGitHubRemoteUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  return /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/.test(
+    url.trim()
+  );
 }
 
 function parseCheckedOutBranches(porcelainOutput: string): Set<string> {
@@ -568,10 +585,19 @@ export class WorkspaceService {
         onScheduleFetch: async (worktreeId, _isCurrent, force) => {
           const target = this.monitors.get(worktreeId);
           if (!target || !target.isRunning) return;
-          await this.fetchCoordinator.fetchForWorktree({
+          const result = await this.fetchCoordinator.fetchForWorktree({
             worktreeId,
             worktreePath: target.path,
             force,
+          });
+          // Skipped for "no-common-dir" (e.g. path was just removed) means we
+          // have no commondir to fan out on — bail.
+          if (result.lastFetchedAt === undefined && result.authFailed === undefined) {
+            return;
+          }
+          this.applyFetchResultToSiblings(target, {
+            lastFetchedAt: result.lastFetchedAt ?? null,
+            authFailed: result.authFailed ?? false,
           });
         },
       },
@@ -603,6 +629,11 @@ export class WorkspaceService {
         this.emitUpdate(monitor);
       }
     })();
+
+    // Resolve origin → github.com? once at monitor start. Setter re-emits the
+    // snapshot only if the value differs from the initial `false`, so this is
+    // a no-op for the (small) set of non-GitHub repos.
+    void this.probeGitHubRemoteAsync(monitor);
   }
 
   private async initResourceConfigAsync(
@@ -713,6 +744,55 @@ export class WorkspaceService {
       worktree: snapshot,
     });
     events.emit("sys:worktree:update", snapshot as any);
+  }
+
+  /**
+   * Fan a coordinator-level fetch result out to every monitor sharing the same
+   * `git common-dir`. Linked worktrees back the same `.git/objects`, so a
+   * single `git fetch origin` updates upstream refs for all of them — and the
+   * coordinator's per-commondir `lastSuccessfulFetch` and auth-failure state
+   * apply uniformly. Without this fan-out, only the worktree that triggered
+   * the fetch would surface "Last fetched X ago"; sibling cards would still
+   * show stale (or absent) timestamps.
+   *
+   * `getGitCommonDir` is synchronous and cached, so the O(n) scan is cheap
+   * after the first call per worktree.
+   */
+  private applyFetchResultToSiblings(
+    triggering: WorktreeMonitor,
+    result: { lastFetchedAt: number | null; authFailed: boolean }
+  ): void {
+    const triggeringCommonDir = getGitCommonDir(triggering.path, { logErrors: false });
+    if (!triggeringCommonDir) {
+      // Without a commondir we can't identify siblings. Apply to the
+      // triggering monitor only — its own card still benefits.
+      triggering.setFetchState(result.lastFetchedAt, result.authFailed);
+      return;
+    }
+    for (const monitor of this.monitors.values()) {
+      if (!monitor.isRunning) continue;
+      const monitorCommonDir = getGitCommonDir(monitor.path, { logErrors: false });
+      if (monitorCommonDir === triggeringCommonDir) {
+        monitor.setFetchState(result.lastFetchedAt, result.authFailed);
+      }
+    }
+  }
+
+  /**
+   * Probe origin's fetch URL once and tell the monitor whether it points at
+   * github.com. Runs off the critical path — failures are silent (the
+   * affordance simply stays hidden, which matches the non-GitHub behavior).
+   */
+  private async probeGitHubRemoteAsync(monitor: WorktreeMonitor): Promise<void> {
+    try {
+      const git = createHardenedGit(monitor.path);
+      const remotes = await git.getRemotes(true);
+      const origin = remotes.find((r) => r.name === "origin") ?? remotes[0];
+      const fetchUrl = origin?.refs?.fetch;
+      monitor.setIsGitHubRemote(isGitHubRemoteUrl(fetchUrl));
+    } catch {
+      // Remote probe is best-effort; keep the affordance hidden on failure.
+    }
   }
 
   private handleInotifyLimitReached(): void {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -115,7 +115,9 @@ function escapeBranchRegex(name: string): string {
  */
 function isGitHubRemoteUrl(url: string | undefined): boolean {
   if (!url) return false;
-  return /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/.test(
+  // Hostname is case-insensitive per RFC 3986 — normalize before matching so
+  // `https://GitHub.com/...` and `git@GITHUB.COM:...` are correctly detected.
+  return /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/i.test(
     url.trim()
   );
 }
@@ -592,12 +594,17 @@ export class WorkspaceService {
           });
           // Skipped for "no-common-dir" (e.g. path was just removed) means we
           // have no commondir to fan out on — bail.
-          if (result.lastFetchedAt === undefined && result.authFailed === undefined) {
+          if (
+            result.lastFetchedAt === undefined &&
+            result.authFailed === undefined &&
+            result.networkFailed === undefined
+          ) {
             return;
           }
           this.applyFetchResultToSiblings(target, {
             lastFetchedAt: result.lastFetchedAt ?? null,
             authFailed: result.authFailed ?? false,
+            networkFailed: result.networkFailed ?? false,
           });
         },
       },
@@ -760,20 +767,20 @@ export class WorkspaceService {
    */
   private applyFetchResultToSiblings(
     triggering: WorktreeMonitor,
-    result: { lastFetchedAt: number | null; authFailed: boolean }
+    result: { lastFetchedAt: number | null; authFailed: boolean; networkFailed: boolean }
   ): void {
     const triggeringCommonDir = getGitCommonDir(triggering.path, { logErrors: false });
     if (!triggeringCommonDir) {
       // Without a commondir we can't identify siblings. Apply to the
       // triggering monitor only — its own card still benefits.
-      triggering.setFetchState(result.lastFetchedAt, result.authFailed);
+      triggering.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
       return;
     }
     for (const monitor of this.monitors.values()) {
       if (!monitor.isRunning) continue;
       const monitorCommonDir = getGitCommonDir(monitor.path, { logErrors: false });
       if (monitorCommonDir === triggeringCommonDir) {
-        monitor.setFetchState(result.lastFetchedAt, result.authFailed);
+        monitor.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
       }
     }
   }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -187,6 +187,7 @@ export class WorktreeMonitor {
   // origin URL is probed.
   private _lastFetchedAt: number | null = null;
   private _fetchAuthFailed: boolean = false;
+  private _fetchNetworkFailed: boolean = false;
   private _isGitHubRemote: boolean = false;
   /**
    * When `triggerFetchNow()` is called while a non-force fetch is in-flight,
@@ -298,7 +299,16 @@ export class WorktreeMonitor {
    * either field actually changes so the renderer's tooltip/auth affordance
    * stay in sync without waiting for the next status poll.
    */
-  setFetchState(lastFetchedAt: number | null, authFailed: boolean): void {
+  setFetchState(
+    lastFetchedAt: number | null,
+    authFailed: boolean,
+    networkFailed: boolean = false
+  ): void {
+    // Guard against ghost emits after stop(): the coordinator's fan-out call
+    // may resolve after the monitor has been torn down (project switch,
+    // worktree removal). Without this check, an emit would re-add a removed
+    // worktree to the renderer's store via worktree-update.
+    if (!this._isRunning) return;
     let changed = false;
     if (this._lastFetchedAt !== lastFetchedAt) {
       this._lastFetchedAt = lastFetchedAt;
@@ -306,6 +316,10 @@ export class WorktreeMonitor {
     }
     if (this._fetchAuthFailed !== authFailed) {
       this._fetchAuthFailed = authFailed;
+      changed = true;
+    }
+    if (this._fetchNetworkFailed !== networkFailed) {
+      this._fetchNetworkFailed = networkFailed;
       changed = true;
     }
     if (changed && this._hasInitialStatus) {
@@ -317,8 +331,15 @@ export class WorktreeMonitor {
    * Set once at monitor start when `WorkspaceService` resolves the origin URL.
    * Gates the "Sign in to refresh" affordance — non-GitHub remotes silently
    * hide the affordance even when an auth failure is recorded.
+   *
+   * Guarded against post-stop emits: `probeGitHubRemoteAsync` is a fire-and-
+   * forget async call that may resolve after the monitor is torn down (e.g.
+   * worktree removal, project switch). Without this check the late resolution
+   * would emit a `worktree-update` after `worktree-removed`, re-adding a
+   * ghost card to the renderer.
    */
   setIsGitHubRemote(value: boolean): void {
+    if (!this._isRunning) return;
     if (this._isGitHubRemote === value) return;
     this._isGitHubRemote = value;
     if (this._hasInitialStatus) {
@@ -791,6 +812,7 @@ export class WorktreeMonitor {
       behindCount: this.behindCount,
       lastFetchedAt: this._lastFetchedAt ?? undefined,
       fetchAuthFailed: this._fetchAuthFailed || undefined,
+      fetchNetworkFailed: this._fetchNetworkFailed || undefined,
       // Read in-flight state authoritatively at snapshot time (lesson #1700)
       // so a snapshot emitted between fetch-start and fetch-end always
       // serializes the correct value, never a stale cached copy.

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -177,6 +177,17 @@ export class WorktreeMonitor {
   // `_isCurrent`; rescheduling happens in the `isCurrent` setter.
   private fetchTimer: NodeJS.Timeout | null = null;
   private _pendingFetchPromise: Promise<void> | null = null;
+
+  // Fetch freshness state — surfaced to the renderer via the snapshot so the
+  // worktree card can show "Last fetched X ago", an in-flight pulse, and a
+  // GitHub auth-failure affordance. `_lastFetchedAt` and `_fetchAuthFailed`
+  // are pushed in via `setFetchState` from `WorkspaceService` (which receives
+  // them on every coordinator round-trip and fans them out to siblings sharing
+  // the commondir). `_isGitHubRemote` is set once at monitor start when the
+  // origin URL is probed.
+  private _lastFetchedAt: number | null = null;
+  private _fetchAuthFailed: boolean = false;
+  private _isGitHubRemote: boolean = false;
   /**
    * When `triggerFetchNow()` is called while a non-force fetch is in-flight,
    * we can't drop the force request — wake / auth-rotation hooks rely on it
@@ -276,6 +287,41 @@ export class WorktreeMonitor {
       changed = true;
     }
     if (changed && this._hasInitialStatus) {
+      this.emitUpdate();
+    }
+  }
+
+  /**
+   * Push the latest fetch outcome from `WorkspaceService` (sourced from the
+   * coordinator's per-commondir state). `null` for `lastFetchedAt` means no
+   * successful fetch has landed yet for this repo. Re-emits a snapshot when
+   * either field actually changes so the renderer's tooltip/auth affordance
+   * stay in sync without waiting for the next status poll.
+   */
+  setFetchState(lastFetchedAt: number | null, authFailed: boolean): void {
+    let changed = false;
+    if (this._lastFetchedAt !== lastFetchedAt) {
+      this._lastFetchedAt = lastFetchedAt;
+      changed = true;
+    }
+    if (this._fetchAuthFailed !== authFailed) {
+      this._fetchAuthFailed = authFailed;
+      changed = true;
+    }
+    if (changed && this._hasInitialStatus) {
+      this.emitUpdate();
+    }
+  }
+
+  /**
+   * Set once at monitor start when `WorkspaceService` resolves the origin URL.
+   * Gates the "Sign in to refresh" affordance — non-GitHub remotes silently
+   * hide the affordance even when an auth failure is recorded.
+   */
+  setIsGitHubRemote(value: boolean): void {
+    if (this._isGitHubRemote === value) return;
+    this._isGitHubRemote = value;
+    if (this._hasInitialStatus) {
       this.emitUpdate();
     }
   }
@@ -743,6 +789,13 @@ export class WorktreeMonitor {
       planFilePath: this.planFilePath,
       aheadCount: this.aheadCount,
       behindCount: this.behindCount,
+      lastFetchedAt: this._lastFetchedAt ?? undefined,
+      fetchAuthFailed: this._fetchAuthFailed || undefined,
+      // Read in-flight state authoritatively at snapshot time (lesson #1700)
+      // so a snapshot emitted between fetch-start and fetch-end always
+      // serializes the correct value, never a stale cached copy.
+      isFetchInFlight: this._pendingFetchPromise !== null || undefined,
+      isGitHubRemote: this._isGitHubRemote || undefined,
       isWslPath: this._isWslPath || undefined,
       wslDistro: this._wslDistro,
       wslGitEligible: this._wslGitEligible || undefined,
@@ -1081,6 +1134,13 @@ export class WorktreeMonitor {
         this._pendingFetchPromise = null;
         const queuedForce = this._pendingForceFetch;
         this._pendingForceFetch = false;
+        // Emit so `isFetchInFlight` flips back to false on the renderer.
+        // `WorkspaceService` will follow up with the freshly-resolved
+        // `lastFetchedAt`/`fetchAuthFailed` via `setFetchState`, which emits
+        // again only if those values changed.
+        if (this._hasInitialStatus) {
+          this.emitUpdate();
+        }
         if (this._isRunning) {
           if (queuedForce) {
             void this.runFetch(true);
@@ -1090,6 +1150,11 @@ export class WorktreeMonitor {
         }
       });
     this._pendingFetchPromise = run;
+    // Surface the in-flight transition immediately so the card pulses while
+    // git is talking to the remote, without waiting for a status poll.
+    if (this._hasInitialStatus) {
+      this.emitUpdate();
+    }
     await run;
   }
 

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -50,6 +50,54 @@ describe("RepoFetchCoordinator", () => {
     expect(result.status).toBe("success");
     expect(onFetchSuccess).toHaveBeenCalledWith("wt1");
     expect(coord.getLastSuccessfulFetch("/repo/.git")).not.toBeNull();
+    expect(result.lastFetchedAt).toBe(coord.getLastSuccessfulFetch("/repo/.git"));
+    expect(result.authFailed).toBe(false);
+  });
+
+  it("propagates authFailed=true via FetchResult on auth-class failures and skips", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+    );
+
+    const coord = new RepoFetchCoordinator();
+    const failed = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(failed.status).toBe("failed");
+    expect(failed.authFailed).toBe(true);
+    expect(failed.lastFetchedAt).toBeNull();
+
+    // Subsequent skip from auth suspension also carries authFailed=true so the
+    // renderer keeps the "Sign in to refresh" affordance visible.
+    const skipped = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(skipped.status).toBe("skipped");
+    expect(skipped.skipReason).toBe("auth-suspended");
+    expect(skipped.authFailed).toBe(true);
+  });
+
+  it("preserves the prior lastFetchedAt across a transient failure", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    // First call: success.
+    mockCreateBackgroundFetchGit.mockReturnValueOnce(makeMockGit(() => Promise.resolve()));
+    const coord = new RepoFetchCoordinator();
+    const ok = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(ok.status).toBe("success");
+    const firstTs = ok.lastFetchedAt;
+    expect(firstTs).not.toBeNull();
+
+    // Second call: transient fetch error.
+    mockCreateBackgroundFetchGit.mockReturnValueOnce(
+      makeMockGit(() => Promise.reject(new Error("the remote end hung up unexpectedly")))
+    );
+    const failed = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(failed.status).toBe("failed");
+    expect(failed.authFailed).toBe(false);
+    expect(failed.lastFetchedAt).toBe(firstTs);
   });
 
   it("skips when commondir cannot be resolved", async () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1917,5 +1917,43 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("setIsGitHubRemote / setFetchState do not emit after stop()", async () => {
+      const onUpdate = vi.fn();
+      const callbacks = makeCallbacks({ onUpdate });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+      monitor.stop();
+
+      onUpdate.mockClear();
+      // Late-resolving probe / coordinator fan-out must not re-add a ghost
+      // card to the renderer after the monitor has been torn down.
+      monitor.setIsGitHubRemote(true);
+      monitor.setFetchState(1700000000000, false, false);
+      monitor.setFetchState(1700000000000, true, false);
+
+      expect(onUpdate).not.toHaveBeenCalled();
+    });
+
+    it("setFetchState surfaces fetchNetworkFailed in the snapshot", async () => {
+      const onUpdate = vi.fn();
+      const callbacks = makeCallbacks({ onUpdate });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      onUpdate.mockClear();
+      monitor.setFetchState(1700000000000, false, true);
+      const snap = monitor.getSnapshot();
+      expect(snap.fetchNetworkFailed).toBe(true);
+      expect(snap.fetchAuthFailed).toBeFalsy();
+      expect(onUpdate).toHaveBeenCalled();
+
+      // Idempotent on no-change.
+      onUpdate.mockClear();
+      monitor.setFetchState(1700000000000, false, true);
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1835,5 +1835,87 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("flips isFetchInFlight true while a fetch is pending and false after", async () => {
+      let resolveFetch: (() => void) | undefined;
+      const onScheduleFetch = vi.fn().mockImplementation(() => {
+        return new Promise<void>((res) => {
+          resolveFetch = res;
+        });
+      });
+
+      const onUpdate = vi.fn();
+      const callbacks = makeCallbacks({ onScheduleFetch, onUpdate });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      onUpdate.mockClear();
+
+      // Fire the initial-delay timer.
+      await vi.advanceTimersByTimeAsync(6_000);
+      // Drain microtasks so the runFetch's start-emit lands.
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      // While in-flight, the snapshot should report isFetchInFlight=true.
+      const startSnapshot = monitor.getSnapshot();
+      expect(startSnapshot.isFetchInFlight).toBe(true);
+
+      // Resolve the fetch and confirm it flips back to false.
+      resolveFetch?.();
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+      const endSnapshot = monitor.getSnapshot();
+      expect(endSnapshot.isFetchInFlight).toBeFalsy();
+
+      monitor.stop();
+    });
+
+    it("setFetchState mirrors lastFetchedAt and fetchAuthFailed into the snapshot", async () => {
+      const onUpdate = vi.fn();
+      const callbacks = makeCallbacks({ onUpdate });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      onUpdate.mockClear();
+      monitor.setFetchState(1700000000000, false);
+      const afterFirst = monitor.getSnapshot();
+      expect(afterFirst.lastFetchedAt).toBe(1700000000000);
+      expect(afterFirst.fetchAuthFailed).toBeFalsy();
+      expect(onUpdate).toHaveBeenCalled();
+
+      onUpdate.mockClear();
+      monitor.setFetchState(1700000060000, true);
+      const afterAuthFail = monitor.getSnapshot();
+      expect(afterAuthFail.lastFetchedAt).toBe(1700000060000);
+      expect(afterAuthFail.fetchAuthFailed).toBe(true);
+      expect(onUpdate).toHaveBeenCalled();
+
+      // Idempotent — repeating the same values should not re-emit.
+      onUpdate.mockClear();
+      monitor.setFetchState(1700000060000, true);
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
+    it("setIsGitHubRemote mirrors into the snapshot and is idempotent", async () => {
+      const onUpdate = vi.fn();
+      const callbacks = makeCallbacks({ onUpdate });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      // Default is false (undefined-on-the-wire) until set.
+      expect(monitor.getSnapshot().isGitHubRemote).toBeFalsy();
+
+      onUpdate.mockClear();
+      monitor.setIsGitHubRemote(true);
+      expect(monitor.getSnapshot().isGitHubRemote).toBe(true);
+      expect(onUpdate).toHaveBeenCalled();
+
+      onUpdate.mockClear();
+      monitor.setIsGitHubRemote(true);
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
   });
 });

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -122,6 +122,9 @@ export interface WorktreeSnapshot {
   /** True when this worktree's repo is in an auth-failed fetch state. */
   fetchAuthFailed?: boolean;
 
+  /** True when the most recent fetch failed for a transient (non-auth) reason. */
+  fetchNetworkFailed?: boolean;
+
   /** True while a background `git fetch` is in-flight for this worktree's repo. */
   isFetchInFlight?: boolean;
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -112,6 +112,22 @@ export interface WorktreeSnapshot {
   /** Number of commits behind the upstream tracking branch */
   behindCount?: number;
 
+  /**
+   * Epoch ms of the last successful background `git fetch` for this worktree's
+   * repo. Mirrored from `RepoFetchCoordinator` so siblings sharing a commondir
+   * see the same timestamp. `null` until the first success lands.
+   */
+  lastFetchedAt?: number | null;
+
+  /** True when this worktree's repo is in an auth-failed fetch state. */
+  fetchAuthFailed?: boolean;
+
+  /** True while a background `git fetch` is in-flight for this worktree's repo. */
+  isFetchInFlight?: boolean;
+
+  /** True when origin's fetch URL points at github.com (HTTPS or SSH form). */
+  isGitHubRemote?: boolean;
+
   /** Resource status from the last manual status check */
   resourceStatus?: WorktreeResourceStatus;
 

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -164,6 +164,14 @@ export interface Worktree {
    */
   fetchAuthFailed?: boolean;
 
+  /**
+   * True when the most recent fetch failed for a transient reason (network
+   * unavailable / generic transient / repo-not-found-first). Surfaces as a
+   * "Couldn't reach origin" tooltip line so users can distinguish a stale
+   * count from one that's intentionally suppressed.
+   */
+  fetchNetworkFailed?: boolean;
+
   /** True while a background `git fetch` is in-flight for this worktree's repo. */
   isFetchInFlight?: boolean;
 

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -148,6 +148,32 @@ export interface Worktree {
   /** Number of commits behind the upstream tracking branch */
   behindCount?: number;
 
+  /**
+   * Epoch ms of the last successful background `git fetch` for this worktree's
+   * repo. Mirrors `RepoFetchCoordinator`'s per-commondir `lastSuccessfulFetch`
+   * so all sibling worktrees sharing a `.git/objects` see the same timestamp.
+   * `null` until the first successful fetch lands.
+   */
+  lastFetchedAt?: number | null;
+
+  /**
+   * True when this worktree's repo is currently in an auth-failed fetch state
+   * (mirrored from `RepoFetchCoordinator.failure.kind === "auth"`). The card
+   * surfaces a "Sign in to refresh" affordance when this is true and the
+   * remote is GitHub; for other hosts the affordance stays silent.
+   */
+  fetchAuthFailed?: boolean;
+
+  /** True while a background `git fetch` is in-flight for this worktree's repo. */
+  isFetchInFlight?: boolean;
+
+  /**
+   * True when origin's fetch URL points at github.com (HTTPS or SSH form).
+   * Resolved once at monitor start; gates the "Sign in to refresh" affordance
+   * so we don't surface a GitHub-token CTA for non-GitHub remotes.
+   */
+  isGitHubRemote?: boolean;
+
   /** Resource status from the last manual status check */
   resourceStatus?: WorktreeResourceStatus;
 

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -79,6 +79,127 @@ const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
   SubContent: DropdownMenuSubContent,
 };
 
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+function formatLastFetched(epochMs: number, now: number = Date.now()): string {
+  const deltaSeconds = Math.round((epochMs - now) / 1000);
+  const absSeconds = Math.abs(deltaSeconds);
+  if (absSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  const deltaMinutes = Math.round(deltaSeconds / 60);
+  if (Math.abs(deltaMinutes) < 60) return RELATIVE_TIME_FORMATTER.format(deltaMinutes, "minute");
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (Math.abs(deltaHours) < 24) return RELATIVE_TIME_FORMATTER.format(deltaHours, "hour");
+  const deltaDays = Math.round(deltaHours / 24);
+  return RELATIVE_TIME_FORMATTER.format(deltaDays, "day");
+}
+
+interface UpstreamSyncBadgeProps {
+  aheadCount: number | undefined;
+  behindCount: number | undefined;
+  isFetchInFlight: boolean;
+  lastFetchedAt: number | null | undefined;
+  fetchAuthFailed: boolean;
+  isGitHubRemote: boolean;
+  /**
+   * The two render contexts use different gap sizes to align with surrounding
+   * content (`gap-1` in the main-worktree row, `gap-1.5` in the secondary row).
+   * Keep the existing spacing rather than unify it — the visual rhythm is
+   * tuned per layout.
+   */
+  containerGapClass: string;
+}
+
+function UpstreamSyncBadge({
+  aheadCount,
+  behindCount,
+  isFetchInFlight,
+  lastFetchedAt,
+  fetchAuthFailed,
+  isGitHubRemote,
+  containerGapClass,
+}: UpstreamSyncBadgeProps) {
+  const hasAhead = aheadCount !== undefined && aheadCount > 0;
+  const hasBehind = behindCount !== undefined && behindCount > 0;
+
+  const handleSignInClick = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+    void actionService.dispatch(
+      "app.settings.openTab",
+      { tab: "github", sectionId: "github-token" },
+      { source: "user" }
+    );
+  }, []);
+
+  // Auth-failed + GitHub remote: replace the count display with a sign-in CTA.
+  // Non-GitHub remotes silently fall through to the regular count display so
+  // we don't surface a useless GitHub-token CTA for GitLab/Bitbucket/etc.
+  if (fetchAuthFailed && isGitHubRemote) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={handleSignInClick}
+            className="flex items-center text-[10px] text-status-warning/80 hover:text-status-warning transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded-sm cursor-pointer"
+            data-testid="upstream-sync-auth-cta"
+          >
+            Sign in to refresh
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="text-xs">
+          <div>Couldn't reach origin — GitHub credentials failed</div>
+          {lastFetchedAt != null && (
+            <div className="text-text-muted">Last fetched {formatLastFetched(lastFetchedAt)}</div>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  // No counts to show and no fetch state worth surfacing → render nothing.
+  // (The caller already gates on hasUpstreamDelta, so this is the no-counts
+  // path during fetch-only events that didn't move ahead/behind.)
+  if (!hasAhead && !hasBehind) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            "flex items-center text-[10px] font-mono tabular-nums",
+            containerGapClass,
+            isFetchInFlight && "animate-pulse-immediate"
+          )}
+          data-testid="upstream-sync-indicator"
+          data-fetch-in-flight={isFetchInFlight ? "true" : undefined}
+        >
+          {hasAhead && <span className="text-status-success">↑{aheadCount}</span>}
+          {hasBehind && <span className="text-status-warning">↓{behindCount}</span>}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="right" className="text-xs">
+        <div>
+          {hasAhead && (
+            <span>
+              {aheadCount} commit{aheadCount !== 1 ? "s" : ""} ahead
+            </span>
+          )}
+          {hasAhead && hasBehind && <span>, </span>}
+          {hasBehind && (
+            <span>
+              {behindCount} commit{behindCount !== 1 ? "s" : ""} behind
+            </span>
+          )}
+          <span> upstream</span>
+        </div>
+        {lastFetchedAt != null && (
+          <div className="text-text-muted">Last fetched {formatLastFetched(lastFetchedAt)}</div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 interface IssueBadgeProps {
   issueNumber: number;
   issueTitle?: string;
@@ -427,6 +548,10 @@ export function WorktreeHeader({
   const hasUpstreamDelta =
     (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
     (worktree.behindCount !== undefined && worktree.behindCount > 0);
+  // Auth-failed + GitHub remote surfaces a "Sign in to refresh" CTA in place
+  // of (or alongside) the count badge — show the row even if no upstream
+  // delta is present so the user can still recover the auth state.
+  const hasAuthFailedSignIn = Boolean(worktree.fetchAuthFailed && worktree.isGitHubRemote);
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasIssueTitle);
 
   const { visibleStates, sessionAriaLabel } = useMemo(() => {
@@ -781,39 +906,16 @@ export function WorktreeHeader({
             isMuted={isMuted}
             isMainWorktree={false}
           />
-          {hasUpstreamDelta && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="flex items-center gap-1 text-[10px] font-mono tabular-nums"
-                  data-testid="upstream-sync-indicator"
-                >
-                  {worktree.aheadCount !== undefined && worktree.aheadCount > 0 && (
-                    <span className="text-status-success">↑{worktree.aheadCount}</span>
-                  )}
-                  {worktree.behindCount !== undefined && worktree.behindCount > 0 && (
-                    <span className="text-status-warning">↓{worktree.behindCount}</span>
-                  )}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="right" className="text-xs">
-                {worktree.aheadCount !== undefined && worktree.aheadCount > 0 && (
-                  <span>
-                    {worktree.aheadCount} commit{worktree.aheadCount !== 1 ? "s" : ""} ahead
-                  </span>
-                )}
-                {worktree.aheadCount !== undefined &&
-                  worktree.aheadCount > 0 &&
-                  worktree.behindCount !== undefined &&
-                  worktree.behindCount > 0 && <span>, </span>}
-                {worktree.behindCount !== undefined && worktree.behindCount > 0 && (
-                  <span>
-                    {worktree.behindCount} commit{worktree.behindCount !== 1 ? "s" : ""} behind
-                  </span>
-                )}
-                <span> upstream</span>
-              </TooltipContent>
-            </Tooltip>
+          {(hasUpstreamDelta || hasAuthFailedSignIn) && (
+            <UpstreamSyncBadge
+              aheadCount={worktree.aheadCount}
+              behindCount={worktree.behindCount}
+              isFetchInFlight={Boolean(worktree.isFetchInFlight)}
+              lastFetchedAt={worktree.lastFetchedAt}
+              fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
+              isGitHubRemote={Boolean(worktree.isGitHubRemote)}
+              containerGapClass="gap-1"
+            />
           )}
           {aggregateCounts && aggregateCounts.worktrees > 0 && (
             <>
@@ -883,6 +985,7 @@ export function WorktreeHeader({
           (worktree.issueNumber && !hasIssueTitle) ||
           (worktree.prNumber && worktree.prState !== "closed") ||
           hasUpstreamDelta ||
+          hasAuthFailedSignIn ||
           hasPlanFile) && (
           <div className="flex flex-col gap-0.5 mt-1.5">
             {worktree.issueNumber && !hasIssueTitle && (
@@ -905,39 +1008,16 @@ export function WorktreeHeader({
                 underlineOnHover={underlineOnHover}
               />
             )}
-            {hasUpstreamDelta && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="flex items-center gap-1.5 text-[10px] font-mono tabular-nums"
-                    data-testid="upstream-sync-indicator"
-                  >
-                    {worktree.aheadCount !== undefined && worktree.aheadCount > 0 && (
-                      <span className="text-status-success">↑{worktree.aheadCount}</span>
-                    )}
-                    {worktree.behindCount !== undefined && worktree.behindCount > 0 && (
-                      <span className="text-status-warning">↓{worktree.behindCount}</span>
-                    )}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="right" className="text-xs">
-                  {worktree.aheadCount !== undefined && worktree.aheadCount > 0 && (
-                    <span>
-                      {worktree.aheadCount} commit{worktree.aheadCount !== 1 ? "s" : ""} ahead
-                    </span>
-                  )}
-                  {worktree.aheadCount !== undefined &&
-                    worktree.aheadCount > 0 &&
-                    worktree.behindCount !== undefined &&
-                    worktree.behindCount > 0 && <span>, </span>}
-                  {worktree.behindCount !== undefined && worktree.behindCount > 0 && (
-                    <span>
-                      {worktree.behindCount} commit{worktree.behindCount !== 1 ? "s" : ""} behind
-                    </span>
-                  )}
-                  <span> upstream</span>
-                </TooltipContent>
-              </Tooltip>
+            {(hasUpstreamDelta || hasAuthFailedSignIn) && (
+              <UpstreamSyncBadge
+                aheadCount={worktree.aheadCount}
+                behindCount={worktree.behindCount}
+                isFetchInFlight={Boolean(worktree.isFetchInFlight)}
+                lastFetchedAt={worktree.lastFetchedAt}
+                fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
+                isGitHubRemote={Boolean(worktree.isGitHubRemote)}
+                containerGapClass="gap-1.5"
+              />
             )}
             {hasIssueTitle && (
               <BranchLabel

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -99,6 +99,7 @@ interface UpstreamSyncBadgeProps {
   isFetchInFlight: boolean;
   lastFetchedAt: number | null | undefined;
   fetchAuthFailed: boolean;
+  fetchNetworkFailed: boolean;
   isGitHubRemote: boolean;
   /**
    * The two render contexts use different gap sizes to align with surrounding
@@ -115,6 +116,7 @@ function UpstreamSyncBadge({
   isFetchInFlight,
   lastFetchedAt,
   fetchAuthFailed,
+  fetchNetworkFailed,
   isGitHubRemote,
   containerGapClass,
 }: UpstreamSyncBadgeProps) {
@@ -192,6 +194,11 @@ function UpstreamSyncBadge({
           )}
           <span> upstream</span>
         </div>
+        {fetchNetworkFailed && (
+          <div className="text-status-warning/80" data-testid="upstream-sync-network-warning">
+            Couldn't reach origin
+          </div>
+        )}
         {lastFetchedAt != null && (
           <div className="text-text-muted">Last fetched {formatLastFetched(lastFetchedAt)}</div>
         )}
@@ -913,6 +920,7 @@ export function WorktreeHeader({
               isFetchInFlight={Boolean(worktree.isFetchInFlight)}
               lastFetchedAt={worktree.lastFetchedAt}
               fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
+              fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
               isGitHubRemote={Boolean(worktree.isGitHubRemote)}
               containerGapClass="gap-1"
             />
@@ -1015,6 +1023,7 @@ export function WorktreeHeader({
                 isFetchInFlight={Boolean(worktree.isFetchInFlight)}
                 lastFetchedAt={worktree.lastFetchedAt}
                 fetchAuthFailed={Boolean(worktree.fetchAuthFailed)}
+                fetchNetworkFailed={Boolean(worktree.fetchNetworkFailed)}
                 isGitHubRemote={Boolean(worktree.isGitHubRemote)}
                 containerGapClass="gap-1.5"
               />

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1135,4 +1135,19 @@ describe("WorktreeHeader upstream sync indicator", () => {
       { source: "user" }
     );
   });
+
+  it("renders the count display (no auth CTA) when only fetchNetworkFailed is set", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 1,
+        fetchNetworkFailed: true,
+      },
+    });
+    // The badge still renders the count display (transient failure doesn't
+    // replace the indicator with a CTA — only auth+github does).
+    expect(screen.getByTestId("upstream-sync-indicator")).toBeDefined();
+    // No auth CTA for transient failures.
+    expect(screen.queryByTestId("upstream-sync-auth-cta")).toBeNull();
+  });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1041,3 +1041,98 @@ describe("WorktreeHeader token-missing badge behavior", () => {
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });
 });
+
+describe("WorktreeHeader upstream sync indicator", () => {
+  beforeEach(() => {
+    mockMissingToken = false;
+    vi.clearAllMocks();
+  });
+
+  it("shows ahead/behind counts and renders the indicator", () => {
+    renderHeader({
+      worktree: { ...baseWorktree, aheadCount: 3, behindCount: 1 },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator).toBeDefined();
+    expect(indicator.textContent).toContain("↑3");
+    expect(indicator.textContent).toContain("↓1");
+  });
+
+  it("applies animate-pulse-immediate while a fetch is in-flight", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 2,
+        behindCount: 0,
+        isFetchInFlight: true,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).toContain("animate-pulse-immediate");
+    expect(indicator.getAttribute("data-fetch-in-flight")).toBe("true");
+  });
+
+  it("does not pulse when no fetch is in-flight", () => {
+    renderHeader({
+      worktree: { ...baseWorktree, aheadCount: 2, behindCount: 0 },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.className).not.toContain("animate-pulse-immediate");
+  });
+
+  it("renders 'Sign in to refresh' affordance only when auth-failed AND github remote", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 1,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+      },
+    });
+    const cta = screen.getByTestId("upstream-sync-auth-cta");
+    expect(cta).toBeDefined();
+    expect(cta.textContent).toBe("Sign in to refresh");
+    // The count indicator is replaced by the CTA — both shouldn't render.
+    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
+  });
+
+  it("hides 'Sign in to refresh' affordance for non-GitHub auth failures", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 1,
+        fetchAuthFailed: true,
+        isGitHubRemote: false,
+      },
+    });
+    expect(screen.queryByTestId("upstream-sync-auth-cta")).toBeNull();
+    // Falls through to the regular count display.
+    expect(screen.getByTestId("upstream-sync-indicator")).toBeDefined();
+  });
+
+  it("hides the indicator entirely when there are no counts and no auth-fail CTA", () => {
+    renderHeader({
+      worktree: { ...baseWorktree, aheadCount: 0, behindCount: 0 },
+    });
+    expect(screen.queryByTestId("upstream-sync-indicator")).toBeNull();
+    expect(screen.queryByTestId("upstream-sync-auth-cta")).toBeNull();
+  });
+
+  it("dispatches openTab → github settings on Sign in CTA click", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 1,
+        fetchAuthFailed: true,
+        isGitHubRemote: true,
+      },
+    });
+    const cta = screen.getByTestId("upstream-sync-auth-cta");
+    fireEvent.click(cta);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "github", sectionId: "github-token" },
+      { source: "user" }
+    );
+  });
+});

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -186,6 +186,10 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.planFilePath === b.planFilePath &&
     a.aheadCount === b.aheadCount &&
     a.behindCount === b.behindCount &&
+    a.lastFetchedAt === b.lastFetchedAt &&
+    a.fetchAuthFailed === b.fetchAuthFailed &&
+    a.isFetchInFlight === b.isFetchInFlight &&
+    a.isGitHubRemote === b.isGitHubRemote &&
     a.worktreeMode === b.worktreeMode &&
     a.worktreeEnvironmentLabel === b.worktreeEnvironmentLabel &&
     a.hasResourceConfig === b.hasResourceConfig &&

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -188,6 +188,7 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.behindCount === b.behindCount &&
     a.lastFetchedAt === b.lastFetchedAt &&
     a.fetchAuthFailed === b.fetchAuthFailed &&
+    a.fetchNetworkFailed === b.fetchNetworkFailed &&
     a.isFetchInFlight === b.isFetchInFlight &&
     a.isGitHubRemote === b.isGitHubRemote &&
     a.worktreeMode === b.worktreeMode &&


### PR DESCRIPTION
## Summary

- The upstream sync badge on the worktree dashboard card now shows how fresh its data actually is: a relative "Last fetched X ago" line in the tooltip, a pulse on the count text while a fetch is in-flight, and failure signals for auth and network errors
- `UpstreamSyncBadge` replaces two near-identical inline blocks in `WorktreeHeader.tsx` — same output, one place to change
- Backend plumbing threads `lastFetchedAt`, `fetchAuthFailed`, `fetchNetworkFailed`, `isFetchInFlight`, and `isGitHubRemote` through `RepoFetchCoordinator` → `WorkspaceService` → `WorktreeMonitor` → snapshot → store

Resolves #6543

## Changes

- `shared/types/worktree.ts` + `shared/types/workspace-host.ts`: 5 new optional primitive fields on `WorktreeSnapshot`/`Worktree`
- `RepoFetchCoordinator`: `FetchResult` now carries `lastFetchedAt`, `authFailed`, `networkFailed` so `WorkspaceService` doesn't reach into coordinator internals
- `WorktreeMonitor`: tracks fetch state per snapshot; emits at fetch start (sets in-flight) and end (clears pulse, stores fresh timestamps). `isFetchInFlight` is read from `_pendingFetchPromise` at snapshot time. Post-stop guards on `setFetchState` and `setIsGitHubRemote` prevent ghost cards after `monitor.stop()`
- `WorkspaceService`: captures `FetchResult`, fans state out to all monitors sharing the triggering worktree's git common-dir (linked worktrees share `.git/objects`, so a single fetch refreshes all sibling cards). GitHub remote detection via inline case-insensitive regex at monitor start
- `WorktreeHeader`: `UpstreamSyncBadge` local helper consolidates the two identical upstream indicator blocks. Pulse uses `animate-pulse-immediate` (`animate-pulse-delayed` would hide visible text for 400ms via `opacity: 0`). "Last fetched X ago" via `Intl.RelativeTimeFormat`. "Sign in to refresh" CTA dispatches `app.settings.openTab` → GitHub settings tab, only when `fetchAuthFailed && isGitHubRemote` — silent for non-GitHub hosts
- `createWorktreeStore`: `snapshotsEqual` extended with the new primitive fields
- New tests: `RepoFetchCoordinator.test.ts` (FetchResult enrichment), `WorktreeMonitor.test.ts` (in-flight transition, setter idempotency, post-stop guard, networkFailed), `WorktreeHeader.test.tsx` (pulse, CTA, network failure UI)

## Testing

- 1502 tests pass; typecheck, lint, and format all clean
- In-flight pulse, last-fetched tooltip line, "Couldn't reach origin" network failure line, and "Sign in to refresh" auth CTA covered by new unit tests
- Linked worktree fan-out (sibling cards refresh together) verified via `WorkspaceService` unit coverage