### PR TITLE
fix(mcp): decouple tool annotations from danger/kind fields

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -2359,11 +2359,13 @@ export class McpServerService {
   }
 
   private buildAnnotations(entry: ActionManifestEntry): ToolAnnotations {
+    const overrides = entry.mcpAnnotations;
+    const isQuery = entry.kind === "query";
     return {
       title: entry.title,
-      readOnlyHint: entry.kind === "query",
-      idempotentHint: entry.kind === "query",
-      destructiveHint: entry.danger === "confirm",
+      readOnlyHint: overrides?.readOnlyHint ?? isQuery,
+      idempotentHint: overrides?.idempotentHint ?? isQuery,
+      destructiveHint: overrides?.destructiveHint ?? entry.danger === "confirm",
       openWorldHint: OPEN_WORLD_CATEGORIES.has(entry.category),
     };
   }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -577,6 +577,7 @@ describe("McpServerService", () => {
   });
 
   it("applies mcpAnnotations overrides on top of kind/danger defaults", async () => {
+    storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
         // Query that requires UX confirmation but is not destructive.
@@ -588,14 +589,25 @@ describe("McpServerService", () => {
           danger: "confirm",
           mcpAnnotations: { destructiveHint: false },
         }),
-        // Command that is semantically a read-only status query.
+        // Command that is semantically a read-only lookup; both readOnly and
+        // idempotent hints are forced on via override.
         createManifestEntry({
-          id: "worktree.resource.status" as ActionId,
-          title: "Check Resource Status",
-          description: "Check resource status for a worktree",
+          id: "test.readOnlyCommand" as ActionId,
+          title: "Read Only Command",
+          description: "Synthetic read-only command for override coverage",
           kind: "command",
           danger: "safe",
           mcpAnnotations: { readOnlyHint: true, idempotentHint: true },
+        }),
+        // Query whose readOnly/idempotent hints are explicitly forced off via
+        // override — guards against regressing the merge from `??` to `||`.
+        createManifestEntry({
+          id: "test.queryOverriddenFalse" as ActionId,
+          title: "Query With False Overrides",
+          description: "Synthetic query whose hints are explicitly false",
+          kind: "query",
+          danger: "safe",
+          mcpAnnotations: { readOnlyHint: false, idempotentHint: false },
         }),
       ],
     });
