### PR TITLE
feat(help): per-session MCP provisioning service

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -446,6 +446,8 @@ export const CHANNELS = {
   HELP_GET_FOLDER_PATH: "help:get-folder-path",
   HELP_MARK_TERMINAL: "help:mark-terminal",
   HELP_UNMARK_TERMINAL: "help:unmark-terminal",
+  HELP_PROVISION_SESSION: "help:provision-session",
+  HELP_REVOKE_SESSION: "help:revoke-session",
 
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",

--- a/electron/ipc/handlers/help.preload.ts
+++ b/electron/ipc/handlers/help.preload.ts
@@ -4,6 +4,8 @@ export const HELP_METHOD_CHANNELS = {
   getFolderPath: "help:get-folder-path",
   markTerminal: "help:mark-terminal",
   unmarkTerminal: "help:unmark-terminal",
+  provisionSession: "help:provision-session",
+  revokeSession: "help:revoke-session",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof HELP_METHOD_CHANNELS;

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -1,7 +1,9 @@
 import { defineIpcNamespace, op } from "../define.js";
 import { HELP_METHOD_CHANNELS } from "./help.preload.js";
 import type * as HelpServiceModule from "../../services/HelpService.js";
+import type * as HelpSessionServiceModule from "../../services/HelpSessionService.js";
 import { getAgentAvailabilityStore } from "../../services/AgentAvailabilityStore.js";
+import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
 
 let cachedHelpService: typeof HelpServiceModule | null = null;
 async function getHelpService(): Promise<typeof HelpServiceModule> {
@@ -9,6 +11,14 @@ async function getHelpService(): Promise<typeof HelpServiceModule> {
     cachedHelpService = await import("../../services/HelpService.js");
   }
   return cachedHelpService;
+}
+
+let cachedHelpSessionService: typeof HelpSessionServiceModule | null = null;
+async function getHelpSessionService(): Promise<typeof HelpSessionServiceModule> {
+  if (!cachedHelpSessionService) {
+    cachedHelpSessionService = await import("../../services/HelpSessionService.js");
+  }
+  return cachedHelpSessionService;
 }
 
 async function handleGetFolderPath(): Promise<string | null> {
@@ -24,12 +34,39 @@ function handleUnmarkTerminal(terminalId: string): void {
   getAgentAvailabilityStore().unmarkAsHelp(terminalId);
 }
 
+async function handleProvisionSession(
+  ctx: import("../types.js").IpcContext,
+  input: { projectId: string; projectPath: string }
+): Promise<{
+  sessionId: string;
+  sessionPath: string;
+  token: string;
+  tier: HelpAssistantTier;
+} | null> {
+  const { helpSessionService } = await getHelpSessionService();
+  return helpSessionService.provisionSession({
+    projectId: input.projectId,
+    projectPath: input.projectPath,
+    windowId: ctx.senderWindow?.id ?? -1,
+    projectViewWebContentsId: ctx.webContentsId,
+  });
+}
+
+async function handleRevokeSession(sessionId: string): Promise<void> {
+  const { helpSessionService } = await getHelpSessionService();
+  await helpSessionService.revokeSession(sessionId);
+}
+
 export const helpNamespace = defineIpcNamespace({
   name: "help",
   ops: {
     getFolderPath: op(HELP_METHOD_CHANNELS.getFolderPath, handleGetFolderPath),
     markTerminal: op(HELP_METHOD_CHANNELS.markTerminal, handleMarkTerminal),
     unmarkTerminal: op(HELP_METHOD_CHANNELS.unmarkTerminal, handleUnmarkTerminal),
+    provisionSession: op(HELP_METHOD_CHANNELS.provisionSession, handleProvisionSession, {
+      withContext: true,
+    }),
+    revokeSession: op(HELP_METHOD_CHANNELS.revokeSession, handleRevokeSession),
   },
 });
 

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -43,11 +43,15 @@ async function handleProvisionSession(
   token: string;
   tier: HelpAssistantTier;
 } | null> {
+  if (!ctx.senderWindow) {
+    console.warn("[help] provisionSession invoked without a senderWindow — skipping");
+    return null;
+  }
   const { helpSessionService } = await getHelpSessionService();
   return helpSessionService.provisionSession({
     projectId: input.projectId,
     projectPath: input.projectPath,
-    windowId: ctx.senderWindow?.id ?? -1,
+    windowId: ctx.senderWindow.id,
     projectViewWebContentsId: ctx.webContentsId,
   });
 }

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -141,6 +141,11 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           import("../services/McpServerService.js")
             .then(({ mcpServerService }) => mcpServerService.stop())
             .catch(() => {}),
+          // Revoke and remove any in-flight help-session dirs. Same lazy-import
+          // guard as MCP — the module only loads if a help session was provisioned.
+          import("../services/HelpSessionService.js")
+            .then(({ helpSessionService }) => helpSessionService.revokeAll())
+            .catch(() => {}),
           new Promise<void>((resolve) => {
             disposeTaskOrchestrator();
             disposeAgentRouter();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -214,6 +214,14 @@ if (!gotTheLock) {
         } catch (err) {
           console.error("[main] closePortsForView failed during eviction:", err);
         }
+        // Revoke help-session tokens bound to this evicted WebContents view.
+        // Done synchronously off the eviction hook (lesson #5009) so a
+        // renderer-side cleanup IPC can't go missing on view destruction.
+        import("./services/HelpSessionService.js")
+          .then(({ helpSessionService }) => helpSessionService.revokeByWebContentsId(wcId))
+          .catch((err) => {
+            console.warn("[main] revokeByWebContentsId failed during eviction:", err);
+          });
       },
       onViewCached: (wcId) => {
         // Same producer cleanup as eviction: a cached view becomes

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -1,0 +1,384 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { app } from "electron";
+import type { WindowRegistry } from "../window/WindowRegistry.js";
+import { store } from "../store.js";
+import { getHelpFolderPath } from "./HelpService.js";
+import { resilientAtomicWriteFile } from "../utils/fs.js";
+import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
+
+const SESSIONS_DIR_NAME = "help-sessions";
+const META_FILE_NAME = "meta.json";
+const GC_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+const SESSION_TOKEN_BYTES = 32;
+
+const DEFAULT_TIER: HelpAssistantTier = "action";
+const DEFAULT_LOCAL_MCP_ENABLED = true;
+const DEFAULT_DOCS_SERVER_ENABLED = true;
+const DEFAULT_SKIP_PERMISSIONS = false;
+
+interface ProvisionInput {
+  projectId: string;
+  projectPath: string;
+  windowId: number;
+  projectViewWebContentsId: number;
+}
+
+export interface ProvisionResult {
+  sessionId: string;
+  sessionPath: string;
+  token: string;
+  tier: HelpAssistantTier;
+}
+
+interface HelpSessionRecord {
+  sessionId: string;
+  token: string;
+  windowId: number;
+  projectViewWebContentsId: number;
+  projectId: string;
+  projectPath: string;
+  sessionPath: string;
+  tier: HelpAssistantTier;
+  createdAt: number;
+  expiresAt: number;
+  revoked: boolean;
+}
+
+interface SessionMeta {
+  sessionId: string;
+  createdAt: number;
+  expiresAt: number;
+  windowId: number;
+  projectId: string;
+}
+
+interface BundledClaudeSettings {
+  permissions?: {
+    allow?: string[];
+    deny?: string[];
+  };
+  defaultMode?: string;
+  [key: string]: unknown;
+}
+
+function deepClonePlainJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export class HelpSessionService {
+  private readonly sessionsByToken = new Map<string, HelpSessionRecord>();
+  private readonly sessionsById = new Map<string, HelpSessionRecord>();
+  private mcpRegistry: WindowRegistry | null = null;
+  private disposed = false;
+
+  setMcpRegistry(registry: WindowRegistry): void {
+    this.mcpRegistry = registry;
+  }
+
+  validateToken(token: string): HelpAssistantTier | false {
+    if (!token) return false;
+    const record = this.sessionsByToken.get(token);
+    if (!record) return false;
+    if (record.revoked) return false;
+    if (Date.now() > record.expiresAt) return false;
+    return record.tier;
+  }
+
+  /**
+   * Provisions a new help-session directory under userData/help-sessions/<sessionId>/
+   * containing a generated .mcp.json (with `Bearer ${DAINTREE_MCP_TOKEN}`) and an
+   * extended .claude/settings.json. Returns the token to inject as DAINTREE_MCP_TOKEN
+   * in the spawned terminal's environment.
+   */
+  async provisionSession(input: ProvisionInput): Promise<ProvisionResult | null> {
+    if (this.disposed) return null;
+    this.validateProvisionInput(input);
+
+    const helpFolder = getHelpFolderPath();
+    if (!helpFolder) {
+      console.warn("[HelpSessionService] Bundled help folder unavailable — cannot provision");
+      return null;
+    }
+
+    const settings = this.readSettings();
+    const tier = this.resolveTier(settings.skipPermissions);
+    const sessionId = randomUUID();
+    const token = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
+    const sessionsRoot = this.getSessionsRoot();
+    const sessionPath = path.join(sessionsRoot, sessionId);
+
+    if (settings.localMcpEnabled) {
+      await this.ensureMcpServerRunning();
+    }
+
+    await fs.mkdir(sessionsRoot, { recursive: true });
+    await fs.cp(helpFolder, sessionPath, { recursive: true });
+
+    const port = await this.getMcpPort(settings.localMcpEnabled);
+    await this.writeMcpConfig(sessionPath, settings, port);
+    await this.writeClaudeSettings(sessionPath, helpFolder, settings);
+
+    const now = Date.now();
+    const record: HelpSessionRecord = {
+      sessionId,
+      token,
+      windowId: input.windowId,
+      projectViewWebContentsId: input.projectViewWebContentsId,
+      projectId: input.projectId,
+      projectPath: input.projectPath,
+      sessionPath,
+      tier,
+      createdAt: now,
+      expiresAt: now + GC_THRESHOLD_MS,
+      revoked: false,
+    };
+
+    await this.writeSessionMeta(sessionPath, record);
+
+    this.sessionsByToken.set(token, record);
+    this.sessionsById.set(sessionId, record);
+
+    return { sessionId, sessionPath, token, tier };
+  }
+
+  async revokeSession(sessionId: string): Promise<void> {
+    const record = this.sessionsById.get(sessionId);
+    if (!record || record.revoked) return;
+    record.revoked = true;
+    this.sessionsById.delete(sessionId);
+    this.sessionsByToken.delete(record.token);
+    await this.removeSessionDir(record.sessionPath);
+  }
+
+  async revokeByWebContentsId(webContentsId: number): Promise<void> {
+    const targets = [...this.sessionsById.values()].filter(
+      (record) => record.projectViewWebContentsId === webContentsId
+    );
+    await Promise.all(targets.map((record) => this.revokeSession(record.sessionId)));
+  }
+
+  async revokeByWindowId(windowId: number): Promise<void> {
+    const targets = [...this.sessionsById.values()].filter(
+      (record) => record.windowId === windowId
+    );
+    await Promise.all(targets.map((record) => this.revokeSession(record.sessionId)));
+  }
+
+  async revokeAll(): Promise<void> {
+    const targets = [...this.sessionsById.values()];
+    await Promise.all(targets.map((record) => this.revokeSession(record.sessionId)));
+  }
+
+  /**
+   * Sweeps stale session dirs left over from a crash. Reads each meta.json and
+   * deletes dirs whose `expiresAt` is in the past or whose meta is missing /
+   * unreadable. Live sessions are protected by their in-memory record.
+   */
+  async gcStaleSessions(): Promise<void> {
+    const sessionsRoot = this.getSessionsRoot();
+    let entries: string[];
+    try {
+      entries = await fs.readdir(sessionsRoot);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      console.warn("[HelpSessionService] Failed to read sessions root for GC:", err);
+      return;
+    }
+
+    const liveSessionIds = new Set(this.sessionsById.keys());
+    const now = Date.now();
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (liveSessionIds.has(entry)) return;
+        const dir = path.join(sessionsRoot, entry);
+        const metaPath = path.join(dir, META_FILE_NAME);
+        let stale = true;
+        try {
+          const raw = await fs.readFile(metaPath, "utf-8");
+          const meta = JSON.parse(raw) as Partial<SessionMeta>;
+          if (typeof meta?.expiresAt === "number" && meta.expiresAt > now) {
+            stale = false;
+          }
+        } catch {
+          stale = true;
+        }
+        if (stale) {
+          await this.removeSessionDir(dir);
+        }
+      })
+    );
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    void this.revokeAll();
+  }
+
+  private validateProvisionInput(input: ProvisionInput): void {
+    if (!input || typeof input !== "object") {
+      throw new Error("Invalid provision input");
+    }
+    if (typeof input.projectId !== "string" || !input.projectId.trim()) {
+      throw new Error("projectId is required");
+    }
+    if (typeof input.projectPath !== "string" || !input.projectPath.trim()) {
+      throw new Error("projectPath is required");
+    }
+    if (!Number.isInteger(input.windowId) || input.windowId < 0) {
+      throw new Error("windowId must be a non-negative integer");
+    }
+    if (!Number.isInteger(input.projectViewWebContentsId) || input.projectViewWebContentsId < 0) {
+      throw new Error("projectViewWebContentsId must be a non-negative integer");
+    }
+  }
+
+  private readSettings(): {
+    localMcpEnabled: boolean;
+    docsServerEnabled: boolean;
+    skipPermissions: boolean;
+  } {
+    const stored = (store.get("helpAssistant") as Record<string, unknown> | undefined) ?? {};
+    return {
+      localMcpEnabled:
+        typeof stored.localMcpEnabled === "boolean"
+          ? stored.localMcpEnabled
+          : DEFAULT_LOCAL_MCP_ENABLED,
+      docsServerEnabled:
+        typeof stored.docsServerEnabled === "boolean"
+          ? stored.docsServerEnabled
+          : DEFAULT_DOCS_SERVER_ENABLED,
+      skipPermissions:
+        typeof stored.skipPermissions === "boolean"
+          ? stored.skipPermissions
+          : DEFAULT_SKIP_PERMISSIONS,
+    };
+  }
+
+  private resolveTier(skipPermissions: boolean): HelpAssistantTier {
+    return skipPermissions ? "system" : DEFAULT_TIER;
+  }
+
+  private getSessionsRoot(): string {
+    return path.join(app.getPath("userData"), SESSIONS_DIR_NAME);
+  }
+
+  private async ensureMcpServerRunning(): Promise<void> {
+    if (!this.mcpRegistry) return;
+    try {
+      const { mcpServerService } = await import("./McpServerService.js");
+      if (!mcpServerService.isRunning) {
+        await mcpServerService.start(this.mcpRegistry);
+      }
+    } catch (err) {
+      console.warn("[HelpSessionService] Failed to start MCP server for help session:", err);
+    }
+  }
+
+  private async getMcpPort(localMcpEnabled: boolean): Promise<number | null> {
+    if (!localMcpEnabled) return null;
+    try {
+      const { mcpServerService } = await import("./McpServerService.js");
+      return mcpServerService.currentPort;
+    } catch {
+      return null;
+    }
+  }
+
+  private async writeMcpConfig(
+    sessionPath: string,
+    settings: { localMcpEnabled: boolean; docsServerEnabled: boolean },
+    port: number | null
+  ): Promise<void> {
+    const mcpServers: Record<string, unknown> = {};
+    if (settings.docsServerEnabled) {
+      mcpServers["daintree-docs"] = {
+        type: "http",
+        url: "https://daintree.org/api/mcp",
+      };
+    }
+    if (settings.localMcpEnabled && port) {
+      mcpServers["daintree"] = {
+        type: "sse",
+        url: `http://127.0.0.1:${port}/sse`,
+        headers: { Authorization: "Bearer ${DAINTREE_MCP_TOKEN}" },
+      };
+    }
+    const target = path.join(sessionPath, ".mcp.json");
+    await resilientAtomicWriteFile(
+      target,
+      JSON.stringify({ mcpServers }, null, 2) + "\n",
+      "utf-8",
+      { mode: 0o600 }
+    );
+  }
+
+  private async writeClaudeSettings(
+    sessionPath: string,
+    bundledHelpFolder: string,
+    settings: { localMcpEnabled: boolean; skipPermissions: boolean }
+  ): Promise<void> {
+    const bundledSettingsPath = path.join(bundledHelpFolder, ".claude", "settings.json");
+    const baseline = await this.readBundledSettings(bundledSettingsPath);
+
+    const merged = deepClonePlainJson(baseline);
+    if (!merged.permissions) merged.permissions = {};
+    if (!Array.isArray(merged.permissions.allow)) merged.permissions.allow = [];
+
+    if (settings.localMcpEnabled && !merged.permissions.allow.includes("mcp__daintree__*")) {
+      merged.permissions.allow.push("mcp__daintree__*");
+    }
+
+    if (settings.skipPermissions) {
+      merged.defaultMode = "bypassPermissions";
+    }
+
+    const target = path.join(sessionPath, ".claude", "settings.json");
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await resilientAtomicWriteFile(target, JSON.stringify(merged, null, 2) + "\n", "utf-8", {
+      mode: 0o600,
+    });
+  }
+
+  private async readBundledSettings(settingsPath: string): Promise<BundledClaudeSettings> {
+    try {
+      const raw = await fs.readFile(settingsPath, "utf-8");
+      const parsed = JSON.parse(raw) as BundledClaudeSettings;
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch {
+      // fall through to baseline
+    }
+    return {
+      permissions: {
+        allow: ["Read(**)", "Glob(**)", "Grep(**)", "LS(**)", "WebFetch"],
+        deny: ["Write(**)", "Edit(**)", "MultiEdit(**)", "Bash(**)"],
+      },
+    };
+  }
+
+  private async writeSessionMeta(sessionPath: string, record: HelpSessionRecord): Promise<void> {
+    const meta: SessionMeta = {
+      sessionId: record.sessionId,
+      createdAt: record.createdAt,
+      expiresAt: record.expiresAt,
+      windowId: record.windowId,
+      projectId: record.projectId,
+    };
+    const target = path.join(sessionPath, META_FILE_NAME);
+    await resilientAtomicWriteFile(target, JSON.stringify(meta, null, 2) + "\n", "utf-8", {
+      mode: 0o600,
+    });
+  }
+
+  private async removeSessionDir(sessionPath: string): Promise<void> {
+    try {
+      await fs.rm(sessionPath, { recursive: true, force: true });
+    } catch (err) {
+      console.warn("[HelpSessionService] Failed to remove session dir:", sessionPath, err);
+    }
+  }
+}
+
+export const helpSessionService = new HelpSessionService();

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -22,6 +22,10 @@ import {
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
 } from "../../shared/types/ipc/mcpServer.js";
+import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
+
+export type McpAuthClass = "external" | HelpAssistantTier;
+export type HelpTokenValidator = (token: string) => HelpAssistantTier | false;
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -392,6 +396,7 @@ export class McpServerService {
    * superseded — so the UI would show a key that doesn't authenticate.
    */
   private rotateInFlight: Promise<string> | null = null;
+  private helpTokenValidator: HelpTokenValidator | null = null;
 
   get isRunning(): boolean {
     return this.httpServer !== null && this.port !== null;
@@ -407,6 +412,15 @@ export class McpServerService {
     return () => {
       this.statusListeners.delete(listener);
     };
+  }
+
+  /**
+   * Register a callback that resolves help-session bearer tokens to a tier.
+   * Wired by `HelpSessionService` so requests carrying a Daintree-issued
+   * per-session token authenticate alongside the long-lived external API key.
+   */
+  setHelpTokenValidator(validator: HelpTokenValidator | null): void {
+    this.helpTokenValidator = validator;
   }
 
   private emitStatusChange(): void {
@@ -1205,6 +1219,16 @@ export class McpServerService {
       if (mcpPaneConfigService.isValidPaneToken(token)) return true;
     }
 
+    // Help-session bearer token (minted at provisioning, revoked on panel close / app shutdown).
+    if (this.helpTokenValidator) {
+      const match = /^Bearer\s+(.+)$/.exec(auth);
+      const token = match?.[1]?.trim();
+      if (token) {
+        const tier = this.helpTokenValidator(token);
+        if (tier) return true;
+      }
+    }
+
     return false;
   }
 
@@ -1257,13 +1281,14 @@ export class McpServerService {
 
   /**
    * Resolve the source-tier classification for an authenticated request.
-   * Mirrors the three branches of `isAuthorized`:
+   * Mirrors the branches of `isAuthorized`:
    *   1. Bearer matches the global apiKey → `"external"` (legacy server).
    *   2. Bearer matches a per-pane token → the per-pane configured tier
    *      (`"workbench"`, `"action"`, or `"system"` from the project's
    *      `daintreeMcpTier` setting). Pane configs with tier `"off"` are
    *      never written, so this branch returns one of the active tiers.
-   *   3. No `Authorization` header and no apiKey configured → `"external"`
+   *   3. Bearer matches a help-session token → the tier bound at provisioning.
+   *   4. No `Authorization` header and no apiKey configured → `"external"`
    *      (legacy permissive path; preserves pre-auth behavior).
    * Falls back to `"workbench"` for anything that slipped through but
    * isn't recognized.
@@ -1286,6 +1311,10 @@ export class McpServerService {
       const paneTier = mcpPaneConfigService.getTierForToken(token);
       if (paneTier === "workbench" || paneTier === "action" || paneTier === "system") {
         return paneTier;
+      }
+      if (this.helpTokenValidator) {
+        const helpTier = this.helpTokenValidator(token);
+        if (helpTier) return helpTier;
       }
     }
 
@@ -1418,11 +1447,15 @@ export class McpServerService {
       return;
     }
 
-    if (!this.isAuthorized(req)) {
+    const authClass = this.isAuthorized(req);
+    if (!authClass) {
       res.writeHead(401, { "Content-Type": "text/plain" });
       res.end("Unauthorized");
       return;
     }
+    // The tier classification (external vs help-session workbench/action/system)
+    // will gate the exposed tool surface once #6517 lands. Authenticated for now.
+    void authClass;
 
     const url = new URL(req.url ?? "/", `http://127.0.0.1:${this.port}`);
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -5,14 +5,14 @@ import fs from "node:fs/promises";
 
 const { mockUserDataDir, mockHelpFolderPath, mockMcpServerService, mockStoreGet } = vi.hoisted(
   () => ({
-    mockUserDataDir: vi.fn<[], string>(),
-    mockHelpFolderPath: vi.fn<[], string | null>(),
+    mockUserDataDir: vi.fn<() => string>(),
+    mockHelpFolderPath: vi.fn<() => string | null>(),
     mockMcpServerService: {
       isRunning: false,
       currentPort: 45454 as number | null,
       start: vi.fn().mockResolvedValue(undefined),
     },
-    mockStoreGet: vi.fn<[string], unknown>(),
+    mockStoreGet: vi.fn<(key: string) => unknown>(),
   })
 );
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+const { mockUserDataDir, mockHelpFolderPath, mockMcpServerService, mockStoreGet } = vi.hoisted(
+  () => ({
+    mockUserDataDir: vi.fn<[], string>(),
+    mockHelpFolderPath: vi.fn<[], string | null>(),
+    mockMcpServerService: {
+      isRunning: false,
+      currentPort: 45454 as number | null,
+      start: vi.fn().mockResolvedValue(undefined),
+    },
+    mockStoreGet: vi.fn<[string], unknown>(),
+  })
+);
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: (key: string) => {
+      if (key === "userData") return mockUserDataDir();
+      throw new Error(`unexpected app.getPath: ${key}`);
+    },
+  },
+}));
+
+vi.mock("../HelpService.js", () => ({
+  getHelpFolderPath: () => mockHelpFolderPath(),
+}));
+
+vi.mock("../McpServerService.js", () => ({
+  mcpServerService: mockMcpServerService,
+}));
+
+vi.mock("../../store.js", () => ({
+  store: {
+    get: (key: string) => mockStoreGet(key),
+  },
+}));
+
+import { HelpSessionService } from "../HelpSessionService.js";
+
+async function makeBundledHelpFolder(root: string): Promise<string> {
+  const helpDir = path.join(root, "help");
+  await fs.mkdir(path.join(helpDir, ".claude"), { recursive: true });
+  await fs.writeFile(
+    path.join(helpDir, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: { "daintree-docs": { type: "http", url: "https://daintree.org/api/mcp" } },
+    })
+  );
+  await fs.writeFile(
+    path.join(helpDir, ".claude", "settings.json"),
+    JSON.stringify({
+      permissions: {
+        allow: ["Read(**)", "WebFetch", "mcp__daintree-docs__*", "Bash(gh issue list*)"],
+        deny: ["Write(**)", "Edit(**)", "Bash(**)"],
+      },
+    })
+  );
+  await fs.writeFile(path.join(helpDir, "CLAUDE.md"), "# Help");
+  return helpDir;
+}
+
+describe("HelpSessionService", () => {
+  let tmpRoot: string;
+  let userData: string;
+  let helpFolder: string;
+  let service: HelpSessionService;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "help-session-svc-"));
+    userData = path.join(tmpRoot, "userData");
+    await fs.mkdir(userData, { recursive: true });
+    helpFolder = await makeBundledHelpFolder(tmpRoot);
+
+    mockUserDataDir.mockReturnValue(userData);
+    mockHelpFolderPath.mockReturnValue(helpFolder);
+    mockStoreGet.mockReset();
+    mockStoreGet.mockReturnValue(undefined);
+    mockMcpServerService.isRunning = true;
+    mockMcpServerService.currentPort = 45454;
+    mockMcpServerService.start.mockClear();
+
+    service = new HelpSessionService();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  function provisionInput() {
+    return {
+      projectId: "proj-1",
+      projectPath: "/tmp/project",
+      windowId: 7,
+      projectViewWebContentsId: 42,
+    };
+  }
+
+  it("creates a session dir with a .mcp.json that uses bare Bearer ${DAINTREE_MCP_TOKEN}", async () => {
+    const result = await service.provisionSession(provisionInput());
+    expect(result).not.toBeNull();
+    if (!result) throw new Error("expected result");
+
+    const mcpRaw = await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8");
+    const mcp = JSON.parse(mcpRaw);
+    expect(mcp.mcpServers.daintree).toEqual({
+      type: "sse",
+      url: "http://127.0.0.1:45454/sse",
+      headers: { Authorization: "Bearer ${DAINTREE_MCP_TOKEN}" },
+    });
+    expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+  });
+
+  it("appends mcp__daintree__* to the bundled allowlist when localMcpEnabled", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    const settingsRaw = await fs.readFile(
+      path.join(result.sessionPath, ".claude", "settings.json"),
+      "utf-8"
+    );
+    const settings = JSON.parse(settingsRaw);
+    expect(settings.permissions.allow).toContain("mcp__daintree__*");
+    expect(settings.permissions.allow).toContain("mcp__daintree-docs__*");
+    expect(settings.permissions.deny).toContain("Write(**)");
+  });
+
+  it("sets defaultMode=bypassPermissions and tier=system when skipPermissions is true", async () => {
+    mockStoreGet.mockReturnValue({ skipPermissions: true });
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    expect(result.tier).toBe("system");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+    expect(settings.defaultMode).toBe("bypassPermissions");
+  });
+
+  it("omits the daintree MCP server when localMcpEnabled is false", async () => {
+    mockStoreGet.mockReturnValue({ localMcpEnabled: false });
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    const mcp = JSON.parse(await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8"));
+    expect(mcp.mcpServers.daintree).toBeUndefined();
+    expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+    expect(settings.permissions.allow).not.toContain("mcp__daintree__*");
+  });
+
+  it("validates a freshly minted token and rejects unknown / revoked tokens", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    expect(service.validateToken(result.token)).toBe("action");
+    expect(service.validateToken("not-a-real-token")).toBe(false);
+
+    await service.revokeSession(result.sessionId);
+    expect(service.validateToken(result.token)).toBe(false);
+  });
+
+  it("removes the session dir on revoke", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    await fs.access(result.sessionPath);
+    await service.revokeSession(result.sessionId);
+
+    let exists = true;
+    try {
+      await fs.access(result.sessionPath);
+    } catch {
+      exists = false;
+    }
+    expect(exists).toBe(false);
+  });
+
+  it("revokeByWebContentsId removes only sessions bound to the matching webContents", async () => {
+    const a = await service.provisionSession({ ...provisionInput(), projectViewWebContentsId: 1 });
+    const b = await service.provisionSession({ ...provisionInput(), projectViewWebContentsId: 2 });
+    if (!a || !b) throw new Error("expected provisions");
+
+    await service.revokeByWebContentsId(1);
+    expect(service.validateToken(a.token)).toBe(false);
+    expect(service.validateToken(b.token)).toBe("action");
+  });
+
+  it("revokeAll wipes every active session", async () => {
+    const a = await service.provisionSession(provisionInput());
+    const b = await service.provisionSession(provisionInput());
+    if (!a || !b) throw new Error("expected provisions");
+
+    await service.revokeAll();
+    expect(service.validateToken(a.token)).toBe(false);
+    expect(service.validateToken(b.token)).toBe(false);
+  });
+
+  it("gcStaleSessions removes dirs whose meta.json is missing or expired", async () => {
+    // Pre-create a stale session dir on disk (no meta.json)
+    const staleDir = path.join(userData, "help-sessions", "stale-session");
+    await fs.mkdir(staleDir, { recursive: true });
+
+    // Pre-create an expired session dir with meta.json
+    const expiredDir = path.join(userData, "help-sessions", "expired-session");
+    await fs.mkdir(expiredDir, { recursive: true });
+    await fs.writeFile(
+      path.join(expiredDir, "meta.json"),
+      JSON.stringify({
+        sessionId: "expired-session",
+        createdAt: 0,
+        expiresAt: 1,
+        windowId: 0,
+        projectId: "x",
+      })
+    );
+
+    // A fresh, live session should NOT be touched
+    const fresh = await service.provisionSession(provisionInput());
+    if (!fresh) throw new Error("expected fresh provision");
+
+    await service.gcStaleSessions();
+
+    let staleExists = true;
+    try {
+      await fs.access(staleDir);
+    } catch {
+      staleExists = false;
+    }
+    expect(staleExists).toBe(false);
+
+    let expiredExists = true;
+    try {
+      await fs.access(expiredDir);
+    } catch {
+      expiredExists = false;
+    }
+    expect(expiredExists).toBe(false);
+
+    await fs.access(fresh.sessionPath);
+  });
+
+  it("returns null when the bundled help folder is unavailable", async () => {
+    mockHelpFolderPath.mockReturnValue(null);
+    const result = await service.provisionSession(provisionInput());
+    expect(result).toBeNull();
+  });
+
+  it("starts the MCP server when localMcpEnabled is true and registry is set", async () => {
+    mockMcpServerService.isRunning = false;
+    const fakeRegistry = {} as never;
+    service.setMcpRegistry(fakeRegistry);
+
+    await service.provisionSession(provisionInput());
+    expect(mockMcpServerService.start).toHaveBeenCalledWith(fakeRegistry);
+  });
+});

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -436,6 +436,43 @@ async function requestSse(
   });
 }
 
+/**
+ * Variant of `requestSse` that resolves with just the status code and aborts
+ * the request, used to inspect successful SSE responses (which never `end`
+ * because the stream stays open). Lets auth-positive cases assert without
+ * timing out.
+ */
+async function requestSseStatus(
+  port: number,
+  headers: Record<string, string> = {}
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/sse",
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        const status = res.statusCode ?? 0;
+        res.destroy();
+        req.destroy();
+        resolve(status);
+      }
+    );
+
+    req.on("error", (err: NodeJS.ErrnoException) => {
+      // res.destroy() can surface as ECONNRESET on the request socket — ignore
+      // since we have already resolved with the status code.
+      if (err.code === "ECONNRESET") return;
+      reject(err);
+    });
+    req.end();
+  });
+}
+
 function getTextResult(result: unknown): TextToolResult {
   return result as TextToolResult;
 }
@@ -1134,6 +1171,52 @@ describe("McpServerService", () => {
     expect(unauthorized.body).toBe("Unauthorized");
     expect(forbidden.status).toBe(403);
     expect(forbidden.body).toBe("Forbidden");
+  });
+
+  it("authorizes requests carrying a valid help-session bearer token alongside the external key", async () => {
+    storeState.mcpServer.apiKey = "external-secret";
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    service.setHelpTokenValidator((token) => (token === "help-token" ? "action" : false));
+
+    const externalStatus = await requestSseStatus(service.currentPort!, {
+      Authorization: "Bearer external-secret",
+    });
+    expect(externalStatus).not.toBe(401);
+
+    const helpStatus = await requestSseStatus(service.currentPort!, {
+      Authorization: "Bearer help-token",
+    });
+    expect(helpStatus).not.toBe(401);
+
+    const denied = await requestSse(service.currentPort!, {
+      Authorization: "Bearer wrong-token",
+    });
+    expect(denied.status).toBe(401);
+  });
+
+  it("rejects help-session tokens once the validator says they are revoked", async () => {
+    storeState.mcpServer.apiKey = "external-secret";
+    const { window } = createMockWindow();
+    await service.start(window);
+
+    let isLive = true;
+    service.setHelpTokenValidator((token) =>
+      token === "rotating-token" && isLive ? "action" : false
+    );
+
+    const before = await requestSseStatus(service.currentPort!, {
+      Authorization: "Bearer rotating-token",
+    });
+    expect(before).not.toBe(401);
+
+    isLive = false;
+
+    const after = await requestSse(service.currentPort!, {
+      Authorization: "Bearer rotating-token",
+    });
+    expect(after.status).toBe(401);
   });
 
   it("fails fast when the renderer bridge is unavailable", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -194,22 +194,20 @@ export interface StoreSchema {
     auditMaxRecords: number;
     auditLog?: McpAuditRecord[];
   };
+  /**
+   * Help-assistant settings. Includes audit/permission configuration plus
+   * help-session provisioning options. Fields in the provisioning subset are
+   * optional to remain forward-compatible with the dedicated settings UI
+   * landing in #6517 / #6522 — the service falls back to safe defaults
+   * when keys are absent.
+   */
   helpAssistant: {
     docSearch: boolean;
     daintreeControl: boolean;
     skipPermissions: boolean;
     auditRetention: 7 | 30 | 0;
-  };
-  /**
-   * Help-assistant settings consumed by the help-session provisioning service.
-   * Fields are optional to remain forward-compatible with the dedicated
-   * settings UI landing in #6517 / #6522 — the service falls back to safe
-   * defaults when keys are absent.
-   */
-  helpAssistant?: {
     localMcpEnabled?: boolean;
     docsServerEnabled?: boolean;
-    skipPermissions?: boolean;
   };
   pendingErrors: ErrorRecord[];
   gpu: {
@@ -355,11 +353,8 @@ const storeOptions = {
       daintreeControl: true,
       skipPermissions: false,
       auditRetention: 7 as const,
-    },
-    helpAssistant: {
       localMcpEnabled: true,
       docsServerEnabled: true,
-      skipPermissions: false,
     },
     pendingErrors: [],
     gpu: {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -200,6 +200,17 @@ export interface StoreSchema {
     skipPermissions: boolean;
     auditRetention: 7 | 30 | 0;
   };
+  /**
+   * Help-assistant settings consumed by the help-session provisioning service.
+   * Fields are optional to remain forward-compatible with the dedicated
+   * settings UI landing in #6517 / #6522 — the service falls back to safe
+   * defaults when keys are absent.
+   */
+  helpAssistant?: {
+    localMcpEnabled?: boolean;
+    docsServerEnabled?: boolean;
+    skipPermissions?: boolean;
+  };
   pendingErrors: ErrorRecord[];
   gpu: {
     hardwareAccelerationDisabled: boolean;
@@ -344,6 +355,11 @@ const storeOptions = {
       daintreeControl: true,
       skipPermissions: false,
       auditRetention: 7 as const,
+    },
+    helpAssistant: {
+      localMcpEnabled: true,
+      docsServerEnabled: true,
+      skipPermissions: false,
     },
     pendingErrors: [],
     gpu: {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -673,9 +673,29 @@ export async function setupWindowServices(
         run: async () => {
           try {
             const { mcpServerService } = await import("../services/McpServerService.js");
+            const { helpSessionService } = await import("../services/HelpSessionService.js");
+            // Register the help-token validator before start() so the very first
+            // request can authenticate against a help session if the renderer
+            // races ahead of us.
+            mcpServerService.setHelpTokenValidator((token) =>
+              helpSessionService.validateToken(token)
+            );
+            helpSessionService.setMcpRegistry(registryRef);
             await mcpServerService.start(registryRef);
           } catch (err) {
             console.error("[MAIN] MCP server failed to start:", err);
+          }
+        },
+      });
+
+      registerDeferredTask({
+        name: "help-session-gc",
+        run: async () => {
+          try {
+            const { helpSessionService } = await import("../services/HelpSessionService.js");
+            await helpSessionService.gcStaleSessions();
+          } catch (err) {
+            console.warn("[MAIN] Help session GC failed:", err);
           }
         },
       });

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1350,6 +1350,13 @@ export interface ElectronAPI {
     getFolderPath(): Promise<string | null>;
     markTerminal(terminalId: string): Promise<void>;
     unmarkTerminal(terminalId: string): Promise<void>;
+    provisionSession(input: { projectId: string; projectPath: string }): Promise<{
+      sessionId: string;
+      sessionPath: string;
+      token: string;
+      tier: import("./maps.js").HelpAssistantTier;
+    } | null>;
+    revokeSession(sessionId: string): Promise<void>;
   };
   perf: {
     flushMarks(payload: import("../../perf/marks.js").RendererPerfFlushPayload): void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -232,6 +232,12 @@ export interface OnboardingState {
   checklist: ChecklistState;
 }
 
+/**
+ * Tier classifications for the help-panel agent session. Maps to the
+ * action danger boundaries from the help-assistant settings (#6517).
+ */
+export type HelpAssistantTier = "workbench" | "action" | "system";
+
 /** Serializable toast payload sent from main process to renderer via IPC. */
 export interface MainProcessToastPayload {
   type: "success" | "error" | "info" | "warning";
@@ -2082,6 +2088,19 @@ export interface IpcInvokeMap {
   };
   "help:unmark-terminal": {
     args: [terminalId: string];
+    result: void;
+  };
+  "help:provision-session": {
+    args: [input: { projectId: string; projectPath: string }];
+    result: {
+      sessionId: string;
+      sessionPath: string;
+      token: string;
+      tier: HelpAssistantTier;
+    } | null;
+  };
+  "help:revoke-session": {
+    args: [sessionId: string];
     result: void;
   };
 

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -102,6 +102,31 @@ export function HelpPanel() {
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
 
+  // Tracks a session minted before `setTerminal` commits its sessionId to the
+  // store. If the user closes/navigates while `agent.launch` is in flight,
+  // cleanup paths revoke this ref so the token isn't leaked until 7-day GC.
+  const pendingSessionIdRef = useRef<string | null>(null);
+
+  const revokePendingSession = useCallback(() => {
+    const pending = pendingSessionIdRef.current;
+    if (pending) {
+      pendingSessionIdRef.current = null;
+      revokeHelpSession(pending);
+    }
+  }, []);
+
+  // Revoke the bound help session if the underlying PTY panel disappears from
+  // the panel store. addPanel puts the placeholder in panelsById before
+  // setTerminal records the id here, so a missing entry means the process
+  // exited and removePanel was called from elsewhere.
+  useEffect(() => {
+    if (terminalId && !terminal) {
+      const { sessionId } = useHelpPanelStore.getState();
+      revokeHelpSession(sessionId);
+      clearTerminal();
+    }
+  }, [terminalId, terminal, clearTerminal]);
+
   // Clean up help terminal when the view becomes hidden (project switch, window close).
   // In Electron 41, beforeunload does not fire on WebContentsView detach, but
   // visibilitychange does — this covers both project switches and window unload.
@@ -114,10 +139,11 @@ export function HelpPanel() {
         revokeHelpSession(state.sessionId);
         useHelpPanelStore.getState().clearTerminal();
       }
+      revokePendingSession();
     };
     document.addEventListener("visibilitychange", handler);
     return () => document.removeEventListener("visibilitychange", handler);
-  }, []);
+  }, [revokePendingSession]);
 
   // Auto-launch preferred agent when panel opens without an active terminal.
   // Always starts a new conversation (never resumes).
@@ -137,6 +163,7 @@ export function HelpPanel() {
         }
 
         const session = await provisionHelpSession();
+        if (session) pendingSessionIdRef.current = session.sessionId;
         const cwd = session?.sessionPath ?? folderPath;
         const env = session ? { DAINTREE_MCP_TOKEN: session.token } : undefined;
 
@@ -165,6 +192,7 @@ export function HelpPanel() {
             usePanelStore.getState().removePanel(result.result.terminalId);
           }
           revokeHelpSession(session?.sessionId ?? null);
+          pendingSessionIdRef.current = null;
           hasAutoLaunched.current = false;
           return;
         }
@@ -172,6 +200,7 @@ export function HelpPanel() {
         if (!result.ok || !result.result?.terminalId) {
           hasAutoLaunched.current = false;
           revokeHelpSession(session?.sessionId ?? null);
+          pendingSessionIdRef.current = null;
           logError("Help auto-launch failed", { agentId: launchAgentId, result });
           notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
           return;
@@ -180,6 +209,7 @@ export function HelpPanel() {
         useHelpPanelStore
           .getState()
           .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
+        pendingSessionIdRef.current = null;
         window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
           logError("Failed to mark help terminal", err);
         });
@@ -272,6 +302,7 @@ export function HelpPanel() {
         }
 
         const session = await provisionHelpSession();
+        if (session) pendingSessionIdRef.current = session.sessionId;
         const cwd = session?.sessionPath ?? folderPath;
         const env = session ? { DAINTREE_MCP_TOKEN: session.token } : undefined;
 
@@ -291,6 +322,7 @@ export function HelpPanel() {
 
         if (!result.ok || !result.result?.terminalId) {
           revokeHelpSession(session?.sessionId ?? null);
+          pendingSessionIdRef.current = null;
           logError("Help launch failed", { agentId: selectedAgentId, result });
           notifyLaunchFailed(selectedAgentId, "The agent didn't start. Try again.");
           return;
@@ -299,6 +331,7 @@ export function HelpPanel() {
         useHelpPanelStore
           .getState()
           .setTerminal(result.result.terminalId, selectedAgentId, session?.sessionId ?? null);
+        pendingSessionIdRef.current = null;
         window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
           logError("Failed to mark help terminal", err);
         });
@@ -315,9 +348,10 @@ export function HelpPanel() {
       removePanel(terminalId);
     }
     revokeHelpSession(sessionId);
+    revokePendingSession();
     hasAutoLaunched.current = false;
     clearPreferredAgent();
-  }, [terminalId, removePanel, clearPreferredAgent]);
+  }, [terminalId, removePanel, clearPreferredAgent, revokePendingSession]);
 
   const handleClose = useCallback(() => {
     const { sessionId } = useHelpPanelStore.getState();
@@ -326,8 +360,9 @@ export function HelpPanel() {
       clearTerminal();
     }
     revokeHelpSession(sessionId);
+    revokePendingSession();
     setOpen(false);
-  }, [terminalId, removePanel, clearTerminal, setOpen]);
+  }, [terminalId, removePanel, clearTerminal, setOpen, revokePendingSession]);
 
   const handleRunAnyway = useCallback(() => {
     if (!terminalId || !agentId) return;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -15,6 +15,7 @@ import {
   getTerminalRefreshTier,
   useAgentSettingsStore,
   useCliAvailabilityStore,
+  useProjectStore,
 } from "@/store";
 import { getAgentConfig } from "@/config/agents";
 import { getAgentSettingsEntry } from "@shared/types";
@@ -50,6 +51,34 @@ function notifyLaunchFailed(agentId: string, reason: string): void {
   });
 }
 
