### PR TITLE
feat(help-panel): filter agent picker to assistant-supported agents only

### DIFF
--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -267,6 +267,16 @@ export interface AgentConfig {
   /** Available models for per-panel model selection at launch time */
   models?: AgentModelConfig[];
   supportsContextInjection: boolean;
+  /**
+   * When `true`, this agent has the full assistant wiring required for the
+   * Daintree help panel — MCP overlay, `.claude/settings.json` permission
+   * bake, bearer-token `.mcp.json`, and trust-dialog handling. Only agents
+   * with this flag are offered in `HelpAgentPicker`. Today this is Claude
+   * only; flip the flag on another agent's config when its overlay wiring
+   * lands. Omit (or set false) to keep an agent out of the help-panel
+   * picker even when its CLI is installed.
+   */
+  supportsAssistant?: boolean;
   shortcut?: string | null;
   tooltip?: string;
   usageUrl?: string;
@@ -538,6 +548,16 @@ export function getAgentModelConfig(
 ): AgentModelConfig | undefined {
   const config = getEffectiveAgentConfig(agentId);
   return config?.models?.find((m) => m.id === modelId);
+}
+
+/**
+ * IDs of built-in agents that pass the `supportsAssistant` gate. Used by the
+ * HelpPanel agent picker to filter the visible options and by the
+ * `helpPanelStore` rehydration guard to drop stale persisted preferences for
+ * agents that aren't (yet) wired for the assistant overlay.
+ */
+export function getAssistantSupportedAgentIds(): string[] {
+  return BUILT_IN_AGENT_IDS.filter((id) => AGENT_REGISTRY[id]?.supportsAssistant === true);
 }
 
 /**

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -15,6 +15,7 @@ export const config: AgentConfig = {
   color: "#CC785C",
   iconId: "claude",
   supportsContextInjection: true,
+  supportsAssistant: true,
   shortcut: "Cmd/Ctrl+Alt+C",
   usageUrl: "https://claude.ai/settings/usage",
   version: {

--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -40,9 +40,9 @@ export function HelpAgentPicker({ onSelectAgent, supportedAgentIds }: HelpAgentP
   if (supportedAgentIds.length === 0) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-daintree-text/50">No agents are installed.</p>
+        <p className="text-sm text-daintree-text/50">No assistant agents installed.</p>
         <p className="text-xs text-daintree-text/40">
-          Install an agent using the setup wizard to use as your Daintree assistant.
+          Install a supported agent using the setup wizard to use as your Daintree assistant.
         </p>
         <Button
           type="button"

--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -1,29 +1,29 @@
-import { useMemo, useCallback } from "react";
+import { useCallback } from "react";
 import { Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { AGENT_REGISTRY } from "@/config/agents";
 import { BrandMark } from "@/components/icons";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 
 interface HelpAgentPickerProps {
   onSelectAgent: (agentId: string) => void;
+  /**
+   * IDs of agents that are both wired for the assistant overlay AND installed
+   * locally. Computed by `HelpPanel` so the picker and the single-supported
+   * agent auto-skip effect agree on the visible set. The picker just renders
+   * this list; it still reads `hasRealData` to distinguish "loading" from
+   * "no installed agents".
+   */
+  supportedAgentIds: string[];
 }
 
