### PR TITLE
feat(actions): default cwd/worktreeId/projectId to active context in MCP dispatch

### DIFF
--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -597,7 +597,7 @@ describe("system action hardening", () => {
     ]);
 
     const filesSearch = actions.get("files.search")!();
-    expect(filesSearch.description).toContain("project.getCurrent");
+    expect(filesSearch.description).toContain("active worktree");
     expect(filesSearch.description).not.toContain("project_getCurrent");
   });
 

--- a/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
@@ -218,6 +218,14 @@ describe("gitActions adversarial", () => {
     );
   });
 
+  it("git.getProjectPulse preserves explicit rangeDays even when worktreeId falls back to ctx", async () => {
+    const { run, git } = setupActions();
+    await run("git.getProjectPulse", { rangeDays: 120 }, { activeWorktreeId: "wt-ctx" });
+    expect(git.getProjectPulse).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: "wt-ctx", rangeDays: 120 })
+    );
+  });
+
   it("git.snapshotGet falls back to ctx.activeWorktreeId", async () => {
     const { run, git } = setupActions();
     await run("git.snapshotGet", undefined, { activeWorktreeId: "wt-1" });

--- a/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/gitActions.adversarial.test.ts
@@ -146,4 +146,86 @@ describe("gitActions adversarial", () => {
     await expect(run("git.commit", { cwd: "/repo" })).rejects.toThrow(/Commit message is required/);
     expect(git.commit).not.toHaveBeenCalled();
   });
+
+  it("git.getStagingStatus falls back to ctx.activeWorktreePath when no args", async () => {
+    const { run, git } = setupActions();
+    await run("git.getStagingStatus", undefined, { activeWorktreePath: "/repo" });
+    expect(git.getStagingStatus).toHaveBeenCalledWith("/repo");
+  });
+
+  it("git.getStagingStatus prefers explicit cwd over ctx", async () => {
+    const { run, git } = setupActions();
+    await run("git.getStagingStatus", { cwd: "/explicit" }, { activeWorktreePath: "/ctx" });
+    expect(git.getStagingStatus).toHaveBeenCalledWith("/explicit");
+  });
+
+  it("git.getStagingStatus throws when no cwd and no ctx", async () => {
+    const { run } = setupActions();
+    await expect(run("git.getStagingStatus")).rejects.toThrow("No active worktree");
+  });
+
+  it("git.getFileDiff falls back to ctx.activeWorktreePath", async () => {
+    const { run, git } = setupActions();
+    await run(
+      "git.getFileDiff",
+      { filePath: "x.ts", status: "modified" },
+      { activeWorktreePath: "/repo" }
+    );
+    expect(git.getFileDiff).toHaveBeenCalledWith("/repo", "x.ts", "modified");
+  });
+
+  it("git.listCommits falls back to ctx.activeWorktreePath and forwards filters", async () => {
+    const { run, git } = setupActions();
+    await run("git.listCommits", { search: "fix", limit: 5 }, { activeWorktreePath: "/repo" });
+    expect(git.listCommits).toHaveBeenCalledWith({ cwd: "/repo", search: "fix", limit: 5 });
+  });
+
+  it("git.stageFile falls back to ctx.activeWorktreePath", async () => {
+    const { run, git } = setupActions();
+    await run("git.stageFile", { filePath: "a.ts" }, { activeWorktreePath: "/repo" });
+    expect(git.stageFile).toHaveBeenCalledWith("/repo", "a.ts");
+  });
+
+  it("git.unstageFile falls back to ctx.activeWorktreePath", async () => {
+    const { run, git } = setupActions();
+    await run("git.unstageFile", { filePath: "a.ts" }, { activeWorktreePath: "/repo" });
+    expect(git.unstageFile).toHaveBeenCalledWith("/repo", "a.ts");
+  });
+
+  it("git.unstageAll falls back to ctx.activeWorktreePath", async () => {
+    const { run, git } = setupActions();
+    await run("git.unstageAll", undefined, { activeWorktreePath: "/repo" });
+    expect(git.unstageAll).toHaveBeenCalledWith("/repo");
+  });
+
+  it("git.getProjectPulse falls back to ctx.activeWorktreeId and defaults rangeDays to 60", async () => {
+    const { run, git } = setupActions();
+    await run("git.getProjectPulse", undefined, { activeWorktreeId: "wt-1" });
+    expect(git.getProjectPulse).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: "wt-1", rangeDays: 60 })
+    );
+  });
+
+  it("git.getProjectPulse preserves explicit rangeDays and forwards include flags", async () => {
+    const { run, git } = setupActions();
+    await run(
+      "git.getProjectPulse",
+      { worktreeId: "wt-2", rangeDays: 180, includeDelta: true },
+      { activeWorktreeId: "wt-ctx" }
+    );
+    expect(git.getProjectPulse).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: "wt-2", rangeDays: 180, includeDelta: true })
+    );
+  });
+
+  it("git.snapshotGet falls back to ctx.activeWorktreeId", async () => {
+    const { run, git } = setupActions();
+    await run("git.snapshotGet", undefined, { activeWorktreeId: "wt-1" });
+    expect(git.snapshotGet).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("git.snapshotGet throws when no worktreeId and no ctx", async () => {
+    const { run } = setupActions();
+    await expect(run("git.snapshotGet")).rejects.toThrow("No active worktree");
+  });
 });

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -36,6 +36,15 @@ function setupActions() {
   };
 }
 
+async function runAction(
+  id: string,
+  args?: unknown,
+  ctx?: Record<string, unknown>
+): Promise<unknown> {
+  const def = setupActions()(id);
+  return def.run(args, (ctx ?? {}) as never);
+}
+
 function setCurrentProject(project: { path?: string } | null) {
   projectStoreMock.getState.mockReturnValue({ currentProject: project });
 }
