### PR TITLE
test(agent-fsm): add property-based tests for transition table

### DIFF
--- a/shared/utils/__tests__/agentFsm.property.test.ts
+++ b/shared/utils/__tests__/agentFsm.property.test.ts
@@ -38,33 +38,18 @@ const inputRecoveryStateArb = fc.constantFrom(
   "completed" as const
 );
 
+// Derive arbitraries directly from `eventConstructors` so adding a new variant
+// flows through the `satisfies` ratchet into both arbitraries automatically.
 const eventArb: fc.Arbitrary<AgentEvent> = fc.oneof(
-  eventConstructors.start,
-  eventConstructors.busy,
-  eventConstructors.output,
-  eventConstructors.prompt,
-  eventConstructors.completion,
-  eventConstructors.input,
-  eventConstructors.exit,
-  eventConstructors.error,
-  eventConstructors.kill,
-  eventConstructors.respawn,
-  eventConstructors["watchdog-timeout"]
+  ...(Object.values(eventConstructors) as fc.Arbitrary<AgentEvent>[])
 );
 
 // Natural-lifecycle events: everything except `kill`, which is a hard-reset
 // override that bypasses VALID_TRANSITIONS by design.
 const naturalEventArb: fc.Arbitrary<AgentEvent> = fc.oneof(
-  eventConstructors.start,
-  eventConstructors.busy,
-  eventConstructors.output,
-  eventConstructors.prompt,
-  eventConstructors.completion,
-  eventConstructors.input,
-  eventConstructors.exit,
-  eventConstructors.error,
-  eventConstructors.respawn,
-  eventConstructors["watchdog-timeout"]
+  ...(Object.entries(eventConstructors)
+    .filter(([type]) => type !== "kill")
+    .map(([, arb]) => arb) as fc.Arbitrary<AgentEvent>[])
 );
 
 describe("agentFsm property tests", () => {
@@ -116,15 +101,17 @@ describe("agentFsm property tests", () => {
     }
   );
 
-  test.prop([stateArb, naturalEventArb])(
-    "directing is renderer-only and isolated from natural-lifecycle events",
+  // Per the FSM spec, `directing` is a renderer-only state — no main-process
+  // natural event should ever produce it. We use `mainProcessStateArb` here
+  // because the from-directing exit behavior is intentionally not asserted:
+  // `nextAgentState("directing", { type: "exit", code: N })` returns `"exited"`
+  // (the `exit` case fires for any non-`exited` current state), and the
+  // existing hand-written invariant test in `agentFsm.test.ts` likewise
+  // excludes `directing` from its from-state set for the same reason.
+  test.prop([mainProcessStateArb, naturalEventArb])(
+    "no natural-lifecycle event from a non-directing state produces directing",
     (from, event) => {
-      const to = nextAgentState(from, event);
-      if (from === "directing") {
-        expect(to).toBe("directing");
-      } else {
-        expect(to).not.toBe("directing");
-      }
+      expect(nextAgentState(from, event)).not.toBe("directing");
     }
   );
 });

--- a/shared/utils/__tests__/agentFsm.property.test.ts
+++ b/shared/utils/__tests__/agentFsm.property.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect } from "vitest";
+import { fc, test } from "@fast-check/vitest";
+import {
+  VALID_TRANSITIONS,
+  isValidTransition,
+  nextAgentState,
+  type AgentEvent,
+} from "../agentFsm.js";
+import type { AgentState } from "../../types/agent.js";
+
+const ALL_STATES = ["idle", "working", "waiting", "directing", "completed", "exited"] as const;
+const MAIN_PROCESS_STATES = ["idle", "working", "waiting", "completed", "exited"] as const;
+
+// `satisfies Record<AgentEvent["type"], ...>` is a compile-time coverage ratchet:
+// adding a new variant to AgentEvent forces a corresponding entry here before
+// these tests will compile. The exit constructor MUST emit a numeric `code` —
+// the FSM treats exit events without one as no-ops (agentFsm.ts:47-49), so
+// omitting the code would silently hide → exited transitions in sequence tests.
+const eventConstructors = {
+  start: fc.constant({ type: "start" } as const),
+  busy: fc.constant({ type: "busy" } as const),
+  output: fc.record({ type: fc.constant("output" as const), data: fc.string() }),
+  prompt: fc.constant({ type: "prompt" } as const),
+  completion: fc.constant({ type: "completion" } as const),
+  input: fc.constant({ type: "input" } as const),
+  exit: fc.record({ type: fc.constant("exit" as const), code: fc.integer() }),
+  error: fc.record({ type: fc.constant("error" as const), error: fc.string() }),
+  kill: fc.constant({ type: "kill" } as const),
+  respawn: fc.constant({ type: "respawn" } as const),
+  "watchdog-timeout": fc.constant({ type: "watchdog-timeout" } as const),
+} satisfies Record<AgentEvent["type"], fc.Arbitrary<AgentEvent>>;
+
+const stateArb = fc.constantFrom(...ALL_STATES);
+const mainProcessStateArb = fc.constantFrom(...MAIN_PROCESS_STATES);
+const inputRecoveryStateArb = fc.constantFrom(
+  "idle" as const,
+  "waiting" as const,
+  "completed" as const
+);
+
+const eventArb: fc.Arbitrary<AgentEvent> = fc.oneof(
+  eventConstructors.start,
+  eventConstructors.busy,
+  eventConstructors.output,
+  eventConstructors.prompt,
+  eventConstructors.completion,
+  eventConstructors.input,
+  eventConstructors.exit,
+  eventConstructors.error,
+  eventConstructors.kill,
+  eventConstructors.respawn,
+  eventConstructors["watchdog-timeout"]
+);
+
+// Natural-lifecycle events: everything except `kill`, which is a hard-reset
+// override that bypasses VALID_TRANSITIONS by design.
+const naturalEventArb: fc.Arbitrary<AgentEvent> = fc.oneof(
+  eventConstructors.start,
+  eventConstructors.busy,
+  eventConstructors.output,
+  eventConstructors.prompt,
+  eventConstructors.completion,
+  eventConstructors.input,
+  eventConstructors.exit,
+  eventConstructors.error,
+  eventConstructors.respawn,
+  eventConstructors["watchdog-timeout"]
+);
+
+describe("agentFsm property tests", () => {
+  test.prop([mainProcessStateArb, naturalEventArb])(
+    "every state-changing natural-lifecycle transition is permitted by VALID_TRANSITIONS",
+    (from, event) => {
+      const to = nextAgentState(from, event);
+      if (to !== from) {
+        expect(VALID_TRANSITIONS[from]).toContain(to);
+        expect(isValidTransition(from, to)).toBe(true);
+      }
+    }
+  );
+
+  test.prop([stateArb])("kill is a hard reset to idle from any state", (from) => {
+    expect(nextAgentState(from, { type: "kill" })).toBe("idle");
+  });
+
+  test.prop([naturalEventArb])(
+    "exited is quasi-terminal under any natural event other than respawn",
+    (event) => {
+      fc.pre(event.type !== "respawn");
+      expect(nextAgentState("exited", event)).toBe("exited");
+    }
+  );
+
+  test.prop([inputRecoveryStateArb])(
+    "input event recovers idle/waiting/completed to working (#3195 regression guard)",
+    (from) => {
+      expect(nextAgentState(from, { type: "input" })).toBe("working");
+    }
+  );
+
+  test.prop([stateArb, fc.array(eventArb, { maxLength: 50 })])(
+    "any event sequence from any state lands in a canonical AgentState",
+    (start, events) => {
+      const terminal = events.reduce<AgentState>(
+        (state, event) => nextAgentState(state, event),
+        start
+      );
+      expect(ALL_STATES).toContain(terminal);
+    }
+  );
+
+  test.prop([stateArb, stateArb])(
+    "isValidTransition agrees with VALID_TRANSITIONS membership for every cell",
+    (from, to) => {
+      expect(isValidTransition(from, to)).toBe(VALID_TRANSITIONS[from].includes(to));
+    }
+  );
+
+  test.prop([stateArb, naturalEventArb])(
+    "directing is renderer-only and isolated from natural-lifecycle events",
+    (from, event) => {
+      const to = nextAgentState(from, event);
+      if (from === "directing") {
+        expect(to).toBe("directing");
+      } else {
+        expect(to).not.toBe("directing");
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

- Adds `shared/utils/__tests__/agentFsm.property.test.ts` with 7 fast-check property-based tests for the agent FSM transition table
- Covers the gaps that bit us in #4998: a hand-coded per-cell approach can miss cells; iterating the matrix programmatically can't
- Uses `satisfies Record<AgentEvent["type"], fc.Arbitrary<AgentEvent>>` as a compile-time coverage ratchet so any future `AgentEvent` variant flows through automatically

Resolves #6663

## Changes

- **Transition-table consistency** — every state-changing natural transition is declared in `VALID_TRANSITIONS`
- **Kill universality** — hard reset to idle is reachable from any state
- **Exited quasi-terminality** — `exited` only exits under respawn, not under any other natural event
- **Input-recovery reachability** — `idle`, `waiting`, and `completed` can reach `working`; regression guard for #3195
- **Sequence state-universe membership** — any event sequence lands in a canonical `AgentState`
- **Matrix consistency** — `isValidTransition` agrees with `VALID_TRANSITIONS` lookup for every cell
- **Directing entry guard** — no natural-lifecycle event produces `directing` (renderer worker is the only producer)

No existing files modified. No new dependencies.

## Testing

All 7 new property tests pass. Existing `agentFsm.test.ts` (24 tests) and adversarial suite unaffected. Typecheck clean across renderer, main, and preload. Lint ratchet improved by 3 warnings.