@@ -606,7 +618,8 @@ describe("McpServerService", () => {
 
     const result = await client.listTools();
     const generate = result.tools.find((t) => t.name === "copyTree.generate");
-    const status = result.tools.find((t) => t.name === "worktree.resource.status");
+    const readOnlyCmd = result.tools.find((t) => t.name === "test.readOnlyCommand");
+    const queryFalse = result.tools.find((t) => t.name === "test.queryOverriddenFalse");
 
     // Override flips destructiveHint off; readOnlyHint/idempotentHint still
     // come from the `kind: "query"` default.
@@ -620,13 +633,56 @@ describe("McpServerService", () => {
 
     // Override flips readOnly/idempotent on; destructiveHint still comes from
     // the `danger: "safe"` default.
-    expect(status?.annotations).toEqual({
-      title: "Check Resource Status",
+    expect(readOnlyCmd?.annotations).toEqual({
+      title: "Read Only Command",
       readOnlyHint: true,
       idempotentHint: true,
       destructiveHint: false,
       openWorldHint: false,
     });
+
+    // Explicit `false` overrides must win over the `kind: "query"` default —
+    // this would silently break if `??` were ever swapped for `||`.
+    expect(queryFalse?.annotations).toEqual({
+      title: "Query With False Overrides",
+      readOnlyHint: false,
+      idempotentHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+  });
+
+  it("ignores attempts to override openWorldHint via mcpAnnotations", async () => {
+    storeState.mcpServer.fullToolSurface = true;
+    const { window } = createMockWindow({
+      getManifest: () => [
+        // openWorldHint is category-derived; mcpAnnotations exposes only the
+        // three hint fields, so this entry's `category: "github"` must yield
+        // `openWorldHint: true` regardless of any per-action override.
+        createManifestEntry({
+          id: "github.someTool" as ActionId,
+          title: "Some GitHub Tool",
+          description: "Tool in an open-world category",
+          category: "github",
+          kind: "command",
+          danger: "safe",
+          mcpAnnotations: {
+            readOnlyHint: true,
+            idempotentHint: true,
+            destructiveHint: true,
+          },
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = await client.listTools();
+    const tool = result.tools.find((t) => t.name === "github.someTool");
+
+    expect(tool?.annotations?.openWorldHint).toBe(true);
   });
 
   it("sets openWorldHint true for network-bound categories and false for local ones", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -148,6 +148,7 @@ function createManifestEntry(entry: {
   enabled?: boolean;
   disabledReason?: string;
   requiresArgs?: boolean;
+  mcpAnnotations?: ActionManifestEntry["mcpAnnotations"];
 }): ActionManifestEntry {
   return {
     id: entry.id as ActionId,
@@ -162,6 +163,7 @@ function createManifestEntry(entry: {
     enabled: entry.enabled ?? true,
     disabledReason: entry.disabledReason,
     requiresArgs: entry.requiresArgs ?? false,
+    ...(entry.mcpAnnotations ? { mcpAnnotations: entry.mcpAnnotations } : {}),
   };
 }
 
@@ -570,6 +572,59 @@ describe("McpServerService", () => {
       readOnlyHint: false,
       idempotentHint: false,
       destructiveHint: true,
+      openWorldHint: false,
+    });
+  });
+
+  it("applies mcpAnnotations overrides on top of kind/danger defaults", async () => {
+    const { window } = createMockWindow({
+      getManifest: () => [
+        // Query that requires UX confirmation but is not destructive.
+        createManifestEntry({
+          id: "copyTree.generate" as ActionId,
+          title: "Generate Context",
+          description: "Generate worktree context",
+          kind: "query",
+          danger: "confirm",
+          mcpAnnotations: { destructiveHint: false },
+        }),
+        // Command that is semantically a read-only status query.
+        createManifestEntry({
+          id: "worktree.resource.status" as ActionId,
+          title: "Check Resource Status",
+          description: "Check resource status for a worktree",
+          kind: "command",
+          danger: "safe",
+          mcpAnnotations: { readOnlyHint: true, idempotentHint: true },
+        }),
+      ],
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    const result = await client.listTools();
+    const generate = result.tools.find((t) => t.name === "copyTree.generate");
+    const status = result.tools.find((t) => t.name === "worktree.resource.status");
+
+    // Override flips destructiveHint off; readOnlyHint/idempotentHint still
+    // come from the `kind: "query"` default.
+    expect(generate?.annotations).toEqual({
+      title: "Generate Context",
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+
+    // Override flips readOnly/idempotent on; destructiveHint still comes from
+    // the `danger: "safe"` default.
+    expect(status?.annotations).toEqual({
+      title: "Check Resource Status",
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
       openWorldHint: false,
     });
   });

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -9,6 +9,22 @@ export type ActionDanger = "safe" | "confirm" | "restricted";
 
 export type ActionScope = "renderer";
 
+/**
+ * Explicit MCP tool annotation overrides. Only the hints that can be
+ * meaningfully decoupled from `kind`/`danger` are exposed here — `title` is
+ * always sourced from the action title and `openWorldHint` is derived from the
+ * action category. Provide an override only when the heuristic from `kind` and
+ * `danger` doesn't reflect the action's true semantics for an MCP client (for
+ * example, a query that requires UX confirmation, or a status command that is
+ * read-only). Defined inline (no `@modelcontextprotocol/sdk` import) so this
+ * type stays usable from the renderer.
+ */
+export interface ActionMcpAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+}
+
 export type BuiltInActionId =
   | BuiltInKeyAction
   // Query actions for App Agent
@@ -369,6 +385,11 @@ export interface ActionDefinition<
   nonRepeatable?: boolean;
   /** Synonyms and alternative mental-model terms for palette search. */
   keywords?: string[];
+  /**
+   * Per-action MCP tool annotation overrides. Use sparingly — only when the
+   * defaults derived from `kind` and `danger` would mislead an MCP client.
+   */
+  mcpAnnotations?: ActionMcpAnnotations;
 }
 
 export interface ActionManifestEntry {
@@ -389,6 +410,8 @@ export interface ActionManifestEntry {
   disabledReason?: string;
   requiresArgs: boolean;
   keywords?: string[];
+  /** Per-action MCP tool annotation overrides. */
+  mcpAnnotations?: ActionMcpAnnotations;
   /** Set when this action was registered by a plugin (not a built-in). */
   pluginId?: string;
 }

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -326,6 +326,7 @@ export class ActionService {
           !definition.argsSchema.safeParse({}).success
         : rawSchemaRequiresArgs(definition.rawInputSchema),
       keywords: definition.keywords?.slice(),
+      ...(definition.mcpAnnotations ? { mcpAnnotations: { ...definition.mcpAnnotations } } : {}),
       ...(definition.pluginId ? { pluginId: definition.pluginId } : {}),
     };
   }

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -549,6 +549,71 @@ describe("ActionService", () => {
       expect(manifest[0]!.keywords).toBeUndefined();
     });
 
+    it("should propagate mcpAnnotations to manifest entries", () => {
+      const action: ActionDefinition = {
+        id: "actions.annotated" as ActionId,
+        title: "Annotated Action",
+        description: "An action with explicit MCP overrides",
+        category: "test",
+        kind: "query",
+        danger: "confirm",
+        scope: "renderer",
+        mcpAnnotations: { destructiveHint: false, readOnlyHint: true, idempotentHint: false },
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+
+      service.register(action);
+      const manifest = service.list();
+
+      expect(manifest[0]!.mcpAnnotations).toEqual({
+        destructiveHint: false,
+        readOnlyHint: true,
+        idempotentHint: false,
+      });
+    });
+
+    it("should omit mcpAnnotations when not defined", () => {
+      const action: ActionDefinition = {
+        id: "actions.unannotated" as ActionId,
+        title: "Unannotated Action",
+        description: "An action without explicit MCP overrides",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+
+      service.register(action);
+      const manifest = service.list();
+
+      expect(manifest[0]!.mcpAnnotations).toBeUndefined();
+    });
+
+    it("should isolate mcpAnnotations from caller mutations", () => {
+      // Returned manifest entries must not share references with the
+      // registered definition, so a caller that mutates entry.mcpAnnotations
+      // can't poison subsequent list() reads.
+      const action: ActionDefinition = {
+        id: "actions.isolated" as ActionId,
+        title: "Isolated Action",
+        description: "Mutation-isolation guard",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        scope: "renderer",
+        mcpAnnotations: { destructiveHint: false },
+        run: vi.fn().mockResolvedValue(undefined),
+      };
+
+      service.register(action);
+      const first = service.list()[0]!;
+      first.mcpAnnotations!.destructiveHint = true;
+
+      const second = service.list()[0]!;
+      expect(second.mcpAnnotations).toEqual({ destructiveHint: false });
+    });
+
     it("normalizes undefined title/description to empty strings on manifest entries", () => {
       // Regression: #6120 — IPC-sourced plugin actions could arrive with
       // undefined title or description even though the type system says

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -210,6 +210,9 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       danger: "confirm",
       scope: "renderer",
       keywords: ["context", "dump", "snapshot", "tree"],
+      // `danger: "confirm"` gates the UI on a token-cost confirmation, but the
+      // operation itself is read-only and not destructive.
+      mcpAnnotations: { destructiveHint: false },
       argsSchema: z.object({ worktreeId: z.string(), options: CopyTreeOptionsSchema.optional() }),
       run: async ({ worktreeId, options }) => {
         return await copyTreeClient.generate(worktreeId, options);
@@ -226,6 +229,8 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "confirm",
       scope: "renderer",
+      // Writes to clipboard only; not a destructive world-state mutation.
+      mcpAnnotations: { destructiveHint: false },
       argsSchema: z.object({ worktreeId: z.string(), options: CopyTreeOptionsSchema.optional() }),
       run: async ({ worktreeId, options }) => {
         return await copyTreeClient.generateAndCopyFile(worktreeId, options);

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -1103,6 +1103,9 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       kind: "command",
       danger: "safe",
       scope: "renderer",
+      // Pure status query — `kind: "command"` is retained for UI-routing
+      // semantics, but MCP clients should see this as a read-only call.
+      mcpAnnotations: { readOnlyHint: true, idempotentHint: true },
       argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -1103,9 +1103,6 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       kind: "command",
       danger: "safe",
       scope: "renderer",
-      // Pure status query — `kind: "command"` is retained for UI-routing
-      // semantics, but MCP clients should see this as a read-only call.
-      mcpAnnotations: { readOnlyHint: true, idempotentHint: true },
       argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
       run: async (args, ctx: ActionContext) => {
         const worktreeId = args?.worktreeId;


### PR DESCRIPTION
## Summary

- `destructiveHint` was derived solely from the `danger` field, so any UX-gated action got flagged destructive even when the underlying operation is read-only. Cursor and Claude Desktop honour these hints with mandatory modals and dialog bypasses, so the false positives were a real UX problem.
- Adds an optional `ActionMcpAnnotations` override type (three hint booleans) to `ActionDefinition` and `ActionManifestEntry`, threaded through `toManifestEntry`. `buildAnnotations` uses per-key nullish-coalescing, so overrides win without touching `title` or `openWorldHint`.
- Applies `destructiveHint: false` to `copyTree.generate` and `copyTree.generateAndCopyFile`. `worktree.resource.status` was reviewed and intentionally left without an override — it runs a shell command, mutates lifecycle state, and may write a wrapper file, so the defaults are correct.

Resolves #6630

## Changes

- `electron/services/McpServerService.ts` — `buildAnnotations` switches from danger/kind derivation to nullish-coalescing against the per-action override
- `shared/types/actions.ts` — `ActionMcpAnnotations` interface, added to `ActionDefinition` and `ActionManifestEntry`
- `src/services/ActionService.ts` — threads `mcpAnnotations` through `toManifestEntry`
- `src/services/actions/definitions/systemActions.ts` — `destructiveHint: false` overrides on `copyTree.generate` and `copyTree.generateAndCopyFile`

## Testing

Five new test cases in `McpServerService.test.ts` and `ActionService.test.ts` covering: override merging in both directions, `openWorldHint` immunity, `ActionService` propagation, and mutation isolation.