@@ -148,8 +157,7 @@ describe("githubActions adversarial", () => {
 
   it("listIssues falls back to ctx.activeWorktreePath when cwd omitted", async () => {
     githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
-    const def = setupActions()("github.listIssues");
-    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    await runAction("github.listIssues", {}, { activeWorktreePath: "/repo" });
     expect(githubClientMock.listIssues).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: "/repo" })
     );
@@ -157,10 +165,10 @@ describe("githubActions adversarial", () => {
 
   it("listIssues preserves all filter fields when falling back to ctx", async () => {
     githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
-    const def = setupActions()("github.listIssues");
-    await def.run(
-      { search: "q", state: "open", cursor: "c1" } as never,
-      { activeWorktreePath: "/repo" } as never
+    await runAction(
+      "github.listIssues",
+      { search: "q", state: "open", cursor: "c1" },
+      { activeWorktreePath: "/repo" }
     );
     expect(githubClientMock.listIssues).toHaveBeenCalledWith({
       cwd: "/repo",
@@ -172,10 +180,10 @@ describe("githubActions adversarial", () => {
 
   it("listPullRequests preserves all filter fields when falling back to ctx", async () => {
     githubClientMock.listPullRequests.mockResolvedValue({ pullRequests: [], nextCursor: null });
-    const def = setupActions()("github.listPullRequests");
-    await def.run(
-      { search: "q", state: "merged", cursor: "c1" } as never,
-      { activeWorktreePath: "/repo" } as never
+    await runAction(
+      "github.listPullRequests",
+      { search: "q", state: "merged", cursor: "c1" },
+      { activeWorktreePath: "/repo" }
     );
     expect(githubClientMock.listPullRequests).toHaveBeenCalledWith({
       cwd: "/repo",
@@ -186,14 +194,12 @@ describe("githubActions adversarial", () => {
   });
 
   it("listIssues throws when no cwd and no ctx.activeWorktreePath", async () => {
-    const def = setupActions()("github.listIssues");
-    await expect(def.run({} as never, {} as never)).rejects.toThrow("No active worktree");
+    await expect(runAction("github.listIssues", {})).rejects.toThrow("No active worktree");
   });
 
   it("listIssues prefers explicit cwd over ctx", async () => {
     githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
-    const def = setupActions()("github.listIssues");
-    await def.run({ cwd: "/explicit" }, { activeWorktreePath: "/ctx" } as never);
+    await runAction("github.listIssues", { cwd: "/explicit" }, { activeWorktreePath: "/ctx" });
     expect(githubClientMock.listIssues).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: "/explicit" })
     );
@@ -201,29 +207,25 @@ describe("githubActions adversarial", () => {
 
   it("listPullRequests falls back to ctx.activeWorktreePath when cwd omitted", async () => {
     githubClientMock.listPullRequests.mockResolvedValue({ pullRequests: [], nextCursor: null });
-    const def = setupActions()("github.listPullRequests");
-    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    await runAction("github.listPullRequests", {}, { activeWorktreePath: "/repo" });
     expect(githubClientMock.listPullRequests).toHaveBeenCalledWith(
       expect.objectContaining({ cwd: "/repo" })
     );
   });
 
   it("openIssue falls back to ctx.activeWorktreePath", async () => {
-    const def = setupActions()("github.openIssue");
-    await def.run({ issueNumber: 7 } as never, { activeWorktreePath: "/repo" } as never);
+    await runAction("github.openIssue", { issueNumber: 7 }, { activeWorktreePath: "/repo" });
     expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
   });
 
   it("getRepoStats falls back to ctx.activeWorktreePath", async () => {
-    const def = setupActions()("github.getRepoStats");
-    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    await runAction("github.getRepoStats", {}, { activeWorktreePath: "/repo" });
     expect(githubClientMock.getRepoStats).toHaveBeenCalledWith("/repo", undefined);
   });
 
   it("getIssueByNumber falls back to ctx.activeWorktreePath", async () => {
     githubClientMock.getIssueByNumber.mockResolvedValue(null);
-    const def = setupActions()("github.getIssueByNumber");
-    await def.run({ issueNumber: 5 } as never, { activeWorktreePath: "/repo" } as never);
+    await runAction("github.getIssueByNumber", { issueNumber: 5 }, { activeWorktreePath: "/repo" });
     expect(githubClientMock.getIssueByNumber).toHaveBeenCalledWith("/repo", 5);
   });
 });

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -155,6 +155,36 @@ describe("githubActions adversarial", () => {
     );
   });
 
+  it("listIssues preserves all filter fields when falling back to ctx", async () => {
+    githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
+    const def = setupActions()("github.listIssues");
+    await def.run(
+      { search: "q", state: "open", cursor: "c1" } as never,
+      { activeWorktreePath: "/repo" } as never
+    );
+    expect(githubClientMock.listIssues).toHaveBeenCalledWith({
+      cwd: "/repo",
+      search: "q",
+      state: "open",
+      cursor: "c1",
+    });
+  });
+
+  it("listPullRequests preserves all filter fields when falling back to ctx", async () => {
+    githubClientMock.listPullRequests.mockResolvedValue({ pullRequests: [], nextCursor: null });
+    const def = setupActions()("github.listPullRequests");
+    await def.run(
+      { search: "q", state: "merged", cursor: "c1" } as never,
+      { activeWorktreePath: "/repo" } as never
+    );
+    expect(githubClientMock.listPullRequests).toHaveBeenCalledWith({
+      cwd: "/repo",
+      search: "q",
+      state: "merged",
+      cursor: "c1",
+    });
+  });
+
   it("listIssues throws when no cwd and no ctx.activeWorktreePath", async () => {
     const def = setupActions()("github.listIssues");
     await expect(def.run({} as never, {} as never)).rejects.toThrow("No active worktree");

--- a/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/githubActions.adversarial.test.ts
@@ -145,4 +145,55 @@ describe("githubActions adversarial", () => {
     expect(githubClientMock.getIssueByNumber).toHaveBeenCalledWith("/repo", 42);
     expect(result).toBeNull();
   });
+
+  it("listIssues falls back to ctx.activeWorktreePath when cwd omitted", async () => {
+    githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
+    const def = setupActions()("github.listIssues");
+    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    expect(githubClientMock.listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/repo" })
+    );
+  });
+
+  it("listIssues throws when no cwd and no ctx.activeWorktreePath", async () => {
+    const def = setupActions()("github.listIssues");
+    await expect(def.run({} as never, {} as never)).rejects.toThrow("No active worktree");
+  });
+
+  it("listIssues prefers explicit cwd over ctx", async () => {
+    githubClientMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
+    const def = setupActions()("github.listIssues");
+    await def.run({ cwd: "/explicit" }, { activeWorktreePath: "/ctx" } as never);
+    expect(githubClientMock.listIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/explicit" })
+    );
+  });
+
+  it("listPullRequests falls back to ctx.activeWorktreePath when cwd omitted", async () => {
+    githubClientMock.listPullRequests.mockResolvedValue({ pullRequests: [], nextCursor: null });
+    const def = setupActions()("github.listPullRequests");
+    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    expect(githubClientMock.listPullRequests).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/repo" })
+    );
+  });
+
+  it("openIssue falls back to ctx.activeWorktreePath", async () => {
+    const def = setupActions()("github.openIssue");
+    await def.run({ issueNumber: 7 } as never, { activeWorktreePath: "/repo" } as never);
+    expect(githubClientMock.openIssue).toHaveBeenCalledWith("/repo", 7);
+  });
+
+  it("getRepoStats falls back to ctx.activeWorktreePath", async () => {
+    const def = setupActions()("github.getRepoStats");
+    await def.run({} as never, { activeWorktreePath: "/repo" } as never);
+    expect(githubClientMock.getRepoStats).toHaveBeenCalledWith("/repo", undefined);
+  });
+
+  it("getIssueByNumber falls back to ctx.activeWorktreePath", async () => {
+    githubClientMock.getIssueByNumber.mockResolvedValue(null);
+    const def = setupActions()("github.getIssueByNumber");
+    await def.run({ issueNumber: 5 } as never, { activeWorktreePath: "/repo" } as never);
+    expect(githubClientMock.getIssueByNumber).toHaveBeenCalledWith("/repo", 5);
+  });
 });

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -85,5 +85,11 @@ describe("projectActions adversarial", () => {
       await def.run({ projectId: "explicit" } as never, { projectId: "ctx" } as never);
       expect(projectClientMock.getStats).toHaveBeenCalledWith("explicit");
     });
+
+    it("throws and skips client call when no projectId and no ctx", async () => {
+      const def = setupActions()("project.getStats");
+      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+      expect(projectClientMock.getStats).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -20,17 +20,22 @@ vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
 
 import { registerProjectActions } from "../projectActions";
 
-function setupActions() {
+function setupActions(): {
+  run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
+} {
   const actions: ActionRegistry = new Map();
   const callbacks: ActionCallbacks = {
     onOpenProjectSwitcherPalette: vi.fn(),
     onConfirmCloseActiveProject: vi.fn(),
   } as unknown as ActionCallbacks;
   registerProjectActions(actions, callbacks);
-  return (id: string) => {
-    const factory = actions.get(id);
-    if (!factory) throw new Error(`missing ${id}`);
-    return factory() as AnyActionDefinition;
+  return {
+    run: async (id, args, ctx) => {
+      const factory = actions.get(id);
+      if (!factory) throw new Error(`missing ${id}`);
+      const def = factory() as AnyActionDefinition;
+      return def.run(args, (ctx ?? {}) as never);
+    },
   };
 }
 
@@ -43,52 +48,52 @@ beforeEach(() => {
 describe("projectActions adversarial", () => {
   describe("project.getSettings", () => {
     it("falls back to ctx.projectId when projectId is omitted", async () => {
-      const def = setupActions()("project.getSettings");
-      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      const { run } = setupActions();
+      await run("project.getSettings", undefined, { projectId: "proj-active" });
       expect(projectClientMock.getSettings).toHaveBeenCalledWith("proj-active");
     });
 
     it("prefers explicit projectId over ctx", async () => {
-      const def = setupActions()("project.getSettings");
-      await def.run({ projectId: "proj-explicit" } as never, { projectId: "proj-ctx" } as never);
+      const { run } = setupActions();
+      await run("project.getSettings", { projectId: "proj-explicit" }, { projectId: "proj-ctx" });
       expect(projectClientMock.getSettings).toHaveBeenCalledWith("proj-explicit");
     });
 
     it("throws when projectId is omitted and no active project in ctx", async () => {
-      const def = setupActions()("project.getSettings");
-      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+      const { run } = setupActions();
+      await expect(run("project.getSettings", undefined)).rejects.toThrow("No active project");
     });
   });
 
   describe("project.detectRunners", () => {
     it("falls back to ctx.projectId when projectId is omitted", async () => {
-      const def = setupActions()("project.detectRunners");
-      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      const { run } = setupActions();
+      await run("project.detectRunners", undefined, { projectId: "proj-active" });
       expect(projectClientMock.detectRunners).toHaveBeenCalledWith("proj-active");
     });
 
     it("throws when no projectId and no ctx", async () => {
-      const def = setupActions()("project.detectRunners");
-      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+      const { run } = setupActions();
+      await expect(run("project.detectRunners", undefined)).rejects.toThrow("No active project");
     });
   });
 
   describe("project.getStats", () => {
     it("falls back to ctx.projectId when projectId is omitted", async () => {
-      const def = setupActions()("project.getStats");
-      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      const { run } = setupActions();
+      await run("project.getStats", undefined, { projectId: "proj-active" });
       expect(projectClientMock.getStats).toHaveBeenCalledWith("proj-active");
     });
 
     it("preserves explicit projectId over ctx", async () => {
-      const def = setupActions()("project.getStats");
-      await def.run({ projectId: "explicit" } as never, { projectId: "ctx" } as never);
+      const { run } = setupActions();
+      await run("project.getStats", { projectId: "explicit" }, { projectId: "ctx" });
       expect(projectClientMock.getStats).toHaveBeenCalledWith("explicit");
     });
 
     it("throws and skips client call when no projectId and no ctx", async () => {
-      const def = setupActions()("project.getStats");
-      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+      const { run } = setupActions();
+      await expect(run("project.getStats", undefined)).rejects.toThrow("No active project");
       expect(projectClientMock.getStats).not.toHaveBeenCalled();
     });
   });

--- a/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/projectActions.adversarial.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const projectClientMock = vi.hoisted(() => ({
+  openDialog: vi.fn(),
+  getAll: vi.fn(),
+  getCurrent: vi.fn(),
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  detectRunners: vi.fn(),
+  getStats: vi.fn(),
+}));
+
+const projectStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+
+vi.mock("@/clients", () => ({ projectClient: projectClientMock }));
+vi.mock("@/store/projectStore", () => ({ useProjectStore: projectStoreMock }));
+vi.mock("@/lib/projectMru", () => ({ getMruProjects: vi.fn(() => []) }));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+import { registerProjectActions } from "../projectActions";
+
+function setupActions() {
+  const actions: ActionRegistry = new Map();
+  const callbacks: ActionCallbacks = {
+    onOpenProjectSwitcherPalette: vi.fn(),
+    onConfirmCloseActiveProject: vi.fn(),
+  } as unknown as ActionCallbacks;
+  registerProjectActions(actions, callbacks);
+  return (id: string) => {
+    const factory = actions.get(id);
+    if (!factory) throw new Error(`missing ${id}`);
+    return factory() as AnyActionDefinition;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const fn of Object.values(projectClientMock)) fn.mockResolvedValue(undefined);
+  projectStoreMock.getState.mockReturnValue({ currentProject: null, projects: [] });
+});
+
+describe("projectActions adversarial", () => {
+  describe("project.getSettings", () => {
+    it("falls back to ctx.projectId when projectId is omitted", async () => {
+      const def = setupActions()("project.getSettings");
+      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      expect(projectClientMock.getSettings).toHaveBeenCalledWith("proj-active");
+    });
+
+    it("prefers explicit projectId over ctx", async () => {
+      const def = setupActions()("project.getSettings");
+      await def.run({ projectId: "proj-explicit" } as never, { projectId: "proj-ctx" } as never);
+      expect(projectClientMock.getSettings).toHaveBeenCalledWith("proj-explicit");
+    });
+
+    it("throws when projectId is omitted and no active project in ctx", async () => {
+      const def = setupActions()("project.getSettings");
+      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+    });
+  });
+
+  describe("project.detectRunners", () => {
+    it("falls back to ctx.projectId when projectId is omitted", async () => {
+      const def = setupActions()("project.detectRunners");
+      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      expect(projectClientMock.detectRunners).toHaveBeenCalledWith("proj-active");
+    });
+
+    it("throws when no projectId and no ctx", async () => {
+      const def = setupActions()("project.detectRunners");
+      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active project");
+    });
+  });
+
+  describe("project.getStats", () => {
+    it("falls back to ctx.projectId when projectId is omitted", async () => {
+      const def = setupActions()("project.getStats");
+      await def.run(undefined as never, { projectId: "proj-active" } as never);
+      expect(projectClientMock.getStats).toHaveBeenCalledWith("proj-active");
+    });
+
+    it("preserves explicit projectId over ctx", async () => {
+      const def = setupActions()("project.getStats");
+      await def.run({ projectId: "explicit" } as never, { projectId: "ctx" } as never);
+      expect(projectClientMock.getStats).toHaveBeenCalledWith("explicit");
+    });
+  });
+});

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -47,14 +47,19 @@ vi.mock("@/clients", () => ({
 
 import { registerSystemActions } from "../systemActions";
 
-function setupActions() {
+function setupActions(): {
+  run: (id: string, args?: unknown, ctx?: Record<string, unknown>) => Promise<unknown>;
+} {
   const actions: ActionRegistry = new Map();
   const callbacks: ActionCallbacks = {} as unknown as ActionCallbacks;
   registerSystemActions(actions, callbacks);
-  return (id: string) => {
-    const factory = actions.get(id);
-    if (!factory) throw new Error(`missing ${id}`);
-    return factory() as AnyActionDefinition;
+  return {
+    run: async (id, args, ctx) => {
+      const factory = actions.get(id);
+      if (!factory) throw new Error(`missing ${id}`);
+      const def = factory() as AnyActionDefinition;
+      return def.run(args, (ctx ?? {}) as never);
+    },
   };
 }
 
@@ -68,52 +73,47 @@ beforeEach(() => {
 describe("systemActions adversarial", () => {
   describe("files.search", () => {
     it("falls back to ctx.activeWorktreePath when cwd is omitted", async () => {
-      const def = setupActions()("files.search");
-      await def.run({ query: "Foo" } as never, { activeWorktreePath: "/repo" } as never);
+      const { run } = setupActions();
+      await run("files.search", { query: "Foo" }, { activeWorktreePath: "/repo" });
       expect(filesClientMock.search).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: "/repo", query: "Foo" })
       );
     });
 
     it("prefers explicit cwd over ctx", async () => {
-      const def = setupActions()("files.search");
-      await def.run(
-        { cwd: "/explicit", query: "Foo" } as never,
-        { activeWorktreePath: "/ctx" } as never
-      );
+      const { run } = setupActions();
+      await run("files.search", { cwd: "/explicit", query: "Foo" }, { activeWorktreePath: "/ctx" });
       expect(filesClientMock.search).toHaveBeenCalledWith(
         expect.objectContaining({ cwd: "/explicit" })
       );
     });
 
     it("throws when cwd is omitted and no active worktree", async () => {
-      const def = setupActions()("files.search");
-      await expect(def.run({ query: "Foo" } as never, {} as never)).rejects.toThrow(
-        "No active worktree"
-      );
+      const { run } = setupActions();
+      await expect(run("files.search", { query: "Foo" })).rejects.toThrow("No active worktree");
     });
   });
 
   describe("slashCommands.list", () => {
     it("defaults agentId to 'claude' when omitted", async () => {
-      const def = setupActions()("slashCommands.list");
-      await def.run(undefined as never, {} as never);
+      const { run } = setupActions();
+      await run("slashCommands.list", undefined);
       expect(slashCommandsClientMock.list).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: "claude" })
       );
     });
 
     it("preserves explicit agentId", async () => {
-      const def = setupActions()("slashCommands.list");
-      await def.run({ agentId: "codex" } as never, {} as never);
+      const { run } = setupActions();
+      await run("slashCommands.list", { agentId: "codex" });
       expect(slashCommandsClientMock.list).toHaveBeenCalledWith(
         expect.objectContaining({ agentId: "codex" })
       );
     });
 
     it("forwards projectPath unchanged", async () => {
-      const def = setupActions()("slashCommands.list");
-      await def.run({ projectPath: "/repo" } as never, {} as never);
+      const { run } = setupActions();
+      await run("slashCommands.list", { projectPath: "/repo" });
       expect(slashCommandsClientMock.list).toHaveBeenCalledWith({
         agentId: "claude",
         projectPath: "/repo",
@@ -123,36 +123,40 @@ describe("systemActions adversarial", () => {
 
   describe("copyTree.generate", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
-      const def = setupActions()("copyTree.generate");
-      await def.run(undefined as never, { activeWorktreeId: "wt-active" } as never);
+      const { run } = setupActions();
+      await run("copyTree.generate", undefined, { activeWorktreeId: "wt-active" });
       expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined);
     });
 
     it("forwards options when provided", async () => {
-      const def = setupActions()("copyTree.generate");
+      const { run } = setupActions();
       const options = { format: "xml" as const };
-      await def.run({ options } as never, { activeWorktreeId: "wt-active" } as never);
+      await run("copyTree.generate", { options }, { activeWorktreeId: "wt-active" });
       expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", options);
     });
 
     it("throws when worktreeId is omitted and no active worktree", async () => {
-      const def = setupActions()("copyTree.generate");
-      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active worktree");
+      const { run } = setupActions();
+      await expect(run("copyTree.generate", undefined)).rejects.toThrow("No active worktree");
     });
   });
 
   describe("copyTree.generateAndCopyFile", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
-      const def = setupActions()("copyTree.generateAndCopyFile");
-      await def.run(undefined as never, { activeWorktreeId: "wt-active" } as never);
+      const { run } = setupActions();
+      await run("copyTree.generateAndCopyFile", undefined, { activeWorktreeId: "wt-active" });
       expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-active", undefined);
     });
   });
 
   describe("copyTree.injectToTerminal", () => {
     it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
-      const def = setupActions()("copyTree.injectToTerminal");
-      await def.run({ terminalId: "t-1" } as never, { activeWorktreeId: "wt-active" } as never);
+      const { run } = setupActions();
+      await run(
+        "copyTree.injectToTerminal",
+        { terminalId: "t-1" },
+        { activeWorktreeId: "wt-active" }
+      );
       expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
         "t-1",
         "wt-active",
@@ -161,10 +165,11 @@ describe("systemActions adversarial", () => {
     });
 
     it("preserves explicit worktreeId over ctx", async () => {
-      const def = setupActions()("copyTree.injectToTerminal");
-      await def.run(
-        { terminalId: "t-1", worktreeId: "wt-explicit" } as never,
-        { activeWorktreeId: "wt-ctx" } as never
+      const { run } = setupActions();
+      await run(
+        "copyTree.injectToTerminal",
+        { terminalId: "t-1", worktreeId: "wt-explicit" },
+        { activeWorktreeId: "wt-ctx" }
       );
       expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
         "t-1",
@@ -174,8 +179,8 @@ describe("systemActions adversarial", () => {
     });
 
     it("throws when worktreeId is omitted and no active worktree", async () => {
-      const def = setupActions()("copyTree.injectToTerminal");
-      await expect(def.run({ terminalId: "t-1" } as never, {} as never)).rejects.toThrow(
+      const { run } = setupActions();
+      await expect(run("copyTree.injectToTerminal", { terminalId: "t-1" })).rejects.toThrow(
         "No active worktree"
       );
     });

--- a/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/systemActions.adversarial.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const filesClientMock = vi.hoisted(() => ({
+  search: vi.fn(),
+}));
+
+const copyTreeClientMock = vi.hoisted(() => ({
+  isAvailable: vi.fn(),
+  generate: vi.fn(),
+  generateAndCopyFile: vi.fn(),
+  injectToTerminal: vi.fn(),
+  cancel: vi.fn(),
+  getFileTree: vi.fn(),
+}));
+
+const slashCommandsClientMock = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const systemClientMock = vi.hoisted(() => ({
+  openExternal: vi.fn(),
+  openPath: vi.fn(),
+  checkCommand: vi.fn(),
+  checkDirectory: vi.fn(),
+  getHomeDir: vi.fn(),
+}));
+
+const cliAvailabilityClientMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+const artifactClientMock = vi.hoisted(() => ({
+  saveToFile: vi.fn(),
+  applyPatch: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  filesClient: filesClientMock,
+  copyTreeClient: copyTreeClientMock,
+  slashCommandsClient: slashCommandsClientMock,
+  systemClient: systemClientMock,
+  cliAvailabilityClient: cliAvailabilityClientMock,
+  artifactClient: artifactClientMock,
+}));
+
+import { registerSystemActions } from "../systemActions";
+
+function setupActions() {
+  const actions: ActionRegistry = new Map();
+  const callbacks: ActionCallbacks = {} as unknown as ActionCallbacks;
+  registerSystemActions(actions, callbacks);
+  return (id: string) => {
+    const factory = actions.get(id);
+    if (!factory) throw new Error(`missing ${id}`);
+    return factory() as AnyActionDefinition;
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const fn of Object.values(filesClientMock)) fn.mockResolvedValue(undefined);
+  for (const fn of Object.values(copyTreeClientMock)) fn.mockResolvedValue(undefined);
+  for (const fn of Object.values(slashCommandsClientMock)) fn.mockResolvedValue(undefined);
+});
+
+describe("systemActions adversarial", () => {
+  describe("files.search", () => {
+    it("falls back to ctx.activeWorktreePath when cwd is omitted", async () => {
+      const def = setupActions()("files.search");
+      await def.run({ query: "Foo" } as never, { activeWorktreePath: "/repo" } as never);
+      expect(filesClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: "/repo", query: "Foo" })
+      );
+    });
+
+    it("prefers explicit cwd over ctx", async () => {
+      const def = setupActions()("files.search");
+      await def.run(
+        { cwd: "/explicit", query: "Foo" } as never,
+        { activeWorktreePath: "/ctx" } as never
+      );
+      expect(filesClientMock.search).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: "/explicit" })
+      );
+    });
+
+    it("throws when cwd is omitted and no active worktree", async () => {
+      const def = setupActions()("files.search");
+      await expect(def.run({ query: "Foo" } as never, {} as never)).rejects.toThrow(
+        "No active worktree"
+      );
+    });
+  });
+
+  describe("slashCommands.list", () => {
+    it("defaults agentId to 'claude' when omitted", async () => {
+      const def = setupActions()("slashCommands.list");
+      await def.run(undefined as never, {} as never);
+      expect(slashCommandsClientMock.list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "claude" })
+      );
+    });
+
+    it("preserves explicit agentId", async () => {
+      const def = setupActions()("slashCommands.list");
+      await def.run({ agentId: "codex" } as never, {} as never);
+      expect(slashCommandsClientMock.list).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "codex" })
+      );
+    });
+
+    it("forwards projectPath unchanged", async () => {
+      const def = setupActions()("slashCommands.list");
+      await def.run({ projectPath: "/repo" } as never, {} as never);
+      expect(slashCommandsClientMock.list).toHaveBeenCalledWith({
+        agentId: "claude",
+        projectPath: "/repo",
+      });
+    });
+  });
+
+  describe("copyTree.generate", () => {
+    it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
+      const def = setupActions()("copyTree.generate");
+      await def.run(undefined as never, { activeWorktreeId: "wt-active" } as never);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", undefined);
+    });
+
+    it("forwards options when provided", async () => {
+      const def = setupActions()("copyTree.generate");
+      const options = { format: "xml" as const };
+      await def.run({ options } as never, { activeWorktreeId: "wt-active" } as never);
+      expect(copyTreeClientMock.generate).toHaveBeenCalledWith("wt-active", options);
+    });
+
+    it("throws when worktreeId is omitted and no active worktree", async () => {
+      const def = setupActions()("copyTree.generate");
+      await expect(def.run(undefined as never, {} as never)).rejects.toThrow("No active worktree");
+    });
+  });
+
+  describe("copyTree.generateAndCopyFile", () => {
+    it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
+      const def = setupActions()("copyTree.generateAndCopyFile");
+      await def.run(undefined as never, { activeWorktreeId: "wt-active" } as never);
+      expect(copyTreeClientMock.generateAndCopyFile).toHaveBeenCalledWith("wt-active", undefined);
+    });
+  });
+
+  describe("copyTree.injectToTerminal", () => {
+    it("falls back to ctx.activeWorktreeId when worktreeId is omitted", async () => {
+      const def = setupActions()("copyTree.injectToTerminal");
+      await def.run({ terminalId: "t-1" } as never, { activeWorktreeId: "wt-active" } as never);
+      expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
+        "t-1",
+        "wt-active",
+        undefined
+      );
+    });
+
+    it("preserves explicit worktreeId over ctx", async () => {
+      const def = setupActions()("copyTree.injectToTerminal");
+      await def.run(
+        { terminalId: "t-1", worktreeId: "wt-explicit" } as never,
+        { activeWorktreeId: "wt-ctx" } as never
+      );
+      expect(copyTreeClientMock.injectToTerminal).toHaveBeenCalledWith(
+        "t-1",
+        "wt-explicit",
+        undefined
+      );
+    });
+
+    it("throws when worktreeId is omitted and no active worktree", async () => {
+      const def = setupActions()("copyTree.injectToTerminal");
+      await expect(def.run({ terminalId: "t-1" } as never, {} as never)).rejects.toThrow(
+        "No active worktree"
+      );
+    });
+  });
+});

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -77,6 +77,15 @@ function setupActions(callbacks: MockCallbacks) {
   };
 }
 
+async function runWorkflow(
+  id: string,
+  args?: unknown,
+  ctx?: Record<string, unknown>
+): Promise<unknown> {
+  const def = setupActions(makeCallbacks())(id);
+  return def.run(args, (ctx ?? {}) as never);
+}
+
 function setProject(project: { id?: string; path?: string } | null) {
   projectStoreMock.getState.mockReturnValue({ currentProject: project });
 }
@@ -824,14 +833,14 @@ describe("workflow.prepBranchForReview", () => {
       repoState: "CLEAN",
     });
     projectClientMock.detectRunners.mockResolvedValue([]);
-    const def = setupActions(makeCallbacks())("workflow.prepBranchForReview");
-    await def.run({} as never, { activeWorktreePath: "/repo/active" } as never);
+    await runWorkflow("workflow.prepBranchForReview", {}, { activeWorktreePath: "/repo/active" });
     expect(gitGetStagingStatusMock).toHaveBeenCalledWith("/repo/active");
   });
 
   it("throws when cwd is omitted and no active worktree in ctx", async () => {
-    const def = setupActions(makeCallbacks())("workflow.prepBranchForReview");
-    await expect(def.run({} as never, {} as never)).rejects.toThrow("No active worktree");
+    await expect(runWorkflow("workflow.prepBranchForReview", {})).rejects.toThrow(
+      "No active worktree"
+    );
   });
 });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -814,6 +814,25 @@ describe("workflow.prepBranchForReview", () => {
     expect(result.detectedRunners).toEqual([]);
     expect(result.verdict).toBe("no_runners_detected");
   });
+
+  it("falls back to ctx.activeWorktreePath when cwd is omitted", async () => {
+    gitGetStagingStatusMock.mockResolvedValue({
+      staged: [],
+      unstaged: [],
+      conflictedFiles: [],
+      currentBranch: "feature/x",
+      repoState: "CLEAN",
+    });
+    projectClientMock.detectRunners.mockResolvedValue([]);
+    const def = setupActions(makeCallbacks())("workflow.prepBranchForReview");
+    await def.run({} as never, { activeWorktreePath: "/repo/active" } as never);
+    expect(gitGetStagingStatusMock).toHaveBeenCalledWith("/repo/active");
+  });
+
+  it("throws when cwd is omitted and no active worktree in ctx", async () => {
+    const def = setupActions(makeCallbacks())("workflow.prepBranchForReview");
+    await expect(def.run({} as never, {} as never)).rejects.toThrow("No active worktree");
+  });
 });
 
 describe("workflow.focusNextAttention", () => {

--- a/src/services/actions/definitions/gitActions.ts
+++ b/src/services/actions/definitions/gitActions.ts
@@ -12,15 +12,30 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({
-      worktreeId: z.string(),
-      rangeDays: PulseRangeDaysSchema,
-      includeDelta: z.boolean().optional(),
-      includeRecentCommits: z.boolean().optional(),
-      forceRefresh: z.boolean().optional(),
-    }),
-    run: async (args: unknown) => {
-      return await window.electron.git.getProjectPulse(args as any);
+    argsSchema: z
+      .object({
+        worktreeId: z.string().optional().describe("Worktree ID. Defaults to the active worktree."),
+        rangeDays: PulseRangeDaysSchema,
+        includeDelta: z.boolean().optional(),
+        includeRecentCommits: z.boolean().optional(),
+        forceRefresh: z.boolean().optional(),
+      })
+      .optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const merged = (args ?? {}) as {
+        worktreeId?: string;
+        rangeDays?: 60 | 120 | 180;
+        includeDelta?: boolean;
+        includeRecentCommits?: boolean;
+        forceRefresh?: boolean;
+      };
+      const resolvedWorktreeId = merged.worktreeId ?? ctx.activeWorktreeId;
+      if (!resolvedWorktreeId) throw new Error("No active worktree");
+      return await window.electron.git.getProjectPulse({
+        ...merged,
+        worktreeId: resolvedWorktreeId,
+        rangeDays: merged.rangeDays ?? 60,
+      } as any);
     },
   }));
 
@@ -33,17 +48,22 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     danger: "safe",
     scope: "renderer",
     argsSchema: z.object({
-      cwd: z.string(),
+      cwd: z
+        .string()
+        .optional()
+        .describe("Repository working directory. Defaults to the active worktree path."),
       filePath: z.string(),
       status: GitStatusSchema,
     }),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx: ActionContext) => {
       const { cwd, filePath, status } = args as {
-        cwd: string;
+        cwd?: string;
         filePath: string;
         status: z.infer<typeof GitStatusSchema>;
       };
-      return await window.electron.git.getFileDiff(cwd, filePath, status as any);
+      const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      return await window.electron.git.getFileDiff(resolvedCwd, filePath, status as any);
     },
   }));
 
@@ -55,15 +75,29 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({
-      cwd: z.string(),
-      search: z.string().optional(),
-      branch: z.string().optional(),
-      skip: z.number().int().nonnegative().optional(),
-      limit: z.number().int().positive().optional(),
-    }),
-    run: async (args: unknown) => {
-      return await window.electron.git.listCommits(args as any);
+    argsSchema: z
+      .object({
+        cwd: z
+          .string()
+          .optional()
+          .describe("Repository working directory. Defaults to the active worktree path."),
+        search: z.string().optional(),
+        branch: z.string().optional(),
+        skip: z.number().int().nonnegative().optional(),
+        limit: z.number().int().positive().optional(),
+      })
+      .optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const merged = (args ?? {}) as {
+        cwd?: string;
+        search?: string;
+        branch?: string;
+        skip?: number;
+        limit?: number;
+      };
+      const resolvedCwd = merged.cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      return await window.electron.git.listCommits({ ...merged, cwd: resolvedCwd } as any);
     },
   }));
 
