### PR TITLE
fix(pty): replace OutputVolumeDetector AND-gate with cadence-invariant leaky bucket

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -42,9 +42,9 @@ export interface ActivityMonitorOptions {
   processStateValidator?: ProcessStateValidator;
   outputActivityDetection?: {
     enabled?: boolean;
-    windowMs?: number;
-    minFrames?: number;
-    minBytes?: number;
+    leakRatePerMs?: number;
+    activationThreshold?: number;
+    maxBytesPerFrame?: number;
   };
   highOutputThreshold?: {
     enabled?: boolean;
@@ -78,10 +78,9 @@ export interface ActivityMonitorOptions {
   };
   pollingIntervalMs?: number;
   workingRecoveryDelayMs?: number;
-  // Background polling tier overrides — applied automatically by setPollingInterval()
-  // when intervalMs > 50. When unset, fall back to the active values so behavior
+  // Background polling tier override — applied automatically by setPollingInterval()
+  // when intervalMs > 50. When unset, fall back to the active value so behavior
   // matches today's defaults until the call site opts in.
-  backgroundOutputWindowMs?: number;
   backgroundWorkingRecoveryDelayMs?: number;
   pollingMaxBootMs?: number;
   maxWorkingSilenceMs?: number;
@@ -198,13 +197,12 @@ export class ActivityMonitor {
   // Polling interval configuration
   private POLLING_INTERVAL_MS: number;
 
-  // Tier-aware recovery thresholds (#6641). Active values must match the
-  // pre-fix hardcoded behavior so the 50ms tier is unchanged. Background
-  // values widen the volume window and shorten the debouncer delay so
-  // backgrounded agents can escape "waiting" when output resumes.
+  // Tier-aware recovery thresholds (#6641). The output volume detector is now
+  // sample-cadence invariant (#6666), so only the working-signal debouncer
+  // needs tier-specific tuning. Active values must match the pre-fix hardcoded
+  // behavior so the 50ms tier is unchanged. Background shortens the debouncer
+  // delay so backgrounded agents can escape "waiting" when output resumes.
   private _tier: "active" | "background" = "active";
-  private readonly activeOutputWindowMs: number;
-  private readonly backgroundOutputWindowMs: number;
   private readonly activeWorkingRecoveryDelayMs: number;
   private readonly backgroundWorkingRecoveryDelayMs: number;
 
@@ -255,12 +253,10 @@ export class ActivityMonitor {
       options?.workingRecoveryDelayMs ?? 1500
     );
 
-    // Snapshot tier-aware recovery thresholds. Active values default to the
-    // detector-instantiation values so the active-tier path is identical to
-    // pre-fix behavior. Background values default to active values when the
+    // Snapshot tier-aware recovery thresholds. Active value defaults to the
+    // debouncer-instantiation value so the active-tier path is identical to
+    // pre-fix behavior. Background defaults to the active value when the
     // caller doesn't opt in, preserving compatibility for non-agent terminals.
-    this.activeOutputWindowMs = this.outputVolumeDetector.windowMs;
-    this.backgroundOutputWindowMs = options?.backgroundOutputWindowMs ?? this.activeOutputWindowMs;
     this.activeWorkingRecoveryDelayMs = this.workingSignalDebouncer.delayMs;
     this.backgroundWorkingRecoveryDelayMs =
       options?.backgroundWorkingRecoveryDelayMs ?? this.activeWorkingRecoveryDelayMs;
@@ -321,17 +317,13 @@ export class ActivityMonitor {
   private applyTier(tier: "active" | "background"): void {
     if (this._tier === tier) return;
     this._tier = tier;
-    if (tier === "background") {
-      this.outputVolumeDetector.reconfigureWindow(this.backgroundOutputWindowMs);
-      this.workingSignalDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
-      this.cosmeticRecoveryDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
-      this.structuralRecoveryDebouncer.setDelay(this.backgroundWorkingRecoveryDelayMs);
-    } else {
-      this.outputVolumeDetector.reconfigureWindow(this.activeOutputWindowMs);
-      this.workingSignalDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
-      this.cosmeticRecoveryDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
-      this.structuralRecoveryDebouncer.setDelay(this.activeWorkingRecoveryDelayMs);
-    }
+    const delay =
+      tier === "background"
+        ? this.backgroundWorkingRecoveryDelayMs
+        : this.activeWorkingRecoveryDelayMs;
+    this.workingSignalDebouncer.setDelay(delay);
+    this.cosmeticRecoveryDebouncer.setDelay(delay);
+    this.structuralRecoveryDebouncer.setDelay(delay);
   }
 
   onInput(data: string): void {
@@ -809,7 +801,7 @@ export class ActivityMonitor {
 
     const hasRecentOutputActivity =
       this.lastOutputActivityAt > 0 &&
-      now - this.lastOutputActivityAt <= this.outputVolumeDetector.windowMs;
+      now - this.lastOutputActivityAt <= this.outputVolumeDetector.recencyWindowMs;
     const isSpinnerActive = this.lineRewriteDetector.isSpinnerActive(now, this.SPINNER_ACTIVE_MS);
     const isOutputQuiet = quietForMs >= this.PROMPT_QUIET_MS;
     const promptStableForMs = this.promptStableSince === 0 ? 0 : now - this.promptStableSince;
@@ -1031,9 +1023,10 @@ export class ActivityMonitor {
       this.pollingInterval = setInterval(() => this.runPollingCycle(), this.POLLING_INTERVAL_MS);
     }
 
-    // Recovery thresholds need to track the polling cadence, otherwise the
-    // 1000ms volume window and 1500ms debouncer become impossible to satisfy
-    // at 500ms polling. See #6641.
+    // The working-signal debouncer needs to track polling cadence, otherwise
+    // the 1500ms delay becomes impossible to satisfy at 500ms polling (#6641).
+    // The output volume detector is sample-cadence invariant (#6666) and
+    // needs no tier handling here.
     this.applyTier(this.tierForInterval(intervalMs));
   }
 

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -558,20 +558,21 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should not escalate idle→busy from idle-noise sequences with low minBytes (#6365)", () => {
+    it("should not escalate idle→busy from idle-noise sequences (#6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 300,
         outputActivityDetection: {
           enabled: true,
-          windowMs: 1000,
-          minFrames: 2,
-          minBytes: 1,
+          activationThreshold: 200,
+          maxBytesPerFrame: 120,
+          leakRatePerMs: 0.1,
         },
       });
 
       // Monitor is idle. A stream of pure DECSET/OSC/CPR noise must not
-      // trigger volume-based idle→busy escalation now that minBytes is 1.
+      // trigger volume-based idle→busy escalation — these sequences are
+      // stripped by stripIdleTerminalSequences before reaching the detector.
       expect(monitor.getState()).toBe("idle");
       onStateChange.mockClear();
 
@@ -618,9 +619,9 @@ describe("ActivityMonitor", () => {
         idleDebounceMs: 300,
         outputActivityDetection: {
           enabled: true,
-          windowMs: 1000,
-          minFrames: 2,
-          minBytes: 1,
+          activationThreshold: 200,
+          maxBytesPerFrame: 120,
+          leakRatePerMs: 0.1,
         },
       });
 
@@ -640,15 +641,15 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should not escalate idle→busy from a single noise frame at minBytes:1 (#6365)", () => {
+    it("should not escalate idle→busy from a single unfiltered noise frame (#6365)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         idleDebounceMs: 300,
         outputActivityDetection: {
           enabled: true,
-          windowMs: 1000,
-          minFrames: 2,
-          minBytes: 1,
+          activationThreshold: 200,
+          maxBytesPerFrame: 120,
+          leakRatePerMs: 0.1,
         },
       });
 
@@ -656,8 +657,8 @@ describe("ActivityMonitor", () => {
       onStateChange.mockClear();
 
       // A single chunk that gets past the filter (e.g. an OSC variant we
-      // don't recognize) must not escalate idle→busy on its own — minFrames
-      // is the per-chunk guard once minBytes is lowered to 1.
+      // don't recognize) must not escalate idle→busy on its own — the
+      // maxBytesPerFrame cap is the per-chunk noise gate.
       monitor.onData("\x1b]999;some-experimental-payload\x07");
 
       expect(monitor.getState()).toBe("idle");
@@ -721,7 +722,12 @@ describe("ActivityMonitor", () => {
       };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         processStateValidator,
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       // User types (sets recent input timestamp)
@@ -743,7 +749,12 @@ describe("ActivityMonitor", () => {
       };
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         processStateValidator,
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       // Press Enter first to set pending input
@@ -764,7 +775,12 @@ describe("ActivityMonitor", () => {
     it("should not re-emit busy when output arrives after Enter has set state to busy", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       monitor.onInput("\r");
@@ -783,7 +799,12 @@ describe("ActivityMonitor", () => {
     it("should NOT trigger busy from output during echo window even without validator - Issue #1476", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       // User types (sets recent input timestamp)
@@ -1086,7 +1107,12 @@ describe("ActivityMonitor", () => {
     it("should not fire duplicate busy from output after Enter", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       // Press Enter first to allow output-based busy
@@ -1214,7 +1240,12 @@ describe("ActivityMonitor", () => {
     it("should NOT re-enter busy from idle via output during echo window - Issue #1476", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
         idleDebounceMs: 2500,
       });
 
@@ -1240,7 +1271,12 @@ describe("ActivityMonitor", () => {
     it("should re-enter busy when Enter is pressed again after going idle", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
         idleDebounceMs: 2500,
       });
 
@@ -1551,7 +1587,12 @@ describe("ActivityMonitor", () => {
     it("should transition to idle on dispose when busy", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
       });
 
       // Press Enter to enter busy state
@@ -1606,7 +1647,12 @@ describe("ActivityMonitor", () => {
     it("should ignore onData and onInput calls after dispose", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1, windowMs: 500 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.002,
+        },
       });
 
       monitor.dispose();
@@ -2051,7 +2097,12 @@ describe("ActivityMonitor", () => {
     it("should recover from idle when output occurs without recent user input", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
         idleDebounceMs: 2500,
       });
 
@@ -2076,7 +2127,12 @@ describe("ActivityMonitor", () => {
     it("should NOT recover from idle when output is likely a character echo", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
         idleDebounceMs: 2500,
       });
 
@@ -2182,7 +2238,12 @@ describe("ActivityMonitor", () => {
     it("should recover after echo window expires even if user typed recently", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
-        outputActivityDetection: { enabled: true, minFrames: 1, minBytes: 1 },
+        outputActivityDetection: {
+          enabled: true,
+          activationThreshold: 1,
+          maxBytesPerFrame: 65536,
+          leakRatePerMs: 0.001,
+        },
         idleDebounceMs: 2500,
       });
 
@@ -3892,7 +3953,6 @@ describe("ActivityMonitor", () => {
         getCursorLine: () => null,
         pollingIntervalMs: 500,
         bootCompletePatterns: [/booted/i],
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
@@ -3934,7 +3994,6 @@ describe("ActivityMonitor", () => {
         pollingIntervalMs: 500,
         initialState: "idle",
         skipInitialStateEmit: true,
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
@@ -3969,7 +4028,6 @@ describe("ActivityMonitor", () => {
         getCursorLine: () => null,
         pollingIntervalMs: 50,
         bootCompletePatterns: [/booted/i],
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
@@ -4019,7 +4077,6 @@ describe("ActivityMonitor", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("plain-1", 1000, onStateChange, {
         pollingIntervalMs: 500,
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
@@ -4046,7 +4103,6 @@ describe("ActivityMonitor", () => {
         getVisibleLines: () => [],
         getCursorLine: () => null,
         pollingIntervalMs: 500,
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 300,
       });
@@ -4141,10 +4197,11 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("widens output volume window for sparse background streaming", () => {
-      // At 500ms polling with the old 1000ms window, two frames 1700ms apart
-      // would reset the window and never trigger recovery. With the widened
-      // 2500ms window, the same frames now satisfy the AND-gate.
+    it("triggers volume recovery on sustained background-tier output (#6666)", () => {
+      // The pre-#6666 windowed AND-gate required tier-specific window widening
+      // because frames straddled the fixed window boundary at 500ms polling.
+      // The leaky-bucket detector is sample-cadence invariant: the same byte
+      // stream fires at any tier without tier-specific tuning.
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("bg-vol", 1000, onStateChange, {
         getVisibleLines: () => [],
@@ -4153,48 +4210,49 @@ describe("ActivityMonitor", () => {
         bootCompletePatterns: [/ready/i],
         outputActivityDetection: {
           enabled: true,
-          windowMs: 1000,
-          minFrames: 2,
-          minBytes: 1,
+          activationThreshold: 200,
+          maxBytesPerFrame: 120,
+          leakRatePerMs: 0.1,
         },
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
 
       monitor.onData("\nready\n");
-      // Drain the volume detector's window (boot data already filled frame 1).
+      // Let any boot-data accumulation drain.
       vi.advanceTimersByTime(3000);
       onStateChange.mockClear();
 
-      // Frame 1 of the actual scenario: starts a fresh volume window.
-      monitor.onData("a");
+      // Three 100-byte chunks at 500ms cadence (typical batched background
+      // streaming): drain=50/cycle, fill=100/cycle. F1 level=100, F2=150,
+      // F3=200 ≥ threshold → fire.
+      monitor.onData("x".repeat(100));
       expect(monitor.getState()).toBe("idle");
-
-      // Frame 2, 1700ms later — would have expired the 1000ms window but fits
-      // inside the widened 2500ms window, satisfying the AND-gate.
-      vi.advanceTimersByTime(1700);
-      monitor.onData("b");
+      vi.advanceTimersByTime(500);
+      monitor.onData("x".repeat(100));
+      expect(monitor.getState()).toBe("idle");
+      vi.advanceTimersByTime(500);
+      monitor.onData("x".repeat(100));
 
       expect(monitor.getState()).toBe("busy");
 
       monitor.dispose();
     });
 
-    it("restores active thresholds when polling switches back to active", () => {
+    it("restores active debouncer threshold when polling switches back to active", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("tier-switch", 1000, onStateChange, {
         getVisibleLines: () => [],
         getCursorLine: () => null,
         pollingIntervalMs: 50,
         bootCompletePatterns: [/booted/i],
-        backgroundOutputWindowMs: 2500,
         backgroundWorkingRecoveryDelayMs: 600,
         idleDebounceMs: 4000,
       });
 
-      // Switch to background then back to active. Pre-fix, the volume window
-      // would have been left at 2500ms; the tier setter must restore it.
+      // Switch to background then back to active. The cosmeticRecoveryDebouncer
+      // delay must track the tier round-trip — pre-fix the 600ms background
+      // value would persist into the active tier and false-fire recovery.
       monitor.setPollingInterval(500);
       monitor.setPollingInterval(50);
 

--- a/electron/services/__tests__/fixtures/activity-monitor/claude-normal-turn.expected.json
+++ b/electron/services/__tests__/fixtures/activity-monitor/claude-normal-turn.expected.json
@@ -3,7 +3,7 @@
   "settleMs": 4000,
   "transitions": [
     { "atMs": 0, "state": "busy", "trigger": "pattern" },
-    { "atMs": 3550, "state": "completed", "trigger": "pattern", "sessionCost": 0.0123 },
-    { "atMs": 4050, "state": "idle", "trigger": "pattern" }
+    { "atMs": 2950, "state": "completed", "trigger": "pattern", "sessionCost": 0.0123 },
+    { "atMs": 3450, "state": "idle", "trigger": "pattern" }
   ]
 }

--- a/electron/services/pty/IdleSequenceFilter.ts
+++ b/electron/services/pty/IdleSequenceFilter.ts
@@ -14,7 +14,7 @@
 // The filter is intentionally stateless — escape sequences split across PTY
 // chunk boundaries (rare in practice, since node-pty reads at OS boundaries
 // and most idle-noise sequences are short) are not stripped. OutputVolumeDetector's
-// minFrames gate is the secondary defense for those cases.
+// maxBytesPerFrame cap is the secondary defense for those cases.
 //
 // `?2026h` / `?2026l` (DEC mode 2026 — Synchronized Output) is stripped here
 // for the renderer-bound and byte-volume paths, but the headless terminal in

--- a/electron/services/pty/OutputVolumeDetector.ts
+++ b/electron/services/pty/OutputVolumeDetector.ts
@@ -30,7 +30,13 @@ export class OutputVolumeDetector {
       activationThreshold: 2048,
       maxBytesPerFrame: 1024,
     };
-    const c = { ...defaults, ...config };
+    // Filter out explicit-undefined fields before merging so callers passing
+    // `{ leakRatePerMs: undefined }` (e.g. spreading partial options) don't
+    // override the defaults with undefined and trip the clamp fallback.
+    const filtered = config
+      ? Object.fromEntries(Object.entries(config).filter(([, v]) => v !== undefined))
+      : {};
+    const c = { ...defaults, ...filtered } as Required<OutputVolumeConfig>;
     this.enabled = c.enabled;
     // Defensive clamps. leakRatePerMs > 0 is required so recencyWindowMs is
     // finite; activationThreshold and maxBytesPerFrame must be positive so the

--- a/electron/services/pty/OutputVolumeDetector.ts
+++ b/electron/services/pty/OutputVolumeDetector.ts
@@ -1,38 +1,51 @@
 export interface OutputVolumeConfig {
   enabled?: boolean;
-  windowMs?: number;
-  minFrames?: number;
-  minBytes?: number;
+  // Leaky-bucket drain in bytes/ms. Higher = bucket forgets older bytes faster.
+  leakRatePerMs?: number;
+  // Bucket level at which the detector fires.
+  activationThreshold?: number;
+  // Per-frame contribution cap. The noise gate that prevents a single oversized
+  // chunk (status-line write, bracketed status payload) from filling the bucket
+  // on its own — replaces the old minFrames AND-gate.
+  maxBytesPerFrame?: number;
 }
 
+// Sample-cadence-invariant output classifier. Bytes accumulate into a bucket
+// that drains at a constant rate; the result depends only on the underlying
+// byte stream, not on how frequently `update()` is called. This eliminates the
+// tier-specific window widening that the old fixed-window AND-gate required
+// (#6641, #6666).
 export class OutputVolumeDetector {
   readonly enabled: boolean;
-  private _windowMs: number;
-  private readonly minFrames: number;
-  private readonly minBytes: number;
-  private windowStart = 0;
-  private framesInWindow = 0;
-  private bytesInWindow = 0;
+  private readonly leakRatePerMs: number;
+  private readonly activationThreshold: number;
+  private readonly maxBytesPerFrame: number;
+  private level = 0;
+  private lastUpdateMs = 0;
 
   constructor(config?: OutputVolumeConfig) {
-    const defaults = { enabled: false, windowMs: 500, minFrames: 3, minBytes: 2048 };
+    const defaults = {
+      enabled: false,
+      leakRatePerMs: 2.048,
+      activationThreshold: 2048,
+      maxBytesPerFrame: 1024,
+    };
     const c = { ...defaults, ...config };
     this.enabled = c.enabled;
-    this._windowMs = c.windowMs;
-    this.minFrames = c.minFrames;
-    this.minBytes = c.minBytes;
+    // Defensive clamps. leakRatePerMs > 0 is required so recencyWindowMs is
+    // finite; activationThreshold and maxBytesPerFrame must be positive so the
+    // detector can ever fire and the noise gate is meaningful.
+    this.leakRatePerMs = c.leakRatePerMs > 0 ? c.leakRatePerMs : 0.001;
+    this.activationThreshold = c.activationThreshold > 0 ? c.activationThreshold : 1;
+    this.maxBytesPerFrame = c.maxBytesPerFrame > 0 ? c.maxBytesPerFrame : 1;
   }
 
-  get windowMs(): number {
-    return this._windowMs;
-  }
-
-  // Background polling tier (500ms) widens this window so consecutive frames
-  // stop straddling the 1000ms boundary and pinning framesInWindow at 1.
-  reconfigureWindow(windowMs: number): void {
-    if (this._windowMs === windowMs) return;
-    this._windowMs = windowMs;
-    this.resetWindow();
+  // Time after a fire-event that the consumer should still consider output
+  // "recent" — derived as the time it takes to drain a full bucket from the
+  // activation threshold. Replaces the old windowMs getter on line-672 of
+  // ActivityMonitor's hasRecentOutputActivity check.
+  get recencyWindowMs(): number {
+    return this.activationThreshold / this.leakRatePerMs;
   }
 
   update(dataLength: number, now: number): boolean {
@@ -40,35 +53,25 @@ export class OutputVolumeDetector {
       return false;
     }
 
-    if (this.windowStart === 0 || now - this.windowStart > this._windowMs) {
-      this.windowStart = now;
-      this.framesInWindow = 1;
-      this.bytesInWindow = dataLength;
-    } else {
-      this.framesInWindow++;
-      this.bytesInWindow += dataLength;
+    if (this.lastUpdateMs > 0) {
+      const elapsedMs = Math.max(0, now - this.lastUpdateMs);
+      this.level = Math.max(0, this.level - elapsedMs * this.leakRatePerMs);
     }
+    this.lastUpdateMs = now;
 
-    // Require BOTH frames AND bytes — minFrames is the noise gate that prevents
-    // a single unfiltered control sequence (e.g. an OSC variant we missed, or an
-    // escape split across PTY chunks) from triggering escalation. With
-    // minBytes lowered to 1 (#6365), this gate is the primary defense against
-    // false-positive idle→busy escalation from protocol noise.
-    if (this.framesInWindow >= this.minFrames && this.bytesInWindow >= this.minBytes) {
-      this.resetWindow();
+    const contribution = Math.min(Math.max(0, dataLength), this.maxBytesPerFrame);
+    this.level += contribution;
+
+    if (this.level >= this.activationThreshold) {
+      this.reset();
       return true;
     }
 
     return false;
   }
 
-  resetWindow(): void {
-    this.windowStart = 0;
-    this.framesInWindow = 0;
-    this.bytesInWindow = 0;
-  }
-
   reset(): void {
-    this.resetWindow();
+    this.level = 0;
+    this.lastUpdateMs = 0;
   }
 }

--- a/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
+++ b/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
@@ -110,9 +110,9 @@ describe("OutputVolumeDetector", () => {
       // Two small frames with a backward timestamp on the second. The clamp
       // must prevent negative drain from inflating the level above what the
       // raw byte contributions would justify.
-      d.update(50, 2000);
-      d.update(50, 1000);
-      // Two 50-byte frames cannot reach activationThreshold=200 even when
+      expect(d.update(50, 2000)).toBe(false);
+      expect(d.update(50, 1000)).toBe(false);
+      // Three 50-byte frames cannot reach activationThreshold=200 even when
       // drain is clamped to zero — the cap on per-frame contribution holds.
       expect(d.update(50, 1500)).toBe(false);
     });
@@ -151,8 +151,34 @@ describe("OutputVolumeDetector", () => {
         activationThreshold: 100,
         maxBytesPerFrame: 50,
       });
-      // recencyWindowMs must be finite even with 0 input.
-      expect(Number.isFinite(d.recencyWindowMs)).toBe(true);
+      // recencyWindowMs must be finite and bounded — a clamp that yields an
+      // absurdly large value (e.g. 100,000ms+) would silently break the
+      // hasRecentOutputActivity gate. The 0.001 floor / 100 threshold gives
+      // 100,000ms, so the clamp must keep recencyWindowMs ≤ that bound. This
+      // assertion catches accidental "tighten the clamp" regressions.
+      expect(d.recencyWindowMs).toBeGreaterThan(0);
+      expect(d.recencyWindowMs).toBeLessThanOrEqual(100_000);
+    });
+
+    it("ignores explicit-undefined config fields and falls through to defaults", () => {
+      // Callers that spread a partial options object can pass `{ leakRatePerMs:
+      // undefined }`; the spread must not override the default with undefined
+      // and trip the clamp fallback.
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        leakRatePerMs: undefined,
+        activationThreshold: undefined,
+        maxBytesPerFrame: undefined,
+      });
+      // Default recency = 2048 / 2.048 = 1000ms. A bug here would yield
+      // recency = 1 / 0.001 = 1000ms by coincidence — guard with a second
+      // assertion that the bucket actually reaches the default threshold.
+      expect(d.recencyWindowMs).toBe(1000);
+      // A single 1024-byte frame must not fire (confirms activationThreshold
+      // was not clamped to 1). Two simultaneous 1024-byte frames sum to
+      // exactly 2048 with no drain — fires.
+      expect(d.update(1024, 1000)).toBe(false);
+      expect(d.update(1024, 1000)).toBe(true);
     });
 
     it("clamps non-positive activationThreshold to 1 (always fireable)", () => {

--- a/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
+++ b/electron/services/pty/__tests__/OutputVolumeDetector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { OutputVolumeDetector } from "../OutputVolumeDetector.js";
 
 describe("OutputVolumeDetector", () => {
@@ -7,126 +7,177 @@ describe("OutputVolumeDetector", () => {
     expect(d.update(5000, 1000)).toBe(false);
   });
 
-  describe("enabled", () => {
-    let detector: OutputVolumeDetector;
+  describe("enabled (leaky bucket)", () => {
+    const config = {
+      enabled: true,
+      leakRatePerMs: 0.1,
+      activationThreshold: 200,
+      maxBytesPerFrame: 120,
+    };
 
-    beforeEach(() => {
-      detector = new OutputVolumeDetector({
-        enabled: true,
-        windowMs: 500,
-        minFrames: 3,
-        minBytes: 2048,
-      });
+    it("does not trigger on a single oversized burst (noise gate)", () => {
+      // The maxBytesPerFrame cap is the primary defense against single big
+      // chunks (status-line writes, OSC variants we don't strip). A 5KB chunk
+      // contributes at most maxBytesPerFrame=120 bytes, well below the 200
+      // threshold.
+      const d = new OutputVolumeDetector(config);
+      expect(d.update(5000, 1000)).toBe(false);
     });
 
-    it("does not trigger below thresholds", () => {
-      expect(detector.update(100, 1000)).toBe(false);
-      expect(detector.update(100, 1050)).toBe(false);
+    it("triggers on sustained byte production", () => {
+      const d = new OutputVolumeDetector(config);
+      // Three 100-byte chunks 50ms apart: each contributes 100 (under cap),
+      // drain per gap = 5 bytes. After frame 3 level≈290 ≥ 200 → fire.
+      expect(d.update(100, 1000)).toBe(false);
+      expect(d.update(100, 1050)).toBe(false);
+      expect(d.update(100, 1100)).toBe(true);
     });
 
-    it("does not trigger on a single big burst (minFrames not met)", () => {
-      // minFrames is a noise gate — a single chunk, no matter how large, must
-      // pair with at least one follow-up frame before escalation fires.
-      expect(detector.update(3000, 1000)).toBe(false);
+    it("is sample-cadence invariant: fires at 50ms cadence", () => {
+      const d = new OutputVolumeDetector(config);
+      // 50-byte chunks at 50ms: drain=5 per gap, net +45/cycle.
+      expect(d.update(50, 1000)).toBe(false);
+      expect(d.update(50, 1050)).toBe(false);
+      expect(d.update(50, 1100)).toBe(false);
+      expect(d.update(50, 1150)).toBe(false);
+      expect(d.update(50, 1200)).toBe(true);
     });
 
-    it("triggers when both frame and byte thresholds met", () => {
-      detector.update(700, 1000);
-      detector.update(700, 1050);
-      expect(detector.update(700, 1100)).toBe(true);
+    it("is sample-cadence invariant: fires at 500ms cadence", () => {
+      const d = new OutputVolumeDetector(config);
+      // 100-byte chunks at 500ms: drain=50 per gap, net +50/cycle.
+      // F1: 100, F2: 50+100=150, F3: 100+100=200 → fire.
+      expect(d.update(100, 1000)).toBe(false);
+      expect(d.update(100, 1500)).toBe(false);
+      expect(d.update(100, 2000)).toBe(true);
     });
 
-    it("does not trigger when frame threshold met but byte threshold missed", () => {
-      expect(detector.update(10, 1000)).toBe(false);
-      expect(detector.update(10, 1050)).toBe(false);
-      expect(detector.update(10, 1100)).toBe(false);
+    it("drains during idle gaps", () => {
+      const d = new OutputVolumeDetector(config);
+      d.update(100, 1000);
+      // 3000ms gap drains 300 bytes — bucket is now empty.
+      expect(d.update(100, 4000)).toBe(false);
+      // Subsequent burst at this cadence also doesn't fire from carryover.
+      expect(d.update(100, 4050)).toBe(false);
     });
 
-    it("does not trigger on a single byte even at minBytes:1 (split-sequence guard)", () => {
-      const d = new OutputVolumeDetector({
-        enabled: true,
-        windowMs: 500,
-        minFrames: 2,
-        minBytes: 1,
-      });
-      expect(d.update(1, 1000)).toBe(false);
+    it("does not trigger on Braille spinner residuals (3 bytes / 100ms)", () => {
+      // Even if cosmetic-redraw filtering somehow lets a Braille glyph through,
+      // 3-byte chunks at 100ms drain 10 bytes per cycle and contribute 3 —
+      // bucket is pinned at zero, never reaches activation.
+      const d = new OutputVolumeDetector(config);
+      let fired = false;
+      for (let i = 0; i < 100; i++) {
+        if (d.update(3, 1000 + i * 100)) {
+          fired = true;
+          break;
+        }
+      }
+      expect(fired).toBe(false);
     });
 
-    it("triggers on second byte after first at minBytes:1", () => {
-      const d = new OutputVolumeDetector({
-        enabled: true,
-        windowMs: 500,
-        minFrames: 2,
-        minBytes: 1,
-      });
-      d.update(1, 1000);
-      expect(d.update(1, 1050)).toBe(true);
+    it("does not trigger on Braille spinner residuals at 500ms cadence", () => {
+      const d = new OutputVolumeDetector(config);
+      let fired = false;
+      for (let i = 0; i < 100; i++) {
+        if (d.update(3, 1000 + i * 500)) {
+          fired = true;
+          break;
+        }
+      }
+      expect(fired).toBe(false);
     });
 
-    it("resets window after expiry", () => {
-      detector.update(500, 1000);
-      // Window expires after 500ms
-      expect(detector.update(500, 1600)).toBe(false);
+    it("resets after firing", () => {
+      const d = new OutputVolumeDetector(config);
+      d.update(100, 1000);
+      d.update(100, 1050);
+      expect(d.update(100, 1100)).toBe(true);
+      // Bucket reset — the next single small chunk cannot fire on residual.
+      expect(d.update(50, 1150)).toBe(false);
     });
 
-    it("resets after trigger", () => {
-      detector.update(3000, 1000);
-      // After trigger, window resets so small data doesn't trigger
-      expect(detector.update(100, 1050)).toBe(false);
+    it("reset() clears state", () => {
+      const d = new OutputVolumeDetector(config);
+      d.update(100, 1000);
+      d.update(100, 1050);
+      d.reset();
+      expect(d.update(50, 1100)).toBe(false);
     });
 
-    it("reset clears state", () => {
-      detector.update(1000, 1000);
-      detector.reset();
-      expect(detector.update(100, 1050)).toBe(false);
+    it("clamps non-monotonic timestamps to zero elapsed (no negative drain)", () => {
+      const d = new OutputVolumeDetector(config);
+      // Two small frames with a backward timestamp on the second. The clamp
+      // must prevent negative drain from inflating the level above what the
+      // raw byte contributions would justify.
+      d.update(50, 2000);
+      d.update(50, 1000);
+      // Two 50-byte frames cannot reach activationThreshold=200 even when
+      // drain is clamped to zero — the cap on per-frame contribution holds.
+      expect(d.update(50, 1500)).toBe(false);
+    });
+
+    it("clamps negative dataLength to zero contribution", () => {
+      const d = new OutputVolumeDetector(config);
+      // Defensive: a caller mistake mustn't blow up the bucket.
+      expect(d.update(-50, 1000)).toBe(false);
+      expect(d.update(-50, 1050)).toBe(false);
     });
   });
 
-  describe("reconfigureWindow", () => {
-    it("widens window so frames that straddled the old boundary are detectable", () => {
+  describe("recencyWindowMs", () => {
+    it("derives from activationThreshold / leakRatePerMs", () => {
       const d = new OutputVolumeDetector({
         enabled: true,
-        windowMs: 1000,
-        minFrames: 2,
-        minBytes: 1,
+        leakRatePerMs: 0.1,
+        activationThreshold: 200,
+        maxBytesPerFrame: 120,
       });
-      d.reconfigureWindow(2500);
-      d.update(1, 1000);
-      // 1700ms later — would have expired the 1000ms window, fits inside 2500ms.
-      expect(d.update(1, 2700)).toBe(true);
+      expect(d.recencyWindowMs).toBe(2000);
     });
 
-    it("clears in-flight frame accumulation on reconfigure", () => {
+    it("uses defaults when no params are provided", () => {
+      // Defaults: activationThreshold=2048, leakRatePerMs=2.048 → 1000ms.
+      const d = new OutputVolumeDetector({ enabled: true });
+      expect(d.recencyWindowMs).toBe(1000);
+    });
+  });
+
+  describe("defensive clamps", () => {
+    it("clamps non-positive leakRatePerMs to a small finite value", () => {
       const d = new OutputVolumeDetector({
         enabled: true,
-        windowMs: 1000,
-        minFrames: 2,
-        minBytes: 1,
+        leakRatePerMs: 0,
+        activationThreshold: 100,
+        maxBytesPerFrame: 50,
       });
-      d.update(1, 1000);
-      d.reconfigureWindow(2500);
-      // Prior frame was discarded — first frame after reconfigure cannot trigger.
-      expect(d.update(1, 1050)).toBe(false);
+      // recencyWindowMs must be finite even with 0 input.
+      expect(Number.isFinite(d.recencyWindowMs)).toBe(true);
     });
 
-    it("is a no-op when called with the current window size", () => {
+    it("clamps non-positive activationThreshold to 1 (always fireable)", () => {
       const d = new OutputVolumeDetector({
         enabled: true,
-        windowMs: 1000,
-        minFrames: 2,
-        minBytes: 1,
+        leakRatePerMs: 0.1,
+        activationThreshold: 0,
+        maxBytesPerFrame: 50,
       });
-      d.update(1, 1000);
-      d.reconfigureWindow(1000);
-      // Same value should preserve in-flight state.
-      expect(d.update(1, 1050)).toBe(true);
+      expect(d.update(1, 1000)).toBe(true);
     });
 
-    it("exposes the current windowMs through the getter", () => {
-      const d = new OutputVolumeDetector({ enabled: true, windowMs: 1000 });
-      expect(d.windowMs).toBe(1000);
-      d.reconfigureWindow(2500);
-      expect(d.windowMs).toBe(2500);
+    it("clamps non-positive maxBytesPerFrame to 1", () => {
+      const d = new OutputVolumeDetector({
+        enabled: true,
+        leakRatePerMs: 0.001,
+        activationThreshold: 2,
+        maxBytesPerFrame: 0,
+      });
+      // Each frame contributes at most 1 byte; 2 frames at fast cadence trigger.
+      d.update(100, 1000);
+      // Need a third frame because drain happens between frames; with cap=1
+      // and threshold=2, F2 level ≈ 1.95 < 2 → no trigger; F3 level ≈ 2.9.
+      d.update(100, 1050);
+      expect(d.update(100, 1100)).toBe(true);
     });
   });
 });

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -228,20 +228,20 @@ describe("buildActivityMonitorOptions", () => {
     const result = buildActivityMonitorOptions("claude", {});
     expect(result.outputActivityDetection).toEqual({
       enabled: true,
-      windowMs: 1000,
-      minFrames: 2,
-      minBytes: 1,
+      leakRatePerMs: 0.1,
+      activationThreshold: 200,
+      maxBytesPerFrame: 120,
     });
     expect(result.patternConfig).toBeDefined();
     expect(result.bootCompletePatterns).toBeDefined();
   });
 
-  it("sets background-tier recovery thresholds (#6641)", () => {
-    // Background polling (500ms) widens the volume window and shortens the
-    // recovery debouncer so backgrounded agents can escape "waiting" when
-    // output resumes. Active polling (50ms) keeps the existing thresholds.
+  it("sets background-tier recovery threshold (#6641)", () => {
+    // Background polling (500ms) shortens the recovery debouncer so
+    // backgrounded agents can escape "waiting" when output resumes. The
+    // volume detector is sample-cadence invariant (#6666), so no tier-
+    // specific window widening is needed.
     const result = buildActivityMonitorOptions("claude", {});
-    expect(result.backgroundOutputWindowMs).toBe(2500);
     expect(result.backgroundWorkingRecoveryDelayMs).toBe(600);
   });
 });

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -181,11 +181,17 @@ export function buildActivityMonitorOptions(
   const promptHintPatterns = buildPromptHintPatterns(detection, effectiveAgentId);
   const completionPatterns = buildCompletionPatterns(detection, effectiveAgentId);
 
+  // Sample-cadence-invariant leaky bucket (#6666). Drains at 100 bytes/sec,
+  // fires when ≥200 bytes accumulate, single chunks contribute at most 120
+  // bytes (the noise gate that prevents one oversized status-line write from
+  // tripping the gate). At 50ms tier with 50-byte chunks the bucket fills in
+  // ~5 frames; at 500ms tier with 100-byte chunks it fills in 3 frames —
+  // identical work-detection sensitivity at either polling cadence.
   const outputActivityDetection = {
     enabled: true,
-    windowMs: 1000,
-    minFrames: 2,
-    minBytes: 1,
+    leakRatePerMs: 0.1,
+    activationThreshold: 200,
+    maxBytesPerFrame: 120,
   };
 
   const getVisibleLines = effectiveAgentId ? deps.getVisibleLines : undefined;
@@ -208,11 +214,10 @@ export function buildActivityMonitorOptions(
     idleDebounceMs: effectiveAgentId ? (detection?.debounceMs ?? 4000) : undefined,
     promptFastPathMinQuietMs: detection?.promptFastPathMinQuietMs,
     maxWaitingSilenceMs: 600_000,
-    // Background polling (500ms) widens the volume window and shortens the
-    // recovery debouncer so backgrounded agents can escape "waiting" when
-    // output resumes (#6641). Active polling (50ms) keeps the existing
-    // outputActivityDetection.windowMs (1000ms) and 1500ms debouncer.
-    backgroundOutputWindowMs: 2500,
+    // Background polling (500ms) shortens the recovery debouncer so
+    // backgrounded agents can escape "waiting" when output resumes (#6641).
+    // The volume detector is now sample-cadence invariant (#6666) and needs
+    // no tier-specific override.
     backgroundWorkingRecoveryDelayMs: 600,
   };
 }


### PR DESCRIPTION
## Summary

- Replaces the windowed AND-gate activity classifier in `OutputVolumeDetector.ts` with a cadence-invariant leaky bucket. The old design used `minFrames`, `minBytes`, and `windowMs` thresholds that were only valid at the foreground polling cadence and broke silently at the background cadence.
- Removes the tier-aware override knobs (`backgroundOutputWindowMs`, `activeOutputWindowMs`, `reconfigureWindow()`) from `ActivityMonitor.ts` — those were a workaround for a fundamental design problem, not a fix.
- The new design is evaluation-rate invariant: the same byte stream produces the same classification regardless of how often the observer samples.

Resolves #6666

## Changes

- `OutputVolumeDetector.ts` — leaky bucket replaces AND-gate; `minFrames`/`minBytes`/`windowMs` constructor params removed
- `ActivityMonitor.ts` — tier-override path removed; `applyTier()` no longer calls `reconfigureWindow()`
- `terminalActivityPatterns.ts` / `IdleSequenceFilter.ts` — minor alignment with new detector interface
- `OutputVolumeDetector.test.ts`, `ActivityMonitor.test.ts`, `terminalActivityPatterns.test.ts` — tests rewritten and hardened; constructor guard against undefined-spread added and covered

## Testing

Unit tests cover the leaky bucket at both foreground (50ms) and background (500ms) polling cadences, verifying identical classification for identical byte streams. Constructor edge cases and the cosmetic-recovery debouncer path both have explicit coverage.