### PR TITLE
feat(mcp): add terminal.waitUntilIdle native MCP tool (#6636)

### DIFF
--- a/electron/services/AgentAvailabilityStore.ts
+++ b/electron/services/AgentAvailabilityStore.ts
@@ -157,6 +157,22 @@ export class AgentAvailabilityStore {
   }
 
   /**
+   * Resolve the agentId associated with a terminal, if any.
+   * Returns undefined for terminals that have never spawned an agent (e.g. plain shells).
+   */
+  getAgentIdForTerminal(terminalId: string): string | undefined {
+    return this.terminalToAgent.get(terminalId);
+  }
+
+  /**
+   * Timestamp (ms) of the most recent state transition for an agent, sourced from the
+   * canonical event payload rather than wall-clock time.
+   */
+  getLastStateChange(agentId: string): number | undefined {
+    return this.lastStateChange.get(agentId);
+  }
+
+  /**
    * Get the number of concurrent tasks assigned to an agent.
    */
   getConcurrentTaskCount(agentId: string): number {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1532,9 +1532,13 @@ export class McpServerService {
         };
 
         // 1. Subscribe BEFORE reading current state to avoid losing a
-        //    transition that fires between read and subscribe.
+        //    transition that fires between read and subscribe. Filter on
+        //    `terminalId` because `agentId` is the agent *type* (e.g.
+        //    "claude") and is shared across every terminal running that
+        //    agent — without the per-terminal filter another Claude
+        //    terminal completing would falsely satisfy this wait.
         unsubscribe = events.on("agent:state-changed", (payload) => {
-          if (payload.agentId !== agentId) return;
+          if (payload.terminalId !== terminalId) return;
           if (payload.state === "working") return;
           settle({
             kind: "transition",

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -41,12 +41,96 @@ import { summarizeMcpArgs } from "../../shared/utils/mcpArgsSummary.js";
 import { mcpPaneConfigService } from "./McpPaneConfigService.js";
 import { events } from "./events.js";
 import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
+import type { AgentState } from "../../shared/types/agent.js";
 
 const MCP_SERVER_KEY = "daintree";
 
 const DEFAULT_PORT = 45454;
 const MAX_PORT_RETRIES = 10;
 const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * Native MCP tool — implemented entirely in this service rather than backed by
+ * a renderer action. Used as the assistant's await primitive: long-poll a
+ * terminal until its agent transitions out of `working` (or times out, or the
+ * client cancels).
+ */
+const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
+
+/** Default ceiling on how long a single waitUntilIdle call may block. */
+const DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** Hard upper bound; clients that pass higher values are clamped silently. */
+const MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+
+type WaitUntilIdleResult = {
+  terminalId: string;
+  agentId?: string;
+  busyState: "working" | "idle";
+  idleReason?: "idle" | "waiting_for_user" | "completed" | "exited" | "unknown";
+  previousBusyState?: "working" | "idle";
+  lastTransitionAt?: number;
+  timedOut: boolean;
+};
+
+const WAIT_UNTIL_IDLE_INPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    terminalId: {
+      type: "string",
+      description: "Panel UUID returned by `terminal.list` (the `id` field).",
+    },
+    timeoutMs: {
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+      description: `Maximum time to block in milliseconds. Defaults to ${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000} minutes); clamped to ${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000 / 60} hours). Use 0 for an immediate snapshot.`,
+    },
+  },
+  required: ["terminalId"],
+  additionalProperties: false,
+};
+
+const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    terminalId: { type: "string" },
+    agentId: { type: "string" },
+    busyState: { type: "string", enum: ["working", "idle"] },
+    idleReason: {
+      type: "string",
+      enum: ["idle", "waiting_for_user", "completed", "exited", "unknown"],
+    },
+    previousBusyState: { type: "string", enum: ["working", "idle"] },
+    lastTransitionAt: { type: "number" },
+    timedOut: { type: "boolean" },
+  },
+  required: ["terminalId", "busyState", "timedOut"],
+};
+
+const WAIT_UNTIL_IDLE_DESCRIPTION =
+  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. Honours client cancellation.";
+
+function mapAgentStateToBusyState(state: AgentState | undefined): "working" | "idle" {
+  return state === "working" ? "working" : "idle";
+}
+
+function mapAgentStateToIdleReason(
+  state: AgentState | undefined
+): WaitUntilIdleResult["idleReason"] {
+  switch (state) {
+    case "idle":
+      return "idle";
+    case "waiting":
+      return "waiting_for_user";
+    case "completed":
+      return "completed";
+    case "exited":
+      return "exited";
+    default:
+      return "unknown";
+  }
+}
 
 const AUDIT_FLUSH_DEBOUNCE_MS = 2000;
 const CONFIRMATION_REQUIRED_CODE = "CONFIRMATION_REQUIRED";
@@ -153,6 +237,7 @@ const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
   "terminal.sendCommand",
   "terminal.close",
   "terminal.closeAll",
+  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
 
   "recipe.list",
   "recipe.run",
@@ -241,6 +326,7 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "terminal.sendCommand",
   "terminal.inject",
   "terminal.new",
+  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
 
   "worktree.list",
   "worktree.getCurrent",
@@ -1332,6 +1418,192 @@ export class McpServerService {
     });
   }
 