@@ -75,10 +109,18 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ cwd: z.string(), filePath: z.string() }),
-    run: async (args: unknown) => {
-      const { cwd, filePath } = args as { cwd: string; filePath: string };
-      await window.electron.git.stageFile(cwd, filePath);
+    argsSchema: z.object({
+      cwd: z
+        .string()
+        .optional()
+        .describe("Repository working directory. Defaults to the active worktree path."),
+      filePath: z.string(),
+    }),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { cwd, filePath } = args as { cwd?: string; filePath: string };
+      const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      await window.electron.git.stageFile(resolvedCwd, filePath);
     },
   }));
 
@@ -90,10 +132,18 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ cwd: z.string(), filePath: z.string() }),
-    run: async (args: unknown) => {
-      const { cwd, filePath } = args as { cwd: string; filePath: string };
-      await window.electron.git.unstageFile(cwd, filePath);
+    argsSchema: z.object({
+      cwd: z
+        .string()
+        .optional()
+        .describe("Repository working directory. Defaults to the active worktree path."),
+      filePath: z.string(),
+    }),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { cwd, filePath } = args as { cwd?: string; filePath: string };
+      const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      await window.electron.git.unstageFile(resolvedCwd, filePath);
     },
   }));
 
@@ -122,10 +172,12 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ cwd: z.string() }),
-    run: async (args: unknown) => {
-      const { cwd } = args as { cwd: string };
-      await window.electron.git.unstageAll(cwd);
+    argsSchema: z.object({ cwd: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { cwd } = (args ?? {}) as { cwd?: string };
+      const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      await window.electron.git.unstageAll(resolvedCwd);
     },
   }));
 
