### PR TITLE
feat(assistant): convert Daintree Assistant to right-side push sidebar

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -87,13 +87,24 @@ function revokeHelpSession(sessionId: string | null): void {
   });
 }
 
-export function HelpPanel() {
+interface HelpPanelProps {
+  /**
+   * Effective rendered width in pixels. Owned by `AppLayout` so focus mode
+   * and `helpPanelOpen` collapse the panel to 0 without unmounting the
+   * xterm PTY. Width 0 means hidden chrome (aria-hidden, no pointer
+   * events, no focusable children).
+   */
+  width: number;
+}
+
+export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const animateWidth = !isResizing && !reduceAnimations;
+  const isVisible = effectiveWidth > 0;
 
   const {
     isOpen,
@@ -519,14 +530,13 @@ export function HelpPanel() {
 
   const showTerminal = terminalId && terminal;
   const isMissingCli = showTerminal && terminal?.spawnStatus === "missing-cli";
-  const effectiveWidth = isOpen ? width : 0;
 
   return (
     <aside
       ref={panelRef}
       tabIndex={-1}
       aria-label="Daintree Assistant"
-      aria-hidden={!isOpen}
+      aria-hidden={!isVisible}
       data-macro-focus={isMacroFocused ? "true" : undefined}
       className={cn(
         "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
@@ -534,7 +544,7 @@ export function HelpPanel() {
         "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
         animateWidth &&
           "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
-        !isOpen && "pointer-events-none"
+        !isVisible && "pointer-events-none"
       )}
       style={{ width: effectiveWidth }}
     >
@@ -543,8 +553,8 @@ export function HelpPanel() {
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize help panel"
-        tabIndex={isOpen ? 0 : -1}
-        aria-hidden={!isOpen}
+        tabIndex={isVisible ? 0 : -1}
+        aria-hidden={!isVisible}
         className={cn(
           "absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10",
           "hover:bg-overlay-soft active:bg-overlay-medium transition-colors",

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -17,9 +17,13 @@ import {
   useCliAvailabilityStore,
   useProjectStore,
 } from "@/store";
+import { useMacroFocusStore } from "@/store/macroFocusStore";
+import { usePreferencesStore } from "@/store";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { actionService } from "@/services/ActionService";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
+import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
@@ -84,9 +88,12 @@ function revokeHelpSession(sessionId: string | null): void {
 }
 
 export function HelpPanel() {
-  const panelRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
+  const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
+  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
+  const animateWidth = !isResizing && !reduceAnimations;
 
   const {
     isOpen,
@@ -252,17 +259,12 @@ export function HelpPanel() {
     }
   }, [isOpen]);
 
-  // Click-away handler
+  // Register the panel root with the macro-focus store so the assistant
+  // participates in cross-region cycling.
   useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (panelRef.current?.contains(e.target as Node)) return;
-      if ((e.target as HTMLElement).closest('[aria-label="Help Agent"]')) return;
-      setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [isOpen, setOpen]);
+    useMacroFocusStore.getState().setRegionRef("assistant", panelRef.current);
+    return () => useMacroFocusStore.getState().setRegionRef("assistant", null);
+  }, []);
 
   // Resize via mouse drag
   const handleResizeStart = useCallback(
@@ -421,8 +423,19 @@ export function HelpPanel() {
     }
     revokeHelpSession(sessionId);
     revokePendingSession();
+    suppressSidebarResizes();
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen, revokePendingSession]);
+
+  // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
+  // running PTY (Codex/Claude/etc.) when the assistant terminal has focus
+  // instead of closing the panel out from under the user.
+  const handleEscape = useCallback(() => {
+    const active = document.activeElement as HTMLElement | null;
+    if (active?.closest(".xterm-helper-textarea")) return;
+    handleClose();
+  }, [handleClose]);
+  useEscapeStack(isOpen, handleEscape);
 
   const handleIntroLinkClick = useCallback(() => {
     dismissIntro();
@@ -506,22 +519,32 @@ export function HelpPanel() {
 
   const showTerminal = terminalId && terminal;
   const isMissingCli = showTerminal && terminal?.spawnStatus === "missing-cli";
+  const effectiveWidth = isOpen ? width : 0;
 
   return (
-    <div
+    <aside
       ref={panelRef}
+      tabIndex={-1}
+      aria-label="Daintree Assistant"
+      aria-hidden={!isOpen}
+      data-macro-focus={isMacroFocused ? "true" : undefined}
       className={cn(
-        "flex flex-col h-full bg-daintree-bg relative",
-        "border-l border-daintree-border shadow-2xl"
+        "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
+        "bg-daintree-bg border-l border-daintree-border",
+        "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
+        animateWidth &&
+          "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+        !isOpen && "pointer-events-none"
       )}
-      style={{ width }}
+      style={{ width: effectiveWidth }}
     >
       {/* Resize handle */}
       <div
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize help panel"
-        tabIndex={0}
+        tabIndex={isOpen ? 0 : -1}
+        aria-hidden={!isOpen}
         className={cn(
           "absolute left-0 top-0 bottom-0 w-1.5 cursor-col-resize z-10",
           "hover:bg-overlay-soft active:bg-overlay-medium transition-colors",
@@ -612,6 +635,6 @@ export function HelpPanel() {
           </a>
         </div>
       )}
-    </div>
+    </aside>
   );
 }

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -270,7 +270,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -284,7 +284,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -301,7 +301,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: false });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -317,7 +317,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: null } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -332,7 +332,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
   it("notifies and aborts when help folder is null", async () => {
     mockGetFolderPath.mockResolvedValue(null);
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -354,7 +354,7 @@ describe("HelpPanel — manual select agent (handleSelectAgent)", () => {
       })
     );
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     // First click — kicks off async launch
     await act(async () => {
@@ -385,7 +385,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith("auto-term-1", "claude", null);
@@ -397,7 +397,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockDispatch).toHaveBeenCalledWith(
@@ -419,7 +419,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     );
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     // Simulate user clicking Back during the in-flight launch:
@@ -439,7 +439,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     mockDispatch.mockResolvedValue({ ok: false });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
@@ -458,7 +458,7 @@ describe("HelpPanel — intro banner visibility", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Dismiss"]')).toBeTruthy();
   });
@@ -471,7 +471,7 @@ describe("HelpPanel — intro banner visibility", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Dismiss"]')).toBeNull();
   });
@@ -480,7 +480,7 @@ describe("HelpPanel — intro banner visibility", () => {
     helpPanelState.terminalId = null;
     helpPanelState.introDismissed = false;
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Dismiss"]')).toBeNull();
   });
@@ -494,7 +494,7 @@ describe("HelpPanel — intro banner visibility", () => {
     };
     mockDispatch.mockResolvedValue({ ok: true });
 
-    const { getByText } = render(<HelpPanel />);
+    const { getByText } = render(<HelpPanel width={380} />);
 
     fireEvent.click(getByText("See what the Daintree Assistant can do"));
 
@@ -514,7 +514,7 @@ describe("HelpPanel — intro banner visibility", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container, getByTestId } = render(<HelpPanel />);
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
 
     const dismissBtn = container.querySelector('button[aria-label="Dismiss"]')!;
     const xterm = getByTestId("xterm-adapter");
@@ -530,7 +530,7 @@ describe("HelpPanel — intro banner visibility", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
     const dismissBtn = container.querySelector('button[aria-label="Dismiss"]');
     expect(dismissBtn).toBeTruthy();
     fireEvent.click(dismissBtn!);
@@ -555,7 +555,7 @@ describe("HelpPanel — render gates", () => {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
 
-    const { getByTestId, queryByTestId } = render(<HelpPanel />);
+    const { getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
 
     expect(getByTestId("missing-cli-gate")).toBeTruthy();
     expect(queryByTestId("xterm-adapter")).toBeNull();
@@ -568,7 +568,7 @@ describe("HelpPanel — render gates", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { getByTestId, queryByTestId } = render(<HelpPanel />);
+    const { getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
 
     expect(getByTestId("xterm-adapter")).toBeTruthy();
     expect(queryByTestId("missing-cli-gate")).toBeNull();
@@ -595,7 +595,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     };
     panelStoreState.addPanel = vi.fn().mockResolvedValue("restarted-term");
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("run-anyway"));
@@ -628,7 +628,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     };
     panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("run-anyway"));
@@ -668,7 +668,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     });
     panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("run-anyway"));
@@ -692,7 +692,7 @@ describe("HelpPanel — session provisioning", () => {
     });
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -731,7 +731,7 @@ describe("HelpPanel — session provisioning", () => {
     });
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-2" } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -769,7 +769,7 @@ describe("HelpPanel — session provisioning", () => {
       })
     );
 
-    const { getByTestId, container } = render(<HelpPanel />);
+    const { getByTestId, container } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -817,7 +817,7 @@ describe("HelpPanel — session provisioning", () => {
       })
     );
 
