### PR TITLE
feat(mcp): expose prompts capability with starter slash commands

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -16,6 +16,8 @@ import {
   ReadResourceRequestSchema,
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   McpError,
   ErrorCode,
 } from "@modelcontextprotocol/sdk/types.js";
@@ -327,6 +329,126 @@ const RESOURCE_BACKING_ACTIONS: Readonly<Record<ResourceKind, string>> = {
 const RESOURCE_TEXT_MAX_BYTES = 50 * 1024;
 
 const RESOURCE_SCROLLBACK_TAIL_LINES = 200;
+
+/**
+ * Live state stitched into prompt bodies at `prompts/get` time. Each field
+ * is best-effort: if the renderer is unavailable or the underlying query
+ * action fails, the field is absent and the prompt template falls back to a
+ * placeholder string. This keeps prompt expansion non-blocking — a degraded
+ * prompt is preferable to a hard failure that strands the user mid-flow.
+ */
+interface PromptRenderContext {
+  worktreePath?: string;
+  worktreeBranch?: string;
+  worktreeIssueNumber?: number;
+  terminalOutput?: string;
+}
+
+interface PromptArgumentDefinition {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+interface PromptDefinition {
+  name: string;
+  description: string;
+  arguments: PromptArgumentDefinition[];
+  render(args: Record<string, string>, context: PromptRenderContext): string;
+}
+
+/**
+ * Static set of slash commands surfaced by Claude Code as
+ * `/mcp__daintree__<name>`. Bodies are plain markdown so the assistant
+ * receives a single user-role message with the interpolated state. Keep
+ * each prompt focused on a workflow entry point — they are user-triggered
+ * macros, not behavioural guidance (which belongs in `help/CLAUDE.md`).
+ */
+const PROMPT_DEFINITIONS: readonly PromptDefinition[] = [
+  {
+    name: "start_issue",
+    description: "Start work on a GitHub issue with worktree and project context primed.",
+    arguments: [
+      {
+        name: "issue_number",
+        description: "GitHub issue number to start work on (e.g. '6610').",
+        required: true,
+      },
+    ],
+    render(args, context) {
+      const issueNumber = args.issue_number;
+      const worktree = context.worktreePath ?? "(no active worktree detected)";
+      const branch = context.worktreeBranch ?? "(unknown branch)";
+      return [
+        `Help me start work on GitHub issue #${issueNumber}.`,
+        "",
+        "Active workspace:",
+        `- Worktree: ${worktree}`,
+        `- Branch: ${branch}`,
+        "",
+        `Please:`,
+        `1. Read issue #${issueNumber} (use the GitHub tools or \`gh issue view ${issueNumber}\`) and summarise the goal in one sentence.`,
+        "2. Confirm the worktree above is the right place to do the work, or suggest creating a new one.",
+        "3. Outline the first 2–3 concrete steps so I can sign off before you begin editing.",
+      ].join("\n");
+    },
+  },
+  {
+    name: "triage_failed_agent",
+    description: "Diagnose a stuck or failed agent terminal and propose next steps.",
+    arguments: [
+      {
+        name: "terminal_id",
+        description:
+          "Terminal ID of the failed agent (from `terminal.list`). Optional — omit to triage the current worktree without specific terminal output.",
+        required: false,
+      },
+    ],
+    render(args, context) {
+      const terminalId = args.terminal_id?.trim();
+      const worktree = context.worktreePath ?? "(no active worktree detected)";
+      const branch = context.worktreeBranch ?? "(unknown branch)";
+
+      const lines: string[] = [
+        "An agent appears to be stuck or failed. Help me diagnose what went wrong and decide what to do next.",
+        "",
+        "Active workspace:",
+        `- Worktree: ${worktree}`,
+        `- Branch: ${branch}`,
+      ];
+
+      if (terminalId) {
+        lines.push(`- Failed terminal: ${terminalId}`);
+        lines.push("");
+        if (context.terminalOutput) {
+          lines.push("Recent terminal output (most recent lines):");
+          lines.push("```");
+          lines.push(context.terminalOutput);
+          lines.push("```");
+        } else {
+          lines.push(
+            `Terminal output for ${terminalId} could not be fetched — call \`terminal.getOutput\` directly to retrieve it.`
+          );
+        }
+      } else {
+        lines.push("");
+        lines.push(
+          "No terminal_id was provided. Use `terminal.list` to find the stuck agent's terminal, then `terminal.getOutput` to inspect its recent activity."
+        );
+      }
+
+      lines.push("");
+      lines.push("Please:");
+      lines.push("1. Read the current git status (`git.getStagingStatus`) to see what changed.");
+      lines.push("2. Identify the root cause (error message, missing prerequisite, infinite loop, etc.).");
+      lines.push(
+        "3. Recommend a concrete next step: retry, kill and restart, hand back to me, or escalate."
+      );
+
+      return lines.join("\n");
+    },
+  },
+];
 
 interface PendingRequest<T> {
   resolve: (value: T) => void;
@@ -1193,6 +1315,7 @@ export class McpServerService {
         capabilities: {
           tools: {},
           resources: { subscribe: true, listChanged: false },
+          prompts: {},
         },
       }
     );
@@ -1355,6 +1478,54 @@ export class McpServerService {
     server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
       this.unsubscribeResource(sessionId, request.params.uri);
       return {};
+    });
+
+    server.setRequestHandler(ListPromptsRequestSchema, async () => {
+      return {
+        prompts: PROMPT_DEFINITIONS.map((def) => ({
+          name: def.name,
+          description: def.description,
+          arguments: def.arguments,
+        })),
+      };
+    });
+
+    server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      const name = request.params.name;
+      const definition = PROMPT_DEFINITIONS.find((def) => def.name === name);
+      if (!definition) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
+      }
+
+      const rawArgs = request.params.arguments ?? {};
+      const args: Record<string, string> = {};
+      for (const [key, value] of Object.entries(rawArgs)) {
+        if (typeof value === "string") {
+          args[key] = value;
+        }
+      }
+
+      for (const arg of definition.arguments) {
+        if (arg.required && !args[arg.name]?.trim()) {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `Missing required argument for prompt '${name}': ${arg.name}`
+          );
+        }
+      }
+
+      const context = await this.collectPromptContext(definition, args);
+      const text = definition.render(args, context);
+
+      return {
+        description: definition.description,
+        messages: [
+          {
+            role: "user" as const,
+            content: { type: "text" as const, text },
+          },
+        ],
+      };
     });
 
     return server;
