### PR TITLE
fix(HelpPanel): confirm before closing assistant chat with in-flight turn

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -28,6 +28,8 @@ import { TerminalRefreshTier } from "@/types";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 const RESIZE_STEP = 10;
 
@@ -103,8 +105,10 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
   const [isResizing, setIsResizing] = useState(false);
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
+  const skipWorkingCloseConfirm = usePreferencesStore((s) => s.skipWorkingCloseConfirm);
   const animateWidth = !isResizing && !reduceAnimations;
   const isVisible = effectiveWidth > 0;
+  const [pendingAction, setPendingAction] = useState<"close" | "back" | null>(null);
 
   const {
     isOpen,
@@ -415,7 +419,7 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
     handleSelectAgent,
   ]);
 
-  const handleBack = useCallback(() => {
+  const doBack = useCallback(() => {
     const { sessionId } = useHelpPanelStore.getState();
     if (terminalId) {
       removePanel(terminalId);
@@ -426,7 +430,7 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
     clearPreferredAgent();
   }, [terminalId, removePanel, clearPreferredAgent, revokePendingSession]);
 
-  const handleClose = useCallback(() => {
+  const doClose = useCallback(() => {
     const { sessionId } = useHelpPanelStore.getState();
     if (terminalId) {
       removePanel(terminalId);
@@ -437,6 +441,42 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
     suppressSidebarResizes();
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen, revokePendingSession]);
+
+  // Confirm before discarding an in-flight assistant turn. Mirrors the
+  // CLOSE_CONFIRM_AGENT_STATES gate used by GridPanel/DockedPanel/*TabGroup
+  // and honours the same skipWorkingCloseConfirm preference, so the
+  // assistant chat behaves consistently with regular terminal close paths.
+  const shouldConfirmClose =
+    !skipWorkingCloseConfirm &&
+    terminal?.agentState !== undefined &&
+    CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState);
+
+  const handleBack = useCallback(() => {
+    if (shouldConfirmClose) {
+      setPendingAction("back");
+      return;
+    }
+    doBack();
+  }, [shouldConfirmClose, doBack]);
+
+  const handleClose = useCallback(() => {
+    if (shouldConfirmClose) {
+      setPendingAction("close");
+      return;
+    }
+    doClose();
+  }, [shouldConfirmClose, doClose]);
+
+  const handleConfirmPendingAction = useCallback(() => {
+    const action = pendingAction;
+    setPendingAction(null);
+    if (action === "close") doClose();
+    else if (action === "back") doBack();
+  }, [pendingAction, doClose, doBack]);
+
+  const handleCancelPendingAction = useCallback(() => {
+    setPendingAction(null);
+  }, []);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY (Codex/Claude/etc.) when the assistant terminal has focus
@@ -645,6 +685,20 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
           </a>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={pendingAction !== null}
+        title="Stop this agent?"
+        description={
+          pendingAction === "back"
+            ? "The agent is currently working. Switching agents will stop it."
+            : "The agent is currently working. Closing this tab will stop it."
+        }
+        confirmLabel={pendingAction === "back" ? "Stop and switch" : "Stop and close"}
+        onConfirm={handleConfirmPendingAction}
+        onClose={handleCancelPendingAction}
+        variant="destructive"
+      />
     </aside>
   );
 }

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -692,7 +692,7 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
         description={
           pendingAction === "back"
             ? "The agent is currently working. Switching agents will stop it."
-            : "The agent is currently working. Closing this tab will stop it."
+            : "The agent is currently working. Closing the assistant panel will stop it."
         }
         confirmLabel={pendingAction === "back" ? "Stop and switch" : "Stop and close"}
         onConfirm={handleConfirmPendingAction}

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -16,6 +16,7 @@ const {
   cliAvailabilityState,
   agentSettingsState,
   projectStoreState,
+  preferencesState,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNotify: vi.fn().mockReturnValue(""),
@@ -60,6 +61,7 @@ const {
   projectStoreState: {
     currentProject: null as { id: string; path: string } | null,
   },
+  preferencesState: { reduceAnimations: false, skipWorkingCloseConfirm: false },
 }));
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
@@ -169,7 +171,6 @@ vi.mock("@/store", () => {
     selector ? selector(projectStoreState) : projectStoreState;
   projectStore.getState = () => projectStoreState;
 
-  const preferencesState = { reduceAnimations: false };
   const preferencesStore = (selector?: (state: typeof preferencesState) => unknown) =>
     selector ? selector(preferencesState) : preferencesState;
   preferencesStore.getState = () => preferencesState;
@@ -193,6 +194,38 @@ vi.mock("@/store/macroFocusStore", () => {
 
 vi.mock("@/lib/sidebarToggle", () => ({
   suppressSidebarResizes: vi.fn(),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    confirmLabel,
+    cancelLabel = "Cancel",
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    description?: React.ReactNode;
+    confirmLabel: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onClose?: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog">
+        <h2 data-testid="dialog-title">{title}</h2>
+        <p data-testid="dialog-description">{description}</p>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          {cancelLabel}
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/hooks/useEscapeStack", () => ({
@@ -254,6 +287,8 @@ function resetState() {
   agentSettingsState.settings = { agents: {} };
 
   projectStoreState.currentProject = null;
+  preferencesState.reduceAnimations = false;
+  preferencesState.skipWorkingCloseConfirm = false;
   mockProvisionSession.mockReset();
   mockProvisionSession.mockResolvedValue(null);
   mockRevokeSession.mockReset();
@@ -1035,5 +1070,219 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
     const { container } = render(<HelpPanel width={380} />);
 
     expect(container.querySelector('button[aria-label="Back to agent picker"]')).not.toBeNull();
+  });
+});
+
+describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
+  it("closes immediately when the assistant is idle (no dialog)", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "idle",
+      },
+    };
+
+    const { container, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the confirm dialog when closing during an in-flight turn", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(getByTestId("dialog-description").textContent).toContain(
+      "Closing this tab will stop it"
+    );
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+  });
+
+  it("keeps the panel open when the user cancels the close dialog", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+  });
+
+  it("runs the close cleanup when the user confirms", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+    expect(helpPanelState.clearPreferredAgent).not.toHaveBeenCalled();
+  });
+
+  it("shows the back-specific copy when Back is clicked during an in-flight turn", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Back to agent picker"]')!);
+
+    expect(helpPanelState.clearPreferredAgent).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-description").textContent).toContain(
+      "Switching agents will stop it"
+    );
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and switch");
+  });
+
+  it("runs the back cleanup (without clearTerminal/setOpen) when the user confirms back", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Back to agent picker"]')!);
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(helpPanelState.clearPreferredAgent).toHaveBeenCalled();
+    expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+    expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not run back cleanup when the user cancels the back dialog", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Back to agent picker"]')!);
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.clearPreferredAgent).not.toHaveBeenCalled();
+  });
+
+  it.each(["waiting", "directing"] as const)(
+    "closes immediately for %s agent state (only 'working' triggers confirm)",
+    (state) => {
+      helpPanelState.terminalId = "term-1";
+      helpPanelState.agentId = "claude";
+      panelStoreState.panelsById = {
+        "term-1": {
+          id: "term-1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: state,
+        },
+      };
+
+      const { container, queryByTestId } = render(<HelpPanel width={380} />);
+      fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+      expect(queryByTestId("confirm-dialog")).toBeNull();
+      expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+      expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+    }
+  );
+
+  it("closes immediately when skipWorkingCloseConfirm preference is on", () => {
+    preferencesState.skipWorkingCloseConfirm = true;
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { container, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -254,6 +254,7 @@ vi.mock("../HelpAgentPicker", () => ({
 }));
 
 import { HelpPanel } from "../HelpPanel";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 
 function resetState() {
   helpPanelState.isOpen = true;
@@ -1116,7 +1117,7 @@ describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
     expect(helpPanelState.setOpen).not.toHaveBeenCalled();
     expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
     expect(getByTestId("dialog-description").textContent).toContain(
-      "Closing this tab will stop it"
+      "Closing the assistant panel will stop it"
     );
     expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
   });
@@ -1143,9 +1144,10 @@ describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
     expect(helpPanelState.setOpen).not.toHaveBeenCalled();
   });
 
