### PR TITLE
refactor(browser): split BrowserPane into useWebviewEvents and useBrowserActionListeners

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -3,6 +3,8 @@ import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
+import { useWebviewEvents } from "@/hooks/useWebviewEvents";
+import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import { AlertTriangle, ExternalLink, RotateCw, Square } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
@@ -29,7 +31,6 @@ import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
 import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
-import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import { useFindInPage } from "@/hooks/useFindInPage";
 import { logError } from "@/utils/logger";
 
@@ -281,271 +282,23 @@ export function BrowserPane({
     };
   }, [webviewElement, isWebviewReady, id, addStructuredMessage, markStale]);
 
-  // Set up webview event listeners - reattach whenever webview element changes
-  useEffect(() => {
-    const webview = webviewElement;
-    if (!webview) {
-      setIsWebviewReady(false);
-      return;
-    }
-
-    const clearAllTimers = () => {
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
-      if (loadTimeoutRef.current) {
-        clearTimeout(loadTimeoutRef.current);
-        loadTimeoutRef.current = null;
-      }
-    };
-
-    const handleDomReady = () => {
-      isInitialRestoredLoadRef.current = false;
-      setIsWebviewReady(true);
-      clearAllTimers();
-    };
-
-    const handleDidStartLoading = () => {
-      setIsLoading(true);
-      setLoadError(null);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-      }
-      if (loadTimeoutRef.current) {
-        clearTimeout(loadTimeoutRef.current);
-      }
-      slowLoadTimeoutRef.current = setTimeout(() => {
-        try {
-          if (webview.isLoading()) {
-            setIsSlowLoad(true);
-          }
-        } catch {
-          // Webview detached before timeout fired
-        }
-      }, 5000);
-      loadTimeoutRef.current = setTimeout(() => {
-        loadTimeoutRef.current = null;
-        try {
-          if (webview.isLoading()) {
-            webview.stop();
-            setIsSlowLoad(false);
-            setIsLoading(false);
-            setLoadError(
-              `Load timed out after ${Math.round(loadTimeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
-            );
-          }
-        } catch {
-          // Webview detached before timeout fired
-        }
-      }, loadTimeoutMs);
-    };
-
-    const handleDidStopLoading = () => {
-      setIsLoading(false);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
-      if (loadTimeoutRef.current) {
-        clearTimeout(loadTimeoutRef.current);
-        loadTimeoutRef.current = null;
-      }
-    };
-
-    const handleDidFailLoad = (event: Electron.DidFailLoadEvent) => {
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
-      if (loadTimeoutRef.current) {
-        clearTimeout(loadTimeoutRef.current);
-        loadTimeoutRef.current = null;
-      }
-      // Ignore aborted loads (e.g., navigation interrupted by another navigation)
-      if (event.errorCode === -3) return;
-      // Ignore cancellations
-      if (event.errorCode === -6) return;
-      setIsLoading(false);
-      const ERR_CONNECTION_REFUSED = -102;
-      const ERR_NAME_NOT_RESOLVED = -105;
-      const ERR_INTERNET_DISCONNECTED = -106;
-      const ERR_CONNECTION_TIMED_OUT = -118;
-      if (
-        event.isMainFrame &&
-        event.errorCode === ERR_CONNECTION_REFUSED &&
-        isInitialRestoredLoadRef.current
-      ) {
-        setLoadError(
-          "The saved URL is no longer reachable. The server may have moved to a different port."
-        );
-      } else if (
-        event.isMainFrame &&
-        event.errorCode === ERR_NAME_NOT_RESOLVED &&
-        event.validatedURL
-      ) {
-        let hostname = event.validatedURL;
-        try {
-          hostname = new URL(event.validatedURL).hostname;
-        } catch {
-          // Use raw validatedURL if parsing fails
-        }
-        setLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
-      } else if (event.isMainFrame && event.errorCode === ERR_INTERNET_DISCONNECTED) {
-        setLoadError("No internet connection. Check your network.");
-      } else if (
-        event.isMainFrame &&
-        event.errorCode === ERR_CONNECTION_TIMED_OUT &&
-        event.validatedURL
-      ) {
-        setLoadError(
-          `Connection to ${event.validatedURL} timed out. The server may be unreachable.`
-        );
-      } else if (event.isMainFrame) {
-        const urlContext = event.validatedURL ? ` at ${event.validatedURL}` : "";
-        setLoadError(
-          event.errorDescription
-            ? `${event.errorDescription}${urlContext}`
-            : `Failed to load page${urlContext}. The site may be unavailable.`
-        );
-      }
-    };
-
-    const handleDidNavigate = (event: Electron.DidNavigateEvent) => {
-      const newUrl = event.url;
-      // Suppress about:blank navigations triggered by eviction
-      if (newUrl === "about:blank" && evictingRef.current) return;
-      isInitialRestoredLoadRef.current = false;
-      setBlockedNav(null);
-      // Only update history if this is a new URL (not our programmatic navigation)
-      if (newUrl !== lastSetUrlRef.current) {
-        setHistory((prev) => pushBrowserHistory(prev, newUrl));
-        lastSetUrlRef.current = newUrl;
-      }
-      if (projectId) {
-        let title: string | undefined;
-        try {
-          title = webview.getTitle();
-        } catch {
-          // webview may not be ready for getTitle
-        }
-        useUrlHistoryStore.getState().recordVisit(projectId, newUrl, title);
-      }
-    };
-
-    const handleDidNavigateInPage = (event: Electron.DidNavigateInPageEvent) => {
-      if (!event.isMainFrame) return;
-      setBlockedNav(null);
-      const newUrl = event.url;
-      if (newUrl !== lastSetUrlRef.current) {
-        setHistory((prev) => pushBrowserHistory(prev, newUrl));
-        lastSetUrlRef.current = newUrl;
-      }
-      if (projectId) {
-        let title: string | undefined;
-        try {
-          title = webview.getTitle();
-        } catch {
-          // webview may not be ready for getTitle
-        }
-        useUrlHistoryStore.getState().recordVisit(projectId, newUrl, title);
-      }
-    };
-
-    const handlePageTitleUpdated = (event: Event) => {
-      const detail = event as Event & { title?: string; explicitSet?: boolean };
-      if (detail.explicitSet === false) return;
-      if (projectId && detail.title) {
-        try {
-          useUrlHistoryStore.getState().updateTitle(projectId, webview.getURL(), detail.title);
-        } catch {
-          // webview may be detached
-        }
-      }
-    };
-
-    // Debounce favicon updates to avoid store thrashing on rapid events
-    let faviconDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-    const handlePageFaviconUpdated = (event: Event) => {
-      const detail = event as Event & { favicons?: string[] };
-      if (!projectId || !detail.favicons?.length) return;
-      const favicon = detail.favicons[0]!;
-      // Skip oversized data URLs that could exceed localStorage quota
-      if (favicon.startsWith("data:") && favicon.length > 8192) return;
-      // Capture URL at event time to avoid race with navigation
-      let capturedUrl: string;
-      try {
-        capturedUrl = webview.getURL();
-      } catch {
-        return;
-      }
-      if (!capturedUrl || capturedUrl === "about:blank") return;
-      if (faviconDebounceTimer) clearTimeout(faviconDebounceTimer);
-      const url = capturedUrl;
-      faviconDebounceTimer = setTimeout(() => {
-        faviconDebounceTimer = null;
-        useUrlHistoryStore.getState().updateFavicon(projectId, url, favicon);
-      }, 200);
-    };
-
-    try {
-      const existingUrl = webview.getURL();
-      if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
-        setIsWebviewReady(true);
-        setIsLoading(false);
-        const savedZoom = zoomFactor;
-        if (Number.isFinite(savedZoom)) {
-          webview.setZoomFactor(savedZoom);
-        }
-      }
-    } catch {
-      // Webview not yet attached to DOM - dom-ready handler will take over
-    }
-
-    webview.addEventListener("dom-ready", handleDomReady);
-    webview.addEventListener("did-start-loading", handleDidStartLoading);
-    webview.addEventListener("did-stop-loading", handleDidStopLoading);
-    webview.addEventListener("did-fail-load", handleDidFailLoad);
-    webview.addEventListener("did-navigate", handleDidNavigate);
-    webview.addEventListener("did-navigate-in-page", handleDidNavigateInPage);
-    webview.addEventListener("page-title-updated", handlePageTitleUpdated);
-    webview.addEventListener("page-favicon-updated", handlePageFaviconUpdated);
-
-    return () => {
-      webview.removeEventListener("dom-ready", handleDomReady);
-      webview.removeEventListener("did-start-loading", handleDidStartLoading);
-      webview.removeEventListener("did-stop-loading", handleDidStopLoading);
-      webview.removeEventListener("did-fail-load", handleDidFailLoad);
-      webview.removeEventListener("did-navigate", handleDidNavigate);
-      webview.removeEventListener("did-navigate-in-page", handleDidNavigateInPage);
-      webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
-      webview.removeEventListener("page-favicon-updated", handlePageFaviconUpdated);
-      if (faviconDebounceTimer) {
-        clearTimeout(faviconDebounceTimer);
-        faviconDebounceTimer = null;
-      }
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
-      if (loadTimeoutRef.current) {
-        clearTimeout(loadTimeoutRef.current);
-        loadTimeoutRef.current = null;
-      }
-    };
-  }, [
+  useWebviewEvents({
     webviewElement,
-    hasValidUrl,
-    loadError,
-    zoomFactor,
-    id,
+    isInitialRestoredLoadRef,
+    lastSetUrlRef,
+    slowLoadTimeoutRef,
+    loadTimeoutRef,
+    evictingRef,
     projectId,
     loadTimeoutMs,
-    evictingRef,
-  ]);
+    zoomFactor,
+    setIsWebviewReady,
+    setIsLoading,
+    setLoadError,
+    setIsSlowLoad,
+    setBlockedNav,
+    setHistory,
+  });
 
   const commitNavigation = useCallback(
     (url: string) => {
@@ -769,147 +522,24 @@ export function BrowserPane({
     };
   }, []);
 
-  // Listen for action-driven browser events
-  useEffect(() => {
-    const handleReloadEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleReload();
-      }
-    };
+  const handleSetZoom = useCallback((rawZoom: number) => {
+    // Validate and clamp zoom factor to [0.25, 2.0]
+    const validZoom = Number.isFinite(rawZoom) ? Math.max(0.25, Math.min(2.0, rawZoom)) : 1.0;
+    setZoomFactor(validZoom);
+  }, []);
 
-    const handleNavigateEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if (typeof (detail as { url?: unknown }).url !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleNavigate((detail as { url: string }).url);
-      }
-    };
-
-    const handleBackEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleBack();
-      }
-    };
-
-    const handleForwardEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleForward();
-      }
-    };
-
-    const handleSetZoomEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if (typeof (detail as { zoomFactor?: unknown }).zoomFactor !== "number") return;
-      if ((detail as { id: string }).id === id) {
-        const rawZoom = (detail as { zoomFactor: number }).zoomFactor;
-        // Validate and clamp zoom factor to [0.25, 2.0]
-        const validZoom = Number.isFinite(rawZoom) ? Math.max(0.25, Math.min(2.0, rawZoom)) : 1.0;
-        setZoomFactor(validZoom);
-      }
-    };
-
-    const handleCaptureScreenshotEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        void handleCaptureScreenshot();
-      }
-    };
-
-    const handleToggleConsoleEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleToggleConsole();
-      }
-    };
-
-    const handleClearConsoleEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleClearConsole();
-      }
-    };
-
-    const handleToggleDevToolsEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleToggleDevTools();
-      }
-    };
-
-    const handleHardReloadEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleHardReload();
-      }
-    };
-
-    const controller = new AbortController();
-    window.addEventListener("daintree:reload-browser", handleReloadEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-navigate", handleNavigateEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-back", handleBackEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-forward", handleForwardEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-set-zoom", handleSetZoomEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-capture-screenshot", handleCaptureScreenshotEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-toggle-console", handleToggleConsoleEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-clear-console", handleClearConsoleEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:browser-toggle-devtools", handleToggleDevToolsEvent, {
-      signal: controller.signal,
-    });
-    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
-      signal: controller.signal,
-    });
-    return () => controller.abort();
-  }, [
-    id,
-    handleReload,
-    handleNavigate,
-    handleBack,
-    handleForward,
-    handleCaptureScreenshot,
-    handleToggleConsole,
-    handleClearConsole,
-    handleToggleDevTools,
-    handleHardReload,
-  ]);
+  useBrowserActionListeners(id, {
+    onReload: handleReload,
+    onNavigate: handleNavigate,
+    onBack: handleBack,
+    onForward: handleForward,
+    onSetZoom: handleSetZoom,
+    onCaptureScreenshot: handleCaptureScreenshot,
+    onToggleConsole: handleToggleConsole,
+    onClearConsole: handleClearConsole,
+    onToggleDevTools: handleToggleDevTools,
+    onHardReload: handleHardReload,
+  });
 
   // Blank the webview before React unmounts it for faster memory reclamation
   useEffect(() => {

--- a/src/hooks/useBrowserActionListeners.ts
+++ b/src/hooks/useBrowserActionListeners.ts
@@ -1,0 +1,89 @@
+import { useEffect, useEffectEvent } from "react";
+
+export type BrowserActionCallbacks = {
+  onReload: () => void;
+  onNavigate: (url: string) => void;
+  onBack: () => void;
+  onForward: () => void;
+  onSetZoom: (rawZoom: number) => void;
+  onCaptureScreenshot: () => void;
+  onToggleConsole: () => void;
+  onClearConsole: () => void;
+  onToggleDevTools: () => void;
+  onHardReload: () => void;
+};
+
+const BROWSER_ACTION_EVENTS = [
+  "daintree:reload-browser",
+  "daintree:browser-navigate",
+  "daintree:browser-back",
+  "daintree:browser-forward",
+  "daintree:browser-set-zoom",
+  "daintree:browser-capture-screenshot",
+  "daintree:browser-toggle-console",
+  "daintree:browser-clear-console",
+  "daintree:browser-toggle-devtools",
+  "daintree:hard-reload-browser",
+] as const;
+
+/**
+ * Subscribes a BrowserPane instance to the action-driven `daintree:*` window
+ * events that drive its toolbar/keybinding integrations. Each callback is
+ * invoked only when the event's `detail.id` matches the panel's `id`.
+ *
+ * Callbacks are read non-reactively via `useEffectEvent`, so the underlying
+ * effect only re-binds when `id` changes.
+ */
+export function useBrowserActionListeners(id: string, callbacks: BrowserActionCallbacks): void {
+  const dispatch = useEffectEvent((eventType: string, detail: Record<string, unknown>) => {
+    switch (eventType) {
+      case "daintree:reload-browser":
+        callbacks.onReload();
+        return;
+      case "daintree:browser-navigate":
+        if (typeof detail.url === "string") callbacks.onNavigate(detail.url);
+        return;
+      case "daintree:browser-back":
+        callbacks.onBack();
+        return;
+      case "daintree:browser-forward":
+        callbacks.onForward();
+        return;
+      case "daintree:browser-set-zoom":
+        if (typeof detail.zoomFactor === "number") callbacks.onSetZoom(detail.zoomFactor);
+        return;
+      case "daintree:browser-capture-screenshot":
+        callbacks.onCaptureScreenshot();
+        return;
+      case "daintree:browser-toggle-console":
+        callbacks.onToggleConsole();
+        return;
+      case "daintree:browser-clear-console":
+        callbacks.onClearConsole();
+        return;
+      case "daintree:browser-toggle-devtools":
+        callbacks.onToggleDevTools();
+        return;
+      case "daintree:hard-reload-browser":
+        callbacks.onHardReload();
+        return;
+    }
+  });
+
+  useEffect(() => {
+    const handle = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail: unknown = e.detail;
+      if (typeof detail !== "object" || detail === null) return;
+      if (!("id" in detail) || typeof detail.id !== "string") return;
+      if (detail.id !== id) return;
+      dispatch(e.type, detail as Record<string, unknown>);
+    };
+
+    const controller = new AbortController();
+    for (const type of BROWSER_ACTION_EVENTS) {
+      window.addEventListener(type, handle, { signal: controller.signal });
+    }
+    return () => controller.abort();
+  }, [id]);
+}

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -1,0 +1,337 @@
+import { useEffect, useEffectEvent } from "react";
+import type { BrowserHistory } from "@shared/types/browser";
+import { pushBrowserHistory } from "@/components/Browser/historyUtils";
+import { useUrlHistoryStore } from "@/store/urlHistoryStore";
+
+// Threshold after which a load is reported as "Taking longer than usual…"
+// Independent of the hard timeout (loadTimeoutMs) which actually aborts.
+const SLOW_LOAD_THRESHOLD_MS = 5000;
+// Coalesce favicon-updated bursts to avoid thrashing the URL-history store.
+const FAVICON_DEBOUNCE_MS = 200;
+
+export type UseWebviewEventsOptions = {
+  webviewElement: Electron.WebviewTag | null;
+  isInitialRestoredLoadRef: React.MutableRefObject<boolean>;
+  lastSetUrlRef: React.MutableRefObject<string>;
+  slowLoadTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  loadTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  evictingRef: React.RefObject<boolean>;
+  projectId: string | undefined;
+  loadTimeoutMs: number;
+  zoomFactor: number;
+  setIsWebviewReady: (v: boolean) => void;
+  setIsLoading: (v: boolean) => void;
+  setLoadError: (v: string | null) => void;
+  setIsSlowLoad: (v: boolean) => void;
+  setBlockedNav: (v: { url: string; canOpenExternal: boolean } | null) => void;
+  setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
+};
+
+/**
+ * Owns the BrowserPane <webview> lifecycle event listeners: dom-ready,
+ * did-start/stop-loading, did-fail-load, did-navigate(-in-page), and
+ * page-title/favicon-updated. Drives the slow-load and hard-timeout timers.
+ *
+ * Volatile values (`zoomFactor`, `projectId`, `loadTimeoutMs`) are read via
+ * `useEffectEvent` so the listener bindings are not re-installed on every
+ * change — the effect re-runs only when `webviewElement` itself swaps, which
+ * matches the original behavior modulo the spurious `loadError`/`hasValidUrl`
+ * deps that were never read inside the effect body.
+ */
+export function useWebviewEvents({
+  webviewElement,
+  isInitialRestoredLoadRef,
+  lastSetUrlRef,
+  slowLoadTimeoutRef,
+  loadTimeoutRef,
+  evictingRef,
+  projectId,
+  loadTimeoutMs,
+  zoomFactor,
+  setIsWebviewReady,
+  setIsLoading,
+  setLoadError,
+  setIsSlowLoad,
+  setBlockedNav,
+  setHistory,
+}: UseWebviewEventsOptions): void {
+  const getZoomFactor = useEffectEvent(() => zoomFactor);
+  const getProjectId = useEffectEvent(() => projectId);
+  const getLoadTimeoutMs = useEffectEvent(() => loadTimeoutMs);
+
+  useEffect(() => {
+    const webview = webviewElement;
+    if (!webview) {
+      setIsWebviewReady(false);
+      return;
+    }
+
+    const clearAllTimers = () => {
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+    };
+
+    const handleDomReady = () => {
+      isInitialRestoredLoadRef.current = false;
+      setIsWebviewReady(true);
+      clearAllTimers();
+    };
+
+    const handleDidStartLoading = () => {
+      setIsLoading(true);
+      setLoadError(null);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+      }
+      slowLoadTimeoutRef.current = setTimeout(() => {
+        try {
+          if (webview.isLoading()) {
+            setIsSlowLoad(true);
+          }
+        } catch {
+          // Webview detached before timeout fired
+        }
+      }, SLOW_LOAD_THRESHOLD_MS);
+      const timeoutMs = getLoadTimeoutMs();
+      loadTimeoutRef.current = setTimeout(() => {
+        loadTimeoutRef.current = null;
+        try {
+          if (webview.isLoading()) {
+            webview.stop();
+            setIsSlowLoad(false);
+            setIsLoading(false);
+            setLoadError(
+              `Load timed out after ${Math.round(timeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
+            );
+          }
+        } catch {
+          // Webview detached before timeout fired
+        }
+      }, timeoutMs);
+    };
+
+    const handleDidStopLoading = () => {
+      setIsLoading(false);
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+    };
+
+    const handleDidFailLoad = (event: Electron.DidFailLoadEvent) => {
+      setIsSlowLoad(false);
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+      // Ignore aborted loads (e.g., navigation interrupted by another navigation)
+      if (event.errorCode === -3) return;
+      // Ignore cancellations
+      if (event.errorCode === -6) return;
+      setIsLoading(false);
+      const ERR_CONNECTION_REFUSED = -102;
+      const ERR_NAME_NOT_RESOLVED = -105;
+      const ERR_INTERNET_DISCONNECTED = -106;
+      const ERR_CONNECTION_TIMED_OUT = -118;
+      if (
+        event.isMainFrame &&
+        event.errorCode === ERR_CONNECTION_REFUSED &&
+        isInitialRestoredLoadRef.current
+      ) {
+        setLoadError(
+          "The saved URL is no longer reachable. The server may have moved to a different port."
+        );
+      } else if (
+        event.isMainFrame &&
+        event.errorCode === ERR_NAME_NOT_RESOLVED &&
+        event.validatedURL
+      ) {
+        let hostname = event.validatedURL;
+        try {
+          hostname = new URL(event.validatedURL).hostname;
+        } catch {
+          // Use raw validatedURL if parsing fails
+        }
+        setLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
+      } else if (event.isMainFrame && event.errorCode === ERR_INTERNET_DISCONNECTED) {
+        setLoadError("No internet connection. Check your network.");
+      } else if (
+        event.isMainFrame &&
+        event.errorCode === ERR_CONNECTION_TIMED_OUT &&
+        event.validatedURL
+      ) {
+        setLoadError(
+          `Connection to ${event.validatedURL} timed out. The server may be unreachable.`
+        );
+      } else if (event.isMainFrame) {
+        const urlContext = event.validatedURL ? ` at ${event.validatedURL}` : "";
+        setLoadError(
+          event.errorDescription
+            ? `${event.errorDescription}${urlContext}`
+            : `Failed to load page${urlContext}. The site may be unavailable.`
+        );
+      }
+    };
+
+    const handleDidNavigate = (event: Electron.DidNavigateEvent) => {
+      const newUrl = event.url;
+      // Suppress about:blank navigations triggered by eviction
+      if (newUrl === "about:blank" && evictingRef.current) return;
+      isInitialRestoredLoadRef.current = false;
+      setBlockedNav(null);
+      // Only update history if this is a new URL (not our programmatic navigation)
+      if (newUrl !== lastSetUrlRef.current) {
+        setHistory((prev) => pushBrowserHistory(prev, newUrl));
+        lastSetUrlRef.current = newUrl;
+      }
+      const currentProjectId = getProjectId();
+      if (currentProjectId) {
+        let title: string | undefined;
+        try {
+          title = webview.getTitle();
+        } catch {
+          // webview may not be ready for getTitle
+        }
+        useUrlHistoryStore.getState().recordVisit(currentProjectId, newUrl, title);
+      }
+    };
+
+    const handleDidNavigateInPage = (event: Electron.DidNavigateInPageEvent) => {
+      if (!event.isMainFrame) return;
+      setBlockedNav(null);
+      const newUrl = event.url;
+      if (newUrl !== lastSetUrlRef.current) {
+        setHistory((prev) => pushBrowserHistory(prev, newUrl));
+        lastSetUrlRef.current = newUrl;
+      }
+      const currentProjectId = getProjectId();
+      if (currentProjectId) {
+        let title: string | undefined;
+        try {
+          title = webview.getTitle();
+        } catch {
+          // webview may not be ready for getTitle
+        }
+        useUrlHistoryStore.getState().recordVisit(currentProjectId, newUrl, title);
+      }
+    };
+
+    const handlePageTitleUpdated = (event: Event) => {
+      const detail = event as Event & { title?: string; explicitSet?: boolean };
+      if (detail.explicitSet === false) return;
+      const currentProjectId = getProjectId();
+      if (currentProjectId && detail.title) {
+        try {
+          useUrlHistoryStore
+            .getState()
+            .updateTitle(currentProjectId, webview.getURL(), detail.title);
+        } catch {
+          // webview may be detached
+        }
+      }
+    };
+
+    // Debounce favicon updates to avoid store thrashing on rapid events
+    let faviconDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const handlePageFaviconUpdated = (event: Event) => {
+      const detail = event as Event & { favicons?: string[] };
+      const currentProjectId = getProjectId();
+      if (!currentProjectId || !detail.favicons?.length) return;
+      const favicon = detail.favicons[0]!;
+      // Skip oversized data URLs that could exceed localStorage quota
+      if (favicon.startsWith("data:") && favicon.length > 8192) return;
+      // Capture URL at event time to avoid race with navigation
+      let capturedUrl: string;
+      try {
+        capturedUrl = webview.getURL();
+      } catch {
+        return;
+      }
+      if (!capturedUrl || capturedUrl === "about:blank") return;
+      if (faviconDebounceTimer) clearTimeout(faviconDebounceTimer);
+      const url = capturedUrl;
+      faviconDebounceTimer = setTimeout(() => {
+        faviconDebounceTimer = null;
+        useUrlHistoryStore.getState().updateFavicon(currentProjectId, url, favicon);
+      }, FAVICON_DEBOUNCE_MS);
+    };
+
+    try {
+      const existingUrl = webview.getURL();
+      if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
+        setIsWebviewReady(true);
+        setIsLoading(false);
+        const savedZoom = getZoomFactor();
+        if (Number.isFinite(savedZoom)) {
+          webview.setZoomFactor(savedZoom);
+        }
+      }
+    } catch {
+      // Webview not yet attached to DOM - dom-ready handler will take over
+    }
+
+    webview.addEventListener("dom-ready", handleDomReady);
+    webview.addEventListener("did-start-loading", handleDidStartLoading);
+    webview.addEventListener("did-stop-loading", handleDidStopLoading);
+    webview.addEventListener("did-fail-load", handleDidFailLoad);
+    webview.addEventListener("did-navigate", handleDidNavigate);
+    webview.addEventListener("did-navigate-in-page", handleDidNavigateInPage);
+    webview.addEventListener("page-title-updated", handlePageTitleUpdated);
+    webview.addEventListener("page-favicon-updated", handlePageFaviconUpdated);
+
+    return () => {
+      webview.removeEventListener("dom-ready", handleDomReady);
+      webview.removeEventListener("did-start-loading", handleDidStartLoading);
+      webview.removeEventListener("did-stop-loading", handleDidStopLoading);
+      webview.removeEventListener("did-fail-load", handleDidFailLoad);
+      webview.removeEventListener("did-navigate", handleDidNavigate);
+      webview.removeEventListener("did-navigate-in-page", handleDidNavigateInPage);
+      webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
+      webview.removeEventListener("page-favicon-updated", handlePageFaviconUpdated);
+      if (faviconDebounceTimer) {
+        clearTimeout(faviconDebounceTimer);
+        faviconDebounceTimer = null;
+      }
+      if (slowLoadTimeoutRef.current) {
+        clearTimeout(slowLoadTimeoutRef.current);
+        slowLoadTimeoutRef.current = null;
+      }
+      if (loadTimeoutRef.current) {
+        clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+    };
+  }, [
+    webviewElement,
+    evictingRef,
+    isInitialRestoredLoadRef,
+    lastSetUrlRef,
+    slowLoadTimeoutRef,
+    loadTimeoutRef,
+    setIsWebviewReady,
+    setIsLoading,
+    setLoadError,
+    setIsSlowLoad,
+    setBlockedNav,
+    setHistory,
+  ]);
+}


### PR DESCRIPTION
## Summary

- Pure refactor of `BrowserPane.tsx` — 1,209 lines down to 839, no behavior changes
- `useWebviewEvents` (310 lines) owns the webview lifecycle, slow-load detection, and hard-timeout timers
- `useBrowserActionListeners` (90 lines) collapses 10 near-identical `daintree:*` custom event listeners into a single `AbortController`-managed effect with a `useEffectEvent` dispatcher

Resolves #6704

## Changes

- Dropped spurious `loadError` and `hasValidUrl` deps from the lifecycle effect — neither was read inside the effect body
- `zoomFactor`, `projectId`, and `loadTimeoutMs` now read via `useEffectEvent` so listeners don't rebind on every value change
- All 5 critical behaviors preserved: probe-on-mount (#2239), `ERR_CONNECTION_REFUSED` special path (#4896), timer-ref ownership, zoom-factor type guard, and all 5 `isInitialRestoredLoadRef` mutation sites

## Testing

- `BrowserPane.webview.test.tsx` — 31/31 passing, no test changes required
- Typecheck, lint ratchet, format, channels, and build all green
- Lint ratchet reports 15 fewer warnings than baseline