@@ -177,10 +229,12 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ cwd: z.string() }),
-    run: async (args: unknown) => {
-      const { cwd } = args as { cwd: string };
-      return await window.electron.git.getStagingStatus(cwd);
+    argsSchema: z.object({ cwd: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { cwd } = (args ?? {}) as { cwd?: string };
+      const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+      if (!resolvedCwd) throw new Error("No active worktree");
+      return await window.electron.git.getStagingStatus(resolvedCwd);
     },
   }));
 
@@ -192,10 +246,12 @@ export function registerGitActions(actions: ActionRegistry, _callbacks: ActionCa
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string() }),
-    run: async (args: unknown) => {
-      const { worktreeId } = args as { worktreeId: string };
-      return await window.electron.git.snapshotGet(worktreeId);
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const resolvedWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      if (!resolvedWorktreeId) throw new Error("No active worktree");
+      return await window.electron.git.snapshotGet(resolvedWorktreeId);
     },
   }));
 

--- a/src/services/actions/definitions/githubActions.ts
+++ b/src/services/actions/definitions/githubActions.ts
@@ -1,11 +1,15 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import type { ActionContext } from "@shared/types/actions";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { githubClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 
 const GitHubListOptionsSchema = z.object({
-  cwd: z.string().describe("Working directory of the git repo"),
+  cwd: z
+    .string()
+    .optional()
+    .describe("Working directory of the git repo. Defaults to the active worktree path."),
   search: z.string().optional().describe("Search query"),
   state: z
     .enum(["open", "closed", "merged", "all"])
@@ -106,9 +110,17 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "command",
       danger: "safe",
       scope: "renderer",
-      argsSchema: z.object({ cwd: z.string(), issueNumber: z.number().int().positive() }),
-      run: async ({ cwd, issueNumber }) => {
-        await githubClient.openIssue(cwd, issueNumber);
+      argsSchema: z.object({
+        cwd: z
+          .string()
+          .optional()
+          .describe("Working directory of the git repo. Defaults to the active worktree path."),
+        issueNumber: z.number().int().positive(),
+      }),
+      run: async ({ cwd, issueNumber }, ctx: ActionContext) => {
+        const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        await githubClient.openIssue(resolvedCwd, issueNumber);
       },
     })
   );
@@ -138,9 +150,17 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       kind: "query",
       danger: "safe",
       scope: "renderer",
-      argsSchema: z.object({ cwd: z.string(), bypassCache: z.boolean().optional() }),
-      run: async ({ cwd, bypassCache }) => {
-        return await githubClient.getRepoStats(cwd, bypassCache);
+      argsSchema: z.object({
+        cwd: z
+          .string()
+          .optional()
+          .describe("Working directory of the git repo. Defaults to the active worktree path."),
+        bypassCache: z.boolean().optional(),
+      }),
+      run: async ({ cwd, bypassCache }, ctx: ActionContext) => {
+        const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        return await githubClient.getRepoStats(resolvedCwd, bypassCache);
       },
     })
   );
