### PR TITLE
fix(pty): don't inject /quit into demoted agent terminals on shutdown

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1158,6 +1158,16 @@ export class TerminalProcess {
 
         if (resolved) return;
 
+        // Re-check liveness: if the agent demoted during the clear-delay
+        // window (e.g. user typed /quit milliseconds before shutdown), the
+        // pending write would land in a plain shell.
+        if (!this.isAgentLive) {
+          origOnData.dispose();
+          origOnExit.dispose();
+          finish(null);
+          return;
+        }
+
         try {
           if (shutdownKeySequence) {
             terminal.ptyProcess.write(shutdownKeySequence);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1059,6 +1059,13 @@ export class TerminalProcess {
       return null;
     }
 
+    // Don't inject quit into terminals whose agent already exited — e.g.
+    // user typed /quit and the terminal demoted to a plain shell. The
+    // launchAgentId persists for identity, but the agent is gone.
+    if (!this.isAgentLive) {
+      return null;
+    }
+
     const liveAgentId = getLiveAgentId(terminal);
     const agentConfig = liveAgentId ? getEffectiveAgentConfig(liveAgentId) : undefined;
     const resume = agentConfig?.resume;

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -261,6 +261,48 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     expect(handles.writeMock).not.toHaveBeenCalled();
   });
 
+  it("skips the quit write when the agent demotes during the clear-delay window", async () => {
+    // Race-guard companion to the #6605 fix: if the agent exits between the
+    // prelude write and the clear-delay timeout, the post-delay write must
+    // also short-circuit — otherwise /quit lands in a plain shell.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+
+    // Demote mid-flight — same mutation the demotion path performs.
+    terminal.getInfo().agentState = "exited";
+    terminal.getInfo().detectedAgentId = undefined;
+
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+    expect(handles.writeMock).toHaveBeenCalledTimes(1);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+  });
+
+  it("still injects quit for a live launched agent that has not been detected yet", async () => {
+    // Regression guard: the new isAgentLive gate must NOT block cold-launched
+    // agents that haven't yet been detected by the process tree scan
+    // (launchAgentId set, detectedAgentId undefined, agentState !== "exited").
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
+    expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
+
+    handles.emitData("claude --resume live-agent\n");
+    await expect(shutdownPromise).resolves.toBe("live-agent");
+  });
+
   it("project-scoped (Kiro) skips the session-ID capture loop and resolves null", async () => {
     // Lesson #4781: agents with directory-based sessions never emit session
     // IDs. The capture regex must NOT run for `project-scoped` resume kinds

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -246,6 +246,21 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     expect(handles.writeMock).not.toHaveBeenCalled();
   });
 
+  it("skips quit injection when agent already exited via /quit (issue #6605)", async () => {
+    // Repro #6605: user types /quit, terminal demotes to plain shell (agentState
+    // becomes "exited", detectedAgentId clears) but launchAgentId persists. On
+    // app shutdown, gracefulShutdown must NOT inject /quit into what is now a
+    // plain interactive shell.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    terminal.getInfo().agentState = "exited";
+    terminal.getInfo().detectedAgentId = undefined;
+
+    await expect(terminal.gracefulShutdown()).resolves.toBeNull();
+    expect(handles.writeMock).not.toHaveBeenCalled();
+  });
+
   it("project-scoped (Kiro) skips the session-ID capture loop and resolves null", async () => {
     // Lesson #4781: agents with directory-based sessions never emit session
     // IDs. The capture regex must NOT run for `project-scoped` resume kinds


### PR DESCRIPTION
## Summary

- `gracefulShutdown` in `TerminalProcess.ts` was injecting `/quit` into any terminal that once hosted an agent, even if the agent had already exited and the terminal had demoted back to a plain shell.
- Adds a guard to skip injection for demoted terminals, and closes a race where a terminal could demote between the initial check and the actual injection.
- Three new unit tests cover the demoted-at-check, demoted-between-check-and-inject, and normal shutdown paths.

Resolves #6605

## Changes

- `electron/services/pty/TerminalProcess.ts` — guard in `gracefulShutdown` checks agent state before injecting, with a re-check immediately before write to close the race
- `electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts` — 3 new tests

## Testing

Unit tests added and passing. Manually verified: open an agent terminal, type `/quit`, then quit the app — no stray `/quit` lands in the shell.