-    const { getByTestId, container } = render(<HelpPanel />);
+    const { getByTestId, container } = render(<HelpPanel width={380} />);
 
     await act(async () => {
       fireEvent.click(getByTestId("pick-claude"));
@@ -849,7 +849,7 @@ describe("HelpPanel — session provisioning", () => {
     panelStoreState.panelsById = {};
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
@@ -876,7 +876,7 @@ describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
         })
       );
 
-    const { rerender } = render(<HelpPanel />);
+    const { rerender } = render(<HelpPanel width={380} />);
 
     // User switches preferred agent while first launch is in flight (stale path)
     helpPanelState.preferredAgentId = "gemini";
@@ -891,7 +891,7 @@ describe("HelpPanel — hasAutoLaunched stale reset (regression)", () => {
 
     // Trigger the effect again with the new preferredAgentId.
     await act(async () => {
-      rerender(<HelpPanel />);
+      rerender(<HelpPanel width={380} />);
     });
 
     // The follow-up auto-launch must fire — this is the regression bug.
@@ -919,7 +919,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-skip-term" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockDispatch).toHaveBeenCalledWith(
@@ -938,7 +938,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockDispatch).not.toHaveBeenCalled();
@@ -953,7 +953,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockDispatch).not.toHaveBeenCalled();
@@ -969,7 +969,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
 
     await act(async () => {
-      render(<HelpPanel />);
+      render(<HelpPanel width={380} />);
     });
 
     expect(mockDispatch).not.toHaveBeenCalled();
@@ -983,7 +983,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "should-not-fire" } });
 
