### PR TITLE
feat(mcp): single worktree creation tool with PR support

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -227,7 +227,6 @@ const WORKBENCH_TOOLS: ReadonlySet<string> = new Set([
  * GitHub URLs.
  */
 const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
-  "worktree.create",
   "worktree.createWithRecipe",
   "worktree.setActive",
   "worktree.refresh",
@@ -331,7 +330,6 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "worktree.list",
   "worktree.getCurrent",
   "worktree.refresh",
-  "worktree.create",
   "worktree.createWithRecipe",
   "worktree.listBranches",
   "worktree.getDefaultPath",

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1571,6 +1571,11 @@ describe("McpServerService", () => {
         title: "Create Worktree",
         description: "Create a new worktree",
       }),
+      createManifestEntry({
+        id: "worktree.createWithRecipe" as ActionId,
+        title: "Create Worktree with Recipe",
+        description: "Create worktree, optionally check out a PR, optionally run a recipe",
+      }),
       // System-only tools — irreversible or externally-visible mutations.
       createManifestEntry({
         id: "git.commit" as ActionId,
@@ -1716,7 +1721,8 @@ describe("McpServerService", () => {
 
       const ids = (await client.listTools()).tools.map((tool) => tool.name);
       expect(ids).toContain("worktree.list");
-      expect(ids).toContain("worktree.create");
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).toContain("worktree.createWithRecipe");
       for (const id of ACTION_TIER_TOOLS) {
         expect(ids).toContain(id);
       }
@@ -1740,7 +1746,8 @@ describe("McpServerService", () => {
 
       const ids = (await client.listTools()).tools.map((tool) => tool.name);
       expect(ids).toContain("worktree.list");
-      expect(ids).toContain("worktree.create");
+      expect(ids).not.toContain("worktree.create");
+      expect(ids).toContain("worktree.createWithRecipe");
       for (const id of ACTION_TIER_TOOLS) {
         expect(ids).toContain(id);
       }

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1325,7 +1325,7 @@ describe("McpServerService", () => {
       const ids = [
         "actions.list",
         "worktree.list",
-        "worktree.create",
+        "worktree.createWithRecipe",
         "worktree.delete",
         "terminal.list",
         "terminal.inject",
@@ -1368,7 +1368,10 @@ describe("McpServerService", () => {
 
       // Mutation denied — workbench cannot create worktrees
       const denied = getTextResult(
-        await client.callTool({ name: "worktree.create", arguments: { name: "x" } })
+        await client.callTool({
+          name: "worktree.createWithRecipe",
+          arguments: { branchName: "x" },
+        })
       );
       expect(denied.isError).toBe(true);
       expect(denied.content[0].text).toContain("TIER_NOT_PERMITTED");
@@ -1399,6 +1402,7 @@ describe("McpServerService", () => {
       expect(ids).toContain("terminal.list");
       // Mutations and destructive operations are absent.
       expect(ids).not.toContain("worktree.create");
+      expect(ids).not.toContain("worktree.createWithRecipe");
       expect(ids).not.toContain("worktree.delete");
       expect(ids).not.toContain("terminal.inject");
       expect(ids).not.toContain("terminal.sendCommand");
@@ -1425,6 +1429,10 @@ describe("McpServerService", () => {
       // External tier inherits the legacy MCP_TOOL_ALLOWLIST — destructive
       // actions in that list (e.g. terminal.sendCommand, worktree.delete)
       // remain callable so existing user-facing clients keep working.
+      const ids = (await client.listTools()).tools.map((t) => t.name);
+      expect(ids).toContain("worktree.createWithRecipe");
+      expect(ids).not.toContain("worktree.create");
+
       const result = getTextResult(
         await client.callTool({
           name: "terminal.sendCommand",

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
@@ -46,6 +47,7 @@ vi.mock("@/store/createWorktreeStore", () => currentViewStoreMock);
 vi.mock("@/store/panelStore", () => ({ usePanelStore: panelStoreMock }));
 vi.mock("@/store/slices/panelRegistry", () => selectorMock);
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 (globalThis as unknown as { window: { electron: { git: { getStagingStatus: unknown } } } }).window =
   { electron: { git: { getStagingStatus: gitGetStagingStatusMock } } };
 
@@ -63,11 +65,13 @@ function makeCallbacks(): MockCallbacks & Pick<ActionCallbacks, "onLaunchAgent">
 
 function setupActions(callbacks: MockCallbacks) {
   const actions: ActionRegistry = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   registerWorkflowActions(actions, callbacks as unknown as Pick<ActionCallbacks, "onLaunchAgent">);
   return (id: string) => {
     const factory = actions.get(id);
     if (!factory) throw new Error(`missing ${id}`);
-    return factory() as AnyActionDefinition;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return factory() as unknown as AnyActionDefinition;
   };
 }
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -5,10 +5,12 @@ const worktreeClientMock = vi.hoisted(() => ({
   getAvailableBranch: vi.fn(),
   getDefaultPath: vi.fn(),
   create: vi.fn(),
+  fetchPRBranch: vi.fn(),
 }));
 
 const githubClientMock = vi.hoisted(() => ({
   getIssueByNumber: vi.fn(),
+  getPRByNumber: vi.fn(),
   assignIssue: vi.fn(),
 }));
 
@@ -122,6 +124,7 @@ beforeEach(() => {
   worktreeClientMock.getAvailableBranch.mockResolvedValue("feature/issue-6609-add-tools");
   worktreeClientMock.getDefaultPath.mockResolvedValue("/repo/feature/issue-6609-add-tools");
   worktreeClientMock.create.mockResolvedValue("wt-new");
+  worktreeClientMock.fetchPRBranch.mockResolvedValue(undefined);
   githubClientMock.assignIssue.mockResolvedValue(undefined);
   copyTreeClientMock.injectToTerminal.mockResolvedValue(undefined);
   setProject({ id: "p1", path: "/repo" });
@@ -136,6 +139,143 @@ beforeEach(() => {
     isInTrash: vi.fn().mockReturnValue(false),
     focusNextWaiting: vi.fn(),
     focusNextWorking: vi.fn(),
+  });
+});
+
+describe("worktree.createWithRecipe", () => {
+  it("happy path: resolves available branch, creates worktree, returns identifiers", async () => {
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    const result = (await def.run({ branchName: "feature/foo" }, {} as never)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(worktreeClientMock.getAvailableBranch).toHaveBeenCalledWith("/repo", "feature/foo");
+    expect(worktreeClientMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseBranch: "main",
+        newBranch: "feature/issue-6609-add-tools",
+        path: "/repo/feature/issue-6609-add-tools",
+        fromRemote: false,
+        useExistingBranch: false,
+      }),
+      "/repo"
+    );
+    expect(githubClientMock.getPRByNumber).not.toHaveBeenCalled();
+    expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
+    expect(result.worktreeId).toBe("wt-new");
+    expect(result.branch).toBe("feature/issue-6609-add-tools");
+    expect(result.recipeLaunched).toBe(false);
+  });
+
+  it("PR path: resolves head branch, fetches PR, creates worktree on existing local branch", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue({
+      number: 42,
+      headRefName: "contrib/feature-x",
+      title: "Some PR",
+      url: "https://github.com/x/y/pull/42",
+    });
+    worktreeClientMock.getDefaultPath.mockResolvedValue("/repo/contrib/feature-x");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    const result = (await def.run({ pullRequestNumber: 42 }, {} as never)) as Record<
+      string,
+      unknown
+    >;
+
+    expect(githubClientMock.getPRByNumber).toHaveBeenCalledWith("/repo", 42);
+    expect(worktreeClientMock.fetchPRBranch).toHaveBeenCalledWith("/repo", 42, "contrib/feature-x");
+    // PR path uses the head ref directly — must not call getAvailableBranch (which would suffix on conflict).
+    expect(worktreeClientMock.getAvailableBranch).not.toHaveBeenCalled();
+    expect(worktreeClientMock.getDefaultPath).toHaveBeenCalledWith("/repo", "contrib/feature-x");
+    expect(worktreeClientMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseBranch: "contrib/feature-x",
+        newBranch: "contrib/feature-x",
+        path: "/repo/contrib/feature-x",
+        fromRemote: false,
+        useExistingBranch: true,
+      }),
+      "/repo"
+    );
+    expect(result.branch).toBe("contrib/feature-x");
+    expect(result.worktreeId).toBe("wt-new");
+  });
+
+  it("PR path throws when the PR is not found", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue(null);
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({ pullRequestNumber: 999 }, {} as never)).rejects.toThrow(
+      /Pull request #999 not found/
+    );
+    expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+  });
+
+  it("PR path throws when headRefName is missing on the resolved PR", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue({
+      number: 42,
+      title: "x",
+      url: "u",
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({ pullRequestNumber: 42 }, {} as never)).rejects.toThrow(/no head branch/);
+    expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+  });
+
+  it("PR path surfaces fetchPRBranch failures (no worktree created)", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue({
+      number: 42,
+      headRefName: "contrib/x",
+      title: "x",
+      url: "u",
+    });
+    worktreeClientMock.fetchPRBranch.mockRejectedValue(new Error("git fetch failed"));
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({ pullRequestNumber: 42 }, {} as never)).rejects.toThrow(
+      /git fetch failed/
+    );
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects calls that supply both issueNumber and pullRequestNumber", async () => {
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(
+      def.run({ branchName: "feature/foo", issueNumber: 1, pullRequestNumber: 2 }, {} as never)
+    ).rejects.toThrow(/mutually exclusive/);
+  });
+
+  it("non-PR path requires branchName at runtime", async () => {
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({}, {} as never)).rejects.toThrow(/branchName is required/);
+  });
+
+  it("recipe runs with the PR's branch name when pullRequestNumber is provided", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue({
+      number: 42,
+      headRefName: "contrib/feature-x",
+      title: "x",
+      url: "u",
+    });
+    worktreeClientMock.getDefaultPath.mockResolvedValue("/repo/contrib/feature-x");
+    const runRecipe = vi.fn().mockResolvedValue(undefined);
+    recipeStoreMock.getState.mockReturnValue({
+      getRecipeById: vi.fn().mockReturnValue({ id: "recipe-1" }),
+      runRecipe,
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    const result = (await def.run(
+      { pullRequestNumber: 42, recipeId: "recipe-1" },
+      {} as never
+    )) as Record<string, unknown>;
+    expect(runRecipe).toHaveBeenCalledWith(
+      "recipe-1",
+      "/repo/contrib/feature-x",
+      "wt-new",
+      expect.objectContaining({ branchName: "contrib/feature-x" })
+    );
+    expect(result.recipeLaunched).toBe(true);
   });
 });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -251,7 +251,7 @@ describe("worktree.createWithRecipe", () => {
     await expect(def.run({}, {} as never)).rejects.toThrow(/branchName is required/);
   });
 
-  it("recipe runs with the PR's branch name when pullRequestNumber is provided", async () => {
+  it("recipe context carries prNumber (not issueNumber) when pullRequestNumber is provided", async () => {
     githubClientMock.getPRByNumber.mockResolvedValue({
       number: 42,
       headRefName: "contrib/feature-x",
@@ -269,13 +269,44 @@ describe("worktree.createWithRecipe", () => {
       { pullRequestNumber: 42, recipeId: "recipe-1" },
       {} as never
     )) as Record<string, unknown>;
-    expect(runRecipe).toHaveBeenCalledWith(
-      "recipe-1",
-      "/repo/contrib/feature-x",
-      "wt-new",
-      expect.objectContaining({ branchName: "contrib/feature-x" })
-    );
+    expect(runRecipe).toHaveBeenCalledWith("recipe-1", "/repo/contrib/feature-x", "wt-new", {
+      worktreePath: "/repo/contrib/feature-x",
+      branchName: "contrib/feature-x",
+      issueNumber: undefined,
+      prNumber: 42,
+    });
     expect(result.recipeLaunched).toBe(true);
+  });
+
+  it("recipe failure after worktree creation throws PARTIAL_SUCCESS with worktree info", async () => {
+    setRecipe("recipe-1", async () => {
+      throw new Error("recipe boom");
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    try {
+      await def.run({ branchName: "feature/foo", recipeId: "recipe-1" }, {} as never);
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toMatch(/^PARTIAL_SUCCESS:\s+\{/);
+      const payload = JSON.parse(message.slice(message.indexOf("{")));
+      expect(payload.message).toContain("recipe boom");
+      expect(payload.partialResult.worktreeId).toBe("wt-new");
+      expect(payload.partialResult.recipeLaunched).toBe(false);
+    }
+    expect(worktreeClientMock.create).toHaveBeenCalled();
+  });
+
+  it("treats empty-string headRefName the same as missing", async () => {
+    githubClientMock.getPRByNumber.mockResolvedValue({
+      number: 42,
+      headRefName: "",
+      title: "x",
+      url: "u",
+    });
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+    await expect(def.run({ pullRequestNumber: 42 }, {} as never)).rejects.toThrow(/no head branch/);
+    expect(worktreeClientMock.fetchPRBranch).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/actions/definitions/workflowActions.ts
+++ b/src/services/actions/definitions/workflowActions.ts
@@ -38,7 +38,7 @@ export function registerWorkflowActions(
       id: "worktree.createWithRecipe",
       title: "Create Worktree with Recipe",
       description:
-        "Create a worktree with branch and path setup, optionally check out a PR's head branch, optionally run a recipe, and optionally assign the linked issue.",
+        "Create a worktree with branch setup, optionally from a PR, with recipe and issue assignment.",
       category: "worktree",
       kind: "command",
       danger: "safe",

--- a/src/services/actions/definitions/workflowActions.ts
+++ b/src/services/actions/definitions/workflowActions.ts
@@ -38,38 +38,53 @@ export function registerWorkflowActions(
       id: "worktree.createWithRecipe",
       title: "Create Worktree with Recipe",
       description:
-        "Create a worktree with branch and path setup, optionally run a recipe, and optionally assign the linked issue.",
+        "Create a worktree with branch and path setup, optionally check out a PR's head branch, optionally run a recipe, and optionally assign the linked issue.",
       category: "worktree",
       kind: "command",
       danger: "safe",
       scope: "renderer",
-      argsSchema: z.object({
-        branchName: z
-          .string()
-          .trim()
-          .min(1)
-          .describe("Name for the new branch (will be sanitized for git compatibility)"),
-        baseBranch: z
-          .string()
-          .trim()
-          .min(1)
-          .optional()
-          .describe("Branch to base the worktree on (defaults to main worktree's branch)"),
-        recipeId: z.string().optional().describe("Recipe ID to run after creation"),
-        fromRemote: z.boolean().optional().describe("Set true if baseBranch is a remote branch"),
-        useExistingBranch: z
-          .boolean()
-          .optional()
-          .describe("Use an existing branch instead of creating a new one"),
-        issueNumber: z
-          .number()
-          .optional()
-          .describe("GitHub issue number to link with the worktree"),
-        assignToSelf: z
-          .boolean()
-          .optional()
-          .describe("Explicitly assign the linked issue to the current user (default: false)"),
-      }),
+      argsSchema: z
+        .object({
+          branchName: z
+            .string()
+            .trim()
+            .min(1)
+            .optional()
+            .describe(
+              "Name for the new branch (will be sanitized for git compatibility). Required unless pullRequestNumber is provided — the PR's head branch is used in that case."
+            ),
+          baseBranch: z
+            .string()
+            .trim()
+            .min(1)
+            .optional()
+            .describe("Branch to base the worktree on (defaults to main worktree's branch)"),
+          recipeId: z.string().optional().describe("Recipe ID to run after creation"),
+          fromRemote: z.boolean().optional().describe("Set true if baseBranch is a remote branch"),
+          useExistingBranch: z
+            .boolean()
+            .optional()
+            .describe("Use an existing branch instead of creating a new one"),
+          issueNumber: z
+            .number()
+            .optional()
+            .describe(
+              "GitHub issue number to link with the worktree. Mutually exclusive with pullRequestNumber."
+            ),
+          pullRequestNumber: z
+            .number()
+            .optional()
+            .describe(
+              "GitHub pull request number to check out. Resolves the PR's head branch automatically and creates the worktree on it. Mutually exclusive with issueNumber."
+            ),
+          assignToSelf: z
+            .boolean()
+            .optional()
+            .describe("Explicitly assign the linked issue to the current user (default: false)"),
+        })
+        .refine((d) => !(d.issueNumber !== undefined && d.pullRequestNumber !== undefined), {
+          message: "issueNumber and pullRequestNumber are mutually exclusive",
+        }),
       resultSchema: z.object({
         worktreeId: z.string(),
         worktreePath: z.string(),
@@ -84,30 +99,19 @@ export function registerWorkflowActions(
         fromRemote,
         useExistingBranch,
         issueNumber,
+        pullRequestNumber,
         assignToSelf,
       }) => {
+        if (issueNumber !== undefined && pullRequestNumber !== undefined) {
+          throw new Error("issueNumber and pullRequestNumber are mutually exclusive");
+        }
+
         const currentProject = useProjectStore.getState().currentProject;
         if (!currentProject) {
           throw new Error("No active project");
         }
 
         const rootPath = currentProject.path;
-
-        let baseRef: string | undefined = baseBranch;
-        if (!baseRef) {
-          const mainWorktree = Array.from(getCurrentViewStore().getState().worktrees.values()).find(
-            (w) => w.isMainWorktree
-          );
-          if (!mainWorktree) {
-            throw new Error(
-              "No base branch specified and no main worktree found. Please specify baseBranch parameter."
-            );
-          }
-          baseRef = mainWorktree.branch;
-        }
-        if (!baseRef) {
-          throw new Error("Base branch is required but was not determined");
-        }
 
         if (recipeId) {
           const recipe = useRecipeStore.getState().getRecipeById(recipeId);
@@ -118,16 +122,61 @@ export function registerWorkflowActions(
           }
         }
 
-        const availableBranch = await worktreeClient.getAvailableBranch(rootPath, branchName);
-        const path = await worktreeClient.getDefaultPath(rootPath, availableBranch);
+        let effectiveBranch: string;
+        let effectiveBase: string;
+        let effectiveUseExisting: boolean;
+        let effectiveFromRemote: boolean;
+
+        if (pullRequestNumber !== undefined) {
+          const pr = await githubClient.getPRByNumber(rootPath, pullRequestNumber);
+          if (!pr) {
+            throw new Error(`Pull request #${pullRequestNumber} not found in ${rootPath}`);
+          }
+          if (!pr.headRefName) {
+            throw new Error(
+              `Pull request #${pullRequestNumber} has no head branch — cannot create worktree`
+            );
+          }
+          // fetchPRBranch uses pull/N/head:branch refspec so fork PR branches resolve too.
+          await worktreeClient.fetchPRBranch(rootPath, pullRequestNumber, pr.headRefName);
+          effectiveBranch = pr.headRefName;
+          effectiveBase = pr.headRefName;
+          effectiveUseExisting = true;
+          effectiveFromRemote = false;
+        } else {
+          if (!branchName) {
+            throw new Error("branchName is required when pullRequestNumber is not provided");
+          }
+          let baseRef: string | undefined = baseBranch;
+          if (!baseRef) {
+            const mainWorktree = Array.from(
+              getCurrentViewStore().getState().worktrees.values()
+            ).find((w) => w.isMainWorktree);
+            if (!mainWorktree) {
+              throw new Error(
+                "No base branch specified and no main worktree found. Please specify baseBranch parameter."
+              );
+            }
+            baseRef = mainWorktree.branch;
+          }
+          if (!baseRef) {
+            throw new Error("Base branch is required but was not determined");
+          }
+          effectiveBranch = await worktreeClient.getAvailableBranch(rootPath, branchName);
+          effectiveBase = baseRef;
+          effectiveUseExisting = useExistingBranch ?? false;
+          effectiveFromRemote = fromRemote ?? false;
+        }
+
+        const path = await worktreeClient.getDefaultPath(rootPath, effectiveBranch);
 
         const worktreeId = await worktreeClient.create(
           {
-            baseBranch: baseRef,
-            newBranch: availableBranch,
+            baseBranch: effectiveBase,
+            newBranch: effectiveBranch,
             path,
-            fromRemote: fromRemote ?? false,
-            useExistingBranch: useExistingBranch ?? false,
+            fromRemote: effectiveFromRemote,
+            useExistingBranch: effectiveUseExisting,
           },
           rootPath
         );
@@ -140,7 +189,7 @@ export function registerWorkflowActions(
         if (recipeId) {
           await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, {
             worktreePath: path,
-            branchName: availableBranch,
+            branchName: effectiveBranch,
             issueNumber,
           });
           recipeLaunched = true;
@@ -162,7 +211,7 @@ export function registerWorkflowActions(
         return {
           worktreeId,
           worktreePath: path,
-          branch: availableBranch,
+          branch: effectiveBranch,
           recipeLaunched,
           assignedToSelf,
         };

--- a/src/services/actions/definitions/workflowActions.ts
+++ b/src/services/actions/definitions/workflowActions.ts
@@ -73,6 +73,8 @@ export function registerWorkflowActions(
             ),
           pullRequestNumber: z
             .number()
+            .int()
+            .positive()
             .optional()
             .describe(
               "GitHub pull request number to check out. Resolves the PR's head branch automatically and creates the worktree on it. Mutually exclusive with issueNumber."
@@ -187,12 +189,26 @@ export function registerWorkflowActions(
 
         let recipeLaunched = false;
         if (recipeId) {
-          await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, {
-            worktreePath: path,
-            branchName: effectiveBranch,
-            issueNumber,
-          });
-          recipeLaunched = true;
+          try {
+            await useRecipeStore.getState().runRecipe(recipeId, path, worktreeId, {
+              worktreePath: path,
+              branchName: effectiveBranch,
+              issueNumber,
+              prNumber: pullRequestNumber,
+            });
+            recipeLaunched = true;
+          } catch (err) {
+            throw partialSuccessError(
+              `Recipe ${recipeId} failed to run: ${formatErrorMessage(err, "unknown error")}`,
+              {
+                worktreeId,
+                worktreePath: path,
+                branch: effectiveBranch,
+                recipeLaunched: false,
+                assignedToSelf: false,
+              }
+            );
+          }
         }
 
         let assignedToSelf = false;


### PR DESCRIPTION
## Summary

- Removes `worktree.create` from the MCP tier sets so agents see only `worktree.createWithRecipe` — the orchestrator is a strict superset and there's no reason to surface both
- Adds `pullRequestNumber` to `worktree.createWithRecipe`: auto-resolves the PR's head branch via `githubClient.getPRByNumber`, fetches it locally with `worktreeClient.fetchPRBranch`, then creates the worktree — mirrors the existing from-issue path
- Wraps `runRecipe` in try/catch returning `PARTIAL_SUCCESS` so callers don't lose track of an orphan worktree if the recipe fails after creation

Resolves #6622

## Changes

- `McpServerService.ts` — dropped `worktree.create` from both the action tier and external allowlist
- `workflowActions.ts` — extended `worktree.createWithRecipe` schema with optional `pullRequestNumber` (mutually exclusive with `issueNumber`); `branchName` is now required only on the non-PR path; passes `prNumber` into `RecipeContext` so `{{pr_number}}` expands correctly
- `workflowActions.adversarial.test.ts` — 8 new cases: PR happy path, PR-not-found, missing/empty `headRefName`, `fetchPRBranch` failure, mutual exclusion (schema + runtime), `branchName`-required runtime check, recipe context shape, and `PARTIAL_SUCCESS` on recipe failure
- `McpServerService.test.ts` — updated tier assertions and external-tier `listTools` expectations

## Testing

Unit tests cover the full PR path — happy path through to `PARTIAL_SUCCESS` on recipe failure, plus all the error branches (`getPRByNumber` returning null, empty `headRefName`, `fetchPRBranch` throwing). Existing from-issue and blank-creation paths are unchanged and still covered by the pre-existing test suite.