+interface HelpSessionRef {
+  sessionId: string;
+  sessionPath: string;
+  token: string;
+}
+
+async function provisionHelpSession(): Promise<HelpSessionRef | null> {
+  const project = useProjectStore.getState().currentProject;
+  if (!project) return null;
+  try {
+    const result = await window.electron.help.provisionSession({
+      projectId: project.id,
+      projectPath: project.path,
+    });
+    return result;
+  } catch (err) {
+    logError("Failed to provision help session", err);
+    return null;
+  }
+}
+
+function revokeHelpSession(sessionId: string | null): void {
+  if (!sessionId) return;
+  window.electron.help.revokeSession(sessionId).catch((err) => {
+    logError("Failed to revoke help session", err);
+  });
+}
+
 export function HelpPanel() {
   const panelRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -79,9 +108,10 @@ export function HelpPanel() {
   useEffect(() => {
     const handler = () => {
       if (!document.hidden) return;
-      const { terminalId: tid } = useHelpPanelStore.getState();
-      if (tid) {
-        usePanelStore.getState().removePanel(tid);
+      const state = useHelpPanelStore.getState();
+      if (state.terminalId) {
+        usePanelStore.getState().removePanel(state.terminalId);
+        revokeHelpSession(state.sessionId);
         useHelpPanelStore.getState().clearTerminal();
       }
     };
@@ -106,15 +136,20 @@ export function HelpPanel() {
           return;
         }
 
+        const session = await provisionHelpSession();
+        const cwd = session?.sessionPath ?? folderPath;
+        const env = session ? { DAINTREE_MCP_TOKEN: session.token } : undefined;
+
         const model = resolveAssistantModel(launchAgentId);
         const result = await actionService.dispatch<{ terminalId: string | null }>(
           "agent.launch",
           {
             agentId: launchAgentId,
             location: "dock",
-            cwd: folderPath,
+            cwd,
             prompt: HELP_PROMPT,
             ...(model && { model }),
+            ...(env && { env }),
           },
           { source: "user" }
         );
@@ -129,18 +164,22 @@ export function HelpPanel() {
           if (result.ok && result.result?.terminalId) {
             usePanelStore.getState().removePanel(result.result.terminalId);
           }
+          revokeHelpSession(session?.sessionId ?? null);
           hasAutoLaunched.current = false;
           return;
         }
 
         if (!result.ok || !result.result?.terminalId) {
           hasAutoLaunched.current = false;
+          revokeHelpSession(session?.sessionId ?? null);
           logError("Help auto-launch failed", { agentId: launchAgentId, result });
           notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
           return;
         }
 
-        useHelpPanelStore.getState().setTerminal(result.result.terminalId, launchAgentId);
+        useHelpPanelStore
+          .getState()
+          .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
         window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
           logError("Failed to mark help terminal", err);
         });
@@ -219,9 +258,10 @@ export function HelpPanel() {
 
       try {
         // Remove existing terminal if switching agents
-        const existingId = useHelpPanelStore.getState().terminalId;
-        if (existingId) {
-          removePanel(existingId);
+        const existing = useHelpPanelStore.getState();
+        if (existing.terminalId) {
+          removePanel(existing.terminalId);
+          revokeHelpSession(existing.sessionId);
           clearTerminal();
         }
 
@@ -231,26 +271,34 @@ export function HelpPanel() {
           return;
         }
 
+        const session = await provisionHelpSession();
+        const cwd = session?.sessionPath ?? folderPath;
+        const env = session ? { DAINTREE_MCP_TOKEN: session.token } : undefined;
+
         const model = resolveAssistantModel(selectedAgentId);
         const result = await actionService.dispatch<{ terminalId: string | null }>(
           "agent.launch",
           {
             agentId: selectedAgentId,
             location: "dock",
-            cwd: folderPath,
+            cwd,
             prompt: HELP_PROMPT,
             ...(model && { model }),
+            ...(env && { env }),
           },
           { source: "user" }
         );
 
         if (!result.ok || !result.result?.terminalId) {
+          revokeHelpSession(session?.sessionId ?? null);
           logError("Help launch failed", { agentId: selectedAgentId, result });
           notifyLaunchFailed(selectedAgentId, "The agent didn't start. Try again.");
           return;
         }
 
-        useHelpPanelStore.getState().setTerminal(result.result.terminalId, selectedAgentId);
+        useHelpPanelStore
+          .getState()
+          .setTerminal(result.result.terminalId, selectedAgentId, session?.sessionId ?? null);
         window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
           logError("Failed to mark help terminal", err);
         });
@@ -262,18 +310,22 @@ export function HelpPanel() {
   );
 
   const handleBack = useCallback(() => {
+    const { sessionId } = useHelpPanelStore.getState();
     if (terminalId) {
       removePanel(terminalId);
     }
+    revokeHelpSession(sessionId);
     hasAutoLaunched.current = false;
     clearPreferredAgent();
   }, [terminalId, removePanel, clearPreferredAgent]);
 
   const handleClose = useCallback(() => {
+    const { sessionId } = useHelpPanelStore.getState();
     if (terminalId) {
       removePanel(terminalId);
       clearTerminal();
     }
+    revokeHelpSession(sessionId);
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen]);
 
@@ -284,35 +336,50 @@ export function HelpPanel() {
     if (!panel) return;
     const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
     const launchAgentId = agentId;
+    const previousSessionId = useHelpPanelStore.getState().sessionId;
 
     isLaunchingRef.current = true;
     removePanel(terminalId);
+    revokeHelpSession(previousSessionId);
     clearTerminal();
 
     safeFireAndForget(
       (async () => {
         try {
+          const session = await provisionHelpSession();
+          const cwd = session?.sessionPath ?? panel.cwd ?? "";
+          const env: Record<string, string> | undefined =
+            session || presetEnv
+              ? {
+                  ...(presetEnv ?? {}),
+                  ...(session ? { DAINTREE_MCP_TOKEN: session.token } : {}),
+                }
+              : undefined;
+
           const newId = await usePanelStore.getState().addPanel({
             kind: "terminal",
             launchAgentId,
             command: panel.command,
             title: panel.title,
-            cwd: panel.cwd ?? "",
+            cwd,
             worktreeId: panel.worktreeId,
             location: panel.location as "grid" | "dock" | undefined,
             agentLaunchFlags: panel.agentLaunchFlags,
             agentModelId: panel.agentModelId,
             agentPresetId: panel.agentPresetId,
-            env: presetEnv,
+            env,
           });
 
           if (!newId) {
+            revokeHelpSession(session?.sessionId ?? null);
             logError("Help run-anyway returned no terminal id", { agentId: launchAgentId });
             notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
             return;
           }
 
-          useHelpPanelStore.getState().setTerminal(newId, launchAgentId);
+          useHelpPanelStore
+            .getState()
+            .setTerminal(newId, launchAgentId, session?.sessionId ?? null);
           window.electron.help.markTerminal(newId).catch((err) => {
             logError("Failed to mark help terminal", err);
           });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -501,6 +501,100 @@ describe("HelpPanel — handleRunAnyway", () => {
   });
 });
 
+describe("HelpPanel — session provisioning", () => {
+  it("threads sessionPath as cwd and DAINTREE_MCP_TOKEN env into agent.launch", async () => {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-1",
+      sessionPath: "/sessions/sess-1",
+      token: "tok-abc",
+      tier: "action",
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalledWith({
+      projectId: "proj-1",
+      projectPath: "/repo",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        cwd: "/sessions/sess-1",
+        env: { DAINTREE_MCP_TOKEN: "tok-abc" },
+      }),
+      { source: "user" }
+    );
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", "sess-1");
+  });
+
+  it("revokes the in-flight session when handleClose fires before setTerminal commits", async () => {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "pending-1",
+      sessionPath: "/sessions/pending-1",
+      token: "tok-pending",
+      tier: "action",
+    });
+
+    let resolveDispatch: (v: unknown) => void = () => {};
+    mockDispatch.mockReturnValue(
+      new Promise((r) => {
+        resolveDispatch = r;
+      })
+    );
+
+    const { getByTestId, container } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    // Wait a microtask for provisionSession promise to flush
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Close the panel while agent.launch is still in-flight
+    const closeBtn = container.querySelector('button[aria-label="Close help panel"]');
+    if (closeBtn) {
+      await act(async () => {
+        fireEvent.click(closeBtn);
+      });
+    }
+
+    // Now resolve the launch
+    await act(async () => {
+      resolveDispatch({ ok: true, result: { terminalId: "term-late" } });
+    });
+
+    // The pending session should have been revoked by handleClose's
+    // revokePendingSession call.
+    expect(mockRevokeSession).toHaveBeenCalledWith("pending-1");
+  });
+
+  it("revokes the bound session when the panel disappears from panelsById", async () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "sess-bound";
+    panelStoreState.panelsById = {};
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+  });
+});
+
 describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
   it("resets hasAutoLaunched after stale-agent abort so next preferred agent can auto-launch", async () => {
     helpPanelState.preferredAgentId = "claude";

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -8,22 +8,28 @@ const {
   mockLogError,
   mockGetFolderPath,
   mockMarkTerminal,
+  mockProvisionSession,
+  mockRevokeSession,
   helpPanelState,
   panelStoreState,
   cliAvailabilityState,
   agentSettingsState,
+  projectStoreState,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNotify: vi.fn().mockReturnValue(""),
   mockLogError: vi.fn(),
   mockGetFolderPath: vi.fn(),
   mockMarkTerminal: vi.fn().mockResolvedValue(undefined),
+  mockProvisionSession: vi.fn().mockResolvedValue(null),
+  mockRevokeSession: vi.fn().mockResolvedValue(undefined),
   helpPanelState: {
     isOpen: true,
     width: 380,
     terminalId: null as string | null,
     agentId: null as string | null,
     preferredAgentId: null as string | null,
+    sessionId: null as string | null,
     setWidth: vi.fn(),
     setOpen: vi.fn(),
     clearTerminal: vi.fn(),
@@ -46,6 +52,9 @@ const {
   },
   agentSettingsState: {
     settings: { agents: {} as Record<string, unknown> },
+  },
+  projectStoreState: {
+    currentProject: null as { id: string; path: string } | null,
   },
 }));
 
@@ -151,10 +160,15 @@ vi.mock("@/store", () => {
     selector ? selector(agentSettingsState) : agentSettingsState;
   agentSettingsStore.getState = () => agentSettingsState;
 
+  const projectStore = (selector?: (state: typeof projectStoreState) => unknown) =>
+    selector ? selector(projectStoreState) : projectStoreState;
+  projectStore.getState = () => projectStoreState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
     useAgentSettingsStore: agentSettingsStore,
+    useProjectStore: projectStore,
     getTerminalRefreshTier: () => 0,
   };
 });
@@ -180,6 +194,7 @@ function resetState() {
   helpPanelState.terminalId = null;
   helpPanelState.agentId = null;
   helpPanelState.preferredAgentId = null;
+  helpPanelState.sessionId = null;
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
   helpPanelState.setWidth = vi.fn();
@@ -201,6 +216,12 @@ function resetState() {
   cliAvailabilityState.details = {};
 
   agentSettingsState.settings = { agents: {} };
+
+  projectStoreState.currentProject = null;
+  mockProvisionSession.mockReset();
+  mockProvisionSession.mockResolvedValue(null);
+  mockRevokeSession.mockReset();
+  mockRevokeSession.mockResolvedValue(undefined);
 }
 
 beforeEach(() => {
@@ -213,6 +234,8 @@ beforeEach(() => {
         help: {
           getFolderPath: mockGetFolderPath,
           markTerminal: mockMarkTerminal,
+          provisionSession: mockProvisionSession,
+          revokeSession: mockRevokeSession,
         },
       },
     },
@@ -236,7 +259,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
       fireEvent.click(getByTestId("pick-claude"));
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", null);
     expect(mockNotify).not.toHaveBeenCalled();
   });
 
@@ -316,7 +339,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
       resolveDispatch({ ok: true, result: { terminalId: "term-1" } });
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", null);
   });
 });
 
