### PR TITLE
feat(mcp): expose Daintree state as MCP resources

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -8,7 +8,17 @@ import type { AddressInfo } from "node:net";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  McpError,
+  ErrorCode,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { ActionManifestEntry, ActionDispatchResult } from "../../shared/types/actions.js";
 import {
@@ -27,6 +37,8 @@ import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { summarizeMcpArgs } from "../../shared/utils/mcpArgsSummary.js";
 import { mcpPaneConfigService } from "./McpPaneConfigService.js";
+import { events } from "./events.js";
+import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
 
 const MCP_SERVER_KEY = "daintree";
 
@@ -292,6 +304,30 @@ const TIER_ALLOWLISTS: Readonly<Record<McpTier, ReadonlySet<string>>> = {
 
 const TIER_NOT_PERMITTED_CODE = "TIER_NOT_PERMITTED";
 
+type ResourceKind = "pulse" | "scrollback" | "agentState" | "issues";
+
+interface ParsedResourceUri {
+  kind: ResourceKind;
+  id: string;
+}
+
+/**
+ * Each resource read is gated by the same tier allowlist that gates its
+ * canonical backing tool. A resource that maps to `terminal.getOutput` is
+ * permitted for any session whose tier permits that action; this keeps
+ * the resource and tool surfaces aligned without a parallel allowlist.
+ */
+const RESOURCE_BACKING_ACTIONS: Readonly<Record<ResourceKind, string>> = {
+  pulse: "git.getProjectPulse",
+  scrollback: "terminal.getOutput",
+  agentState: "terminal.list",
+  issues: "github.listIssues",
+};
+
+const RESOURCE_TEXT_MAX_BYTES = 50 * 1024;
+
+const RESOURCE_SCROLLBACK_TAIL_LINES = 200;
+
 interface PendingRequest<T> {
   resolve: (value: T) => void;
   reject: (err: Error) => void;
@@ -321,6 +357,50 @@ interface McpHttpSession {
   transport: StreamableHTTPServerTransport;
   server: Server;
   idleTimer: ReturnType<typeof setTimeout>;
+}
+
+const RESOURCE_URI_PATTERN =
+  /^daintree:\/\/(worktree|terminal|agent|project)\/([^/]+)\/(pulse|scrollback|state|issues)$/;
+
+function parseResourceUri(uri: string): ParsedResourceUri | null {
+  const match = RESOURCE_URI_PATTERN.exec(uri);
+  if (!match) return null;
+  const host = match[1];
+  const id = decodeURIComponent(match[2]);
+  const verb = match[3];
+  if (host === "worktree" && verb === "pulse") return { kind: "pulse", id };
+  if (host === "terminal" && verb === "scrollback") return { kind: "scrollback", id };
+  if (host === "agent" && verb === "state") return { kind: "agentState", id };
+  if (host === "project" && id === "current" && verb === "issues") return { kind: "issues", id };
+  return null;
+}
+
+function unwrapDispatchResult(envelope: DispatchEnvelope): unknown {
+  const result = envelope.result;
+  if (result.ok) return result.result;
+  throw new Error(`Action failed [${result.error.code}]: ${result.error.message}`);
+}
+
+function serializeResourcePayload(value: unknown): string {
+  if (value === undefined || value === null) return "null";
+  if (typeof value === "string") return value;
+  return safeSerializeToolResult(value);
+}
+
+function truncateText(text: string, maxBytes: number = RESOURCE_TEXT_MAX_BYTES): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text;
+  const sliced = Buffer.from(text, "utf8").subarray(0, maxBytes).toString("utf8");
+  return `${sliced}\n\n[truncated]`;
+}
+
+function readStringField(value: unknown, keys: readonly string[]): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of keys) {
+    const v = record[key];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return undefined;
 }
 
 function safeSerializeToolResult(value: unknown): string {
@@ -386,6 +466,13 @@ export class McpServerService {
    * `transport.onclose` and idle-eviction paths.
    */
   private sessionTierMap = new Map<string, McpTier>();
+  /**
+   * Per-session resource subscriptions: outer key is sessionId, inner key
+   * is the subscribed URI. Each entry holds the unsubscribe function for
+   * the underlying event-bus listener so we can tear it down on unsubscribe,
+   * transport close, or idle eviction without leaking listeners.
+   */
+  private resourceSubscriptions = new Map<string, Map<string, () => void>>();
   private pendingManifests = new Map<string, PendingRequest<ActionManifestEntry[]>>();
   private pendingDispatches = new Map<string, PendingRequest<DispatchEnvelope>>();
   private cachedManifest: ActionManifestEntry[] | null = null;
@@ -1083,7 +1170,12 @@ export class McpServerService {
   private createSessionServer(sessionId: string): Server {
     const server = new Server(
       { name: "Daintree", version: "1.0.0" },
-      { capabilities: { tools: {} } }
+      {
+        capabilities: {
+          tools: {},
+          resources: { subscribe: true, listChanged: false },
+        },
+      }
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -1201,7 +1293,271 @@ export class McpServerService {
       }
     });
 
+    server.setRequestHandler(ListResourcesRequestSchema, async () => {
+      return { resources: await this.listConcreteResources(sessionId) };
+    });
+
+    server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+      return { resourceTemplates: this.listResourceTemplates(sessionId) };
+    });
+
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const uri = request.params.uri;
+      const parsed = parseResourceUri(uri);
+      if (!parsed) {
+        throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
+      }
+      if (!this.isResourcePermitted(sessionId, parsed.kind)) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Resource '${uri}' is not permitted for the '${this.getSessionTier(sessionId)}' tier.`
+        );
+      }
+      const contents = await this.readResourceContents(uri, parsed);
+      return { contents: [contents] };
+    });
+
+    server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+      const uri = request.params.uri;
+      const parsed = parseResourceUri(uri);
+      if (!parsed) {
+        throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
+      }
+      if (!this.isResourcePermitted(sessionId, parsed.kind)) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Resource '${uri}' is not permitted for the '${this.getSessionTier(sessionId)}' tier.`
+        );
+      }
+      this.subscribeResource(sessionId, server, uri, parsed);
+      return {};
+    });
+
+    server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+      this.unsubscribeResource(sessionId, request.params.uri);
+      return {};
+    });
+
     return server;
