### PR TITLE
test(replay): extend cast harness to AgentStateMachine end-to-end

### DIFF
--- a/electron/services/__tests__/AgentStateMachine.replay.test.ts
+++ b/electron/services/__tests__/AgentStateMachine.replay.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  loadExpectedFsm,
+  matchFsmTransitions,
+  replayCastFsm,
+  type ExpectedFsmTransition,
+  type RecordedFsmTransition,
+  type ReplayCastFsmOpts,
+} from "./replay/castReplayHarness.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.join(__dirname, "fixtures", "agent-state-machine");
+
+function fixture(name: string) {
+  return {
+    cast: path.join(FIXTURE_DIR, `${name}.cast`),
+    expected: path.join(FIXTURE_DIR, `${name}.expected.json`),
+  };
+}
+
+interface ReplayCase {
+  name: string;
+  agentId: string;
+}
+
+const REPLAY_CASES: ReplayCase[] = [
+  { name: "claude-watchdog-timeout", agentId: "claude" },
+  { name: "claude-respawn", agentId: "claude" },
+];
+
+describe("AgentStateMachine replay harness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Anchor to a positive epoch so AgentStateChangedSchema's
+    // `timestamp: z.number().int().positive()` accepts the very first
+    // emitted event. Starting at 0 silently drops the first transition.
+    vi.setSystemTime(1);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  describe.each(REPLAY_CASES)("$name (no fragmentation)", ({ name, agentId }) => {
+    it("produces the expected FSM transition sequence", async () => {
+      const { cast, expected } = fixture(name);
+      const expectedFile = loadExpectedFsm(expected);
+      const opts: ReplayCastFsmOpts = {
+        agentId: expectedFile.agentId ?? agentId,
+        settleMs: expectedFile.settleMs,
+        pollingMaxBootMs: expectedFile.pollingMaxBootMs,
+        maxWorkingSilenceMs: expectedFile.maxWorkingSilenceMs,
+        maxWaitingSilenceMs: expectedFile.maxWaitingSilenceMs,
+        idleDebounceMs: expectedFile.idleDebounceMs,
+        promptFastPathMinQuietMs: expectedFile.promptFastPathMinQuietMs,
+      };
+      const recorded = await replayCastFsm(cast, opts);
+      const failures = matchFsmTransitions(recorded, expectedFile.transitions, {
+        allowExtraTransitions: expectedFile.allowExtraTransitions ?? false,
+      });
+      expect(failures, formatFailures(failures, recorded)).toHaveLength(0);
+    });
+  });
+
+  describe.each([
+    { name: "claude-watchdog-timeout", agentId: "claude", seed: 1 },
+    { name: "claude-watchdog-timeout", agentId: "claude", seed: 2 },
+    { name: "claude-watchdog-timeout", agentId: "claude", seed: 3 },
+    { name: "claude-respawn", agentId: "claude", seed: 1 },
+    { name: "claude-respawn", agentId: "claude", seed: 2 },
+    { name: "claude-respawn", agentId: "claude", seed: 3 },
+  ])("$name fragmented (seed=$seed)", ({ name, agentId, seed }) => {
+    it("preserves the expected FSM state sequence under chunk-boundary fragmentation", async () => {
+      const { cast, expected } = fixture(name);
+      const expectedFile = loadExpectedFsm(expected);
+      const recorded = await replayCastFsm(cast, {
+        agentId: expectedFile.agentId ?? agentId,
+        settleMs: expectedFile.settleMs,
+        pollingMaxBootMs: expectedFile.pollingMaxBootMs,
+        maxWorkingSilenceMs: expectedFile.maxWorkingSilenceMs,
+        maxWaitingSilenceMs: expectedFile.maxWaitingSilenceMs,
+        idleDebounceMs: expectedFile.idleDebounceMs,
+        promptFastPathMinQuietMs: expectedFile.promptFastPathMinQuietMs,
+        fragmentation: { seed, maxSplits: 4 },
+      });
+      // Fragmented playback exercises chunk-boundary parsing in xterm. The
+      // load-bearing invariant is the FSM state sequence — chunk boundaries
+      // can introduce extra activity-driven pulses (e.g. a brief
+      // working→completed→waiting trio) that don't change the load-bearing
+      // exit/respawn/watchdog transitions, so allowExtraTransitions is on.
+      const failures = matchFsmTransitions(recorded, expectedFile.transitions, {
+        allowExtraTransitions: true,
+      });
+      expect(failures, formatFailures(failures, recorded)).toHaveLength(0);
+    });
+  });
+});
+
+function formatFailures(
+  failures: ReturnType<typeof matchFsmTransitions>,
+  recorded: RecordedFsmTransition[]
+): string {
+  if (failures.length === 0) return "";
+  const fail = failures
+    .map((f) => {
+      const expected = formatExpected(f.expected);
+      const actual = f.actual ? formatTransition(f.actual) : "";
+      return `  - [${f.index}] ${f.kind}${expected ? `: expected ${expected}` : ""}${actual ? ` got ${actual}` : ""}${f.detail ? ` (${f.detail})` : ""}`;
+    })
+    .join("\n");
+  return `Match failures:\n${fail}\n${formatRecorded(recorded)}`;
+}
+
+function formatExpected(t?: ExpectedFsmTransition): string {
+  if (!t) return "";
+  const parts: string[] = [`state=${t.state}`];
+  if (t.previousState) parts.push(`previousState=${t.previousState}`);
+  if (t.trigger) parts.push(`trigger=${t.trigger}`);
+  if (t.confidence !== undefined) parts.push(`confidence=${t.confidence}`);
+  return `{ ${parts.join(", ")} }`;
+}
+
+function formatTransition(t: RecordedFsmTransition): string {
+  return `{ replayMs=${t.replayMs}, ${t.previousState}→${t.state}, trigger=${t.trigger}, confidence=${t.confidence} }`;
+}
+
+function formatRecorded(recorded: RecordedFsmTransition[]): string {
+  const lines = recorded.map(
+    (r) => `  ${r.replayMs}ms ${r.previousState}→${r.state}/${r.trigger} (conf=${r.confidence})`
+  );
+  return `Recorded transitions (${recorded.length}):\n${lines.join("\n")}`;
+}