@@ -156,10 +176,15 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       danger: "safe",
       scope: "renderer",
       argsSchema: GitHubListOptionsSchema,
-      run: async (args) => {
+      run: async (args, ctx: ActionContext) => {
+        const resolvedCwd = args.cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
         // Schema allows `state: "merged"` (valid for PRs); the issues client API
         // does not. Preserved as a runtime gap — see githubActions.adversarial.test.ts.
-        return await githubClient.listIssues(args as Parameters<typeof githubClient.listIssues>[0]);
+        return await githubClient.listIssues({
+          ...args,
+          cwd: resolvedCwd,
+        } as Parameters<typeof githubClient.listIssues>[0]);
       },
     })
   );
@@ -174,11 +199,16 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       danger: "safe",
       scope: "renderer",
       argsSchema: z.object({
-        cwd: z.string().describe("Working directory of the git repo"),
+        cwd: z
+          .string()
+          .optional()
+          .describe("Working directory of the git repo. Defaults to the active worktree path."),
         issueNumber: z.number().int().positive().describe("Issue number to fetch"),
       }),
-      run: async ({ cwd, issueNumber }) => {
-        return await githubClient.getIssueByNumber(cwd, issueNumber);
+      run: async ({ cwd, issueNumber }, ctx: ActionContext) => {
+        const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        return await githubClient.getIssueByNumber(resolvedCwd, issueNumber);
       },
     })
   );
