### PR TITLE
Replace assistant auto-greeting prompt with dismissible intro banner

### DIFF
--- a/src/components/HelpPanel/HelpIntroBanner.tsx
+++ b/src/components/HelpPanel/HelpIntroBanner.tsx
@@ -1,0 +1,50 @@
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface HelpIntroBannerProps {
+  onDismiss: () => void;
+  onLinkClick: () => void;
+}
+
+export function HelpIntroBanner({ onDismiss, onLinkClick }: HelpIntroBannerProps) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      onDismiss();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-1.5 shrink-0",
+        "bg-wash-subtle border-b border-subtle text-[11px] text-text-secondary"
+      )}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="flex-1 min-w-0 truncate">
+        New here?{" "}
+        <button
+          type="button"
+          onClick={onLinkClick}
+          className={cn(
+            "text-text-primary underline underline-offset-4",
+            "decoration-border-subtle hover:decoration-text-primary",
+            "transition-colors"
+          )}
+        >
+          See what the Daintree Assistant can do
+        </button>
+        .
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="text-text-muted hover:text-text-secondary transition-colors"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -5,6 +5,7 @@ import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import { HelpAgentPicker } from "./HelpAgentPicker";
+import { HelpIntroBanner } from "./HelpIntroBanner";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -26,7 +27,7 @@ import { safeFireAndForget } from "@/utils/safeFireAndForget";
 
 const RESIZE_STEP = 10;
 