@@ -1580,6 +1751,65 @@ export class McpServerService {
       }
     }
     this.resourceSubscriptions.delete(sessionId);
+  }
+
+  /**
+   * Best-effort fetch of the live state a prompt template wants to
+   * interpolate. Each query is wrapped in `safeDispatch` so a renderer that
+   * is unavailable, slow, or rejects produces a `null` rather than aborting
+   * the entire `prompts/get` call. Templates handle missing fields with
+   * placeholder copy — degraded prompts beat hard failures mid-flow.
+   */
+  private async collectPromptContext(
+    definition: PromptDefinition,
+    args: Record<string, string>
+  ): Promise<PromptRenderContext> {
+    const context: PromptRenderContext = {};
+
+    const worktree = await this.safeDispatch("worktree.getCurrent", undefined);
+    if (worktree && typeof worktree === "object") {
+      const w = worktree as Record<string, unknown>;
+      if (typeof w.path === "string") context.worktreePath = w.path;
+      if (typeof w.branch === "string") context.worktreeBranch = w.branch;
+      if (typeof w.issueNumber === "number") context.worktreeIssueNumber = w.issueNumber;
+    }
+
+    if (definition.name === "triage_failed_agent") {
+      const terminalId = args.terminal_id?.trim();
+      if (terminalId) {
+        const result = await this.safeDispatch("terminal.getOutput", {
+          terminalId,
+          maxLines: 100,
+          stripAnsi: true,
+        });
+        if (result && typeof result === "object") {
+          const r = result as Record<string, unknown>;
+          if (typeof r.content === "string" && r.content.length > 0) {
+            context.terminalOutput = r.content;
+          }
+        }
+      }
+    }
+
+    return context;
+  }
+
+  /**
+   * Wraps `dispatchAction` for the prompt-rendering path. Returns the
+   * unwrapped result on success and `null` on any failure (renderer
+   * unavailable, action errored, dispatch rejected). Never throws — prompt
+   * expansion must remain non-blocking.
+   */
+  private async safeDispatch(actionId: string, args: unknown): Promise<unknown> {
+    try {
+      const envelope = await this.dispatchAction(actionId, args);
+      if (envelope.result.ok) {
+        return envelope.result.result;
+      }
+      return null;
+    } catch {
+      return null;
+    }
   }
 
   private isValidHost(req: http.IncomingMessage): boolean {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -357,6 +357,27 @@ interface PromptDefinition {
   render(args: Record<string, string>, context: PromptRenderContext): string;
 }
 
+const PROMPT_TERMINAL_OUTPUT_MAX_CHARS = 16_000;
+
+/**
+ * Pick a backtick run that does not appear inside the supplied content so a
+ * fenced code block embedding `content` cannot be terminated early by a
+ * matching backtick run inside the content itself. Starts at 3 backticks
+ * (the markdown minimum) and grows until a non-colliding marker is found.
+ */
+function pickFenceMarker(content: string): string {
+  let length = 3;
+  // Reasonable cap — content with 12+ consecutive backticks is pathological.
+  while (length < 12) {
+    const candidate = "`".repeat(length);
+    if (!content.includes(candidate)) {
+      return candidate;
+    }
+    length += 1;
+  }
+  return "`".repeat(length);
+}
+
 /**
  * Static set of slash commands surfaced by Claude Code as
  * `/mcp__daintree__<name>`. Bodies are plain markdown so the assistant
@@ -376,7 +397,7 @@ const PROMPT_DEFINITIONS: readonly PromptDefinition[] = [
       },
     ],
     render(args, context) {
-      const issueNumber = args.issue_number;
+      const issueNumber = args.issue_number.trim();
       const worktree = context.worktreePath ?? "(no active worktree detected)";
       const branch = context.worktreeBranch ?? "(unknown branch)";
       return [
@@ -420,11 +441,20 @@ const PROMPT_DEFINITIONS: readonly PromptDefinition[] = [
       if (terminalId) {
         lines.push(`- Failed terminal: ${terminalId}`);
         lines.push("");
-        if (context.terminalOutput) {
-          lines.push("Recent terminal output (most recent lines):");
-          lines.push("```");
-          lines.push(context.terminalOutput);
-          lines.push("```");
+        if (context.terminalOutput !== undefined) {
+          if (context.terminalOutput.length === 0) {
+            lines.push(
+              `Terminal output for ${terminalId} was fetched but is empty — the terminal may have just started or been cleared.`
+            );
+          } else {
+            // Use a fence marker that cannot collide with any backtick run in
+            // the terminal output. Picks the smallest backtick run not present.
+            const fence = pickFenceMarker(context.terminalOutput);
+            lines.push("Recent terminal output (most recent lines):");
+            lines.push(fence);
+            lines.push(context.terminalOutput);
+            lines.push(fence);
+          }
         } else {
           lines.push(
             `Terminal output for ${terminalId} could not be fetched — call \`terminal.getOutput\` directly to retrieve it.`
@@ -1497,13 +1527,13 @@ export class McpServerService {
         throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
       }
 
-      const rawArgs = request.params.arguments ?? {};
-      const args: Record<string, string> = {};
-      for (const [key, value] of Object.entries(rawArgs)) {
-        if (typeof value === "string") {
-          args[key] = value;
-        }
-      }
+      // The SDK's GetPromptRequestSchema already validates `arguments` as
+      // Record<string, string>, so any non-string value is rejected before
+      // reaching this handler.
+      const args: Record<string, string> = (request.params.arguments ?? {}) as Record<
+        string,
+        string
+      >;
 
       for (const arg of definition.arguments) {
         if (arg.required && !args[arg.name]?.trim()) {
@@ -1784,8 +1814,17 @@ export class McpServerService {
         });
         if (result && typeof result === "object") {
           const r = result as Record<string, unknown>;
-          if (typeof r.content === "string" && r.content.length > 0) {
-            context.terminalOutput = r.content;
+          if (typeof r.content === "string") {
+            // Cap the embedded slice so a single very long line cannot blow
+            // up the prompt response; keep the tail since recency matters
+            // most when triaging a failed agent.
+            const content = r.content;
+            if (content.length > PROMPT_TERMINAL_OUTPUT_MAX_CHARS) {
+              const tail = content.slice(-PROMPT_TERMINAL_OUTPUT_MAX_CHARS);
+              context.terminalOutput = `… [truncated to last ${PROMPT_TERMINAL_OUTPUT_MAX_CHARS} chars]\n${tail}`;
+            } else {
+              context.terminalOutput = content;
+            }
           }
         }
       }

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -470,7 +470,9 @@ const PROMPT_DEFINITIONS: readonly PromptDefinition[] = [
       lines.push("");
       lines.push("Please:");
       lines.push("1. Read the current git status (`git.getStagingStatus`) to see what changed.");
-      lines.push("2. Identify the root cause (error message, missing prerequisite, infinite loop, etc.).");
+      lines.push(
+        "2. Identify the root cause (error message, missing prerequisite, infinite loop, etc.)."
+      );
       lines.push(
         "3. Recommend a concrete next step: retry, kill and restart, hand back to me, or escalate."
       );

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2880,6 +2880,180 @@ describe("McpServerService", () => {
     });
   });
 
+
+  describe("prompts", () => {
+    it("advertises the prompts capability and lists the starter prompts with argument metadata", async () => {
+      const { window } = createMockWindow();
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      expect(client.getServerCapabilities()?.prompts).toBeDefined();
+
+      const result = await client.listPrompts();
+      const startIssue = result.prompts.find((p) => p.name === "start_issue");
+      const triage = result.prompts.find((p) => p.name === "triage_failed_agent");
+
+      expect(startIssue).toBeDefined();
+      expect(startIssue?.description).toContain("issue");
+      expect(startIssue?.arguments).toEqual([
+        expect.objectContaining({ name: "issue_number", required: true }),
+      ]);
+
+      expect(triage).toBeDefined();
+      expect(triage?.arguments).toEqual([
+        expect.objectContaining({ name: "terminal_id", required: false }),
+      ]);
+    });
+
+    it("renders start_issue with the issue number and live worktree context", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return {
+              ok: true,
+              result: {
+                id: "wt-1",
+                path: "/Users/test/proj/feature-foo",
+                branch: "feature/foo",
+                isMain: false,
+                issueNumber: 42,
+              },
+            };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "start_issue",
+        arguments: { issue_number: "6610" },
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe("user");
+      const content = result.messages[0].content;
+      expect(content.type).toBe("text");
+      const text = (content as { type: "text"; text: string }).text;
+      expect(text).toContain("6610");
+      expect(text).toContain("/Users/test/proj/feature-foo");
+      expect(text).toContain("feature/foo");
+    });
+
+    it("renders triage_failed_agent without arguments and falls back to placeholder copy", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return {
+              ok: true,
+              result: {
+                id: "wt-1",
+                path: "/wt",
+                branch: "develop",
+                isMain: true,
+              },
+            };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({ name: "triage_failed_agent" });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      expect(text).toContain("/wt");
+      expect(text).toContain("terminal.list");
+    });
+
+    it("renders triage_failed_agent with terminal output when terminal_id is supplied", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return {
+              ok: true,
+              result: { id: "wt-1", path: "/wt", branch: "feat/x", isMain: false },
+            };
+          }
+          if (payload.actionId === "terminal.getOutput") {
+            return {
+              ok: true,
+              result: {
+                terminalId: "term-7",
+                content: "ERROR: agent crashed\nstack trace line 1",
+                lineCount: 2,
+                truncated: false,
+              },
+            };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "triage_failed_agent",
+        arguments: { terminal_id: "term-7" },
+      });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      expect(text).toContain("term-7");
+      expect(text).toContain("ERROR: agent crashed");
+      expect(text).toContain("stack trace line 1");
+    });
+
+    it("throws InvalidParams for an unknown prompt name", async () => {
+      const { window } = createMockWindow();
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(client.getPrompt({ name: "no_such_prompt" })).rejects.toMatchObject({
+        code: -32602,
+      });
+    });
+
+    it("throws InvalidParams when a required argument is missing", async () => {
+      const { window } = createMockWindow();
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(
+        client.getPrompt({ name: "start_issue", arguments: {} })
+      ).rejects.toMatchObject({ code: -32602 });
+    });
+
+    it("falls back to placeholder text when the renderer dispatch fails", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: () => ({
+          ok: false,
+          error: { code: "RENDERER_DEAD", message: "renderer is gone" },
+        }),
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "start_issue",
+        arguments: { issue_number: "1" },
+      });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      expect(text).toContain("(no active worktree detected)");
+      expect(text).toContain("(unknown branch)");
+      expect(text).toContain("#1");
+    });
+  });
+
   describe("resources", () => {
     function manifestForResources(): ActionManifestEntry[] {
       return [

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -3052,6 +3052,120 @@ describe("McpServerService", () => {
       expect(text).toContain("(unknown branch)");
       expect(text).toContain("#1");
     });
+
+    it("uses a fence marker that does not collide with backtick runs in terminal output", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return { ok: true, result: { id: "wt", path: "/wt", branch: "b", isMain: false } };
+          }
+          if (payload.actionId === "terminal.getOutput") {
+            return {
+              ok: true,
+              result: {
+                terminalId: "t",
+                content: "before\n```\nadversarial markdown\n```\nafter",
+                lineCount: 5,
+                truncated: false,
+              },
+            };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "triage_failed_agent",
+        arguments: { terminal_id: "t" },
+      });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      // Outer fence must be 4 backticks so the embedded ``` runs can't
+      // terminate it early. The exact-match toContain proves the wrapping
+      // marker is wider than any backtick run inside the content.
+      expect(text).toContain("````\nbefore\n```\nadversarial markdown\n```\nafter\n````");
+    });
+
+    it("distinguishes a fetched-but-empty terminal from a fetch failure", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return { ok: true, result: { id: "wt", path: "/wt", branch: "b", isMain: false } };
+          }
+          if (payload.actionId === "terminal.getOutput") {
+            return {
+              ok: true,
+              result: { terminalId: "t-empty", content: "", lineCount: 0, truncated: false },
+            };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "triage_failed_agent",
+        arguments: { terminal_id: "t-empty" },
+      });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      expect(text).toContain("fetched but is empty");
+      expect(text).not.toContain("could not be fetched");
+    });
+
+    it("preserves worktree context when only terminal.getOutput fails", async () => {
+      const { window } = createMockWindow({
+        dispatchAction: (payload) => {
+          if (payload.actionId === "worktree.getCurrent") {
+            return {
+              ok: true,
+              result: { id: "wt", path: "/proj/wt-x", branch: "feat/x", isMain: false },
+            };
+          }
+          if (payload.actionId === "terminal.getOutput") {
+            return { ok: false, error: { code: "RENDERER_FAIL", message: "boom" } };
+          }
+          return { ok: true, result: null };
+        },
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.getPrompt({
+        name: "triage_failed_agent",
+        arguments: { terminal_id: "t" },
+      });
+      const text = (result.messages[0].content as { type: "text"; text: string }).text;
+
+      expect(text).toContain("/proj/wt-x");
+      expect(text).toContain("feat/x");
+      expect(text).toContain("could not be fetched");
+    });
+
+    it("rejects non-string argument values via the SDK schema validator", async () => {
+      const { window } = createMockWindow();
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      // The SDK's GetPromptRequestSchema enforces Record<string, string> on
+      // arguments. Numeric values are rejected (the SDK surfaces this as a
+      // request-level error) before our handler runs — the surface signal
+      // for client authors that the MCP spec requires string-valued prompt
+      // arguments.
+      await expect(
+        client.getPrompt({
+          name: "start_issue",
+          arguments: { issue_number: 6610 as unknown as string },
+        })
+      ).rejects.toThrow();
+    });
   });
 
   describe("resources", () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -3026,16 +3026,16 @@ describe("McpServerService", () => {
       const { client, transport } = await connectClient(service.currentPort!);
       transports.push(transport);
 
-      await expect(
-        client.getPrompt({ name: "start_issue", arguments: {} })
-      ).rejects.toMatchObject({ code: -32602 });
+      await expect(client.getPrompt({ name: "start_issue", arguments: {} })).rejects.toMatchObject({
+        code: -32602,
+      });
     });
 
     it("falls back to placeholder text when the renderer dispatch fails", async () => {
       const { window } = createMockWindow({
         dispatchAction: () => ({
           ok: false,
-          error: { code: "RENDERER_DEAD", message: "renderer is gone" },
+          error: { code: "EXECUTION_ERROR", message: "renderer is gone" },
         }),
       });
       await service.start(window);
@@ -3128,7 +3128,7 @@ describe("McpServerService", () => {
             };
           }
           if (payload.actionId === "terminal.getOutput") {
-            return { ok: false, error: { code: "RENDERER_FAIL", message: "boom" } };
+            return { ok: false, error: { code: "EXECUTION_ERROR", message: "boom" } };
           }
           return { ok: true, result: null };
         },


### PR DESCRIPTION
## Summary

- Adds the MCP `prompts` capability to the Daintree MCP server alongside the existing `tools` capability, registering `ListPromptsRequestSchema` and `GetPromptRequestSchema` handlers in `createSessionServer`.
- Ships two starter slash commands surfaced by Claude Code as `/mcp__daintree__start_issue` (required `issue_number` arg) and `/mcp__daintree__triage_failed_agent` (optional `terminal_id` arg). Prompts are defined inline via a typed `PROMPT_DEFINITIONS` constant with `render(args, context)` template functions — no template engine, no external files, no new dependencies.
- Live state injection via a new private `safeDispatch` wrapper around the existing `dispatchAction` IPC bridge. Calls workbench-tier query actions (`worktree.getCurrent`, `terminal.getOutput`); failures degrade gracefully to placeholder copy rather than aborting prompt expansion.

Resolves #6610

## Changes

- `electron/services/McpServerService.ts` — `ListPromptsRequestSchema` and `GetPromptRequestSchema` handlers; `PROMPT_DEFINITIONS` with typed `render` functions; `safeDispatch` wrapper; `pickFenceMarker` helper (grows the fence marker until non-colliding with embedded terminal output); prompt size capped at 16k chars.
- `electron/services/__tests__/McpServerService.test.ts` — 11 new vitest cases against the real MCP Client covering list, get, argument validation, state injection, and fence-marker hardening. 76 tests total (was 65).

## Testing

Full vitest suite passes. `npm run check` clean (typecheck + lint:ratchet + check:channels + format:check).