### PR TITLE
fix(agent): unify FSM between main process and renderer worker

### DIFF
--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -1,107 +1,15 @@
-import type { AgentState } from "../types/index.js";
+/**
+ * Thin re-export wrapper around the canonical FSM in `shared/utils/agentFsm.ts`.
+ * Both the main process and the renderer Web Worker share the same source of truth
+ * to prevent drift between contexts.
+ */
 
-export type AgentEvent =
-  | { type: "start" }
-  | { type: "output"; data: string }
-  | { type: "busy" } // Agent is actively receiving data
-  | { type: "prompt" } // Agent has been idle (no data for debounce period)
-  | { type: "completion" } // Agent completed a task (pattern-detected)
-  | { type: "input" } // User input received
-  | { type: "exit"; code: number; signal?: number }
-  | { type: "error"; error: string }
-  | { type: "kill" } // Intentional kill by user
-  | { type: "respawn" } // New agent session detected in same PTY after a prior exit
-  | { type: "watchdog-timeout" }; // Watchdog: waiting state timed out with dead children
-
-const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
-  idle: ["working", "exited"],
-  working: ["waiting", "completed", "exited"],
-  waiting: ["working", "completed", "exited", "idle"],
-  directing: [], // Renderer-only state, never produced by main process
-  completed: ["working", "waiting", "exited"],
-  exited: ["idle"], // Terminal per agent lifecycle; `respawn` allows a fresh agent session in the same PTY
-};
-
-export function isValidTransition(from: AgentState, to: AgentState): boolean {
-  return VALID_TRANSITIONS[from].includes(to);
-}
-
-export function nextAgentState(current: AgentState, event: AgentEvent): AgentState {
-  if (!event || typeof event !== "object" || typeof event.type !== "string") {
-    return current;
-  }
-
-  if (event.type === "exit" && typeof event.code !== "number") {
-    return current;
-  }
-
-  // Error events are no-ops
-  if (event.type === "error") {
-    return current;
-  }
-
-  if (event.type === "kill") {
-    return "idle";
-  }
-
-  switch (event.type) {
-    case "start":
-      if (current === "idle") {
-        return "working";
-      }
-      break;
-
-    case "busy":
-      // Handles re-entry to working from waiting/idle/completed states when agent resumes activity
-      if (current === "waiting" || current === "idle" || current === "completed") {
-        return "working";
-      }
-      break;
-
-    case "output":
-      // Output events no longer trigger state changes - activity is handled by ActivityMonitor
-      break;
-
-    case "completion":
-      if (current === "working") {
-        return "completed";
-      }
-      break;
-
-    case "prompt":
-      // Activity monitor detected silence - transition to waiting
-      if (current === "working" || current === "completed") {
-        return "waiting";
-      }
-      break;
-
-    case "input":
-      if (current === "waiting" || current === "idle" || current === "completed") {
-        return "working";
-      }
-      break;
-
-    case "exit":
-      if (current !== "exited") {
-        return "exited";
-      }
-      break;
-
-    case "respawn":
-      if (current === "exited") {
-        return "idle";
-      }
-      break;
-
-    case "watchdog-timeout":
-      if (current === "waiting") {
-        return "idle";
-      }
-      break;
-  }
-
-  return current;
-}
+export {
+  VALID_TRANSITIONS,
+  isValidTransition,
+  nextAgentState,
+} from "../../shared/utils/agentFsm.js";
+export type { AgentEvent } from "../../shared/utils/agentFsm.js";
 
 export function getStateChangeTimestamp(): number {
   return Date.now();

--- a/shared/utils/__tests__/agentFsm.test.ts
+++ b/shared/utils/__tests__/agentFsm.test.ts
@@ -25,6 +25,39 @@ describe("agentFsm", () => {
     });
   });
 