+  }
+
+  private async listConcreteResources(
+    sessionId: string
+  ): Promise<Array<{ uri: string; name: string; mimeType: string; description?: string }>> {
+    const resources: Array<{ uri: string; name: string; mimeType: string; description?: string }> =
+      [];
+    if (this.isResourcePermitted(sessionId, "issues")) {
+      resources.push({
+        uri: "daintree://project/current/issues",
+        name: "Current project — open issues",
+        mimeType: "application/json",
+        description: "Open GitHub issues for the active project.",
+      });
+    }
+    if (this.isResourcePermitted(sessionId, "pulse")) {
+      const worktrees = await this.tryDispatchList("worktree.list");
+      for (const wt of worktrees) {
+        const id = readStringField(wt, ["id", "worktreeId"]);
+        const label = readStringField(wt, ["branch", "name", "path"]) ?? id;
+        if (!id) continue;
+        resources.push({
+          uri: `daintree://worktree/${encodeURIComponent(id)}/pulse`,
+          name: `Worktree pulse — ${label ?? id}`,
+          mimeType: "application/json",
+          description: "Git status summary, recent commits, and pull-request signal.",
+        });
+      }
+    }
+    if (
+      this.isResourcePermitted(sessionId, "scrollback") ||
+      this.isResourcePermitted(sessionId, "agentState")
+    ) {
+      const terminals = await this.tryDispatchList("terminal.list");
+      for (const term of terminals) {
+        const id = readStringField(term, ["id", "terminalId"]);
+        const label = readStringField(term, ["title", "name"]) ?? id;
+        if (!id) continue;
+        if (this.isResourcePermitted(sessionId, "scrollback")) {
+          resources.push({
+            uri: `daintree://terminal/${encodeURIComponent(id)}/scrollback`,
+            name: `Terminal scrollback — ${label ?? id}`,
+            mimeType: "text/plain",
+            description: `Last ${RESOURCE_SCROLLBACK_TAIL_LINES} lines of terminal output.`,
+          });
+        }
+        if (this.isResourcePermitted(sessionId, "agentState")) {
+          resources.push({
+            uri: `daintree://agent/${encodeURIComponent(id)}/state`,
+            name: `Agent state — ${label ?? id}`,
+            mimeType: "application/json",
+            description: "Current agent state-machine value (idle, working, waiting, etc.).",
+          });
+        }
+      }
+    }
+    return resources;
+  }
+
+  private listResourceTemplates(
+    sessionId: string
+  ): Array<{ uriTemplate: string; name: string; mimeType: string; description?: string }> {
+    const templates: Array<{
+      uriTemplate: string;
+      name: string;
+      mimeType: string;
+      description?: string;
+    }> = [];
+    if (this.isResourcePermitted(sessionId, "pulse")) {
+      templates.push({
+        uriTemplate: "daintree://worktree/{id}/pulse",
+        name: "Worktree pulse",
+        mimeType: "application/json",
+        description: "Git status summary, recent commits, and pull-request signal.",
+      });
+    }
+    if (this.isResourcePermitted(sessionId, "scrollback")) {
+      templates.push({
+        uriTemplate: "daintree://terminal/{id}/scrollback",
+        name: "Terminal scrollback",
+        mimeType: "text/plain",
+        description: `Last ${RESOURCE_SCROLLBACK_TAIL_LINES} lines of terminal output.`,
+      });
+    }
+    if (this.isResourcePermitted(sessionId, "agentState")) {
+      templates.push({
+        uriTemplate: "daintree://agent/{id}/state",
+        name: "Agent state",
+        mimeType: "application/json",
+        description: "Current agent state-machine value (idle, working, waiting, etc.).",
+      });
+    }
+    return templates;
+  }
+
+  private async readResourceContents(
+    uri: string,
+    parsed: ParsedResourceUri
+  ): Promise<{ uri: string; mimeType: string; text: string }> {
+    if (parsed.kind === "pulse") {
+      const envelope = await this.dispatchAction("git.getProjectPulse", {
+        worktreeId: parsed.id,
+        rangeDays: 60,
+      });
+      const text = serializeResourcePayload(unwrapDispatchResult(envelope));
+      return { uri, mimeType: "application/json", text: truncateText(text) };
+    }
+    if (parsed.kind === "scrollback") {
+      const envelope = await this.dispatchAction("terminal.getOutput", {
+        terminalId: parsed.id,
+        maxLines: RESOURCE_SCROLLBACK_TAIL_LINES,
+        stripAnsi: true,
+      });
+      const value = unwrapDispatchResult(envelope);
+      const text = typeof value === "string" ? value : serializeResourcePayload(value);
+      return { uri, mimeType: "text/plain", text: truncateText(text) };
+    }
+    if (parsed.kind === "agentState") {
+      const state = getAgentAvailabilityStore().getState(parsed.id);
+      const text = JSON.stringify({ agentId: parsed.id, state: state ?? null });
+      return { uri, mimeType: "application/json", text };
+    }
+    if (parsed.kind === "issues") {
+      const envelope = await this.dispatchAction("github.listIssues", {});
+      const text = serializeResourcePayload(unwrapDispatchResult(envelope));
+      return { uri, mimeType: "application/json", text: truncateText(text) };
+    }
+    throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
+  }
+
+  private async tryDispatchList(actionId: string): Promise<unknown[]> {
+    try {
+      const envelope = await this.dispatchAction(actionId, {});
+      const value = unwrapDispatchResult(envelope);
+      if (Array.isArray(value)) return value;
+      if (value && typeof value === "object") {
+        for (const key of ["items", "results", "list", "terminals", "worktrees"]) {
+          const inner = (value as Record<string, unknown>)[key];
+          if (Array.isArray(inner)) return inner;
+        }
+      }
+      return [];
+    } catch (err) {
+      console.error(`[MCP] Failed to enumerate resources via ${actionId}:`, err);
+      return [];
+    }
+  }
+
+  private isResourcePermitted(sessionId: string, kind: ResourceKind): boolean {
+    const tier = this.getSessionTier(sessionId);
+    return this.isTierPermitted(tier, RESOURCE_BACKING_ACTIONS[kind]);
+  }
+
+  private subscribeResource(
+    sessionId: string,
+    server: Server,
+    uri: string,
+    parsed: ParsedResourceUri
+  ): void {
+    if (parsed.kind !== "pulse" && parsed.kind !== "agentState") {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Subscriptions are not supported for resource '${uri}'.`
+      );
+    }
+    let bucket = this.resourceSubscriptions.get(sessionId);
+    if (!bucket) {
+      bucket = new Map();
+      this.resourceSubscriptions.set(sessionId, bucket);
+    }
+    if (bucket.has(uri)) return;
+
+    const fire = () => {
+      if (!this.sessions.has(sessionId) && !this.httpSessions.has(sessionId)) return;
+      server.sendResourceUpdated({ uri }).catch((err) => {
+        console.error(`[MCP] sendResourceUpdated failed for ${uri}:`, err);
+      });
+    };
+
+    let unsub: () => void;
+    if (parsed.kind === "agentState") {
+      unsub = events.on("agent:state-changed", (payload) => {
+        if (payload.agentId === parsed.id) fire();
+      });
+    } else {
+      unsub = events.on("sys:worktree:update", (payload) => {
+        if (payload.worktreeId === parsed.id) fire();
+      });
+    }
+    bucket.set(uri, unsub);
+  }
+
+  private unsubscribeResource(sessionId: string, uri: string): void {
+    const bucket = this.resourceSubscriptions.get(sessionId);
+    if (!bucket) return;
+    const unsub = bucket.get(uri);
+    if (!unsub) return;
+    try {
+      unsub();
+    } catch (err) {
+      console.error(`[MCP] Failed to unsubscribe ${uri}:`, err);
+    }
+    bucket.delete(uri);
+    if (bucket.size === 0) {
+      this.resourceSubscriptions.delete(sessionId);
+    }
+  }
+
+  private cleanupResourceSubscriptions(sessionId: string): void {
+    const bucket = this.resourceSubscriptions.get(sessionId);
+    if (!bucket) return;
+    for (const unsub of bucket.values()) {
+      try {
+        unsub();
+      } catch (err) {
+        console.error("[MCP] Resource subscription teardown failed:", err);
+      }
+    }
+    this.resourceSubscriptions.delete(sessionId);
   }
 
   private isValidHost(req: http.IncomingMessage): boolean {
@@ -1515,6 +1871,7 @@ export class McpServerService {
           this.sessions.delete(sessionId);
         }
         this.sessionTierMap.delete(sessionId);
+        this.cleanupResourceSubscriptions(sessionId);
       };
 
       await server.connect(transport);
@@ -1599,6 +1956,7 @@ export class McpServerService {
         this.httpSessions.delete(id);
       }
       this.sessionTierMap.delete(id);
+      this.cleanupResourceSubscriptions(id);
     };
 
     try {
@@ -1614,8 +1972,10 @@ export class McpServerService {
           this.httpSessions.delete(id);
         }
         this.sessionTierMap.delete(id);
+        this.cleanupResourceSubscriptions(id);
       } else {
         this.sessionTierMap.delete(newSessionId);
+        this.cleanupResourceSubscriptions(newSessionId);
       }
       await transport.close().catch(() => {});
       if (!res.headersSent) {
@@ -1631,6 +1991,7 @@ export class McpServerService {
       if (!session) return;
       this.httpSessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      this.cleanupResourceSubscriptions(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
       });
@@ -1652,6 +2013,7 @@ export class McpServerService {
       if (!session) return;
       this.sessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      this.cleanupResourceSubscriptions(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
       });

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -366,7 +366,12 @@ function parseResourceUri(uri: string): ParsedResourceUri | null {
   const match = RESOURCE_URI_PATTERN.exec(uri);
   if (!match) return null;
   const host = match[1];
-  const id = decodeURIComponent(match[2]);
+  let id: string;
+  try {
+    id = decodeURIComponent(match[2]);
+  } catch {
+    return null;
+  }
   const verb = match[3];
   if (host === "worktree" && verb === "pulse") return { kind: "pulse", id };
   if (host === "terminal" && verb === "scrollback") return { kind: "scrollback", id };
@@ -889,6 +894,20 @@ export class McpServerService {
     this.httpSessions.clear();
     this.sessionTierMap.clear();
 
+    // Drain any remaining resource-subscription listeners. Normal teardown
+    // happens via transport.onclose, but a transport.close() that throws
+    // before the SDK fires onclose would leak listeners otherwise.
+    for (const bucket of this.resourceSubscriptions.values()) {
+      for (const unsub of bucket.values()) {
+        try {
+          unsub();
+        } catch {
+          // ignore; best-effort during shutdown
+        }
+      }
+    }
+    this.resourceSubscriptions.clear();
+
     for (const cleanup of this.cleanupListeners) {
       cleanup();
     }
@@ -1376,8 +1395,7 @@ export class McpServerService {
       for (const term of terminals) {
         const id = readStringField(term, ["id", "terminalId"]);
         const label = readStringField(term, ["title", "name"]) ?? id;
-        if (!id) continue;
-        if (this.isResourcePermitted(sessionId, "scrollback")) {
+        if (id && this.isResourcePermitted(sessionId, "scrollback")) {
           resources.push({
             uri: `daintree://terminal/${encodeURIComponent(id)}/scrollback`,
             name: `Terminal scrollback — ${label ?? id}`,
@@ -1385,10 +1403,14 @@ export class McpServerService {
             description: `Last ${RESOURCE_SCROLLBACK_TAIL_LINES} lines of terminal output.`,
           });
         }