-const HELP_PROMPT = "Briefly tell me what you can do.";
+const ASSISTANT_DOCS_URL = "https://daintree.org/assistant";
 
 function notifyLaunchFailed(agentId: string, reason: string): void {
   const cfg = getAgentConfig(agentId);
@@ -93,10 +94,12 @@ export function HelpPanel() {
     terminalId,
     agentId,
     preferredAgentId,
+    introDismissed,
     setWidth,
     setOpen,
     clearTerminal,
     clearPreferredAgent,
+    dismissIntro,
   } = useHelpPanelStore();
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
@@ -189,7 +192,6 @@ export function HelpPanel() {
             agentId: launchAgentId,
             location: "dock",
             cwd,
-            prompt: HELP_PROMPT,
             ephemeral: true,
             ...(env && { env }),
           },
@@ -338,7 +340,6 @@ export function HelpPanel() {
             agentId: selectedAgentId,
             location: "dock",
             cwd,
-            prompt: HELP_PROMPT,
             ephemeral: true,
             ...(env && { env }),
           },
@@ -422,6 +423,15 @@ export function HelpPanel() {
     revokePendingSession();
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen, revokePendingSession]);
+
+  const handleIntroLinkClick = useCallback(() => {
+    dismissIntro();
+    void actionService.dispatch(
+      "system.openExternal",
+      { url: ASSISTANT_DOCS_URL },
+      { source: "user" }
+    );
+  }, [dismissIntro]);
 
   const handleRunAnyway = useCallback(() => {
     if (!terminalId || !agentId) return;
@@ -559,16 +569,21 @@ export function HelpPanel() {
               onRunAnyway={handleRunAnyway}
             />
           ) : (
-            <div className="absolute inset-0">
-              <Suspense fallback={null}>
-                <XtermAdapter
-                  terminalId={terminalId}
-                  launchAgentId={agentId ?? undefined}
-                  getRefreshTier={getRefreshTier}
-                  cwd={terminal.cwd}
-                />
-              </Suspense>
-            </div>
+            <>
+              {!introDismissed && (
+                <HelpIntroBanner onDismiss={dismissIntro} onLinkClick={handleIntroLinkClick} />
+              )}
+              <div className="flex-1 relative min-h-0">
+                <Suspense fallback={null}>
+                  <XtermAdapter
+                    terminalId={terminalId}
+                    launchAgentId={agentId ?? undefined}
+                    getRefreshTier={getRefreshTier}
+                    cwd={terminal.cwd}
+                  />
+                </Suspense>
+              </div>
+            </>
           )
         ) : (
           <HelpAgentPicker

--- a/src/components/HelpPanel/__tests__/HelpIntroBanner.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpIntroBanner.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+import { HelpIntroBanner } from "../HelpIntroBanner";
+
+describe("HelpIntroBanner", () => {
+  it("renders the link copy and a Dismiss button", () => {
+    const { getByText, getByLabelText } = render(
+      <HelpIntroBanner onDismiss={vi.fn()} onLinkClick={vi.fn()} />
+    );
+
+    expect(getByText("See what the Daintree Assistant can do")).toBeTruthy();
+    expect(getByLabelText("Dismiss")).toBeTruthy();
+  });
+
+  it("calls onLinkClick when the link is clicked", () => {
+    const onLinkClick = vi.fn();
+    const { getByText } = render(<HelpIntroBanner onDismiss={vi.fn()} onLinkClick={onLinkClick} />);
+
+    fireEvent.click(getByText("See what the Daintree Assistant can do"));
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDismiss when the X button is clicked", () => {
+    const onDismiss = vi.fn();
+    const { getByLabelText } = render(
+      <HelpIntroBanner onDismiss={onDismiss} onLinkClick={vi.fn()} />
+    );
+
+    fireEvent.click(getByLabelText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDismiss when Escape is pressed inside the bar (with stopPropagation)", () => {
+    const onDismiss = vi.fn();
+    const outerKeyDown = vi.fn();
+    const { getByLabelText } = render(
+      <div onKeyDown={outerKeyDown}>
+        <HelpIntroBanner onDismiss={onDismiss} onLinkClick={vi.fn()} />
+      </div>
+    );
+
+    fireEvent.keyDown(getByLabelText("Dismiss"), { key: "Escape" });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    // Escape should not propagate beyond the banner — outer handler must not see it.
+    expect(outerKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("dismisses on Escape when focus is on the link button", () => {
+    const onDismiss = vi.fn();
+    const outerKeyDown = vi.fn();
+    const { getByText } = render(
+      <div onKeyDown={outerKeyDown}>
+        <HelpIntroBanner onDismiss={onDismiss} onLinkClick={vi.fn()} />
+      </div>
+    );
+
+    fireEvent.keyDown(getByText("See what the Daintree Assistant can do"), { key: "Escape" });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(outerKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("does not call onDismiss for non-Escape keys", () => {
+    const onDismiss = vi.fn();
+    const { getByLabelText } = render(
+      <HelpIntroBanner onDismiss={onDismiss} onLinkClick={vi.fn()} />
+    );
+
+    fireEvent.keyDown(getByLabelText("Dismiss"), { key: "Enter" });
+    fireEvent.keyDown(getByLabelText("Dismiss"), { key: "Tab" });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -32,11 +32,13 @@ const {
     agentId: null as string | null,
     preferredAgentId: null as string | null,
     sessionId: null as string | null,
+    introDismissed: true,
     setWidth: vi.fn(),
     setOpen: vi.fn(),
     clearTerminal: vi.fn(),
     clearPreferredAgent: vi.fn(),
     setTerminal: vi.fn(),
+    dismissIntro: vi.fn(),
   },
   panelStoreState: {
     panelsById: {} as Record<string, unknown>,
@@ -206,11 +208,13 @@ function resetState() {
   helpPanelState.agentId = null;
   helpPanelState.preferredAgentId = null;
   helpPanelState.sessionId = null;
+  helpPanelState.introDismissed = true;
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
   helpPanelState.setWidth = vi.fn();
   helpPanelState.clearTerminal = vi.fn();
   helpPanelState.clearPreferredAgent = vi.fn();
+  helpPanelState.dismissIntro = vi.fn();
 
   panelStoreState.panelsById = {};
   panelStoreState.removePanel = vi.fn();
@@ -274,6 +278,23 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
 
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", null);
     expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("dispatches agent.launch without a prompt field (regression: auto-greeting removed)", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("pick-claude"));
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.not.objectContaining({ prompt: expect.anything() }),
+      { source: "user" }
+    );
   });
 
   it("notifies and does not commit terminal when result.ok is false", async () => {
@@ -370,6 +391,22 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-term-1", "claude", null);
   });
 
+  it("dispatches auto-launch agent.launch without a prompt field", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.not.objectContaining({ prompt: expect.anything() }),
+      { source: "user" }
+    );
+  });
+
   it("does not commit terminal and cleans up if user navigated away (preferredAgentId cleared) during in-flight launch", async () => {
     helpPanelState.preferredAgentId = "claude";
     mockGetFolderPath.mockResolvedValue("/help");
@@ -409,6 +446,96 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", title: "Assistant launch failed" })
     );
+  });
+});
+
+describe("HelpPanel — intro banner visibility", () => {
+  it("renders the banner when the terminal is healthy and introDismissed=false", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.introDismissed = false;
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container } = render(<HelpPanel />);
+
+    expect(container.querySelector('button[aria-label="Dismiss"]')).toBeTruthy();
+  });
+
+  it("hides the banner when introDismissed=true", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.introDismissed = true;
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container } = render(<HelpPanel />);
+
+    expect(container.querySelector('button[aria-label="Dismiss"]')).toBeNull();
+  });
+
+  it("does not render the banner on the picker view (no terminal)", () => {
+    helpPanelState.terminalId = null;
+    helpPanelState.introDismissed = false;
+
+    const { container } = render(<HelpPanel />);
+
+    expect(container.querySelector('button[aria-label="Dismiss"]')).toBeNull();
+  });
+
+  it("dismisses the banner and opens the docs URL when the link is clicked", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.introDismissed = false;
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+    mockDispatch.mockResolvedValue({ ok: true });
+
+    const { getByText } = render(<HelpPanel />);
+
+    fireEvent.click(getByText("See what the Daintree Assistant can do"));
+
+    expect(helpPanelState.dismissIntro).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://daintree.org/assistant" },
+      { source: "user" }
+    );
+  });
+
+  it("renders the banner above the XtermAdapter (DOM order protects flex layout)", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.introDismissed = false;
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel />);
+
+    const dismissBtn = container.querySelector('button[aria-label="Dismiss"]')!;
+    const xterm = getByTestId("xterm-adapter");
+    const order = dismissBtn.compareDocumentPosition(xterm);
+    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("dismisses the banner when the X button is clicked", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.introDismissed = false;
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container } = render(<HelpPanel />);
+    const dismissBtn = container.querySelector('button[aria-label="Dismiss"]');
+    expect(dismissBtn).toBeTruthy();
+    fireEvent.click(dismissBtn!);
+
+    expect(helpPanelState.dismissIntro).toHaveBeenCalled();
   });
 });
 

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -136,10 +136,73 @@ describe("helpPanelStore persistence migration", () => {
     expect(written).toBeDefined();
     const parsed = JSON.parse(written!) as {
       version: number;
-      state: { width: number; preferredAgentId: string | null };
+      state: { width: number; preferredAgentId: string | null; introDismissed: boolean };
     };
     expect(parsed.version).toBe(1);
     expect(parsed.state.width).toBe(450);
     expect(parsed.state.preferredAgentId).toBeNull();
+  });
+
+  it("migrates a v0 blob to v1 with introDismissed defaulted to false", async () => {
+    const v0Blob = JSON.stringify({
+      version: 0,
+      state: { width: 400, preferredAgentId: "claude" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v0Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().introDismissed).toBe(false);
+    expect(store.getState().preferredAgentId).toBe("claude");
+  });
+
+  it("preserves introDismissed: true from a v1 blob across rehydration", async () => {
+    const v1Blob = JSON.stringify({
+      version: 1,
+      state: { width: 400, preferredAgentId: null, introDismissed: true },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v1Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().introDismissed).toBe(true);
+  });
+
+  it("starts with introDismissed: false on a fresh install", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().introDismissed).toBe(false);
+  });
+
+  it("falls back to false when persisted introDismissed has a non-boolean type", async () => {
+    const malformed = JSON.stringify({
+      version: 1,
+      state: { width: 400, preferredAgentId: null, introDismissed: "true" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: malformed });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().introDismissed).toBe(false);
+  });
+
+  it("dismissIntro() sets introDismissed: true and persists it", async () => {
+    const backing = installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().dismissIntro();
+
+    expect(store.getState().introDismissed).toBe(true);
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { introDismissed: boolean };
+    };
+    expect(parsed.version).toBe(1);
+    expect(parsed.state.introDismissed).toBe(true);
   });
 });

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -198,11 +198,10 @@ describe("helpPanelStore persistence migration", () => {
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();
-    const parsed = JSON.parse(written!) as {
-      version: number;
-      state: { introDismissed: boolean };
-    };
-    expect(parsed.version).toBe(1);
-    expect(parsed.state.introDismissed).toBe(true);
+    const parsed: unknown = JSON.parse(written!);
+    expect(parsed).toMatchObject({
+      version: 1,
+      state: { introDismissed: true },
+    });
   });
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -19,6 +19,7 @@ interface HelpPanelState {
   agentId: string | null;
   preferredAgentId: string | null;
   sessionId: string | null;
+  introDismissed: boolean;
 }
 
 interface HelpPanelActions {
@@ -28,6 +29,7 @@ interface HelpPanelActions {
   setTerminal: (terminalId: string, agentId: string, sessionId: string | null) => void;
   clearTerminal: () => void;
   clearPreferredAgent: () => void;
+  dismissIntro: () => void;
 }
 
 const initialState: HelpPanelState = {
@@ -37,6 +39,7 @@ const initialState: HelpPanelState = {
   agentId: null,
   preferredAgentId: null,
   sessionId: null,
+  introDismissed: false,
 };
 
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
@@ -60,19 +63,24 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
 
       clearPreferredAgent: () =>
         set({ terminalId: null, agentId: null, sessionId: null, preferredAgentId: null }),
+
+      dismissIntro: () => set({ introDismissed: true }),
     }),
     {
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
       version: 1,
-      // v1 marks that the `preferredAgentId` rehydration guard (issue #6612)
-      // is in effect. The cleanup itself runs in `merge` below — it fires on
-      // every rehydration, so a v0 blob with `preferredAgentId: "gemini"`
-      // becomes `null` before any subscriber sees it.
-      migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
+      migrate: (persistedState, version) => {
+        const s = (persistedState ?? {}) as Partial<HelpPanelState>;
+        if (version < 1) {
+          return { ...s, introDismissed: false } as HelpPanelState & HelpPanelActions;
+        }
+        return s as HelpPanelState & HelpPanelActions;
+      },
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,
+        introDismissed: state.introDismissed,
       }),
       merge: (persistedState: unknown, currentState) => {
         const persisted = persistedState as Partial<HelpPanelState>;
@@ -85,6 +93,10 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
             ? persisted.preferredAgentId
             : null,
+          introDismissed:
+            typeof persisted.introDismissed === "boolean"
+              ? persisted.introDismissed
+              : currentState.introDismissed,
         };
       },
     }
