### PR TITLE
fix(agent-state): show indicators for runtime-detected agent terminals

### DIFF
--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -121,10 +121,9 @@ export class AgentStateService {
     sessionTokens?: number
   ): boolean {
     // Detection wins; fall back to the launch hint during the boot window.
+    // May be undefined for runtime-detected-only flows; consumers fall back to
+    // terminalId for routing.
     const effectiveAgentId = terminal.detectedAgentId ?? terminal.launchAgentId;
-    if (!effectiveAgentId) {
-      return false;
-    }
 
     const previousState = terminal.agentState || "idle";
     const newState = nextAgentState(previousState, event);
@@ -311,10 +310,6 @@ export class AgentStateService {
       sessionTokens?: number;
     }
   ): void {
-    if (!terminal.detectedAgentId && !terminal.launchAgentId) {
-      return;
-    }
-
     const event: AgentEvent =
       activity === "busy"
         ? metadata?.trigger === "input"

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -299,24 +299,55 @@ describe("AgentStateService", () => {
       expect(stateChanges[0]?.agentId).toBe("gemini");
     });
 
-    it("does nothing when both agentId and detectedAgentType are absent", () => {
+    // #6650 — Identity-less terminals (no detectedAgentId, no launchAgentId)
+    // must still flow through the state machine so the renderer can show an
+    // active-state indicator during the boot/identity-commit window.
+    it("emits state-changed for identity-less terminal with agentId undefined (#6650)", () => {
       const service = new AgentStateService();
       const terminal = createTerminal({
         launchAgentId: undefined,
         detectedAgentId: undefined,
         agentState: "idle",
       });
-      const stateChanges: unknown[] = [];
+      const stateChanges: Array<{ state: string; agentId?: string }> = [];
 
       events.on("agent:state-changed", (payload) => {
-        stateChanges.push(payload);
+        stateChanges.push({ state: payload.state, agentId: payload.agentId });
       });
 
       const changed = service.updateAgentState(terminal, { type: "busy" });
 
-      expect(changed).toBe(false);
-      expect(terminal.agentState).toBe("idle");
-      expect(stateChanges).toHaveLength(0);
+      expect(changed).toBe(true);
+      expect(terminal.agentState).toBe("working");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.state).toBe("working");
+      expect(stateChanges[0]?.agentId).toBeUndefined();
+    });
+
+    it("handleActivityState emits state-changed for identity-less terminal (#6650)", () => {
+      const service = new AgentStateService();
+      const terminal = createTerminal({
+        launchAgentId: undefined,
+        detectedAgentId: undefined,
+        agentState: "idle",
+      });
+      const stateChanges: Array<{ state: string; agentId?: string; trigger: string }> = [];
+
+      events.on("agent:state-changed", (payload) => {
+        stateChanges.push({
+          state: payload.state,
+          agentId: payload.agentId,
+          trigger: payload.trigger,
+        });
+      });
+
+      service.handleActivityState(terminal, "busy", { trigger: "output" });
+
+      expect(terminal.agentState).toBe("working");
+      expect(stateChanges).toHaveLength(1);
+      expect(stateChanges[0]?.state).toBe("working");
+      expect(stateChanges[0]?.agentId).toBeUndefined();
+      expect(stateChanges[0]?.trigger).toBe("output");
     });
 
     it("emitTerminalActivity produces agent-style headline for detectedAgentType-only terminal", () => {

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -13,7 +13,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
   // Drag visual color mirrors the same chrome descriptor used by tabs/panels.
   const chrome = deriveTerminalChrome(terminal);
   const brandColor = chrome.color;
-  const isWorking = chrome.isAgent && terminal.agentState === "working";
+  const isWorking = terminal.agentState === "working";
   const isGroupDrag = (groupTabCount ?? 0) > 1;
 
   return (

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -438,13 +438,14 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     exitCode: activePanel.exitCode,
     presetColor: brandColor,
   });
-  const agentState = activeChrome.isAgent ? getDockDisplayAgentState(activePanel) : undefined;
+  const agentState = getDockDisplayAgentState(activePanel);
   const isWorking = agentState === "working";
   const isWaiting = agentState === "waiting";
   const isActive = isWorking || isWaiting;
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
   const displayTitle = getBaseTitle(activePanel.title);
-  const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
+  const showStateIcon =
+    agentState && agentState !== "idle" && agentState !== "completed" && agentState !== "exited";
   const StateIcon = showStateIcon
     ? getEffectiveStateIcon(agentState, activePanel.waitingReason)
     : null;
@@ -603,9 +604,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                           title={getBaseTitle(panel.title)}
                           chrome={tabChrome}
                           kind={panel.kind ?? "terminal"}
-                          agentState={
-                            tabChrome.isAgent ? getDockDisplayAgentState(panel) : undefined
-                          }
+                          agentState={getDockDisplayAgentState(panel)}
                           isActive={panel.id === activeTabId}
                           presetColor={panelPresetColors.get(panel.id)}
                           isUsingFallback={panel.isUsingFallback}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -261,7 +261,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     ]
   );
 
-  const agentState = chrome.isAgent ? getDockDisplayAgentState(terminal) : undefined;
+  const agentState = getDockDisplayAgentState(terminal);
   const isWorking = agentState === "working";
   const isWaiting = agentState === "waiting";
   const isActive = isWorking || isWaiting;

--- a/src/components/Layout/__tests__/dockAgentState.test.ts
+++ b/src/components/Layout/__tests__/dockAgentState.test.ts
@@ -54,4 +54,55 @@ describe("dock display agent state", () => {
   it("does not deprioritize a group with working activity even before agentState catches up", () => {
     expect(isGroupDeprioritized([agent({ activityStatus: "working" })])).toBe(false);
   });
+
+  // #6650 — Identity-less terminals with active agentState must surface the
+  // dock indicator. The backend only emits "working"/"waiting"/"directing"
+  // from agent-sourced events, so we trust the state during the boot window.
+  describe("identity-less active states (#6650)", () => {
+    it("returns 'working' for a panel with no identity fields and agentState='working'", () => {
+      expect(getDockDisplayAgentState({ agentState: "working" })).toBe("working");
+    });
+
+    it("returns 'waiting' for a panel with no identity fields and agentState='waiting'", () => {
+      expect(getDockDisplayAgentState({ agentState: "waiting" })).toBe("waiting");
+    });
+
+    it("returns 'directing' for a panel with no identity fields and agentState='directing'", () => {
+      expect(getDockDisplayAgentState({ agentState: "directing" })).toBe("directing");
+    });
+
+    it("returns undefined for an identity-less panel with agentState='idle'", () => {
+      expect(
+        getDockDisplayAgentState({
+          launchAgentId: undefined,
+          detectedAgentId: undefined,
+          agentState: "idle",
+        })
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for an identity-less panel with agentState='exited'", () => {
+      expect(
+        getDockDisplayAgentState({
+          launchAgentId: undefined,
+          detectedAgentId: undefined,
+          agentState: "exited",
+        })
+      ).toBeUndefined();
+    });
+
+    it("does not bleed plain-shell activity into agent state", () => {
+      expect(
+        getDockDisplayAgentState({
+          launchAgentId: undefined,
+          detectedAgentId: undefined,
+          activityStatus: "working",
+        })
+      ).toBeUndefined();
+    });
+
+    it("preserves canonical-agent path when launchAgentId is set", () => {
+      expect(getDockDisplayAgentState(agent({ agentState: "working" }))).toBe("working");
+    });
+  });
 });

--- a/src/components/Layout/useDockBlockedState.ts
+++ b/src/components/Layout/useDockBlockedState.ts
@@ -24,10 +24,22 @@ type AgentStateSource = {
 };
 
 function hasRuntimeAgentIdentity(panel: AgentStateSource): boolean {
-  // An active agentState ("working" | "waiting" | "directing") signals an
-  // in-flight agent run even when identity hasn't been committed yet — the
-  // backend only emits these states from agent-sourced events, so trust the
-  // signal during the identity-boot window.
+  const hasIdentityFields =
+    "runtimeIdentity" in panel ||
+    "detectedAgentId" in panel ||
+    "launchAgentId" in panel ||
+    "runtimeStatus" in panel ||
+    "exitCode" in panel;
+
+  // If identity fields are present, check them definitively.
+  if (hasIdentityFields) {
+    return isAgentTerminal(panel);
+  }
+
+  // No identity fields present: An active agentState ("working" | "waiting" |
+  // "directing") signals an in-flight agent run during the identity-boot
+  // window — the backend only emits these states from agent-sourced events,
+  // so trust the signal until identity fields arrive.
   if (
     panel.agentState === "working" ||
     panel.agentState === "waiting" ||
@@ -35,9 +47,7 @@ function hasRuntimeAgentIdentity(panel: AgentStateSource): boolean {
   ) {
     return true;
   }
-  if ("runtimeIdentity" in panel || "detectedAgentId" in panel) {
-    return isAgentTerminal(panel);
-  }
+
   // Backward-compatible for unit tests and pure callers that pass only state.
   return true;
 }

--- a/src/components/Layout/useDockBlockedState.ts
+++ b/src/components/Layout/useDockBlockedState.ts
@@ -24,6 +24,17 @@ type AgentStateSource = {
 };
 
 function hasRuntimeAgentIdentity(panel: AgentStateSource): boolean {
+  // An active agentState ("working" | "waiting" | "directing") signals an
+  // in-flight agent run even when identity hasn't been committed yet — the
+  // backend only emits these states from agent-sourced events, so trust the
+  // signal during the identity-boot window.
+  if (
+    panel.agentState === "working" ||
+    panel.agentState === "waiting" ||
+    panel.agentState === "directing"
+  ) {
+    return true;
+  }
   if ("runtimeIdentity" in panel || "detectedAgentId" in panel) {
     return isAgentTerminal(panel);
   }

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -266,7 +266,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
       presetColor,
     ]
   );
-  const ownAgentState = terminalChrome.isAgent ? agentState : undefined;
+  const ownAgentState = agentState;
   // Determine effective agent state for container border styling.
   // ambientAgentState takes priority so tab groups can surface highest-urgency
   // state from hidden live-agent tabs without affecting the active header chip.

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -250,7 +250,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     | WaitingReason
     | undefined;
   const showStateIcon =
-    chrome.isAgent && agentState && agentState !== "idle" && agentState !== "completed";
+    agentState && agentState !== "idle" && agentState !== "completed" && agentState !== "exited";
   const StateIcon = showStateIcon ? getEffectiveStateIcon(agentState, waitingReason) : null;
 
   return (

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -371,4 +371,63 @@ describe("TabButton", () => {
       expect(input.tagName).toBe("INPUT");
     });
   });
+
+  // #6650 — State indicator must render whenever agentState is active, even
+  // when chrome.isAgent is false (identity hasn't committed yet).
+  describe("state indicator visibility (#6650)", () => {
+    it("renders working spinner when agentState='working' even with non-agent chrome", () => {
+      const { container } = render(
+        <TabButton {...defaultProps} chrome={deriveTerminalChrome()} agentState="working" />
+      );
+      const spinner = container.querySelector(".text-state-working");
+      expect(spinner).not.toBeNull();
+    });
+
+    // The state icon is the only element that combines "shrink-0" with
+    // "motion-reduce:animate-none" (TabButton.tsx:330-339). That class combo is
+    // a stable identifier across all six AgentState values.
+    const queryStateIcon = (container: Element) =>
+      Array.from(container.querySelectorAll("svg")).find((svg) => {
+        const cls = svg.getAttribute("class") ?? "";
+        return cls.includes("shrink-0") && cls.includes("motion-reduce:animate-none");
+      });
+
+    it("does not render state icon when agentState='exited'", () => {
+      const { container } = render(
+        <TabButton
+          {...defaultProps}
+          chrome={deriveTerminalChrome({ launchAgentId: "claude" })}
+          agentState="exited"
+        />
+      );
+      expect(queryStateIcon(container)).toBeUndefined();
+    });
+
+    it("does not render state icon when agentState='idle'", () => {
+      const { container } = render(
+        <TabButton
+          {...defaultProps}
+          chrome={deriveTerminalChrome({ launchAgentId: "claude" })}
+          agentState="idle"
+        />
+      );
+      expect(queryStateIcon(container)).toBeUndefined();
+    });
+
+    it("does not render state icon when agentState='completed'", () => {
+      const { container } = render(
+        <TabButton
+          {...defaultProps}
+          chrome={deriveTerminalChrome({ launchAgentId: "claude" })}
+          agentState="completed"
+        />
+      );
+      expect(queryStateIcon(container)).toBeUndefined();
+    });
+
+    it("does not render state icon when agentState is undefined (plain shell)", () => {
+      const { container } = render(<TabButton {...defaultProps} chrome={deriveTerminalChrome()} />);
+      expect(queryStateIcon(container)).toBeUndefined();
+    });
+  });
 });

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -84,7 +84,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
   const isArmed = useFleetArmingStore((s) => s.armedIds.has(term.id));
   const armBadge = useFleetArmingStore((s) => s.armOrderById[term.id]);
   const chrome = deriveTerminalChrome(term);