+  describe("FSM invariant", () => {
+    // VALID_TRANSITIONS describes the natural lifecycle. `kill` is a hard-reset
+    // override that bypasses the table by design, so it is excluded from this
+    // invariant. `directing` is renderer-only and never receives main-process
+    // events; we don't assert table coverage for transitions out of it.
+    it("every natural-lifecycle nextAgentState result is permitted by VALID_TRANSITIONS", () => {
+      const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
+      const events: AgentEvent[] = [
+        { type: "start" },
+        { type: "busy" },
+        { type: "prompt" },
+        { type: "completion" },
+        { type: "input" },
+        { type: "exit", code: 0 },
+        { type: "respawn" },
+        { type: "watchdog-timeout" },
+        { type: "error", error: "x" },
+        { type: "output", data: "x" },
+      ];
+      for (const from of states) {
+        for (const event of events) {
+          const to = nextAgentState(from, event);
+          if (to !== from) {
+            expect(
+              isValidTransition(from, to),
+              `${from} -[${event.type}]-> ${to} must be in VALID_TRANSITIONS`
+            ).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
   describe("isValidTransition", () => {
     it("allows canonical forward transitions", () => {
       expect(isValidTransition("idle", "working")).toBe(true);
@@ -35,9 +68,12 @@ describe("agentFsm", () => {
       expect(isValidTransition("exited", "idle")).toBe(true);
     });
 
-    it("rejects transitions out of directing", () => {
+    it("rejects all transitions out of directing (renderer-managed state)", () => {
       expect(isValidTransition("directing", "idle")).toBe(false);
       expect(isValidTransition("directing", "working")).toBe(false);
+      expect(isValidTransition("directing", "waiting")).toBe(false);
+      expect(isValidTransition("directing", "completed")).toBe(false);
+      expect(isValidTransition("directing", "exited")).toBe(false);
     });
 
     it("rejects unknown transitions", () => {
@@ -91,7 +127,14 @@ describe("agentFsm", () => {
     });
 
     it("treats kill as a hard reset to idle from any state", () => {
-      const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
+      const states: AgentState[] = [
+        "idle",
+        "working",
+        "waiting",
+        "directing",
+        "completed",
+        "exited",
+      ];
       for (const state of states) {
         expect(nextAgentState(state, { type: "kill" })).toBe("idle");
       }

--- a/shared/utils/__tests__/agentFsm.test.ts
+++ b/shared/utils/__tests__/agentFsm.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  VALID_TRANSITIONS,
+  isValidTransition,
+  nextAgentState,
+  type AgentEvent,
+} from "../agentFsm.js";
+import type { AgentState } from "../../types/agent.js";
+
+describe("agentFsm", () => {
+  describe("VALID_TRANSITIONS", () => {
+    it("covers all six canonical agent states", () => {
+      const keys = Object.keys(VALID_TRANSITIONS).sort();
+      expect(keys).toEqual(
+        ["completed", "directing", "exited", "idle", "waiting", "working"].sort()
+      );
+    });
+
+    it("leaves directing empty (renderer-only state, never produced by main process)", () => {
+      expect(VALID_TRANSITIONS.directing).toEqual([]);
+    });
+
+    it("permits exited → idle for respawn", () => {
+      expect(VALID_TRANSITIONS.exited).toEqual(["idle"]);
+    });
+  });
+
+  describe("isValidTransition", () => {
+    it("allows canonical forward transitions", () => {
+      expect(isValidTransition("idle", "working")).toBe(true);
+      expect(isValidTransition("working", "waiting")).toBe(true);
+      expect(isValidTransition("working", "completed")).toBe(true);
+      expect(isValidTransition("waiting", "working")).toBe(true);
+      expect(isValidTransition("completed", "working")).toBe(true);
+      expect(isValidTransition("exited", "idle")).toBe(true);
+    });
+
+    it("rejects transitions out of directing", () => {
+      expect(isValidTransition("directing", "idle")).toBe(false);
+      expect(isValidTransition("directing", "working")).toBe(false);
+    });
+
+    it("rejects unknown transitions", () => {
+      expect(isValidTransition("idle", "completed")).toBe(false);
+      expect(isValidTransition("idle", "waiting")).toBe(false);
+      expect(isValidTransition("exited", "working")).toBe(false);
+    });
+  });
+
+  describe("nextAgentState", () => {
+    it("transitions idle → working on start", () => {
+      expect(nextAgentState("idle", { type: "start" })).toBe("working");
+    });
+
+    it("transitions idle/waiting/completed → working on busy", () => {
+      expect(nextAgentState("idle", { type: "busy" })).toBe("working");
+      expect(nextAgentState("waiting", { type: "busy" })).toBe("working");
+      expect(nextAgentState("completed", { type: "busy" })).toBe("working");
+    });
+
+    it("transitions working → completed on completion", () => {
+      expect(nextAgentState("working", { type: "completion" })).toBe("completed");
+    });
+
+    it("ignores completion from non-working states", () => {
+      expect(nextAgentState("idle", { type: "completion" })).toBe("idle");
+      expect(nextAgentState("waiting", { type: "completion" })).toBe("waiting");
+      expect(nextAgentState("completed", { type: "completion" })).toBe("completed");
+    });
+
+    it("transitions working/completed → waiting on prompt", () => {
+      expect(nextAgentState("working", { type: "prompt" })).toBe("waiting");
+      expect(nextAgentState("completed", { type: "prompt" })).toBe("waiting");
+    });
+
+    it("transitions waiting/idle/completed → working on input", () => {
+      expect(nextAgentState("waiting", { type: "input" })).toBe("working");
+      expect(nextAgentState("idle", { type: "input" })).toBe("working");
+      expect(nextAgentState("completed", { type: "input" })).toBe("working");
+    });
+
+    it("transitions any non-exited state → exited on exit", () => {
+      const states: AgentState[] = ["idle", "working", "waiting", "completed"];
+      for (const state of states) {
+        expect(nextAgentState(state, { type: "exit", code: 0 })).toBe("exited");
+      }
+    });
+
+    it("does not retransition exited on exit (terminal state)", () => {
+      expect(nextAgentState("exited", { type: "exit", code: 0 })).toBe("exited");
+    });
+
+    it("treats kill as a hard reset to idle from any state", () => {
+      const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
+      for (const state of states) {
+        expect(nextAgentState(state, { type: "kill" })).toBe("idle");
+      }
+    });
+
+    it("transitions exited → idle on respawn", () => {
+      expect(nextAgentState("exited", { type: "respawn" })).toBe("idle");
+    });
+
+    it("ignores respawn from non-exited states", () => {
+      expect(nextAgentState("idle", { type: "respawn" })).toBe("idle");
+      expect(nextAgentState("working", { type: "respawn" })).toBe("working");
+    });
+
+    it("transitions waiting → idle on watchdog-timeout", () => {
+      expect(nextAgentState("waiting", { type: "watchdog-timeout" })).toBe("idle");
+    });
+
+    it("ignores watchdog-timeout from non-waiting states", () => {
+      expect(nextAgentState("working", { type: "watchdog-timeout" })).toBe("working");
+      expect(nextAgentState("completed", { type: "watchdog-timeout" })).toBe("completed");
+      expect(nextAgentState("exited", { type: "watchdog-timeout" })).toBe("exited");
+    });
+
+    it("treats error events as no-ops in every state", () => {
+      const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
+      for (const state of states) {
+        expect(nextAgentState(state, { type: "error", error: "boom" })).toBe(state);
+      }
+    });
+
+    it("treats output events as no-ops", () => {
+      expect(nextAgentState("working", { type: "output", data: "x" })).toBe("working");
+      expect(nextAgentState("idle", { type: "output", data: "x" })).toBe("idle");
+    });
+
+    it("guards against malformed events", () => {
+      expect(nextAgentState("working", null as unknown as AgentEvent)).toBe("working");
+      expect(nextAgentState("working", undefined as unknown as AgentEvent)).toBe("working");
+      expect(nextAgentState("working", {} as unknown as AgentEvent)).toBe("working");
+    });
+
+    it("ignores exit events without a numeric code", () => {
+      const malformed = { type: "exit" } as unknown as AgentEvent;
+      expect(nextAgentState("working", malformed)).toBe("working");
+    });
+  });
+});

--- a/shared/utils/agentFsm.ts
+++ b/shared/utils/agentFsm.ts
@@ -21,13 +21,18 @@ export type AgentEvent =
   | { type: "respawn" } // New agent session detected in same PTY after a prior exit
   | { type: "watchdog-timeout" }; // Watchdog: waiting state timed out with dead children
 
+// Natural-lifecycle transitions — the set of state changes produced by ordinary
+// agent events (start/busy/prompt/completion/input/exit/respawn/watchdog-timeout).
+// `kill` is a hard-reset override that bypasses this table by design and
+// returns to `idle` from any state, so `kill`-driven transitions are
+// intentionally NOT enumerated here.
 export const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   idle: ["working", "exited"],
   working: ["waiting", "completed", "exited"],
   waiting: ["working", "completed", "exited", "idle"],
-  directing: [], // Renderer-only state, never produced by main process
+  directing: [], // Renderer-only state, never produced by main process.
   completed: ["working", "waiting", "exited"],
-  exited: ["idle"], // Terminal per agent lifecycle; `respawn` allows a fresh agent session in the same PTY
+  exited: ["idle"], // Terminal per agent lifecycle; `respawn` allows a fresh agent session in the same PTY.
 };
 
 export function isValidTransition(from: AgentState, to: AgentState): boolean {

--- a/shared/utils/agentFsm.ts
+++ b/shared/utils/agentFsm.ts
@@ -1,0 +1,112 @@
+/**
+ * Canonical agent finite-state machine, shared between the main process
+ * (`electron/services/AgentStateMachine.ts`) and the renderer Web Worker
+ * (`src/workers/WorkerAgentStateService.ts`).
+ *
+ * Browser-safe: no Node or DOM imports.
+ */
+
+import type { AgentState } from "../types/agent.js";
+
+export type AgentEvent =
+  | { type: "start" }
+  | { type: "output"; data: string }
+  | { type: "busy" } // Agent is actively receiving data
+  | { type: "prompt" } // Agent has been idle (no data for debounce period)
+  | { type: "completion" } // Agent completed a task (pattern-detected)
+  | { type: "input" } // User input received
+  | { type: "exit"; code: number; signal?: number }
+  | { type: "error"; error: string }
+  | { type: "kill" } // Intentional kill by user
+  | { type: "respawn" } // New agent session detected in same PTY after a prior exit
+  | { type: "watchdog-timeout" }; // Watchdog: waiting state timed out with dead children
+
+export const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
+  idle: ["working", "exited"],
+  working: ["waiting", "completed", "exited"],
+  waiting: ["working", "completed", "exited", "idle"],
+  directing: [], // Renderer-only state, never produced by main process
+  completed: ["working", "waiting", "exited"],
+  exited: ["idle"], // Terminal per agent lifecycle; `respawn` allows a fresh agent session in the same PTY
+};
+
+export function isValidTransition(from: AgentState, to: AgentState): boolean {
+  return VALID_TRANSITIONS[from].includes(to);
+}
+
+export function nextAgentState(current: AgentState, event: AgentEvent): AgentState {
+  if (!event || typeof event !== "object" || typeof event.type !== "string") {
+    return current;
+  }
+
+  if (event.type === "exit" && typeof event.code !== "number") {
+    return current;
+  }
+
+  // Error events are no-ops
+  if (event.type === "error") {
+    return current;
+  }
+
+  if (event.type === "kill") {
+    return "idle";
+  }
+
+  switch (event.type) {
+    case "start":
+      if (current === "idle") {
+        return "working";
+      }
+      break;
+
+    case "busy":
+      // Handles re-entry to working from waiting/idle/completed states when agent resumes activity
+      if (current === "waiting" || current === "idle" || current === "completed") {
+        return "working";
+      }
+      break;
+
+    case "output":
+      // Output events no longer trigger state changes - activity is handled by ActivityMonitor
+      break;
+
+    case "completion":
+      if (current === "working") {
+        return "completed";
+      }
+      break;
+
+    case "prompt":
+      // Activity monitor detected silence - transition to waiting
+      if (current === "working" || current === "completed") {
+        return "waiting";
+      }
+      break;
+
+    case "input":
+      if (current === "waiting" || current === "idle" || current === "completed") {
+        return "working";
+      }
+      break;
+
+    case "exit":
+      if (current !== "exited") {
+        return "exited";
+      }
+      break;
+
+    case "respawn":
+      if (current === "exited") {
+        return "idle";
+      }
+      break;
+
+    case "watchdog-timeout":
+      if (current === "waiting") {
+        return "idle";
+      }
+      break;
+  }
+
+  return current;
+}

--- a/src/workers/WorkerAgentStateService.ts
+++ b/src/workers/WorkerAgentStateService.ts
@@ -57,45 +57,16 @@ function inferTrigger(event: AgentEvent): AgentStateChangeTrigger {
 }
 
 /**
- * Infer confidence level based on event type and trigger.
+ * Infer confidence level based on trigger. The worker's `inferTrigger` never
+ * returns "heuristic" or "ai-classification" (those are produced only by
+ * main-process pattern/AI detection paths), so this only covers the triggers
+ * the worker can actually emit.
  */
-function inferConfidence(event: AgentEvent, trigger: AgentStateChangeTrigger): number {
-  if (trigger === "input" || trigger === "exit") {
-    return 1.0;
-  }
-
-  if (trigger === "output") {
-    return 1.0;
-  }
-
-  if (trigger === "activity") {
-    return 1.0;
-  }
-
-  if (trigger === "heuristic") {
-    if (event.type === "busy") {
-      return 0.9;
-    }
-    if (event.type === "prompt") {
-      return 0.75;
-    }
-    if (event.type === "start") {
-      return 0.7;
-    }
-    if (event.type === "error") {
-      return 0.65;
-    }
-  }
-
-  if (trigger === "ai-classification") {
-    return 0.85;
-  }
-
+function inferConfidence(_event: AgentEvent, trigger: AgentStateChangeTrigger): number {
   if (trigger === "timeout") {
     return 0.6;
   }
-
-  return 0.5;
+  return 1.0;
 }
 
 /**

--- a/src/workers/WorkerAgentStateService.ts
+++ b/src/workers/WorkerAgentStateService.ts
@@ -5,16 +5,9 @@
 
 import type { AgentState, AgentStateChangeTrigger } from "../../shared/types/agent.js";
 import type { WorkerTerminalState } from "../../shared/types/worker-messages.js";
+import { type AgentEvent, nextAgentState } from "../../shared/utils/agentFsm.js";
 
-/** Event types for agent state transitions */
-export type AgentEvent =
-  | { type: "start" }
-  | { type: "output"; data: string }
-  | { type: "busy" }
-  | { type: "prompt" }
-  | { type: "input" }
-  | { type: "exit"; code: number }
-  | { type: "error"; error: string };
+export type { AgentEvent } from "../../shared/utils/agentFsm.js";
 
 /** Result of a state change calculation */
 export interface StateChangeResult {
@@ -29,49 +22,10 @@ export interface StateChangeResult {
   traceId?: string;
 }
 
-/** Calculate the next agent state based on current state and event */
-function nextAgentState(current: AgentState, event: AgentEvent): AgentState {
-  switch (event.type) {
-    case "start":
-      if (current === "idle") {
-        return "working";
-      }
-      break;
-
-    case "busy":
-      if (current === "waiting" || current === "idle" || current === "completed") {
-        return "working";
-      }
-      break;
-
-    case "output":
-      // Output events no longer trigger state changes directly
-      break;
-
-    case "prompt":
-      if (current === "working" || current === "completed") {
-        return "waiting";
-      }
-      break;
-
-    case "input":
-      if (current === "waiting" || current === "idle" || current === "completed") {
-        return "working";
-      }
-      break;
-
-    case "exit":
-      if (current !== "idle" && current !== "exited") {
-        return "exited";
-      }
-      break;
-  }
-
-  return current;
-}
-
 /**
  * Infer the trigger type from an agent event.
+ * Mirrors `AgentStateService.inferTrigger` in the main process so worker- and
+ * main-side state-change events carry consistent trigger metadata.
  */
 function inferTrigger(event: AgentEvent): AgentStateChangeTrigger {
   switch (event.type) {
@@ -85,10 +39,18 @@ function inferTrigger(event: AgentEvent): AgentStateChangeTrigger {
       return "activity";
     case "exit":
       return "exit";
+    case "kill":
+      return "exit";
     case "start":
       return "activity";
     case "error":
       return "activity";
+    case "completion":
+      return "activity";
+    case "respawn":
+      return "activity";
+    case "watchdog-timeout":
+      return "timeout";
     default:
       return "output";
   }

--- a/src/workers/__tests__/WorkerAgentStateService.test.ts
+++ b/src/workers/__tests__/WorkerAgentStateService.test.ts
@@ -108,12 +108,81 @@ describe("WorkerAgentStateService", () => {
         expect(calcState("completed", { type: "exit", code: 0 })).toBe("exited");
       });
 
-      it("should not transition from idle on exit", () => {
-        expect(calcState("idle", { type: "exit", code: 0 })).toBe("idle");
+      it("should transition idle → exited on exit (canonical guard)", () => {
+        // Regression for the worker's drifted guard which previously blocked idle→exited.
+        expect(calcState("idle", { type: "exit", code: 0 })).toBe("exited");
       });
 
       it("should not transition from exited on exit (terminal state)", () => {
         expect(calcState("exited", { type: "exit", code: 0 })).toBe("exited");
+      });
+
+      it("should be a no-op when exit code is missing", () => {
+        const malformed = { type: "exit" } as unknown as AgentEvent;
+        expect(calcState("working", malformed)).toBe("working");
+      });
+    });
+
+    describe("completion event", () => {
+      it("should transition working → completed on completion", () => {
+        expect(calcState("working", { type: "completion" })).toBe("completed");
+      });
+
+      it("should not transition from non-working states on completion", () => {
+        expect(calcState("idle", { type: "completion" })).toBe("idle");
+        expect(calcState("waiting", { type: "completion" })).toBe("waiting");
+        expect(calcState("completed", { type: "completion" })).toBe("completed");
+        expect(calcState("exited", { type: "completion" })).toBe("exited");
+      });
+    });
+
+    describe("kill event", () => {
+      it("should transition to idle from any non-idle state on kill", () => {
+        expect(calcState("working", { type: "kill" })).toBe("idle");
+        expect(calcState("waiting", { type: "kill" })).toBe("idle");
+        expect(calcState("completed", { type: "kill" })).toBe("idle");
+        expect(calcState("exited", { type: "kill" })).toBe("idle");
+      });
+
+      it("should remain idle when killed from idle", () => {
+        expect(calcState("idle", { type: "kill" })).toBe("idle");
+      });
+    });
+
+    describe("respawn event", () => {
+      it("should transition exited → idle on respawn", () => {
+        expect(calcState("exited", { type: "respawn" })).toBe("idle");
+      });
+
+      it("should not transition from non-exited states on respawn", () => {
+        expect(calcState("idle", { type: "respawn" })).toBe("idle");
+        expect(calcState("working", { type: "respawn" })).toBe("working");
+        expect(calcState("waiting", { type: "respawn" })).toBe("waiting");
+        expect(calcState("completed", { type: "respawn" })).toBe("completed");
+      });
+    });
+
+    describe("watchdog-timeout event", () => {
+      it("should transition waiting → idle on watchdog-timeout", () => {
+        expect(calcState("waiting", { type: "watchdog-timeout" })).toBe("idle");
+      });
+
+      it("should not transition from non-waiting states on watchdog-timeout", () => {
+        expect(calcState("idle", { type: "watchdog-timeout" })).toBe("idle");
+        expect(calcState("working", { type: "watchdog-timeout" })).toBe("working");
+        expect(calcState("completed", { type: "watchdog-timeout" })).toBe("completed");
+        expect(calcState("exited", { type: "watchdog-timeout" })).toBe("exited");
+      });
+    });
+
+    describe("malformed events", () => {
+      it("should be a no-op for null/undefined events", () => {
+        expect(calcState("working", null as unknown as AgentEvent)).toBe("working");
+        expect(calcState("working", undefined as unknown as AgentEvent)).toBe("working");
+      });
+
+      it("should be a no-op when type is missing", () => {
+        expect(calcState("working", {} as unknown as AgentEvent)).toBe("working");
       });
     });
 

--- a/src/workers/__tests__/WorkerAgentStateService.test.ts
+++ b/src/workers/__tests__/WorkerAgentStateService.test.ts
@@ -118,6 +118,8 @@ describe("WorkerAgentStateService", () => {
       });
 
       it("should be a no-op when exit code is missing", () => {
+        // Exercises the runtime guard for an exit event missing the required `code` field.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const malformed = { type: "exit" } as unknown as AgentEvent;
         expect(calcState("working", malformed)).toBe("working");
       });
@@ -176,6 +178,9 @@ describe("WorkerAgentStateService", () => {
     });
 
     describe("malformed events", () => {
+      // These cases exercise the runtime guard in nextAgentState against inputs
+      // that TypeScript would normally reject. The unsafe casts are deliberate.
+      /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
       it("should be a no-op for null/undefined events", () => {
         expect(calcState("working", null as unknown as AgentEvent)).toBe("working");
         expect(calcState("working", undefined as unknown as AgentEvent)).toBe("working");
@@ -184,6 +189,7 @@ describe("WorkerAgentStateService", () => {
       it("should be a no-op when type is missing", () => {
         expect(calcState("working", {} as unknown as AgentEvent)).toBe("working");
       });
+      /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */
     });
 
     describe("error event", () => {


### PR DESCRIPTION
## Summary

- Extracted `AgentEvent`, `VALID_TRANSITIONS`, and `nextAgentState` into `shared/utils/agentFsm.ts` — a single browser-safe module both the main process and the renderer worker import from
- `electron/services/AgentStateMachine.ts` is now a thin re-export wrapper; `src/workers/WorkerAgentStateService.ts` drops its drifted local copy
- Worker now correctly handles `completion`, `kill`, `respawn`, and `watchdog-timeout` events that were previously silent no-ops; the `exit` guard is fixed so idle agents transition to `exited` as the canonical FSM expects

Resolves #6662

## Changes

- `shared/utils/agentFsm.ts` — canonical FSM: `AgentEvent` union (11 variants), `VALID_TRANSITIONS` table, `nextAgentState`, `isValidTransition`. Browser-safe, no Node imports. Includes a top-of-file note explaining the intentional asymmetry of the `directing` row (renderer-only, empty main-process entry)
- `electron/services/AgentStateMachine.ts` — reduced to a re-export wrapper; all logic lives in the shared module
- `src/workers/WorkerAgentStateService.ts` — removed the drifted FSM copy; aligned `inferTrigger` with `AgentStateService`; dropped dead `heuristic` confidence branch
- `shared/utils/__tests__/agentFsm.test.ts` — new: full transition table coverage, `isValidTransition` guard, natural-lifecycle invariant
- `src/workers/__tests__/WorkerAgentStateService.test.ts` — new coverage for the four previously-missing events and malformed-input guards

## Testing

134 tests passing across `shared/utils/agentFsm`, `electron/services/AgentStateMachine`, and the worker test suite.