+  /**
+   * Native handler for `terminal.waitUntilIdle`. Long-polls until the agent
+   * attached to `terminalId` transitions out of `working`, the configured
+   * timeout elapses, or the client cancels via `extra.signal`.
+   *
+   * Subscribe-then-read ordering is mandatory: if the read happens first and
+   * the transition fires before the listener is wired, the wait would hang
+   * until timeout.
+   */
+  private async handleWaitUntilIdle(
+    rawArgs: unknown,
+    signal: AbortSignal
+  ): Promise<WaitUntilIdleResult> {
+    const argsObj =
+      rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs)
+        ? (rawArgs as Record<string, unknown>)
+        : null;
+    if (!argsObj) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "terminal.waitUntilIdle requires an object argument with a `terminalId` field."
+      );
+    }
+    const terminalIdRaw = argsObj["terminalId"];
+    if (typeof terminalIdRaw !== "string" || terminalIdRaw.trim() === "") {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "terminal.waitUntilIdle requires a non-empty `terminalId` string."
+      );
+    }
+    const terminalId = terminalIdRaw;
+
+    let timeoutMs = DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS;
+    const rawTimeout = argsObj["timeoutMs"];
+    if (rawTimeout !== undefined) {
+      if (
+        typeof rawTimeout !== "number" ||
+        !Number.isFinite(rawTimeout) ||
+        rawTimeout < 0 ||
+        Math.floor(rawTimeout) !== rawTimeout
+      ) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          "terminal.waitUntilIdle `timeoutMs` must be a non-negative integer."
+        );
+      }
+      timeoutMs = Math.min(rawTimeout, MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS);
+    }
+
+    if (signal.aborted) {
+      throw new McpError(ErrorCode.RequestTimeout, "Request was cancelled.");
+    }
+
+    const store = getAgentAvailabilityStore();
+    const agentId = store.getAgentIdForTerminal(terminalId);
+
+    // Plain shell terminals (no spawned agent) have no tracked state — treat
+    // them as idle so callers don't need to special-case the absence of an
+    // agent.
+    if (!agentId) {
+      return {
+        terminalId,
+        busyState: "idle",
+        idleReason: "unknown",
+        timedOut: false,
+      };
+    }
+
+    let unsubscribe: (() => void) | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
+    let settled = false;
+
+    const cleanup = () => {
+      if (unsubscribe) {
+        try {
+          unsubscribe();
+        } catch (err) {
+          console.error("[MCP] waitUntilIdle: unsubscribe failed:", err);
+        }
+        unsubscribe = undefined;
+      }
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      if (abortListener) {
+        signal.removeEventListener("abort", abortListener);
+        abortListener = undefined;
+      }
+    };
+
+    type Settlement =
+      | {
+          kind: "transition";
+          state: AgentState;
+          previousState: AgentState;
+          timestamp: number;
+        }
+      | { kind: "already-idle"; state: AgentState }
+      | { kind: "timeout" }
+      | { kind: "abort" };
+
+    const previousState = store.getState(agentId);
+
+    try {
+      const settlement = await new Promise<Settlement>((resolve) => {
+        const settle = (value: Settlement) => {
+          if (settled) return;
+          settled = true;
+          resolve(value);
+        };
+
+        // 1. Subscribe BEFORE reading current state to avoid losing a
+        //    transition that fires between read and subscribe.
+        unsubscribe = events.on("agent:state-changed", (payload) => {
+          if (payload.agentId !== agentId) return;
+          if (payload.state === "working") return;
+          settle({
+            kind: "transition",
+            state: payload.state,
+            previousState: payload.previousState,
+            timestamp: payload.timestamp,
+          });
+        });
+
+        // 2. Read current state. Anything other than `working` resolves now.
+        const currentState = store.getState(agentId);
+        if (currentState !== "working") {
+          settle({ kind: "already-idle", state: currentState ?? "idle" });
+          return;
+        }
+
+        // 3. Race against client cancellation and the configured timeout.
+        if (signal.aborted) {
+          settle({ kind: "abort" });
+          return;
+        }
+        abortListener = () => settle({ kind: "abort" });
+        signal.addEventListener("abort", abortListener, { once: true });
+
+        timeoutHandle = setTimeout(() => settle({ kind: "timeout" }), timeoutMs);
+      });
+
+      if (settlement.kind === "abort") {
+        throw new McpError(ErrorCode.RequestTimeout, "Request was cancelled.");
+      }
+
+      if (settlement.kind === "timeout") {
+        return {
+          terminalId,
+          agentId,
+          busyState: "working",
+          previousBusyState: mapAgentStateToBusyState(previousState),
+          lastTransitionAt: store.getLastStateChange(agentId),
+          timedOut: true,
+        };
+      }
+
+      if (settlement.kind === "transition") {
+        return {
+          terminalId,
+          agentId,
+          busyState: mapAgentStateToBusyState(settlement.state),
+          idleReason: mapAgentStateToIdleReason(settlement.state),
+          previousBusyState: mapAgentStateToBusyState(settlement.previousState),
+          lastTransitionAt: settlement.timestamp,
+          timedOut: false,
+        };
+      }
+
+      // already-idle
+      return {
+        terminalId,
+        agentId,
+        busyState: mapAgentStateToBusyState(settlement.state),
+        idleReason: mapAgentStateToIdleReason(settlement.state),
+        previousBusyState: mapAgentStateToBusyState(previousState),
+        lastTransitionAt: store.getLastStateChange(agentId),
+        timedOut: false,
+      };
+    } finally {
+      cleanup();
+    }
+  }
+
   private createSessionServer(sessionId: string): Server {
     const server = new Server(
       { name: "Daintree", version: "1.0.0" },
@@ -1347,23 +1619,41 @@ export class McpServerService {
     server.setRequestHandler(ListToolsRequestSchema, async () => {
       const manifest = await this.requestManifest();
       const tier = this.getSessionTier(sessionId);
-      return {
-        tools: manifest
-          .filter((entry) => this.shouldExposeTool(entry, tier))
-          .map((entry) => {
-            const outputSchema = this.buildToolOutputSchema(entry);
-            return {
-              name: entry.id,
-              description: this.buildToolDescription(entry),
-              inputSchema: this.buildToolInputSchema(entry),
-              annotations: this.buildAnnotations(entry),
-              ...(outputSchema ? { outputSchema } : {}),
-            };
-          }),
-      };
+      const tools = manifest
+        .filter((entry) => this.shouldExposeTool(entry, tier))
+        .map((entry) => {
+          const outputSchema = this.buildToolOutputSchema(entry);
+          return {
+            name: entry.id,
+            description: this.buildToolDescription(entry),
+            inputSchema: this.buildToolInputSchema(entry),
+            annotations: this.buildAnnotations(entry),
+            ...(outputSchema ? { outputSchema } : {}),
+          };
+        });
+
+      // Native tools live outside the renderer action manifest. Append them
+      // after the manifest-backed tools so existing ordering is preserved.
+      if (this.isTierPermitted(tier, TERMINAL_WAIT_UNTIL_IDLE_TOOL)) {
+        tools.push({
+          name: TERMINAL_WAIT_UNTIL_IDLE_TOOL,
+          description: WAIT_UNTIL_IDLE_DESCRIPTION,
+          inputSchema: WAIT_UNTIL_IDLE_INPUT_SCHEMA,
+          annotations: {
+            title: "Wait until terminal idle",
+            readOnlyHint: true,
+            idempotentHint: false,
+            destructiveHint: false,
+            openWorldHint: false,
+          },
+          outputSchema: WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+        });
+      }
+
+      return { tools };
     });
 
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const actionId = request.params.name;
       const { args, confirmed } = this.parseToolArguments(request.params.arguments);
       const startedAt = Date.now();
@@ -1391,6 +1681,50 @@ export class McpServerService {
           ],
           isError: true,
         };
+      }
+
+      // Native tools intercept BEFORE the renderer dispatch path — they have
+      // no manifest entry and dispatchAction would reject them.
+      if (actionId === TERMINAL_WAIT_UNTIL_IDLE_TOOL) {
+        let nativeOutcome:
+          | { kind: "result"; value: ActionDispatchResult }
+          | { kind: "throw"; error: unknown }
+          | undefined;
+        try {
+          const result = await this.handleWaitUntilIdle(args, extra.signal);
+          nativeOutcome = { kind: "result", value: { ok: true, result } };
+          return {
+            content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (err) {
+          nativeOutcome = { kind: "throw", error: err };
+          if (err instanceof McpError) {
+            throw err;
+          }
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: ${formatErrorMessage(err, "waitUntilIdle failed")}`,
+              },
+            ],
+            isError: true,
+          };
+        } finally {
+          try {
+            this.appendAuditRecord({
+              toolId: actionId,
+              sessionId,
+              tier,
+              args,
+              durationMs: Date.now() - startedAt,
+              outcome: nativeOutcome ?? { kind: "throw", error: new Error("unknown") },
+            });
+          } catch (auditErr) {
+            console.error("[MCP] Failed to append audit record:", auditErr);
+          }
+        }
       }
 
       let outcome:

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -3720,4 +3720,331 @@ describe("McpServerService", () => {
       ).not.toThrow();
     });
   });
+
+  describe("terminal.waitUntilIdle native tool", () => {
+    let uniqueCounter = 0;
+    const nextIds = () => {
+      uniqueCounter += 1;
+      return {
+        terminalId: `wait-term-${uniqueCounter}-${Math.random().toString(36).slice(2, 6)}`,
+        agentId: `wait-agent-${uniqueCounter}-${Math.random().toString(36).slice(2, 6)}`,
+      };
+    };
+
+    const seedTerminalAgent = async (
+      terminalId: string,
+      agentId: string,
+      state: "idle" | "working" | "waiting" | "completed" | "exited" = "idle"
+    ) => {
+      const { events } = await import("../events.js");
+      const { getAgentAvailabilityStore } = await import("../AgentAvailabilityStore.js");
+      // Force singleton wiring before any emit.
+      getAgentAvailabilityStore();
+      events.emit("agent:spawned", {
+        agentId,
+        terminalId,
+        timestamp: Date.now(),
+      });
+      events.emit("agent:state-changed", {
+        agentId,
+        state,
+        previousState: state === "working" ? "idle" : "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: Date.now(),
+      });
+    };
+
+    it("listTools advertises the native tool with the documented schema for the action tier", async () => {
+      paneTokenTiers.set("token-wait-action", "action");
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wait-action",
+      });
+      transports.push(transport);
+
+      const result = await client.listTools();
+      const tool = result.tools.find((t) => t.name === "terminal.waitUntilIdle");
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema.required).toEqual(["terminalId"]);
+      expect(tool?.inputSchema.additionalProperties).toBe(false);
+      expect(tool?.annotations?.readOnlyHint).toBe(true);
+      expect(tool?.annotations?.destructiveHint).toBe(false);
+    });
+
+    it("listTools hides the native tool from the workbench tier", async () => {
+      paneTokenTiers.set("token-wait-wb", "workbench");
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wait-wb",
+      });
+      transports.push(transport);
+
+      const ids = (await client.listTools()).tools.map((t) => t.name);
+      expect(ids).not.toContain("terminal.waitUntilIdle");
+    });
+
+    it("returns immediately for a terminal that is already idle", async () => {
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "idle");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const startedAt = Date.now();
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      })) as TextToolResult & { structuredContent?: Record<string, unknown> };
+      const elapsed = Date.now() - startedAt;
+
+      expect(result.isError).toBeFalsy();
+      expect(elapsed).toBeLessThan(1000);
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId,
+        agentId,
+        busyState: "idle",
+        idleReason: "idle",
+        timedOut: false,
+      });
+      expect(result.structuredContent).toMatchObject({
+        terminalId,
+        busyState: "idle",
+        timedOut: false,
+      });
+    });
+
+    it("returns immediately as idle for a terminal with no spawned agent", async () => {
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId: "plain-shell-term" },
+      })) as TextToolResult;
+
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId: "plain-shell-term",
+        busyState: "idle",
+        idleReason: "unknown",
+        timedOut: false,
+      });
+      expect(payload.agentId).toBeUndefined();
+    });
+
+    it("blocks on a working terminal and resolves when state transitions to idle", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      }) as Promise<TextToolResult>;
+
+      // Give the call time to register its listener.
+      await new Promise((r) => setTimeout(r, 30));
+
+      const transitionTs = Date.now();
+      events.emit("agent:state-changed", {
+        agentId,
+        state: "completed",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: transitionTs,
+      });
+
+      const result = await callPromise;
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId,
+        agentId,
+        busyState: "idle",
+        idleReason: "completed",
+        previousBusyState: "working",
+        lastTransitionAt: transitionTs,
+        timedOut: false,
+      });
+    });
+
+    it("ignores agent:state-changed events that stay in working state", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId, timeoutMs: 200 },
+      }) as Promise<TextToolResult>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      // working → working is a no-op for the tool — the listener must not resolve.
+      events.emit("agent:state-changed", {
+        agentId,
+        state: "working",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: Date.now(),
+      });
+
+      const result = await callPromise;
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.timedOut).toBe(true);
+      expect(payload.busyState).toBe("working");
+    });
+
+    it("returns timedOut:true when the timeout elapses without a transition", async () => {
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId, timeoutMs: 80 },
+      })) as TextToolResult;
+
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId,
+        agentId,
+        busyState: "working",
+        timedOut: true,
+      });
+      expect(payload.previousBusyState).toBe("working");
+    });
+
+    it("filters state-change events by the resolved agentId", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      const otherAgent = `other-${Math.random().toString(36).slice(2)}`;
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId, timeoutMs: 150 },
+      }) as Promise<TextToolResult>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Unrelated agent transitions must not satisfy the wait.
+      events.emit("agent:state-changed", {
+        agentId: otherAgent,
+        state: "idle",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: Date.now(),
+      });
+
+      const result = await callPromise;
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.timedOut).toBe(true);
+      expect(payload.agentId).toBe(agentId);
+    });
+
+    it("rejects calls with a missing or empty terminalId", async () => {
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(
+        client.callTool({
+          name: "terminal.waitUntilIdle",
+          arguments: { terminalId: "" },
+        })
+      ).rejects.toThrow(/non-empty/);
+    });
+
+    it("rejects calls with an invalid timeoutMs", async () => {
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      await expect(
+        client.callTool({
+          name: "terminal.waitUntilIdle",
+          arguments: { terminalId: "any", timeoutMs: -1 },
+        })
+      ).rejects.toThrow(/non-negative integer/);
+    });
+
+    it("rejects callTool from a workbench-tier session before invoking the handler", async () => {
+      paneTokenTiers.set("token-wait-deny", "workbench");
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, {
+        Authorization: "Bearer token-wait-deny",
+      });
+      transports.push(transport);
+
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId: "anything" },
+      })) as TextToolResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]!.text).toContain("TIER_NOT_PERMITTED");
+    });
+
+    it("releases its event listener after resolving so repeated calls do not leak", async () => {
+      const { events } = await import("../events.js");
+      const innerBus = (events as unknown as { bus: import("node:events").EventEmitter }).bus;
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "idle");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const baseline = innerBus.listenerCount("agent:state-changed");
+
+      for (let i = 0; i < 3; i += 1) {
+        const result = (await client.callTool({
+          name: "terminal.waitUntilIdle",
+          arguments: { terminalId },
+        })) as TextToolResult;
+        expect(result.isError).toBeFalsy();
+      }
+
+      // Listener count should not grow per call — the handler must remove its
+      // subscription on every exit path.
+      expect(innerBus.listenerCount("agent:state-changed")).toBe(baseline);
+    });
+  });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -3747,6 +3747,7 @@ describe("McpServerService", () => {
       });
       events.emit("agent:state-changed", {
         agentId,
+        terminalId,
         state,
         previousState: state === "working" ? "idle" : "working",
         trigger: "output",
@@ -3862,6 +3863,7 @@ describe("McpServerService", () => {
       const transitionTs = Date.now();
       events.emit("agent:state-changed", {
         agentId,
+        terminalId,
         state: "completed",
         previousState: "working",
         trigger: "output",
@@ -3903,6 +3905,7 @@ describe("McpServerService", () => {
       // working → working is a no-op for the tool — the listener must not resolve.
       events.emit("agent:state-changed", {
         agentId,
+        terminalId,
         state: "working",
         previousState: "working",
         trigger: "output",
@@ -3973,6 +3976,52 @@ describe("McpServerService", () => {
       const payload = JSON.parse(result.content[0]!.text);
       expect(payload.timedOut).toBe(true);
       expect(payload.agentId).toBe(agentId);
+    });
+
+    it("does not resolve when another terminal sharing the same agent type transitions", async () => {
+      const { events } = await import("../events.js");
+      // Two Claude terminals — same `agentId` ("claude"), different terminalIds.
+      // A transition for terminal B must NOT satisfy a wait on terminal A.
+      const sharedAgentId = "claude";
+      const terminalA = `share-A-${Math.random().toString(36).slice(2)}`;
+      const terminalB = `share-B-${Math.random().toString(36).slice(2)}`;
+      await seedTerminalAgent(terminalA, sharedAgentId, "working");
+      // Note: emitting agent:spawned for terminalB overwrites the
+      // agentToTerminal mapping for sharedAgentId; this is a known
+      // AgentAvailabilityStore limitation and not something this tool can fix.
+      events.emit("agent:spawned", {
+        agentId: sharedAgentId,
+        terminalId: terminalB,
+        timestamp: Date.now(),
+      });
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId: terminalA, timeoutMs: 120 },
+      }) as Promise<TextToolResult>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      // Terminal B finishes — must NOT resolve the wait on terminal A.
+      events.emit("agent:state-changed", {
+        agentId: sharedAgentId,
+        terminalId: terminalB,
+        state: "completed",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: Date.now(),
+      });
+
+      const result = await callPromise;
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.timedOut).toBe(true);
+      expect(payload.terminalId).toBe(terminalA);
     });
 
     it("rejects calls with a missing or empty terminalId", async () => {


### PR DESCRIPTION
## Summary

- Adds `terminal.waitUntilIdle` — a native MCP long-poll tool that lets the assistant block until a specific terminal's agent reaches idle state
- Filters the state-change listener by `terminalId` rather than `agentId`, since `agentId` is shared across terminals running the same agent type
- Plain-shell fallthrough for terminals with no associated agent (resolves immediately)

Resolves #6636

## Changes

- `McpServerService.ts` — new `terminal.waitUntilIdle` tool handler with subscribe-then-read ordering to avoid the classic race, single cleanup path in a `finally` block, no custom `CancelledNotification` handler, `extra.signal` cancellation, default 30-minute timeout with a 2-hour ceiling
- `AgentAvailabilityStore.ts` — adds `getAgentIdForTerminal` and `getLastStateChange` accessors needed by the new handler

## Testing

13 new tests in `McpServerService.test.ts` covering: immediate idle resolution, wait-then-idle, timeout expiry, signal cancellation, plain-shell fallthrough, per-terminal listener isolation (cross-terminal collision regression), and cleanup path correctness.