-    const { getByTestId } = render(<HelpPanel />);
+    const { getByTestId } = render(<HelpPanel width={380} />);
 
     expect(getByTestId("help-agent-picker").dataset.supported).toBe("claude,codex");
   });
@@ -997,7 +997,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Back to agent picker"]')).toBeNull();
   });
@@ -1011,7 +1011,7 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
       "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
     };
 
-    const { container } = render(<HelpPanel />);
+    const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Back to agent picker"]')).not.toBeNull();
   });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -169,14 +169,35 @@ vi.mock("@/store", () => {
     selector ? selector(projectStoreState) : projectStoreState;
   projectStore.getState = () => projectStoreState;
 
+  const preferencesState = { reduceAnimations: false };
+  const preferencesStore = (selector?: (state: typeof preferencesState) => unknown) =>
+    selector ? selector(preferencesState) : preferencesState;
+  preferencesStore.getState = () => preferencesState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
     useAgentSettingsStore: agentSettingsStore,
     useProjectStore: projectStore,
+    usePreferencesStore: preferencesStore,
     getTerminalRefreshTier: () => 0,
   };
 });
+
+vi.mock("@/store/macroFocusStore", () => {
+  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
+  store.getState = () => state;
+  return { useMacroFocusStore: store };
+});
+
+vi.mock("@/lib/sidebarToggle", () => ({
+  suppressSidebarResizes: vi.fn(),
+}));
+
+vi.mock("@/hooks/useEscapeStack", () => ({
+  useEscapeStack: vi.fn(),
+}));
 
 vi.mock("@/types", () => ({
   TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 },

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -393,7 +393,7 @@ export function AppLayout({
             </main>
           </ErrorBoundary>
           <ErrorBoundary variant="section" componentName="HelpPanel">
-            <HelpPanel />
+            <HelpPanel width={effectiveAssistantWidth} />
           </ErrorBoundary>
         </div>
         {/* Unified diagnostics dock replaces LogsPanel, EventInspectorPanel, and ProblemsPanel */}

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -76,6 +76,8 @@ export function AppLayout({
   const themeBrowserOpen = useThemeBrowserStore((s) => s.isOpen);
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const showSidebar = !layout.isFocusMode && currentProject != null;
+  const showAssistant = !layout.isFocusMode && layout.helpPanelOpen;
+  const effectiveAssistantWidth = showAssistant ? layout.helpPanelWidth : 0;
 
   useEffect(() => {
     if (layout.performanceMode) {
@@ -277,6 +279,10 @@ export function AppLayout({
     useMacroFocusStore.getState().setVisibility("portal", layout.portalOpen);
   }, [layout.portalOpen]);
 
+  useEffect(() => {
+    useMacroFocusStore.getState().setVisibility("assistant", showAssistant);
+  }, [showAssistant]);
+
   // Clear macro focus on mouse interaction
   useEffect(() => {
     const handleMouseDown = () => useMacroFocusStore.getState().clearFocus();
@@ -309,13 +315,14 @@ export function AppLayout({
   const effectiveSidebarWidth = layout.isFocusMode ? 0 : sidebarWidth;
 
   useEffect(() => {
-    const offset = layout.portalOpen ? `${layout.portalWidth}px` : "0px";
-    document.body.style.setProperty("--portal-right-offset", offset);
+    const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
+    const totalOffset = portalOffset + effectiveAssistantWidth;
+    document.body.style.setProperty("--portal-right-offset", `${totalOffset}px`);
 
     return () => {
       document.body.style.removeProperty("--portal-right-offset");
     };
-  }, [layout.portalOpen, layout.portalWidth]);
+  }, [layout.portalOpen, layout.portalWidth, effectiveAssistantWidth]);
 
   return (
     <div
@@ -376,18 +383,6 @@ export function AppLayout({
               <div className="flex-1 overflow-hidden min-h-0">{children}</div>
               {/* Terminal Dock Region - manages dock visibility and overlays */}
               <TerminalDockRegion />
-              {layout.helpPanelOpen && (
-                <ErrorBoundary variant="section" componentName="HelpPanel">
-                  <div
-                    className="absolute top-0 bottom-0 z-40"
-                    style={{
-                      right: layout.portalOpen ? `${layout.portalWidth}px` : "0px",
-                    }}
-                  >
-                    <HelpPanel />
-                  </div>
-                </ErrorBoundary>
-              )}
               {layout.portalOpen && (
                 <ErrorBoundary variant="section" componentName="PortalDock">
                   <div className="absolute right-0 top-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border">
@@ -396,6 +391,9 @@ export function AppLayout({
                 </ErrorBoundary>
               )}
             </main>
+          </ErrorBoundary>
+          <ErrorBoundary variant="section" componentName="HelpPanel">
+            <HelpPanel />
           </ErrorBoundary>
         </div>
         {/* Unified diagnostics dock replaces LogsPanel, EventInspectorPanel, and ProblemsPanel */}

--- a/src/components/Layout/HelpAgentDockButton.tsx
+++ b/src/components/Layout/HelpAgentDockButton.tsx
@@ -4,12 +4,14 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 
 export function HelpAgentDockButton() {
   const isOpen = useHelpPanelStore((s) => s.isOpen);
   const toggle = useHelpPanelStore((s) => s.toggle);
 
   const handleClick = useCallback(() => {
+    suppressSidebarResizes();
     toggle();
   }, [toggle]);
 

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -56,8 +56,14 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     // toggle) must not be reintroduced.
     expect(source).not.toMatch(/\{layout\.helpPanelOpen && \(\s*\n\s*<ErrorBoundary[^>]*HelpPanel/);
     expect(source).toMatch(
-      /<ErrorBoundary[^>]*componentName="HelpPanel"[^>]*>\s*\n\s*<HelpPanel\s*\/>/
+      /<ErrorBoundary[^>]*componentName="HelpPanel"[^>]*>\s*\n\s*<HelpPanel\s+width=\{effectiveAssistantWidth\}\s*\/>/
     );
+  });
+
+  it("passes effectiveAssistantWidth to HelpPanel so focus mode collapses width to 0", () => {
+    // Without the prop, HelpPanel reads its own store and ignores focus mode,
+    // leaving the panel at full width when the user enters focus mode.
+    expect(source).toContain("<HelpPanel width={effectiveAssistantWidth} />");
   });
 
   it("uses showAssistant for the macro-focus assistant visibility effect", () => {

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -33,3 +33,41 @@ describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", 
     expect(source).not.toMatch(/setVisibility\("sidebar",\s*!layout\.isFocusMode\)/);
   });
 });
+
+describe("AppLayout assistant push sidebar — issue #6619", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("derives showAssistant from isFocusMode and helpPanelOpen", () => {
+    expect(source).toContain("const showAssistant = !layout.isFocusMode && layout.helpPanelOpen");
+  });
+
+  it("computes effectiveAssistantWidth so focus mode collapses the panel without unmounting", () => {
+    expect(source).toContain(
+      "const effectiveAssistantWidth = showAssistant ? layout.helpPanelWidth : 0"
+    );
+  });
+
+  it("mounts HelpPanel unconditionally as a flex sibling so the xterm PTY survives close (issue #6619)", () => {
+    // The old conditional-render guard (which destroyed the PTY on every
+    // toggle) must not be reintroduced.
+    expect(source).not.toMatch(/\{layout\.helpPanelOpen && \(\s*\n\s*<ErrorBoundary[^>]*HelpPanel/);
+    expect(source).toMatch(
+      /<ErrorBoundary[^>]*componentName="HelpPanel"[^>]*>\s*\n\s*<HelpPanel\s*\/>/
+    );
+  });
+
+  it("uses showAssistant for the macro-focus assistant visibility effect", () => {
+    expect(source).toContain('setVisibility("assistant", showAssistant)');
+    expect(source).toContain("[showAssistant]");
+  });
+
+  it("sums portal and assistant widths into --portal-right-offset", () => {
+    expect(source).toContain("portalOffset + effectiveAssistantWidth");
+    expect(source).toContain("--portal-right-offset");
+    expect(source).toMatch(/\[layout\.portalOpen, layout\.portalWidth, effectiveAssistantWidth\]/);
+  });
+});

--- a/src/hooks/app/useAppEventListeners.ts
+++ b/src/hooks/app/useAppEventListeners.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { useHelpPanelStore, usePaletteStore, useThemeBrowserStore } from "@/store";
+import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 
 export function useAppEventListeners() {
   useEffect(() => {
@@ -14,7 +15,10 @@ export function useAppEventListeners() {
       // stacking two right-edge panels, and open the browser itself. Settings
       // close/reopen is coordinated separately by a Settings-scoped effect
       // (see App.tsx) because `setIsSettingsOpen` lives in useSettingsDialog.
-      useHelpPanelStore.getState().setOpen(false);
+      if (useHelpPanelStore.getState().isOpen) {
+        suppressSidebarResizes();
+        useHelpPanelStore.getState().setOpen(false);
+      }
       useThemeBrowserStore.getState().open();
     };
 

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -49,6 +49,10 @@ vi.mock("@/utils/logger", () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
 }));
 
+vi.mock("@/lib/sidebarToggle", () => ({
+  suppressSidebarResizes: vi.fn(),
+}));
+
 vi.mock("@shared/config/agentRegistry", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@shared/config/agentRegistry")>();
   return {

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -10,6 +10,7 @@ import {
   worktreeConfigClient,
 } from "@/clients";
 import { dispatchEscape } from "@/lib/escapeStack";
+import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
@@ -768,7 +769,10 @@ export function registerPreferencesActions(
         useHelpPanelStore
           .getState()
           .setTerminal(result.result.terminalId, agentId, session?.sessionId ?? null);
-        useHelpPanelStore.getState().setOpen(true);
+        if (!useHelpPanelStore.getState().isOpen) {
+          suppressSidebarResizes();
+          useHelpPanelStore.getState().setOpen(true);
+        }
         window.electron.help.markTerminal(result.result.terminalId).catch(() => {});
       } else if (session) {
         window.electron.help.revokeSession(session.sessionId).catch((err) => {
@@ -788,6 +792,7 @@ export function registerPreferencesActions(
     scope: "renderer",
     keywords: ["docs", "support", "guide", "assistant"],
     run: async () => {
+      suppressSidebarResizes();
       useHelpPanelStore.getState().toggle();
     },
   }));

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -123,7 +123,7 @@ describe("helpPanelStore persistence migration", () => {
     expect(store.getState().preferredAgentId).toBeNull();
   });
 
-  it("writes version: 1 with a cleared preferredAgentId after rehydrating an unsupported v0 agent", async () => {
+  it("writes version: 2 with a cleared preferredAgentId after rehydrating an unsupported v0 agent", async () => {
     const legacyBlob = JSON.stringify({
       state: { width: 420, preferredAgentId: "gemini" },
     });
@@ -136,9 +136,14 @@ describe("helpPanelStore persistence migration", () => {
     expect(written).toBeDefined();
     const parsed = JSON.parse(written!) as {
       version: number;
-      state: { width: number; preferredAgentId: string | null; introDismissed: boolean };
+      state: {
+        isOpen: boolean;
+        width: number;
+        preferredAgentId: string | null;
+        introDismissed: boolean;
+      };
     };
-    expect(parsed.version).toBe(1);
+    expect(parsed.version).toBe(2);
     expect(parsed.state.width).toBe(450);
     expect(parsed.state.preferredAgentId).toBeNull();
   });
@@ -200,8 +205,70 @@ describe("helpPanelStore persistence migration", () => {
     expect(written).toBeDefined();
     const parsed: unknown = JSON.parse(written!);
     expect(parsed).toMatchObject({
-      version: 1,
+      version: 2,
       state: { introDismissed: true },
     });
+  });
+
+  it("defaults isOpen to false when migrating a v1 blob without it (issue #6619)", async () => {
+    const v1Blob = JSON.stringify({
+      version: 1,
+      state: { width: 400, preferredAgentId: "claude", introDismissed: true },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v1Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().isOpen).toBe(false);
+    expect(store.getState().preferredAgentId).toBe("claude");
+    expect(store.getState().introDismissed).toBe(true);
+  });
+
+  it("preserves isOpen: true from a v2 blob across rehydration", async () => {
+    const v2Blob = JSON.stringify({
+      version: 2,
+      state: { isOpen: true, width: 400, preferredAgentId: null, introDismissed: false },
+    });
+    installLocalStorage({ [STORAGE_KEY]: v2Blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().isOpen).toBe(true);
+  });
+
+  it("falls back to false when persisted isOpen has a non-boolean type", async () => {
+    const malformed = JSON.stringify({
+      version: 2,
+      state: { isOpen: "yes", width: 400, preferredAgentId: null, introDismissed: false },
+    });
+    installLocalStorage({ [STORAGE_KEY]: malformed });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().isOpen).toBe(false);
+  });
+
+  it("setOpen(true) persists isOpen to localStorage", async () => {
+    const backing = installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().setOpen(true);
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: { isOpen: boolean };
+    };
+    expect(parsed.version).toBe(2);
+    expect(parsed.state.isOpen).toBe(true);
+  });
+
+  it("starts with isOpen: false on a fresh install", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().isOpen).toBe(false);
   });
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -69,9 +69,10 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     {
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
-      version: 1,
+      version: 2,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
+        isOpen: state.isOpen,
         width: state.width,
         preferredAgentId: state.preferredAgentId,
         introDismissed: state.introDismissed,
@@ -80,6 +81,7 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
         const persisted = persistedState as Partial<HelpPanelState>;
         return {
           ...currentState,
+          isOpen: typeof persisted.isOpen === "boolean" ? persisted.isOpen : currentState.isOpen,
           width:
             typeof persisted.width === "number"
               ? Math.min(Math.max(persisted.width, HELP_PANEL_MIN_WIDTH), HELP_PANEL_MAX_WIDTH)
@@ -100,5 +102,6 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
 registerPersistedStore({
   storeId: "helpPanelStore",
   store: useHelpPanelStore,
-  persistedStateType: "Pick<HelpPanelState, 'width' | 'preferredAgentId' | 'introDismissed'>",
+  persistedStateType:
+    "Pick<HelpPanelState, 'isOpen' | 'width' | 'preferredAgentId' | 'introDismissed'>",
 });

--- a/src/store/macroFocusStore.ts
+++ b/src/store/macroFocusStore.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
 
-export type MacroRegion = "grid" | "dock" | "sidebar" | "portal";
+export type MacroRegion = "grid" | "dock" | "sidebar" | "portal" | "assistant";
 
-const REGION_ORDER: MacroRegion[] = ["grid", "dock", "sidebar", "portal"];
+const REGION_ORDER: MacroRegion[] = ["grid", "dock", "sidebar", "portal", "assistant"];
 
 interface MacroFocusState {
   focusedRegion: MacroRegion | null;
@@ -21,7 +21,7 @@ function getVisibleRegions(visibility: Record<MacroRegion, boolean>): MacroRegio
 
 export const useMacroFocusStore = create<MacroFocusState>((set, get) => ({
   focusedRegion: null,
-  visibility: { grid: true, dock: false, sidebar: true, portal: false },
+  visibility: { grid: true, dock: false, sidebar: true, portal: false, assistant: false },
   refs: new Map(),
 
   setRegionRef: (region, el) => {


### PR DESCRIPTION
## Summary

- Converts the Daintree Assistant from an absolute-positioned overlay inside `<main>` to a flex sibling on the right edge, mirroring how the worktree Sidebar works on the left. Opening it narrows `<main>` rather than floating over it.
- Four key behavioral changes: always mounted with `width: 0` / `overflow: hidden` / `aria-hidden` when closed (preserves the xterm PTY across toggles); `isOpen` persisted via `helpPanelStore` v1→v2 migration; Escape-to-close via `useEscapeStack` with a `.xterm-helper-textarea` guard so Escape still reaches the agent CLI; new `"assistant"` macro-focus region added so the panel participates in global focus cycling.
- Portal and assistant widths are summed into `--portal-right-offset` so both surfaces coexist without overlap.

Resolves #6619

## Changes

- `AppLayout.tsx` — assistant renders as a flex sibling of `<main>` with `effectiveAssistantWidth` driving its inline width; unconditionally mounted
- `HelpPanel.tsx` — click-away listener removed; width and `aria-hidden` driven by props; resize handle retained
- `helpPanelStore.ts` — v1→v2 migration adds `isOpen` to the persistence allowlist
- `macroFocusStore.ts` — `"assistant"` added to the `MacroRegion` union
- `useAppEventListeners.ts` — Escape handler registered via `useEscapeStack` with xterm textarea guard
- `preferencesActions.ts` — `toggle-help-panel` action wired to the new store shape
- `HelpAgentDockButton.tsx` — minor prop threading for open state
- Tests: `helpPanelStore.test.ts` (v1→v2 migration, `isOpen` persistence, malformed input), `AppLayout.sidebar.test.ts` (source-scan assertions for unconditional mount, `effectiveAssistantWidth`, macro-focus, `--portal-right-offset`), `HelpPanel.helpLaunch.test.tsx` (updated for prop-driven width)

## Testing

- Unit: `helpPanelStore` migration path, `isOpen` persistence, malformed `isOpen` fallback, `AppLayout` source-scan assertions, `HelpPanel` prop-driven rendering
- Manual: open/close via dock button, `Cmd+Shift+H`, X button, and Escape; confirm Escape inside the agent terminal still reaches the CLI; enter focus mode and confirm assistant collapses to 0 without unmounting; restart app and confirm `isOpen` persists