### PR TITLE
fix(keybindings): scope Cmd+W escape-stack diversion to non-grid focus

### DIFF
--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -112,6 +112,89 @@ describe("useGlobalKeybindings — Cmd+W escape stack guard", () => {
     );
   });
 
+  it("dispatches terminal.close when focus is inside a grid panel even with handlers registered", () => {
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "terminal.close" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const gridPanel = document.createElement("div");
+    gridPanel.setAttribute("data-panel-location", "grid");
+    const focusable = document.createElement("div");
+    focusable.tabIndex = -1;
+    gridPanel.appendChild(focusable);
+    document.body.appendChild(gridPanel);
+
+    try {
+      const escapeHandler = vi.fn();
+      registerEscape(escapeHandler);
+
+      render(<Host />);
+      focusable.focus();
+      expect(document.activeElement).toBe(focusable);
+
+      pressCmdW();
+
+      expect(escapeHandler).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).toHaveBeenCalledWith(
+        "terminal.close",
+        undefined,
+        expect.objectContaining({ source: "keybinding" })
+      );
+    } finally {
+      gridPanel.remove();
+    }
+  });
+
+  it("routes Cmd+W to escape stack when focus is inside a dock panel", () => {
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "terminal.close" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const dockPanel = document.createElement("div");
+    dockPanel.setAttribute("data-panel-location", "dock");
+    const focusable = document.createElement("div");
+    focusable.tabIndex = -1;
+    dockPanel.appendChild(focusable);
+    document.body.appendChild(dockPanel);
+
+    try {
+      const escapeHandler = vi.fn();
+      registerEscape(escapeHandler);
+
+      render(<Host />);
+      focusable.focus();
+      expect(document.activeElement).toBe(focusable);
+
+      pressCmdW();
+
+      expect(escapeHandler).toHaveBeenCalledTimes(1);
+      expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+    } finally {
+      dockPanel.remove();
+    }
+  });
+
+  it("routes Cmd+W to escape stack when focus has no panel ancestor (dialog/body)", () => {
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "terminal.close" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    const escapeHandler = vi.fn();
+    registerEscape(escapeHandler);
+
+    render(<Host />);
+    pressCmdW();
+
+    expect(escapeHandler).toHaveBeenCalledTimes(1);
+    expect(mocks.actionService.dispatch).not.toHaveBeenCalled();
+  });
+
   it("falls back to terminal.close after the dialog unregisters its escape handler", () => {
     mocks.keybindingService.resolveKeybinding.mockReturnValue({
       match: { actionId: "terminal.close" },

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -106,9 +106,17 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
         if (result.match) {
           // When a dialog/palette is open, route Cmd+W to the escape stack so it
           // dismisses the topmost layer instead of falling through to the terminal.
+          // Skip this diversion when focus is inside a grid panel — persistent
+          // docks like the assistant keep an escape handler registered the whole
+          // time they are open, but Cmd+W from a focused grid panel must close
+          // that panel rather than the dock.
           if (result.match.actionId === "terminal.close" && hasHandlers()) {
-            dispatchEscape();
-            return;
+            const active = document.activeElement as HTMLElement | null;
+            const isFocusInsideGridPanel = active?.closest("[data-panel-location='grid']") != null;
+            if (!isFocusInsideGridPanel) {
+              dispatchEscape();
+              return;
+            }
           }
 
           // Dispatch through ActionService


### PR DESCRIPTION
## Summary

- `Cmd+W` was always closing the assistant panel when it was open, even when focus was inside a different agent terminal in the grid. The assistant registers a persistent escape handler via `useEscapeStack`, so `hasHandlers()` was always true while it was open — causing the escape-stack short-circuit to fire regardless of where focus actually was.
- The fix adds a guard to `useGlobalKeybindings.ts` that checks whether the currently focused panel is a grid panel before routing `Cmd+W` to the escape stack. If focus is inside the grid, the keypress falls through to `terminal.close` against the focused panel ID as expected.
- Transient overlays (palettes, dialogs) are unaffected — the guard only bypasses the diversion when a grid panel has focus.

Resolves #6675

## Changes

- `src/hooks/useGlobalKeybindings.ts` — expanded the escape-stack guard to include a `isFocusedPanelInGrid` check alongside `hasHandlers()`
- `src/hooks/__tests__/useGlobalKeybindings.test.tsx` — three new unit tests covering the grid-focus case (dispatches `terminal.close`), assistant-focus case (routes to escape stack), and overlay-dismissal case (routes to escape stack)

## Testing

All 11 unit tests pass. `npm run check` (typecheck + lint + format + build) clean.