### PR TITLE
feat(mcp): expose project edit actions over MCP

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -250,6 +250,10 @@ const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
   "agent.terminal",
 
   "workflow.startWorkOnIssue",
+
+  "project.update",
+  "project.saveSettings",
+  "project.muteNotifications",
 ]);
 
 /**
@@ -357,6 +361,9 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "project.getSettings",
   "project.getStats",
   "project.detectRunners",
+  "project.update",
+  "project.saveSettings",
+  "project.muteNotifications",
 
   "recipe.list",
   "recipe.run",

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1844,6 +1844,9 @@ describe("McpServerService", () => {
       expect(ids).not.toContain("worktree.create");
       expect(ids).not.toContain("git.commit");
       expect(ids).not.toContain("workflow.startWorkOnIssue");
+      expect(ids).not.toContain("project.update");
+      expect(ids).not.toContain("project.saveSettings");
+      expect(ids).not.toContain("project.muteNotifications");
       for (const id of NEVER_EXPOSED_VIA_MCP) {
         expect(ids).not.toContain(id);
       }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1774,6 +1774,21 @@ describe("McpServerService", () => {
         title: "Focus Next Attention",
         description: "Focus next waiting/working agent with priority",
       }),
+      createManifestEntry({
+        id: "project.update" as ActionId,
+        title: "Update Project",
+        description: "Update project metadata",
+      }),
+      createManifestEntry({
+        id: "project.saveSettings" as ActionId,
+        title: "Save Project Settings",
+        description: "Save a project's settings",
+      }),
+      createManifestEntry({
+        id: "project.muteNotifications" as ActionId,
+        title: "Mute Project Notifications",
+        description: "Suppress future agent notifications for a project",
+      }),
     ];
 
     // Spawning terminals/agents, driving them via sent commands, and trashing
@@ -1786,6 +1801,9 @@ describe("McpServerService", () => {
       "agent.terminal",
       "agent.launch",
       "workflow.startWorkOnIssue",
+      "project.update",
+      "project.saveSettings",
+      "project.muteNotifications",
     ] as const;
 
     const WORKBENCH_TIER_TOOLS = ["workflow.prepBranchForReview"] as const;

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -477,6 +477,99 @@ describe("project action hardening", () => {
     expect(dispatchEvent).toHaveBeenCalledWith(expect.any(CustomEvent));
     expect(dispatchEvent.mock.calls.at(-1)?.[0].type).toBe("daintree:open-settings-tab");
   });
+
+  it("project.saveSettings merges partial input over current settings", async () => {
+    mocks.projectClient.getSettings.mockResolvedValueOnce({
+      runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+      devServerCommand: "npm run dev",
+    });
+    mocks.projectClient.saveSettings.mockResolvedValueOnce(undefined);
+    const { service } = buildService(registerProjectActions);
+
+    const result = await service.dispatch(
+      "project.saveSettings",
+      { projectId: "project-1", settings: { devServerCommand: "vite" } },
+      { source: "user" }
+    );
+
+    expect(result).toEqual({ ok: true, result: undefined });
+    expect(mocks.projectClient.saveSettings).toHaveBeenCalledWith("project-1", {
+      runCommands: [{ id: "r1", label: "dev", command: "npm run dev" }],
+      devServerCommand: "vite",
+    });
+  });
+
+  it("project.saveSettings strips daintreeMcpTier and exposeDaintreeMcpToAgents to block self-elevation", async () => {
+    mocks.projectClient.getSettings.mockResolvedValueOnce({
+      runCommands: [],
+      daintreeMcpTier: "workbench",
+    });
+    mocks.projectClient.saveSettings.mockResolvedValueOnce(undefined);
+    const { service } = buildService(registerProjectActions);
+
+    const result = await service.dispatch(
+      "project.saveSettings",
+      {
+        projectId: "project-1",
+        settings: {
+          devServerCommand: "vite",
+          daintreeMcpTier: "system",
+          exposeDaintreeMcpToAgents: true,
+        },
+      },
+      { source: "user" }
+    );
+
+    expect(result).toEqual({ ok: true, result: undefined });
+    const saved = mocks.projectClient.saveSettings.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(saved.daintreeMcpTier).toBe("workbench");
+    expect(saved.exposeDaintreeMcpToAgents).toBeUndefined();
+    expect(saved.devServerCommand).toBe("vite");
+  });
+
+  it("project.muteNotifications surfaces saveSettings failures as { ok: false }", async () => {
+    mocks.projectClient.getSettings.mockResolvedValueOnce({
+      runCommands: [],
+      notificationOverrides: { completedEnabled: true },
+    });
+    mocks.projectClient.saveSettings.mockRejectedValueOnce(new Error("disk full"));
+    const { service } = buildService(registerProjectActions);
+
+    const result = await service.dispatch(
+      "project.muteNotifications",
+      { projectId: "project-1" },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("EXECUTION_ERROR");
+      expect(result.error.message).toBe("disk full");
+    }
+  });
+
+  it("project.update strips fields outside the allowlist before reaching the store", async () => {
+    const updateProject = vi.fn().mockResolvedValue(undefined);
+    useProjectStore.setState({ updateProject });
+    const { service } = buildService(registerProjectActions);
+
+    const result = await service.dispatch(
+      "project.update",
+      {
+        projectId: "project-1",
+        updates: {
+          name: "Renamed",
+          status: "missing",
+          inRepoSettings: true,
+          frecencyScore: 9999,
+        } as never,
+      },
+      { source: "user" }
+    );
+
+    expect(result).toEqual({ ok: true, result: undefined });
+    expect(updateProject).toHaveBeenCalledWith("project-1", { name: "Renamed" });
+  });
 });
 
 describe("system action hardening", () => {

--- a/src/services/actions/definitions/__tests__/projectMuteAction.test.ts
+++ b/src/services/actions/definitions/__tests__/projectMuteAction.test.ts
@@ -118,7 +118,7 @@ describe("project.muteNotifications", () => {
     getSettingsMock.mockRejectedValue(new Error("read failed"));
 
     const action = muteAction();
-    await action.run({ projectId: "p1" }, {} as never);
+    await expect(action.run({ projectId: "p1" }, {} as never)).rejects.toThrow("read failed");
 
     expect(saveSettingsMock).not.toHaveBeenCalled();
     expect(notifyMock).toHaveBeenCalledTimes(1);
@@ -134,7 +134,7 @@ describe("project.muteNotifications", () => {
     saveSettingsMock.mockRejectedValue(new Error("write failed"));
 
     const action = muteAction();
-    await action.run({ projectId: "p1" }, {} as never);
+    await expect(action.run({ projectId: "p1" }, {} as never)).rejects.toThrow("write failed");
 
     expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", message: "write failed" })

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -261,7 +261,16 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
         projectId: string;
         settings: Record<string, unknown>;
       };
-      await projectClient.saveSettings(projectId, settings as any);
+      // Merge over current settings rather than full-replace so dispatchers
+      // (notably MCP callers) cannot wipe unrelated fields by sending a
+      // partial object. Strip privilege-escalation keys before merging —
+      // the MCP-tier knob lives in ProjectSettings and must not be
+      // self-mutable by an agent.
+      const current = await projectClient.getSettings(projectId);
+      const sanitized: Record<string, unknown> = { ...settings };
+      delete sanitized.daintreeMcpTier;
+      delete sanitized.exposeDaintreeMcpToAgents;
+      await projectClient.saveSettings(projectId, { ...current, ...sanitized } as any);
     },
   }));
 
@@ -298,6 +307,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
           message: formatErrorMessage(error, "Failed to mute project notifications"),
           duration: 5000,
         });
+        throw error;
       }
     },
   }));

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -138,13 +138,21 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "command",
     danger: "confirm",
     scope: "renderer",
-    argsSchema: z.object({ projectId: z.string(), updates: z.record(z.string(), z.unknown()) }),
+    argsSchema: z.object({
+      projectId: z.string(),
+      updates: z.object({
+        name: z.string().optional(),
+        emoji: z.string().optional(),
+        color: z.string().optional(),
+        pinned: z.boolean().optional(),
+      }),
+    }),
     run: async (args: unknown) => {
       const { projectId, updates } = args as {
         projectId: string;
-        updates: Record<string, unknown>;
+        updates: { name?: string; emoji?: string; color?: string; pinned?: boolean };
       };
-      await useProjectStore.getState().updateProject(projectId, updates as any);
+      await useProjectStore.getState().updateProject(projectId, updates);
     },
   }));
 


### PR DESCRIPTION
## Summary

- Exposes `project.update`, `project.saveSettings`, and `project.muteNotifications` over MCP — the first write-capable project actions available to MCP callers
- Tightens `project.update`'s args schema to `{name?, emoji?, color?, pinned?}`, preventing arbitrary field updates through the MCP surface
- Hardens `project.saveSettings` (merge semantics, strips `daintreeMcpTier` from caller input) and `project.muteNotifications` (rethrows errors so callers see failures)

Resolves #6626

## Changes

- `src/services/actions/definitions/projectActions.ts` — tightened `project.update` schema; added merge + tier-strip logic to `project.saveSettings`; rethrow in `project.muteNotifications`
- `electron/services/McpServerService.ts` — added all three actions to `ACTION_TIER_ADDONS` and `MCP_TOOL_ALLOWLIST`
- `electron/services/__tests__/McpServerService.test.ts` — extended tier manifest, allowlist, and workbench exclusion assertions
- `src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts` — four adversarial tests: merge semantics, `daintreeMcpTier` stripping, error propagation, and field stripping on `project.update`

## Testing

131 tests pass across `McpServerService` and the project actions adversarial suite. Typecheck, lint, format, and build all clean.