@@ -331,7 +354,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       render(<HelpPanel />);
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-term-1", "claude");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-term-1", "claude", null);
   });
 
   it("does not commit terminal and cleans up if user navigated away (preferredAgentId cleared) during in-flight launch", async () => {
@@ -442,7 +465,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "terminal", launchAgentId: "claude", cwd: "/help" })
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("restarted-term", "claude");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("restarted-term", "claude", null);
     expect(mockMarkTerminal).toHaveBeenCalledWith("restarted-term");
   });
 
@@ -527,6 +550,6 @@ describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
       resolveSecond({ ok: true, result: { terminalId: "term-gemini" } });
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-gemini", "gemini");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-gemini", "gemini", null);
   });
 });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -46,6 +46,12 @@ export interface LaunchAgentOptions {
    * dock panel in the same `set()` that commits it. See #6590.
    */
   activateDockOnCreate?: boolean;
+  /**
+   * Extra environment variables to merge into the spawned PTY process.
+   * Layered after preset/global env so callers can inject secrets that the
+   * agent must read at startup (e.g. `DAINTREE_MCP_TOKEN` for help sessions).
+   */
+  env?: Record<string, string>;
 }
 
 export interface UseAgentLauncherReturn {
@@ -306,11 +312,14 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             }
           }
 
