### PR TITLE
fix(dock): initialize wasJustOpenedRef at mount to prevent spurious popover close

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -108,12 +108,9 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // that mounts already-open is armed before Radix's DismissableLayer can fire a spurious
   // mount-time onOpenChange(false).
   const wasJustOpenedRef = useRef(isOpen);
-  const prevIsOpenRef = useRef(isOpen);
   const [tabListEl, setTabListEl] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    prevIsOpenRef.current = isOpen;
-
     if (!isOpen) return;
 
     wasJustOpenedRef.current = true;

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -104,8 +104,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Derive isOpen from store state - open if ANY panel in this group is active
   const isOpen = panels.some((p) => p.id === activeDockTerminalId);
 
-  // Track when popover was just programmatically opened
-  const wasJustOpenedRef = useRef(false);
+  // Track when popover was just programmatically opened. Initialized to `isOpen` so a group
+  // that mounts already-open is armed before Radix's DismissableLayer can fire a spurious
+  // mount-time onOpenChange(false).
+  const wasJustOpenedRef = useRef(isOpen);
   const prevIsOpenRef = useRef(isOpen);
   const [tabListEl, setTabListEl] = useState<HTMLDivElement | null>(null);
 

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -52,12 +52,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // Initialized to `isOpen` so a component that mounts already-open is armed before Radix's
   // DismissableLayer can fire a spurious mount-time onOpenChange(false).
   const wasJustOpenedRef = useRef(isOpen);
