### PR TITLE
refactor(activity): extract CpuHighStateTracker and WaitingWatchdog

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -26,6 +26,8 @@ import { detectCompletion } from "./pty/CompletionDetector.js";
 import { CompletionTimer } from "./pty/CompletionTimer.js";
 import { BootDetector } from "./pty/BootDetector.js";
 import { classifyWaitingReason } from "./pty/WaitingReasonClassifier.js";
+import { CpuHighStateTracker } from "./pty/CpuHighStateTracker.js";
+import { WaitingWatchdog } from "./pty/WaitingWatchdog.js";
 import type { WaitingReason } from "../../shared/types/agent.js";
 
 export interface ProcessStateValidator {
@@ -118,18 +120,9 @@ export class ActivityMonitor {
   private readonly WORKING_INDICATOR_TTL_MS = 5000;
   private readonly MAX_WORKING_SILENCE_MS: number;
   private readonly MAX_WAITING_SILENCE_MS: number;
-  private readonly WATCHDOG_FAIL_THRESHOLD: number;
-  // CPU is a bounded busy-state backstop only. It never creates activity by
-  // itself; output, visible redraws, patterns, or input must put the monitor
-  // into busy first.
-  private readonly MAX_CPU_HIGH_ESCAPE_MS: number;
   private readonly CPU_HIGH_THRESHOLD = 10;
   private readonly CPU_LOW_THRESHOLD = 3;
-  private isCpuHigh = false;
-  private cpuHighSince = 0;
   private idleSince = 0;
-  private waitingWatchdogFired = false;
-  private watchdogFailCount = 0;
   private lastPatternResultAt = 0;
   private workingHoldUntil = 0;
 
@@ -158,6 +151,8 @@ export class ActivityMonitor {
   // time-counter. Driven by SynchronizedFrameDetector in TerminalProcess via
   // onSynchronizedFrame().
   private readonly synchronizedFrameAnalyzer: SynchronizedFrameAnalyzer;
+  private readonly cpuTracker: CpuHighStateTracker;
+  private readonly waitingWatchdog: WaitingWatchdog;
 
   // Resize suppression
   private resizeSuppressUntil = 0;
@@ -216,10 +211,10 @@ export class ActivityMonitor {
     this.PROMPT_FAST_PATH_MIN_QUIET_MS = options?.promptFastPathMinQuietMs ?? 3000;
     this.POLLING_MAX_BOOT_MS = options?.pollingMaxBootMs ?? 15000;
     this.MAX_WORKING_SILENCE_MS = options?.maxWorkingSilenceMs ?? 180000;
-    this.MAX_CPU_HIGH_ESCAPE_MS = options?.maxCpuHighEscapeMs ?? 60000;
+    const maxCpuHighEscapeMs = options?.maxCpuHighEscapeMs ?? 60000;
     this.MAX_WAITING_SILENCE_MS = options?.maxWaitingSilenceMs ?? 600000;
     const rawThreshold = options?.waitingWatchdogFailThreshold ?? 3;
-    this.WATCHDOG_FAIL_THRESHOLD = Number.isFinite(rawThreshold) ? Math.max(1, rawThreshold) : 3;
+    const watchdogFailThreshold = Number.isFinite(rawThreshold) ? Math.max(1, rawThreshold) : 3;
 
     this.idleSince = Date.now();
 
@@ -294,6 +289,23 @@ export class ActivityMonitor {
     // Polling interval
     this.POLLING_INTERVAL_MS = options?.pollingIntervalMs ?? 50;
 
+    this.cpuTracker = new CpuHighStateTracker(this.processStateValidator, {
+      cpuHighThreshold: this.CPU_HIGH_THRESHOLD,
+      cpuLowThreshold: this.CPU_LOW_THRESHOLD,
+      maxCpuHighEscapeMs,
+    });
+
+    this.waitingWatchdog = new WaitingWatchdog({
+      failThreshold: watchdogFailThreshold,
+      maxWaitingSilenceMs: this.MAX_WAITING_SILENCE_MS,
+      workingIndicatorTtlMs: this.WORKING_INDICATOR_TTL_MS,
+      cpuTracker: this.cpuTracker,
+      processStateValidator: this.processStateValidator,
+      onFire: (id, spawnedAt) => {
+        this.onWaitingTimeout?.(id, spawnedAt);
+      },
+    });
+
     // Apply initial tier so a monitor constructed with a background polling
     // interval (e.g. project starts hidden) gets the right thresholds before
     // any output arrives.
@@ -302,7 +314,7 @@ export class ActivityMonitor {
     // Lightweight watchdog interval: runs the waiting watchdog check periodically
     // even when there's no output/activity. 5s keeps overhead negligible while
     // ensuring hung waiting states are caught within a reasonable window.
-    this.watchdogInterval = setInterval(() => this.checkWaitingWatchdog(Date.now()), 5000);
+    this.watchdogInterval = setInterval(() => this.runWaitingWatchdogCheck(Date.now()), 5000);
   }
 
   private tierForInterval(intervalMs: number): "active" | "background" {
@@ -585,8 +597,7 @@ export class ActivityMonitor {
         // Callback failure must not prevent cleanup
       }
     }
-    this.waitingWatchdogFired = false;
-    this.watchdogFailCount = 0;
+    this.waitingWatchdog.reset();
     this.idleSince = 0;
     if (this.watchdogInterval) {
       clearInterval(this.watchdogInterval);
@@ -611,8 +622,7 @@ export class ActivityMonitor {
     this.resizeSuppressUntil = 0;
     this.lastPatternResult = undefined;
     this.lastPatternResultAt = 0;
-    this.isCpuHigh = false;
-    this.cpuHighSince = 0;
+    this.cpuTracker.reset();
     this.workingHoldUntil = 0;
     this.lastDataTimestamp = 0;
     this.lastOutputActivityAt = 0;
@@ -753,7 +763,7 @@ export class ActivityMonitor {
       }
     }
 
-    this.updateCpuHighState(now);
+    this.cpuTracker.update(now);
 
     // Safety timeout: if no PTY output for MAX_WORKING_SILENCE_MS, force idle
     if (this.isWorkingSilenceTimeout(now)) {
@@ -901,7 +911,7 @@ export class ActivityMonitor {
       shouldPreferPrompt &&
       quietForMs >= this.PROMPT_FAST_PATH_MIN_QUIET_MS &&
       now >= this.workingHoldUntil &&
-      !this.isCpuHighAndNotDeadlined(now) &&
+      !this.cpuTracker.isHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
@@ -930,7 +940,7 @@ export class ActivityMonitor {
       !hasHighOutputActivity &&
       quietForMs >= LEXEME_STALL_MIN_QUIET_MS &&
       now >= this.workingHoldUntil &&
-      !this.isCpuHighAndNotDeadlined(now) &&
+      !this.cpuTracker.isHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       const candidateLine =
@@ -958,7 +968,7 @@ export class ActivityMonitor {
       isQuietForIdle &&
       now >= this.workingHoldUntil &&
       !hasHighOutputActivity &&
-      !this.isCpuHighAndNotDeadlined(now) &&
+      !this.cpuTracker.isHighAndNotDeadlined(now) &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {
       this.state = "idle";
@@ -1047,8 +1057,7 @@ export class ActivityMonitor {
     this.lastDataTimestamp = now;
     this.recordWorkingSignal(now);
     this.resetDebounceTimer();
-    this.waitingWatchdogFired = false;
-    this.watchdogFailCount = 0;
+    this.waitingWatchdog.reset();
     // Clear any in-flight cosmetic-redraw accumulator so the next idle cycle
     // starts fresh — otherwise a single spinner tick after busy→idle would
     // immediately re-trigger recovery without sustained signal.
@@ -1130,7 +1139,7 @@ export class ActivityMonitor {
         return;
       }
 
-      if (this.isCpuHighAndNotDeadlined(now)) {
+      if (this.cpuTracker.isHighAndNotDeadlined(now)) {
         this.resetDebounceTimer();
         return;
       }
@@ -1149,111 +1158,21 @@ export class ActivityMonitor {
     // Non-polling terminals have no boot phase; polling terminals must exit boot first
     if (this.getVisibleLines && !this.bootDetector.hasExitedBootState) return false;
     // High CPU prevents premature silence timeout, but only up to the escape deadline.
-    if (this.isCpuHighAndNotDeadlined(now)) return false;
+    if (this.cpuTracker.isHighAndNotDeadlined(now)) return false;
     return true;
   }
 
-  private checkWaitingWatchdog(now: number): void {
-    if (this.state !== "idle") return;
-    if (this.waitingWatchdogFired) return;
-    if (now - this.idleSince < this.MAX_WAITING_SILENCE_MS) return;
+  private runWaitingWatchdogCheck(now: number): void {
     if (!this.onWaitingTimeout) return;
-
-    // Alive-veto probes — any positive signal that the agent is still alive
-    // resets the consecutive-fail streak. Order matters only insofar as the
-    // cheapest checks come first. A single lenient veto here is preferable
-    // to a stuck dead-vote streak: the 10-minute ceiling has already elapsed,
-    // so any fresh evidence of life genuinely should restart the consensus.
-    if (this.lineRewriteDetector.isSpinnerActive(now, this.SPINNER_ACTIVE_MS)) {
-      this.watchdogFailCount = 0;
-      return;
-    }
-    if (
-      this.lastPatternResult?.isWorking &&
-      now - this.lastPatternResultAt < this.WORKING_INDICATOR_TTL_MS
-    ) {
-      this.watchdogFailCount = 0;
-      return;
-    }
-    // Veto when PTY data arrived during the current waiting period AND the
-    // arrival was recent. The `> idleSince` guard rejects the field's
-    // construction-time default (set equal to idleSince) and any stale value
-    // carried over from a prior busy cycle; the recency window
-    // (WORKING_INDICATOR_TTL_MS, matched to the 5s watchdog cadence) decays so
-    // a single mid-cycle data event doesn't pin the streak open forever.
-    if (
-      this.lastDataTimestamp > this.idleSince &&
-      now - this.lastDataTimestamp < this.WORKING_INDICATOR_TTL_MS
-    ) {
-      this.watchdogFailCount = 0;
-      return;
-    }
-    if (this.isCpuHighAndNotDeadlined(now)) {
-      this.watchdogFailCount = 0;
-      return;
-    }
-
-    // Process-tree probe is the sole dead-vote signal. `null` (validator
-    // unavailable or threw) is ambiguous and resets the streak — silence
-    // alone, without an affirmative dead vote, must never fire the watchdog.
-    const hasChildren = this.hasActiveChildrenSafe();
-    if (hasChildren !== false) {
-      this.watchdogFailCount = 0;
-      return;
-    }
-
-    this.watchdogFailCount += 1;
-    if (this.watchdogFailCount < this.WATCHDOG_FAIL_THRESHOLD) return;
-
-    this.waitingWatchdogFired = true;
-    this.onWaitingTimeout(this.terminalId, this.spawnedAt);
-  }
-
-  private hasActiveChildrenSafe(): boolean | null {
-    if (!this.processStateValidator) {
-      return null;
-    }
-    try {
-      return this.processStateValidator.hasActiveChildren();
-    } catch (error) {
-      if (process.env.DAINTREE_VERBOSE) {
-        console.warn("[ActivityMonitor] Process state validation failed:", error);
-      }
-      return true;
-    }
-  }
-
-  private getCpuUsageSafe(): number | null {
-    if (!this.processStateValidator?.getDescendantsCpuUsage) {
-      return null;
-    }
-    try {
-      return this.processStateValidator.getDescendantsCpuUsage();
-    } catch (error) {
-      if (process.env.DAINTREE_VERBOSE) {
-        console.warn("[ActivityMonitor] CPU usage query failed:", error);
-      }
-      return null;
-    }
-  }
-
-  private updateCpuHighState(now: number): void {
-    const cpu = this.getCpuUsageSafe();
-    if (cpu === null) return;
-    if (this.isCpuHigh) {
-      if (cpu < this.CPU_LOW_THRESHOLD) {
-        this.isCpuHigh = false;
-        this.cpuHighSince = 0;
-      }
-    } else if (cpu >= this.CPU_HIGH_THRESHOLD) {
-      this.isCpuHigh = true;
-      this.cpuHighSince = now;
-    }
-  }
-
-  private isCpuHighAndNotDeadlined(now: number): boolean {
-    this.updateCpuHighState(now);
-    if (!this.isCpuHigh) return false;
-    return now - this.cpuHighSince < this.MAX_CPU_HIGH_ESCAPE_MS;
+    this.waitingWatchdog.check(now, {
+      state: this.state,
+      idleSince: this.idleSince,
+      isSpinnerActive: this.lineRewriteDetector.isSpinnerActive(now, this.SPINNER_ACTIVE_MS),
+      lastPatternResult: this.lastPatternResult,
+      lastPatternResultAt: this.lastPatternResultAt,
+      lastDataTimestamp: this.lastDataTimestamp,
+      terminalId: this.terminalId,
+      spawnedAt: this.spawnedAt,
+    });
   }
 }

--- a/electron/services/pty/CpuHighStateTracker.ts
+++ b/electron/services/pty/CpuHighStateTracker.ts
@@ -1,0 +1,69 @@
+import type { ProcessStateValidator } from "../ActivityMonitor.js";
+
+export interface CpuHighStateTrackerOptions {
+  cpuHighThreshold: number;
+  cpuLowThreshold: number;
+  maxCpuHighEscapeMs: number;
+}
+
+// CPU is a bounded busy-state backstop only. It never creates activity by
+// itself; output, visible redraws, patterns, or input must put the monitor
+// into busy first. Null validator → fail-open (no veto).
+export class CpuHighStateTracker {
+  private isCpuHigh = false;
+  private cpuHighSince = 0;
+
+  private readonly cpuHighThreshold: number;
+  private readonly cpuLowThreshold: number;
+  private readonly maxCpuHighEscapeMs: number;
+  private readonly validator?: ProcessStateValidator;
+
+  constructor(validator: ProcessStateValidator | undefined, opts: CpuHighStateTrackerOptions) {
+    this.validator = validator;
+    this.cpuHighThreshold = opts.cpuHighThreshold;
+    this.cpuLowThreshold = opts.cpuLowThreshold;
+    this.maxCpuHighEscapeMs = opts.maxCpuHighEscapeMs;
+  }
+
+  isHighAndNotDeadlined(now: number): boolean {
+    this.update(now);
+    if (!this.isCpuHigh) return false;
+    return now - this.cpuHighSince < this.maxCpuHighEscapeMs;
+  }
+
+  reset(): void {
+    this.isCpuHigh = false;
+    this.cpuHighSince = 0;
+  }
+
+  // Pull a fresh CPU sample and refresh internal state. Callers in a polling
+  // cycle should invoke this once per tick so cpuHighSince accumulates against
+  // wall time even when no isHighAndNotDeadlined() check fires.
+  update(now: number): void {
+    const cpu = this.getCpuUsageSafe();
+    if (cpu === null) return;
+    if (this.isCpuHigh) {
+      if (cpu < this.cpuLowThreshold) {
+        this.isCpuHigh = false;
+        this.cpuHighSince = 0;
+      }
+    } else if (cpu >= this.cpuHighThreshold) {
+      this.isCpuHigh = true;
+      this.cpuHighSince = now;
+    }
+  }
+
+  private getCpuUsageSafe(): number | null {
+    if (!this.validator?.getDescendantsCpuUsage) {
+      return null;
+    }
+    try {
+      return this.validator.getDescendantsCpuUsage();
+    } catch (error) {
+      if (process.env.DAINTREE_VERBOSE) {
+        console.warn("[ActivityMonitor] CPU usage query failed:", error);
+      }
+      return null;
+    }
+  }
+}

--- a/electron/services/pty/WaitingWatchdog.ts
+++ b/electron/services/pty/WaitingWatchdog.ts
@@ -1,0 +1,118 @@
+import type { PatternDetectionResult } from "./AgentPatternDetector.js";
+import type { ProcessStateValidator } from "../ActivityMonitor.js";
+import type { CpuHighStateTracker } from "./CpuHighStateTracker.js";
+
+export interface WaitingWatchdogOptions {
+  failThreshold: number;
+  maxWaitingSilenceMs: number;
+  workingIndicatorTtlMs: number;
+  cpuTracker: CpuHighStateTracker;
+  processStateValidator?: ProcessStateValidator;
+  onFire: (id: string, spawnedAt: number) => void;
+}
+
+export interface WaitingWatchdogProbeInputs {
+  state: "busy" | "idle";
+  idleSince: number;
+  isSpinnerActive: boolean;
+  lastPatternResult: PatternDetectionResult | undefined;
+  lastPatternResultAt: number;
+  lastDataTimestamp: number;
+  terminalId: string;
+  spawnedAt: number;
+}
+
+export class WaitingWatchdog {
+  private failCount = 0;
+  private fired = false;
+
+  private readonly failThreshold: number;
+  private readonly maxWaitingSilenceMs: number;
+  private readonly workingIndicatorTtlMs: number;
+  private readonly cpuTracker: CpuHighStateTracker;
+  private readonly validator?: ProcessStateValidator;
+  private readonly onFire: (id: string, spawnedAt: number) => void;
+
+  constructor(opts: WaitingWatchdogOptions) {
+    this.failThreshold = opts.failThreshold;
+    this.maxWaitingSilenceMs = opts.maxWaitingSilenceMs;
+    this.workingIndicatorTtlMs = opts.workingIndicatorTtlMs;
+    this.cpuTracker = opts.cpuTracker;
+    this.validator = opts.processStateValidator;
+    this.onFire = opts.onFire;
+  }
+
+  check(now: number, inputs: WaitingWatchdogProbeInputs): void {
+    if (inputs.state !== "idle") return;
+    if (this.fired) return;
+    if (now - inputs.idleSince < this.maxWaitingSilenceMs) return;
+
+    // Alive-veto probes — any positive signal that the agent is still alive
+    // resets the consecutive-fail streak. Order matters only insofar as the
+    // cheapest checks come first. A single lenient veto here is preferable
+    // to a stuck dead-vote streak: the 10-minute ceiling has already elapsed,
+    // so any fresh evidence of life genuinely should restart the consensus.
+    if (inputs.isSpinnerActive) {
+      this.failCount = 0;
+      return;
+    }
+    if (
+      inputs.lastPatternResult?.isWorking &&
+      now - inputs.lastPatternResultAt < this.workingIndicatorTtlMs
+    ) {
+      this.failCount = 0;
+      return;
+    }
+    // Veto when PTY data arrived during the current waiting period AND the
+    // arrival was recent. The `> idleSince` guard rejects the field's
+    // construction-time default (set equal to idleSince) and any stale value
+    // carried over from a prior busy cycle; the recency window
+    // (workingIndicatorTtlMs, matched to the 5s watchdog cadence) decays so
+    // a single mid-cycle data event doesn't pin the streak open forever.
+    if (
+      inputs.lastDataTimestamp > inputs.idleSince &&
+      now - inputs.lastDataTimestamp < this.workingIndicatorTtlMs
+    ) {
+      this.failCount = 0;
+      return;
+    }
+    if (this.cpuTracker.isHighAndNotDeadlined(now)) {
+      this.failCount = 0;
+      return;
+    }
+
+    // Process-tree probe is the sole dead-vote signal. `null` (validator
+    // unavailable or threw) is ambiguous and resets the streak — silence
+    // alone, without an affirmative dead vote, must never fire the watchdog.
+    const hasChildren = this.hasActiveChildrenSafe();
+    if (hasChildren !== false) {
+      this.failCount = 0;
+      return;
+    }
+
+    this.failCount += 1;
+    if (this.failCount < this.failThreshold) return;
+
+    this.fired = true;
+    this.onFire(inputs.terminalId, inputs.spawnedAt);
+  }
+
+  reset(): void {
+    this.failCount = 0;
+    this.fired = false;
+  }
+
+  private hasActiveChildrenSafe(): boolean | null {
+    if (!this.validator) {
+      return null;
+    }
+    try {
+      return this.validator.hasActiveChildren();
+    } catch (error) {
+      if (process.env.DAINTREE_VERBOSE) {
+        console.warn("[ActivityMonitor] Process state validation failed:", error);
+      }
+      return true;
+    }
+  }
+}

--- a/electron/services/pty/__tests__/CpuHighStateTracker.test.ts
+++ b/electron/services/pty/__tests__/CpuHighStateTracker.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import { CpuHighStateTracker } from "../CpuHighStateTracker.js";
+import type { ProcessStateValidator } from "../../ActivityMonitor.js";
+
+const OPTS = {
+  cpuHighThreshold: 10,
+  cpuLowThreshold: 3,
+  maxCpuHighEscapeMs: 60000,
+};
+
+function makeValidator(cpuValues: number[]): ProcessStateValidator {
+  let i = 0;
+  return {
+    hasActiveChildren: () => true,
+    getDescendantsCpuUsage: () => cpuValues[Math.min(i++, cpuValues.length - 1)],
+  };
+}
+
+describe("CpuHighStateTracker", () => {
+  describe("threshold transitions", () => {
+    it("flips low → high at the high threshold", () => {
+      const validator = makeValidator([9, 10, 11]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+
+      // 9: below high threshold, stays low
+      expect(t.isHighAndNotDeadlined(1000)).toBe(false);
+      // 10: at threshold, flips high (>=)
+      expect(t.isHighAndNotDeadlined(2000)).toBe(true);
+      // 11: stays high
+      expect(t.isHighAndNotDeadlined(3000)).toBe(true);
+    });
+
+    it("flips high → low only when CPU drops below the low threshold", () => {
+      // Start by flipping high.
+      const validator = makeValidator([15, 4, 3, 2]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(true);
+      // 4: between thresholds (hysteresis band) — stays high
+      expect(t.isHighAndNotDeadlined(2000)).toBe(true);
+      // 3: at the low threshold — must drop strictly BELOW to flip
+      expect(t.isHighAndNotDeadlined(3000)).toBe(true);
+      // 2: now below low threshold — flips low
+      expect(t.isHighAndNotDeadlined(4000)).toBe(false);
+    });
+  });
+
+  describe("deadline", () => {
+    it("returns false once now - cpuHighSince >= maxCpuHighEscapeMs", () => {
+      const validator = makeValidator([15, 15, 15]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(true); // cpuHighSince = 1000
+      expect(t.isHighAndNotDeadlined(60999)).toBe(true); // 59999 < 60000
+      expect(t.isHighAndNotDeadlined(61000)).toBe(false); // 60000 >= 60000 — deadlined
+    });
+
+    it("re-arms cpuHighSince after a low → high cycle", () => {
+      const validator = makeValidator([15, 2, 15]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(true); // cpuHighSince = 1000
+      expect(t.isHighAndNotDeadlined(2000)).toBe(false); // dropped low, cpuHighSince = 0
+      expect(t.isHighAndNotDeadlined(3000)).toBe(true); // re-armed at 3000
+      // The new arm fires its own deadline window, not the old one.
+      expect(t.isHighAndNotDeadlined(62000)).toBe(true); // 59000 < 60000
+    });
+  });
+
+  describe("null-safe fail-open", () => {
+    it("returns false when validator is undefined", () => {
+      const t = new CpuHighStateTracker(undefined, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(false);
+    });
+
+    it("returns false when validator lacks getDescendantsCpuUsage", () => {
+      const validator: ProcessStateValidator = {
+        hasActiveChildren: () => true,
+      };
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(false);
+    });
+
+    it("returns false when getDescendantsCpuUsage throws", () => {
+      const validator: ProcessStateValidator = {
+        hasActiveChildren: () => true,
+        getDescendantsCpuUsage: vi.fn(() => {
+          throw new Error("kaput");
+        }),
+      };
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(false);
+    });
+  });
+
+  describe("reset()", () => {
+    it("clears isCpuHigh and cpuHighSince", () => {
+      // Push to high, then reset; the next call must re-arm cpuHighSince to the new now.
+      const validator = makeValidator([15, 15]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+      expect(t.isHighAndNotDeadlined(1000)).toBe(true); // cpuHighSince = 1000
+      t.reset();
+      // Without reset, t=70_000 would be deadlined. After reset, isCpuHigh=false; next sample re-arms.
+      expect(t.isHighAndNotDeadlined(70000)).toBe(true); // cpuHighSince = 70000
+      expect(t.isHighAndNotDeadlined(70500)).toBe(true); // 500 < 60000
+    });
+  });
+
+  describe("update()", () => {
+    it("advances internal state without returning a boolean", () => {
+      const validator = makeValidator([15]);
+      const t = new CpuHighStateTracker(validator, OPTS);
+      t.update(1000);
+      // After update at t=1000, isHighAndNotDeadlined still returns true at t=1500
+      // and resamples a fresh value (validator returns last value when exhausted).
+      expect(t.isHighAndNotDeadlined(1500)).toBe(true);
+    });
+  });
+});

--- a/electron/services/pty/__tests__/CpuHighStateTracker.test.ts
+++ b/electron/services/pty/__tests__/CpuHighStateTracker.test.ts
@@ -104,13 +104,23 @@ describe("CpuHighStateTracker", () => {
   });
 
   describe("update()", () => {
-    it("advances internal state without returning a boolean", () => {
-      const validator = makeValidator([15]);
+    it("advances internal state when called standalone — proves no-op update is detected", () => {
+      // Validator returns 15 on call 1 (high), then 0 on call 2+ (well below low threshold).
+      // If update(1000) is a no-op, isHighAndNotDeadlined(1001) would consume sample #1 (15)
+      // and return true. With a real update(1000), sample #1 is consumed there, then
+      // isHighAndNotDeadlined(1001) consumes sample #2 (0) → drops low → returns false.
+      const validator: ProcessStateValidator = (() => {
+        const cpuValues = [15, 0];
+        let i = 0;
+        return {
+          hasActiveChildren: () => true,
+          getDescendantsCpuUsage: () => cpuValues[Math.min(i++, cpuValues.length - 1)],
+        };
+      })();
       const t = new CpuHighStateTracker(validator, OPTS);
-      t.update(1000);
-      // After update at t=1000, isHighAndNotDeadlined still returns true at t=1500
-      // and resamples a fresh value (validator returns last value when exhausted).
-      expect(t.isHighAndNotDeadlined(1500)).toBe(true);
+      t.update(1000); // arms high (sample 15), cpuHighSince = 1000
+      // isHighAndNotDeadlined consumes sample 0 → drops low.
+      expect(t.isHighAndNotDeadlined(1001)).toBe(false);
     });
   });
 });

--- a/electron/services/pty/__tests__/WaitingWatchdog.test.ts
+++ b/electron/services/pty/__tests__/WaitingWatchdog.test.ts
@@ -31,7 +31,7 @@ function makeWatchdog(opts?: {
   return { watchdog, onFire };
 }
 
-function deadProbe(now: number, idleSince: number): WaitingWatchdogProbeInputs {
+function deadProbe(_now: number, idleSince: number): WaitingWatchdogProbeInputs {
   return {
     state: "idle",
     idleSince,

--- a/electron/services/pty/__tests__/WaitingWatchdog.test.ts
+++ b/electron/services/pty/__tests__/WaitingWatchdog.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi } from "vitest";
+import { WaitingWatchdog, type WaitingWatchdogProbeInputs } from "../WaitingWatchdog.js";
+import { CpuHighStateTracker } from "../CpuHighStateTracker.js";
+import type { ProcessStateValidator } from "../../ActivityMonitor.js";
+
+const SILENCE_MS = 600000;
+const TTL_MS = 5000;
+const FAIL_THRESHOLD = 3;
+
+function makeWatchdog(opts?: {
+  validator?: ProcessStateValidator;
+  cpuTracker?: CpuHighStateTracker;
+  failThreshold?: number;
+}): { watchdog: WaitingWatchdog; onFire: ReturnType<typeof vi.fn> } {
+  const onFire = vi.fn<(id: string, spawnedAt: number) => void>();
+  const cpuTracker =
+    opts?.cpuTracker ??
+    new CpuHighStateTracker(undefined, {
+      cpuHighThreshold: 10,
+      cpuLowThreshold: 3,
+      maxCpuHighEscapeMs: 60000,
+    });
+  const watchdog = new WaitingWatchdog({
+    failThreshold: opts?.failThreshold ?? FAIL_THRESHOLD,
+    maxWaitingSilenceMs: SILENCE_MS,
+    workingIndicatorTtlMs: TTL_MS,
+    cpuTracker,
+    processStateValidator: opts?.validator,
+    onFire,
+  });
+  return { watchdog, onFire };
+}
+
+function deadProbe(now: number, idleSince: number): WaitingWatchdogProbeInputs {
+  return {
+    state: "idle",
+    idleSince,
+    isSpinnerActive: false,
+    lastPatternResult: undefined,
+    lastPatternResultAt: 0,
+    lastDataTimestamp: idleSince, // = idleSince so the > guard rejects it
+    terminalId: "term-1",
+    spawnedAt: 1000,
+  };
+}
+
+describe("WaitingWatchdog", () => {
+  it("fires after failThreshold consecutive dead-looking ticks", () => {
+    const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+    const { watchdog, onFire } = makeWatchdog({ validator });
+
+    const idleSince = 1000;
+    const start = idleSince + SILENCE_MS;
+
+    watchdog.check(start, deadProbe(start, idleSince)); // 1
+    expect(onFire).not.toHaveBeenCalled();
+    watchdog.check(start + 5000, deadProbe(start + 5000, idleSince)); // 2
+    expect(onFire).not.toHaveBeenCalled();
+    watchdog.check(start + 10000, deadProbe(start + 10000, idleSince)); // 3 — fires
+    expect(onFire).toHaveBeenCalledTimes(1);
+    expect(onFire).toHaveBeenCalledWith("term-1", 1000);
+  });
+
+  it("does not fire before maxWaitingSilenceMs has elapsed", () => {
+    const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+    const { watchdog, onFire } = makeWatchdog({ validator });
+
+    const idleSince = 1000;
+    // Just below the silence threshold.
+    watchdog.check(idleSince + SILENCE_MS - 1, deadProbe(idleSince + SILENCE_MS - 1, idleSince));
+    watchdog.check(idleSince + SILENCE_MS - 1, deadProbe(idleSince + SILENCE_MS - 1, idleSince));
+    watchdog.check(idleSince + SILENCE_MS - 1, deadProbe(idleSince + SILENCE_MS - 1, idleSince));
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when state is busy", () => {
+    const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+    const { watchdog, onFire } = makeWatchdog({ validator });
+
+    const idleSince = 1000;
+    const now = idleSince + SILENCE_MS + 20000;
+    const busy: WaitingWatchdogProbeInputs = { ...deadProbe(now, idleSince), state: "busy" };
+    watchdog.check(now, busy);
+    watchdog.check(now + 5000, busy);
+    watchdog.check(now + 10000, busy);
+    watchdog.check(now + 15000, busy);
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it("only fires once (one-shot until reset)", () => {
+    const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+    const { watchdog, onFire } = makeWatchdog({ validator });
+
+    const idleSince = 1000;
+    const start = idleSince + SILENCE_MS;
+    for (let i = 0; i < 10; i++) {
+      const now = start + i * 5000;
+      watchdog.check(now, deadProbe(now, idleSince));
+    }
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset() rearms the watchdog after a busy cycle", () => {
+    const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+    const { watchdog, onFire } = makeWatchdog({ validator });
+
+    const firstIdle = 1000;
+    const first = firstIdle + SILENCE_MS;
+    watchdog.check(first, deadProbe(first, firstIdle));
+    watchdog.check(first + 5000, deadProbe(first + 5000, firstIdle));
+    watchdog.check(first + 10000, deadProbe(first + 10000, firstIdle));
+    expect(onFire).toHaveBeenCalledTimes(1);
+
+    // New idle cycle after a busy → reset
+    watchdog.reset();
+    const secondIdle = first + 100000;
+    const second = secondIdle + SILENCE_MS;
+    watchdog.check(second, deadProbe(second, secondIdle));
+    watchdog.check(second + 5000, deadProbe(second + 5000, secondIdle));
+    watchdog.check(second + 10000, deadProbe(second + 10000, secondIdle));
+    expect(onFire).toHaveBeenCalledTimes(2);
+  });
+
+  describe("alive vetoes", () => {
+    it("active spinner resets failCount", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      watchdog.check(start, deadProbe(start, idleSince)); // failCount=1
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince)); // failCount=2
+
+      // Spinner active — resets failCount
+      const aliveProbe: WaitingWatchdogProbeInputs = {
+        ...deadProbe(start + 10000, idleSince),
+        isSpinnerActive: true,
+      };
+      watchdog.check(start + 10000, aliveProbe);
+
+      // One more dead tick should not fire — would have without the reset.
+      watchdog.check(start + 15000, deadProbe(start + 15000, idleSince)); // failCount=1
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("recent working pattern within TTL resets failCount", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      watchdog.check(start, deadProbe(start, idleSince)); // 1
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince)); // 2
+
+      const aliveProbe: WaitingWatchdogProbeInputs = {
+        ...deadProbe(start + 10000, idleSince),
+        lastPatternResult: { isWorking: true, confidence: 0.9, matchTier: "primary" },
+        lastPatternResultAt: start + 8000,
+      };
+      watchdog.check(start + 10000, aliveProbe);
+      watchdog.check(start + 15000, deadProbe(start + 15000, idleSince));
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("expired working pattern (older than TTL) does NOT reset", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      const aliveProbe = (now: number): WaitingWatchdogProbeInputs => ({
+        ...deadProbe(now, idleSince),
+        lastPatternResult: { isWorking: true, confidence: 0.9, matchTier: "primary" },
+        lastPatternResultAt: now - TTL_MS - 1, // older than TTL
+      });
+      watchdog.check(start, aliveProbe(start));
+      watchdog.check(start + 5000, aliveProbe(start + 5000));
+      watchdog.check(start + 10000, aliveProbe(start + 10000));
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+
+    it("recent PTY data resets failCount", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      watchdog.check(start, deadProbe(start, idleSince));
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince));
+
+      const aliveProbe: WaitingWatchdogProbeInputs = {
+        ...deadProbe(start + 10000, idleSince),
+        lastDataTimestamp: start + 9000, // > idleSince and within TTL
+      };
+      watchdog.check(start + 10000, aliveProbe);
+      watchdog.check(start + 15000, deadProbe(start + 15000, idleSince));
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("data exactly at idleSince does NOT veto (must be strictly greater)", () => {
+      // deadProbe sets lastDataTimestamp = idleSince; this should not count as a veto.
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      watchdog.check(start, deadProbe(start, idleSince));
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince));
+      watchdog.check(start + 10000, deadProbe(start + 10000, idleSince));
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+
+    it("CPU high (and not deadlined) resets failCount", () => {
+      const validator: ProcessStateValidator = {
+        hasActiveChildren: () => false,
+        getDescendantsCpuUsage: () => 50,
+      };
+      const cpuTracker = new CpuHighStateTracker(validator, {
+        cpuHighThreshold: 10,
+        cpuLowThreshold: 3,
+        maxCpuHighEscapeMs: 60000,
+      });
+      const { watchdog, onFire } = makeWatchdog({ validator, cpuTracker });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      // First call arms the CPU tracker at `start`. From this moment, the
+      // tracker's deadline is `start + 60_000`. Each tick CPU is high → veto.
+      watchdog.check(start, deadProbe(start, idleSince));
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince));
+      watchdog.check(start + 10000, deadProbe(start + 10000, idleSince));
+      watchdog.check(start + 15000, deadProbe(start + 15000, idleSince));
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("hasActiveChildren === true resets failCount (alive)", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => true };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      for (let i = 0; i < 5; i++) {
+        const now = start + i * 5000;
+        watchdog.check(now, deadProbe(now, idleSince));
+      }
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("missing validator (null) resets failCount — never fires on silence alone", () => {
+      // No validator at all.
+      const { watchdog, onFire } = makeWatchdog();
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      for (let i = 0; i < 5; i++) {
+        const now = start + i * 5000;
+        watchdog.check(now, deadProbe(now, idleSince));
+      }
+      expect(onFire).not.toHaveBeenCalled();
+    });
+
+    it("validator throws → treated as alive (true), resets failCount", () => {
+      const validator: ProcessStateValidator = {
+        hasActiveChildren: () => {
+          throw new Error("psutil exploded");
+        },
+      };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      for (let i = 0; i < 5; i++) {
+        const now = start + i * 5000;
+        watchdog.check(now, deadProbe(now, idleSince));
+      }
+      expect(onFire).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("custom failThreshold", () => {
+    it("clamps to 1 — fires on the first dead tick", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator, failThreshold: 1 });
+
+      const idleSince = 1000;
+      const now = idleSince + SILENCE_MS;
+      watchdog.check(now, deadProbe(now, idleSince));
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/electron/services/pty/__tests__/WaitingWatchdog.test.ts
+++ b/electron/services/pty/__tests__/WaitingWatchdog.test.ts
@@ -277,6 +277,65 @@ describe("WaitingWatchdog", () => {
     });
   });
 
+  describe("contract: busy skip does not reset failCount", () => {
+    it("partial dead-vote streak persists across a busy tick — only reset() clears it", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      // Accumulate failCount = 2.
+      watchdog.check(start, deadProbe(start, idleSince));
+      watchdog.check(start + 5000, deadProbe(start + 5000, idleSince));
+      // Busy tick: early-return, must NOT reset.
+      const busyProbe: WaitingWatchdogProbeInputs = {
+        ...deadProbe(start + 10000, idleSince),
+        state: "busy",
+      };
+      watchdog.check(start + 10000, busyProbe);
+      // One more dead tick → failCount becomes 3 → fires.
+      watchdog.check(start + 15000, deadProbe(start + 15000, idleSince));
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("TTL boundary for lastDataTimestamp veto", () => {
+    it("data exactly at the TTL boundary does NOT veto (strict <)", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      // lastDataTimestamp at start - TTL_MS → now - lastDataTimestamp = TTL_MS (not < TTL).
+      // Also must satisfy lastDataTimestamp > idleSince. With idleSince=1000 and TTL=5000,
+      // lastDataTimestamp = start - TTL = 596000 which is > 1000.
+      const probe = (now: number, dataAt: number): WaitingWatchdogProbeInputs => ({
+        ...deadProbe(now, idleSince),
+        lastDataTimestamp: dataAt,
+      });
+      watchdog.check(start, probe(start, start - TTL_MS));
+      watchdog.check(start + 5000, probe(start + 5000, start + 5000 - TTL_MS));
+      watchdog.check(start + 10000, probe(start + 10000, start + 10000 - TTL_MS));
+      expect(onFire).toHaveBeenCalledTimes(1);
+    });
+
+    it("data 1ms inside the TTL boundary DOES veto", () => {
+      const validator: ProcessStateValidator = { hasActiveChildren: () => false };
+      const { watchdog, onFire } = makeWatchdog({ validator });
+
+      const idleSince = 1000;
+      const start = idleSince + SILENCE_MS;
+      const probe = (now: number, dataAt: number): WaitingWatchdogProbeInputs => ({
+        ...deadProbe(now, idleSince),
+        lastDataTimestamp: dataAt,
+      });
+      watchdog.check(start, probe(start, start - TTL_MS + 1));
+      watchdog.check(start + 5000, probe(start + 5000, start + 5000 - TTL_MS + 1));
+      watchdog.check(start + 10000, probe(start + 10000, start + 10000 - TTL_MS + 1));
+      expect(onFire).not.toHaveBeenCalled();
+    });
+  });
+
   describe("custom failThreshold", () => {
     it("clamps to 1 — fires on the first dead tick", () => {
       const validator: ProcessStateValidator = { hasActiveChildren: () => false };


### PR DESCRIPTION
## Summary

- `ActivityMonitor.ts` was 1259 lines. Two coherent subsystems — CPU-high state tracking and the waiting watchdog — have been extracted into their own files in `electron/services/pty/`, following the precedent set by the existing subsystems there.
- Pure refactor, no behaviour changes. All existing `ActivityMonitor`, pattern, and agent-detection tests stay green.
- 27 new isolated unit tests added across two new test files.

Resolves #6709

## Changes

- `electron/services/pty/CpuHighStateTracker.ts` — extracted from `ActivityMonitor.ts` (`getCpuUsageSafe`, `updateCpuHighState`, `isCpuHighAndNotDeadlined`, `hasActiveChildrenSafe`)
- `electron/services/pty/WaitingWatchdog.ts` — extracted from `ActivityMonitor.ts` (the dedicated 5 s `setInterval`, `checkWaitingWatchdog`, `waitingWatchdogFired`, `watchdogFailCount`, `WATCHDOG_FAIL_THRESHOLD`)
- `electron/services/ActivityMonitor.ts` — down from 1259 to 1178 lines; delegates to the two new classes
- `electron/services/pty/__tests__/CpuHighStateTracker.test.ts` — 11 unit tests
- `electron/services/pty/__tests__/WaitingWatchdog.test.ts` — 16 unit tests

## Testing

All 246 pre-existing `ActivityMonitor`, pattern, and agent-detection tests pass. 27 new tests cover the extracted classes in isolation. Typecheck, lint, and format all clean.