### PR TITLE
feat(activity): add structural-signal tier above regex pack in PTY detection

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -12,6 +12,11 @@ import { WorkingSignalDebouncer } from "./pty/WorkingSignalDebouncer.js";
 import { LineRewriteDetector, isStatusLineRewrite } from "./pty/LineRewriteDetector.js";
 import { stripIdleTerminalSequences } from "./pty/IdleSequenceFilter.js";
 import {
+  SynchronizedFrameAnalyzer,
+  type FrameSnapshot,
+  type StructuralSignal,
+} from "./pty/SynchronizedFrameAnalyzer.js";
+import {
   detectPrompt,
   detectPromptLexeme,
   DEFAULT_PROMPT_PATTERNS,
@@ -140,9 +145,25 @@ export class ActivityMonitor {
   // "no working signal" branch resets sustainedSince every poll, which would
   // erase accumulated spinner-tick signal between sparse cosmetic frames.
   private readonly cosmeticRecoveryDebouncer: WorkingSignalDebouncer;
+  // Structural tier (#6668) cannot share workingSignalDebouncer because
+  // runPollingCycle's "no working signal this tick" branch calls
+  // shouldTriggerRecovery(now, false), which would zero the structural
+  // sustainedSince between sparse frame-close events (one every 80-100ms is
+  // typical, vs. the polling cycle's 50ms cadence).
+  private readonly structuralRecoveryDebouncer: WorkingSignalDebouncer;
   private readonly lineRewriteDetector: LineRewriteDetector;
   private readonly completionTimer: CompletionTimer;
   private readonly bootDetector: BootDetector;
+  // Structural-signal tier (#6668). Sits above the regex-based pattern tier:
+  // classifies DEC mode 2026 frame snapshots as cosmetic-only (suppress
+  // idle→working escalation), spinner, or time-counter. Driven by
+  // SynchronizedFrameDetector in TerminalProcess via onSynchronizedFrame().
+  private readonly synchronizedFrameAnalyzer: SynchronizedFrameAnalyzer;
+  // Sticky window during which idle→working escalation from cosmetic line
+  // rewrites is suppressed. Set by onSynchronizedFrame when a structural
+  // cosmetic-only signal arrives; consulted in onData()'s recovery path.
+  private lastStructuralCosmeticOnlyUntil = 0;
+  private static readonly STRUCTURAL_COSMETIC_ONLY_TTL_MS = 600;
 
   // Resize suppression
   private resizeSuppressUntil = 0;
@@ -230,6 +251,9 @@ export class ActivityMonitor {
     this.cosmeticRecoveryDebouncer = new WorkingSignalDebouncer(
       options?.workingRecoveryDelayMs ?? 1500
     );
+    this.structuralRecoveryDebouncer = new WorkingSignalDebouncer(
+      options?.workingRecoveryDelayMs ?? 1500
+    );
 
     // Snapshot tier-aware recovery thresholds. Active values default to the
     // detector-instantiation values so the active-tier path is identical to
@@ -242,6 +266,8 @@ export class ActivityMonitor {
       options?.backgroundWorkingRecoveryDelayMs ?? this.activeWorkingRecoveryDelayMs;
 
     this.lineRewriteDetector = new LineRewriteDetector(options?.lineRewriteDetection);
+
+    this.synchronizedFrameAnalyzer = new SynchronizedFrameAnalyzer();
 
     this.completionTimer = new CompletionTimer();
 
@@ -299,10 +325,12 @@ export class ActivityMonitor {
       this.outputVolumeDetector.reconfigureWindow(this.backgroundOutputWindowMs);
       this.workingSignalDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
       this.cosmeticRecoveryDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
+      this.structuralRecoveryDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
     } else {
       this.outputVolumeDetector.reconfigureWindow(this.activeOutputWindowMs);
       this.workingSignalDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
       this.cosmeticRecoveryDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
+      this.structuralRecoveryDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
     }
   }
 
@@ -427,17 +455,29 @@ export class ActivityMonitor {
       // through a dedicated debouncer. Gated on getVisibleLines so this only
       // applies to agent terminals, and on isResizeSuppressed so window-resize
       // redraws don't false-positive recovery.
+      //
+      // Structural cosmetic-only suppression (#6668): a recent
+      // synchronized-output frame classified as "cosmetic-only" disqualifies
+      // this recovery path. Without this guard, a spinner-only redraw inside
+      // a 2026 frame would still escalate idle→busy via the line-rewrite
+      // tier, which is exactly the false positive the structural tier exists
+      // to prevent.
       if (
         this.getVisibleLines &&
         this.state === "idle" &&
         !this.isResizeSuppressed(now) &&
         !this.inputTracker.isRecentUserInput(now) &&
-        this.bootDetector.hasExitedBootState
+        this.bootDetector.hasExitedBootState &&
+        now >= this.lastStructuralCosmeticOnlyUntil
       ) {
         if (this.cosmeticRecoveryDebouncer.shouldTriggerRecovery(now, true)) {
           this.cosmeticRecoveryDebouncer.reset();
           this.becomeBusy({ trigger: "output" }, now);
         }
+      } else if (now < this.lastStructuralCosmeticOnlyUntil) {
+        // Drop accumulated cosmetic-recovery signal so the next legitimate
+        // burst starts fresh.
+        this.cosmeticRecoveryDebouncer.reset();
       }
       return;
     }
@@ -489,6 +529,71 @@ export class ActivityMonitor {
     }
   }
 
+  // Structural-signal tier entry point (#6668). Called by
+  // SynchronizedFrameDetector once per DEC mode 2026 frame-close. Runs three
+  // classifiers (cosmetic-only, time-counter, spinner) over the snapshot and
+  // applies the result:
+  //
+  //   * cosmetic-only → set a sticky TTL during which idle→busy escalation
+  //     from the line-rewrite tier is suppressed
+  //   * spinner / time-counter → confirmatory working signal, recorded
+  //     through the existing workingSignalDebouncer pathway
+  //
+  // Frames are dropped when resize-suppressed, before boot-complete, or when
+  // there's no visible-lines accessor (non-agent terminals).
+  onSynchronizedFrame(snapshot: FrameSnapshot): void {
+    if (this.isDisposed) return;
+    if (!this.getVisibleLines) return;
+
+    const now = Date.now();
+    if (this.isResizeSuppressed(now)) return;
+    // Pre-boot frames are part of the agent's startup chrome — let the boot
+    // detector handle them via the regular onData path.
+    if (!this.bootDetector.hasExitedBootState) return;
+
+    const result = this.synchronizedFrameAnalyzer.classify(snapshot);
+    this.applyStructuralSignal(result.signal, result.confidence, now);
+  }
+
+  private applyStructuralSignal(signal: StructuralSignal, confidence: number, now: number): void {
+    if (signal === "cosmetic-only") {
+      this.lastStructuralCosmeticOnlyUntil = now + ActivityMonitor.STRUCTURAL_COSMETIC_ONLY_TTL_MS;
+      // Drop in-flight cosmetic recovery accumulation: the structural tier
+      // has overruled any half-built escalation from the regex tier.
+      this.cosmeticRecoveryDebouncer.reset();
+      return;
+    }
+
+    if (signal === "spinner" || signal === "time-counter") {
+      this.noteStructuralWorkingSignal(now, confidence);
+    }
+  }
+
+  private noteStructuralWorkingSignal(now: number, confidence: number): void {
+    if (this.inputTracker.isRecentUserInput(now)) {
+      // The user just typed; require sustained signal across user input
+      // before recovering (matches the regex tier's behavior).
+      this.structuralRecoveryDebouncer.shouldTriggerRecovery(now, false);
+      return;
+    }
+
+    // For an already-busy monitor, structural confirmation is a heartbeat:
+    // refresh workingHoldUntil so the idle debounce timer doesn't fire mid-
+    // thought (#6365 lesson).
+    if (this.state === "busy") {
+      this.recordWorkingSignal(now);
+      this.resetDebounceTimer();
+      return;
+    }
+
+    // Idle → busy recovery: a single blip is not enough; signal must persist
+    // across the structural-tier debounce window.
+    if (this.structuralRecoveryDebouncer.shouldTriggerRecovery(now, true)) {
+      this.structuralRecoveryDebouncer.reset();
+      this.becomeBusy({ trigger: "pattern", patternConfidence: confidence }, now);
+    }
+  }
+
   isHighOutputActivity(now: number = Date.now()): boolean {
     return this.highOutputDetector.isHighOutput(now);
   }
@@ -524,7 +629,10 @@ export class ActivityMonitor {
     this.highOutputDetector.reset();
     this.workingSignalDebouncer.reset();
     this.cosmeticRecoveryDebouncer.reset();
+    this.structuralRecoveryDebouncer.reset();
     this.lineRewriteDetector.reset();
+    this.synchronizedFrameAnalyzer.reset();
+    this.lastStructuralCosmeticOnlyUntil = 0;
     this.patternBuf.reset();
     this.bootDetector.reset();
     this.resizeSuppressUntil = 0;
@@ -559,6 +667,11 @@ export class ActivityMonitor {
     this.lastPatternResult = undefined;
     this.lastPatternResultAt = 0;
     this.lastWorkingIndicatorTimestamp = 0;
+    // Structural tier holds per-cell ring-buffer history that is implicitly
+    // tied to the current agent's rendering. Swapping detectors is a strong
+    // signal that the agent identity changed — discard accumulated state.
+    this.synchronizedFrameAnalyzer.reset();
+    this.lastStructuralCosmeticOnlyUntil = 0;
   }
 
   notifySubmission(): void {
@@ -569,6 +682,11 @@ export class ActivityMonitor {
   notifyResize(suppressionMs = 1000): void {
     this.resizeSuppressUntil = Date.now() + suppressionMs;
     this.highOutputDetector.resetWindow();
+    // Structural tier keys cell ring buffers by viewport-bottom-relative
+    // (rowOffset, col); a resize invalidates that mapping. Reset so the
+    // first post-resize frame doesn't compare against pre-resize cells.
+    this.synchronizedFrameAnalyzer.reset();
+    this.lastStructuralCosmeticOnlyUntil = 0;
   }
 
   private isResizeSuppressed(now: number): boolean {
@@ -963,6 +1081,7 @@ export class ActivityMonitor {
     // starts fresh — otherwise a single spinner tick after busy→idle would
     // immediately re-trigger recovery without sustained signal.
     this.cosmeticRecoveryDebouncer.reset();
+    this.structuralRecoveryDebouncer.reset();
 
     // Reset completion state for the new work cycle
     this.completionTimer.reset();

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -372,7 +372,15 @@ export class ActivityMonitor {
       // Spinner/status-line rewrite — latch lastSpinnerDetectedAt for polling's isSpinnerActive()
       // check, but do not call becomeBusy() here. Entry into working state requires pattern
       // detection or sustained output, not cosmetic line rewrites alone.
-      this.lineRewriteDetector.update(data, now);
+      //
+      // Structural cosmetic-only suppression (#6668): when the structural
+      // tier has just classified a 2026 frame as cosmetic-only,
+      // lineRewriteDetector must NOT latch — otherwise polling's
+      // isSpinnerActive() would feed the working-signal debouncer for up
+      // to SPINNER_ACTIVE_MS (1500ms) and bypass the suppression.
+      if (now >= this.lastStructuralCosmeticOnlyUntil) {
+        this.lineRewriteDetector.update(data, now);
+      }
     }
 
     // For polling-enabled terminals: check raw stream for patterns FIRST

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -4318,13 +4318,13 @@ describe("ActivityMonitor", () => {
       expect(monitor.getState()).toBe("idle");
       onStateChange.mockClear();
 
-      // Build a spinner cycle at col 0 across 12 frames — the cell cycles
-      // through 4 distinct codepoints at 100ms intervals while the rest of
-      // the row stays static. 12 × 100ms = 1200ms spans the 800ms recovery
-      // debounce (with the spinner classifier needing 3 frames to identify
-      // the cycle, leaving ~900ms of sustained signal).
+      // 4-item cycle × 4 = 16 frames at 100ms → 1600ms total. The spinner
+      // classifier needs the ring to satisfy `length > distinct`, which
+      // requires at least 5 frames (cycle revisits index 0 on frame 5).
+      // After detection, the structural-recovery debouncer needs 800ms of
+      // sustained signal — so recovery fires around frame 13.
       const cycle = [0x280b, 0x2819, 0x2839, 0x2838];
-      for (let i = 0; i < 12; i++) {
+      for (let i = 0; i < 16; i++) {
         vi.advanceTimersByTime(100);
         monitor.onSynchronizedFrame(
           buildSnapshot({
@@ -4411,6 +4411,55 @@ describe("ActivityMonitor", () => {
         );
       }
 
+      expect(monitor.getState()).toBe("idle");
+      monitor.dispose();
+    });
+
+    it("cosmetic-only also blocks the lineRewriteDetector → isSpinnerActive bypass", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-bypass", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        workingRecoveryDelayMs: 1500,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(2500);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Two frames classified cosmetic-only set the structural TTL.
+      monitor.onSynchronizedFrame(
+        buildSnapshot({
+          capturedAt: Date.now(),
+          higherRows: ["upper", "middle"],
+          bottomRowText: "spinner ✦",
+        })
+      );
+      vi.advanceTimersByTime(100);
+      monitor.onSynchronizedFrame(
+        buildSnapshot({
+          capturedAt: Date.now(),
+          higherRows: ["upper", "middle"],
+          bottomRowText: "spinner ✧",
+        })
+      );
+
+      // Drive cosmetic redraws through onData. Without the structural
+      // suppression, lineRewriteDetector would latch and runPollingCycle's
+      // isSpinnerActive() would feed workingSignalDebouncer → becomeBusy
+      // within SPINNER_ACTIVE_MS (1500ms). With the structural suppression,
+      // lineRewriteDetector.update() must not run while the TTL is hot.
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(80);
+        monitor.onData(`\r⠙ working tick ${i}`);
+      }
+
+      // Walk forward through several poll cycles; state must remain idle.
+      vi.advanceTimersByTime(1000);
       expect(monitor.getState()).toBe("idle");
       monitor.dispose();
     });

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -4212,4 +4212,240 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
   });
+
+  describe("Structural-signal tier (Issue #6668)", () => {
+    type FrameSnapshot = import("../pty/SynchronizedFrameAnalyzer.js").FrameSnapshot;
+
+    function buildSnapshot(opts: {
+      capturedAt: number;
+      bottomRowText: string;
+      higherRows?: string[];
+      cols?: number;
+      cycleAtCol?: { col: number; codes: number[]; frameIndex: number };
+    }): FrameSnapshot {
+      const cols = opts.cols ?? 40;
+      const rows: { code: number; width: number }[][] = [];
+      const higherRows = opts.higherRows ?? [];
+
+      for (const text of higherRows) {
+        const row: { code: number; width: number }[] = [];
+        for (let i = 0; i < cols; i++) {
+          row.push({ code: i < text.length ? text.codePointAt(i)! : 0x20, width: 1 });
+        }
+        rows.push(row);
+      }
+
+      const bottomRow: { code: number; width: number }[] = [];
+      const text = opts.bottomRowText;
+      for (let i = 0; i < cols; i++) {
+        let code = i < text.length ? text.codePointAt(i)! : 0x20;
+        if (opts.cycleAtCol && i === opts.cycleAtCol.col) {
+          code = opts.cycleAtCol.codes[opts.cycleAtCol.frameIndex % opts.cycleAtCol.codes.length];
+        }
+        bottomRow.push({ code, width: 1 });
+      }
+      rows.push(bottomRow);
+
+      return {
+        capturedAt: opts.capturedAt,
+        terminalRows: 24,
+        terminalCols: cols,
+        rows,
+        bottomRowText: text,
+        secondToBottomText: higherRows.length > 0 ? higherRows[higherRows.length - 1] : "",
+      };
+    }
+
+    it("idles agent stays idle on cosmetic-only frames (no false-positive escalation)", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-1", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        workingRecoveryDelayMs: 1500,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(2500);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Two structural frames classify as cosmetic-only — only the bottom
+      // row changes between them.
+      monitor.onSynchronizedFrame(
+        buildSnapshot({
+          capturedAt: Date.now(),
+          higherRows: ["upper line", "middle line"],
+          bottomRowText: "spinner ✦",
+        })
+      );
+      vi.advanceTimersByTime(100);
+      monitor.onSynchronizedFrame(
+        buildSnapshot({
+          capturedAt: Date.now(),
+          higherRows: ["upper line", "middle line"],
+          bottomRowText: "spinner ✧",
+        })
+      );
+
+      // Now feed a cosmetic redraw — would normally escalate idle→busy via
+      // the line-rewrite tier's recovery debouncer, but the structural
+      // cosmetic-only flag must suppress it.
+      vi.advanceTimersByTime(100);
+      monitor.onData("\r⠙ working");
+      vi.advanceTimersByTime(100);
+      monitor.onData("\r⠹ working");
+
+      expect(monitor.getState()).toBe("idle");
+      monitor.dispose();
+    });
+
+    it("recovers idle→busy on sustained spinner frames", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-2", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        workingRecoveryDelayMs: 800,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(2500);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Build a spinner cycle at col 0 across 12 frames — the cell cycles
+      // through 4 distinct codepoints at 100ms intervals while the rest of
+      // the row stays static. 12 × 100ms = 1200ms spans the 800ms recovery
+      // debounce (with the spinner classifier needing 3 frames to identify
+      // the cycle, leaving ~900ms of sustained signal).
+      const cycle = [0x280b, 0x2819, 0x2839, 0x2838];
+      for (let i = 0; i < 12; i++) {
+        vi.advanceTimersByTime(100);
+        monitor.onSynchronizedFrame(
+          buildSnapshot({
+            capturedAt: Date.now(),
+            bottomRowText: " static text",
+            cycleAtCol: { col: 0, codes: cycle, frameIndex: i },
+          })
+        );
+      }
+
+      // After the workingRecoveryDelayMs window, recovery should have fired.
+      expect(monitor.getState()).toBe("busy");
+      monitor.dispose();
+    });
+
+    it("recovers idle→busy on monotonic time-counter frames", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-3", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        workingRecoveryDelayMs: 800,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(2500);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // First two frames establish the increment streak (signal=time-counter
+      // fires on frame 2 once counterStreak reaches 2). Subsequent frames
+      // sustain the structural signal across the 800ms debounce window.
+      monitor.onSynchronizedFrame(
+        buildSnapshot({ capturedAt: Date.now(), bottomRowText: "Working… 1s" })
+      );
+      vi.advanceTimersByTime(200);
+      monitor.onSynchronizedFrame(
+        buildSnapshot({ capturedAt: Date.now(), bottomRowText: "Working… 2s" })
+      );
+      vi.advanceTimersByTime(400);
+      monitor.onSynchronizedFrame(
+        buildSnapshot({ capturedAt: Date.now(), bottomRowText: "Working… 3s" })
+      );
+      vi.advanceTimersByTime(500);
+      monitor.onSynchronizedFrame(
+        buildSnapshot({ capturedAt: Date.now(), bottomRowText: "Working… 4s" })
+      );
+
+      expect(monitor.getState()).toBe("busy");
+      monitor.dispose();
+    });
+
+    it("ignores frames during resize suppression", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-4", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        workingRecoveryDelayMs: 800,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      vi.advanceTimersByTime(2500);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      monitor.notifyResize(1000);
+
+      const cycle = [0x280b, 0x2819, 0x2839, 0x2838];
+      for (let i = 0; i < 8; i++) {
+        // Stop short of the 1000ms suppression window so every frame is
+        // suppressed.
+        vi.advanceTimersByTime(100);
+        monitor.onSynchronizedFrame(
+          buildSnapshot({
+            capturedAt: Date.now(),
+            bottomRowText: " static",
+            cycleAtCol: { col: 0, codes: cycle, frameIndex: i },
+          })
+        );
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      monitor.dispose();
+    });
+
+    it("ignores frames before boot completes", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("struct-5", 1000, onStateChange, {
+        getVisibleLines: () => ["", "Booting..."],
+        getCursorLine: () => "Booting...",
+        workingRecoveryDelayMs: 800,
+        idleDebounceMs: 2500,
+      });
+
+      monitor.startPolling();
+      // Don't advance enough for boot to complete; remain in boot.
+      onStateChange.mockClear();
+
+      const cycle = [0x280b, 0x2819, 0x2839, 0x2838];
+      for (let i = 0; i < 6; i++) {
+        monitor.onSynchronizedFrame(
+          buildSnapshot({
+            capturedAt: Date.now() + i * 100,
+            bottomRowText: " static",
+            cycleAtCol: { col: 0, codes: cycle, frameIndex: i },
+          })
+        );
+      }
+
+      // No state-change calls from the structural tier during boot.
+      const structuralCalls = onStateChange.mock.calls.filter(
+        ([, , , metadata]) => metadata?.trigger === "pattern"
+      );
+      expect(structuralCalls).toHaveLength(0);
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -15,6 +15,14 @@
 // chunk boundaries (rare in practice, since node-pty reads at OS boundaries
 // and most idle-noise sequences are short) are not stripped. OutputVolumeDetector's
 // minFrames gate is the secondary defense for those cases.
+//
+// `?2026h` / `?2026l` (DEC mode 2026 — Synchronized Output) is stripped here
+// for the renderer-bound and byte-volume paths, but the headless terminal in
+// TerminalProcess writes the raw PTY data straight through, which lets
+// SynchronizedFrameDetector hook xterm's parser for frame-close events
+// (#6668). Removing 2026 from this list would re-introduce the false-positive
+// idle→busy escalations on cosmetic redraws that the structural tier exists
+// to prevent.
 
 // eslint-disable-next-line no-control-regex
 const DECSET_NOISE = /\x1b\[\?(?:25|1004|2004|2026|1049)[hl]/gu;

--- a/electron/services/pty/SynchronizedFrameAnalyzer.ts
+++ b/electron/services/pty/SynchronizedFrameAnalyzer.ts
@@ -306,24 +306,32 @@ function evaluateCycleStrength(ring: CycleRingEntry[]): number {
     return 0;
   }
 
-  // Inter-frame interval must fall in spinner range.
-  let totalInterval = 0;
-  let intervalCount = 0;
+  // Require revisitation: a real glyph cycle returns to previously-seen
+  // codepoints (⠋→⠙→⠹→⠸→⠋), whereas a monotonically-incrementing counter
+  // (0→1→2→3) would otherwise pass distinct-count + interval checks. Once
+  // the ring is longer than the distinct-codepoint count, at least one
+  // codepoint has been revisited.
+  if (ring.length <= distinctCodes.size) return 0;
+
+  // Inter-frame interval must fall in spinner range. Tolerate a single
+  // out-of-range interval (e.g. user input pause or PTY backpressure) before
+  // rejecting; exclude that outlier from the average so a slow chunk of
+  // frames doesn't drag a real spinner past the upper bound.
+  let totalIntervalInRange = 0;
+  let inRangeCount = 0;
   let outOfRangeIntervals = 0;
   for (let i = 1; i < ring.length; i++) {
     const dt = ring[i].capturedAt - ring[i - 1].capturedAt;
-    totalInterval += dt;
-    intervalCount += 1;
     if (dt < MIN_CELL_INTERVAL_MS || dt > MAX_CELL_INTERVAL_MS) {
       outOfRangeIntervals += 1;
+    } else {
+      totalIntervalInRange += dt;
+      inRangeCount += 1;
     }
   }
-  if (intervalCount === 0) return 0;
-  // Tolerate a single out-of-range interval (e.g. user input pause) before
-  // rejecting outright. The remaining intervals must still average inside
-  // the spinner window.
   if (outOfRangeIntervals > 1) return 0;
-  const avgInterval = totalInterval / intervalCount;
+  if (inRangeCount === 0) return 0;
+  const avgInterval = totalIntervalInRange / inRangeCount;
   if (avgInterval < MIN_CELL_INTERVAL_MS || avgInterval > MAX_CELL_INTERVAL_MS) {
     return 0;
   }

--- a/electron/services/pty/SynchronizedFrameAnalyzer.ts
+++ b/electron/services/pty/SynchronizedFrameAnalyzer.ts
@@ -1,0 +1,338 @@
+// Structural-signal classifier (#6668). Sits above the regex-based
+// AgentPatternDetector tier and consumes per-frame snapshots of the headless
+// terminal's bottom rows, captured at DEC mode 2026 frame-close events
+// (\x1b[?2026l). Three classifiers run per frame:
+//
+//   1. Bottom-row invariant — frame-to-frame diff confined to the bottom rows
+//      indicates a cosmetic redraw; suppresses idle→working escalation that
+//      would otherwise fire on raw line rewrites.
+//   2. Monotonic time-counter — strictly increasing "1s/2s/3s" / "1m" / "1h"
+//      tokens on the bottom row plus a structurally identical non-numeric
+//      prefix is a positive working confirmation independent of glyph cycling.
+//   3. Per-cell codepoint cycle — a cell that revisits 2-20 distinct codepoints
+//      across recent frames while its neighbors stay stable is a spinner.
+//
+// All classifier state is held internally and resets on `reset()`. Inputs are
+// pure data (no xterm dependency); the analyzer is safe to unit-test without
+// a real terminal.
+
+export type StructuralSignal = "none" | "cosmetic-only" | "time-counter" | "spinner";
+
+export interface FrameCell {
+  // UTF32 codepoint of the cell's last codepoint (matches IBufferCell.getCode).
+  // Allocation-free integer compare for the cycle ring buffer.
+  code: number;
+  // 0 (wide continuation), 1, or 2 — matches IBufferCell.getWidth.
+  width: number;
+}
+
+export interface FrameSnapshot {
+  // Captured at \x1b[?2026l (frame-close) time.
+  capturedAt: number;
+  // Total terminal rows at capture time. Used for resize invalidation.
+  terminalRows: number;
+  // Total terminal cols at capture time. Used for resize invalidation.
+  terminalCols: number;
+  // Bottom N rows, ordered top-to-bottom (so `rows[rows.length - 1]` is the
+  // viewport bottom). Each inner array is exactly `terminalCols` cells long.
+  rows: FrameCell[][];
+  // Bottom-row text (already-translated string for the time-counter regex).
+  // Avoids a second pass when the analyzer needs character-level data.
+  bottomRowText: string;
+  // The next row up — used by the cosmetic classifier to determine whether
+  // changes are confined to the bottom row (vs. spreading further up).
+  // Empty string when terminalRows < 2.
+  secondToBottomText: string;
+}
+
+export interface StructuralSignalResult {
+  signal: StructuralSignal;
+  // 0..1 confidence — higher means more certain. Used by ActivityMonitor when
+  // building state-change metadata for "pattern" trigger events.
+  confidence: number;
+}
+
+interface CycleRingEntry {
+  // Codepoint at this cell, captured `capturedAt` on this frame.
+  code: number;
+  capturedAt: number;
+}
+
+const TIME_COUNTER_REGEX = /\b(\d+)\s*([smh])\b/i;
+// Bottom 3 rows are snapshotted; cosmetic-only suppression is gated on the
+// LAST row being the only changing region. The cycle detector also scans the
+// bottom 3 rows since some agents (Codex) put the spinner glyph one row up.
+const RING_BUFFER_SIZE = 8;
+const MIN_DISTINCT_VALUES_FOR_CYCLE = 2;
+const MAX_DISTINCT_VALUES_FOR_CYCLE = 20;
+const MIN_FRAMES_FOR_SPINNER = 3;
+const MIN_CELL_INTERVAL_MS = 60;
+const MAX_CELL_INTERVAL_MS = 250;
+// Neighborhood radius checked for stability when validating spinner candidate.
+const NEIGHBOR_RADIUS = 2;
+
+export class SynchronizedFrameAnalyzer {
+  private previousSnapshot: FrameSnapshot | null = null;
+
+  // Time-counter history: prefix string + last seen integer + unit. Reset on
+  // any structural change to the prefix or unit.
+  private lastCounterPrefix: string | null = null;
+  private lastCounterValue = 0;
+  private lastCounterUnit = "";
+  private counterStreak = 0;
+
+  // Per-cell ring buffers keyed by viewport-bottom-relative `(rowOffset, col)`.
+  // rowOffset 0 = bottom row, 1 = second-to-bottom, 2 = third-to-bottom.
+  private cellRings = new Map<string, CycleRingEntry[]>();
+
+  classify(snapshot: FrameSnapshot): StructuralSignalResult {
+    if (
+      this.previousSnapshot &&
+      (this.previousSnapshot.terminalRows !== snapshot.terminalRows ||
+        this.previousSnapshot.terminalCols !== snapshot.terminalCols)
+    ) {
+      // Resize invalidates all per-cell history. Keep the new snapshot but
+      // skip classification this frame — there is no comparable prior state.
+      this.cellRings.clear();
+      this.lastCounterPrefix = null;
+      this.lastCounterValue = 0;
+      this.lastCounterUnit = "";
+      this.counterStreak = 0;
+      this.previousSnapshot = snapshot;
+      return { signal: "none", confidence: 0 };
+    }
+
+    this.recordCellRings(snapshot);
+
+    const counterResult = this.detectTimeCounter(snapshot);
+    if (counterResult.signal !== "none") {
+      this.previousSnapshot = snapshot;
+      return counterResult;
+    }
+
+    const spinnerResult = this.detectSpinner(snapshot);
+    if (spinnerResult.signal !== "none") {
+      this.previousSnapshot = snapshot;
+      return spinnerResult;
+    }
+
+    const cosmeticResult = this.detectCosmeticOnly(snapshot);
+    this.previousSnapshot = snapshot;
+    return cosmeticResult;
+  }
+
+  reset(): void {
+    this.previousSnapshot = null;
+    this.cellRings.clear();
+    this.lastCounterPrefix = null;
+    this.lastCounterValue = 0;
+    this.lastCounterUnit = "";
+    this.counterStreak = 0;
+  }
+
+  private detectTimeCounter(snapshot: FrameSnapshot): StructuralSignalResult {
+    const match = TIME_COUNTER_REGEX.exec(snapshot.bottomRowText);
+    if (!match) {
+      this.lastCounterPrefix = null;
+      this.lastCounterValue = 0;
+      this.lastCounterUnit = "";
+      this.counterStreak = 0;
+      return { signal: "none", confidence: 0 };
+    }
+
+    const value = Number.parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+    const prefix = snapshot.bottomRowText.slice(0, match.index).trim();
+
+    if (
+      this.lastCounterPrefix === prefix &&
+      this.lastCounterUnit === unit &&
+      value > this.lastCounterValue
+    ) {
+      this.lastCounterValue = value;
+      this.counterStreak += 1;
+      // Two consecutive increments confirm a live counter; one could be a
+      // first observation of a static value followed by a second frame.
+      if (this.counterStreak >= 2) {
+        return { signal: "time-counter", confidence: 0.9 };
+      }
+      return { signal: "none", confidence: 0 };
+    }
+
+    this.lastCounterPrefix = prefix;
+    this.lastCounterValue = value;
+    this.lastCounterUnit = unit;
+    this.counterStreak = 1;
+    return { signal: "none", confidence: 0 };
+  }
+
+  private detectSpinner(snapshot: FrameSnapshot): StructuralSignalResult {
+    if (snapshot.rows.length === 0) {
+      return { signal: "none", confidence: 0 };
+    }
+
+    let bestConfidence = 0;
+    let foundSpinner = false;
+
+    for (let rowOffset = 0; rowOffset < snapshot.rows.length; rowOffset++) {
+      const cols = snapshot.rows[snapshot.rows.length - 1 - rowOffset];
+      if (!cols) continue;
+      for (let col = 0; col < cols.length; col++) {
+        const ring = this.cellRings.get(this.cellKey(rowOffset, col));
+        if (!ring || ring.length < MIN_FRAMES_FOR_SPINNER) continue;
+
+        const cycleStrength = evaluateCycleStrength(ring);
+        if (cycleStrength === 0) continue;
+
+        // Neighbor stability: cells within NEIGHBOR_RADIUS columns on the same
+        // row should NOT also be cycling — that would indicate a pure
+        // cosmetic redraw of the whole row, not a localized spinner glyph.
+        if (!this.neighborsStable(rowOffset, col, cols.length)) continue;
+
+        foundSpinner = true;
+        if (cycleStrength > bestConfidence) {
+          bestConfidence = cycleStrength;
+        }
+      }
+    }
+
+    if (foundSpinner) {
+      return { signal: "spinner", confidence: bestConfidence };
+    }
+    return { signal: "none", confidence: 0 };
+  }
+
+  private detectCosmeticOnly(snapshot: FrameSnapshot): StructuralSignalResult {
+    const prev = this.previousSnapshot;
+    if (!prev) {
+      return { signal: "none", confidence: 0 };
+    }
+
+    if (prev.rows.length === 0 || snapshot.rows.length === 0) {
+      return { signal: "none", confidence: 0 };
+    }
+
+    const prevBottom = prev.rows[prev.rows.length - 1];
+    const currBottom = snapshot.rows[snapshot.rows.length - 1];
+
+    const bottomChanged = !cellRowsEqual(prevBottom, currBottom);
+    if (!bottomChanged) {
+      return { signal: "none", confidence: 0 };
+    }
+
+    // Any change in rows above the bottom disqualifies "cosmetic-only" —
+    // genuine work scrolls or paints higher rows. Compare the rows pairwise
+    // when both snapshots have the same number of captured rows.
+    const minHigherRows = Math.min(prev.rows.length, snapshot.rows.length) - 1;
+    for (let i = 0; i < minHigherRows; i++) {
+      if (!cellRowsEqual(prev.rows[i], snapshot.rows[i])) {
+        return { signal: "none", confidence: 0 };
+      }
+    }
+
+    return { signal: "cosmetic-only", confidence: 0.8 };
+  }
+
+  private recordCellRings(snapshot: FrameSnapshot): void {
+    for (let rowOffset = 0; rowOffset < snapshot.rows.length; rowOffset++) {
+      const cols = snapshot.rows[snapshot.rows.length - 1 - rowOffset];
+      if (!cols) continue;
+      for (let col = 0; col < cols.length; col++) {
+        const cell = cols[col];
+        if (!cell) continue;
+        if (cell.width === 0) continue;
+        const key = this.cellKey(rowOffset, col);
+        let ring = this.cellRings.get(key);
+        if (!ring) {
+          ring = [];
+          this.cellRings.set(key, ring);
+        }
+        ring.push({ code: cell.code, capturedAt: snapshot.capturedAt });
+        if (ring.length > RING_BUFFER_SIZE) {
+          ring.shift();
+        }
+      }
+    }
+  }
+
+  private neighborsStable(rowOffset: number, col: number, rowWidth: number): boolean {
+    let cyclingNeighbors = 0;
+    for (let dx = -NEIGHBOR_RADIUS; dx <= NEIGHBOR_RADIUS; dx++) {
+      if (dx === 0) continue;
+      const neighborCol = col + dx;
+      if (neighborCol < 0 || neighborCol >= rowWidth) continue;
+      const neighborRing = this.cellRings.get(this.cellKey(rowOffset, neighborCol));
+      if (!neighborRing || neighborRing.length < MIN_FRAMES_FOR_SPINNER) continue;
+      if (evaluateCycleStrength(neighborRing) > 0) {
+        cyclingNeighbors += 1;
+      }
+    }
+    // Allow at most 1 cycling neighbor (some spinner glyphs are 2 cells wide
+    // for combining marks). More than that and it's likely a row-wide
+    // cosmetic redraw.
+    return cyclingNeighbors <= 1;
+  }
+
+  private cellKey(rowOffset: number, col: number): string {
+    return `${rowOffset}:${col}`;
+  }
+}
+
+function cellRowsEqual(a: FrameCell[] | undefined, b: FrameCell[] | undefined): boolean {
+  if (!a || !b) return a === b;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].code !== b[i].code) return false;
+    if (a[i].width !== b[i].width) return false;
+  }
+  return true;
+}
+
+// Returns 0 when the ring is not a spinner candidate; otherwise 0..1 confidence.
+function evaluateCycleStrength(ring: CycleRingEntry[]): number {
+  if (ring.length < MIN_FRAMES_FOR_SPINNER) return 0;
+
+  const distinctCodes = new Set<number>();
+  for (const entry of ring) {
+    distinctCodes.add(entry.code);
+  }
+
+  // A static cell (no rotation) is not a spinner. A cell hopping through too
+  // many distinct codepoints (e.g. fast-scrolling text) isn't either.
+  if (
+    distinctCodes.size < MIN_DISTINCT_VALUES_FOR_CYCLE ||
+    distinctCodes.size > MAX_DISTINCT_VALUES_FOR_CYCLE
+  ) {
+    return 0;
+  }
+
+  // Inter-frame interval must fall in spinner range.
+  let totalInterval = 0;
+  let intervalCount = 0;
+  let outOfRangeIntervals = 0;
+  for (let i = 1; i < ring.length; i++) {
+    const dt = ring[i].capturedAt - ring[i - 1].capturedAt;
+    totalInterval += dt;
+    intervalCount += 1;
+    if (dt < MIN_CELL_INTERVAL_MS || dt > MAX_CELL_INTERVAL_MS) {
+      outOfRangeIntervals += 1;
+    }
+  }
+  if (intervalCount === 0) return 0;
+  // Tolerate a single out-of-range interval (e.g. user input pause) before
+  // rejecting outright. The remaining intervals must still average inside
+  // the spinner window.
+  if (outOfRangeIntervals > 1) return 0;
+  const avgInterval = totalInterval / intervalCount;
+  if (avgInterval < MIN_CELL_INTERVAL_MS || avgInterval > MAX_CELL_INTERVAL_MS) {
+    return 0;
+  }
+
+  // Confidence: more distinct values + consistent interval = higher confidence.
+  const distinctScore = Math.min(distinctCodes.size / 4, 1);
+  const intervalScore =
+    1 -
+    Math.abs(avgInterval - (MIN_CELL_INTERVAL_MS + MAX_CELL_INTERVAL_MS) / 2) /
+      ((MAX_CELL_INTERVAL_MS - MIN_CELL_INTERVAL_MS) / 2);
+  return Math.max(0.5, Math.min(1, 0.6 * distinctScore + 0.4 * intervalScore));
+}

--- a/electron/services/pty/SynchronizedFrameDetector.ts
+++ b/electron/services/pty/SynchronizedFrameDetector.ts
@@ -176,10 +176,16 @@ export class SynchronizedFrameDetector {
 }
 
 function matchesParam(params: (number | number[])[], target: number): boolean {
-  if (params.length === 0) return false;
-  const head = params[0];
-  if (Array.isArray(head)) {
-    return head.length > 0 && head[0] === target;
+  // xterm groups CSI params separated by `;` as flat entries (e.g.
+  // `\x1b[?25;2026h` arrives as `params = [25, 2026]`). Scan all entries so
+  // combined private-mode sequences still trigger the handler. Sub-param
+  // arrays (colon-separated, e.g. `\x1b[?2026:1h`) are matched on the head.
+  for (const param of params) {
+    if (Array.isArray(param)) {
+      if (param.length > 0 && param[0] === target) return true;
+    } else if (param === target) {
+      return true;
+    }
   }
-  return head === target;
+  return false;
 }

--- a/electron/services/pty/SynchronizedFrameDetector.ts
+++ b/electron/services/pty/SynchronizedFrameDetector.ts
@@ -1,0 +1,185 @@
+// Hooks the headless terminal's parser for DEC mode 2026 (Synchronized Output)
+// brackets and emits a frame-close event with a snapshot of the bottom rows.
+//
+// `\x1b[?2026h` opens a frame; `\x1b[?2026l` closes it. The parser API
+// (Terminal.parser.registerCsiHandler) handles fragmented CSI sequences
+// correctly — node-pty can deliver `\x1b[?20` and `26h` in separate chunks,
+// and naive raw-byte scanning would miss the split (#4899). Returning `false`
+// from the handler lets xterm's built-in DEC handler run too, preserving
+// `terminal.modes.synchronizedOutputMode` for any other consumer.
+//
+// A 1500ms timeout force-resets the nesting counter if a `?2026h` is not
+// followed by a `?2026l` (e.g. agent crash mid-frame). Without this safety
+// net the detector would silently stop firing frame events and the
+// structural-signal tier would degrade to never-fire (#4974).
+//
+// Snapshots use `IBuffer.getNullCell()` as a reusable cell object to avoid
+// allocating a fresh `IBufferCell` per cell per frame — at 100ms cadence and
+// 200 columns × 3 rows that's ~6,000 cells/sec.
+
+import type { Terminal as HeadlessTerminal, IDisposable, IBufferCell } from "@xterm/headless";
+import type { FrameSnapshot, FrameCell } from "./SynchronizedFrameAnalyzer.js";
+
+const MISSING_CLOSE_TIMEOUT_MS = 1500;
+const SNAPSHOT_ROW_COUNT = 3;
+
+export interface SynchronizedFrameDetectorOptions {
+  // Number of bottom rows to capture per frame. Defaults to 3.
+  snapshotRowCount?: number;
+  // How long to wait for a `?2026l` before force-resetting the counter.
+  // Defaults to 1500ms.
+  missingCloseTimeoutMs?: number;
+}
+
+export class SynchronizedFrameDetector {
+  private readonly disposables: IDisposable[] = [];
+  private nestingDepth = 0;
+  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  private readonly snapshotRowCount: number;
+  private readonly missingCloseTimeoutMs: number;
+  private isDisposed = false;
+
+  constructor(
+    private readonly terminal: HeadlessTerminal,
+    private readonly onFrameClose: (snapshot: FrameSnapshot) => void,
+    options?: SynchronizedFrameDetectorOptions
+  ) {
+    this.snapshotRowCount = options?.snapshotRowCount ?? SNAPSHOT_ROW_COUNT;
+    this.missingCloseTimeoutMs = options?.missingCloseTimeoutMs ?? MISSING_CLOSE_TIMEOUT_MS;
+
+    const openHandler = terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) =>
+      this.handleOpen(params)
+    );
+    const closeHandler = terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) =>
+      this.handleClose(params)
+    );
+    this.disposables.push(openHandler, closeHandler);
+  }
+
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+    for (const d of this.disposables) {
+      try {
+        d.dispose();
+      } catch {
+        // Disposable already torn down — ignore.
+      }
+    }
+    this.disposables.length = 0;
+    this.nestingDepth = 0;
+  }
+
+  // Test-only accessor — exposed for unit tests that need to verify the
+  // counter state. Not part of the public contract.
+  getNestingDepth(): number {
+    return this.nestingDepth;
+  }
+
+  private handleOpen(params: (number | number[])[]): boolean {
+    if (this.isDisposed) return false;
+    if (!matchesParam(params, 2026)) return false;
+
+    this.nestingDepth += 1;
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+    }
+    this.timeoutHandle = setTimeout(() => {
+      // Missing close — force-reset so the next legitimate open re-arms the
+      // detector. Do NOT emit a frame on timeout: the snapshot would reflect
+      // a half-rendered state.
+      this.nestingDepth = 0;
+      this.timeoutHandle = null;
+    }, this.missingCloseTimeoutMs);
+    return false;
+  }
+
+  private handleClose(params: (number | number[])[]): boolean {
+    if (this.isDisposed) return false;
+    if (!matchesParam(params, 2026)) return false;
+
+    if (this.nestingDepth === 0) {
+      // Stray close (likely the timeout already cleared the counter, or the
+      // CLI emitted an unbalanced close on startup). Don't fire.
+      return false;
+    }
+    this.nestingDepth -= 1;
+    if (this.nestingDepth > 0) {
+      // Inner close — the outermost frame hasn't committed yet.
+      return false;
+    }
+
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+
+    try {
+      const snapshot = this.captureSnapshot();
+      this.onFrameClose(snapshot);
+    } catch (error) {
+      if (process.env.DAINTREE_VERBOSE) {
+        console.warn("[SynchronizedFrameDetector] Snapshot capture failed:", error);
+      }
+    }
+    return false;
+  }
+
+  private captureSnapshot(): FrameSnapshot {
+    const terminal = this.terminal;
+    const buffer = terminal.buffer.active;
+    const rowCount = Math.min(this.snapshotRowCount, terminal.rows);
+    const viewportBottom = buffer.baseY + terminal.rows;
+    const startY = viewportBottom - rowCount;
+
+    const reusableCell: IBufferCell = buffer.getNullCell();
+    const rows: FrameCell[][] = [];
+    let bottomRowText = "";
+    let secondToBottomText = "";
+
+    for (let y = startY; y < viewportBottom; y++) {
+      const line = buffer.getLine(y);
+      if (!line) {
+        rows.push(new Array<FrameCell>(terminal.cols).fill({ code: 0, width: 1 }));
+        continue;
+      }
+      const cols: FrameCell[] = new Array(terminal.cols);
+      for (let x = 0; x < terminal.cols; x++) {
+        const cell = line.getCell(x, reusableCell);
+        if (cell) {
+          cols[x] = { code: cell.getCode(), width: cell.getWidth() };
+        } else {
+          cols[x] = { code: 0, width: 1 };
+        }
+      }
+      rows.push(cols);
+      if (y === viewportBottom - 1) {
+        bottomRowText = line.translateToString(true);
+      } else if (y === viewportBottom - 2) {
+        secondToBottomText = line.translateToString(true);
+      }
+    }
+
+    return {
+      capturedAt: Date.now(),
+      terminalRows: terminal.rows,
+      terminalCols: terminal.cols,
+      rows,
+      bottomRowText,
+      secondToBottomText,
+    };
+  }
+}
+
+function matchesParam(params: (number | number[])[], target: number): boolean {
+  if (params.length === 0) return false;
+  const head = params[0];
+  if (Array.isArray(head)) {
+    return head.length > 0 && head[0] === target;
+  }
+  return head === target;
+}

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -34,6 +34,7 @@ import type { PtyPool } from "../PtyPool.js";
 import { installHeadlessResponder } from "./headlessResponder.js";
 import { handleOscColorQueries } from "./OscResponder.js";
 import { classifyExitOutput, shouldTriggerFallback } from "./FallbackErrorClassifier.js";
+import { SynchronizedFrameDetector } from "./SynchronizedFrameDetector.js";
 
 // Extracted modules
 import {
@@ -167,6 +168,7 @@ export class TerminalProcess {
 
   private _scrollback: number;
   private headlessResponderDisposable: { dispose: () => void } | null = null;
+  private synchronizedFrameDetector: SynchronizedFrameDetector | null = null;
   private sessionSnapshotter!: SessionSnapshotter;
 
   private readonly terminalInfo: TerminalInfo;
@@ -331,6 +333,15 @@ export class TerminalProcess {
     const serializeAddon: SerializeAddonType = new SerializeAddon();
     headlessTerminal.loadAddon(serializeAddon);
 
+    // Structural-signal tier (#6668): hook the headless parser for DEC mode
+    // 2026 brackets so frame snapshots can drive the analyzer. Lifetime ties
+    // to the headless terminal — disposed alongside it in disposeHeadless().
+    // The callback resolves activityMonitor lazily so frame events fire even
+    // for plain terminals that are promoted to agents post-spawn.
+    this.synchronizedFrameDetector = new SynchronizedFrameDetector(headlessTerminal, (snapshot) => {
+      this.activityMonitor?.onSynchronizedFrame(snapshot);
+    });
+
     this.terminalInfo = {
       id,
       projectId: options.projectId,
@@ -494,6 +505,14 @@ export class TerminalProcess {
         // Ignore disposal errors
       }
       this.headlessResponderDisposable = null;
+    }
+    if (this.synchronizedFrameDetector) {
+      try {
+        this.synchronizedFrameDetector.dispose();
+      } catch {
+        // Ignore disposal errors
+      }
+      this.synchronizedFrameDetector = null;
     }
     try {
       terminal.headlessTerminal.dispose();

--- a/electron/services/pty/__tests__/SynchronizedFrameAnalyzer.test.ts
+++ b/electron/services/pty/__tests__/SynchronizedFrameAnalyzer.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  SynchronizedFrameAnalyzer,
+  type FrameCell,
+  type FrameSnapshot,
+} from "../SynchronizedFrameAnalyzer.js";
+
+function cell(code: number, width = 1): FrameCell {
+  return { code, width };
+}
+
+function rowOf(text: string, padToCols: number): FrameCell[] {
+  const out: FrameCell[] = [];
+  for (let i = 0; i < text.length; i++) {
+    out.push(cell(text.codePointAt(i)!));
+  }
+  while (out.length < padToCols) {
+    out.push(cell(0x20));
+  }
+  return out;
+}
+
+function snapshot(opts: {
+  rows: string[];
+  cols: number;
+  capturedAt: number;
+  terminalRows?: number;
+}): FrameSnapshot {
+  const cols = opts.cols;
+  const rows = opts.rows.map((r) => rowOf(r, cols));
+  return {
+    capturedAt: opts.capturedAt,
+    terminalRows: opts.terminalRows ?? 24,
+    terminalCols: cols,
+    rows,
+    bottomRowText: opts.rows[opts.rows.length - 1] ?? "",
+    secondToBottomText: opts.rows.length >= 2 ? opts.rows[opts.rows.length - 2] : "",
+  };
+}
+
+describe("SynchronizedFrameAnalyzer", () => {
+  let analyzer: SynchronizedFrameAnalyzer;
+
+  beforeEach(() => {
+    analyzer = new SynchronizedFrameAnalyzer();
+  });
+
+  describe("time-counter classifier", () => {
+    it("returns time-counter on strictly increasing seconds with stable prefix", () => {
+      analyzer.classify(snapshot({ rows: ["", "Working… 1s"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Working… 2s"], cols: 40, capturedAt: 1100 }));
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Working… 3s"], cols: 40, capturedAt: 1200 })
+      );
+      expect(result.signal).toBe("time-counter");
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it("does not return time-counter on a decreasing counter", () => {
+      analyzer.classify(snapshot({ rows: ["", "Working… 5s"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Working… 4s"], cols: 40, capturedAt: 1100 }));
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Working… 3s"], cols: 40, capturedAt: 1200 })
+      );
+      expect(result.signal).not.toBe("time-counter");
+    });
+
+    it("does not return time-counter when prefix keeps changing", () => {
+      analyzer.classify(snapshot({ rows: ["", "Compiling 1s"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Linking 2s"], cols: 40, capturedAt: 1100 }));
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Bundling 3s"], cols: 40, capturedAt: 1200 })
+      );
+      // Each frame has a different prefix, so counterStreak resets every
+      // frame and never reaches the 2-frame threshold.
+      expect(result.signal).not.toBe("time-counter");
+    });
+
+    it("recognizes minute counters", () => {
+      analyzer.classify(snapshot({ rows: ["", "Running 1m"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Running 2m"], cols: 40, capturedAt: 61000 }));
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Running 3m"], cols: 40, capturedAt: 121000 })
+      );
+      expect(result.signal).toBe("time-counter");
+    });
+
+    it("does not return time-counter when no counter is present", () => {
+      analyzer.classify(snapshot({ rows: ["", "Working"], cols: 40, capturedAt: 1000 }));
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Working"], cols: 40, capturedAt: 1100 })
+      );
+      expect(result.signal).not.toBe("time-counter");
+    });
+  });
+
+  describe("cosmetic-only classifier", () => {
+    it("returns cosmetic-only when only the bottom row changes", () => {
+      // Use bottom rows without digit+unit patterns to avoid hitting the
+      // time-counter classifier. Two frames isn't enough for the spinner
+      // classifier (MIN_FRAMES_FOR_SPINNER=3), so this falls through to
+      // cosmetic-only.
+      const snap1 = snapshot({
+        rows: ["import foo from 'bar'", "console.log(1)", "spinner ✦"],
+        cols: 40,
+        capturedAt: 1000,
+      });
+      const snap2 = snapshot({
+        rows: ["import foo from 'bar'", "console.log(1)", "spinner ✧"],
+        cols: 40,
+        capturedAt: 1100,
+      });
+      analyzer.classify(snap1);
+      const result = analyzer.classify(snap2);
+      expect(result.signal).toBe("cosmetic-only");
+    });
+
+    it("does NOT return cosmetic-only when higher rows change", () => {
+      const snap1 = snapshot({
+        rows: ["line 1 v1", "line 2 v1", "spinner ✦"],
+        cols: 40,
+        capturedAt: 1000,
+      });
+      const snap2 = snapshot({
+        rows: ["line 1 v2", "line 2 v1", "spinner ✦"],
+        cols: 40,
+        capturedAt: 1100,
+      });
+      analyzer.classify(snap1);
+      const result = analyzer.classify(snap2);
+      expect(result.signal).not.toBe("cosmetic-only");
+    });
+
+    it("returns none when nothing changed", () => {
+      const snap1 = snapshot({
+        rows: ["unchanged", "row", "bottom"],
+        cols: 40,
+        capturedAt: 1000,
+      });
+      const snap2 = snapshot({
+        rows: ["unchanged", "row", "bottom"],
+        cols: 40,
+        capturedAt: 1100,
+      });
+      analyzer.classify(snap1);
+      const result = analyzer.classify(snap2);
+      expect(result.signal).toBe("none");
+    });
+  });
+
+  describe("spinner classifier", () => {
+    it("returns spinner when one cell cycles through codepoints at 100ms cadence", () => {
+      const cycle = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+      let lastResult = analyzer.classify(
+        snapshot({ rows: ["", "  static text"], cols: 40, capturedAt: 1000 })
+      );
+      for (let i = 0; i < 6; i++) {
+        const ch = cycle[i % cycle.length];
+        const row = `${ch} static text`;
+        lastResult = analyzer.classify(
+          snapshot({ rows: ["", row], cols: 40, capturedAt: 1100 + i * 100 })
+        );
+      }
+      expect(lastResult.signal).toBe("spinner");
+      expect(lastResult.confidence).toBeGreaterThan(0.4);
+    });
+
+    it("does NOT return spinner when neighbors also cycle (whole-row redraw)", () => {
+      // Every cell on the bottom row cycles — that's a paint, not a spinner.
+      const charsByFrame = ["abcdefgh", "bcdefgha", "cdefghab", "defghabc"];
+      let result = analyzer.classify(
+        snapshot({ rows: ["", "        "], cols: 8, capturedAt: 1000 })
+      );
+      for (let i = 0; i < charsByFrame.length; i++) {
+        result = analyzer.classify(
+          snapshot({ rows: ["", charsByFrame[i]], cols: 8, capturedAt: 1100 + i * 100 })
+        );
+      }
+      expect(result.signal).not.toBe("spinner");
+    });
+
+    it("does NOT return spinner when cell stays static across frames", () => {
+      let result = analyzer.classify(
+        snapshot({ rows: ["", "✦ static"], cols: 40, capturedAt: 1000 })
+      );
+      for (let i = 0; i < 6; i++) {
+        result = analyzer.classify(
+          snapshot({ rows: ["", "✦ static"], cols: 40, capturedAt: 1100 + i * 100 })
+        );
+      }
+      expect(result.signal).not.toBe("spinner");
+    });
+
+    it("does NOT return spinner when interval is too slow", () => {
+      const cycle = ["⠋", "⠙", "⠹", "⠸"];
+      let result = analyzer.classify(
+        snapshot({ rows: ["", "  static"], cols: 40, capturedAt: 1000 })
+      );
+      for (let i = 0; i < 6; i++) {
+        const row = `${cycle[i % cycle.length]} static`;
+        result = analyzer.classify(
+          // 800ms intervals — far too slow to be a spinner glyph.
+          snapshot({ rows: ["", row], cols: 40, capturedAt: 1800 + i * 800 })
+        );
+      }
+      expect(result.signal).not.toBe("spinner");
+    });
+  });
+
+  describe("resize handling", () => {
+    it("clears state and returns none on terminal-cols change", () => {
+      const cycle = ["⠋", "⠙", "⠹", "⠸"];
+      analyzer.classify(snapshot({ rows: ["", "  static"], cols: 40, capturedAt: 1000 }));
+      for (let i = 0; i < 3; i++) {
+        const row = `${cycle[i]} static`;
+        analyzer.classify(snapshot({ rows: ["", row], cols: 40, capturedAt: 1100 + i * 100 }));
+      }
+      // Resize: same content, new col count.
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "⠋ static"], cols: 80, capturedAt: 1500 })
+      );
+      expect(result.signal).toBe("none");
+    });
+
+    it("clears state and returns none on terminal-rows change", () => {
+      analyzer.classify(snapshot({ rows: ["", "Working 1s"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Working 2s"], cols: 40, capturedAt: 1100 }));
+      const result = analyzer.classify(
+        snapshot({
+          rows: ["", "Working 3s"],
+          cols: 40,
+          capturedAt: 1200,
+          terminalRows: 30,
+        })
+      );
+      expect(result.signal).toBe("none");
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all internal state", () => {
+      analyzer.classify(snapshot({ rows: ["", "Working 1s"], cols: 40, capturedAt: 1000 }));
+      analyzer.classify(snapshot({ rows: ["", "Working 2s"], cols: 40, capturedAt: 1100 }));
+      analyzer.reset();
+      const result = analyzer.classify(
+        snapshot({ rows: ["", "Working 3s"], cols: 40, capturedAt: 1200 })
+      );
+      // After reset the analyzer treats this as the first observation, so it
+      // can't yet conclude anything is incrementing.
+      expect(result.signal).toBe("none");
+    });
+  });
+});

--- a/electron/services/pty/__tests__/SynchronizedFrameAnalyzer.test.ts
+++ b/electron/services/pty/__tests__/SynchronizedFrameAnalyzer.test.ts
@@ -150,11 +150,13 @@ describe("SynchronizedFrameAnalyzer", () => {
 
   describe("spinner classifier", () => {
     it("returns spinner when one cell cycles through codepoints at 100ms cadence", () => {
-      const cycle = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"];
+      // 4-item cycle iterated twice — each codepoint is revisited, which
+      // satisfies the revisitation requirement (rejects monotonic counters).
+      const cycle = ["⠋", "⠙", "⠹", "⠸"];
       let lastResult = analyzer.classify(
         snapshot({ rows: ["", "  static text"], cols: 40, capturedAt: 1000 })
       );
-      for (let i = 0; i < 6; i++) {
+      for (let i = 0; i < 8; i++) {
         const ch = cycle[i % cycle.length];
         const row = `${ch} static text`;
         lastResult = analyzer.classify(
@@ -189,6 +191,39 @@ describe("SynchronizedFrameAnalyzer", () => {
         );
       }
       expect(result.signal).not.toBe("spinner");
+    });
+
+    it("does NOT classify monotonic counter cell as spinner", () => {
+      // A digit cell incrementing 0→1→2→3→… without repeats has the right
+      // distinct-count and cadence, but no revisitation. Real spinners
+      // return to previously-seen codepoints.
+      const chars = ["0", "1", "2", "3", "4", "5", "6"];
+      let result = analyzer.classify(
+        snapshot({ rows: ["", `${chars[0]} progress`], cols: 40, capturedAt: 1000 })
+      );
+      for (let i = 0; i < 6; i++) {
+        const row = `${chars[i + 1]} progress`;
+        result = analyzer.classify(
+          snapshot({ rows: ["", row], cols: 40, capturedAt: 1100 + i * 100 })
+        );
+      }
+      expect(result.signal).not.toBe("spinner");
+    });
+
+    it("returns spinner when cell revisits codepoints", () => {
+      // 4-frame braille cycle revisited across 8 frames — each codepoint
+      // appears twice, satisfying the revisitation requirement.
+      const cycle = ["⠋", "⠙", "⠹", "⠸"];
+      let result = analyzer.classify(
+        snapshot({ rows: ["", "  static"], cols: 40, capturedAt: 1000 })
+      );
+      for (let i = 0; i < 8; i++) {
+        const ch = cycle[i % cycle.length];
+        result = analyzer.classify(
+          snapshot({ rows: ["", `${ch} static`], cols: 40, capturedAt: 1100 + i * 100 })
+        );
+      }
+      expect(result.signal).toBe("spinner");
     });
 
     it("does NOT return spinner when interval is too slow", () => {

--- a/electron/services/pty/__tests__/SynchronizedFrameDetector.test.ts
+++ b/electron/services/pty/__tests__/SynchronizedFrameDetector.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Terminal } from "@xterm/headless";
+import type { FrameSnapshot } from "../SynchronizedFrameAnalyzer.js";
+import { SynchronizedFrameDetector } from "../SynchronizedFrameDetector.js";
+
+const OPEN = "\x1b[?2026h";
+const CLOSE = "\x1b[?2026l";
+
+async function flushTerminal(terminal: Terminal): Promise<void> {
+  return new Promise((resolve) => terminal.write("", resolve));
+}
+
+describe("SynchronizedFrameDetector", () => {
+  let terminal: Terminal;
+  let frames: FrameSnapshot[];
+  let detector: SynchronizedFrameDetector;
+
+  beforeEach(() => {
+    terminal = new Terminal({ cols: 40, rows: 10, allowProposedApi: true });
+    frames = [];
+    detector = new SynchronizedFrameDetector(terminal, (snap) => {
+      frames.push(snap);
+    });
+  });
+
+  afterEach(() => {
+    detector.dispose();
+    terminal.dispose();
+  });
+
+  it("fires exactly one frame-close on a balanced 2026 bracket pair", async () => {
+    terminal.write(`${OPEN}hello world${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].terminalCols).toBe(40);
+    expect(frames[0].rows.length).toBeGreaterThan(0);
+    expect(frames[0].bottomRowText).toBe("");
+  });
+
+  it("fires once for nested 2026 brackets — outer close commits", async () => {
+    terminal.write(`${OPEN}outer${OPEN}inner${CLOSE} more${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+  });
+
+  it("handles CSI sequences split across writes", async () => {
+    // node-pty can deliver `\x1b[?20` and `26h` in separate chunks. The
+    // xterm parser stitches them back together; verify the detector sees
+    // the open as if it were one chunk.
+    terminal.write("\x1b[?20");
+    terminal.write("26h frame body \x1b[?2026l");
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+  });
+
+  it("captures bottom rows in the snapshot", async () => {
+    // Move to bottom-1 and write a known marker, then bracket a frame.
+    terminal.write(`\x1b[10;1Hbottom-row-marker${OPEN}${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+    const snap = frames[0];
+    expect(snap.bottomRowText).toContain("bottom-row-marker");
+    // Snapshot should have the configured row count (default 3) up to
+    // terminal.rows.
+    expect(snap.rows.length).toBe(3);
+    // Each row has exactly terminal.cols cells.
+    for (const row of snap.rows) {
+      expect(row.length).toBe(40);
+    }
+  });
+
+  it("ignores non-2026 DECSET sequences", async () => {
+    // Bracketed paste mode (?2004), application cursor keys (?1)
+    terminal.write("\x1b[?2004h\x1b[?1h\x1b[?2004l\x1b[?1l");
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(0);
+  });
+
+  it("force-resets nesting counter on missing close after timeout", async () => {
+    detector.dispose();
+    const detector2 = new SynchronizedFrameDetector(terminal, (snap) => frames.push(snap), {
+      missingCloseTimeoutMs: 50,
+    });
+    try {
+      terminal.write(OPEN);
+      await flushTerminal(terminal);
+      expect(detector2.getNestingDepth()).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(detector2.getNestingDepth()).toBe(0);
+      // Snapshot must NOT have been emitted on timeout — would reflect a
+      // half-rendered state.
+      expect(frames).toHaveLength(0);
+    } finally {
+      detector2.dispose();
+    }
+  });
+
+  it("ignores stray close brackets", async () => {
+    terminal.write(CLOSE);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(0);
+  });
+
+  it("stops emitting frames after dispose", async () => {
+    terminal.write(`${OPEN}first${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+    detector.dispose();
+    terminal.write(`${OPEN}second${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+  });
+
+  it("does not double-fire when the same write batch contains multiple frames", async () => {
+    terminal.write(`${OPEN}one${CLOSE}${OPEN}two${CLOSE}${OPEN}three${CLOSE}`);
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(3);
+  });
+});

--- a/electron/services/pty/__tests__/SynchronizedFrameDetector.test.ts
+++ b/electron/services/pty/__tests__/SynchronizedFrameDetector.test.ts
@@ -116,4 +116,19 @@ describe("SynchronizedFrameDetector", () => {
     await flushTerminal(terminal);
     expect(frames).toHaveLength(3);
   });
+
+  it("matches 2026 in combined DEC params (e.g. ?25;2026h)", async () => {
+    // Many TUIs collapse cursor-visibility + sync-output into a single CSI:
+    // \x1b[?25;2026h ... \x1b[?25;2026l. xterm delivers `params = [25, 2026]`
+    // — the detector must scan all params, not just params[0].
+    terminal.write("\x1b[?25;2026h frame body \x1b[?25;2026l");
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+  });
+
+  it("matches 2026 in reversed combined DEC params (e.g. ?2026;25h)", async () => {
+    terminal.write("\x1b[?2026;25h frame body \x1b[?2026;25l");
+    await flushTerminal(terminal);
+    expect(frames).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a new structural-signal tier above the existing regex pack in PTY activity detection, hooking the headless terminal parser for DEC mode 2026 (`\e[?2026h/l`) bracket pairs to capture per-frame snapshots
- Three classifiers run per frame: bottom-row invariant (cosmetic-only check), monotonic time-counter, and per-cell codepoint cycle (spinner detection) — cosmetic-only frames suppress idle→busy escalation from the line-rewrite tier, fixing the false-positive issue the feature request describes
- Spinner and time-counter signals feed a dedicated recovery debouncer so sustained idle→busy transitions still fire correctly

Resolves #6668

## Changes

- `SynchronizedFrameDetector` — parses DEC mode 2026 bracket pairs from raw PTY output and emits complete frame snapshots via the headless xterm parser
- `SynchronizedFrameAnalyzer` — runs the three classifiers against each snapshot and returns a `FrameSignal` (cosmetic | spinner | time-counter | unknown)
- `ActivityMonitor` — wired in as the top tier; cosmetic signals suppress line-rewrite escalation, spinner/time-counter signals drive the recovery debouncer
- `IdleSequenceFilter` — minor touch to pass raw bytes through to the frame detector before stripping ANSI sequences
- `TerminalProcess` — initialises and connects the new tier on PTY spawn

## Testing

24 new unit and integration tests across 3 test files (`SynchronizedFrameDetector.test.ts`, `SynchronizedFrameAnalyzer.test.ts`, `ActivityMonitor.test.ts`); 192 tests passing across the affected files. All `npm run check` gates green.