-  const prevIsOpenRef = useRef(isOpen);
 
   useEffect(() => {
-    prevIsOpenRef.current = isOpen;
-
-    // Detect programmatic open (isOpen changed from false to true externally)
     if (!isOpen) return;
 
     wasJustOpenedRef.current = true;

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -48,8 +48,10 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // Derive isOpen from store state
   const isOpen = activeDockTerminalId === terminal.id;
 
-  // Track when popover was just programmatically opened to ignore immediate close events
-  const wasJustOpenedRef = useRef(false);
+  // Track when popover was just programmatically opened to ignore immediate close events.
+  // Initialized to `isOpen` so a component that mounts already-open is armed before Radix's
+  // DismissableLayer can fire a spurious mount-time onOpenChange(false).
+  const wasJustOpenedRef = useRef(isOpen);
   const prevIsOpenRef = useRef(isOpen);
 
   useEffect(() => {

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -284,4 +284,32 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
     expect(openDockTerminalMock).not.toHaveBeenCalled();
   });
+
+  it("still honors a real onOpenChange(false) when mounted closed", () => {
+    // Regression guard against accidentally arming the ref unconditionally.
+    mockActiveDockTerminalId = null;
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+    expect(capturedOnOpenChange).not.toBeNull();
+
+    act(() => {
+      capturedOnOpenChange?.(false);
+    });
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores spurious close when active panel is not the group's stored active tab", () => {
+    // isOpen derives from `panels.some(p => p.id === activeDockTerminalId)`, not
+    // from group.activeTabId. A panel made active out-of-band (e.g., by an agent
+    // launcher that activates t-2 while the group's stored activeTabId is still
+    // t-1) must still arm the mount guard.
+    mockActiveDockTerminalId = "t-2";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+/**
+ * DockedTabGroup — mount-time spurious-close guard (#6602).
+ *
+ * Same root cause as DockedTerminalItem: Radix's DismissableLayer fires
+ * onOpenChange(false) synchronously during the mount commit when PopoverContent
+ * mounts with open=true (e.g., a freshly created tab whose panel is the active
+ * dock terminal). The fix initializes wasJustOpenedRef = useRef(isOpen).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@/types";
+
+const trashPanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const setFocusedMock = vi.fn();
+const openDockTerminalMock = vi.fn();
+const closeDockTerminalMock = vi.fn();
+const moveTerminalToGridMock = vi.fn();
+const updateTitleMock = vi.fn();
+const reorderPanelsInGroupMock = vi.fn();
+const addPanelMock = vi.fn();
+const addPanelToGroupMock = vi.fn();
+
+let mockActiveDockTerminalId: string | null = null;
+let mockTabGroups = new Map<string, TabGroup>();
+let capturedOnOpenChange: ((open: boolean) => void) | null = null;
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeDockTerminalId: mockActiveDockTerminalId,
+      openDockTerminal: openDockTerminalMock,
+      closeDockTerminal: closeDockTerminalMock,
+      moveTerminalToGrid: moveTerminalToGridMock,
+      backendStatus: "connected",
+      setActiveTab: setActiveTabMock,
+      setFocused: setFocusedMock,
+      trashPanel: trashPanelMock,
+      updateTitle: updateTitleMock,
+      reorderPanelsInGroup: reorderPanelsInGroupMock,
+      addPanel: addPanelMock,
+      addPanelToGroup: addPanelToGroupMock,
+      tabGroups: mockTabGroups,
+    }),
+  useTerminalInputStore: (
+    selector: (s: { hybridInputEnabled: boolean; hybridInputAutoFocus: boolean }) => unknown
+  ) => selector({ hybridInputEnabled: false, hybridInputAutoFocus: false }),
+  usePortalStore: (selector: (s: { isOpen: boolean; width: number }) => unknown) =>
+    selector({ isOpen: false, width: 0 }),
+  useFocusStore: (selector: (s: { isFocusMode: boolean }) => unknown) =>
+    selector({ isFocusMode: false }),
+  usePreferencesStore: (
+    selector: (s: { showDockAgentHighlights: boolean; skipWorkingCloseConfirm: boolean }) => unknown
+  ) => selector({ showDockAgentHighlights: false, skipWorkingCloseConfirm: false }),
+}));
+
+vi.mock("@/hooks", () => ({
+  useTabOverflow: () => new Set<string>(),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fit: () => ({ cols: 80, rows: 24 }),
+    applyRendererPolicy: vi.fn(),
+    focus: vi.fn(),
+  },
+}));
+
+vi.mock("../DockPanelOffscreenContainer", () => ({
+  useDockPanelPortal: () => vi.fn(),
+}));
+
+vi.mock("../useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+  getDockDisplayAgentState: () => undefined,
+  getGroupBlockedAgentState: () => null,
+  isGroupDeprioritized: () => false,
+}));
+
+vi.mock("../dockPopoverGuard", () => ({
+  handleDockInteractOutside: vi.fn(),
+  handleDockEscapeKeyDown: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/components/Worktree/terminalStateConfig", () => ({
+  getEffectiveStateIcon: () => null,
+  getEffectiveStateColor: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  getTerminalFocusTarget: () => "terminal",
+}));
+
+// Active Popover mock: simulates Radix DismissableLayer firing onOpenChange(false)
+// once after mount when open=true, mirroring the real spurious-close timing.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    capturedOnOpenChange = onOpenChange ?? null;
+    useEffect(() => {
+      if (open && onOpenChange) {
+        onOpenChange(false);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <>{children}</>;
+  },
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Panel/SortableTabButton", () => ({
+  SortableTabButton: ({ id }: { id: string }) => <button data-testid={`tab-${id}`}>{id}</button>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDndMonitor: vi.fn(),
+  closestCenter: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+  PointerSensor: class {},
+  TouchSensor: class {},
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[]) => arr,
+}));
+
+vi.mock("@dnd-kit/modifiers", () => ({
+  restrictToHorizontalAxis: vi.fn(),
+  restrictToParentElement: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  domMax: {},
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+import { DockedTabGroup } from "../DockedTabGroup";
+
+function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {
+  return {
+    id: "g-1",
+    location: "dock",
+    worktreeId: "wt-1",
+    activeTabId,
+    panelIds,
+  };
+}
+
+describe("DockedTabGroup mount-time close guard (#6602)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    setFocusedMock.mockClear();
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    moveTerminalToGridMock.mockClear();
+    mockActiveDockTerminalId = null;
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+    capturedOnOpenChange = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ignores spurious onOpenChange(false) when mounted with an active panel", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it("allows close once the guard window drains", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+    expect(capturedOnOpenChange).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    act(() => {
+      capturedOnOpenChange?.(false);
+    });
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when mounted with no active panel in the group", () => {
+    mockActiveDockTerminalId = null;
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+    expect(openDockTerminalMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -209,4 +209,18 @@ describe("DockedTerminalItem mount-time close guard (#6602)", () => {
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
     expect(openDockTerminalMock).not.toHaveBeenCalled();
   });
+
+  it("still honors a real onOpenChange(false) when mounted closed", () => {
+    // Regression guard against accidentally arming the ref unconditionally.
+    mockActiveDockTerminalId = null;
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(capturedOnOpenChange).not.toBeNull();
+
+    act(() => {
+      capturedOnOpenChange?.(false);
+    });
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+/**
+ * DockedTerminalItem — mount-time spurious-close guard (#6602).
+ *
+ * Radix's DismissableLayer fires onOpenChange(false) synchronously during the
+ * mount commit when PopoverContent mounts with open=true. That happens before
+ * the useEffect that arms wasJustOpenedRef can run. The fix initializes
+ * useRef(isOpen) so the guard is armed at first render and the spurious close
+ * is ignored.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+import type { TerminalInstance } from "@/store";
+
+const openDockTerminalMock = vi.fn();
+const closeDockTerminalMock = vi.fn();
+const moveTerminalToGridMock = vi.fn();
+
+let mockActiveDockTerminalId: string | null = null;
+let capturedOnOpenChange: ((open: boolean) => void) | null = null;
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeDockTerminalId: mockActiveDockTerminalId,
+      openDockTerminal: openDockTerminalMock,
+      closeDockTerminal: closeDockTerminalMock,
+      moveTerminalToGrid: moveTerminalToGridMock,
+      backendStatus: "connected",
+      showDockAgentHighlights: false,
+    }),
+  useTerminalInputStore: (
+    selector: (s: { hybridInputEnabled: boolean; hybridInputAutoFocus: boolean }) => unknown
+  ) => selector({ hybridInputEnabled: false, hybridInputAutoFocus: false }),
+  usePortalStore: (selector: (s: { isOpen: boolean; width: number }) => unknown) =>
+    selector({ isOpen: false, width: 0 }),
+  useFocusStore: (selector: (s: { isFocusMode: boolean }) => unknown) =>
+    selector({ isFocusMode: false }),
+  usePreferencesStore: (selector: (s: { showDockAgentHighlights: boolean }) => unknown) =>
+    selector({ showDockAgentHighlights: false }),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fit: () => ({ cols: 80, rows: 24 }),
+    applyRendererPolicy: vi.fn(),
+    focus: vi.fn(),
+  },
+}));
+
+vi.mock("../DockPanelOffscreenContainer", () => ({
+  useDockPanelPortal: () => vi.fn(),
+}));
+
+vi.mock("../useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+  getDockDisplayAgentState: () => undefined,
+}));
+
+vi.mock("../dockPopoverGuard", () => ({
+  handleDockInteractOutside: vi.fn(),
+  handleDockEscapeKeyDown: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/components/Worktree/terminalStateConfig", () => ({
+  getEffectiveStateIcon: () => null,
+  getEffectiveStateColor: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  getTerminalFocusTarget: () => "terminal",
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "",
+}));
+
+vi.mock("@/lib/tooltipShortcut", () => ({
+  createTooltipContent: () => null,
+}));
+
+// Active Popover mock: simulates Radix DismissableLayer firing onOpenChange(false)
+// synchronously after mount when open=true. A useEffect runs after commit/paint, which
+// matches the timing of native focusin events arriving from the same commit. The
+// callback is also captured so tests can invoke it manually after the guard window.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    capturedOnOpenChange = onOpenChange ?? null;
+    useEffect(() => {
+      if (open && onOpenChange) {
+        onOpenChange(false);
+      }
+      // Only simulate the spurious mount close once.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <>{children}</>;
+  },
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDndMonitor: vi.fn(),
+}));
+
+import { DockedTerminalItem } from "../DockedTerminalItem";
+
+function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+describe("DockedTerminalItem mount-time close guard (#6602)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    moveTerminalToGridMock.mockClear();
+    mockActiveDockTerminalId = null;
+    capturedOnOpenChange = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ignores spurious onOpenChange(false) when mounted already-open", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+
+  it("allows close once the guard window drains", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+    expect(capturedOnOpenChange).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    act(() => {
+      capturedOnOpenChange?.(false);
+    });
+
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when mounted closed (no spurious close to ignore)", () => {
+    mockActiveDockTerminalId = null;
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+    expect(openDockTerminalMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `wasJustOpenedRef` was initialized to `false` in both `DockedTerminalItem` and `DockedTabGroup`. When a new panel mounted with `isOpen` already `true`, Radix fired `onOpenChange(false)` before the arming effect ran — the guard was still `false`, so `closeDockTerminal()` executed and the popover collapsed immediately.
- Fix: initialize the ref with `useRef(isOpen)` instead of `useRef(false)`. The guard is armed at mount, so any spurious close event that arrives before the first effect pass is correctly ignored.
- Also removed the dead `prevIsOpenRef` from both components, and added 8 new mount-guard tests across `DockedTerminalItem.mountGuard.test.tsx` and `DockedTabGroup.mountGuard.test.tsx`.

Resolves #6602

## Changes

- `DockedTerminalItem.tsx` — `useRef(false)` → `useRef(isOpen)`; drop `prevIsOpenRef`
- `DockedTabGroup.tsx` — same change, same cleanup
- `DockedTerminalItem.mountGuard.test.tsx` — 4 new tests covering single-panel mount-open guard
- `DockedTabGroup.mountGuard.test.tsx` — 4 new tests covering grouped mount-open guard

## Testing

37 targeted tests pass (existing dock suite + 8 new mount-guard tests). Typecheck and lint clean. The mount-guard tests directly simulate the Radix `onOpenChange(false)` call arriving at mount before any effects have run, confirming the guard blocks it when the component mounts open.