-  it("runs the close cleanup when the user confirms", () => {
+  it("runs the close cleanup and revokes the bound session when the user confirms", () => {
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "sess-bound";
     panelStoreState.panelsById = {
       "term-1": {
         id: "term-1",
@@ -1164,6 +1166,7 @@ describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
     expect(helpPanelState.clearPreferredAgent).not.toHaveBeenCalled();
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
   });
 
   it("shows the back-specific copy when Back is clicked during an in-flight turn", () => {
@@ -1240,7 +1243,7 @@ describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
     expect(helpPanelState.clearPreferredAgent).not.toHaveBeenCalled();
   });
 
-  it.each(["waiting", "directing"] as const)(
+  it.each(["waiting", "directing", "completed", "exited"] as const)(
     "closes immediately for %s agent state (only 'working' triggers confirm)",
     (state) => {
       helpPanelState.terminalId = "term-1";
@@ -1284,5 +1287,38 @@ describe("HelpPanel — close/back confirmation guard (issue #6623)", () => {
     expect(queryByTestId("confirm-dialog")).toBeNull();
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
     expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("Escape inherits the guard via handleClose (working state shows dialog, no cleanup)", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    const { getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
+
+    // Capture the callback registered with useEscapeStack and invoke it
+    // directly — equivalent to a real Escape press hitting the LIFO stack
+    // when no xterm-helper-textarea has focus.
+    const escapeMock = vi.mocked(useEscapeStack);
+    const lastCall = escapeMock.mock.calls.at(-1);
+    const callback = lastCall?.[1];
+    expect(callback).toBeTypeOf("function");
+
+    act(() => {
+      callback?.();
+    });
+
+    expect(queryByTestId("confirm-dialog")).not.toBeNull();
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.setOpen).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Closing the assistant chat panel (X button or Back button in `HelpPanel`) had no in-flight confirmation, even when a turn was mid-stream. Both buttons are now gated on `CLOSE_CONFIRM_AGENT_STATES` — the same threshold used by `GridPanel`, `DockedPanel`, and `GridTabGroup`.
- Distinct copy for the two actions: Back shows "Stop and switch" (returns to the agent picker), X shows "Stop and close" (closes the panel entirely). Cleanup paths stay strictly separate. The `skipWorkingCloseConfirm` preference is honoured for parity with the other close guards.
- `handleEscape` inherits the guard automatically by delegating to `handleClose`, so Escape also prompts when a turn is in flight and the terminal doesn't have focus.

Resolves #6623

## Changes

- `HelpPanel.tsx` — added in-flight guard to `handleClose` and `handleBack`; distinct dialog copy per action; separate cleanup paths (`clearTerminal` + `setOpen` for close, `clearPreferredAgent` only for back)
- `HelpPanel.helpLaunch.test.tsx` — 11 new tests: idle close, working close (dialog shown), cancel, confirm + session revocation, back-specific copy, confirm-back cleanup separation, cancel-back, waiting/directing/completed/exited immediate close, `skipWorkingCloseConfirm` bypass, Escape inheriting the guard

## Testing

Vitest: 47 tests pass in the changed test file. Typecheck, lint, format, and build all clean.