@@ -194,8 +224,10 @@ export function registerGithubActions(actions: ActionRegistry, _callbacks: Actio
       danger: "safe",
       scope: "renderer",
       argsSchema: GitHubListOptionsSchema,
-      run: async (args) => {
-        return await githubClient.listPullRequests(args);
+      run: async (args, ctx: ActionContext) => {
+        const resolvedCwd = args.cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        return await githubClient.listPullRequests({ ...args, cwd: resolvedCwd });
       },
     })
   );

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -1,4 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import type { ActionContext } from "@shared/types/actions";
 import { z } from "zod";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
@@ -240,10 +241,12 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ projectId: z.string() }),
-    run: async (args: unknown) => {
-      const { projectId } = args as { projectId: string };
-      return await projectClient.getSettings(projectId);
+    argsSchema: z.object({ projectId: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { projectId } = (args ?? {}) as { projectId?: string };
+      const resolvedProjectId = projectId ?? ctx.projectId;
+      if (!resolvedProjectId) throw new Error("No active project");
+      return await projectClient.getSettings(resolvedProjectId);
     },
   }));
 
@@ -320,10 +323,12 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ projectId: z.string() }),
-    run: async (args: unknown) => {
-      const { projectId } = args as { projectId: string };
-      return await projectClient.detectRunners(projectId);
+    argsSchema: z.object({ projectId: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { projectId } = (args ?? {}) as { projectId?: string };
+      const resolvedProjectId = projectId ?? ctx.projectId;
+      if (!resolvedProjectId) throw new Error("No active project");
+      return await projectClient.detectRunners(resolvedProjectId);
     },
   }));
 
