### PR TITLE
chore(mcp): remove fleet-broadcast and focus-shift tools from allowlists

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -151,7 +151,6 @@ const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
   "terminal.inject",
   "terminal.new",
   "terminal.sendCommand",
-  "terminal.bulkCommand",
   "terminal.close",
   "terminal.closeAll",
 
@@ -165,11 +164,8 @@ const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
 
   "agent.launch",
   "agent.terminal",
-  "agent.focusNextWaiting",
-  "agent.focusNextWorking",
 
   "workflow.startWorkOnIssue",
-  "workflow.focusNextAttention",
 ]);
 
 /**
@@ -218,8 +214,6 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
 
   "agent.launch",
   "agent.terminal",
-  "agent.focusNextWaiting",
-  "agent.focusNextWorking",
 
   "git.getProjectPulse",
   "git.getFileDiff",
@@ -245,7 +239,6 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "terminal.list",
   "terminal.getOutput",
   "terminal.sendCommand",
-  "terminal.bulkCommand",
   "terminal.inject",
   "terminal.new",
 
@@ -263,7 +256,6 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
 
   "workflow.startWorkOnIssue",
   "workflow.prepBranchForReview",
-  "workflow.focusNextAttention",
 
   "files.search",
   "file.view",

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1623,6 +1623,30 @@ describe("McpServerService", () => {
         description: "Macro: inspect staging status and detected runners",
         kind: "query",
       }),
+      // Renderer-only primitives included in the manifest so the
+      // NEVER_EXPOSED_VIA_MCP absence loops below catch regressions: a
+      // re-add to any tier's allowlist would surface here as a listTools
+      // hit. Without these manifest entries the absence checks are vacuous.
+      createManifestEntry({
+        id: "terminal.bulkCommand" as ActionId,
+        title: "Broadcast to Terminals",
+        description: "Send a command to multiple terminals at once",
+      }),
+      createManifestEntry({
+        id: "agent.focusNextWaiting" as ActionId,
+        title: "Focus Next Waiting Agent",
+        description: "Focus the next agent awaiting input",
+      }),
+      createManifestEntry({
+        id: "agent.focusNextWorking" as ActionId,
+        title: "Focus Next Working Agent",
+        description: "Focus the next active agent",
+      }),
+      createManifestEntry({
+        id: "workflow.focusNextAttention" as ActionId,
+        title: "Focus Next Attention",
+        description: "Focus next waiting/working agent with priority",
+      }),
     ];
 
     // Spawning terminals/agents, driving them via sent commands, and trashing
@@ -1780,6 +1804,59 @@ describe("McpServerService", () => {
       })) as TextToolResult;
       expect(denied.isError).toBe(true);
       expect(denied.content[0]?.text).toContain("TIER_NOT_PERMITTED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("external tier (apiKey) excludes fleet-broadcast and focus-shift tools from listTools", async () => {
+      const { window } = createMockWindow({ getManifest: tierManifest });
+
+      await service.start(window);
+      // connectClient sends the global apiKey by default → external tier.
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((tool) => tool.name);
+      for (const id of NEVER_EXPOSED_VIA_MCP) {
+        expect(ids).not.toContain(id);
+      }
+    });
+
+    it("rejects callTool for fleet-broadcast and focus-shift tools across every tier with TIER_NOT_PERMITTED", async () => {
+      paneTokenTiers.set("token-wb", "workbench");
+      paneTokenTiers.set("token-action", "action");
+      paneTokenTiers.set("token-sys", "system");
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({ ok: true, result: "should-not-run" })
+      );
+      const { window } = createMockWindow({
+        getManifest: tierManifest,
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+
+      const tierTokens: Array<[string, string]> = [
+        ["workbench", "token-wb"],
+        ["action", "token-action"],
+        ["system", "token-sys"],
+        ["external", ""],
+      ];
+
+      for (const [tier, token] of tierTokens) {
+        const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
+        const { client, transport } = await connectClient(service.currentPort!, headers);
+        transports.push(transport);
+
+        for (const id of NEVER_EXPOSED_VIA_MCP) {
+          const denied = (await client.callTool({
+            name: id,
+            arguments: {},
+          })) as TextToolResult;
+          expect(denied.isError, `${tier} should deny ${id}`).toBe(true);
+          expect(denied.content[0]?.text).toContain("TIER_NOT_PERMITTED");
+        }
+      }
+
       expect(dispatchMock).not.toHaveBeenCalled();
     });
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1623,11 +1623,6 @@ describe("McpServerService", () => {
         description: "Macro: inspect staging status and detected runners",
         kind: "query",
       }),
-      createManifestEntry({
-        id: "workflow.focusNextAttention" as ActionId,
-        title: "Focus Next Attention",
-        description: "Macro: focus next waiting/working agent with priority",
-      }),
     ];
 
     // Spawning terminals/agents, driving them via sent commands, and trashing
@@ -1640,7 +1635,6 @@ describe("McpServerService", () => {
       "agent.terminal",
       "agent.launch",
       "workflow.startWorkOnIssue",
-      "workflow.focusNextAttention",
     ] as const;
 
     const WORKBENCH_TIER_TOOLS = ["workflow.prepBranchForReview"] as const;
@@ -1650,6 +1644,16 @@ describe("McpServerService", () => {
       "git.push",
       "worktree.delete",
       "terminal.kill",
+    ] as const;
+
+    // Fleet-broadcast and focus-shift primitives are renderer-only — they
+    // remain available via keybindings, palette, and menus, but are NOT
+    // exposed through the MCP control plane on any tier.
+    const NEVER_EXPOSED_VIA_MCP = [
+      "terminal.bulkCommand",
+      "agent.focusNextWaiting",
+      "agent.focusNextWorking",
+      "workflow.focusNextAttention",
     ] as const;
 
     it("workbench tier exposes only read-only introspection tools", async () => {
@@ -1671,7 +1675,9 @@ describe("McpServerService", () => {
       expect(ids).not.toContain("worktree.create");
       expect(ids).not.toContain("git.commit");
       expect(ids).not.toContain("workflow.startWorkOnIssue");
-      expect(ids).not.toContain("workflow.focusNextAttention");
+      for (const id of NEVER_EXPOSED_VIA_MCP) {
+        expect(ids).not.toContain(id);
+      }
     });
 
     it("action tier adds non-destructive mutations and terminal/agent spawning, but excludes irreversible ones", async () => {
@@ -1691,6 +1697,9 @@ describe("McpServerService", () => {
         expect(ids).toContain(id);
       }
       for (const id of SYSTEM_ONLY_TOOLS) {
+        expect(ids).not.toContain(id);
+      }
+      for (const id of NEVER_EXPOSED_VIA_MCP) {
         expect(ids).not.toContain(id);
       }
     });
@@ -1713,6 +1722,9 @@ describe("McpServerService", () => {
       }
       for (const id of SYSTEM_ONLY_TOOLS) {
         expect(ids).toContain(id);
+      }
+      for (const id of NEVER_EXPOSED_VIA_MCP) {
+        expect(ids).not.toContain(id);
       }
     });
 


### PR DESCRIPTION
## Summary

- Removes `terminal.bulkCommand`, `agent.focusNextWaiting`, `agent.focusNextWorking`, and `workflow.focusNextAttention` from MCP tier allowlists — these are human UI workflows that don't belong in an agent-driven control plane
- Change is MCP exposure only; all four tools stay as renderer actions backing keybindings, command palette, and menus
- Updates tests with non-vacuous absence assertions and adds new external-tier and cross-tier `callTool` denial tests

Resolves #6634

## Changes

- `electron/services/McpServerService.ts` — removed the four tools from all tier allowlists
- `electron/services/__tests__/McpServerService.test.ts` — made `NEVER_EXPOSED_VIA_MCP` assertions non-vacuous; added external-tier and cross-tier denial coverage

## Testing

Non-vacuous assertions confirm the removed tool IDs are genuinely absent from all tiers. New denial tests exercise `callTool` paths for both external-tier and cross-tier requests, verifying tools are rejected rather than silently ignored.