-export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
-  const availability = useCliAvailabilityStore((s) => s.availability);
+export function HelpAgentPicker({ onSelectAgent, supportedAgentIds }: HelpAgentPickerProps) {
   // Gate on `hasRealData` (not `isInitialized`): `isInitialized` flips true even on probe
   // failure, but `hasRealData` waits for a real result — from localStorage cache or a
   // successful IPC — so users with previously-installed agents don't see the
   // "No agents are installed" empty state flash on cold open.
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
-
-  const installedAgents = useMemo(() => {
-    if (!hasRealData) return [];
-    return BUILT_IN_AGENT_IDS.filter((id) => isAgentInstalled(availability[id]));
-  }, [hasRealData, availability]);
 
   const handleOpenSetupWizard = useCallback(() => {
     window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"));
@@ -37,7 +37,7 @@ export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
     );
   }
 
-  if (installedAgents.length === 0) {
+  if (supportedAgentIds.length === 0) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
         <p className="text-sm text-daintree-text/50">No agents are installed.</p>
@@ -67,7 +67,7 @@ export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
       </div>
 
       <div className="flex flex-col gap-2">
-        {installedAgents.map((id) => {
+        {supportedAgentIds.map((id) => {
           const config = AGENT_REGISTRY[id];
           if (!config) return null;
           const Icon = config.icon;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -523,7 +523,7 @@ export function HelpPanel() {
 
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-daintree-border shrink-0">
-        {showTerminal && (
+        {showTerminal && supportedInstalledAgentIds.length > 1 && (
           <button
             type="button"
             onClick={handleBack}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -16,7 +16,8 @@ import {
   useCliAvailabilityStore,
   useProjectStore,
 } from "@/store";
-import { getAgentConfig } from "@/config/agents";
+import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
+import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { actionService } from "@/services/ActionService";
 import { TerminalRefreshTier } from "@/types";
 import { logError } from "@/utils/logger";
@@ -101,8 +102,20 @@ export function HelpPanel() {
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
   const removePanel = usePanelStore((s) => s.removePanel);
   const cliDetail = useCliAvailabilityStore((s) => (agentId ? s.details[agentId] : undefined));
+  const cliAvailability = useCliAvailabilityStore((s) => s.availability);
+  const cliHasRealData = useCliAvailabilityStore((s) => s.hasRealData);
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
+
+  // Intersection of "wired for the assistant overlay" and "CLI is installed".
+  // Drives the picker's visible options and the single-supported-agent
+  // auto-skip effect below. Recomputes only when availability or load state
+  // changes — `getAssistantSupportedAgentIds()` reads from a static registry.
+  const supportedInstalledAgentIds = useMemo(() => {
+    if (!cliHasRealData) return [];
+    return getAssistantSupportedAgentIds().filter((id) => isAgentInstalled(cliAvailability[id]));
+  }, [cliHasRealData, cliAvailability]);
+  const supportedInstalledAgentIdsKey = supportedInstalledAgentIds.join(",");
 
   // Tracks a session minted before `setTerminal` commits its sessionId to the
   // store. If the user closes/navigates while `agent.launch` is in flight,
@@ -363,6 +376,31 @@ export function HelpPanel() {
     [removePanel, clearTerminal]
   );
 
+  // Single-supported-agent auto-skip: when only one assistant-supported agent
+  // is installed and there's no persisted preference, skip the picker and
+  // launch directly. Mutually exclusive with the preferred-agent auto-launch
+  // (which only runs when `preferredAgentId` is set), so they share the same
+  // `hasAutoLaunched` ref to prevent any double-fire.
+  useEffect(() => {
+    if (!isOpen || terminalId || preferredAgentId || hasAutoLaunched.current) return;
+    if (supportedInstalledAgentIds.length !== 1) return;
+    const onlyAgentId = supportedInstalledAgentIds[0];
+    if (!onlyAgentId) return;
+    hasAutoLaunched.current = true;
+    safeFireAndForget(handleSelectAgent(onlyAgentId), {
+      context: "Auto-launching single supported help agent",
+    });
+    // The agent-id key is included in deps so a change in installed agents
+    // (e.g. user installs a second supported CLI) re-evaluates the gate.
+  }, [
+    isOpen,
+    terminalId,
+    preferredAgentId,
+    supportedInstalledAgentIdsKey,
+    supportedInstalledAgentIds,
+    handleSelectAgent,
+  ]);
+
   const handleBack = useCallback(() => {
     const { sessionId } = useHelpPanelStore.getState();
     if (terminalId) {
@@ -533,7 +571,10 @@ export function HelpPanel() {
             </div>
           )
         ) : (
-          <HelpAgentPicker onSelectAgent={handleSelectAgent} />
+          <HelpAgentPicker
+            onSelectAgent={handleSelectAgent}
+            supportedAgentIds={supportedInstalledAgentIds}
+          />
         )}
       </div>
 

--- a/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
@@ -64,7 +64,7 @@ describe("HelpAgentPicker", () => {
       <HelpAgentPicker onSelectAgent={vi.fn()} supportedAgentIds={[]} />
     );
 
-    expect(screen.getByText("No agents are installed.")).toBeTruthy();
+    expect(screen.getByText("No assistant agents installed.")).toBeTruthy();
     expect(screen.getByText("Run setup wizard")).toBeTruthy();
     expect(container.textContent).not.toMatch(/Enable an agent/i);
   });

--- a/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
@@ -20,10 +20,6 @@ vi.mock("@/components/ui/button", () => ({
   ),
 }));
 
-vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"],
-}));
-
 vi.mock("@/config/agents", () => ({
   AGENT_REGISTRY: {
     claude: { name: "Claude", iconId: "claude", color: "#000", icon: () => null, tooltip: "c" },
@@ -49,29 +45,24 @@ describe("HelpAgentPicker", () => {
     cliAvailabilityState.availability = {};
   });
 
-  it("renders installed agent regardless of pin state (issue #5117)", () => {
+  it("renders only the agents passed via supportedAgentIds (issue #6612)", () => {
     cliAvailabilityState.availability = {
       claude: "ready",
-      gemini: "installed",
-      codex: "missing",
+      gemini: "ready",
+      codex: "ready",
     };
 
-    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} supportedAgentIds={["claude"]} />);
 
     expect(screen.getByText("Claude")).toBeTruthy();
-    expect(screen.getByText("Gemini")).toBeTruthy();
+    expect(screen.queryByText("Gemini")).toBeNull();
     expect(screen.queryByText("Codex")).toBeNull();
   });
 
-  it("renders empty state when real data says no agents are installed — with no 'Enable' copy", () => {
-    cliAvailabilityState.hasRealData = true;
-    cliAvailabilityState.availability = {
-      claude: "missing",
-      gemini: "missing",
-      codex: "missing",
-    };
-
-    const { container } = render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+  it("renders empty state when supportedAgentIds is empty", () => {
+    const { container } = render(
+      <HelpAgentPicker onSelectAgent={vi.fn()} supportedAgentIds={[]} />
+    );
 
     expect(screen.getByText("No agents are installed.")).toBeTruthy();
     expect(screen.getByText("Run setup wizard")).toBeTruthy();
@@ -79,15 +70,8 @@ describe("HelpAgentPicker", () => {
   });
 
   it("setup wizard CTA dispatches daintree:open-agent-setup-wizard", () => {
-    cliAvailabilityState.hasRealData = true;
-    cliAvailabilityState.availability = {
-      claude: "missing",
-      gemini: "missing",
-      codex: "missing",
-    };
-
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
-    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} supportedAgentIds={[]} />);
 
     fireEvent.click(screen.getByText("Run setup wizard"));
 
@@ -103,34 +87,19 @@ describe("HelpAgentPicker", () => {
     // hasRealData=false means neither cache nor probe has landed — don't show
     // "No agents installed" prematurely (avoids flash on cold open with cache).
     cliAvailabilityState.hasRealData = false;
-    cliAvailabilityState.availability = {};
 
-    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} supportedAgentIds={[]} />);
 
     expect(screen.getByText("Checking for installed agents…")).toBeTruthy();
     expect(screen.queryByText("No agents are installed.")).toBeNull();
     expect(screen.queryByText("Claude")).toBeNull();
   });
 
-  it("renders installed agents once cached data lands even before first live probe", () => {
-    // hasRealData=true flips when localStorage cache hydrates the store, even without
-    // a successful IPC call yet. Users with previously-installed agents should see
-    // them immediately on cold open.
-    cliAvailabilityState.hasRealData = true;
-    cliAvailabilityState.availability = { claude: "ready", gemini: "missing", codex: "missing" };
-
-    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
-
-    expect(screen.getByText("Claude")).toBeTruthy();
-    expect(screen.queryByText("Gemini")).toBeNull();
-    expect(screen.queryByText("Checking for installed agents…")).toBeNull();
-  });
-
   it("calls onSelectAgent when an installed agent is clicked", () => {
-    cliAvailabilityState.availability = { claude: "ready", gemini: "missing", codex: "missing" };
+    cliAvailabilityState.availability = { claude: "ready" };
 
     const onSelectAgent = vi.fn();
-    render(<HelpAgentPicker onSelectAgent={onSelectAgent} />);
+    render(<HelpAgentPicker onSelectAgent={onSelectAgent} supportedAgentIds={["claude"]} />);
 
     fireEvent.click(screen.getByText("Claude"));
     expect(onSelectAgent).toHaveBeenCalledWith("claude");

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -860,4 +860,32 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
 
     expect(getByTestId("help-agent-picker").dataset.supported).toBe("claude,codex");
   });
+
+  it("hides the Back button when only one supported agent is installed (no picker to return to)", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container } = render(<HelpPanel />);
+
+    expect(container.querySelector('button[aria-label="Back to agent picker"]')).toBeNull();
+  });
+
+  it("shows the Back button when more than one supported agent is installed", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { container } = render(<HelpPanel />);
+
+    expect(container.querySelector('button[aria-label="Back to agent picker"]')).not.toBeNull();
+  });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -10,6 +10,7 @@ const {
   mockMarkTerminal,
   mockProvisionSession,
   mockRevokeSession,
+  mockGetAssistantSupportedAgentIds,
   helpPanelState,
   panelStoreState,
   cliAvailabilityState,
@@ -23,6 +24,7 @@ const {
   mockMarkTerminal: vi.fn().mockResolvedValue(undefined),
   mockProvisionSession: vi.fn().mockResolvedValue(null),
   mockRevokeSession: vi.fn().mockResolvedValue(undefined),
+  mockGetAssistantSupportedAgentIds: vi.fn(() => ["claude"]),
   helpPanelState: {
     isOpen: true,
     width: 380,
@@ -102,6 +104,7 @@ vi.mock("@/config/agents", () => ({
       gemini: { name: "Gemini", icon: () => null, models: [] },
       codex: { name: "Codex", icon: () => null, models: [] },
     })[id],
+  getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
 }));
 
 vi.mock("@shared/types", async (importOriginal) => {
@@ -179,10 +182,18 @@ vi.mock("@/types", () => ({
 
 // Stub HelpAgentPicker to expose a click target tied to the onSelectAgent prop
 vi.mock("../HelpAgentPicker", () => ({
-  HelpAgentPicker: ({ onSelectAgent }: { onSelectAgent: (id: string) => void }) => (
-    <button type="button" data-testid="pick-claude" onClick={() => onSelectAgent("claude")}>
-      Pick Claude
-    </button>
+  HelpAgentPicker: ({
+    onSelectAgent,
+    supportedAgentIds,
+  }: {
+    onSelectAgent: (id: string) => void;
+    supportedAgentIds: string[];
+  }) => (
+    <div data-testid="help-agent-picker" data-supported={supportedAgentIds.join(",")}>
+      <button type="button" data-testid="pick-claude" onClick={() => onSelectAgent("claude")}>
+        Pick Claude
+      </button>
+    </div>
   ),
 }));
 
@@ -222,6 +233,8 @@ function resetState() {
   mockProvisionSession.mockResolvedValue(null);
   mockRevokeSession.mockReset();
   mockRevokeSession.mockResolvedValue(undefined);
+  mockGetAssistantSupportedAgentIds.mockReset();
+  mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
 }
 
 beforeEach(() => {
@@ -767,5 +780,84 @@ describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
     });
 
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-gemini", "gemini", null);
+  });
+});
+
+describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
+  it("auto-launches the only supported agent without requiring user selection", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-skip-term" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-skip-term", "claude", null);
+  });
+
+  it("does not auto-skip when more than one supported agent is installed", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-skip when no supported agent is installed", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "missing", gemini: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-skip while CLI availability data is still loading", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.hasRealData = false;
+    cliAvailabilityState.availability = { claude: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
+
+    await act(async () => {
+      render(<HelpPanel />);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("passes only assistant-supported installed agents to HelpAgentPicker", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", gemini: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
+
+    const { getByTestId } = render(<HelpPanel />);
+
+    expect(getByTestId("help-agent-picker").dataset.supported).toBe("claude,codex");
   });
 });

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -9,9 +9,10 @@ import {
   getEffectiveAgentIds,
   isEffectivelyRegisteredAgent,
   getAgentDisplayTitle,
+  getAssistantSupportedAgentIds,
 } from "../../shared/config/agentRegistry";
 
-export { getAgentDisplayTitle };
+export { getAgentDisplayTitle, getAssistantSupportedAgentIds };
 export type { AgentPreset, AgentProviderTemplate };
 import { resolveAgentIcon } from "./agentIcons";
 

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -49,7 +49,7 @@ describe("helpPanelStore persistence migration", () => {
     vi.restoreAllMocks();
   });
 
-  it("rehydrates a legacy unversioned blob and preserves in-range width", async () => {
+  it("rehydrates a legacy unversioned blob and preserves an assistant-supported preferredAgentId", async () => {
     const legacyBlob = JSON.stringify({
       state: {
         width: 500,
@@ -87,7 +87,43 @@ describe("helpPanelStore persistence migration", () => {
     expect(store.getState().width).toBeGreaterThanOrEqual(HELP_PANEL_MIN_WIDTH);
   });
 
-  it("writes version: 0 on the next persist after rehydration", async () => {
+  it("clears a legacy preferredAgentId for an agent without assistant wiring (issue #6612)", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { width: 420, preferredAgentId: "gemini" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().preferredAgentId).toBeNull();
+    expect(store.getState().width).toBe(420);
+  });
+
+  it("preserves a v0 preferredAgentId when migrating to v1 if the agent is supported", async () => {
+    const v0Blob = JSON.stringify({
+      version: 0,
+      state: { width: 420, preferredAgentId: "claude" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v0Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().preferredAgentId).toBe("claude");
+  });
+
+  it("clears a v0 preferredAgentId when migrating to v1 if the agent is unsupported", async () => {
+    const v0Blob = JSON.stringify({
+      version: 0,
+      state: { width: 420, preferredAgentId: "codex" },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v0Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().preferredAgentId).toBeNull();
+  });
+
+  it("writes version: 1 with a cleared preferredAgentId after rehydrating an unsupported v0 agent", async () => {
     const legacyBlob = JSON.stringify({
       state: { width: 420, preferredAgentId: "gemini" },
     });
@@ -102,8 +138,8 @@ describe("helpPanelStore persistence migration", () => {
       version: number;
       state: { width: number; preferredAgentId: string | null };
     };
-    expect(parsed.version).toBe(0);
+    expect(parsed.version).toBe(1);
     expect(parsed.state.width).toBe(450);
-    expect(parsed.state.preferredAgentId).toBe("gemini");
+    expect(parsed.state.preferredAgentId).toBeNull();
   });
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -65,22 +65,11 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
       version: 1,
-      // v1 clears any persisted `preferredAgentId` for agents that aren't
-      // wired for the assistant overlay (issue #6612). Without this, users who
-      // previously picked Gemini/Codex would silently fail to auto-launch on
-      // first open after upgrade.
-      migrate: (persistedState, version) => {
-        const persisted = (persistedState ?? {}) as Partial<HelpPanelState>;
-        if (version < 1) {
-          return {
-            ...persisted,
-            preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
-              ? persisted.preferredAgentId
-              : null,
-          } as HelpPanelState & HelpPanelActions;
-        }
-        return persisted as HelpPanelState & HelpPanelActions;
-      },
+      // v1 marks that the `preferredAgentId` rehydration guard (issue #6612)
+      // is in effect. The cleanup itself runs in `merge` below — it fires on
+      // every rehydration, so a v0 blob with `preferredAgentId: "gemini"`
+      // becomes `null` before any subscriber sees it.
+      migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -2,6 +2,11 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
+import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry";
+
+function isAssistantSupportedAgentId(value: unknown): value is string {
+  return typeof value === "string" && getAssistantSupportedAgentIds().includes(value);
+}
 
 export const HELP_PANEL_MIN_WIDTH = 320;
 export const HELP_PANEL_MAX_WIDTH = 800;
@@ -59,8 +64,23 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     {
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
-      version: 0,
-      migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
+      version: 1,
+      // v1 clears any persisted `preferredAgentId` for agents that aren't
+      // wired for the assistant overlay (issue #6612). Without this, users who
+      // previously picked Gemini/Codex would silently fail to auto-launch on
+      // first open after upgrade.
+      migrate: (persistedState, version) => {
+        const persisted = (persistedState ?? {}) as Partial<HelpPanelState>;
+        if (version < 1) {
+          return {
+            ...persisted,
+            preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
+              ? persisted.preferredAgentId
+              : null,
+          } as HelpPanelState & HelpPanelActions;
+        }
+        return persisted as HelpPanelState & HelpPanelActions;
+      },
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,
@@ -73,10 +93,9 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
             typeof persisted.width === "number"
               ? Math.min(Math.max(persisted.width, HELP_PANEL_MIN_WIDTH), HELP_PANEL_MAX_WIDTH)
               : currentState.width,
-          preferredAgentId:
-            typeof persisted.preferredAgentId === "string"
-              ? persisted.preferredAgentId
-              : currentState.preferredAgentId,
+          preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
+            ? persisted.preferredAgentId
+            : null,
         };
       },
     }


### PR DESCRIPTION
## Summary

- Adds a `supportsAssistant` flag to `agentRegistry` and filters the help-panel agent picker to only show agents that actually have working assistant wiring — Claude Code only for now.
- Auto-skips the picker and launches directly when only one supported agent is installed; hides the Back button in that case since there's nothing to go back to.
- Clears a stale `preferredAgentId` on store rehydration if the previously chosen agent is no longer in the supported set.

Resolves #6612

## Changes

- `shared/config/agentRegistry.ts` — `supportsAssistant?: boolean` flag on `AgentConfig`; `getAssistantSupportedAgentIds()` helper
- `shared/config/agents/claude.ts` — `supportsAssistant: true`
- `src/config/agents.ts` — re-exports `getAssistantSupportedAgentIds`
- `src/store/helpPanelStore.ts` — version bump 0→1; merge guard clears stale `preferredAgentId` at rehydration
- `src/components/HelpPanel/HelpPanel.tsx` — computes `supportedInstalledAgentIds` (intersection of supported + installed); single-agent auto-launch effect; passes list as prop to picker
- `src/components/HelpPanel/HelpAgentPicker.tsx` — simplified to render the prop list; empty-state copy refined to "No assistant agents installed."
- Tests updated: `HelpAgentPicker.test.tsx`, `HelpPanel.helpLaunch.test.tsx`, `helpPanelStore.test.ts` — 38 tests passing

## Testing

- `vitest` — 38 tests pass
- `tsc --noEmit` — clean
- `eslint` — no errors
- `vite build` — clean