### PR TITLE
fix(mcp): add additionalProperties: false to tool input schemas

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -2001,7 +2001,7 @@ export class McpServerService {
           };
 
     if (entry.danger !== "confirm") {
-      return baseSchema;
+      return { ...baseSchema, additionalProperties: false };
     }
 
     const properties =
@@ -2026,6 +2026,7 @@ export class McpServerService {
     return {
       ...baseSchema,
       properties,
+      additionalProperties: false,
     };
   }
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -541,6 +541,8 @@ describe("McpServerService", () => {
     expect(safeTool).toBeDefined();
     expect(dangerousTool).toBeDefined();
     expect(dangerousTool?.description).toContain("Requires explicit confirmation");
+    expect(safeTool?.inputSchema.additionalProperties).toBe(false);
+    expect(dangerousTool?.inputSchema.additionalProperties).toBe(false);
     expect(dangerousTool?.inputSchema.properties?._meta).toEqual({
       type: "object",
       description: "Reserved Daintree MCP metadata.",


### PR DESCRIPTION
## Summary

- MCP tool input schemas were missing `additionalProperties: false` at the top level, meaning wrong parameter names were silently ignored and tools fell back to defaults with no error
- Updated `buildToolInputSchema` in `electron/services/McpServerService.ts` to set `additionalProperties: false` on the top-level schema object
- Added a test in `electron/services/__tests__/McpServerService.test.ts` to verify the property is present on generated schemas

Resolves #6633

## Changes

- `electron/services/McpServerService.ts` — `buildToolInputSchema` now includes `additionalProperties: false` on the top-level input schema (the property was previously only set on the inner `_meta` envelope)
- `electron/services/__tests__/McpServerService.test.ts` — new assertion confirming all generated tool schemas carry `additionalProperties: false`

## Testing

Unit test confirms the property is set. Manually verified that passing an unknown parameter name to a tool now falls outside the schema contract rather than silently succeeding.