### PR TITLE
feat(mcp): emit outputSchema and structuredContent for typed tool responses

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -808,6 +808,7 @@ export class McpServerService {
       pending.reject(new Error("MCP server stopped"));
       this.pendingDispatches.delete(id);
     }
+    this.cachedManifest = null;
 
     let wasRunning = false;
     if (this.httpServer) {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -377,6 +377,7 @@ export class McpServerService {
   private sessionTierMap = new Map<string, McpTier>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<DispatchEnvelope>>();
+  private cachedManifest: ActionManifestEntry[] | null = null;
   private cleanupListeners: Array<() => void> = [];
   private statusListeners = new Set<(running: boolean) => void>();
   private auditRecords: McpAuditRecord[] = [];
@@ -908,9 +909,11 @@ export class McpServerService {
       clearTimeout(pending.timer);
       pending.destroyedCleanup?.();
       this.pendingManifests.delete(payload.requestId);
-      pending.resolve(
-        Array.isArray(payload.manifest) ? (payload.manifest as ActionManifestEntry[]) : []
-      );
+      const manifest = Array.isArray(payload.manifest)
+        ? (payload.manifest as ActionManifestEntry[])
+        : [];
+      this.cachedManifest = manifest;
+      pending.resolve(manifest);
     };
 
     const dispatchHandler = (
@@ -1077,12 +1080,16 @@ export class McpServerService {
       return {
         tools: manifest
           .filter((entry) => this.shouldExposeTool(entry, tier))
-          .map((entry) => ({
-            name: entry.id,
-            description: this.buildToolDescription(entry),
-            inputSchema: this.buildToolInputSchema(entry),
-            annotations: this.buildAnnotations(entry),
-          })),
+          .map((entry) => {
+            const outputSchema = this.buildToolOutputSchema(entry);
+            return {
+              name: entry.id,
+              description: this.buildToolDescription(entry),
+              inputSchema: this.buildToolInputSchema(entry),
+              annotations: this.buildAnnotations(entry),
+              ...(outputSchema ? { outputSchema } : {}),
+            };
+          }),
       };
     });
 
@@ -1140,6 +1147,8 @@ export class McpServerService {
         }
 
         if (outcome.value.ok) {
+          const entry = this.cachedManifest?.find((e) => e.id === actionId);
+          const structuredContent = this.buildStructuredContent(entry, outcome.value.result);
           return {
             content: [
               {
@@ -1150,6 +1159,7 @@ export class McpServerService {
                     : "OK",
               },
             ],
+            ...(structuredContent ? { structuredContent } : {}),
           };
         }
 
@@ -1366,6 +1376,30 @@ export class McpServerService {
       destructiveHint: entry.danger === "confirm",
       openWorldHint: OPEN_WORLD_CATEGORIES.has(entry.category),
     };
+  }
+
+  private buildToolOutputSchema(entry: ActionManifestEntry): Record<string, unknown> | undefined {
+    const schema = entry.outputSchema;
+    if (!schema || typeof schema !== "object" || Array.isArray(schema)) return undefined;
+    if (schema["type"] !== "object") return undefined;
+    return schema;
+  }
+
+  private buildStructuredContent(
+    entry: ActionManifestEntry | undefined,
+    result: unknown
+  ): Record<string, unknown> | undefined {
+    if (!entry || !this.buildToolOutputSchema(entry)) return undefined;
+    if (
+      result === null ||
+      result === undefined ||
+      typeof result !== "object" ||
+      Array.isArray(result) ||
+      result instanceof Error
+    ) {
+      return undefined;
+    }
+    return result as Record<string, unknown>;
   }
 
   private parseToolArguments(rawArgs: unknown): { args: unknown; confirmed: boolean } {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2683,6 +2683,9 @@ describe("McpServerService", () => {
       const primitiveTool = result.tools.find((t) => t.name === "worktree.create");
       const noSchemaTool = result.tools.find((t) => t.name === "actions.list");
 
+      expect(objectTool).toBeDefined();
+      expect(primitiveTool).toBeDefined();
+      expect(noSchemaTool).toBeDefined();
       expect(objectTool?.outputSchema).toEqual(objectSchema);
       expect(primitiveTool?.outputSchema).toBeUndefined();
       expect(noSchemaTool?.outputSchema).toBeUndefined();
@@ -2782,6 +2785,36 @@ describe("McpServerService", () => {
 
       expect(result.structuredContent).toBeUndefined();
       expect(result.content[0]?.text).toContain('"foo": "bar"');
+    });
+
+    it("does not emit structuredContent when callTool runs without a prior listTools (cache cold)", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+            kind: "query",
+            outputSchema: objectSchema,
+          }),
+        ],
+        dispatchAction: () => ({ ok: true, result: { count: 1, label: "cold" } }),
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = (await client.callTool({
+        name: "actions.list",
+        arguments: {},
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      };
+
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.content[0]?.text).toContain('"label": "cold"');
     });
 
     it("does not emit structuredContent on failed tool calls", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2831,7 +2831,7 @@ describe("McpServerService", () => {
         ],
         dispatchAction: () => ({
           ok: false,
-          error: { code: "internal_error", message: "boom" },
+          error: { code: "EXECUTION_ERROR", message: "boom" },
         }),
       });
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2632,4 +2632,193 @@ describe("McpServerService", () => {
       Authorization: `Bearer ${service.getStatus().apiKey}`,
     });
   });