@@ -94,5 +106,5 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
 registerPersistedStore({
   storeId: "helpPanelStore",
   store: useHelpPanelStore,
-  persistedStateType: "Pick<HelpPanelState, 'width' | 'preferredAgentId'>",
+  persistedStateType: "Pick<HelpPanelState, 'width' | 'preferredAgentId' | 'introDismissed'>",
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -70,13 +70,7 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
       version: 1,
-      migrate: (persistedState, version) => {
-        const s = (persistedState ?? {}) as Partial<HelpPanelState>;
-        if (version < 1) {
-          return { ...s, introDismissed: false } as HelpPanelState & HelpPanelActions;
-        }
-        return s as HelpPanelState & HelpPanelActions;
-      },
+      migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,


### PR DESCRIPTION
## Summary

- Removes `HELP_PROMPT` and the `prompt` field from both `agent.launch` call sites in `HelpPanel` — the assistant now spawns at an empty prompt, ready for the user's first real question
- Adds `HelpIntroBanner` — a slim top bar above the terminal with a single sentence and a link to `https://daintree.org/assistant`, dismissible via X or Escape (scoped to the bar's container)
- Dismissal is persisted permanently in `helpPanelStore` (version bump `0→1`, migration adds `introDismissed: false` for existing users); semantic tokens used throughout (`bg-wash-subtle`, `border-subtle`, `text-secondary/primary/muted`) so the bar adapts correctly across all 14 built-in themes

Resolves #6611

## Changes

- `src/store/helpPanelStore.ts` — `introDismissed` flag, `dismissIntro` action, persist version `0→1`, migration, partialize, merge
- `src/components/HelpPanel/HelpIntroBanner.tsx` — new dismissible banner component; link opens via `system.openExternal` and also dismisses; Escape closes only when focus is inside the bar; `aria-label="Dismiss"` on X; no entrance animation, inline flex so dismissal smoothly reflows the terminal
- `src/components/HelpPanel/HelpPanel.tsx` — drops `HELP_PROMPT`, removes `prompt:` from both `agent.launch` dispatches, renders `HelpIntroBanner` above the terminal (hidden on picker and `MissingCliGate` states)

## Testing

42 tests across the affected files, covering:

- Store migration (version `0→1`, `introDismissed` seeded `false` for legacy blobs, malformed-state fallback)
- Banner visibility (hidden when dismissed, hidden before terminal is healthy)
- DOM order (banner renders above terminal)
- Link click opens external URL and dismisses
- X click dismisses
- Escape dismisses when focus is inside bar (with `stopPropagation` so it doesn't close the panel)