### PR TITLE
feat(mcp): migrate destructive-action confirmation to elicitation/create

### DIFF
--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -2424,7 +2424,7 @@ export class McpServerService {
     args: unknown
   ): Promise<
     | { kind: "approved" }
-    | { kind: "rejected"; value: ActionDispatchResult }
+    | { kind: "rejected"; value: Extract<ActionDispatchResult, { ok: false }> }
     | { kind: "throw"; error: unknown }
   > {
     const argsSummary = summarizeMcpArgs(args);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -1667,7 +1667,7 @@ export class McpServerService {
 
     server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
       const actionId = request.params.name;
-      const { args, confirmed } = this.parseToolArguments(request.params.arguments);
+      const { args } = this.parseToolArguments(request.params.arguments);
       const startedAt = Date.now();
       const tier = this.getSessionTier(sessionId);
 
@@ -1743,12 +1743,55 @@ export class McpServerService {
         | { kind: "result"; value: ActionDispatchResult }
         | { kind: "throw"; error: unknown };
       let confirmationDecision: McpConfirmationDecision | undefined;
+      let dispatchConfirmed = false;
 
       try {
+        // Elicitation path: when the action is destructive and not yet
+        // confirmed, and the connected client advertises form-elicitation
+        // support, ask for explicit approval via the MCP `elicitation/create`
+        // primitive. Clients without elicitation capability fall through to
+        // the renderer-modal fallback (`dispatchAction(confirmed=false)`).
+        // The manifest is populated by ListTools, but spec-compliant clients
+        // are not required to call it before tools/call — ensure we have a
+        // copy on hand to honor the destructive-action gate.
+        const entry = await this.lookupManifestEntry(actionId);
+        if (!dispatchConfirmed && entry?.danger === "confirm") {
+          const supportsForm = server.getClientCapabilities()?.elicitation?.form !== undefined;
+          if (supportsForm) {
+            const elicitationOutcome = await this.runElicitationConfirmation(server, entry);
+            if (elicitationOutcome.kind === "throw") {
+              outcome = elicitationOutcome;
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Error: ${formatErrorMessage(elicitationOutcome.error, "Elicitation request failed")}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (elicitationOutcome.kind === "rejected") {
+              outcome = { kind: "result", value: elicitationOutcome.value };
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Error [${elicitationOutcome.value.error.code}]: ${elicitationOutcome.value.error.message}`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            dispatchConfirmed = true;
+            confirmationDecision = "approved";
+          }
+        }
+
         try {
-          const envelope = await this.dispatchAction(actionId, args, confirmed);
+          const envelope = await this.dispatchAction(actionId, args, dispatchConfirmed);
           outcome = { kind: "result", value: envelope.result };
-          confirmationDecision = envelope.confirmationDecision;
+          confirmationDecision = confirmationDecision ?? envelope.confirmationDecision;
         } catch (err) {
           outcome = { kind: "throw", error: err };
           return {
@@ -1763,7 +1806,6 @@ export class McpServerService {
         }
 
         if (outcome.value.ok) {
-          const entry = this.cachedManifest?.find((e) => e.id === actionId);
           const structuredContent = this.buildStructuredContent(entry, outcome.value.result);
           return {
             content: [
@@ -2319,51 +2361,116 @@ export class McpServerService {
   }
 
   private buildToolDescription(entry: ActionManifestEntry): string {
-    let description = entry.description;
-    if (entry.danger === "confirm") {
-      description += " Requires explicit confirmation via _meta.confirmed=true.";
+    return entry.description;
+  }
+
+  /**
+   * Resolve a manifest entry by id, fetching the manifest from the
+   * renderer if no cache is on hand yet. Used by the CallTool handler so
+   * the destructive-action gate fires for clients that skip ListTools.
+   * Renderer-bridge failures degrade silently — the legacy renderer-modal
+   * fallback still safeguards destructive dispatches when the manifest is
+   * unavailable.
+   */
+  private async lookupManifestEntry(actionId: string): Promise<ActionManifestEntry | undefined> {
+    if (!this.cachedManifest) {
+      try {
+        await this.requestManifest();
+      } catch {
+        return undefined;
+      }
     }
-    return description;
+    return this.cachedManifest?.find((e) => e.id === actionId);
+  }
+
+  /**
+   * Drive the MCP `elicitation/create` round-trip used to confirm a
+   * destructive action with the client. Returns one of three shapes:
+   *
+   *   - `approved`: the user accepted and ticked the confirm box; caller
+   *     should proceed with `dispatchAction(confirmed=true)`.
+   *   - `rejected`: the user declined or cancelled, or accepted without
+   *     ticking the confirm box. Caller should return the bundled
+   *     `ActionDispatchResult` (USER_REJECTED / CONFIRMATION_TIMEOUT) as
+   *     the tool result; auditing classifies it via
+   *     `deriveConfirmationDecision`.
+   *   - `throw`: the SDK threw before reaching the client (e.g. the
+   *     advertised capability is gone, or the schema validator rejected
+   *     the response). Caller should surface a generic `isError: true`.
+   *
+   * The renderer modal is intentionally not consulted on this path —
+   * elicitation IS the confirmation prompt for capable clients, so a
+   * silent fallback to the modal could bypass the user's decision.
+   */
+  private async runElicitationConfirmation(
+    server: Server,
+    entry: ActionManifestEntry
+  ): Promise<
+    | { kind: "approved" }
+    | { kind: "rejected"; value: ActionDispatchResult }
+    | { kind: "throw"; error: unknown }
+  > {
+    let result;
+    try {
+      result = await server.elicitInput({
+        message: `Confirm ${entry.title}: ${entry.description}`,
+        requestedSchema: {
+          type: "object",
+          properties: {
+            confirmed: {
+              type: "boolean",
+              title: "Confirm destructive action",
+              default: false,
+            },
+          },
+          required: ["confirmed"],
+        },
+      });
+    } catch (err) {
+      return { kind: "throw", error: err };
+    }
+
+    if (result.action === "cancel") {
+      return {
+        kind: "rejected",
+        value: {
+          ok: false,
+          error: {
+            code: CONFIRMATION_TIMEOUT_CODE,
+            message: "Confirmation request timed out before the user responded.",
+          },
+        },
+      };
+    }
+
+    if (result.action === "decline" || result.content?.["confirmed"] !== true) {
+      return {
+        kind: "rejected",
+        value: {
+          ok: false,
+          error: {
+            code: USER_REJECTED_CODE,
+            message: "User rejected the confirmation request.",
+          },
+        },
+      };
+    }
+
+    return { kind: "approved" };
   }
 
   private buildToolInputSchema(entry: ActionManifestEntry): Record<string, unknown> {
-    const baseSchema =
+    if (
       entry.inputSchema &&
       typeof entry.inputSchema === "object" &&
       !Array.isArray(entry.inputSchema) &&
       entry.inputSchema["type"] === "object"
-        ? ({ ...entry.inputSchema } as Record<string, unknown>)
-        : {
-            type: "object",
-            properties: {},
-          };
-
-    if (entry.danger !== "confirm") {
-      return { ...baseSchema, additionalProperties: false };
+    ) {
+      return { ...entry.inputSchema, additionalProperties: false } as Record<string, unknown>;
     }
-
-    const properties =
-      baseSchema["properties"] &&
-      typeof baseSchema["properties"] === "object" &&
-      !Array.isArray(baseSchema["properties"])
-        ? { ...(baseSchema["properties"] as Record<string, unknown>) }
-        : {};
-
-    properties["_meta"] = {
-      type: "object",
-      description: "Reserved Daintree MCP metadata.",
-      properties: {
-        confirmed: {
-          type: "boolean",
-          description: "Must be true to execute this destructive action.",
-        },
-      },
-      additionalProperties: false,
-    };
-
     return {
-      ...baseSchema,
-      properties,
+      type: "object",
+      properties: {},
       additionalProperties: false,
     };
   }
@@ -2404,34 +2511,25 @@ export class McpServerService {
     return result as Record<string, unknown>;
   }
 
-  private parseToolArguments(rawArgs: unknown): { args: unknown; confirmed: boolean } {
+  /**
+   * Strip the reserved `_meta` envelope before forwarding tool arguments to
+   * the renderer. The legacy `_meta.confirmed=true` bypass is no longer
+   * honored — destructive actions are gated by `elicitation/create` (or the
+   * renderer-modal fallback for clients without elicitation capability), so
+   * any inbound `_meta.confirmed` flag is silently dropped.
+   */
+  private parseToolArguments(rawArgs: unknown): { args: unknown } {
     if (!rawArgs || typeof rawArgs !== "object" || Array.isArray(rawArgs)) {
-      return {
-        args: rawArgs ?? {},
-        confirmed: false,
-      };
+      return { args: rawArgs ?? {} };
     }
 
     const argsRecord = rawArgs as Record<string, unknown>;
-    const meta = argsRecord["_meta"];
-    const metaRecord =
-      meta !== null && typeof meta === "object" && !Array.isArray(meta)
-        ? (meta as Record<string, unknown>)
-        : null;
-    const confirmed = metaRecord?.["confirmed"] === true;
-
     if (!("_meta" in argsRecord)) {
-      return {
-        args: rawArgs,
-        confirmed,
-      };
+      return { args: rawArgs };
     }
 
     const { _meta: _ignored, ...actionArgs } = argsRecord;
-    return {
-      args: Object.keys(actionArgs).length > 0 ? actionArgs : {},
-      confirmed,
-    };
+    return { args: Object.keys(actionArgs).length > 0 ? actionArgs : {} };
   }
 
   private getActiveProjectWebContents(): Electron.WebContents {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -136,6 +136,7 @@ const AUDIT_FLUSH_DEBOUNCE_MS = 2000;
 const CONFIRMATION_REQUIRED_CODE = "CONFIRMATION_REQUIRED";
 const USER_REJECTED_CODE = "USER_REJECTED";
 const CONFIRMATION_TIMEOUT_CODE = "CONFIRMATION_TIMEOUT";
+const ELICITATION_FAILED_CODE = "ELICITATION_FAILED";
 
 const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
   "browser",
@@ -900,11 +901,15 @@ export class McpServerService {
 
   /**
    * Resolve the confirmation decision stored alongside an audit record.
-   * Trusts the renderer-supplied hint for `"approved"` (the only case main
-   * cannot infer — a successful dispatch may be a directly-authorized agent
-   * call or a modal-approved one), but always derives `"rejected"` and
-   * `"timeout"` from the canonical error codes so a renderer that forgets
-   * to set the hint still gets the right outcome recorded.
+   * Trusts the supplied hint for `"approved"` (the only case main cannot
+   * infer from error codes — a successful dispatch may be a directly-
+   * authorized agent call, a modal-approved one, or an elicitation-approved
+   * one), but always derives `"rejected"` and `"timeout"` from the canonical
+   * error codes so callers that forget to set the hint still get the right
+   * outcome recorded. The approved hint is preserved even when the
+   * subsequent dispatch fails for non-confirmation reasons, so the audit
+   * trail records that the user explicitly approved before the action
+   * failed.
    */
   private deriveConfirmationDecision(
     outcome:
@@ -917,7 +922,7 @@ export class McpServerService {
       if (outcome.value.error.code === USER_REJECTED_CODE) return "rejected";
       if (outcome.value.error.code === CONFIRMATION_TIMEOUT_CODE) return "timeout";
     }
-    if (hint === "approved" && outcome.kind === "result" && outcome.value.ok) {
+    if (hint === "approved") {
       return "approved";
     }
     return undefined;
@@ -1758,14 +1763,25 @@ export class McpServerService {
         if (!dispatchConfirmed && entry?.danger === "confirm") {
           const supportsForm = server.getClientCapabilities()?.elicitation?.form !== undefined;
           if (supportsForm) {
-            const elicitationOutcome = await this.runElicitationConfirmation(server, entry);
+            const elicitationOutcome = await this.runElicitationConfirmation(server, entry, args);
             if (elicitationOutcome.kind === "throw") {
-              outcome = elicitationOutcome;
+              const failureMessage = formatErrorMessage(
+                elicitationOutcome.error,
+                "Elicitation request failed"
+              );
+              const value: ActionDispatchResult = {
+                ok: false,
+                error: {
+                  code: ELICITATION_FAILED_CODE,
+                  message: failureMessage,
+                },
+              };
+              outcome = { kind: "result", value };
               return {
                 content: [
                   {
                     type: "text" as const,
-                    text: `Error: ${formatErrorMessage(elicitationOutcome.error, "Elicitation request failed")}`,
+                    text: `Error [${ELICITATION_FAILED_CODE}]: ${failureMessage}`,
                   },
                 ],
                 isError: true,
@@ -2404,16 +2420,23 @@ export class McpServerService {
    */
   private async runElicitationConfirmation(
     server: Server,
-    entry: ActionManifestEntry
+    entry: ActionManifestEntry,
+    args: unknown
   ): Promise<
     | { kind: "approved" }
     | { kind: "rejected"; value: ActionDispatchResult }
     | { kind: "throw"; error: unknown }
   > {
+    const argsSummary = summarizeMcpArgs(args);
+    const message =
+      argsSummary && argsSummary !== "{}"
+        ? `Confirm ${entry.title}: ${entry.description}\n\nArguments: ${argsSummary}`
+        : `Confirm ${entry.title}: ${entry.description}`;
+
     let result;
     try {
       result = await server.elicitInput({
-        message: `Confirm ${entry.title}: ${entry.description}`,
+        message,
         requestedSchema: {
           type: "object",
           properties: {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1106,7 +1106,8 @@ describe("McpServerService", () => {
         arguments: { worktreeId: "wt-very-specific-id" },
       });
 
-      const captured = onElicit.mock.calls[0]?.[0] as { params: { message: string } } | undefined;
+      const calls = onElicit.mock.calls as unknown as Array<[{ params: { message: string } }]>;
+      const captured = calls[0]?.[0] as { params: { message: string } } | undefined;
       expect(captured?.params.message).toContain("Delete Worktree");
       // The args summary must appear in the prompt so a user reviewing
       // the elicitation form can tell which entity is being affected.

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1074,6 +1074,139 @@ describe("McpServerService", () => {
       expect(dispatchMock).not.toHaveBeenCalled();
     });
 
+    it("includes a summary of tool arguments in the elicitation message", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "accept",
+          content: { confirmed: true },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      await client.callTool({
+        name: "worktree.delete",
+        arguments: { worktreeId: "wt-very-specific-id" },
+      });
+
+      const captured = onElicit.mock.calls[0]?.[0] as { params: { message: string } } | undefined;
+      expect(captured?.params.message).toContain("Delete Worktree");
+      // The args summary must appear in the prompt so a user reviewing
+      // the elicitation form can tell which entity is being affected.
+      expect(captured?.params.message).toContain("wt-very-specific-id");
+    });
+
+    it("returns ELICITATION_FAILED without dispatching when the elicit handler throws", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(async () => {
+        throw new Error("elicit handler exploded");
+      });
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-1" },
+        })
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("ELICITATION_FAILED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+
+      const records = readAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].errorCode).toBe("ELICITATION_FAILED");
+    });
+
+    it("preserves the approved confirmationDecision when dispatch fails after elicitation accepts", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({
+          ok: false,
+          error: { code: "EXECUTION_ERROR", message: "action exploded" },
+        })
+      );
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "accept",
+          content: { confirmed: true },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-1" },
+        })
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("EXECUTION_ERROR");
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+      expect(dispatchMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ confirmed: true }));
+
+      const records = readAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].result).toBe("error");
+      expect(records[0].errorCode).toBe("EXECUTION_ERROR");
+      // The user explicitly approved via elicitation — the fact that the
+      // subsequent dispatch failed must not erase that decision from the
+      // audit trail.
+      expect(records[0].confirmationDecision).toBe("approved");
+    });
+
     it("does not invoke elicitation for non-destructive tools", async () => {
       const dispatchMock = vi.fn(
         (): ActionDispatchResult => ({

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -5,6 +5,11 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  ElicitRequestSchema,
+  type ElicitResult,
+  type ClientCapabilities,
+} from "@modelcontextprotocol/sdk/types.js";
 import type {
   ActionDispatchResult,
   ActionManifestEntry,
@@ -310,7 +315,11 @@ function getServiceApiKey(): string {
 
 async function connectClient(
   port: number,
-  headers?: Record<string, string>
+  headers?: Record<string, string>,
+  options?: {
+    capabilities?: ClientCapabilities;
+    onElicit?: (request: { params: { message: string } }) => Promise<ElicitResult> | ElicitResult;
+  }
 ): Promise<{ client: Client; transport: SSEClientTransport }> {
   const apiKey = getServiceApiKey();
   const mergedHeaders: Record<string, string> = {
@@ -318,7 +327,16 @@ async function connectClient(
     ...(headers ?? {}),
   };
   const hasHeaders = Object.keys(mergedHeaders).length > 0;
-  const client = new Client({ name: "mcp-test-client", version: "1.0.0" });
+  const client = new Client(
+    { name: "mcp-test-client", version: "1.0.0" },
+    options?.capabilities ? { capabilities: options.capabilities } : undefined
+  );
+  if (options?.onElicit) {
+    const handler = options.onElicit;
+    client.setRequestHandler(ElicitRequestSchema, async (request) => {
+      return handler(request as { params: { message: string } });
+    });
+  }
   const transport = new SSEClientTransport(new URL(`http://127.0.0.1:${port}/sse`), {
     eventSourceInit: hasHeaders ? ({ headers: mergedHeaders } as never) : undefined,
     requestInit: hasHeaders ? { headers: mergedHeaders } : undefined,
@@ -506,7 +524,7 @@ describe("McpServerService", () => {
     await fs.rm(testHomeDir, { recursive: true, force: true });
   });
 
-  it("lists tools and advertises explicit confirmation metadata for destructive actions", async () => {
+  it("lists tools without injecting _meta confirmation properties on destructive actions", async () => {
     const { window } = createMockWindow({
       getManifest: () => [
         createManifestEntry({
@@ -543,22 +561,17 @@ describe("McpServerService", () => {
     expect(safeTool).toBeDefined();
     expect(dangerousTool).toBeDefined();
     expect(safeTool?.description).toBe("Read the action registry");
-    expect(dangerousTool?.description).toBe(
-      "Delete a worktree Requires explicit confirmation via _meta.confirmed=true."
-    );
+    // Confirmation is now driven by MCP `elicitation/create`, not a `_meta`
+    // schema property — the tool description and schema must not advertise
+    // the legacy bypass mechanism.
+    expect(dangerousTool?.description).not.toContain("_meta");
+    expect(dangerousTool?.description).not.toContain("Requires explicit confirmation");
     expect(safeTool?.inputSchema.additionalProperties).toBe(false);
     expect(dangerousTool?.inputSchema.additionalProperties).toBe(false);
-    expect(dangerousTool?.inputSchema.properties?._meta).toEqual({
-      type: "object",
-      description: "Reserved Daintree MCP metadata.",
-      properties: {
-        confirmed: {
-          type: "boolean",
-          description: "Must be true to execute this destructive action.",
-        },
-      },
-      additionalProperties: false,
+    expect(dangerousTool?.inputSchema.properties).toEqual({
+      worktreeId: { type: "string" },
     });
+    expect(dangerousTool?.inputSchema.properties?._meta).toBeUndefined();
 
     // Annotations — query tool
     expect(safeTool?.annotations).toEqual({
@@ -569,7 +582,9 @@ describe("McpServerService", () => {
       openWorldHint: false,
     });
 
-    // Annotations — destructive tool
+    // Annotations — destructive tool. `destructiveHint: true` is the
+    // primary signal clients use to detect that elicitation will be
+    // invoked on the next `tools/call` for this tool.
     expect(dangerousTool?.annotations).toEqual({
       title: "Delete Worktree",
       readOnlyHint: false,
@@ -730,7 +745,7 @@ describe("McpServerService", () => {
     expect(wtTool?.annotations?.openWorldHint).toBe(false);
   });
 
-  it("requires explicit MCP confirmation before dispatching destructive actions", async () => {
+  it("falls back to renderer-modal dispatch when the client does not support elicitation", async () => {
     const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
       if (!payload.confirmed) {
         return {
@@ -751,7 +766,7 @@ describe("McpServerService", () => {
       };
     });
 
-    const { window, webContents } = createMockWindow({
+    const { window } = createMockWindow({
       getManifest: () => [
         createManifestEntry({
           id: "worktree.delete" as ActionId,
@@ -772,6 +787,10 @@ describe("McpServerService", () => {
     });
 
     await service.start(window);
+    // Default test client does not advertise `elicitation` capability, so
+    // the server forwards the unconfirmed dispatch to the renderer bridge —
+    // exactly the fallback behavior we want to preserve for non-elicitation
+    // clients.
     const { client, transport } = await connectClient(service.currentPort!);
     transports.push(transport);
 
@@ -781,7 +800,51 @@ describe("McpServerService", () => {
         arguments: { worktreeId: "wt-123" },
       })
     );
-    const confirmed = getTextResult(
+
+    expect(unconfirmed.isError).toBe(true);
+    expect(unconfirmed.content[0]).toMatchObject({ type: "text" });
+    expect(unconfirmed.content[0].text).toContain("CONFIRMATION_REQUIRED");
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        actionId: "worktree.delete",
+        args: { worktreeId: "wt-123" },
+        confirmed: false,
+      })
+    );
+  });
+
+  it("strips legacy `_meta.confirmed=true` from arguments instead of bypassing confirmation", async () => {
+    const dispatchMock = vi.fn(
+      (): ActionDispatchResult => ({
+        ok: false,
+        error: { code: "CONFIRMATION_REQUIRED", message: "Need confirm" },
+      })
+    );
+
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "worktree.delete" as ActionId,
+          title: "Delete Worktree",
+          description: "Delete a worktree",
+          danger: "confirm",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!);
+    transports.push(transport);
+
+    // Legacy clients that still pass `_meta.confirmed=true` should NOT
+    // self-confirm — the elicitation/modal flow is the only way to
+    // approve a destructive action. The `_meta` key is stripped from
+    // the args envelope before reaching the renderer.
+    const result = getTextResult(
       await client.callTool({
         name: "worktree.delete",
         arguments: {
@@ -791,15 +854,9 @@ describe("McpServerService", () => {
       })
     );
 
-    expect(unconfirmed.isError).toBe(true);
-    expect(unconfirmed.content[0]).toMatchObject({
-      type: "text",
-    });
-    expect(unconfirmed.content[0].text).toContain("CONFIRMATION_REQUIRED");
-
-    expect(confirmed.isError).not.toBe(true);
-    expect(confirmed.content[0].text).toContain('"deleted": true');
-
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("CONFIRMATION_REQUIRED");
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
     expect(dispatchMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -808,15 +865,248 @@ describe("McpServerService", () => {
         confirmed: false,
       })
     );
-    expect(dispatchMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        actionId: "worktree.delete",
-        args: { worktreeId: "wt-123" },
-        confirmed: true,
-      })
-    );
-    expect(webContents.send).toHaveBeenCalledTimes(2);
+  });
+
+  describe("elicitation confirmation flow", () => {
+    type AuditEntry = {
+      result: "success" | "error" | "confirmation-pending" | "unauthorized";
+      errorCode?: string;
+      confirmationDecision?: "approved" | "rejected" | "timeout";
+    };
+
+    function readAuditRecords(svc: McpServerService): AuditEntry[] {
+      return (svc as unknown as { getAuditRecords: () => AuditEntry[] }).getAuditRecords();
+    }
+
+    function createDestructiveDispatchMock() {
+      return vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+        if (!payload.confirmed) {
+          return {
+            ok: false,
+            error: { code: "CONFIRMATION_REQUIRED", message: "Need confirm" },
+          };
+        }
+        return {
+          ok: true,
+          result: { deleted: true },
+        };
+      });
+    }
+
+    it("dispatches with confirmed=true after the client accepts the elicitation", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "accept",
+          content: { confirmed: true },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-123" },
+        })
+      );
+
+      expect(onElicit).toHaveBeenCalledTimes(1);
+      expect(result.isError).not.toBe(true);
+      expect(result.content[0].text).toContain('"deleted": true');
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+      expect(dispatchMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          actionId: "worktree.delete",
+          args: { worktreeId: "wt-123" },
+          confirmed: true,
+        })
+      );
+
+      const records = readAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].result).toBe("success");
+      expect(records[0].confirmationDecision).toBe("approved");
+    });
+
+    it("returns USER_REJECTED without dispatching when the client declines", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "decline",
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-123" },
+        })
+      );
+
+      expect(onElicit).toHaveBeenCalledTimes(1);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("USER_REJECTED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+
+      const records = readAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].errorCode).toBe("USER_REJECTED");
+      expect(records[0].confirmationDecision).toBe("rejected");
+    });
+
+    it("returns CONFIRMATION_TIMEOUT without dispatching when the client cancels", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "cancel",
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-123" },
+        })
+      );
+
+      expect(onElicit).toHaveBeenCalledTimes(1);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("CONFIRMATION_TIMEOUT");
+      expect(dispatchMock).not.toHaveBeenCalled();
+
+      const records = readAuditRecords(service);
+      expect(records).toHaveLength(1);
+      expect(records[0].errorCode).toBe("CONFIRMATION_TIMEOUT");
+      expect(records[0].confirmationDecision).toBe("timeout");
+    });
+
+    it("treats accept-with-confirmed=false as a rejection", async () => {
+      const dispatchMock = createDestructiveDispatchMock();
+      const onElicit = vi.fn(
+        async (): Promise<ElicitResult> => ({
+          action: "accept",
+          content: { confirmed: false },
+        })
+      );
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "worktree.delete" as ActionId,
+            title: "Delete Worktree",
+            description: "Delete a worktree",
+            danger: "confirm",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(
+        await client.callTool({
+          name: "worktree.delete",
+          arguments: { worktreeId: "wt-123" },
+        })
+      );
+
+      expect(onElicit).toHaveBeenCalledTimes(1);
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain("USER_REJECTED");
+      expect(dispatchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not invoke elicitation for non-destructive tools", async () => {
+      const dispatchMock = vi.fn(
+        (): ActionDispatchResult => ({
+          ok: true,
+          result: ["a", "b"],
+        })
+      );
+      const onElicit = vi.fn();
+      const { window } = createMockWindow({
+        getManifest: () => [
+          createManifestEntry({
+            id: "actions.list" as ActionId,
+            title: "List Actions",
+            description: "Read the action registry",
+            kind: "query",
+          }),
+        ],
+        dispatchAction: dispatchMock,
+      });
+
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!, undefined, {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      });
+      transports.push(transport);
+
+      const result = getTextResult(await client.callTool({ name: "actions.list", arguments: {} }));
+
+      expect(onElicit).not.toHaveBeenCalled();
+      expect(result.isError).not.toBe(true);
+      expect(dispatchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("persists the rotated api key to electron-store", async () => {
@@ -3055,7 +3345,7 @@ describe("McpServerService", () => {
       expect(result.content[0]?.text).toContain('"foo": "bar"');
     });
 
-    it("does not emit structuredContent when callTool runs without a prior listTools (cache cold)", async () => {
+    it("warms the manifest cache and emits structuredContent on a cold callTool (no prior listTools)", async () => {
       const { window } = createMockWindow({
         getManifest: () => [
           createManifestEntry({
@@ -3073,6 +3363,10 @@ describe("McpServerService", () => {
       const { client, transport } = await connectClient(service.currentPort!);
       transports.push(transport);
 
+      // The destructive-action gate requires the manifest, so the call
+      // handler now lazy-fetches it on first use. As a side effect, the
+      // structured output schema is also resolved without requiring the
+      // client to call `tools/list` beforehand.
       const result = (await client.callTool({
         name: "actions.list",
         arguments: {},
@@ -3081,7 +3375,7 @@ describe("McpServerService", () => {
         structuredContent?: Record<string, unknown>;
       };
 
-      expect(result.structuredContent).toBeUndefined();
+      expect(result.structuredContent).toEqual({ count: 1, label: "cold" });
       expect(result.content[0]?.text).toContain('"label": "cold"');
     });
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -439,7 +439,8 @@ export type ActionErrorCode =
   | "CONFIRMATION_REQUIRED"
   | "EXECUTION_ERROR"
   | "USER_REJECTED"
-  | "CONFIRMATION_TIMEOUT";
+  | "CONFIRMATION_TIMEOUT"
+  | "ELICITATION_FAILED";
 
 export interface ActionError {
   code: ActionErrorCode;


### PR DESCRIPTION
## Summary

- Migrates 8 destructive MCP tool confirmations from the homegrown `_meta.confirmed` modal pattern to the standards-track `elicitation/create` primitive from `@modelcontextprotocol/sdk@1.27.1`
- `elicitation/create` pauses tool execution and asks the client for input via JSON schema — clients like Cursor render it natively; the old pattern injected confirmation text into tool descriptions and bounced unconfirmed calls to a renderer modal
- Keeps the renderer modal as a fallback for clients that don't negotiate elicitation capability; `action: "decline"` maps to `USER_REJECTED_CODE`, `action: "cancel"` to `CONFIRMATION_TIMEOUT_CODE`

Resolves #6637

## Changes

Tools covered: `terminal.sendCommand`, `worktree.create`, `worktree.delete`, `git.commit`, `git.push`, `copyTree.generate`, `copyTree.generateAndCopyFile`, `copyTree.injectToTerminal`

- `McpServerService.ts` — adds elicitation capability negotiation check; calls `elicitation/create` first on destructive tools, falls back to existing renderer modal for non-supporting clients; removes `_meta.confirmed` description appendix from affected tools
- `shared/types/actions.ts` — tightens `ActionDanger` typing for elicitation path
- `McpServerService.test.ts` — updated to cover elicitation happy path, decline, cancel, and fallback scenarios

## Testing

Unit tests updated and passing. Elicitation flow verified against `elicitation/create` schema; fallback modal path exercised in tests for clients without elicitation capability.