### PR TITLE
fix(activity): tier-aware recovery for background-tier waiting agents

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -117,6 +117,11 @@ export class ActivityMonitor {
   private readonly outputVolumeDetector: OutputVolumeDetector;
   private readonly highOutputDetector: HighOutputDetector;
   private readonly workingSignalDebouncer: WorkingSignalDebouncer;
+  // Dedicated debouncer for the idle-state cosmetic-redraw recovery path
+  // (#6641). Cannot share workingSignalDebouncer because runPollingCycle's
+  // "no working signal" branch resets sustainedSince every poll, which would
+  // erase accumulated spinner-tick signal between sparse cosmetic frames.
+  private readonly cosmeticRecoveryDebouncer: WorkingSignalDebouncer;
   private readonly lineRewriteDetector: LineRewriteDetector;
   private readonly completionTimer: CompletionTimer;
   private readonly bootDetector: BootDetector;
@@ -201,6 +206,9 @@ export class ActivityMonitor {
     this.workingSignalDebouncer = new WorkingSignalDebouncer(
       options?.workingRecoveryDelayMs ?? 1500
     );
+    this.cosmeticRecoveryDebouncer = new WorkingSignalDebouncer(
+      options?.workingRecoveryDelayMs ?? 1500
+    );
 
     // Snapshot tier-aware recovery thresholds. Active values default to the
     // detector-instantiation values so the active-tier path is identical to
@@ -269,9 +277,11 @@ export class ActivityMonitor {
     if (tier === "background") {
       this.outputVolumeDetector.reconfigureWindow(this.backgroundOutputWindowMs);
       this.workingSignalDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
+      this.cosmeticRecoveryDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
     } else {
       this.outputVolumeDetector.reconfigureWindow(this.activeOutputWindowMs);
       this.workingSignalDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
+      this.cosmeticRecoveryDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
     }
   }
 
@@ -393,9 +403,9 @@ export class ActivityMonitor {
     if (isCosmeticRedraw) {
       // Recovery path for idle (waiting) agent terminals (#6641): if a sustained
       // spinner reappears after the agent went quiet, transition back to busy
-      // through the debouncer. Gated on getVisibleLines so this only applies to
-      // agent terminals, and on isResizeSuppressed so window-resize redraws
-      // don't false-positive recovery.
+      // through a dedicated debouncer. Gated on getVisibleLines so this only
+      // applies to agent terminals, and on isResizeSuppressed so window-resize
+      // redraws don't false-positive recovery.
       if (
         this.getVisibleLines &&
         this.state === "idle" &&
@@ -403,7 +413,8 @@ export class ActivityMonitor {
         !this.inputTracker.isRecentUserInput(now) &&
         this.bootDetector.hasExitedBootState
       ) {
-        if (this.workingSignalDebouncer.shouldTriggerRecovery(now, true)) {
+        if (this.cosmeticRecoveryDebouncer.shouldTriggerRecovery(now, true)) {
+          this.cosmeticRecoveryDebouncer.reset();
           this.becomeBusy({ trigger: "output" }, now);
         }
       }
@@ -486,6 +497,7 @@ export class ActivityMonitor {
     this.outputVolumeDetector.reset();
     this.highOutputDetector.reset();
     this.workingSignalDebouncer.reset();
+    this.cosmeticRecoveryDebouncer.reset();
     this.lineRewriteDetector.reset();
     this.patternBuf.reset();
     this.bootDetector.reset();
@@ -910,6 +922,10 @@ export class ActivityMonitor {
     this.recordWorkingSignal(now);
     this.resetDebounceTimer();
     this.waitingWatchdogFired = false;
+    // Clear any in-flight cosmetic-redraw accumulator so the next idle cycle
+    // starts fresh — otherwise a single spinner tick after busy→idle would
+    // immediately re-trigger recovery without sustained signal.
+    this.cosmeticRecoveryDebouncer.reset();
 
     // Reset completion state for the new work cycle
     this.completionTimer.reset();

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -72,6 +72,11 @@ export interface ActivityMonitorOptions {
   };
   pollingIntervalMs?: number;
   workingRecoveryDelayMs?: number;
+  // Background polling tier overrides — applied automatically by setPollingInterval()
+  // when intervalMs > 50. When unset, fall back to the active values so behavior
+  // matches today's defaults until the call site opts in.
+  backgroundOutputWindowMs?: number;
+  backgroundWorkingRecoveryDelayMs?: number;
   pollingMaxBootMs?: number;
   maxWorkingSilenceMs?: number;
   maxWaitingSilenceMs?: number;
@@ -149,6 +154,16 @@ export class ActivityMonitor {
   // Polling interval configuration
   private POLLING_INTERVAL_MS: number;
 
+  // Tier-aware recovery thresholds (#6641). Active values must match the
+  // pre-fix hardcoded behavior so the 50ms tier is unchanged. Background
+  // values widen the volume window and shorten the debouncer delay so
+  // backgrounded agents can escape "waiting" when output resumes.
+  private _tier: "active" | "background" = "active";
+  private readonly activeOutputWindowMs: number;
+  private readonly backgroundOutputWindowMs: number;
+  private readonly activeWorkingRecoveryDelayMs: number;
+  private readonly backgroundWorkingRecoveryDelayMs: number;
+
   constructor(
     private terminalId: string,
     private spawnedAt: number,
@@ -187,6 +202,16 @@ export class ActivityMonitor {
       options?.workingRecoveryDelayMs ?? 1500
     );
 
+    // Snapshot tier-aware recovery thresholds. Active values default to the
+    // detector-instantiation values so the active-tier path is identical to
+    // pre-fix behavior. Background values default to active values when the
+    // caller doesn't opt in, preserving compatibility for non-agent terminals.
+    this.activeOutputWindowMs = this.outputVolumeDetector.windowMs;
+    this.backgroundOutputWindowMs = options?.backgroundOutputWindowMs ?? this.activeOutputWindowMs;
+    this.activeWorkingRecoveryDelayMs = this.workingSignalDebouncer.delayMs;
+    this.backgroundWorkingRecoveryDelayMs =
+      options?.backgroundWorkingRecoveryDelayMs ?? this.activeWorkingRecoveryDelayMs;
+
     this.lineRewriteDetector = new LineRewriteDetector(options?.lineRewriteDetection);
 
     this.completionTimer = new CompletionTimer();
@@ -223,10 +248,31 @@ export class ActivityMonitor {
     // Polling interval
     this.POLLING_INTERVAL_MS = options?.pollingIntervalMs ?? 50;
 
+    // Apply initial tier so a monitor constructed with a background polling
+    // interval (e.g. project starts hidden) gets the right thresholds before
+    // any output arrives.
+    this.applyTier(this.tierForInterval(this.POLLING_INTERVAL_MS));
+
     // Lightweight watchdog interval: runs the waiting watchdog check periodically
     // even when there's no output/activity. 5s keeps overhead negligible while
     // ensuring hung waiting states are caught within a reasonable window.
     this.watchdogInterval = setInterval(() => this.checkWaitingWatchdog(Date.now()), 5000);
+  }
+
+  private tierForInterval(intervalMs: number): "active" | "background" {
+    return intervalMs <= 50 ? "active" : "background";
+  }
+
+  private applyTier(tier: "active" | "background"): void {
+    if (this._tier === tier) return;
+    this._tier = tier;
+    if (tier === "background") {
+      this.outputVolumeDetector.reconfigureWindow(this.backgroundOutputWindowMs);
+      this.workingSignalDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
+    } else {
+      this.outputVolumeDetector.reconfigureWindow(this.activeOutputWindowMs);
+      this.workingSignalDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
+    }
   }
 
   onInput(data: string): void {
@@ -345,6 +391,22 @@ export class ActivityMonitor {
     }
 
     if (isCosmeticRedraw) {
+      // Recovery path for idle (waiting) agent terminals (#6641): if a sustained
+      // spinner reappears after the agent went quiet, transition back to busy
+      // through the debouncer. Gated on getVisibleLines so this only applies to
+      // agent terminals, and on isResizeSuppressed so window-resize redraws
+      // don't false-positive recovery.
+      if (
+        this.getVisibleLines &&
+        this.state === "idle" &&
+        !this.isResizeSuppressed(now) &&
+        !this.inputTracker.isRecentUserInput(now) &&
+        this.bootDetector.hasExitedBootState
+      ) {
+        if (this.workingSignalDebouncer.shouldTriggerRecovery(now, true)) {
+          this.becomeBusy({ trigger: "output" }, now);
+        }
+      }
       return;
     }
 
@@ -794,6 +856,11 @@ export class ActivityMonitor {
       clearInterval(this.pollingInterval);
       this.pollingInterval = setInterval(() => this.runPollingCycle(), this.POLLING_INTERVAL_MS);
     }
+
+    // Recovery thresholds need to track the polling cadence, otherwise the
+    // 1000ms volume window and 1500ms debouncer become impossible to satisfy
+    // at 500ms polling. See #6641.
+    this.applyTier(this.tierForInterval(intervalMs));
   }
 
   private recordWorkingSignal(now: number): void {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3704,6 +3704,45 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
+    it("recovers idle→busy from sparse spinner ticks WITH polling running", () => {
+      // Reproduces the actual production scenario: 500ms polling cycles run
+      // continuously, and sparse spinner ticks (~700ms intervals) accumulate
+      // in the cosmetic-redraw recovery path. The shared workingSignalDebouncer
+      // would have been reset by the polling cycle's "no signal" branch,
+      // defeating recovery; the dedicated cosmeticRecoveryDebouncer survives.
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("bg-poll-1", 1000, onStateChange, {
+        getVisibleLines: () => ["> ready"],
+        getCursorLine: () => "> ready",
+        pollingIntervalMs: 500,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      monitor.startPolling();
+      // Pre-fix, the polling cycle's no-signal branch would have erased the
+      // cosmetic accumulator. Drive several poll cycles with no data so the
+      // shared-debouncer hypothesis would have reset sustainedSince repeatedly
+      // before the next spinner tick.
+      vi.advanceTimersByTime(2000);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Sparse ticks: each tick is 700ms apart, with 500ms polling firing
+      // between them. With the dedicated debouncer, the 600ms gate fires on
+      // the second tick.
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+      vi.advanceTimersByTime(700);
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
     it("does not regress active-tier #3189 — single spinner burst stays idle", () => {
       // Active tier (50ms polling) keeps the original 1500ms debouncer, so a
       // sub-1500ms spinner burst on a non-busy agent must not escalate to busy.

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -3656,4 +3656,228 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
   });
+
+  describe("Background-tier recovery (#6641)", () => {
+    // The background polling tier (500ms) was unable to escape "waiting" when
+    // an agent resumed producing output: the AND-gated volume detector with a
+    // 1000ms window required two frames within the same window, which 500ms
+    // polling rarely satisfies, and the 1500ms debouncer required three
+    // consecutive cycles. Spinner ticks were also short-circuited by the
+    // cosmetic-redraw early-return, so they never reached any recovery path.
+    // The fix applies tier-aware thresholds (2500ms window, 600ms debouncer)
+    // when polling is throttled and adds an idle-state recovery path through
+    // the cosmetic-redraw branch of onData().
+
+    it("recovers idle→busy from sustained spinner ticks at background tier", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("bg-1", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 500,
+        bootCompletePatterns: [/booted/i],
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      // Mark boot complete so the recovery path is reachable.
+      monitor.onData("\nbooted\n");
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // First spinner tick starts the debouncer; not yet sustained.
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+      expect(monitor.getState()).toBe("idle");
+
+      // 700ms elapsed > 600ms debouncer — next tick triggers recovery.
+      vi.advanceTimersByTime(700);
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).toHaveBeenCalledWith(
+        "bg-1",
+        1000,
+        "busy",
+        expect.objectContaining({ trigger: "output" })
+      );
+
+      monitor.dispose();
+    });
+
+    it("does not regress active-tier #3189 — single spinner burst stays idle", () => {
+      // Active tier (50ms polling) keeps the original 1500ms debouncer, so a
+      // sub-1500ms spinner burst on a non-busy agent must not escalate to busy.
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("active-1", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 50,
+        bootCompletePatterns: [/booted/i],
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      monitor.onData("\nbooted\n");
+      onStateChange.mockClear();
+
+      // 1000ms of spinner output — well below the 1500ms active debouncer.
+      for (let i = 0; i < 10; i++) {
+        monitor.onData("\r⠙ Working (esc to interrupt)");
+        vi.advanceTimersByTime(100);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalledWith("active-1", 1000, "busy", expect.anything());
+
+      monitor.dispose();
+    });
+
+    it("recovers active-tier idle→busy after the full 1500ms debouncer", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("active-2", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 50,
+        bootCompletePatterns: [/booted/i],
+        idleDebounceMs: 4000,
+      });
+
+      monitor.onData("\nbooted\n");
+      onStateChange.mockClear();
+
+      // First spinner starts the debouncer.
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+      expect(monitor.getState()).toBe("idle");
+
+      // 1600ms elapsed > 1500ms default active debouncer.
+      vi.advanceTimersByTime(1600);
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("does not recover when getVisibleLines is not provided (non-agent terminal)", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("plain-1", 1000, onStateChange, {
+        pollingIntervalMs: 500,
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      // Even with sustained spinner output, a non-agent terminal must not
+      // false-positive into busy from cosmetic redraws alone.
+      for (let i = 0; i < 6; i++) {
+        monitor.onData("\r⠙ Working (esc to interrupt)");
+        vi.advanceTimersByTime(500);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("preserves #6365: busy-state spinner ticks still reset the debounce timer", () => {
+      // When the agent is already busy, the cosmetic-redraw branch must still
+      // call resetDebounceTimer() — the new idle-recovery path is additive,
+      // not a replacement for the busy-keepalive path.
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("bg-busy", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 500,
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 300,
+      });
+
+      monitor.onInput("run\r");
+      expect(monitor.getState()).toBe("busy");
+      onStateChange.mockClear();
+
+      for (let i = 0; i < 10; i++) {
+        monitor.onData("\r⠙ Working (esc to interrupt)");
+        vi.advanceTimersByTime(100);
+      }
+
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("widens output volume window for sparse background streaming", () => {
+      // At 500ms polling with the old 1000ms window, two frames 1700ms apart
+      // would reset the window and never trigger recovery. With the widened
+      // 2500ms window, the same frames now satisfy the AND-gate.
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("bg-vol", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 500,
+        bootCompletePatterns: [/ready/i],
+        outputActivityDetection: {
+          enabled: true,
+          windowMs: 1000,
+          minFrames: 2,
+          minBytes: 1,
+        },
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      monitor.onData("\nready\n");
+      // Drain the volume detector's window (boot data already filled frame 1).
+      vi.advanceTimersByTime(3000);
+      onStateChange.mockClear();
+
+      // Frame 1 of the actual scenario: starts a fresh volume window.
+      monitor.onData("a");
+      expect(monitor.getState()).toBe("idle");
+
+      // Frame 2, 1700ms later — would have expired the 1000ms window but fits
+      // inside the widened 2500ms window, satisfying the AND-gate.
+      vi.advanceTimersByTime(1700);
+      monitor.onData("b");
+
+      expect(monitor.getState()).toBe("busy");
+
+      monitor.dispose();
+    });
+
+    it("restores active thresholds when polling switches back to active", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("tier-switch", 1000, onStateChange, {
+        getVisibleLines: () => [],
+        getCursorLine: () => null,
+        pollingIntervalMs: 50,
+        bootCompletePatterns: [/booted/i],
+        backgroundOutputWindowMs: 2500,
+        backgroundWorkingRecoveryDelayMs: 600,
+        idleDebounceMs: 4000,
+      });
+
+      // Switch to background then back to active. Pre-fix, the volume window
+      // would have been left at 2500ms; the tier setter must restore it.
+      monitor.setPollingInterval(500);
+      monitor.setPollingInterval(50);
+
+      monitor.onData("\nbooted\n");
+      onStateChange.mockClear();
+
+      // 700ms elapsed — would fire on background's 600ms debouncer but must
+      // NOT fire on active's 1500ms debouncer.
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+      vi.advanceTimersByTime(700);
+      monitor.onData("\r⠙ Working (esc to interrupt)");
+
+      expect(monitor.getState()).toBe("idle");
+
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/pty/OutputVolumeDetector.ts
+++ b/electron/services/pty/OutputVolumeDetector.ts
@@ -7,7 +7,7 @@ export interface OutputVolumeConfig {
 
 export class OutputVolumeDetector {
   readonly enabled: boolean;
-  readonly windowMs: number;
+  private _windowMs: number;
   private readonly minFrames: number;
   private readonly minBytes: number;
   private windowStart = 0;
@@ -18,9 +18,21 @@ export class OutputVolumeDetector {
     const defaults = { enabled: false, windowMs: 500, minFrames: 3, minBytes: 2048 };
     const c = { ...defaults, ...config };
     this.enabled = c.enabled;
-    this.windowMs = c.windowMs;
+    this._windowMs = c.windowMs;
     this.minFrames = c.minFrames;
     this.minBytes = c.minBytes;
+  }
+
+  get windowMs(): number {
+    return this._windowMs;
+  }
+
+  // Background polling tier (500ms) widens this window so consecutive frames
+  // stop straddling the 1000ms boundary and pinning framesInWindow at 1.
+  reconfigureWindow(windowMs: number): void {
+    if (this._windowMs === windowMs) return;
+    this._windowMs = windowMs;
+    this.resetWindow();
   }
 
   update(dataLength: number, now: number): boolean {
@@ -28,7 +40,7 @@ export class OutputVolumeDetector {
       return false;
     }
 
-    if (this.windowStart === 0 || now - this.windowStart > this.windowMs) {
+    if (this.windowStart === 0 || now - this.windowStart > this._windowMs) {
       this.windowStart = now;
       this.framesInWindow = 1;
       this.bytesInWindow = dataLength;

--- a/electron/services/pty/WorkingSignalDebouncer.ts
+++ b/electron/services/pty/WorkingSignalDebouncer.ts
@@ -1,9 +1,19 @@
 export class WorkingSignalDebouncer {
   private sustainedSince = 0;
-  private readonly delayMs: number;
+  private _delayMs: number;
 
   constructor(delayMs: number) {
-    this.delayMs = delayMs;
+    this._delayMs = delayMs;
+  }
+
+  get delayMs(): number {
+    return this._delayMs;
+  }
+
+  // Background polling tier shortens this delay so recovery fires after one
+  // polling cycle instead of three (3 × 500ms = 1500ms would be too coarse).
+  setDelay(delayMs: number): void {
+    this._delayMs = delayMs;
   }
 
   shouldTriggerRecovery(now: number, signalPresent: boolean): boolean {
@@ -12,11 +22,11 @@ export class WorkingSignalDebouncer {
         this.sustainedSince = now;
         if (process.env.DAINTREE_VERBOSE) {
           console.log(
-            `[ActivityMonitor] Working signal detected, starting debounce timer (${this.delayMs}ms)`
+            `[ActivityMonitor] Working signal detected, starting debounce timer (${this._delayMs}ms)`
           );
         }
       }
-      const sustained = now - this.sustainedSince >= this.delayMs;
+      const sustained = now - this.sustainedSince >= this._delayMs;
       if (sustained && process.env.DAINTREE_VERBOSE) {
         console.log(
           `[ActivityMonitor] Working signal sustained for ${now - this.sustainedSince}ms, triggering recovery`

--- a/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
+++ b/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
@@ -81,4 +81,52 @@ describe("OutputVolumeDetector", () => {
       expect(detector.update(100, 1050)).toBe(false);
     });
   });
+
+  describe("reconfigureWindow", () => {
+    it("widens window so frames that straddled the old boundary are detectable", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        windowMs: 1000,
+        minFrames: 2,
+        minBytes: 1,
+      });
+      d.reconfigureWindow(2500);
+      d.update(1, 1000);
+      // 1700ms later — would have expired the 1000ms window, fits inside 2500ms.
+      expect(d.update(1, 2700)).toBe(true);
+    });
+
+    it("clears in-flight frame accumulation on reconfigure", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        windowMs: 1000,
+        minFrames: 2,
+        minBytes: 1,
+      });
+      d.update(1, 1000);
+      d.reconfigureWindow(2500);
+      // Prior frame was discarded — first frame after reconfigure cannot trigger.
+      expect(d.update(1, 1050)).toBe(false);
+    });
+
+    it("is a no-op when called with the current window size", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        windowMs: 1000,
+        minFrames: 2,
+        minBytes: 1,
+      });
+      d.update(1, 1000);
+      d.reconfigureWindow(1000);
+      // Same value should preserve in-flight state.
+      expect(d.update(1, 1050)).toBe(true);
+    });
+
+    it("exposes the current windowMs through the getter", () => {
+      const d = new OutputVolumeDetector({ enabled: true, windowMs: 1000 });
+      expect(d.windowMs).toBe(1000);
+      d.reconfigureWindow(2500);
+      expect(d.windowMs).toBe(2500);
+    });
+  });
 });

--- a/electron/services/pty/__tests__/WorkingSignalDebouncer.test.ts
+++ b/electron/services/pty/__tests__/WorkingSignalDebouncer.test.ts
@@ -36,4 +36,26 @@ describe("WorkingSignalDebouncer", () => {
     debouncer.reset();
     expect(debouncer.shouldTriggerRecovery(2500, true)).toBe(false);
   });
+
+  describe("setDelay", () => {
+    it("shortens the gate so recovery fires sooner", () => {
+      debouncer.setDelay(600);
+      debouncer.shouldTriggerRecovery(1000, true);
+      expect(debouncer.shouldTriggerRecovery(1599, true)).toBe(false);
+      expect(debouncer.shouldTriggerRecovery(1600, true)).toBe(true);
+    });
+
+    it("preserves sustainedSince when changing delay mid-flight", () => {
+      debouncer.shouldTriggerRecovery(1000, true);
+      debouncer.setDelay(600);
+      // Signal started at t=1000; with 600ms delay it should fire at t>=1600.
+      expect(debouncer.shouldTriggerRecovery(1600, true)).toBe(true);
+    });
+
+    it("exposes the current delay through the getter", () => {
+      expect(debouncer.delayMs).toBe(1500);
+      debouncer.setDelay(600);
+      expect(debouncer.delayMs).toBe(600);
+    });
+  });
 });

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -213,4 +213,13 @@ describe("buildActivityMonitorOptions", () => {
     expect(result.patternConfig).toBeDefined();
     expect(result.bootCompletePatterns).toBeDefined();
   });
+
+  it("sets background-tier recovery thresholds (#6641)", () => {
+    // Background polling (500ms) widens the volume window and shortens the
+    // recovery debouncer so backgrounded agents can escape "waiting" when
+    // output resumes. Active polling (50ms) keeps the existing thresholds.
+    const result = buildActivityMonitorOptions("claude", {});
+    expect(result.backgroundOutputWindowMs).toBe(2500);
+    expect(result.backgroundWorkingRecoveryDelayMs).toBe(600);
+  });
 });

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -202,5 +202,11 @@ export function buildActivityMonitorOptions(
     idleDebounceMs: effectiveAgentId ? (detection?.debounceMs ?? 4000) : undefined,
     promptFastPathMinQuietMs: detection?.promptFastPathMinQuietMs,
     maxWaitingSilenceMs: 600_000,
+    // Background polling (500ms) widens the volume window and shortens the
+    // recovery debouncer so backgrounded agents can escape "waiting" when
+    // output resumes (#6641). Active polling (50ms) keeps the existing
+    // outputActivityDetection.windowMs (1000ms) and 1500ms debouncer.
+    backgroundOutputWindowMs: 2500,
+    backgroundWorkingRecoveryDelayMs: 600,
   };
 }


### PR DESCRIPTION
## Summary

Background-tier agent terminals (500ms polling) were unable to escape the `waiting` state when output resumed. Three factors combined to cause this: the `OutputVolumeDetector` AND-gate required two frames within a 1000ms window (rare at 500ms polling); the cosmetic-redraw early-return in `onData()` blocked spinner ticks from any recovery path; and the 1500ms `WorkingSignalDebouncer` required three consecutive 500ms cycles to confirm recovery.

Resolves #6641

## Changes

- `ActivityMonitor` now infers polling tier from `setPollingInterval()` (≤50ms = active, otherwise = background) and propagates it to `OutputVolumeDetector` and `WorkingSignalDebouncer`
- Background tier widens the output volume window to 2500ms and shortens the recovery debouncer to 600ms
- Adds an idle-state recovery path in the cosmetic-redraw branch of `onData()` so spinner ticks can transition agent terminals back to busy — gated on `getVisibleLines` (agent terminals only), boot exit, no recent input, no resize suppression
- Introduces a dedicated `cosmeticRecoveryDebouncer` to avoid races with the polling cycle's shared `WorkingSignalDebouncer` reset
- Active-tier values are unchanged; the #3189 busy-state debounce-keepalive guard is preserved
- `terminalActivityPatterns.ts` sets `backgroundOutputWindowMs: 2500` and `backgroundWorkingRecoveryDelayMs: 600`

## Testing

New tests in `ActivityMonitor.test.ts` (7 tests in "Background-tier recovery (#6641)"): sustained spinner recovery, sparse-tick recovery with polling running (the production scenario), active-tier non-regression for #3189, active-tier 1500ms recovery, non-agent terminals don't recover, #6365 busy-state spinner keepalive preserved, widened volume window, and tier restoration on switching back to active.

Additional unit coverage: `OutputVolumeDetector.test.ts` (reconfigureWindow widens and clears in-flight, no-op on same value, getter), `WorkingSignalDebouncer.test.ts` (setDelay shortens gate, preserves `sustainedSince` mid-flight, getter), `terminalActivityPatterns.test.ts` (production background-tier config).

All 198 tests pass. `npm run check` clean.