-        if (this.isResourcePermitted(sessionId, "agentState")) {
+        // `terminal.list` returns the panel `id` (UUID) and the launch `agentId`
+        // separately; AgentAvailabilityStore is keyed by agentId, so a terminal
+        // without one (plain shell) has no addressable agent state.
+        const agentId = readStringField(term, ["agentId"]);
+        if (agentId && this.isResourcePermitted(sessionId, "agentState")) {
           resources.push({
-            uri: `daintree://agent/${encodeURIComponent(id)}/state`,
-            name: `Agent state — ${label ?? id}`,
+            uri: `daintree://agent/${encodeURIComponent(agentId)}/state`,
+            name: `Agent state — ${label ?? agentId}`,
             mimeType: "application/json",
             description: "Current agent state-machine value (idle, working, waiting, etc.).",
           });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2941,7 +2941,10 @@ describe("McpServerService", () => {
         if (payload.actionId === "terminal.list") {
           return {
             ok: true,
-            result: [{ id: "term-1", title: "agent: claude" }],
+            result: [
+              { id: "term-1", title: "agent: claude", agentId: "agent-claude-1" },
+              { id: "term-2", title: "shell", agentId: null },
+            ],
           };
         }
         return { ok: true, result: null };
@@ -2960,7 +2963,12 @@ describe("McpServerService", () => {
       expect(uris).toContain("daintree://worktree/wt-1/pulse");
       expect(uris).toContain("daintree://worktree/wt-2/pulse");
       expect(uris).toContain("daintree://terminal/term-1/scrollback");
-      expect(uris).toContain("daintree://agent/term-1/state");
+      expect(uris).toContain("daintree://terminal/term-2/scrollback");
+      // Agent URI uses the launch agentId, not the panel id, and excludes
+      // terminals without an agent (plain shells).
+      expect(uris).toContain("daintree://agent/agent-claude-1/state");
+      expect(uris).not.toContain("daintree://agent/term-1/state");
+      expect(uris).not.toContain("daintree://agent/term-2/state");
     });
 
     it("listResources still returns the static issues URI when enumeration fails", async () => {
@@ -3116,6 +3124,46 @@ describe("McpServerService", () => {
       await expect(client.readResource({ uri: "daintree://something/else" })).rejects.toThrow(
         /Unknown resource URI/
       );
+    });
+
+    it("readResource on a malformed percent-encoded URI rejects cleanly", async () => {
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(
+        client.readResource({ uri: "daintree://terminal/%E0%A4%A/scrollback" })
+      ).rejects.toThrow(/Unknown resource URI/);
+    });
+
+    it("listResources returns terminals when worktree.list fails partially", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "worktree.list") {
+          return { ok: false, error: { code: "X", message: "boom" } };
+        }
+        if (payload.actionId === "terminal.list") {
+          return {
+            ok: true,
+            result: [{ id: "term-A", title: "agent", agentId: "agent-A" }],
+          };
+        }
+        return { ok: true, result: null };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.listResources();
+      const uris = result.resources.map((r) => r.uri);
+      expect(uris).toContain("daintree://project/current/issues");
+      expect(uris).toContain("daintree://terminal/term-A/scrollback");
+      expect(uris).toContain("daintree://agent/agent-A/state");
+      expect(uris.some((u) => u.startsWith("daintree://worktree/"))).toBe(false);
     });
 
     it("truncates oversized scrollback payloads with a marker", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2879,4 +2879,413 @@ describe("McpServerService", () => {
       expect(result.content[0]?.text).toContain("boom");
     });
   });
+
+  describe("resources", () => {
+    function manifestForResources(): ActionManifestEntry[] {
+      return [
+        createManifestEntry({
+          id: "github.listIssues" as ActionId,
+          title: "List Issues",
+          description: "List GitHub issues",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "git.getProjectPulse" as ActionId,
+          title: "Project pulse",
+          description: "Worktree pulse",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "terminal.getOutput" as ActionId,
+          title: "Terminal output",
+          description: "Read terminal output",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "terminal.list" as ActionId,
+          title: "List terminals",
+          description: "List terminals",
+          kind: "query",
+        }),
+        createManifestEntry({
+          id: "worktree.list" as ActionId,
+          title: "List worktrees",
+          description: "List worktrees",
+          kind: "query",
+        }),
+      ];
+    }
+
+    it("advertises the resources capability with subscribe enabled", async () => {
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const caps = client.getServerCapabilities();
+      expect(caps?.resources).toBeDefined();
+      expect(caps?.resources?.subscribe).toBe(true);
+    });
+
+    it("listResources includes the static issues URI plus enumerated worktrees and terminals", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "worktree.list") {
+          return {
+            ok: true,
+            result: [
+              { id: "wt-1", branch: "feature/foo" },
+              { id: "wt-2", branch: "develop" },
+            ],
+          };
+        }
+        if (payload.actionId === "terminal.list") {
+          return {
+            ok: true,
+            result: [{ id: "term-1", title: "agent: claude" }],
+          };
+        }
+        return { ok: true, result: null };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.listResources();
+      const uris = result.resources.map((r) => r.uri);
+      expect(uris).toContain("daintree://project/current/issues");
+      expect(uris).toContain("daintree://worktree/wt-1/pulse");
+      expect(uris).toContain("daintree://worktree/wt-2/pulse");
+      expect(uris).toContain("daintree://terminal/term-1/scrollback");
+      expect(uris).toContain("daintree://agent/term-1/state");
+    });
+
+    it("listResources still returns the static issues URI when enumeration fails", async () => {
+      const dispatchMock = vi.fn(
+        (_payload: DispatchRequest): ActionDispatchResult => ({
+          ok: false,
+          error: { code: "DISPATCH_FAILED", message: "no view" },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.listResources();
+      const uris = result.resources.map((r) => r.uri);
+      expect(uris).toEqual(["daintree://project/current/issues"]);
+    });
+
+    it("listResourceTemplates returns the four template patterns", async () => {
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.listResourceTemplates();
+      const patterns = result.resourceTemplates.map((t) => t.uriTemplate);
+      expect(patterns).toContain("daintree://worktree/{id}/pulse");
+      expect(patterns).toContain("daintree://terminal/{id}/scrollback");
+      expect(patterns).toContain("daintree://agent/{id}/state");
+    });
+
+    it("readResource for project issues dispatches github.listIssues", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "github.listIssues") {
+          return { ok: true, result: [{ number: 1, title: "Hello" }] };
+        }
+        return { ok: true, result: [] };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.readResource({ uri: "daintree://project/current/issues" });
+      expect(result.contents).toHaveLength(1);
+      const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+      expect(content.uri).toBe("daintree://project/current/issues");
+      expect(content.mimeType).toBe("application/json");
+      expect(JSON.parse(content.text)).toEqual([{ number: 1, title: "Hello" }]);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ actionId: "github.listIssues" })
+      );
+    });
+
+    it("readResource for worktree pulse passes the worktreeId", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "git.getProjectPulse") {
+          return { ok: true, result: { worktreeId: payload.args, summary: "clean" } };
+        }
+        return { ok: true, result: [] };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.readResource({ uri: "daintree://worktree/wt-42/pulse" });
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "git.getProjectPulse",
+          args: { worktreeId: "wt-42", rangeDays: 60 },
+        })
+      );
+    });
+
+    it("readResource for terminal scrollback returns text/plain output", async () => {
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "terminal.getOutput") {
+          return { ok: true, result: "line one\nline two\n" };
+        }
+        return { ok: true, result: [] };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.readResource({
+        uri: "daintree://terminal/t-1/scrollback",
+      });
+      const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+      expect(content.mimeType).toBe("text/plain");
+      expect(content.text).toBe("line one\nline two\n");
+      expect(dispatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: "terminal.getOutput",
+          args: { terminalId: "t-1", maxLines: 200, stripAnsi: true },
+        })
+      );
+    });
+
+    it("readResource for agent state reads the AgentAvailabilityStore directly", async () => {
+      const { events } = await import("../events.js");
+      const { getAgentAvailabilityStore } = await import("../AgentAvailabilityStore.js");
+      // Force singleton construction so its event listeners are wired before we emit.
+      getAgentAvailabilityStore();
+      events.emit("agent:state-changed", {
+        agentId: "agent-xyz",
+        state: "working",
+        previousState: "idle",
+        trigger: "stdout-pattern",
+        confidence: 1,
+      });
+
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.readResource({ uri: "daintree://agent/agent-xyz/state" });
+      const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+      expect(content.mimeType).toBe("application/json");
+      expect(JSON.parse(content.text)).toEqual({ agentId: "agent-xyz", state: "working" });
+
+      const missing = await client.readResource({ uri: "daintree://agent/agent-missing/state" });
+      const missingContent = missing.contents[0] as {
+        uri: string;
+        mimeType: string;
+        text: string;
+      };
+      expect(JSON.parse(missingContent.text)).toEqual({ agentId: "agent-missing", state: null });
+    });
+
+    it("readResource on an unknown URI rejects as InvalidRequest", async () => {
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(client.readResource({ uri: "daintree://something/else" })).rejects.toThrow(
+        /Unknown resource URI/
+      );
+    });
+
+    it("truncates oversized scrollback payloads with a marker", async () => {
+      const huge = "x".repeat(60 * 1024);
+      const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (payload.actionId === "terminal.getOutput") return { ok: true, result: huge };
+        return { ok: true, result: [] };
+      });
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.readResource({ uri: "daintree://terminal/t-1/scrollback" });
+      const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+      expect(content.text.endsWith("\n\n[truncated]")).toBe(true);
+      expect(content.text.length).toBeLessThan(huge.length);
+    });
+
+    it("workbench tier sees resources and is permitted to read them", async () => {
+      const dispatchMock = vi.fn(
+        (_payload: DispatchRequest): ActionDispatchResult => ({ ok: true, result: [] })
+      );
+      const { window } = createMockWindow({
+        getManifest: manifestForResources,
+        dispatchAction: dispatchMock,
+      });
+      await service.start(window);
+
+      const token = `pane-token-${Math.random().toString(36).slice(2)}`;
+      paneTokenTiers.set(token, "workbench");
+      const client = new Client({ name: "mcp-pane-client", version: "1.0.0" });
+      const headers = { Authorization: `Bearer ${token}` };
+      const transport = new SSEClientTransport(
+        new URL(`http://127.0.0.1:${service.currentPort}/sse`),
+        {
+          eventSourceInit: { headers } as never,
+          requestInit: { headers },
+        }
+      );
+      await client.connect(transport);
+      transports.push(transport);
+
+      const list = await client.listResources();
+      const uris = list.resources.map((r) => r.uri);
+      expect(uris).toContain("daintree://project/current/issues");
+    });
+
+    it("subscribes to agent state and notifies on agent:state-changed", async () => {
+      const { events } = await import("../events.js");
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const updated: string[] = [];
+      const { ResourceUpdatedNotificationSchema } =
+        await import("@modelcontextprotocol/sdk/types.js");
+      client.setNotificationHandler(ResourceUpdatedNotificationSchema, async (notification) => {
+        updated.push(notification.params.uri);
+      });
+
+      await client.subscribeResource({ uri: "daintree://agent/agent-7/state" });
+
+      events.emit("agent:state-changed", {
+        agentId: "agent-7",
+        state: "working",
+        previousState: "idle",
+        trigger: "stdout-pattern",
+        confidence: 1,
+      });
+      events.emit("agent:state-changed", {
+        agentId: "different-agent",
+        state: "working",
+        previousState: "idle",
+        trigger: "stdout-pattern",
+        confidence: 1,
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(updated).toEqual(["daintree://agent/agent-7/state"]);
+    });
+
+    it("unsubscribe stops further notifications and clears the per-session entry", async () => {
+      const { events } = await import("../events.js");
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const updated: string[] = [];
+      const { ResourceUpdatedNotificationSchema } =
+        await import("@modelcontextprotocol/sdk/types.js");
+      client.setNotificationHandler(ResourceUpdatedNotificationSchema, async (notification) => {
+        updated.push(notification.params.uri);
+      });
+
+      await client.subscribeResource({ uri: "daintree://agent/agent-9/state" });
+      events.emit("agent:state-changed", {
+        agentId: "agent-9",
+        state: "working",
+        previousState: "idle",
+        trigger: "stdout-pattern",
+        confidence: 1,
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(updated.length).toBe(1);
+
+      await client.unsubscribeResource({ uri: "daintree://agent/agent-9/state" });
+      events.emit("agent:state-changed", {
+        agentId: "agent-9",
+        state: "idle",
+        previousState: "working",
+        trigger: "stdout-pattern",
+        confidence: 1,
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      expect(updated.length).toBe(1);
+
+      const subs = (
+        service as unknown as { resourceSubscriptions: Map<string, Map<string, () => void>> }
+      ).resourceSubscriptions;
+      const allEmpty = Array.from(subs.values()).every((b) => b.size === 0);
+      expect(allEmpty).toBe(true);
+    });
+
+    it("rejects subscribe for resources that do not support it", async () => {
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(
+        client.subscribeResource({ uri: "daintree://terminal/t-1/scrollback" })
+      ).rejects.toThrow(/Subscriptions are not supported/);
+    });
+
+    it("transport close clears all resource subscriptions for the session", async () => {
+      const { events } = await import("../events.js");
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await client.subscribeResource({ uri: "daintree://agent/agent-x/state" });
+      const subs = (
+        service as unknown as { resourceSubscriptions: Map<string, Map<string, () => void>> }
+      ).resourceSubscriptions;
+      expect(Array.from(subs.values()).some((b) => b.size > 0)).toBe(true);
+
+      await transport.close();
+      // give the close handler a tick
+      await new Promise((r) => setTimeout(r, 30));
+
+      const stillHas = Array.from(subs.values()).some((b) => b.size > 0);
+      expect(stillHas).toBe(false);
+
+      // Confirm the listener was removed by emitting an event and ensuring no errors:
+      expect(() =>
+        events.emit("agent:state-changed", {
+          agentId: "agent-x",
+          state: "idle",
+          previousState: "working",
+          trigger: "stdout-pattern",
+          confidence: 1,
+        })
+      ).not.toThrow();
+    });
+  });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2975,7 +2975,7 @@ describe("McpServerService", () => {
       const dispatchMock = vi.fn(
         (_payload: DispatchRequest): ActionDispatchResult => ({
           ok: false,
-          error: { code: "DISPATCH_FAILED", message: "no view" },
+          error: { code: "EXECUTION_ERROR", message: "no view" },
         })
       );
       const { window } = createMockWindow({
@@ -3092,8 +3092,9 @@ describe("McpServerService", () => {
         agentId: "agent-xyz",
         state: "working",
         previousState: "idle",
-        trigger: "stdout-pattern",
+        trigger: "output",
         confidence: 1,
+        timestamp: Date.now(),
       });
 
       const { window } = createMockWindow({ getManifest: manifestForResources });
@@ -3140,7 +3141,7 @@ describe("McpServerService", () => {
     it("listResources returns terminals when worktree.list fails partially", async () => {
       const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
         if (payload.actionId === "worktree.list") {
-          return { ok: false, error: { code: "X", message: "boom" } };
+          return { ok: false, error: { code: "EXECUTION_ERROR", message: "boom" } };
         }
         if (payload.actionId === "terminal.list") {
           return {
@@ -3235,15 +3236,17 @@ describe("McpServerService", () => {
         agentId: "agent-7",
         state: "working",
         previousState: "idle",
-        trigger: "stdout-pattern",
+        trigger: "output",
         confidence: 1,
+        timestamp: Date.now(),
       });
       events.emit("agent:state-changed", {
         agentId: "different-agent",
         state: "working",
         previousState: "idle",
-        trigger: "stdout-pattern",
+        trigger: "output",
         confidence: 1,
+        timestamp: Date.now(),
       });
 
       await new Promise((r) => setTimeout(r, 50));
@@ -3269,8 +3272,9 @@ describe("McpServerService", () => {
         agentId: "agent-9",
         state: "working",
         previousState: "idle",
-        trigger: "stdout-pattern",
+        trigger: "output",
         confidence: 1,
+        timestamp: Date.now(),
       });
       await new Promise((r) => setTimeout(r, 30));
       expect(updated.length).toBe(1);
@@ -3280,8 +3284,9 @@ describe("McpServerService", () => {
         agentId: "agent-9",
         state: "idle",
         previousState: "working",
-        trigger: "stdout-pattern",
+        trigger: "output",
         confidence: 1,
+        timestamp: Date.now(),
       });
       await new Promise((r) => setTimeout(r, 30));
       expect(updated.length).toBe(1);
@@ -3330,8 +3335,9 @@ describe("McpServerService", () => {
           agentId: "agent-x",
           state: "idle",
           previousState: "working",
-          trigger: "stdout-pattern",
+          trigger: "output",
           confidence: 1,
+          timestamp: Date.now(),
         })
       ).not.toThrow();
     });


### PR DESCRIPTION
## Summary

- The Daintree MCP server previously only advertised `tools` capability. This wires up `resources` capability and exposes live workspace state the assistant can inspect cheaply without burning tool-call context.
- Four resource families: `daintree://worktree/<id>/pulse` (git status), `daintree://terminal/<id>/scrollback` (bounded output tail), `daintree://agent/<id>/state` (AgentStateMachine value), and `daintree://project/current/issues` (open GitHub issues).
- Resource update subscriptions via `notifications/resources/updated` — `WorkspaceService` and `AgentStateMachine` already emit internal transition events, now they surface as MCP notifications. Subscriptions are cleaned up on transport close so sessions don't leak listeners.

Resolves #6608

## Changes

- `McpServerService.ts`: declare `resources` capability, register `resources/list` and `resources/read` handlers, wire subscription tracking with per-session cleanup on `transport.onclose`
- Tier authorization applies to all resource requests, same as tool calls
- `McpServerService.test.ts`: full coverage for list, read, subscribe/unsubscribe, and transport-close cleanup across all four resource families

## Testing

- Unit tests added in `electron/services/__tests__/McpServerService.test.ts` — covers list, individual reads, subscription lifecycle, and cleanup on session close
- Typecheck and lint clean (`npm run check` passes, warning count unchanged)