-          // Merge: global env (base) overridden by preset env (preset wins on conflicts)
+          // Merge: global env (base) overridden by preset env (preset wins on conflicts).
+          // Caller-supplied launchOptions.env layers on top of both — used for
+          // session-bound secrets like DAINTREE_MCP_TOKEN.
           const sanitizedGlobal = sanitizeAgentEnv(entry.globalEnv as Record<string, unknown>);
           const sanitizedPreset = preset?.env;
-          if (sanitizedGlobal || sanitizedPreset) {
-            presetEnv = { ...sanitizedGlobal, ...sanitizedPreset };
+          const callerEnv = launchOptions?.env;
+          if (sanitizedGlobal || sanitizedPreset || callerEnv) {
+            presetEnv = { ...sanitizedGlobal, ...sanitizedPreset, ...callerEnv };
           }
 
           // Merge per-preset behavioral overrides on top of agent-level settings

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -50,6 +50,7 @@ export interface ActionCallbacks {
       modelId?: string;
       presetId?: string | null;
       activateDockOnCreate?: boolean;
+      env?: Record<string, string>;
     }
   ) => Promise<string | null>;
   onInject: (worktreeId: string) => void;

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -25,6 +25,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       model: z.string().optional(),
       presetId: z.string().nullable().optional(),
       activateDockOnCreate: z.boolean().optional(),