+
+  describe("outputSchema and structuredContent", () => {
+    const objectSchema = {
+      type: "object",
+      properties: {
+        count: { type: "number" },
+        label: { type: "string" },
+      },
+      required: ["count", "label"],
+    };
+
+    const primitiveSchema = {
+      type: "string",
+    };
+
+    it("advertises outputSchema in listTools for actions with an object resultSchema", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "log.getEntries" as ActionId,
+            title: "Get Log Entries",
+            description: "Returns log entries",
+            kind: "query",
+            outputSchema: objectSchema,
+          }),
+          createManifestEntry({
+            id: "worktree.create" as ActionId,
+            title: "Create Worktree",
+            description: "Create a worktree",
+            kind: "command",
+            outputSchema: primitiveSchema,
+          }),
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+            kind: "query",
+          }),
+        ],
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.listTools();
+      const objectTool = result.tools.find((t) => t.name === "log.getEntries");
+      const primitiveTool = result.tools.find((t) => t.name === "worktree.create");
+      const noSchemaTool = result.tools.find((t) => t.name === "actions.list");
+
+      expect(objectTool?.outputSchema).toEqual(objectSchema);
+      expect(primitiveTool?.outputSchema).toBeUndefined();
+      expect(noSchemaTool?.outputSchema).toBeUndefined();
+    });
+
+    it("emits structuredContent on callTool when the action has an object outputSchema and an object result", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      const objectResult = { count: 7, label: "ok" };
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "log.getEntries" as ActionId,
+            title: "Get Log Entries",
+            description: "Returns log entries",
+            kind: "query",
+            outputSchema: objectSchema,
+          }),
+        ],
+        dispatchAction: () => ({ ok: true, result: objectResult }),
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.listTools();
+      const result = (await client.callTool({
+        name: "log.getEntries",
+        arguments: {},
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      };
+
+      expect(result.structuredContent).toEqual(objectResult);
+      expect(result.content[0]?.type).toBe("text");
+      expect(JSON.parse(result.content[0]!.text)).toEqual(objectResult);
+    });
+
+    it("omits structuredContent when the action has a primitive resultSchema", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.create" as ActionId,
+            title: "Create Worktree",
+            description: "Create a worktree",
+            kind: "command",
+            outputSchema: primitiveSchema,
+          }),
+        ],
+        dispatchAction: () => ({ ok: true, result: "wt-123" }),
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.listTools();
+      const result = (await client.callTool({
+        name: "worktree.create",
+        arguments: {},
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      };
+
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.content[0]?.text).toContain("wt-123");
+    });
+
+    it("omits structuredContent when the action has no resultSchema", async () => {
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+            kind: "query",
+          }),
+        ],
+        dispatchAction: () => ({ ok: true, result: { foo: "bar" } }),
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.listTools();
+      const result = (await client.callTool({
+        name: "actions.list",
+        arguments: {},
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+      };
+
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.content[0]?.text).toContain('"foo": "bar"');
+    });
+
+    it("does not emit structuredContent on failed tool calls", async () => {
+      storeState.mcpServer.fullToolSurface = true;
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "log.getEntries" as ActionId,
+            title: "Get Log Entries",
+            description: "Returns log entries",
+            kind: "query",
+            outputSchema: objectSchema,
+          }),
+        ],
+        dispatchAction: () => ({
+          ok: false,
+          error: { code: "internal_error", message: "boom" },
+        }),
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.listTools();
+      const result = (await client.callTool({
+        name: "log.getEntries",
+        arguments: {},
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        structuredContent?: Record<string, unknown>;
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.content[0]?.text).toContain("boom");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `outputSchema` to `tools/list` responses for any action that declares a `resultSchema`, so MCP clients get proper type information instead of having to re-parse JSON out of a text block
- Adds `structuredContent` alongside the existing `content` text block on `tools/call` success when the action returns a plain object — backward compatible, the text block is always present
- Caches the action manifest after each `requestManifest` fetch so `callTool` can reuse `listTools` data without a second IPC roundtrip; cache clears on `stop()`

Resolves #6607

## Changes

- `McpServerService`: `cachedManifest` field populated on `tools/list`, spread into `tools/call` lookups; two new helpers `buildToolOutputSchema` and `buildStructuredContent`; cache cleared in `stop()`
- Honors MCP spec 2025-06-18 (`outputSchema.type` must be `"object"`, `structuredContent` must be `Record<string, unknown>` at root)
- Actions without a `resultSchema` are unchanged — text-only response as before

## Testing

- 6 new tests in `McpServerService.test.ts` covering object/primitive/no-schema actions on `listTools` and `callTool`, cold-cache behavior, and the failed-call path
- Full test suite: 71 tests pass
- `npm run check` clean (typecheck, lint, format)