--- a/electron/services/__tests__/AgentStateMachine.replay.test.ts
+++ b/electron/services/__tests__/AgentStateMachine.replay.test.ts
@@ -9,6 +9,7 @@ import {
   type RecordedFsmTransition,
   type ReplayCastFsmOpts,
 } from "./replay/castReplayHarness.js";
+import type { ProcessStateValidator } from "../ActivityMonitor.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = path.join(__dirname, "fixtures", "agent-state-machine");
@@ -63,6 +64,26 @@ describe("AgentStateMachine replay harness", () => {
       });
       expect(failures, formatFailures(failures, recorded)).toHaveLength(0);
     });
+  });
+
+  it("does not fire watchdog when processStateValidator reports active children", async () => {
+    // Inverse of the watchdog-timeout fixture: with hasActiveChildren()===true
+    // the watchdog must NOT fire, and the FSM must stay in `waiting`. Guards
+    // against regressions in the `hasChildren !== false` gate that prevents
+    // the watchdog from forcing idle on agents that are actually still alive.
+    const aliveValidator: ProcessStateValidator = { hasActiveChildren: () => true };
+    const { cast, expected } = fixture("claude-watchdog-timeout");
+    const expectedFile = loadExpectedFsm(expected);
+    const recorded = await replayCastFsm(cast, {
+      agentId: expectedFile.agentId ?? "claude",
+      settleMs: expectedFile.settleMs,
+      maxWorkingSilenceMs: expectedFile.maxWorkingSilenceMs,
+      maxWaitingSilenceMs: expectedFile.maxWaitingSilenceMs,
+      processStateValidator: aliveValidator,
+    });
+    const states = recorded.map((r) => r.state);
+    expect(states, formatRecorded(recorded)).not.toContain("idle");
+    expect(states[states.length - 1], formatRecorded(recorded)).toBe("waiting");
   });
 
   describe.each([

--- a/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.cast
+++ b/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.cast
@@ -1,0 +1,6 @@
+{"version":2,"width":120,"height":10,"timestamp":1700000000,"title":"claude-respawn"}
+[0.05,"o","Claude Code v2.1.79 (Sonnet 4.6)\r\n"]
+[0.10,"o","> "]
+[3.00,"x","0"]
+[4.00,"o","Claude Code v2.1.79 (Sonnet 4.6)\r\n"]
+[4.05,"o","> "]

--- a/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.expected.json
+++ b/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.expected.json
@@ -2,6 +2,7 @@
   "agentId": "claude",
   "settleMs": 6000,
   "maxWorkingSilenceMs": 1500,
+  "_comment": "allowExtraTransitions is on because the second agent boot can fire either an output-trigger working transition followed by a separate watchdog/timeout-driven waiting pulse, or fold them together depending on activity-window timing. The load-bearing invariant is the exit/respawn lifecycle, not the post-respawn settle.",
   "transitions": [
     { "state": "working", "previousState": "idle", "trigger": "heuristic" },
     { "state": "waiting", "previousState": "working", "trigger": "timeout" },

--- a/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.expected.json
+++ b/electron/services/__tests__/fixtures/agent-state-machine/claude-respawn.expected.json
@@ -1,0 +1,13 @@
+{
+  "agentId": "claude",
+  "settleMs": 6000,
+  "maxWorkingSilenceMs": 1500,
+  "transitions": [
+    { "state": "working", "previousState": "idle", "trigger": "heuristic" },
+    { "state": "waiting", "previousState": "working", "trigger": "timeout" },
+    { "state": "exited", "previousState": "waiting", "trigger": "exit", "confidence": 1 },
+    { "state": "idle", "previousState": "exited", "trigger": "activity" },
+    { "state": "working", "previousState": "idle", "trigger": "output" }
+  ],
+  "allowExtraTransitions": true
+}

--- a/electron/services/__tests__/fixtures/agent-state-machine/claude-watchdog-timeout.cast
+++ b/electron/services/__tests__/fixtures/agent-state-machine/claude-watchdog-timeout.cast
@@ -1,0 +1,6 @@
+{"version":2,"width":120,"height":10,"timestamp":1700000000,"title":"claude-watchdog-timeout"}
+[0.05,"o","Claude Code v2.1.79 (Sonnet 4.6)\r\n"]
+[0.10,"o","> "]
+[0.40,"o","✽ Deliberating… (1s · esc to interrupt)"]
+[0.85,"o","\r✽ Deliberating… (2s · esc to interrupt)"]
+[1.30,"o","\r\u001b[2K"]

--- a/electron/services/__tests__/fixtures/agent-state-machine/claude-watchdog-timeout.expected.json
+++ b/electron/services/__tests__/fixtures/agent-state-machine/claude-watchdog-timeout.expected.json
@@ -1,0 +1,11 @@
+{
+  "agentId": "claude",
+  "settleMs": 12000,
+  "maxWorkingSilenceMs": 1500,
+  "maxWaitingSilenceMs": 2000,
+  "transitions": [
+    { "state": "working", "previousState": "idle", "trigger": "heuristic" },
+    { "state": "waiting", "previousState": "working", "trigger": "timeout" },
+    { "state": "idle", "previousState": "waiting", "trigger": "timeout", "confidence": 0.6 }
+  ]
+}

--- a/electron/services/__tests__/replay/castReplayHarness.ts
+++ b/electron/services/__tests__/replay/castReplayHarness.ts
@@ -10,6 +10,12 @@ import {
   type ProcessStateValidator,
 } from "../../ActivityMonitor.js";
 import { buildActivityMonitorOptions } from "../../pty/terminalActivityPatterns.js";
+import { AgentStateService } from "../../pty/AgentStateService.js";
+import { events } from "../../events.js";
+import type { AgentStateChanged, AgentStateChangeTrigger } from "../../../schemas/agent.js";
+import type { TerminalInfo } from "../../pty/types.js";
+import type { AgentState } from "../../../../shared/types/agent.js";
+import type { BuiltInAgentId } from "../../../../shared/config/agentIds.js";
 
 export interface RecordedTransition {
   replayMs: number;
@@ -458,6 +464,301 @@ export function matchTransitions(
         index: j,
         actual: recorded[j],
         detail: `unmatched recorded transition: ${recorded[j].state}/${recorded[j].trigger ?? "-"} at ${recorded[j].replayMs}ms`,
+      });
+    }
+  }
+
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// FSM-driven replay
+// ---------------------------------------------------------------------------
+
+/**
+ * Recorded `agent:state-changed` payload after the cast was replayed through
+ * the full chain: ActivityMonitor → AgentStateService → events bus.
+ * Captures FSM-level state names (working/waiting/idle/completed/exited),
+ * not ActivityMonitor's internal busy/idle/completed states.
+ */
+export interface RecordedFsmTransition {
+  replayMs: number;
+  state: AgentState;
+  previousState: AgentState;
+  trigger: AgentStateChangeTrigger;
+  confidence: number;
+}
+
+export interface ExpectedFsmTransition {
+  state: AgentState;
+  /** Optional invariant on the source state of the transition. */
+  previousState?: AgentState;
+  trigger?: AgentStateChangeTrigger;
+  /** Allowed delta when matched: |actual - expected| ≤ 0.01. */
+  confidence?: number;
+}
+
+export interface ExpectedFsmFile {
+  agentId?: string;
+  pollingMaxBootMs?: number;
+  settleMs?: number;
+  maxWorkingSilenceMs?: number;
+  maxWaitingSilenceMs?: number;
+  idleDebounceMs?: number;
+  promptFastPathMinQuietMs?: number;
+  /**
+   * Default false (strict). When true, recorded FSM transitions that don't
+   * map to an expected entry are tolerated. Used by fragmented variants
+   * where intentional chunk-boundary noise can introduce extra transitions
+   * (e.g., a brief working→completed→waiting pulse) that don't change the
+   * load-bearing state-sequence invariant.
+   */
+  allowExtraTransitions?: boolean;
+  transitions: ExpectedFsmTransition[];
+}
+
+export interface ReplayCastFsmOpts {
+  agentId?: string;
+  fragmentation?: FragmentationOpts;
+  processStateValidator?: ProcessStateValidator;
+  settleMs?: number;
+  pollingIntervalMs?: number;
+  pollingMaxBootMs?: number;
+  maxWorkingSilenceMs?: number;
+  maxWaitingSilenceMs?: number;
+  idleDebounceMs?: number;
+  promptFastPathMinQuietMs?: number;
+}
+
+const FSM_REPLAY_TERMINAL_ID = "fsm-replay-terminal";
+
+/**
+ * Replay an asciicast through the full ActivityMonitor → AgentStateService →
+ * events bus chain and record the resulting `agent:state-changed` payloads.
+ *
+ * Handles the cast's `x` (exit) events by driving a synthetic exit→respawn
+ * sequence into the FSM — production wires these from the PTY's `onExit`
+ * callback and from agent re-detection, neither of which run in the replay
+ * environment. The harness owns the events-bus subscription (subscribes
+ * before `monitor.startPolling()`, unsubscribes after dispose) so callers
+ * never need to clean up listener state.
+ */
+export async function replayCastFsm(
+  castPath: string,
+  opts: ReplayCastFsmOpts = {}
+): Promise<RecordedFsmTransition[]> {
+  const cast = parseCast(castPath);
+  const term = createHeadlessTerminal(cast.cols, cast.rows);
+  const getVisibleLines = makeGetVisibleLines(term);
+  const getCursorLine = makeGetCursorLine(term);
+
+  const baseOptions = buildActivityMonitorOptions(opts.agentId, {
+    getVisibleLines,
+    getCursorLine,
+  });
+
+  const pollingIntervalMs = opts.pollingIntervalMs ?? DEFAULT_POLLING_INTERVAL_MS;
+  const recorded: RecordedFsmTransition[] = [];
+  const startedAt = Date.now();
+
+  // Stub TerminalInfo with the minimal fields AgentStateService and the
+  // AgentStateChangedSchema actually consume. The runtime fields are typed
+  // as never/empty so the schema validates without touching them.
+  const terminal: TerminalInfo = {
+    id: FSM_REPLAY_TERMINAL_ID,
+    cwd: "/tmp/fsm-replay",
+    shell: "/bin/sh",
+    spawnedAt: startedAt,
+    launchAgentId: opts.agentId as BuiltInAgentId | undefined,
+    agentState: "idle",
+    analysisEnabled: false,
+    lastInputTime: 0,
+    lastOutputTime: 0,
+    lastCheckTime: 0,
+    restartCount: 0,
+    ptyProcess: {} as never,
+    outputBuffer: "",
+    semanticBuffer: [],
+  };
+
+  const agentStateService = new AgentStateService();
+
+  // Filter by terminalId so events from other tests/services running on the
+  // shared singleton bus don't pollute the recorded sequence.
+  const listener = (payload: AgentStateChanged): void => {
+    if (payload.terminalId !== FSM_REPLAY_TERMINAL_ID) return;
+    recorded.push({
+      replayMs: Date.now() - startedAt,
+      state: payload.state,
+      previousState: payload.previousState,
+      trigger: payload.trigger,
+      confidence: payload.confidence,
+    });
+  };
+  const unsubscribe = events.on("agent:state-changed", listener);
+
+  try {
+    const monitor = new ActivityMonitor(
+      FSM_REPLAY_TERMINAL_ID,
+      startedAt,
+      (_id, _spawnedAt, state, metadata) => {
+        agentStateService.handleActivityState(terminal, state, metadata);
+      },
+      {
+        ...baseOptions,
+        processStateValidator: opts.processStateValidator ?? NULL_PROCESS_STATE_VALIDATOR,
+        pollingIntervalMs,
+        pollingMaxBootMs: opts.pollingMaxBootMs ?? baseOptions.pollingMaxBootMs,
+        maxWorkingSilenceMs: opts.maxWorkingSilenceMs ?? baseOptions.maxWorkingSilenceMs,
+        maxWaitingSilenceMs: opts.maxWaitingSilenceMs ?? baseOptions.maxWaitingSilenceMs,
+        idleDebounceMs: opts.idleDebounceMs ?? baseOptions.idleDebounceMs,
+        promptFastPathMinQuietMs:
+          opts.promptFastPathMinQuietMs ?? baseOptions.promptFastPathMinQuietMs,
+        onWaitingTimeout: () => {
+          agentStateService.updateAgentState(
+            terminal,
+            { type: "watchdog-timeout" },
+            "timeout",
+            0.6
+          );
+        },
+      }
+    );
+
+    monitor.startPolling();
+
+    const rng = opts.fragmentation ? mulberry32(opts.fragmentation.seed) : null;
+    const maxSplits = opts.fragmentation?.maxSplits ?? DEFAULT_FRAGMENT_MAX_SPLITS;
+
+    let currentMs = 0;
+    for (const event of cast.events) {
+      const delta = Math.max(0, event.absoluteMs - currentMs);
+      if (delta > 0) {
+        vi.advanceTimersByTime(delta);
+        currentMs = event.absoluteMs;
+      }
+
+      if (event.kind === "o") {
+        const bytes = Buffer.from(event.data, "utf8");
+        const fragments = rng ? fragmentBytes(bytes, rng, maxSplits) : [bytes];
+        for (const fragment of fragments) {
+          if (fragment.length === 0) continue;
+          writeBytesToTerminal(term, fragment);
+        }
+        monitor.onData(event.data);
+      } else if (event.kind === "i") {
+        monitor.onInput(event.data);
+      } else if (event.kind === "r") {
+        const match = /^(\d+)x(\d+)$/.exec(event.data);
+        if (match) {
+          const newCols = Number(match[1]);
+          const newRows = Number(match[2]);
+          try {
+            term.resize(Math.max(1, newCols), Math.max(1, newRows));
+          } catch {
+            // Some xterm builds throw if dims unchanged — ignore.
+          }
+          monitor.notifyResize();
+        }
+      } else if (event.kind === "x") {
+        // Drive exit → respawn so subsequent output (a fresh agent restarting
+        // in the same PTY) re-enters working via the natural busy → working
+        // path. Production wires `exit` from the PTY's onExit callback and
+        // `respawn` from agent re-detection; replay synthesizes both
+        // deterministically from the cast's `x` event.
+        const parsedCode = Number.parseInt(event.data, 10);
+        const code = Number.isFinite(parsedCode) ? parsedCode : 0;
+        agentStateService.updateAgentState(terminal, { type: "exit", code }, "exit", 1.0);
+        agentStateService.updateAgentState(terminal, { type: "respawn" }, "activity", 1.0);
+      }
+      // Ignore "m" (markers) — they don't drive state.
+    }
+
+    const settleMs = opts.settleMs ?? DEFAULT_SETTLE_MS;
+    if (settleMs > 0) {
+      vi.advanceTimersByTime(settleMs);
+    }
+
+    monitor.dispose();
+    term.dispose();
+  } finally {
+    unsubscribe();
+  }
+
+  return recorded;
+}
+
+export function loadExpectedFsm(expectedPath: string): ExpectedFsmFile {
+  const raw = readFileSync(expectedPath, "utf8");
+  const parsed = JSON.parse(raw) as ExpectedFsmFile;
+  if (!Array.isArray(parsed.transitions)) {
+    throw new Error(`Expected file missing 'transitions' array: ${expectedPath}`);
+  }
+  return parsed;
+}
+
+export interface FsmMatchOpts {
+  /**
+   * When true, recorded transitions that don't map to an expected entry are
+   * tolerated. Default is strict — any unmatched recorded transition fails.
+   */
+  allowExtraTransitions?: boolean;
+}
+
+export interface FsmMatchFailure {
+  kind: "missing" | "extra";
+  index: number;
+  expected?: ExpectedFsmTransition;
+  actual?: RecordedFsmTransition;
+  detail?: string;
+}
+
+/**
+ * Strict in-order match for FSM transitions. Each expected entry must match
+ * a recorded transition by `state` (required); `previousState`, `trigger`,
+ * and `confidence` are asserted only when the expected entry names them.
+ * Recorded transitions that don't map to an expected entry produce `extra`
+ * failures unless `allowExtraTransitions` is true.
+ */
+export function matchFsmTransitions(
+  recorded: RecordedFsmTransition[],
+  expected: ExpectedFsmTransition[],
+  opts: FsmMatchOpts = {}
+): FsmMatchFailure[] {
+  const failures: FsmMatchFailure[] = [];
+  const matched = new Set<number>();
+  let cursor = 0;
+
+  for (let i = 0; i < expected.length; i++) {
+    const want = expected[i];
+    let foundIndex = -1;
+    for (let j = cursor; j < recorded.length; j++) {
+      if (matched.has(j)) continue;
+      const got = recorded[j];
+      if (got.state !== want.state) continue;
+      if (want.previousState !== undefined && got.previousState !== want.previousState) continue;
+      if (want.trigger !== undefined && got.trigger !== want.trigger) continue;
+      if (want.confidence !== undefined && Math.abs(got.confidence - want.confidence) > 0.01)
+        continue;
+      foundIndex = j;
+      break;
+    }
+    if (foundIndex === -1) {
+      failures.push({ kind: "missing", index: i, expected: want });
+      continue;
+    }
+    matched.add(foundIndex);
+    cursor = foundIndex + 1;
+  }
+
+  if (!opts.allowExtraTransitions) {
+    for (let j = 0; j < recorded.length; j++) {
+      if (matched.has(j)) continue;
+      failures.push({
+        kind: "extra",
+        index: j,
+        actual: recorded[j],
+        detail: `unmatched recorded transition: ${recorded[j].previousState}→${recorded[j].state}/${recorded[j].trigger} at ${recorded[j].replayMs}ms`,
       });
     }
   }

--- a/electron/services/__tests__/replay/castReplayHarness.ts
+++ b/electron/services/__tests__/replay/castReplayHarness.ts
@@ -528,6 +528,14 @@ export interface ReplayCastFsmOpts {
   maxWaitingSilenceMs?: number;
   idleDebounceMs?: number;
   promptFastPathMinQuietMs?: number;
+  /**
+   * When true (default), each cast `x` event drives a synthetic
+   * `exit` → `respawn` pair so a fresh agent restarting in the same PTY can
+   * re-enter `working` via the natural busy path. Set false to exercise the
+   * pure `exited` terminal state (no respawn) — the FSM stays in `exited`
+   * and subsequent output cannot advance it.
+   */
+  injectRespawnOnExit?: boolean;
 }
 
 const FSM_REPLAY_TERMINAL_ID = "fsm-replay-terminal";
@@ -597,34 +605,34 @@ export async function replayCastFsm(
   };
   const unsubscribe = events.on("agent:state-changed", listener);
 
-  try {
-    const monitor = new ActivityMonitor(
-      FSM_REPLAY_TERMINAL_ID,
-      startedAt,
-      (_id, _spawnedAt, state, metadata) => {
-        agentStateService.handleActivityState(terminal, state, metadata);
+  const monitor = new ActivityMonitor(
+    FSM_REPLAY_TERMINAL_ID,
+    startedAt,
+    (_id, _spawnedAt, state, metadata) => {
+      agentStateService.handleActivityState(terminal, state, metadata);
+    },
+    {
+      ...baseOptions,
+      processStateValidator: opts.processStateValidator ?? NULL_PROCESS_STATE_VALIDATOR,
+      pollingIntervalMs,
+      pollingMaxBootMs: opts.pollingMaxBootMs ?? baseOptions.pollingMaxBootMs,
+      maxWorkingSilenceMs: opts.maxWorkingSilenceMs ?? baseOptions.maxWorkingSilenceMs,
+      maxWaitingSilenceMs: opts.maxWaitingSilenceMs ?? baseOptions.maxWaitingSilenceMs,
+      idleDebounceMs: opts.idleDebounceMs ?? baseOptions.idleDebounceMs,
+      promptFastPathMinQuietMs:
+        opts.promptFastPathMinQuietMs ?? baseOptions.promptFastPathMinQuietMs,
+      onWaitingTimeout: () => {
+        agentStateService.updateAgentState(
+          terminal,
+          { type: "watchdog-timeout" },
+          "timeout",
+          0.6
+        );
       },
-      {
-        ...baseOptions,
-        processStateValidator: opts.processStateValidator ?? NULL_PROCESS_STATE_VALIDATOR,
-        pollingIntervalMs,
-        pollingMaxBootMs: opts.pollingMaxBootMs ?? baseOptions.pollingMaxBootMs,
-        maxWorkingSilenceMs: opts.maxWorkingSilenceMs ?? baseOptions.maxWorkingSilenceMs,
-        maxWaitingSilenceMs: opts.maxWaitingSilenceMs ?? baseOptions.maxWaitingSilenceMs,
-        idleDebounceMs: opts.idleDebounceMs ?? baseOptions.idleDebounceMs,
-        promptFastPathMinQuietMs:
-          opts.promptFastPathMinQuietMs ?? baseOptions.promptFastPathMinQuietMs,
-        onWaitingTimeout: () => {
-          agentStateService.updateAgentState(
-            terminal,
-            { type: "watchdog-timeout" },
-            "timeout",
-            0.6
-          );
-        },
-      }
-    );
+    }
+  );
 
+  try {
     monitor.startPolling();
 
     const rng = opts.fragmentation ? mulberry32(opts.fragmentation.seed) : null;
@@ -661,15 +669,18 @@ export async function replayCastFsm(
           monitor.notifyResize();
         }
       } else if (event.kind === "x") {
-        // Drive exit → respawn so subsequent output (a fresh agent restarting
-        // in the same PTY) re-enters working via the natural busy → working
-        // path. Production wires `exit` from the PTY's onExit callback and
-        // `respawn` from agent re-detection; replay synthesizes both
-        // deterministically from the cast's `x` event.
+        // Drive exit so the FSM reaches `exited`. Production wires this from
+        // the PTY's onExit callback. The optional respawn injection (default
+        // on) lets a fresh agent restarting in the same PTY re-enter
+        // `working` via the natural busy → working path; production fires
+        // respawn from agent re-detection. Set injectRespawnOnExit=false to
+        // exercise the pure `exited` terminal state.
         const parsedCode = Number.parseInt(event.data, 10);
         const code = Number.isFinite(parsedCode) ? parsedCode : 0;
         agentStateService.updateAgentState(terminal, { type: "exit", code }, "exit", 1.0);
-        agentStateService.updateAgentState(terminal, { type: "respawn" }, "activity", 1.0);
+        if (opts.injectRespawnOnExit ?? true) {
+          agentStateService.updateAgentState(terminal, { type: "respawn" }, "activity", 1.0);
+        }
       }
       // Ignore "m" (markers) — they don't drive state.
     }
@@ -678,10 +689,9 @@ export async function replayCastFsm(
     if (settleMs > 0) {
       vi.advanceTimersByTime(settleMs);
     }
-
+  } finally {
     monitor.dispose();
     term.dispose();
-  } finally {
     unsubscribe();
   }
 

--- a/electron/services/__tests__/replay/castReplayHarness.ts
+++ b/electron/services/__tests__/replay/castReplayHarness.ts
@@ -622,12 +622,7 @@ export async function replayCastFsm(
       promptFastPathMinQuietMs:
         opts.promptFastPathMinQuietMs ?? baseOptions.promptFastPathMinQuietMs,
       onWaitingTimeout: () => {
-        agentStateService.updateAgentState(
-          terminal,
-          { type: "watchdog-timeout" },
-          "timeout",
-          0.6
-        );
+        agentStateService.updateAgentState(terminal, { type: "watchdog-timeout" }, "timeout", 0.6);
       },
     }
   );


### PR DESCRIPTION
## Summary

- Extends the cast-replay harness to drive the full `ActivityMonitor` → `AgentStateService` → events bus chain, not just `ActivityMonitor` in isolation
- Adds `replayCastFsm`, `matchFsmTransitions`, and `loadExpectedFsm` to `castReplayHarness.ts`, plus a new `AgentStateMachine.replay.test.ts` with 9 tests (2 no-frag, 6 fragmented seeds, 1 negative-watchdog)
- Adds fixture coverage for the two FSM scenarios most likely to drift unobserved: `claude-watchdog-timeout` and `claude-respawn`

Resolves #6664

## Changes

- `castReplayHarness.ts` — three new functions: `replayCastFsm` wires up the full parser → `ActivityMonitor` → `nextAgentState` chain and collects `agent:state-changed` events; `matchFsmTransitions` asserts the ordered state sequence with tolerance for fragmented runs; `loadExpectedFsm` reads the `.expected.json` sidecar
- `AgentStateMachine.replay.test.ts` — 9 tests across two fixtures, mirroring the structure of the existing `ActivityMonitor.replay.test.ts`
- `claude-watchdog-timeout.cast` / `.expected.json` — `waiting` state recovers to `idle` via watchdog when `hasActiveChildren()` returns false
- `claude-respawn.cast` / `.expected.json` — agent transitions through `exit` → `exited` → `idle` (synthetic respawn) → `working` when the agent restarts in the same PTY
- Negative-watchdog test confirms the watchdog does NOT fire when `hasActiveChildren()` returns true (regression guard for #4974)

## Testing

All 9 new tests pass locally. The fragmented-seed runs exercise the same seeded byte-fragmentation jitter the existing `ActivityMonitor` harness uses, so determinism is preserved across runs.