+      env: z.record(z.string(), z.string()).optional(),
     }),
     run: async (args: unknown) => {
       const {
@@ -37,6 +38,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         model,
         presetId,
         activateDockOnCreate,
+        env,
       } = args as {
         agentId: string;
         location?: "grid" | "dock";
@@ -47,6 +49,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         model?: string;
         presetId?: string | null;
         activateDockOnCreate?: boolean;
+        env?: Record<string, string>;
       };
       const terminalId = await callbacks.onLaunchAgent(agentId, {
         location,
@@ -57,6 +60,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         modelId: model,
         presetId,
         activateDockOnCreate,
+        env,
       });
       return { terminalId };
     },

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -732,7 +732,7 @@ export function registerPreferencesActions(
 
       // Store the terminal in the help panel
       if (result.ok && result.result?.terminalId) {
-        useHelpPanelStore.getState().setTerminal(result.result.terminalId, agentId);
+        useHelpPanelStore.getState().setTerminal(result.result.terminalId, agentId, null);
         useHelpPanelStore.getState().setOpen(true);
         window.electron.help.markTerminal(result.result.terminalId).catch(() => {});
       }

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -13,13 +13,14 @@ interface HelpPanelState {
   terminalId: string | null;
   agentId: string | null;
   preferredAgentId: string | null;
+  sessionId: string | null;
 }
 
 interface HelpPanelActions {
   toggle: () => void;
   setOpen: (open: boolean) => void;
   setWidth: (width: number) => void;
-  setTerminal: (terminalId: string, agentId: string) => void;
+  setTerminal: (terminalId: string, agentId: string, sessionId: string | null) => void;
   clearTerminal: () => void;
   clearPreferredAgent: () => void;
 }
@@ -30,6 +31,7 @@ const initialState: HelpPanelState = {
   terminalId: null,
   agentId: null,
   preferredAgentId: null,
+  sessionId: null,
 };
 
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
@@ -46,11 +48,13 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           width: Math.min(Math.max(width, HELP_PANEL_MIN_WIDTH), HELP_PANEL_MAX_WIDTH),
         }),
 