-  const agentState = chrome.isAgent ? term.agentState : undefined;
+  const agentState = term.agentState;
   // Only the primary ("last armed") row gets the accent ring — it's the
   // singular focus anchor that will receive keyboard focus when fleet scope
   // exits. Secondary armed peers keep the dashed shape but use a neutral
@@ -152,6 +152,8 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
 
           {agentState &&
             agentState !== "idle" &&
+            agentState !== "completed" &&
+            agentState !== "exited" &&
             (() => {
               const Icon = getEffectiveStateIcon(agentState, term.waitingReason);
               return (

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -412,3 +412,130 @@ describe("WorktreeTerminalSection arming click handlers", () => {
     expect(scrollContainer).toBeTruthy();
   });
 });
+
+// #6650 — Terminal row state icon must render for any non-idle/non-completed/
+// non-exited agentState, regardless of whether agent identity has committed.
+describe("WorktreeTerminalSection row state icon (#6650)", () => {
+  beforeEach(() => {
+    useFleetArmingStore.setState({
+      armedIds: new Set<string>(),
+      armOrder: [],
+      armOrderById: {},
+      lastArmedId: null,
+    });
+  });
+
+  it("renders working icon when agentState='working' and no agent identity is set", () => {
+    const term = makeTerminal({
+      id: "no-id-1",
+      kind: "terminal",
+      hasPty: true,
+      agentState: "working",
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="no-id-1"]');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute("data-terminal-agent-state")).toBe("working");
+    const stateIcon = row?.querySelector('[aria-label="working"]');
+    expect(stateIcon).not.toBeNull();
+  });
+
+  it("renders waiting icon for identity-less terminal with agentState='waiting'", () => {
+    const term = makeTerminal({
+      id: "no-id-2",
+      kind: "terminal",
+      hasPty: true,
+      agentState: "waiting",
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="no-id-2"]');
+    const stateIcon = row?.querySelector('[aria-label="waiting"]');
+    expect(stateIcon).not.toBeNull();
+  });
+
+  it("does not render state icon when agentState='idle'", () => {
+    const term = makeTerminal({
+      id: "idle-1",
+      kind: "terminal",
+      hasPty: true,
+      detectedAgentId: "claude",
+      agentState: "idle",
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="idle-1"]');
+    const stateIcons = row?.querySelectorAll(
+      '[aria-label="working"], [aria-label="waiting"], [aria-label="directing"]'
+    );
+    expect(stateIcons?.length ?? 0).toBe(0);
+  });
+
+  it("does not render state icon when agentState='exited' (no stale indicator)", () => {
+    const term = makeTerminal({
+      id: "exited-1",
+      kind: "terminal",
+      hasPty: true,
+      launchAgentId: "claude",
+      agentState: "exited",
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="exited-1"]');
+    const stateIcon = row?.querySelector('[aria-label="exited"]');
+    expect(stateIcon).toBeNull();
+  });
+
+  it("does not render state icon when agentState='completed'", () => {
+    const term = makeTerminal({
+      id: "completed-1",
+      kind: "terminal",
+      hasPty: true,
+      detectedAgentId: "claude",
+      agentState: "completed",
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="completed-1"]');
+    const stateIcon = row?.querySelector('[aria-label="done"]');
+    expect(stateIcon).toBeNull();
+  });
+
+  it("does not render state icon when agentState is undefined (plain shell)", () => {
+    const term = makeTerminal({
+      id: "plain-1",
+      kind: "terminal",
+      hasPty: true,
+    });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    const row = container.querySelector('[data-terminal-id="plain-1"]');
+    const stateIcons = row?.querySelectorAll("[aria-label]");
+    const stateRelated = Array.from(stateIcons ?? []).filter((el) => {
+      const label = el.getAttribute("aria-label");
+      return (
+        label === "working" || label === "waiting" || label === "directing" || label === "idle"
+      );
+    });
+    expect(stateRelated.length).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from "vitest";
 import type { TerminalInstance, AgentState } from "../../types";
+import { aggregateAgentStates } from "../useWorktreeTerminals";
 
 /**
  * Helper function that implements the core logic of useWorktreeTerminals
@@ -275,5 +276,80 @@ describe("useWorktreeTerminals logic", () => {
     expect(result.counts.total).toBe(2);
     expect(result.counts.byState.working).toBe(1);
     expect(result.counts.byState.idle).toBe(1);
+  });
+});
+
+// #6650 — Active agentState (working/waiting/directing) credited to counts
+// even when agent identity hasn't committed yet, so collapsed worktree badges
+// surface live progress instead of staying idle until detection lands.
+describe("aggregateAgentStates (#6650)", () => {
+  function term(overrides: Partial<TerminalInstance>): TerminalInstance {
+    return {
+      id: "t-" + Math.random().toString(36).slice(2),
+      worktreeId: "wt-1",
+      title: "T",
+      cwd: "/x",
+      cols: 80,
+      rows: 24,
+      location: "grid",
+      ...overrides,
+    } as TerminalInstance;
+  }
+
+  it("counts a working terminal toward byState.working even with no agent identity", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "working" })]);
+    expect(byState.working).toBe(1);
+    expect(byState.idle).toBe(0);
+    expect(agentStates).toEqual(["working"]);
+  });
+
+  it("counts an identity-less waiting terminal toward byState.waiting", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "waiting" })]);
+    expect(byState.waiting).toBe(1);
+    expect(agentStates).toEqual(["waiting"]);
+  });
+
+  it("counts an identity-less directing terminal toward byState.directing", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "directing" })]);
+    expect(byState.directing).toBe(1);
+    expect(agentStates).toEqual(["directing"]);
+  });
+
+  it("does NOT credit idle for an identity-less terminal with stale 'idle' state", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "idle" })]);
+    expect(byState.idle).toBe(1);
+    expect(agentStates).toEqual([]);
+  });
+
+  it("does NOT credit completed for an identity-less terminal (no stale signal)", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "completed" })]);
+    expect(byState.completed).toBe(0);
+    expect(byState.idle).toBe(1);
+    expect(agentStates).toEqual([]);
+  });
+
+  it("does NOT credit exited for an identity-less terminal", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({ agentState: "exited" })]);
+    expect(byState.exited).toBe(0);
+    expect(byState.idle).toBe(1);
+    expect(agentStates).toEqual([]);
+  });
+
+  it("counts a launchAgentId-anchored agent terminal across all states (canonical path unchanged)", () => {
+    const { byState, agentStates } = aggregateAgentStates([
+      term({ launchAgentId: "claude", agentState: "working" }),
+      term({ launchAgentId: "claude", agentState: "completed" }),
+      term({ launchAgentId: "claude", agentState: "idle" }),
+    ]);
+    expect(byState.working).toBe(1);
+    expect(byState.completed).toBe(1);
+    expect(byState.idle).toBe(1);
+    expect(agentStates).toEqual(["working", "completed", "idle"]);
+  });
+
+  it("treats a plain shell with no agentState as idle", () => {
+    const { byState, agentStates } = aggregateAgentStates([term({})]);
+    expect(byState.idle).toBe(1);
+    expect(agentStates).toEqual([]);
   });
 });

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -16,6 +16,45 @@ export interface UseWorktreeTerminalsResult {
   dominantAgentState: AgentState | null;
 }
 
+/**
+ * Pure aggregator over a worktree's terminal list, exposed for unit tests.
+ *
+ * Active states (working/waiting/directing) are credited to byState even when
+ * agent identity hasn't committed yet — the backend only emits these from
+ * agent-sourced events, so they're trustworthy during the boot window (#6650).
+ * Plain terminals and demoted ex-agents (idle/completed/exited without
+ * identity) fall back to "idle" so stale states don't bleed into badges.
+ */
+export function aggregateAgentStates(terminals: TerminalInstance[]): {
+  byState: Record<AgentState, number>;
+  agentStates: (AgentState | undefined)[];
+} {
+  const byState: Record<AgentState, number> = {
+    idle: 0,
+    working: 0,
+    waiting: 0,
+    directing: 0,
+    completed: 0,
+    exited: 0,
+  };
+  const agentStates: (AgentState | undefined)[] = [];
+
+  terminals.forEach((terminal) => {
+    const isLiveAgent = deriveTerminalChrome(terminal).isAgent;
+    const rawState = terminal.agentState;
+    const isActiveState =
+      rawState === "working" || rawState === "waiting" || rawState === "directing";
+    const state = isLiveAgent ? (rawState ?? "idle") : isActiveState ? rawState : "idle";
+    byState[state] = (byState[state] || 0) + 1;
+
+    if (rawState && (isLiveAgent || isActiveState)) {
+      agentStates.push(rawState);
+    }
+  });
+
+  return { byState, agentStates };
+}
+
 function useDebouncedValue<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
   const isFirstRender = useRef(true);
@@ -57,28 +96,7 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
   );
 
   const result = useMemo(() => {
-    const byState: Record<AgentState, number> = {
-      idle: 0,
-      working: 0,
-      waiting: 0,
-      directing: 0,
-      completed: 0,
-      exited: 0,
-    };
-
-    const agentStates: (AgentState | undefined)[] = [];
-    terminals.forEach((terminal) => {
-      const isLiveAgent = deriveTerminalChrome(terminal).isAgent;
-      // Plain terminals and demoted ex-agents are counted as sessions, but
-      // they must not contribute stale agent states to sidebar badges.
-      const state = isLiveAgent ? (terminal.agentState ?? "idle") : "idle";
-      byState[state] = (byState[state] || 0) + 1;
-
-      if (isLiveAgent && terminal.agentState) {
-        agentStates.push(terminal.agentState);
-      }
-    });
-
+    const { byState, agentStates } = aggregateAgentStates(terminals);
     const dominantAgentState = getDominantAgentState(agentStates);
 
     return {


### PR DESCRIPTION
## Summary

- Removes two early-return identity checks in `AgentStateService` (`updateAgentState` and `handleActivityState`) so `agent:state-changed` events fire for runtime-detected-only flows — terminals where the user typed `claude`/`gemini`/`codex` without going through the canonical launch path
- Drops the `chrome.isAgent` prefix from indicator visibility in `TabButton`, `ContentPanel`, `WorktreeTerminalSection`, `DockedTerminalItem`, `DockedTabGroup`, and `TerminalDragPreview`, restoring the pre-unification state-only check; fixes a hidden second identity gate in `useDockBlockedState` so active states (`working`, `waiting`, `directing`) bypass the identity check
- Refactors `useWorktreeTerminals` state aggregation into a pure `aggregateAgentStates` helper so collapsed worktree badges correctly credit identity-less working/waiting/directing terminals

Resolves #6650

## Changes

- `AgentStateService.ts` — removed `effectiveAgentId` early-returns from `updateAgentState` and `handleActivityState`; state events now emit with `terminalId` as fallback when `agentId` is undefined
- `TabButton.tsx`, `ContentPanel.tsx`, `WorktreeTerminalSection.tsx`, `DockedTerminalItem.tsx`, `DockedTabGroup.tsx`, `TerminalDragPreview.tsx` — dropped `chrome.isAgent &&` gate from indicator visibility; added `agentState !== "exited"` defensive check
- `useDockBlockedState.ts` — active states now bypass the `hasRuntimeAgentIdentity` check
- `useWorktreeTerminals.ts` — extracted `aggregateAgentStates` pure helper; collapsed worktree row badges now count identity-less active terminals

## Testing

26 new test cases across `AgentStateService.test.ts`, `TabButton.test.tsx`, `WorktreeTerminalSection.test.tsx`, `dockAgentState.test.ts`, and `useWorktreeTerminals.test.ts` — covering identity-less state emission, all indicator visibility permutations, dock tab group active state wiring, and aggregator edge cases.