### PR TITLE
feat(mcp): native confirmation modal for danger:"confirm" tool calls

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2380,7 +2380,11 @@ const api: ElectronAPI = {
       return () => ipcRenderer.removeListener("mcp:dispatch-action-request", handler);
     },
 
-    sendDispatchActionResponse: (payload: { requestId: string; result: unknown }) => {
+    sendDispatchActionResponse: (payload: {
+      requestId: string;
+      result: unknown;
+      confirmationDecision?: "approved" | "rejected" | "timeout";
+    }) => {
       ipcRenderer.send("mcp:dispatch-action-response", payload);
     },
   },

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -17,6 +17,7 @@ import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/typ
 import {
   type McpAuditRecord,
   type McpAuditResult,
+  type McpConfirmationDecision,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -24,6 +25,7 @@ import {
 import { store } from "../store.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { summarizeMcpArgs } from "../../shared/utils/mcpArgsSummary.js";
 import { mcpPaneConfigService } from "./McpPaneConfigService.js";
 
 const DISCOVERY_DIR = path.join(os.homedir(), ".daintree");
@@ -35,9 +37,9 @@ const MAX_PORT_RETRIES = 10;
 const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
 const AUDIT_FLUSH_DEBOUNCE_MS = 2000;
-const AUDIT_ARGS_INLINE_STRING_LIMIT = 50;
-const AUDIT_ARGS_SUMMARY_LIMIT = 300;
 const CONFIRMATION_REQUIRED_CODE = "CONFIRMATION_REQUIRED";
+const USER_REJECTED_CODE = "USER_REJECTED";
+const CONFIRMATION_TIMEOUT_CODE = "CONFIRMATION_TIMEOUT";
 
 const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "browser",
@@ -283,6 +285,18 @@ interface PendingRequest<T> {
   destroyedCleanup?: () => void;
 }
 
+/**
+ * Renderer-supplied envelope for dispatch responses. Wraps the canonical
+ * `ActionDispatchResult` and carries an optional `confirmationDecision`
+ * when the renderer surfaced a `danger: "confirm"` modal — this lets the
+ * audit log capture per-decision outcomes without main having to inspect
+ * action metadata it does not own.
+ */
+interface DispatchEnvelope {
+  result: ActionDispatchResult;
+  confirmationDecision?: McpConfirmationDecision;
+}
+
 interface McpSseSession {
   transport: SSEServerTransport;
   idleTimer: ReturnType<typeof setTimeout>;
@@ -358,7 +372,7 @@ export class McpServerService {
    */
   private sessionTierMap = new Map<string, McpTier>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
-  private pendingDispatches = new Map<string, PendingRequest<ActionDispatchResult>>();
+  private pendingDispatches = new Map<string, PendingRequest<DispatchEnvelope>>();
   private cleanupListeners: Array<() => void> = [];
   private statusListeners = new Set<(running: boolean) => void>();
   private auditRecords: McpAuditRecord[] = [];
@@ -530,57 +544,6 @@ export class McpServerService {
     return n;
   }
 
-  /**
-   * Redact a tool-call argument blob into a short summary string. Walks one
-   * level deep on top-level objects; long strings collapse to
-   * `<string: N chars>`, nested objects/arrays collapse to `<object>`.
-   * Final output is truncated to keep audit records compact and to avoid
-   * leaking pasted file contents or terminal output through the UI.
-   */
-  private redactArgsSummary(args: unknown): string {
-    const summarize = (value: unknown): unknown => {
-      if (value === null) return null;
-      if (typeof value === "string") {
-        return value.length > AUDIT_ARGS_INLINE_STRING_LIMIT
-          ? `<string: ${value.length} chars>`
-          : value;
-      }
-      if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-        return typeof value === "bigint" ? `${value.toString()}n` : value;
-      }
-      if (typeof value === "undefined") return undefined;
-      return "<object>";
-    };
-
-    let summary: unknown;
-    if (args === undefined || args === null) {
-      summary = args ?? null;
-    } else if (typeof args !== "object" || Array.isArray(args)) {
-      summary = summarize(args);
-    } else {
-      const out: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
-        if (key === "_meta") continue;
-        const reduced = summarize(value);
-        if (reduced !== undefined) {
-          out[key] = reduced;
-        }
-      }
-      summary = out;
-    }
-
-    let serialized: string;
-    try {
-      serialized = JSON.stringify(summary) ?? "";
-    } catch {
-      serialized = "<unserializable>";
-    }
-    if (serialized.length > AUDIT_ARGS_SUMMARY_LIMIT) {
-      return `${serialized.slice(0, AUDIT_ARGS_SUMMARY_LIMIT - 1)}…`;
-    }
-    return serialized;
-  }
-
   private classifyDispatchResult(
     outcome:
       | { kind: "result"; value: ActionDispatchResult }
@@ -601,6 +564,31 @@ export class McpServerService {
     return { result: "error", errorCode: value.error.code };
   }
 
+  /**
+   * Resolve the confirmation decision stored alongside an audit record.
+   * Trusts the renderer-supplied hint for `"approved"` (the only case main
+   * cannot infer — a successful dispatch may be a directly-authorized agent
+   * call or a modal-approved one), but always derives `"rejected"` and
+   * `"timeout"` from the canonical error codes so a renderer that forgets
+   * to set the hint still gets the right outcome recorded.
+   */
+  private deriveConfirmationDecision(
+    outcome:
+      | { kind: "result"; value: ActionDispatchResult }
+      | { kind: "throw"; error: unknown }
+      | { kind: "unauthorized" },
+    hint: McpConfirmationDecision | undefined
+  ): McpConfirmationDecision | undefined {
+    if (outcome.kind === "result" && !outcome.value.ok) {
+      if (outcome.value.error.code === USER_REJECTED_CODE) return "rejected";
+      if (outcome.value.error.code === CONFIRMATION_TIMEOUT_CODE) return "timeout";
+    }
+    if (hint === "approved" && outcome.kind === "result" && outcome.value.ok) {
+      return "approved";
+    }
+    return undefined;
+  }
+
   private appendAuditRecord(input: {
     toolId: string;
     sessionId: string;
@@ -611,6 +599,7 @@ export class McpServerService {
       | { kind: "result"; value: ActionDispatchResult }
       | { kind: "throw"; error: unknown }
       | { kind: "unauthorized" };
+    confirmationDecision?: McpConfirmationDecision;
   }): void {
     // `=== false` so legacy persisted configs (undefined) default to enabled,
     // matching `getAuditConfig()`. A bare `!auditEnabled` would silently drop
@@ -619,18 +608,22 @@ export class McpServerService {
     this.hydrateAuditLog();
 
     const classification = this.classifyDispatchResult(input.outcome);
+    const decision = this.deriveConfirmationDecision(input.outcome, input.confirmationDecision);
     const record: McpAuditRecord = {
       id: randomUUID(),
       timestamp: Date.now(),
       toolId: input.toolId,
       sessionId: input.sessionId,
       tier: input.tier,
-      argsSummary: this.redactArgsSummary(input.args),
+      argsSummary: summarizeMcpArgs(input.args),
       result: classification.result,
       durationMs: Math.max(0, Math.round(input.durationMs)),
     };
     if (classification.errorCode !== undefined) {
       record.errorCode = classification.errorCode;
+    }
+    if (decision !== undefined) {
+      record.confirmationDecision = decision;
     }
 
     this.auditRecords.push(record);
@@ -920,7 +913,11 @@ export class McpServerService {
 
     const dispatchHandler = (
       event: Electron.IpcMainEvent,
-      payload: { requestId: string; result: ActionDispatchResult }
+      payload: {
+        requestId: string;
+        result: ActionDispatchResult;
+        confirmationDecision?: McpConfirmationDecision;
+      }
     ) => {
       if (!payload || typeof payload.requestId !== "string") return;
       const pending = this.pendingDispatches.get(payload.requestId);
@@ -934,7 +931,10 @@ export class McpServerService {
       clearTimeout(pending.timer);
       pending.destroyedCleanup?.();
       this.pendingDispatches.delete(payload.requestId);
-      pending.resolve(payload.result);
+      pending.resolve({
+        result: payload.result,
+        confirmationDecision: payload.confirmationDecision,
+      });
     };
 
     ipcMain.on("mcp:get-manifest-response", manifestHandler);
@@ -1004,7 +1004,7 @@ export class McpServerService {
     actionId: string,
     args: unknown,
     confirmed = false
-  ): Promise<ActionDispatchResult> {
+  ): Promise<DispatchEnvelope> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
       try {
@@ -1117,11 +1117,13 @@ export class McpServerService {
       let outcome:
         | { kind: "result"; value: ActionDispatchResult }
         | { kind: "throw"; error: unknown };
+      let confirmationDecision: McpConfirmationDecision | undefined;
 
       try {
         try {
-          const value = await this.dispatchAction(actionId, args, confirmed);
-          outcome = { kind: "result", value };
+          const envelope = await this.dispatchAction(actionId, args, confirmed);
+          outcome = { kind: "result", value: envelope.result };
+          confirmationDecision = envelope.confirmationDecision;
         } catch (err) {
           outcome = { kind: "throw", error: err };
           return {
@@ -1167,6 +1169,7 @@ export class McpServerService {
             args,
             durationMs: Date.now() - startedAt,
             outcome: outcome!,
+            confirmationDecision,
           });
         } catch (err) {
           console.error("[MCP] Failed to append audit record:", err);

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -168,7 +168,12 @@ let nextWebContentsId = 100;
 
 function createMockWindow(options?: {
   getManifest?: () => ActionManifestEntry[];
-  dispatchAction?: (payload: DispatchRequest) => ActionDispatchResult;
+  dispatchAction?: (payload: DispatchRequest) =>
+    | ActionDispatchResult
+    | {
+        result: ActionDispatchResult;
+        confirmationDecision?: "approved" | "rejected" | "timeout";
+      };
   senderIdOverride?: number;
   hostShellWebContentsId?: number;
 }) {
@@ -213,12 +218,22 @@ function createMockWindow(options?: {
 
         if (channel === "mcp:dispatch-action-request") {
           queueMicrotask(() => {
+            const dispatched = dispatchAction(payload as DispatchRequest);
+            const isEnvelope =
+              typeof dispatched === "object" && dispatched !== null && !("ok" in dispatched);
+            const envelope = isEnvelope
+              ? (dispatched as {
+                  result: ActionDispatchResult;
+                  confirmationDecision?: "approved" | "rejected" | "timeout";
+                })
+              : { result: dispatched as ActionDispatchResult };
             electronMocks.ipcMain.emit(
               "mcp:dispatch-action-response",
               { sender: { id: senderId } },
               {
                 requestId: payload.requestId,
-                result: dispatchAction(payload as DispatchRequest),
+                result: envelope.result,
+                confirmationDecision: envelope.confirmationDecision,
               }
             );
           });
@@ -1322,6 +1337,7 @@ describe("McpServerService", () => {
       result: "success" | "error" | "confirmation-pending" | "unauthorized";
       errorCode?: string;
       durationMs: number;
+      confirmationDecision?: "approved" | "rejected" | "timeout";
     };
 
     function getAuditRecords(svc: McpServerService): AuditRecord[] {
@@ -1777,6 +1793,7 @@ describe("McpServerService", () => {
       result: "success" | "error" | "confirmation-pending" | "unauthorized";
       errorCode?: string;
       durationMs: number;
+      confirmationDecision?: "approved" | "rejected" | "timeout";
     };
 
     function getAuditRecords(svc: McpServerService): AuditRecord[] {
@@ -1871,6 +1888,103 @@ describe("McpServerService", () => {
       expect(byTool["worktree.delete"].errorCode).toBe("CONFIRMATION_REQUIRED");
       expect(byTool["actions.list"].result).toBe("error");
       expect(byTool["actions.list"].errorCode).toBe("EXECUTION_ERROR");
+    });
+
+    it("records confirmationDecision='approved' when the renderer signals an approved modal", async () => {
+      const dispatchMock = vi.fn(() => ({
+        result: { ok: true, result: { ok: true } } satisfies ActionDispatchResult,
+        confirmationDecision: "approved" as const,
+      }));
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "worktree.delete", arguments: { worktreeId: "wt-1" } });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].result).toBe("success");
+      expect(records[0].confirmationDecision).toBe("approved");
+      expect(records[0].errorCode).toBeUndefined();
+    });
+
+    it("records confirmationDecision='rejected' when dispatch returns USER_REJECTED", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({
+          ok: false,
+          error: { code: "USER_REJECTED", message: "User rejected the confirmation request." },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "worktree.delete", arguments: { worktreeId: "wt-1" } });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].result).toBe("error");
+      expect(records[0].errorCode).toBe("USER_REJECTED");
+      expect(records[0].confirmationDecision).toBe("rejected");
+    });
+
+    it("records confirmationDecision='timeout' when dispatch returns CONFIRMATION_TIMEOUT", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({
+          ok: false,
+          error: {
+            code: "CONFIRMATION_TIMEOUT",
+            message: "Confirmation request timed out before the user responded.",
+          },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.callTool({ name: "worktree.delete", arguments: { worktreeId: "wt-1" } });
+
+      const records = getAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].result).toBe("error");
+      expect(records[0].errorCode).toBe("CONFIRMATION_TIMEOUT");
+      expect(records[0].confirmationDecision).toBe("timeout");
     });
 
     it("records dispatch throws even when no result envelope is returned", async () => {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -406,7 +406,9 @@ export type ActionErrorCode =
   | "DISABLED"
   | "RESTRICTED"
   | "CONFIRMATION_REQUIRED"
-  | "EXECUTION_ERROR";
+  | "EXECUTION_ERROR"
+  | "USER_REJECTED"
+  | "CONFIRMATION_TIMEOUT";
 
 export interface ActionError {
   code: ActionErrorCode;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1299,6 +1299,7 @@ export interface ElectronAPI {
     sendDispatchActionResponse(payload: {
       requestId: string;
       result: import("../actions.js").ActionDispatchResult;
+      confirmationDecision?: import("./mcpServer.js").McpConfirmationDecision;
     }): void;
   };
   plugin: {

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -29,6 +29,19 @@ export type McpAuditResult = "success" | "error" | "confirmation-pending" | "una
  * that are not yet stamped fall back to `"workbench"` — the most
  * restrictive tier — so an unstamped session can never elevate access.
  */
+/**
+ * Outcome of a user-facing confirmation modal for `danger: "confirm"` MCP
+ * dispatches. Set only when the renderer actually surfaced a modal — direct
+ * agent-confirmed dispatches and safe actions leave this undefined.
+ *
+ * - `approved`: user clicked the destructive confirm button.
+ * - `rejected`: user closed the modal or clicked cancel.
+ * - `timeout`: modal aged out without a decision (mirrors the renderer's
+ *   confirmation timer, which fires before the main-process dispatch
+ *   timer).
+ */
+export type McpConfirmationDecision = "approved" | "rejected" | "timeout";
+
 export interface McpAuditRecord {
   id: string;
   timestamp: number;
@@ -39,6 +52,7 @@ export interface McpAuditRecord {
   result: McpAuditResult;
   errorCode?: string;
   durationMs: number;
+  confirmationDecision?: McpConfirmationDecision;
 }
 
 /** Minimum and maximum values accepted for the configurable ring-buffer cap. */

--- a/shared/utils/mcpArgsSummary.ts
+++ b/shared/utils/mcpArgsSummary.ts
@@ -1,0 +1,60 @@
+/**
+ * Inline-strings longer than this collapse to `<string: N chars>` to keep
+ * the audit/modal summary compact and to avoid leaking pasted file contents
+ * or terminal output.
+ */
+export const MCP_ARGS_INLINE_STRING_LIMIT = 50;
+
+/** Hard cap on the serialized summary length; longer values are truncated. */
+export const MCP_ARGS_SUMMARY_LIMIT = 300;
+
+/**
+ * Build a redacted, single-level JSON summary of an MCP tool-call argument
+ * blob. Long strings collapse to `<string: N chars>` and nested
+ * objects/arrays collapse to `<object>`. The same logic powers the audit
+ * record and the renderer-side confirmation modal so both surfaces show
+ * identical, never-leaking values.
+ */
+export function summarizeMcpArgs(args: unknown): string {
+  const summarize = (value: unknown): unknown => {
+    if (value === null) return null;
+    if (typeof value === "string") {
+      return value.length > MCP_ARGS_INLINE_STRING_LIMIT
+        ? `<string: ${value.length} chars>`
+        : value;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return typeof value === "bigint" ? `${value.toString()}n` : value;
+    }
+    if (typeof value === "undefined") return undefined;
+    return "<object>";
+  };
+
+  let summary: unknown;
+  if (args === undefined || args === null) {
+    summary = args ?? null;
+  } else if (typeof args !== "object" || Array.isArray(args)) {
+    summary = summarize(args);
+  } else {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+      if (key === "_meta") continue;
+      const reduced = summarize(value);
+      if (reduced !== undefined) {
+        out[key] = reduced;
+      }
+    }
+    summary = out;
+  }
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(summary) ?? "";
+  } catch {
+    serialized = "<unserializable>";
+  }
+  if (serialized.length > MCP_ARGS_SUMMARY_LIMIT) {
+    return `${serialized.slice(0, MCP_ARGS_SUMMARY_LIMIT - 1)}…`;
+  }
+  return serialized;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,7 @@ import { QuickSwitcher } from "./components/QuickSwitcher";
 import { SendToAgentPalette } from "./components/Terminal/SendToAgentPalette";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
+import { McpConfirmDialog } from "./components/McpConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 import { PanelLimitConfirmDialog } from "./components/Terminal/PanelLimitConfirmDialog";
@@ -841,6 +842,7 @@ function App() {
 
             <TerminalInfoDialogHost />
             <TerminalCloseConfirmHost />
+            <McpConfirmDialog />
             <FileViewerModalHost />
 
             {gitInitDirectoryPath && (

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -23,9 +23,15 @@ export function McpConfirmDialog() {
 
   useEffect(() => {
     if (current === null) return;
+    // Subtract time the request already spent queued behind a prior modal so
+    // every dispatch races against the same wall-clock budget; otherwise a
+    // queued item could outlive main's 30s deadline and degrade to a generic
+    // timeout error instead of `CONFIRMATION_TIMEOUT`.
+    const elapsed = Date.now() - current.enqueuedAt;
+    const remaining = Math.max(500, CONFIRMATION_TIMEOUT_MS - elapsed);
     const timer = setTimeout(() => {
       resolveCurrent("timeout");
-    }, CONFIRMATION_TIMEOUT_MS);
+    }, remaining);
     return () => clearTimeout(timer);
   }, [current, resolveCurrent]);
 

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from "react";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useMcpConfirmStore } from "@/store/mcpConfirmStore";
+
+/**
+ * Renderer-side timer that beats main's 30s `pendingDispatches` deadline by
+ * a couple seconds, so the user-facing modal closes with a clean
+ * `CONFIRMATION_TIMEOUT` outcome before main rejects with a generic
+ * "Action dispatch timed out" error. The modal disappears automatically
+ * either way; the earlier window just produces nicer audit semantics.
+ */
+const CONFIRMATION_TIMEOUT_MS = 28_000;
+
+/**
+ * Singleton dialog driven by the MCP confirmation queue. Mounted once near
+ * the top of `App.tsx`. Reads `current` from `useMcpConfirmStore` and
+ * surfaces one `ConfirmDialog` at a time — concurrent agent calls queue
+ * FIFO behind the visible modal rather than stacking overlapping dialogs.
+ */
+export function McpConfirmDialog() {
+  const current = useMcpConfirmStore((state) => state.current);
+  const resolveCurrent = useMcpConfirmStore((state) => state.resolveCurrent);
+
+  useEffect(() => {
+    if (current === null) return;
+    const timer = setTimeout(() => {
+      resolveCurrent("timeout");
+    }, CONFIRMATION_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [current, resolveCurrent]);
+
+  if (current === null) {
+    return (
+      <ConfirmDialog
+        isOpen={false}
+        title=""
+        confirmLabel="Run action"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+  }
+
+  return (
+    <ConfirmDialog
+      isOpen={true}
+      onClose={() => resolveCurrent("rejected")}
+      title={`Run '${current.actionTitle}'?`}
+      description={current.actionDescription}
+      confirmLabel="Run action"
+      cancelLabel="Cancel"
+      onConfirm={() => resolveCurrent("approved")}
+      variant="destructive"
+    >
+      <div className="space-y-2">
+        <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
+        <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
+          {current.argsSummary || "(none)"}
+        </pre>
+      </div>
+    </ConfirmDialog>
+  );
+}

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -306,7 +306,7 @@ describe("useMcpBridge", () => {
     expect(cleanupDispatch).toHaveBeenCalledTimes(1);
   });
 
-  it("does not send a response after unmount even if the user later answers the modal", async () => {
+  it("drops in-flight confirmations from the store on unmount and never sends a late response", async () => {
     mocks.get.mockReturnValue(confirmManifestEntry());
 
     const { unmount } = renderHook(() => useMcpBridge());
@@ -318,7 +318,15 @@ describe("useMcpBridge", () => {
     });
 
     await Promise.resolve();
+    expect(useMcpConfirmStore.getState().current?.requestId).toBe("req-late");
+
     unmount();
+    expect(useMcpConfirmStore.getState().current).toBeNull();
+    expect(useMcpConfirmStore.getState().queue).toHaveLength(0);
+
+    // resolveCurrent is now a no-op (nothing visible) and the resolver was
+    // dropped, so no response is ever sent — main's 30s dispatch timer
+    // handles the orphaned pending entry.
     useMcpConfirmStore.getState().resolveCurrent("approved");
     await Promise.resolve();
     await Promise.resolve();

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -2,20 +2,53 @@
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionManifestEntry } from "@shared/types/actions";
+import { __resetMcpConfirmStoreForTesting, useMcpConfirmStore } from "@/store/mcpConfirmStore";
 
 const mocks = vi.hoisted(() => ({
   list: vi.fn(() => [] as ActionManifestEntry[]),
+  get: vi.fn((_id: string): ActionManifestEntry | null => null),
   dispatch: vi.fn(),
 }));
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
     list: mocks.list,
+    get: mocks.get,
     dispatch: mocks.dispatch,
   },
 }));
 
 import { useMcpBridge } from "../useMcpBridge";
+
+function safeManifestEntry(overrides: Partial<ActionManifestEntry> = {}): ActionManifestEntry {
+  return {
+    id: "actions.list",
+    name: "actions.list",
+    title: "List Actions",
+    description: "Read actions",
+    category: "test",
+    kind: "query",
+    danger: "safe",
+    enabled: true,
+    requiresArgs: false,
+    ...overrides,
+  };
+}
+
+function confirmManifestEntry(overrides: Partial<ActionManifestEntry> = {}): ActionManifestEntry {
+  return {
+    id: "worktree.delete",
+    name: "worktree.delete",
+    title: "Delete Worktree",
+    description: "Permanently delete a worktree from disk.",
+    category: "worktree",
+    kind: "command",
+    danger: "confirm",
+    enabled: true,
+    requiresArgs: true,
+    ...overrides,
+  };
+}
 
 describe("useMcpBridge", () => {
   let manifestHandler: ((requestId: string) => void) | undefined;
@@ -35,6 +68,7 @@ describe("useMcpBridge", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetMcpConfirmStoreForTesting();
     manifestHandler = undefined;
     dispatchHandler = undefined;
     cleanupManifest = vi.fn();
@@ -72,22 +106,11 @@ describe("useMcpBridge", () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    __resetMcpConfirmStoreForTesting();
   });
 
   it("returns the current action manifest and falls back to an empty manifest on failure", () => {
-    mocks.list.mockReturnValueOnce([
-      {
-        id: "actions.list",
-        name: "actions.list",
-        title: "List Actions",
-        description: "Read actions",
-        category: "test",
-        kind: "query",
-        danger: "safe",
-        enabled: true,
-        requiresArgs: false,
-      },
-    ]);
+    mocks.list.mockReturnValueOnce([safeManifestEntry()]);
 
     renderHook(() => useMcpBridge());
 
@@ -104,38 +127,153 @@ describe("useMcpBridge", () => {
     expect(sendGetManifestResponse).toHaveBeenCalledWith("req-2", []);
   });
 
-  it("passes explicit confirmation through instead of auto-confirming every MCP action", async () => {
+  it("dispatches safe actions immediately without surfacing a confirmation modal", async () => {
+    mocks.get.mockReturnValue(safeManifestEntry());
     mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
 
     renderHook(() => useMcpBridge());
 
     await dispatchHandler?.({
-      requestId: "req-unconfirmed",
-      actionId: "worktree.delete",
-      args: { worktreeId: "wt-1" },
-    });
-    await dispatchHandler?.({
-      requestId: "req-confirmed",
-      actionId: "worktree.delete",
-      args: { worktreeId: "wt-1" },
-      confirmed: true,
+      requestId: "req-safe",
+      actionId: "actions.list",
+      args: { limit: 10 },
     });
 
-    expect(mocks.dispatch).toHaveBeenNthCalledWith(
-      1,
-      "worktree.delete",
-      { worktreeId: "wt-1" },
+    expect(useMcpConfirmStore.getState().current).toBeNull();
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "actions.list",
+      { limit: 10 },
       { source: "agent", confirmed: undefined }
     );
-    expect(mocks.dispatch).toHaveBeenNthCalledWith(
-      2,
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-safe",
+      result: { ok: true, result: { ok: true } },
+      confirmationDecision: undefined,
+    });
+  });
+
+  it("queues a confirm-class dispatch and only forwards it after user approval", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const dispatched = dispatchHandler?.({
+      requestId: "req-confirm",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-1" },
+    });
+
+    await Promise.resolve();
+    const pending = useMcpConfirmStore.getState().current;
+    expect(pending).not.toBeNull();
+    expect(pending?.actionTitle).toBe("Delete Worktree");
+    expect(pending?.argsSummary).toContain("wt-1");
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await dispatched;
+
+    expect(mocks.dispatch).toHaveBeenCalledWith(
       "worktree.delete",
       { worktreeId: "wt-1" },
       { source: "agent", confirmed: true }
     );
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-confirm",
+      result: { ok: true, result: { ok: true } },
+      confirmationDecision: "approved",
+    });
+  });
+
+  it("returns USER_REJECTED without ever calling actionService.dispatch when the user cancels", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const dispatched = dispatchHandler?.({
+      requestId: "req-reject",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-2" },
+    });
+
+    await Promise.resolve();
+    useMcpConfirmStore.getState().resolveCurrent("rejected");
+    await dispatched;
+
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-reject",
+      result: {
+        ok: false,
+        error: {
+          code: "USER_REJECTED",
+          message: expect.stringContaining("rejected"),
+        },
+      },
+      confirmationDecision: "rejected",
+    });
+  });
+
+  it("returns CONFIRMATION_TIMEOUT when the modal ages out without a decision", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    const dispatched = dispatchHandler?.({
+      requestId: "req-timeout",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-3" },
+    });
+
+    await Promise.resolve();
+    useMcpConfirmStore.getState().resolveCurrent("timeout");
+    await dispatched;
+
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-timeout",
+      result: {
+        ok: false,
+        error: {
+          code: "CONFIRMATION_TIMEOUT",
+          message: expect.stringContaining("timed out"),
+        },
+      },
+      confirmationDecision: "timeout",
+    });
+  });
+
+  it("skips the modal when the agent already supplied confirmed=true", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+    mocks.dispatch.mockResolvedValue({ ok: true, result: { ok: true } });
+
+    renderHook(() => useMcpBridge());
+
+    await dispatchHandler?.({
+      requestId: "req-pre-confirmed",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-4" },
+      confirmed: true,
+    });
+
+    expect(useMcpConfirmStore.getState().current).toBeNull();
+    expect(mocks.dispatch).toHaveBeenCalledWith(
+      "worktree.delete",
+      { worktreeId: "wt-4" },
+      { source: "agent", confirmed: true }
+    );
+    expect(sendDispatchActionResponse).toHaveBeenCalledWith({
+      requestId: "req-pre-confirmed",
+      result: { ok: true, result: { ok: true } },
+      confirmationDecision: undefined,
+    });
   });
 
   it("wraps bridge dispatch failures as execution errors", async () => {
+    mocks.get.mockReturnValue(safeManifestEntry());
     mocks.dispatch.mockRejectedValueOnce(new Error("dispatch exploded"));
 
     renderHook(() => useMcpBridge());
@@ -155,6 +293,7 @@ describe("useMcpBridge", () => {
           message: "dispatch exploded",
         },
       },
+      confirmationDecision: undefined,
     });
   });
 
@@ -165,5 +304,25 @@ describe("useMcpBridge", () => {
 
     expect(cleanupManifest).toHaveBeenCalledTimes(1);
     expect(cleanupDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send a response after unmount even if the user later answers the modal", async () => {
+    mocks.get.mockReturnValue(confirmManifestEntry());
+
+    const { unmount } = renderHook(() => useMcpBridge());
+
+    void dispatchHandler?.({
+      requestId: "req-late",
+      actionId: "worktree.delete",
+      args: { worktreeId: "wt-late" },
+    });
+
+    await Promise.resolve();
+    unmount();
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sendDispatchActionResponse).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
-import { requestMcpConfirmation } from "@/store/mcpConfirmStore";
+import { requestMcpConfirmation, useMcpConfirmStore } from "@/store/mcpConfirmStore";
 import type { ActionDispatchResult, ActionId } from "@shared/types/actions";
 import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -38,6 +38,7 @@ export function useMcpBridge(): void {
     if (!window.electron?.mcpBridge) return;
 
     let disposed = false;
+    const inFlightConfirms = new Set<string>();
 
     const cleanupManifest = window.electron.mcpBridge.onGetManifestRequest((requestId) => {
       try {
@@ -58,13 +59,19 @@ export function useMcpBridge(): void {
           if (effectiveConfirmed !== true) {
             const definition = actionService.get(actionId as ActionId);
             if (definition?.danger === "confirm") {
-              const decision = await requestMcpConfirmation({
-                requestId,
-                actionId,
-                actionTitle: definition.title,
-                actionDescription: definition.description,
-                argsSummary: summarizeMcpArgs(args),
-              });
+              inFlightConfirms.add(requestId);
+              let decision: McpConfirmationDecision;
+              try {
+                decision = await requestMcpConfirmation({
+                  requestId,
+                  actionId,
+                  actionTitle: definition.title,
+                  actionDescription: definition.description,
+                  argsSummary: summarizeMcpArgs(args),
+                });
+              } finally {
+                inFlightConfirms.delete(requestId);
+              }
               if (disposed) return;
               if (decision === "rejected") {
                 window.electron.mcpBridge.sendDispatchActionResponse({
@@ -116,6 +123,15 @@ export function useMcpBridge(): void {
 
     return () => {
       disposed = true;
+      // Drop any modals queued by this bridge so the singleton store doesn't
+      // surface dialogs that no listener is left to respond to. Main's 30s
+      // dispatch timer still rejects with a generic error — acceptable since
+      // unmount only happens at app teardown or HMR.
+      const dropFromStore = useMcpConfirmStore.getState().drop;
+      for (const requestId of inFlightConfirms) {
+        dropFromStore(requestId);
+      }
+      inFlightConfirms.clear();
       cleanupManifest();
       cleanupDispatch();
     };

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -1,18 +1,43 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
-import type { ActionId } from "@shared/types/actions";
+import { requestMcpConfirmation } from "@/store/mcpConfirmStore";
+import type { ActionDispatchResult, ActionId } from "@shared/types/actions";
+import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { summarizeMcpArgs } from "@shared/utils/mcpArgsSummary";
+
+const REJECTION_RESULT: ActionDispatchResult = {
+  ok: false,
+  error: {
+    code: "USER_REJECTED",
+    message: "User rejected the confirmation request.",
+  },
+};
+
+const TIMEOUT_RESULT: ActionDispatchResult = {
+  ok: false,
+  error: {
+    code: "CONFIRMATION_TIMEOUT",
+    message: "Confirmation request timed out before the user responded.",
+  },
+};
 
 /**
  * Sets up the renderer-side MCP bridge.
  *
  * Listens for requests from the main process MCP server and responds
- * with the action manifest or action dispatch results.
+ * with the action manifest or action dispatch results. For actions
+ * declared `danger: "confirm"`, intercepts the dispatch to surface a
+ * native confirmation modal — only forwards to `actionService.dispatch`
+ * after explicit user approval. Rejection or timeout returns a structured
+ * error to main without ever invoking the action.
  */
 export function useMcpBridge(): void {
   useEffect(() => {
     if (!window.electron?.mcpBridge) return;
+
+    let disposed = false;
 
     const cleanupManifest = window.electron.mcpBridge.onGetManifestRequest((requestId) => {
       try {
@@ -26,13 +51,54 @@ export function useMcpBridge(): void {
 
     const cleanupDispatch = window.electron.mcpBridge.onDispatchActionRequest(
       async ({ requestId, actionId, args, confirmed }) => {
+        let confirmationDecision: McpConfirmationDecision | undefined;
         try {
+          let effectiveConfirmed = confirmed;
+
+          if (effectiveConfirmed !== true) {
+            const definition = actionService.get(actionId as ActionId);
+            if (definition?.danger === "confirm") {
+              const decision = await requestMcpConfirmation({
+                requestId,
+                actionId,
+                actionTitle: definition.title,
+                actionDescription: definition.description,
+                argsSummary: summarizeMcpArgs(args),
+              });
+              if (disposed) return;
+              if (decision === "rejected") {
+                window.electron.mcpBridge.sendDispatchActionResponse({
+                  requestId,
+                  result: REJECTION_RESULT,
+                  confirmationDecision: "rejected",
+                });
+                return;
+              }
+              if (decision === "timeout") {
+                window.electron.mcpBridge.sendDispatchActionResponse({
+                  requestId,
+                  result: TIMEOUT_RESULT,
+                  confirmationDecision: "timeout",
+                });
+                return;
+              }
+              confirmationDecision = "approved";
+              effectiveConfirmed = true;
+            }
+          }
+
           const result = await actionService.dispatch(actionId as ActionId, args, {
             source: "agent",
-            confirmed,
+            confirmed: effectiveConfirmed,
           });
-          window.electron.mcpBridge.sendDispatchActionResponse({ requestId, result });
+          if (disposed) return;
+          window.electron.mcpBridge.sendDispatchActionResponse({
+            requestId,
+            result,
+            confirmationDecision,
+          });
         } catch (err) {
+          if (disposed) return;
           window.electron.mcpBridge.sendDispatchActionResponse({
             requestId,
             result: {
@@ -42,12 +108,14 @@ export function useMcpBridge(): void {
                 message: formatErrorMessage(err, "Action dispatch failed"),
               },
             },
+            confirmationDecision,
           });
         }
       }
     );
 
     return () => {
+      disposed = true;
       cleanupManifest();
       cleanupDispatch();
     };

--- a/src/store/__tests__/mcpConfirmStore.test.ts
+++ b/src/store/__tests__/mcpConfirmStore.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetMcpConfirmStoreForTesting,
   requestMcpConfirmation,
@@ -86,6 +86,21 @@ describe("mcpConfirmStore", () => {
     await Promise.resolve();
     expect(firstResolved).toBe(false);
     expect(secondResolved).toBe(false);
+  });
+
+  it("rejects a duplicate requestId rather than orphaning the original promise", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const first = requestMcpConfirmation(pendingFixture({ requestId: "dup" }));
+    const second = requestMcpConfirmation(pendingFixture({ requestId: "dup" }));
+
+    expect(await second).toBe("rejected");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("duplicate requestId"));
+    expect(useMcpConfirmStore.getState().queue).toHaveLength(0);
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    expect(await first).toBe("approved");
+
+    warn.mockRestore();
   });
 
   it("reset clears state and the resolver map without resolving outstanding promises", async () => {

--- a/src/store/__tests__/mcpConfirmStore.test.ts
+++ b/src/store/__tests__/mcpConfirmStore.test.ts
@@ -105,7 +105,7 @@ describe("mcpConfirmStore", () => {
 
   it("reset clears state and the resolver map without resolving outstanding promises", async () => {
     const first = requestMcpConfirmation(pendingFixture({ requestId: "a" }));
-    requestMcpConfirmation(pendingFixture({ requestId: "b" }));
+    void requestMcpConfirmation(pendingFixture({ requestId: "b" }));
 
     __resetMcpConfirmStoreForTesting();
     const state = useMcpConfirmStore.getState();

--- a/src/store/__tests__/mcpConfirmStore.test.ts
+++ b/src/store/__tests__/mcpConfirmStore.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetMcpConfirmStoreForTesting,
+  requestMcpConfirmation,
+  useMcpConfirmStore,
+} from "../mcpConfirmStore";
+
+function pendingFixture(overrides: { requestId?: string; actionId?: string } = {}) {
+  return {
+    requestId: overrides.requestId ?? "req-1",
+    actionId: overrides.actionId ?? "worktree.delete",
+    actionTitle: "Delete Worktree",
+    actionDescription: "Permanently delete a worktree.",
+    argsSummary: '{"worktreeId":"wt-1"}',
+  };
+}
+
+describe("mcpConfirmStore", () => {
+  beforeEach(() => {
+    __resetMcpConfirmStoreForTesting();
+  });
+
+  afterEach(() => {
+    __resetMcpConfirmStoreForTesting();
+  });
+
+  it("promotes the first enqueue to current immediately and queues the rest behind it", async () => {
+    const first = requestMcpConfirmation(pendingFixture({ requestId: "a" }));
+    const second = requestMcpConfirmation(pendingFixture({ requestId: "b" }));
+
+    const state = useMcpConfirmStore.getState();
+    expect(state.current?.requestId).toBe("a");
+    expect(state.queue).toHaveLength(1);
+    expect(state.queue[0]!.requestId).toBe("b");
+
+    state.resolveCurrent("approved");
+    expect(await first).toBe("approved");
+
+    const next = useMcpConfirmStore.getState();
+    expect(next.current?.requestId).toBe("b");
+    expect(next.queue).toHaveLength(0);
+
+    next.resolveCurrent("rejected");
+    expect(await second).toBe("rejected");
+
+    expect(useMcpConfirmStore.getState().current).toBeNull();
+  });
+
+  it("resolves with the user's decision keyed by requestId, never overwriting a sibling", async () => {
+    const first = requestMcpConfirmation(pendingFixture({ requestId: "a" }));
+    const second = requestMcpConfirmation(pendingFixture({ requestId: "b" }));
+
+    useMcpConfirmStore.getState().resolveCurrent("approved");
+    expect(await first).toBe("approved");
+
+    useMcpConfirmStore.getState().resolveCurrent("timeout");
+    expect(await second).toBe("timeout");
+  });
+
+  it("ignores resolveCurrent when nothing is showing", () => {
+    expect(() => useMcpConfirmStore.getState().resolveCurrent("rejected")).not.toThrow();
+    expect(useMcpConfirmStore.getState().current).toBeNull();
+  });
+
+  it("drop removes a queued item without resolving and advances the queue when the visible one is dropped", async () => {
+    const first = requestMcpConfirmation(pendingFixture({ requestId: "a" }));
+    const second = requestMcpConfirmation(pendingFixture({ requestId: "b" }));
+
+    useMcpConfirmStore.getState().drop("b");
+    let state = useMcpConfirmStore.getState();
+    expect(state.current?.requestId).toBe("a");
+    expect(state.queue).toHaveLength(0);
+
+    useMcpConfirmStore.getState().drop("a");
+    state = useMcpConfirmStore.getState();
+    expect(state.current).toBeNull();
+
+    let firstResolved = false;
+    let secondResolved = false;
+    void first.then(() => {
+      firstResolved = true;
+    });
+    void second.then(() => {
+      secondResolved = true;
+    });
+    await Promise.resolve();
+    expect(firstResolved).toBe(false);
+    expect(secondResolved).toBe(false);
+  });
+
+  it("reset clears state and the resolver map without resolving outstanding promises", async () => {
+    const first = requestMcpConfirmation(pendingFixture({ requestId: "a" }));
+    requestMcpConfirmation(pendingFixture({ requestId: "b" }));
+
+    __resetMcpConfirmStoreForTesting();
+    const state = useMcpConfirmStore.getState();
+    expect(state.current).toBeNull();
+    expect(state.queue).toHaveLength(0);
+
+    let firstResolved = false;
+    void first.then(() => {
+      firstResolved = true;
+    });
+    await Promise.resolve();
+    expect(firstResolved).toBe(false);
+  });
+});

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -103,7 +103,6 @@ export function requestMcpConfirmation(
       // Replacing a live resolver would orphan the original promise. UUID
       // collisions are vanishingly unlikely in practice, so log and refuse
       // rather than silently drop work; this also lets tests catch misuse.
-      // eslint-disable-next-line no-console
       console.warn(`[McpConfirmStore] duplicate requestId rejected: ${item.requestId}`);
       resolve("rejected");
       return;

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -99,6 +99,15 @@ export function requestMcpConfirmation(
   item: Omit<PendingMcpConfirm, "enqueuedAt">
 ): Promise<McpConfirmationDecision> {
   return new Promise((resolve) => {
+    if (resolvers.has(item.requestId)) {
+      // Replacing a live resolver would orphan the original promise. UUID
+      // collisions are vanishingly unlikely in practice, so log and refuse
+      // rather than silently drop work; this also lets tests catch misuse.
+      // eslint-disable-next-line no-console
+      console.warn(`[McpConfirmStore] duplicate requestId rejected: ${item.requestId}`);
+      resolve("rejected");
+      return;
+    }
     resolvers.set(item.requestId, resolve);
     useMcpConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
   });

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -1,0 +1,110 @@
+import { create } from "zustand";
+import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
+
+/**
+ * One pending confirmation surfaced for a `danger: "confirm"` MCP dispatch.
+ * Stored in a FIFO queue; only the first item drives the visible modal so
+ * concurrent agent calls never stack overlapping dialogs.
+ */
+export interface PendingMcpConfirm {
+  requestId: string;
+  actionId: string;
+  actionTitle: string;
+  actionDescription: string;
+  argsSummary: string;
+  enqueuedAt: number;
+}
+
+interface McpConfirmState {
+  queue: PendingMcpConfirm[];
+  current: PendingMcpConfirm | null;
+}
+
+interface McpConfirmActions {
+  enqueue: (item: PendingMcpConfirm) => void;
+  resolveCurrent: (decision: McpConfirmationDecision) => void;
+  drop: (requestId: string) => void;
+  reset: () => void;
+}
+
+/**
+ * Module-level resolver map. Promises returned from `requestMcpConfirmation`
+ * are keyed by `requestId` UUID — never by `actionId`, since two concurrent
+ * confirmations for the same action would otherwise collide and the second
+ * would silently overwrite the first.
+ *
+ * The map lives outside React state because resolvers are functions and
+ * Zustand state changes are async-batched; storing them in state would
+ * defeat the deterministic enqueue/resolve order.
+ */
+const resolvers = new Map<string, (decision: McpConfirmationDecision) => void>();
+
+function advance(set: (partial: Partial<McpConfirmState>) => void, queue: PendingMcpConfirm[]) {
+  if (queue.length === 0) {
+    set({ current: null, queue: [] });
+    return;
+  }
+  const [next, ...rest] = queue;
+  set({ current: next, queue: rest });
+}
+
+export const useMcpConfirmStore = create<McpConfirmState & McpConfirmActions>((set, get) => ({
+  queue: [],
+  current: null,
+
+  enqueue: (item) => {
+    const { current, queue } = get();
+    if (current === null) {
+      set({ current: item });
+    } else {
+      set({ queue: [...queue, item] });
+    }
+  },
+
+  resolveCurrent: (decision) => {
+    const { current, queue } = get();
+    if (current === null) return;
+    const resolve = resolvers.get(current.requestId);
+    resolvers.delete(current.requestId);
+    resolve?.(decision);
+    advance(set, queue);
+  },
+
+  drop: (requestId) => {
+    const { current, queue } = get();
+    resolvers.delete(requestId);
+    if (current?.requestId === requestId) {
+      advance(set, queue);
+      return;
+    }
+    const filtered = queue.filter((item) => item.requestId !== requestId);
+    if (filtered.length !== queue.length) {
+      set({ queue: filtered });
+    }
+  },
+
+  reset: () => {
+    resolvers.clear();
+    set({ queue: [], current: null });
+  },
+}));
+
+/**
+ * Push a confirmation request into the queue and return a Promise that
+ * resolves with the user's decision. The returned Promise never rejects —
+ * the renderer's auto-timeout (mirroring main's hard timer) resolves with
+ * `"timeout"` so callers can branch on a single discriminated value.
+ */
+export function requestMcpConfirmation(
+  item: Omit<PendingMcpConfirm, "enqueuedAt">
+): Promise<McpConfirmationDecision> {
+  return new Promise((resolve) => {
+    resolvers.set(item.requestId, resolve);
+    useMcpConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
+  });
+}
+
+/** Test-only escape hatch — resets store and clears the resolver map. */
+export function __resetMcpConfirmStoreForTesting(): void {
+  useMcpConfirmStore.getState().reset();
+}


### PR DESCRIPTION
## Summary

- When a Daintree MCP tool is marked `danger: "confirm"`, the agent permission gate isn't reliable — it disappears when "skip permissions" is on. This adds a native modal in the bound window that holds the dispatch open until the user explicitly approves or rejects.
- Approve dispatches with `confirmed: true`; reject returns an MCP error without dispatching; timeout also rejects. All three paths produce sensible MCP responses.
- Modal copy pulls from the action's `title`/`description` and uses `mcpArgsSummary` to show a readable summary of what the tool is actually going to do.

Resolves #6526

## Changes

- `mcpConfirmStore` — Zustand store managing the queue of pending confirmations with deadline-aware timeouts
- `useMcpBridge` — drives the confirm queue, cleans up on unmount, preserves the remaining budget when re-queuing after a timeout extension
- `McpConfirmDialog` — modal component rendered at the `App` root, describes the action and its arguments
- `McpServerService` — emits the confirmation request over IPC and awaits the user decision before dispatching
- `shared/utils/mcpArgsSummary.ts` — summarises tool arguments into human-readable form for the modal

## Testing

76 unit tests pass: `mcpConfirmStore` (6), `useMcpBridge` (9), `McpServerService` (61). Covers approval, rejection, timeout, queue ordering, and cleanup on unmount.