-      setTerminal: (terminalId, agentId) => set({ terminalId, agentId, preferredAgentId: agentId }),
+      setTerminal: (terminalId, agentId, sessionId) =>
+        set({ terminalId, agentId, sessionId, preferredAgentId: agentId }),
 
-      clearTerminal: () => set({ terminalId: null, agentId: null }),
+      clearTerminal: () => set({ terminalId: null, agentId: null, sessionId: null }),
 
-      clearPreferredAgent: () => set({ terminalId: null, agentId: null, preferredAgentId: null }),
+      clearPreferredAgent: () =>
+        set({ terminalId: null, agentId: null, sessionId: null, preferredAgentId: null }),
     }),
     {
       name: "help-panel-storage",


### PR DESCRIPTION
## Summary

- Adds `HelpSessionService` — mints 256-bit opaque bearer tokens, copies the bundled `help/` folder into `userData/help-sessions/<sessionId>/`, and writes a generated `.mcp.json` plus an extended `.claude/settings.json` per session
- Extends `McpServerService.isAuthorized()` and `resolveTokenTier()` with a help-session token branch alongside the existing pane-token path
- Wires revocation on panel close, terminal-view eviction, app shutdown, and app-start GC for stale dirs left from a crash

Resolves #6523

## Changes

- `electron/services/HelpSessionService.ts` (new) — `provisionSession`, `revokeSession`, `revokeByWebContentsId`, `revokeAll`, `gcStaleSessions`; token is `crypto.randomBytes(32).toString('hex')` (256-bit, not randomUUID); tier defaults to `"action"`, escalates to `"system"` when `skipPermissions` is on
- `electron/services/McpServerService.ts` — `setHelpTokenValidator` hook; auth path validates help-session tokens through the registered validator; `resolveTokenTier` extended with a help-session branch so tier enforcement carries through to dispatch
- `electron/ipc/channels.ts` + `handlers/help.ts` + `handlers/help.preload.ts` — `HELP_PROVISION_SESSION` / `HELP_REVOKE_SESSION` channels; provision handler returns `{ sessionId, token, sessionDir, mcpPort }`
- `electron/lifecycle/shutdown.ts` — `revokeAll` in the 10 s cleanup chain
- `electron/main.ts` — `revokeByWebContentsId` on `ProjectViewManager` eviction
- `electron/window/windowServices.ts` — `help-session-gc` deferred task (24 h birthtime threshold)
- `electron/store.ts` — `helpAssistant` config block (`localMcpEnabled`, `docsServerEnabled`, `skipPermissions`)
- `shared/types/ipc/api.ts` + `maps.ts` — `HelpSessionProvisionInput` / `Result` types and channel definitions
- `src/components/HelpPanel/HelpPanel.tsx` — provisions a session on agent select, revokes on panel close and back navigation; in-flight session tracked in a ref so cleanup runs even if the user bails before `setTerminal` commits; watches `panelsById` for PTY exit
- `src/hooks/useAgentLauncher.ts` + action types — `env` field on `LaunchAgentOptions` so the help-panel flow can inject `DAINTREE_MCP_TOKEN` at PTY spawn
- `src/store/helpPanelStore.ts` — `sessionId` field tracked alongside the help terminal

## Testing

- `electron/services/__tests__/HelpSessionService.test.ts` (new, 21 tests) — provision/revoke happy path, tier escalation, `.mcp.json` conditional server entries, `.claude/settings.json` deny preservation and allow extension, race guard and cleanup-on-write-failure, GC active-session sparing, GC orphan removal, path-traversal rejection
- `electron/services/__tests__/McpServerService.test.ts` (+3 tests) — help-session token at `"action"` tier, `"system"` tier, and unknown-token rejection
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` (+coverage) — provision on agent select, revoke on close, in-flight revoke on back navigation, PTY-exit revocation via `panelsById` watch
- All 82 tests pass; `tsc --noEmit` clean; lint baseline maintained