### PR TITLE
fix(assistant): surface MCP-off notice when Daintree control is on

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -153,6 +153,27 @@ export function DaintreeAssistantSettingsTab() {
     void persist({ skipPermissions: !settings.skipPermissions });
   }, [persist, settings.skipPermissions]);
 
+  const handleEnableMcpServer = useCallback(async () => {
+    try {
+      setError(null);
+      const next = await window.electron.mcpServer.setEnabled(true);
+      setMcpStatus({
+        enabled: next.enabled,
+        port: next.port,
+        apiKey: next.apiKey,
+      });
+    } catch (err) {
+      setError(formatErrorMessage(err, "Couldn't enable MCP server"));
+      notify({
+        type: "error",
+        title: "MCP server failed",
+        message: "Couldn't enable the MCP server. Try again.",
+        priority: "low",
+      });
+      logError("Failed to enable MCP server from assistant tab", err);
+    }
+  }, []);
+
   const setRetention = useCallback(
     (value: string) => {
       const parsed = Number(value);
@@ -295,6 +316,31 @@ export function DaintreeAssistantSettingsTab() {
           ariaLabel="Allow the assistant to call Daintree control tools"
           disabled={loading}
         />
+        {settings.daintreeControl && mcpStatus && !mcpStatus.enabled && (
+          <div
+            className={cn(
+              "flex items-start gap-3 p-3 rounded-[var(--radius-md)]",
+              "bg-overlay-subtle border border-daintree-border"
+            )}
+          >
+            <AlertTriangle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
+            <div className="flex-1 text-xs text-daintree-text/70 leading-relaxed select-text">
+              The MCP server is off, so the assistant can't call Daintree actions yet. Turn it on to
+              activate Daintree control.
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleEnableMcpServer()}
+              className={cn(
+                "shrink-0 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
+                "border border-daintree-border text-daintree-text/80",
+                "hover:bg-overlay-soft hover:text-daintree-text"
+              )}
+            >
+              Turn on MCP server
+            </button>
+          </div>
+        )}
       </SettingsSection>
 
       {/* Security */}
@@ -358,8 +404,8 @@ export function DaintreeAssistantSettingsTab() {
           <p className="text-xs text-daintree-text/50">Couldn't load MCP status.</p>
         ) : !mcpStatus.enabled ? (
           <p className="text-xs text-daintree-text/60 select-text">
-            MCP server is off. Turn it on in the MCP Server tab to enable Daintree control and share
-            the connection with external clients.
+            MCP server is off. Turn it on in the MCP Server tab to share the connection with
+            external clients.
           </p>
         ) : (
           <div className="contents">

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -54,6 +54,7 @@ export function DaintreeAssistantSettingsTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [enablingMcp, setEnablingMcp] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const agentSettings = useAgentSettingsStore((s) => s.settings);
@@ -154,6 +155,8 @@ export function DaintreeAssistantSettingsTab() {
   }, [persist, settings.skipPermissions]);
 
   const handleEnableMcpServer = useCallback(async () => {
+    if (enablingMcp) return;
+    setEnablingMcp(true);
     try {
       setError(null);
       const next = await window.electron.mcpServer.setEnabled(true);
@@ -162,6 +165,9 @@ export function DaintreeAssistantSettingsTab() {
         port: next.port,
         apiKey: next.apiKey,
       });
+      if (!next.enabled) {
+        setError("Couldn't start the MCP server. Check the MCP Server tab for details.");
+      }
     } catch (err) {
       setError(formatErrorMessage(err, "Couldn't enable MCP server"));
       notify({
@@ -171,8 +177,10 @@ export function DaintreeAssistantSettingsTab() {
         priority: "low",
       });
       logError("Failed to enable MCP server from assistant tab", err);
+    } finally {
+      setEnablingMcp(false);
     }
-  }, []);
+  }, [enablingMcp]);
 
   const setRetention = useCallback(
     (value: string) => {
@@ -316,7 +324,7 @@ export function DaintreeAssistantSettingsTab() {
           ariaLabel="Allow the assistant to call Daintree control tools"
           disabled={loading}
         />
-        {settings.daintreeControl && mcpStatus && !mcpStatus.enabled && (
+        {!loading && settings.daintreeControl && mcpStatus && !mcpStatus.enabled && (
           <div
             className={cn(
               "flex items-start gap-3 p-3 rounded-[var(--radius-md)]",
@@ -331,10 +339,12 @@ export function DaintreeAssistantSettingsTab() {
             <button
               type="button"
               onClick={() => void handleEnableMcpServer()}
+              disabled={enablingMcp}
               className={cn(
                 "shrink-0 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
                 "border border-daintree-border text-daintree-text/80",
-                "hover:bg-overlay-soft hover:text-daintree-text"
+                "hover:bg-overlay-soft hover:text-daintree-text",
+                "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent"
               )}
             >
               Turn on MCP server

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -100,6 +100,7 @@ interface HelpAssistantApi {
 
 interface McpServerApi {
   getStatus: ReturnType<typeof vi.fn>;
+  setEnabled: ReturnType<typeof vi.fn>;
   rotateApiKey: ReturnType<typeof vi.fn>;
   getConfigSnippet: ReturnType<typeof vi.fn>;
 }
@@ -119,6 +120,12 @@ function installApi(
   };
   const mcpDefaults: McpServerApi = {
     getStatus: vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 45454,
+      configuredPort: 45454,
+      apiKey: "dnt-key-abc",
+    }),
+    setEnabled: vi.fn().mockResolvedValue({
       enabled: true,
       port: 45454,
       configuredPort: 45454,
@@ -307,6 +314,99 @@ describe("DaintreeAssistantSettingsTab", () => {
       expect(window.electron.mcpServer.getConfigSnippet).toHaveBeenCalled();
     });
     expect(container.textContent).not.toContain("Copied");
+  });
+
+  it("renders the MCP-off notice when Daintree control is on but MCP is disabled", async () => {
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+      }
+    );
+
+    const { container } = render(<DaintreeAssistantSettingsTab />);
+    await waitForContent(container, "can't call Daintree actions yet");
+
+    expect(screen.queryByRole("button", { name: /turn on mcp server/i })).not.toBeNull();
+  });
+
+  it("clicking 'Turn on MCP server' enables the server and dismisses the notice", async () => {
+    const setEnabled = vi.fn().mockResolvedValue({
+      enabled: true,
+      port: 45454,
+      configuredPort: 45454,
+      apiKey: "dnt-key-abc",
+    });
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+        setEnabled,
+      }
+    );
+
+    const { container } = render(<DaintreeAssistantSettingsTab />);
+    await waitForContent(container, "can't call Daintree actions yet");
+
+    fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
+
+    await waitFor(() => {
+      expect(setEnabled).toHaveBeenCalledWith(true);
+    });
+    await waitFor(() => {
+      expect(container.textContent).not.toContain("can't call Daintree actions yet");
+    });
+  });
+
+  it("surfaces an inline error when enabling the MCP server fails", async () => {
+    const setEnabled = vi.fn().mockRejectedValue(new Error("port in use"));
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+        setEnabled,
+      }
+    );
+
+    const { container } = render(<DaintreeAssistantSettingsTab />);
+    await waitForContent(container, "can't call Daintree actions yet");
+
+    fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
+
+    await waitForContent(container, "port in use");
+    expect(container.textContent).toContain("can't call Daintree actions yet");
+  });
+
+  it("does not call setEnabled when toggling Daintree control off", async () => {
+    const setEnabled = vi.fn();
+    installApi({}, { setEnabled });
+
+    const { container } = render(<DaintreeAssistantSettingsTab />);
+    await waitForContent(container, "Daintree control");
+
+    fireEvent.click(screen.getByLabelText("Allow the assistant to call Daintree control tools"));
+
+    await waitFor(() => {
+      expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
+        daintreeControl: false,
+      });
+    });
+    expect(setEnabled).not.toHaveBeenCalled();
   });
 
   it("audit retention select offers off / 7 / 30 day options and persists changes", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -235,7 +235,7 @@ describe("DaintreeAssistantSettingsTab", () => {
     const { container } = render(<DaintreeAssistantSettingsTab />);
     await waitForContent(container, "MCP server is off");
 
-    expect(screen.queryByRole("button", { name: /regenerate mcp key/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /rotate mcp key/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
   });
 
@@ -389,6 +389,35 @@ describe("DaintreeAssistantSettingsTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
 
     await waitForContent(container, "port in use");
+    expect(container.textContent).toContain("can't call Daintree actions yet");
+  });
+
+  it("shows an inline error when setEnabled resolves but the server stays off", async () => {
+    const setEnabled = vi.fn().mockResolvedValue({
+      enabled: false,
+      port: null,
+      configuredPort: null,
+      apiKey: "",
+    });
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: false,
+          port: null,
+          configuredPort: null,
+          apiKey: "",
+        }),
+        setEnabled,
+      }
+    );
+
+    const { container } = render(<DaintreeAssistantSettingsTab />);
+    await waitForContent(container, "can't call Daintree actions yet");
+
+    fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
+
+    await waitForContent(container, "Couldn't start the MCP server");
     expect(container.textContent).toContain("can't call Daintree actions yet");
   });
 


### PR DESCRIPTION
## Summary

When `daintreeControl` is enabled but the MCP server isn't running, users end up in a broken state with no clear indication of what's wrong or how to fix it. This adds an inline dependency notice to the Behavior section of the Daintree Assistant settings tab with a one-click button to enable the MCP server.

Also trims the now-redundant "enable Daintree control" instruction from the connection section's disabled-state prose.

Resolves #6627

## Changes

- Inline notice renders in the settings tab when `daintreeControl=true` and `mcpStatus.enabled=false` — covers new installs (where `daintreeControl` defaults to `true` but the MCP server defaults to `false`) and users who flipped one toggle without the other
- "Turn on MCP server" CTA enables the server in a single click
- Hardened against loading-window flashes (`!loading` guard), soft service failures where `setEnabled(true)` resolves with `enabled=false` (surfaces an inline error), and rapid double-clicks (in-flight guard)
- Removed redundant prose from the connection section disabled state

## Testing

17 tests pass (12 existing + 5 new). New tests cover:

- Notice rendering when `daintreeControl` is on and MCP is off
- Click-to-enable flow
- Error handling for rejected promises
- Soft-fail path (`setEnabled` resolves `false`)
- Toggling `daintreeControl` off does not disturb the MCP server