@@ -335,10 +340,12 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ projectId: z.string() }),
-    run: async (args: unknown) => {
-      const { projectId } = args as { projectId: string };
-      return await projectClient.getStats(projectId);
+    argsSchema: z.object({ projectId: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { projectId } = (args ?? {}) as { projectId?: string };
+      const resolvedProjectId = projectId ?? ctx.projectId;
+      if (!resolvedProjectId) throw new Error("No active project");
+      return await projectClient.getStats(resolvedProjectId);
     },
   }));
 

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -52,10 +52,18 @@ export const GitStatusSchema = z.enum([
   "copied",
 ]);
 
-export const PulseRangeDaysSchema = z.union([z.literal(60), z.literal(120), z.literal(180)]);
+export const PulseRangeDaysSchema = z
+  .union([z.literal(60), z.literal(120), z.literal(180)])
+  .optional()
+  .default(60);
 
 export const FileSearchPayloadSchema = z.object({
-  cwd: z.string().describe("Working directory to search in (project root path)"),
+  cwd: z
+    .string()
+    .optional()
+    .describe(
+      "Working directory to search in (project root path). Defaults to the active worktree path."
+    ),
   query: z.string().describe("File name search query"),
   limit: z.number().int().positive().optional().describe("Max results to return"),
 });

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -1,4 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import type { ActionContext } from "@shared/types/actions";
 import { defineAction } from "../defineAction";
 import { CopyTreeOptionsSchema, FileSearchPayloadSchema, BuiltInAgentIdSchema } from "./schemas";
 import { z } from "zod";
