### PR TITLE
fix(portal): cover full viewport width when Assistant is open

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -429,7 +429,14 @@ export function AppLayout({
       {layout.portalOpen &&
         createPortal(
           <ErrorBoundary variant="section" componentName="PortalDock">
-            <div className="fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border">
+            {/* inert mirrors the toolbar / main-content wrappers: when the
+                ThemeBrowser overlay is open, the Portal's React chrome (tabs,
+                toolbar, resize handle) must not be interactive. The native
+                WebContentsView is already hidden via PortalVisibilityController. */}
+            <div
+              {...(isThemeBrowserOpen ? { inert: true } : {})}
+              className="fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
+            >
               <PortalDock />
             </div>
           </ErrorBoundary>,

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -316,7 +316,10 @@ export function AppLayout({
 
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
-    const totalOffset = portalOffset + effectiveAssistantWidth;
+    // Portal overlays the Assistant when both are open, so the rightmost fixed
+    // obstruction is the wider of the two — not their sum. Toaster, popovers,
+    // dropdowns, ReEntrySummary, and GettingStartedChecklist all read this var.
+    const totalOffset = Math.max(portalOffset, effectiveAssistantWidth);
     document.body.style.setProperty("--portal-right-offset", `${totalOffset}px`);
 
     return () => {
@@ -383,13 +386,6 @@ export function AppLayout({
               <div className="flex-1 overflow-hidden min-h-0">{children}</div>
               {/* Terminal Dock Region - manages dock visibility and overlays */}
               <TerminalDockRegion />
-              {layout.portalOpen && (
-                <ErrorBoundary variant="section" componentName="PortalDock">
-                  <div className="absolute right-0 top-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border">
-                    <PortalDock />
-                  </div>
-                </ErrorBoundary>
-              )}
             </main>
           </ErrorBoundary>
           <ErrorBoundary variant="section" componentName="HelpPanel">
@@ -421,13 +417,22 @@ export function AppLayout({
               <div
                 className="fixed inset-y-0 z-40 pointer-events-auto"
                 style={{
-                  right: layout.portalOpen ? `${layout.portalWidth}px` : "0px",
+                  right: "var(--portal-right-offset, 0px)",
                 }}
               >
                 <ThemeBrowser />
               </div>
             </ErrorBoundary>
           </>,
+          document.body
+        )}
+      {layout.portalOpen &&
+        createPortal(
+          <ErrorBoundary variant="section" componentName="PortalDock">
+            <div className="fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border">
+              <PortalDock />
+            </div>
+          </ErrorBoundary>,
           document.body
         )}
       {window.electron?.demo && (

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -99,9 +99,25 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     expect(source).toContain(
       '"fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
     );
+    // The portal target must be document.body to escape the inert subtrees and
+    // the <main> width constraint. A different target would silently reintroduce
+    // the bug.
+    expect(source).toMatch(
+      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?<PortalDock \/>[\s\S]+?document\.body\s*\)/
+    );
     // The old in-<main> absolute wrapper must not be reintroduced.
     expect(source).not.toContain(
       '"absolute right-0 top-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+    );
+  });
+
+  it("disables the Portal chrome when the ThemeBrowser overlay is open", () => {
+    // Body-portaling moved the PortalDock out of the inert main-content
+    // wrapper, so the inert prop must be applied directly to the new wrapper.
+    // Without this, the Portal tabs / toolbar / resize handle remain clickable
+    // through the ThemeBrowser overlay (Portal is z-50, ThemeBrowser is z-40).
+    expect(source).toMatch(
+      /\{layout\.portalOpen &&\s*\n\s*createPortal\([\s\S]+?isThemeBrowserOpen \? \{ inert: true \} : \{\}[\s\S]+?<PortalDock \/>/
     );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -71,9 +71,37 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     expect(source).toContain("[showAssistant]");
   });
 
-  it("sums portal and assistant widths into --portal-right-offset", () => {
-    expect(source).toContain("portalOffset + effectiveAssistantWidth");
+  it("uses max of portal and assistant widths for --portal-right-offset (issue #6629)", () => {
+    // Portal overlays Assistant when both are open, so the rightmost fixed
+    // obstruction is max(portal, assistant), not their sum. The previous sum
+    // logic over-displaced toasts/popovers when both panels were open.
+    expect(source).toContain("Math.max(portalOffset, effectiveAssistantWidth)");
     expect(source).toContain("--portal-right-offset");
     expect(source).toMatch(/\[layout\.portalOpen, layout\.portalWidth, effectiveAssistantWidth\]/);
+    // The old sum semantics must not be reintroduced.
+    expect(source).not.toMatch(/portalOffset \+ effectiveAssistantWidth/);
+  });
+});
+
+describe("AppLayout portal viewport coverage — issue #6629", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("renders PortalDock via body portal so it covers the full viewport width", () => {
+    // Issue #6629: when the Assistant became a flex sibling of <main> in
+    // PR #6620, the Portal (rendered as `absolute right-0` inside <main>)
+    // stopped at the Assistant's left edge. Body-portaling with `position:
+    // fixed` lets the Portal escape <main>'s width and overlay the Assistant.
+    expect(source).toMatch(/\{layout\.portalOpen &&\s*\n\s*createPortal\(/);
+    expect(source).toContain(
+      '"fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+    );
+    // The old in-<main> absolute wrapper must not be reintroduced.
+    expect(source).not.toContain(
+      '"absolute right-0 top-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+    );
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -66,4 +66,15 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     // effect. A static blur here also traps any position:fixed descendants.
     expect(source).not.toMatch(/isThemeBrowserOpen && "bg-scrim-soft\/30 backdrop-blur-\[2px\]"/);
   });
+
+  it("anchors ThemeBrowser right edge via shared --portal-right-offset (issue #6629)", () => {
+    // Both the Portal and the Assistant occupy the right edge of the viewport.
+    // ThemeBrowser must step left of whichever is wider — and previously, when
+    // only the Assistant was open, ThemeBrowser used `right: "0px"` and
+    // overlapped the panel. Routing through the shared CSS var fixes both
+    // cases with a single source of truth.
+    expect(source).toContain('right: "var(--portal-right-offset, 0px)"');
+    // The old hand-computed ternary must not be reintroduced.
+    expect(source).not.toMatch(/right: layout\.portalOpen \? `\$\{layout\.portalWidth\}px` :/);
+  });
 });


### PR DESCRIPTION
## Summary

- `PortalDock` was stopping at `<main>`'s right edge instead of the viewport's right edge after #6620 promoted the Assistant to a flex sibling of `<main>`
- Hoists `PortalDock` into a body portal using `position: fixed`, mirroring how `ThemeBrowser` is positioned
- Changes `--portal-right-offset` semantics from a sum to a `max()` so the layout doesn't double-count when both panels are open simultaneously; adds a secondary fix routing `ThemeBrowser`'s inert behavior through the same shared var, with an `inert` prop on the wrapper to keep overlay behavior intact

Resolves #6629

## Changes

- `AppLayout.tsx`: wraps `PortalDock` in a `ReactDOM.createPortal` targeting `document.body`, switches from `absolute right-0` to `position: fixed` with explicit `top`/`right`/`bottom` coords; updates `--portal-right-offset` from `portalWidth + assistantWidth` to `max(portalWidth, assistantWidth)` when the portal is open; adds `inert` on the `ThemeBrowser` wrapper when `portalOpen` is true
- `AppLayout.sidebar.test.ts`: updates source-scan assertions to match the new portal structure
- `AppLayout.themeBrowser.test.ts`: adds coverage for the inert regression

## Testing

- Verified portal covers the full viewport width when Assistant is open, sits on top of the Assistant, and returns cleanly when closed
- Verified `ThemeBrowser` overlay behavior unchanged when portal is closed
- Unit tests updated and passing