### PR TITLE
fix(agent-state): unify dominant state priority across worktree surfaces

### DIFF
--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -288,6 +288,12 @@ vi.mock("lucide-react", () => ({
   Check: ({ className }: { className?: string }) => (
     <span data-testid="check-icon" data-classname={className} />
   ),
+  Circle: ({ className }: { className?: string }) => (
+    <span data-testid="circle-icon" data-classname={className} />
+  ),
+  CheckCircle2: ({ className }: { className?: string }) => (
+    <span data-testid="check-circle2-icon" data-classname={className} />
+  ),
   Plug: () => <span data-testid="plug-icon" />,
   Pin: ({ className }: { className?: string; strokeWidth?: number }) => (
     <span data-testid="pin-icon" data-classname={className} />

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
 import type { AgentState } from "@/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { STATE_PRIORITY } from "./terminalStateConfig";
 
 interface AgentStatusIndicatorProps {
   state: AgentState | null | undefined;
@@ -115,34 +116,19 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
   );
 }
 
-const STATE_PRIORITY: Record<AgentState, number> = {
-  working: 7,
-  directing: 6,
-  completed: 4,
-  waiting: 3,
-  exited: 2,
-  idle: 1,
-};
-
 export function getDominantAgentState(states: (AgentState | undefined)[]): AgentState | null {
-  const validStates = states.filter((s): s is AgentState => s !== undefined);
-
-  if (validStates.length === 0) {
-    return null;
+  const present = new Set<AgentState>();
+  for (const state of states) {
+    if (state !== undefined) present.add(state);
   }
+  if (present.size === 0) return null;
 
-  let dominant: AgentState = "idle";
-  let highestPriority = 0;
-
-  for (const state of validStates) {
-    const priority = STATE_PRIORITY[state] ?? 0;
-    if (priority > highestPriority) {
-      highestPriority = priority;
-      dominant = state;
+  for (const state of STATE_PRIORITY) {
+    if (present.has(state)) {
+      return state === "idle" ? null : state;
     }
   }
-
-  return dominant === "idle" ? null : dominant;
+  return null;
 }
 
 // Returns null for passive states (working, completed, exited, idle) so the

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -8,6 +8,7 @@ import {
   agentStateDotColor,
   getDominantAgentState,
 } from "../AgentStatusIndicator";
+import { STATE_PRIORITY } from "../terminalStateConfig";
 import type { AgentState } from "@/types";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -143,6 +144,29 @@ describe("getDominantAgentState", () => {
   it("returns waiting when a worktree mixes completed and waiting (waiting outranks completed)", () => {
     expect(getDominantAgentState(["completed", "waiting"])).toBe("waiting");
     expect(getDominantAgentState(["waiting", "completed"])).toBe("waiting");
+  });
+});
+
+// STATE_PRIORITY is consumed directly by WorktreeHeader, WorktreeTerminalSection,
+// and (via getDominantAgentState) every tray/button surface — a silent reorder
+// or omission here would drift behavior across all of them at once. These
+// invariants pin the array shape so the function-level tests above can't be
+// the only thing standing between the source of truth and the UI.
+describe("STATE_PRIORITY contract", () => {
+  it("includes every AgentState exactly once", () => {
+    const all: AgentState[] = ["working", "directing", "waiting", "completed", "exited", "idle"];
+    expect([...STATE_PRIORITY].sort()).toEqual([...all].sort());
+    expect(STATE_PRIORITY.length).toBe(new Set(STATE_PRIORITY).size);
+  });
+
+  it.each([
+    ["working", "directing"],
+    ["directing", "waiting"],
+    ["waiting", "completed"],
+    ["completed", "exited"],
+    ["exited", "idle"],
+  ] as const)("ranks %s above %s", (higher, lower) => {
+    expect(STATE_PRIORITY.indexOf(higher)).toBeLessThan(STATE_PRIORITY.indexOf(lower));
   });
 });
 

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -126,13 +126,23 @@ describe("getDominantAgentState", () => {
 
   // Documents the accepted trade-off: when a worktree has both a passive
   // working session and an actionable waiting session, the dominant state
-  // resolves to working (priority 7 > 3), so agentStateDotColor returns null
-  // and the toolbar dot is suppressed. WorktreeCard's border-flash animation
-  // depends on working outranking waiting; the tray dot rides on the same
-  // priority table. If this priority is ever inverted, this assertion fails
-  // first as a guard.
+  // resolves to working (earlier in STATE_PRIORITY than waiting), so
+  // agentStateDotColor returns null and the toolbar dot is suppressed.
+  // WorktreeCard's border-flash animation depends on working outranking
+  // waiting; the tray dot rides on the same priority array. If this priority
+  // is ever inverted, this assertion fails first as a guard.
   it("returns working when a worktree mixes working and waiting (suppresses tray dot)", () => {
     expect(getDominantAgentState(["working", "waiting"])).toBe("working");
+  });
+
+  // Pins the #6661 fix: waiting (actionable) must outrank completed (passive)
+  // so the tray dot, AgentButton, and the WorktreeCard collapsed-row indicator
+  // all agree on a single winner. Both input orders are asserted because the
+  // implementation is order-independent and a future inline-iteration rewrite
+  // could quietly reintroduce order sensitivity.
+  it("returns waiting when a worktree mixes completed and waiting (waiting outranks completed)", () => {
+    expect(getDominantAgentState(["completed", "waiting"])).toBe("waiting");
+    expect(getDominantAgentState(["waiting", "completed"])).toBe("waiting");
   });
 });
 

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -46,15 +46,6 @@ export const STATE_PRIORITY: AgentState[] = [
   "idle",
 ];
 
-export const STATE_SORT_PRIORITY: Record<AgentState, number> = {
-  working: 0,
-  directing: 1,
-  waiting: 2,
-  idle: 3,
-  completed: 4,
-  exited: 5,
-};
-
 export function getEffectiveStateIcon(
   agentState: AgentState,
   waitingReason?: WaitingReason


### PR DESCRIPTION
## Summary

- Three separate priority tables for `AgentState` existed across two files, causing the tray dot and worktree row to resolve different dominant states for the same agent mix
- Deleted the divergent private `Record` in `AgentStatusIndicator.tsx` and the dead `STATE_SORT_PRIORITY` Record (zero consumers); `STATE_PRIORITY` in `terminalStateConfig.tsx` is now the single source of truth
- `getDominantAgentState` now iterates the priority array via Set membership, matching how `topTerminalState` already worked

Resolves #6661

## Changes

- `AgentStatusIndicator.tsx` — removed private priority `Record`; `getDominantAgentState` delegates to `STATE_PRIORITY` array iteration
- `terminalStateConfig.tsx` — removed dead `STATE_SORT_PRIORITY` Record
- `AgentStatusIndicator.test.tsx` — regression test pinning `waiting > completed` in both input orders; contract tests for adjacent-pair ordering invariants and exhaustiveness

## Testing

- Regression test: `getDominantAgentState(["completed", "waiting"]) === "waiting"` passes in both input orderings
- Contract tests: adjacent-pair ordering invariants and exhaustiveness check ensure future `AgentState` additions or reorders can't silently break the UI
- Existing guard tests unchanged: `["working", "waiting"]` → `"working"` and `agentStateDotColor("directing") === "bg-state-working"` both pass
- `npm run check` clean; 43 unit tests pass for `AgentStatusIndicator` and `terminalStateConfig`