### PR TITLE
fix(mcp): strip [category] Title: prefix from tool descriptions

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -2309,7 +2309,7 @@ export class McpServerService {
   }
 
   private buildToolDescription(entry: ActionManifestEntry): string {
-    let description = `[${entry.category}] ${entry.title}: ${entry.description}`;
+    let description = entry.description;
     if (entry.danger === "confirm") {
       description += " Requires explicit confirmation via _meta.confirmed=true.";
     }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -542,6 +542,9 @@ describe("McpServerService", () => {
 
     expect(safeTool).toBeDefined();
     expect(dangerousTool).toBeDefined();
+    expect(safeTool?.description).toBe("Read the action registry");
+    expect(dangerousTool?.description).not.toMatch(/^\[/);
+    expect(dangerousTool?.description).toContain("Delete a worktree");
     expect(dangerousTool?.description).toContain("Requires explicit confirmation");
     expect(safeTool?.inputSchema.additionalProperties).toBe(false);
     expect(dangerousTool?.inputSchema.additionalProperties).toBe(false);

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -543,9 +543,9 @@ describe("McpServerService", () => {
     expect(safeTool).toBeDefined();
     expect(dangerousTool).toBeDefined();
     expect(safeTool?.description).toBe("Read the action registry");
-    expect(dangerousTool?.description).not.toMatch(/^\[/);
-    expect(dangerousTool?.description).toContain("Delete a worktree");
-    expect(dangerousTool?.description).toContain("Requires explicit confirmation");
+    expect(dangerousTool?.description).toBe(
+      "Delete a worktree Requires explicit confirmation via _meta.confirmed=true."
+    );
     expect(safeTool?.inputSchema.additionalProperties).toBe(false);
     expect(dangerousTool?.inputSchema.additionalProperties).toBe(false);
     expect(dangerousTool?.inputSchema.properties?._meta).toEqual({


### PR DESCRIPTION
## Summary

- All 62 MCP tool descriptions started with `[${category}] ${title}: ` boilerplate that duplicated `annotations.title` — wasting model context on every `tools/list` round-trip with no information gain.
- Stripped the prefix from `buildToolDescription` in `McpServerService.ts`; the MCP 2025-11-25 spec separates description (model-facing) from title (UI-facing), so `annotations.title` is the right place for the labeled name.
- Kept the dangerous-tool confirmation suffix (`Requires explicit confirmation via _meta.confirmed=true`) intact — that's load-bearing until confirmation migrates to elicitation/create.

Resolves #6632

## Changes

- `electron/services/McpServerService.ts` — `buildToolDescription` now returns `entry.description` directly (plus the confirmation suffix for `danger === 'confirm'`)
- `electron/services/__tests__/McpServerService.test.ts` — regression assertions pinning exact description strings for a safe tool and a dangerous tool

## Testing

Existing unit test suite updated with exact-string assertions for both cases. All checks pass (typecheck, lint, format).