@@ -120,14 +121,16 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       id: "files.search",
       title: "Search Files",
       description:
-        "Search for files by name in a directory. Requires cwd (use project.getCurrent to get the project path).",
+        "Search for files by name in a directory. Defaults to the active worktree path when cwd is omitted.",
       category: "files",
       kind: "query",
       danger: "safe",
       scope: "renderer",
       argsSchema: FileSearchPayloadSchema,
-      run: async (payload) => {
-        return await filesClient.search(payload);
+      run: async (payload, ctx: ActionContext) => {
+        const resolvedCwd = payload.cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
+        return await filesClient.search({ ...payload, cwd: resolvedCwd });
       },
     })
   );
@@ -136,14 +139,23 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     defineAction({
       id: "slashCommands.list",
       title: "List Slash Commands",
-      description: "List available slash commands for an agent",
+      description:
+        "List available slash commands for an agent. Defaults to 'claude' when agentId is omitted.",
       category: "agent",
       kind: "query",
       danger: "safe",
       scope: "renderer",
-      argsSchema: z.object({ agentId: BuiltInAgentIdSchema, projectPath: z.string().optional() }),
+      argsSchema: z
+        .object({
+          agentId: BuiltInAgentIdSchema.optional().describe(
+            "Agent ID. Defaults to 'claude' when omitted."
+          ),
+          projectPath: z.string().optional(),
+        })
+        .optional(),
       run: async (payload) => {
-        return await slashCommandsClient.list(payload);
+        const agentId = payload?.agentId ?? "claude";
+        return await slashCommandsClient.list({ agentId, projectPath: payload?.projectPath });
       },
     })
   );
@@ -213,9 +225,19 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       // `danger: "confirm"` gates the UI on a token-cost confirmation, but the
       // operation itself is read-only and not destructive.
       mcpAnnotations: { destructiveHint: false },
-      argsSchema: z.object({ worktreeId: z.string(), options: CopyTreeOptionsSchema.optional() }),
-      run: async ({ worktreeId, options }) => {
-        return await copyTreeClient.generate(worktreeId, options);
+      argsSchema: z
+        .object({
+          worktreeId: z
+            .string()
+            .optional()
+            .describe("Worktree ID. Defaults to the active worktree."),
+          options: CopyTreeOptionsSchema.optional(),
+        })
+        .optional(),
+      run: async (args, ctx: ActionContext) => {
+        const worktreeId = args?.worktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) throw new Error("No active worktree");
+        return await copyTreeClient.generate(worktreeId, args?.options);
       },
     })
   );
@@ -231,9 +253,19 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       scope: "renderer",
       // Writes to clipboard only; not a destructive world-state mutation.
       mcpAnnotations: { destructiveHint: false },
-      argsSchema: z.object({ worktreeId: z.string(), options: CopyTreeOptionsSchema.optional() }),
-      run: async ({ worktreeId, options }) => {
-        return await copyTreeClient.generateAndCopyFile(worktreeId, options);
+      argsSchema: z
+        .object({
+          worktreeId: z
+            .string()
+            .optional()
+            .describe("Worktree ID. Defaults to the active worktree."),
+          options: CopyTreeOptionsSchema.optional(),
+        })
+        .optional(),
+      run: async (args, ctx: ActionContext) => {
+        const worktreeId = args?.worktreeId ?? ctx.activeWorktreeId;
+        if (!worktreeId) throw new Error("No active worktree");
+        return await copyTreeClient.generateAndCopyFile(worktreeId, args?.options);
       },
     })
   );
@@ -250,11 +282,13 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
       keywords: ["context", "inject", "dump"],
       argsSchema: z.object({
         terminalId: z.string(),
-        worktreeId: z.string(),
+        worktreeId: z.string().optional().describe("Worktree ID. Defaults to the active worktree."),
         options: CopyTreeOptionsSchema.optional(),
       }),
-      run: async ({ terminalId, worktreeId, options }) => {
-        return await copyTreeClient.injectToTerminal(terminalId, worktreeId, options);
+      run: async ({ terminalId, worktreeId, options }, ctx: ActionContext) => {
+        const resolvedWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+        if (!resolvedWorktreeId) throw new Error("No active worktree");
+        return await copyTreeClient.injectToTerminal(terminalId, resolvedWorktreeId, options);
       },
     })
   );

--- a/src/services/actions/definitions/workflowActions.ts
+++ b/src/services/actions/definitions/workflowActions.ts
@@ -1,4 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import type { ActionContext } from "@shared/types/actions";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
 import { worktreeClient, githubClient, projectClient, copyTreeClient } from "@/clients";
@@ -498,7 +499,10 @@ export function registerWorkflowActions(
       danger: "safe",
       scope: "renderer",
       argsSchema: z.object({
-        cwd: z.string().describe("Worktree path to inspect"),
+        cwd: z
+          .string()
+          .optional()
+          .describe("Worktree path to inspect. Defaults to the active worktree path when omitted."),
         projectId: z
           .string()
           .optional()
@@ -528,11 +532,13 @@ export function registerWorkflowActions(
           })
         ),
       }),
-      run: async ({ cwd, projectId }) => {
+      run: async ({ cwd, projectId }, ctx: ActionContext) => {
+        const resolvedCwd = cwd ?? ctx.activeWorktreePath;
+        if (!resolvedCwd) throw new Error("No active worktree");
         const resolvedProjectId =
-          projectId ?? useProjectStore.getState().currentProject?.id ?? null;
+          projectId ?? ctx.projectId ?? useProjectStore.getState().currentProject?.id ?? null;
 
-        const status = await window.electron.git.getStagingStatus(cwd);
+        const status = await window.electron.git.getStagingStatus(resolvedCwd);
 
         const detectedRunners = resolvedProjectId
           ? (await projectClient.detectRunners(resolvedProjectId)).map((r) => ({


### PR DESCRIPTION
## Summary

- Made `cwd`, `worktreeId`, and `projectId` optional in 18+ MCP-exposed action definitions — they now default to the active context server-side, saving an extra round-trip to `getContext` per action call.
- Defaulted `rangeDays` to `60` for `git.getProjectPulse` and `agentId` to `claude` for `slashCommands.list`.
- Fixed the broken `daintree://project/current/issues` resource, which was returning a `VALIDATION_ERROR` because its handler invoked `github.listIssues` without `cwd`.

Resolves #6631

## Changes

- `gitActions.ts`, `githubActions.ts`, `projectActions.ts`, `systemActions.ts`, `workflowActions.ts` — context params made optional with active-context fallback
- `schemas.ts` — shared optional schema helpers for context params
- Skipped `worktree.delete` and `worktree.setActive` — destructive actions should require explicit context
- Explicit values still win as overrides; the defaulting only fires when a param is absent

## Testing

Added adversarial tests across five action domains covering:
- Context fallback when params are omitted
- Explicit-value precedence over active context
- Missing-context error paths (no active worktree, no active project)