### PR TITLE
refactor(window): split windowServices startup orchestration

### DIFF
--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // task-ordering assertions below.
 const registeredTaskNames: string[] = [];
 const setMcpRegistry = vi.fn();
+let migrationCurrentVersion = 1;
+let migrationShouldThrow = false;
 
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -16,9 +18,13 @@ vi.mock("../../services/StoreMigrations.js", () => ({
   LATEST_SCHEMA_VERSION: 1,
   MigrationRunner: class {
     getCurrentVersion(): number {
-      return 1;
+      return migrationCurrentVersion;
     }
-    runMigrations = vi.fn();
+    async runMigrations(): Promise<void> {
+      if (migrationShouldThrow) {
+        throw new Error("test-migration-failure");
+      }
+    }
   },
   isStoreMigrationError: () => false,
 }));
@@ -158,13 +164,19 @@ vi.mock("electron", () => ({
 }));
 
 import { initGlobalServices } from "../globalServicesInit.js";
-import { setGlobalServicesInitialized } from "../serviceRefs.js";
+import { getGlobalServicesInitialized, setGlobalServicesInitialized } from "../serviceRefs.js";
 import type { WindowRegistry } from "../WindowRegistry.js";
+import { app } from "electron";
 
 describe("initGlobalServices task ordering", () => {
   beforeEach(() => {
     registeredTaskNames.length = 0;
-    setMcpRegistry.mockClear();
+    // mockReset (not mockClear) so mockImplementation set in one test doesn't
+    // leak into the next — keeps tests independent as the suite grows.
+    setMcpRegistry.mockReset();
+    (app.exit as ReturnType<typeof vi.fn>).mockReset();
+    migrationCurrentVersion = 1;
+    migrationShouldThrow = false;
     setGlobalServicesInitialized(false);
   });
 
@@ -229,5 +241,24 @@ describe("initGlobalServices task ordering", () => {
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     const result = await initGlobalServices(fakeRegistry);
     expect(result).toBe("ok");
+  });
+
+  it("returns 'exit-requested' and calls app.exit(1) when migrations throw", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    // Force the migration runner down the runMigrations() path AND make it throw
+    // — currentVersion must differ from LATEST_SCHEMA_VERSION (mocked at 1).
+    migrationCurrentVersion = 0;
+    migrationShouldThrow = true;
+
+    const result = await initGlobalServices(fakeRegistry);
+
+    expect(result).toBe("exit-requested");
+    expect(app.exit).toHaveBeenCalledWith(1);
+    // No deferred tasks should have been registered after the failure point —
+    // the function returns before reaching the post-migration registrations.
+    expect(registeredTaskNames).toEqual([]);
+    // Guard is set early so a concurrent second window doesn't double-run
+    // migrations; app.exit(1) terminates the process before that matters.
+    expect(getGlobalServicesInitialized()).toBe(true);
   });
 });

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Spy on registerDeferredTask before importing globalServicesInit so that the
+// imported module captures our mock. Names recorded here drive the
+// task-ordering assertions below.
+const registeredTaskNames: string[] = [];
+const setMcpRegistry = vi.fn();
+
+vi.mock("../../utils/performance.js", () => ({
+  markPerformance: vi.fn(),
+  startEventLoopLagMonitor: vi.fn(() => () => {}),
+  startProcessMemoryMonitor: vi.fn(() => () => {}),
+}));
+
+vi.mock("../../services/StoreMigrations.js", () => ({
+  LATEST_SCHEMA_VERSION: 1,
+  MigrationRunner: class {
+    getCurrentVersion(): number {
+      return 1;
+    }
+    runMigrations = vi.fn();
+  },
+  isStoreMigrationError: () => false,
+}));
+
+vi.mock("../../store.js", () => ({
+  store: {
+    get: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock("../../services/TelemetryService.js", () => ({
+  initializeTelemetry: vi.fn(),
+  setOnboardingCompleteTag: vi.fn(),
+}));
+
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: {
+    initializeStorage: vi.fn(),
+    hasToken: () => false,
+    getToken: () => null,
+    getTokenVersion: () => 0,
+    setMemoryToken: vi.fn(),
+    setValidatedUserInfo: vi.fn(),
+    validate: vi.fn(),
+  },
+}));
+
+vi.mock("../../services/github/GitHubTokenHealthService.js", () => ({
+  gitHubTokenHealthService: { start: vi.fn(), dispose: vi.fn() },
+}));
+
+vi.mock("../../services/connectivity/index.js", () => ({
+  agentConnectivityService: { start: vi.fn(), dispose: vi.fn() },
+  getServiceConnectivityRegistry: () => ({ start: vi.fn(), dispose: vi.fn() }),
+}));
+
+vi.mock("../../services/SecureStorage.js", () => ({
+  secureStorage: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock("../../services/NotificationService.js", () => ({
+  notificationService: {
+    showNativeNotification: vi.fn(),
+    isWindowFocused: () => false,
+  },
+}));
+
+vi.mock("../../services/PreAgentSnapshotService.js", () => ({
+  preAgentSnapshotService: { initialize: vi.fn(), dispose: vi.fn() },
+}));
+
+vi.mock("../../services/ActionBreadcrumbService.js", () => ({
+  getActionBreadcrumbService: () => ({ initialize: vi.fn() }),
+}));
+
+vi.mock("../../services/HibernationService.js", () => ({
+  initializeHibernationService: vi.fn(),
+  getHibernationService: () => ({ stop: vi.fn(), hibernateUnderMemoryPressure: vi.fn() }),
+}));
+
+vi.mock("../../services/pty/terminalSessionPersistence.js", () => ({
+  evictSessionFiles: vi.fn(async () => ({ deleted: 0, bytesFreed: 0 })),
+  SESSION_EVICTION_TTL_MS: 0,
+  SESSION_EVICTION_MAX_BYTES: 0,
+}));
+
+vi.mock("../../services/SystemSleepService.js", () => ({
+  initializeSystemSleepService: vi.fn(),
+  getSystemSleepService: () => ({ dispose: vi.fn() }),
+}));
+
+vi.mock("../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: () => ({ startBackupTimer: vi.fn(), stopBackupTimer: vi.fn() }),
+}));
+
+vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
+  startAppMetricsMonitor: vi.fn(() => () => {}),
+}));
+
+vi.mock("../../services/ResourceProfileService.js", () => ({
+  ResourceProfileService: class {
+    start = vi.fn();
+    stop = vi.fn();
+  },
+}));
+
+vi.mock("../../services/DiskSpaceMonitor.js", () => ({
+  startDiskSpaceMonitor: vi.fn(() => () => {}),
+}));
+
+vi.mock("../../ipc/handlers.js", () => ({
+  sendToRenderer: vi.fn(),
+}));
+
+vi.mock("../webContentsRegistry.js", () => ({
+  getAppWebContents: vi.fn(),
+}));
+
+vi.mock("../windowRef.js", () => ({
+  getProjectViewManager: vi.fn(),
+}));
+
+vi.mock("../../ipc/handlers/projectCrud/index.js", () => ({
+  getProjectStatsService: vi.fn(),
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: {
+    getAllProjects: () => [],
+    getProjectState: vi.fn(),
+  },
+}));
+
+vi.mock("../../setup/environment.js", () => ({
+  exposeGc: vi.fn(),
+}));
+
+vi.mock("../../services/HelpSessionService.js", () => ({
+  helpSessionService: {
+    setMcpRegistry,
+    validateToken: vi.fn(),
+  },
+}));
+
+vi.mock("../deferredInitQueue.js", () => ({
+  registerDeferredTask: vi.fn((task: { name: string; run: () => unknown }) => {
+    registeredTaskNames.push(task.name);
+  }),
+  finalizeDeferredRegistration: vi.fn(),
+  resetDeferredQueue: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { exit: vi.fn() },
+  dialog: { showErrorBox: vi.fn() },
+  session: { defaultSession: { clearCache: vi.fn(), clearStorageData: vi.fn() } },
+}));
+
+import { initGlobalServices } from "../globalServicesInit.js";
+import { setGlobalServicesInitialized } from "../serviceRefs.js";
+import type { WindowRegistry } from "../WindowRegistry.js";
+
+describe("initGlobalServices task ordering", () => {
+  beforeEach(() => {
+    registeredTaskNames.length = 0;
+    setMcpRegistry.mockClear();
+    setGlobalServicesInitialized(false);
+  });
+
+  afterEach(() => {
+    setGlobalServicesInitialized(false);
+  });
+
+  it("registers monitor tasks before resource-profile-service so the profile reads ready data", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const lagIndex = registeredTaskNames.indexOf("event-loop-lag-monitor");
+    const metricsIndex = registeredTaskNames.indexOf("app-metrics-monitor");
+    const profileIndex = registeredTaskNames.indexOf("resource-profile-service");
+
+    expect(lagIndex).toBeGreaterThanOrEqual(0);
+    expect(metricsIndex).toBeGreaterThanOrEqual(0);
+    expect(profileIndex).toBeGreaterThanOrEqual(0);
+    expect(profileIndex).toBeGreaterThan(lagIndex);
+    expect(profileIndex).toBeGreaterThan(metricsIndex);
+  });
+
+  it("registers service-connectivity-registry before mcp-server so onStatusChange wires first", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const registryIndex = registeredTaskNames.indexOf("service-connectivity-registry");
+    const mcpIndex = registeredTaskNames.indexOf("mcp-server");
+
+    expect(registryIndex).toBeGreaterThanOrEqual(0);
+    expect(mcpIndex).toBeGreaterThanOrEqual(0);
+    expect(mcpIndex).toBeGreaterThan(registryIndex);
+  });
+
+  it("calls helpSessionService.setMcpRegistry before pushing the mcp-server task", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+
+    // Capture the index at which setMcpRegistry was called by recording a
+    // marker into the same task-name list when the mock fires.
+    setMcpRegistry.mockImplementation(() => {
+      registeredTaskNames.push("__setMcpRegistry__");
+    });
+
+    await initGlobalServices(fakeRegistry);
+
+    const setIdx = registeredTaskNames.indexOf("__setMcpRegistry__");
+    const mcpIdx = registeredTaskNames.indexOf("mcp-server");
+
+    expect(setIdx).toBeGreaterThanOrEqual(0);
+    expect(mcpIdx).toBeGreaterThan(setIdx);
+  });
+
+  it("skips MCP-related tasks when no windowRegistry is supplied", async () => {
+    await initGlobalServices(undefined);
+
+    expect(registeredTaskNames).not.toContain("mcp-server");
+    expect(registeredTaskNames).not.toContain("help-session-gc");
+    expect(setMcpRegistry).not.toHaveBeenCalled();
+  });
+
+  it("returns 'ok' on the happy path", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    const result = await initGlobalServices(fakeRegistry);
+    expect(result).toBe("ok");
+  });
+});

--- a/electron/window/__tests__/serviceRefs.test.ts
+++ b/electron/window/__tests__/serviceRefs.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getPtyClient,
+  setPtyClientRef,
+  getMainProcessWatchdogClientRef,
+  setMainProcessWatchdogClientRef,
+  getWorkspaceClientRef,
+  setWorkspaceClientRef,
+  getWorktreePortBrokerRef,
+  setWorktreePortBrokerRef,
+  getCliAvailabilityServiceRef,
+  setCliAvailabilityServiceRef,
+  getCleanupIpcHandlers,
+  setCleanupIpcHandlers,
+  getCleanupErrorHandlers,
+  setCleanupErrorHandlers,
+  getStopEventLoopLagMonitor,
+  setStopEventLoopLagMonitor,
+  getStopProcessMemoryMonitor,
+  setStopProcessMemoryMonitor,
+  getStopAppMetricsMonitor,
+  setStopAppMetricsMonitor,
+  getStopDiskSpaceMonitor,
+  setStopDiskSpaceMonitor,
+  getResourceProfileService,
+  setResourceProfileService,
+  getCcrConfigService,
+  setCcrConfigService,
+  getAutoUpdaterServiceRef,
+  setAutoUpdaterServiceRef,
+  getAgentNotificationServiceRef,
+  setAgentNotificationServiceRef,
+  getAgentVersionService,
+  setAgentVersionService,
+  getAgentUpdateHandler,
+  setAgentUpdateHandler,
+  getProcessArgvCliHandled,
+  setProcessArgvCliHandled,
+  getIpcHandlersRegistered,
+  setIpcHandlersRegistered,
+  getGlobalServicesInitialized,
+  setGlobalServicesInitialized,
+} from "../serviceRefs.js";
+
+describe("serviceRefs", () => {
+  // Reset every ref to its initial null/false state after each case so
+  // module-level let bindings don't bleed between tests.
+  afterEach(() => {
+    setPtyClientRef(null);
+    setMainProcessWatchdogClientRef(null);
+    setWorkspaceClientRef(null);
+    setWorktreePortBrokerRef(null);
+    setCliAvailabilityServiceRef(null);
+    setCleanupIpcHandlers(null);
+    setCleanupErrorHandlers(null);
+    setStopEventLoopLagMonitor(null);
+    setStopProcessMemoryMonitor(null);
+    setStopAppMetricsMonitor(null);
+    setStopDiskSpaceMonitor(null);
+    setResourceProfileService(null);
+    setCcrConfigService(null);
+    setAutoUpdaterServiceRef(null);
+    setAgentNotificationServiceRef(null);
+    setAgentVersionService(null);
+    setAgentUpdateHandler(null);
+    setProcessArgvCliHandled(false);
+    setIpcHandlersRegistered(false);
+    setGlobalServicesInitialized(false);
+  });
+
+  it("returns null for service refs by default", () => {
+    expect(getPtyClient()).toBeNull();
+    expect(getMainProcessWatchdogClientRef()).toBeNull();
+    expect(getWorkspaceClientRef()).toBeNull();
+    expect(getWorktreePortBrokerRef()).toBeNull();
+    expect(getCliAvailabilityServiceRef()).toBeNull();
+    expect(getCleanupIpcHandlers()).toBeNull();
+    expect(getCleanupErrorHandlers()).toBeNull();
+    expect(getStopEventLoopLagMonitor()).toBeNull();
+    expect(getStopProcessMemoryMonitor()).toBeNull();
+    expect(getStopAppMetricsMonitor()).toBeNull();
+    expect(getStopDiskSpaceMonitor()).toBeNull();
+    expect(getResourceProfileService()).toBeNull();
+    expect(getCcrConfigService()).toBeNull();
+    expect(getAutoUpdaterServiceRef()).toBeNull();
+    expect(getAgentNotificationServiceRef()).toBeNull();
+    expect(getAgentVersionService()).toBeNull();
+    expect(getAgentUpdateHandler()).toBeNull();
+  });
+
+  it("returns false for guard flags by default", () => {
+    expect(getProcessArgvCliHandled()).toBe(false);
+    expect(getIpcHandlersRegistered()).toBe(false);
+    expect(getGlobalServicesInitialized()).toBe(false);
+  });
+
+  it("round-trips function-typed setters", () => {
+    const cleanup = (): void => {};
+    setCleanupIpcHandlers(cleanup);
+    expect(getCleanupIpcHandlers()).toBe(cleanup);
+    setCleanupIpcHandlers(null);
+    expect(getCleanupIpcHandlers()).toBeNull();
+
+    const stop = (): void => {};
+    setStopEventLoopLagMonitor(stop);
+    expect(getStopEventLoopLagMonitor()).toBe(stop);
+  });
+
+  it("round-trips guard flags through their setters", () => {
+    setIpcHandlersRegistered(true);
+    expect(getIpcHandlersRegistered()).toBe(true);
+    setIpcHandlersRegistered(false);
+    expect(getIpcHandlersRegistered()).toBe(false);
+
+    setGlobalServicesInitialized(true);
+    expect(getGlobalServicesInitialized()).toBe(true);
+    setGlobalServicesInitialized(false);
+    expect(getGlobalServicesInitialized()).toBe(false);
+
+    setProcessArgvCliHandled(true);
+    expect(getProcessArgvCliHandled()).toBe(true);
+  });
+
+  it("round-trips object refs (PtyClient, WorkspaceClient stand-ins)", () => {
+    const ptyStub = { id: "pty" } as unknown as Parameters<typeof setPtyClientRef>[0];
+    setPtyClientRef(ptyStub);
+    expect(getPtyClient()).toBe(ptyStub);
+
+    const wsStub = { id: "workspace" } as unknown as Parameters<typeof setWorkspaceClientRef>[0];
+    setWorkspaceClientRef(wsStub);
+    expect(getWorkspaceClientRef()).toBe(wsStub);
+
+    setPtyClientRef(null);
+    setWorkspaceClientRef(null);
+    expect(getPtyClient()).toBeNull();
+    expect(getWorkspaceClientRef()).toBeNull();
+  });
+
+  it("isolates each ref — setting one does not affect another", () => {
+    const ptyStub = {} as unknown as Parameters<typeof setPtyClientRef>[0];
+    setPtyClientRef(ptyStub);
+    expect(getWorkspaceClientRef()).toBeNull();
+    expect(getCliAvailabilityServiceRef()).toBeNull();
+    expect(getCcrConfigService()).toBeNull();
+  });
+});

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -48,7 +48,6 @@ import { projectStore } from "../services/ProjectStore.js";
 import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import {
-  getCcrConfigService,
   setCcrConfigService,
   getResourceProfileService,
   setResourceProfileService,

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -1,0 +1,590 @@
+import { app, dialog, session } from "electron";
+import {
+  LATEST_SCHEMA_VERSION,
+  MigrationRunner,
+  isStoreMigrationError,
+} from "../services/StoreMigrations.js";
+import { initializeTelemetry, setOnboardingCompleteTag } from "../services/TelemetryService.js";
+import { GitHubAuth } from "../services/github/GitHubAuth.js";
+import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
+import {
+  agentConnectivityService,
+  getServiceConnectivityRegistry,
+} from "../services/connectivity/index.js";
+import { secureStorage } from "../services/SecureStorage.js";
+import { notificationService } from "../services/NotificationService.js";
+import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
+import { getActionBreadcrumbService } from "../services/ActionBreadcrumbService.js";
+import {
+  initializeHibernationService,
+  getHibernationService,
+} from "../services/HibernationService.js";
+import {
+  evictSessionFiles,
+  SESSION_EVICTION_TTL_MS,
+  SESSION_EVICTION_MAX_BYTES,
+} from "../services/pty/terminalSessionPersistence.js";
+import { initializeSystemSleepService } from "../services/SystemSleepService.js";
+import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+import {
+  markPerformance,
+  startEventLoopLagMonitor,
+  startProcessMemoryMonitor,
+} from "../utils/performance.js";
+import { startAppMetricsMonitor } from "../services/ProcessMemoryMonitor.js";
+import { ResourceProfileService } from "../services/ResourceProfileService.js";
+import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
+import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
+import { exposeGc } from "../setup/environment.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { CHANNELS } from "../ipc/channels.js";
+import { sendToRenderer } from "../ipc/handlers.js";
+import { getAppWebContents } from "./webContentsRegistry.js";
+import type { WindowRegistry } from "./WindowRegistry.js";
+import { getProjectViewManager } from "./windowRef.js";
+import { getProjectStatsService } from "../ipc/handlers/projectCrud/index.js";
+import { registerDeferredTask } from "./deferredInitQueue.js";
+import { projectStore } from "../services/ProjectStore.js";
+import { store } from "../store.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import {
+  getCcrConfigService,
+  setCcrConfigService,
+  getResourceProfileService,
+  setResourceProfileService,
+  getStopAppMetricsMonitor,
+  setStopAppMetricsMonitor,
+  getStopDiskSpaceMonitor,
+  setStopDiskSpaceMonitor,
+  getStopEventLoopLagMonitor,
+  setStopEventLoopLagMonitor,
+  getStopProcessMemoryMonitor,
+  setStopProcessMemoryMonitor,
+  getPtyClient,
+  getWorkspaceClientRef,
+  setAutoUpdaterServiceRef,
+  setAgentNotificationServiceRef,
+  setGlobalServicesInitialized,
+} from "./serviceRefs.js";
+
+async function evictStaleSessionFiles(): Promise<void> {
+  try {
+    const allProjects = projectStore.getAllProjects();
+    const knownIds = new Set<string>();
+
+    const states = await Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id)));
+    for (const state of states) {
+      if (state?.terminals) {
+        for (const t of state.terminals) {
+          knownIds.add(t.id);
+        }
+      }
+    }
+
+    const appTerminals = store.get("appState")?.terminals;
+    if (Array.isArray(appTerminals)) {
+      for (const t of appTerminals) {
+        knownIds.add(t.id);
+      }
+    }
+
+    const result = await evictSessionFiles({
+      ttlMs: SESSION_EVICTION_TTL_MS,
+      maxBytes: SESSION_EVICTION_MAX_BYTES,
+      knownIds,
+    });
+
+    if (result.deleted > 0) {
+      console.log(
+        `[MAIN] Session eviction: deleted ${result.deleted} file(s), freed ${(result.bytesFreed / 1024 / 1024).toFixed(1)} MB`
+      );
+    }
+  } catch (err) {
+    console.warn("[MAIN] Session eviction failed:", err);
+  }
+}
+
+/**
+ * Run the once-per-app-lifecycle global initialization on the first window
+ * setup. Migrations run inline (synchronous, blocking); everything else is
+ * either a synchronous boot (GitHubAuth storage, preAgentSnapshot, ccrConfig)
+ * or registered as a deferred task that drains after first-interactive.
+ *
+ * Returns "exit-requested" when migrations fail and `app.exit(1)` has been
+ * called — the caller MUST early-return without continuing setup.
+ */
+export async function initGlobalServices(
+  windowRegistry?: WindowRegistry
+): Promise<"ok" | "exit-requested"> {
+  setGlobalServicesInitialized(true);
+  markPerformance(PERF_MARKS.SERVICE_INIT_START);
+
+  // Store migrations — lazy-load the migrations barrel only when the store is
+  // out of sync with the latest schema version. In the common case (already up
+  // to date), this skips parsing ~15KB of migration modules on startup.
+  try {
+    const migrationRunner = new MigrationRunner(store);
+    const currentVersion = migrationRunner.getCurrentVersion();
+    if (currentVersion !== LATEST_SCHEMA_VERSION) {
+      console.log(
+        `[MAIN] Running store migrations (v${currentVersion} -> v${LATEST_SCHEMA_VERSION})...`
+      );
+      const { migrations } = await import("../services/migrations/index.js");
+      await migrationRunner.runMigrations(migrations);
+      console.log("[MAIN] Store migrations completed");
+    }
+    markPerformance(PERF_MARKS.SERVICE_INIT_MIGRATIONS_DONE);
+  } catch (error) {
+    console.error("[MAIN] Store migration failed:", error);
+    const message = formatErrorMessage(error, "Store migration failed");
+    const lines = [`Couldn't migrate application data: ${message}`];
+    if (isStoreMigrationError(error)) {
+      if (error.restored) {
+        // After a successful restore, backupPath has been renamed over
+        // storePath and no longer exists on disk — don't print it.
+        lines.push("", "Your pre-migration data has been restored.");
+      } else if (error.backupPath) {
+        lines.push("", `Pre-migration backup is preserved at:\n${error.backupPath}`);
+      }
+      if (error.failedStatePath) {
+        lines.push("", `Failed migration state preserved at:\n${error.failedStatePath}`);
+      }
+    }
+    lines.push("", "The application will exit.");
+    dialog.showErrorBox("Migration failed", lines.join("\n"));
+    app.exit(1);
+    return "exit-requested";
+  }
+
+  // Sentry and GitHub token validation are deferred to after the renderer
+  // reports first-interactive to avoid contending for the event loop while
+  // React hydrates. GitHubAuth.initializeStorage must stay eager because
+  // other services read tokens synchronously during startup.
+  registerDeferredTask({
+    name: "telemetry",
+    run: async () => {
+      await initializeTelemetry();
+      setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
+    },
+  });
+
+  // Initialize GitHubAuth storage (must stay eager — synchronous reads)
+  GitHubAuth.initializeStorage({
+    get: () => secureStorage.get("userConfig.githubToken"),
+    set: (token) => secureStorage.set("userConfig.githubToken", token),
+    delete: () => secureStorage.delete("userConfig.githubToken"),
+  });
+  console.log("[MAIN] GitHubAuth initialized with storage");
+
+  if (GitHubAuth.hasToken()) {
+    const token = GitHubAuth.getToken();
+    if (token) {
+      const versionAtStart = GitHubAuth.getTokenVersion();
+      registerDeferredTask({
+        name: "github-auth-validate",
+        run: async () => {
+          try {
+            const validation = await GitHubAuth.validate(token);
+            if (validation.valid && validation.username) {
+              GitHubAuth.setValidatedUserInfo(
+                validation.username,
+                validation.avatarUrl,
+                validation.scopes,
+                versionAtStart
+              );
+              console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+            }
+          } catch (err) {
+            console.warn("[MAIN] Failed to validate stored GitHub token:", err);
+          }
+        },
+      });
+    }
+  }
+
+  // E2E hook: seed/clear an in-memory GitHub token so fault-mode tests can
+  // reach IPC paths gated on `hasToken: true` without hitting the network.
+  // Skips token validation by pre-seeding cached user info, mirroring the
+  // post-validate state. Mirrors the __daintreeFaultRegistry / __daintreeResetRateLimits
+  // pattern — gated on DAINTREE_E2E_FAULT_MODE, never present in production.
+  if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {
+    (globalThis as Record<string, unknown>).__daintreeSeedGitHubToken = (token: string) => {
+      GitHubAuth.setMemoryToken(token);
+      const version = GitHubAuth.getTokenVersion();
+      GitHubAuth.setValidatedUserInfo("e2e-user", undefined, ["repo"], version);
+    };
+    (globalThis as Record<string, unknown>).__daintreeClearGitHubToken = () => {
+      GitHubAuth.setMemoryToken(null);
+    };
+  }
+
+  // Notifications (global singletons)
+  // AgentNotificationService is deferred — agents can't emit state events
+  // before the renderer is interactive, and its boot grace period now starts
+  // from the deferred initialize() so the suppression window still covers
+  // the actual agent startup interval.
+  preAgentSnapshotService.initialize();
+  getActionBreadcrumbService().initialize();
+
+  registerDeferredTask({
+    name: "agent-notification-service",
+    run: async () => {
+      const { agentNotificationService } = await import("../services/AgentNotificationService.js");
+      setAgentNotificationServiceRef(agentNotificationService);
+      agentNotificationService.initialize();
+    },
+  });
+
+  // Auto-updater
+  registerDeferredTask({
+    name: "auto-updater",
+    run: async () => {
+      const { autoUpdaterService } = await import("../services/AutoUpdaterService.js");
+      setAutoUpdaterServiceRef(autoUpdaterService);
+      autoUpdaterService.initialize();
+    },
+  });
+
+  // CCR config — discover Claude Code Router models as agent presets
+  try {
+    const { CcrConfigService } = await import("../services/CcrConfigService.js");
+    const ccr = CcrConfigService.getInstance();
+    setCcrConfigService(ccr);
+    await ccr.loadAndApply();
+    ccr.startWatching();
+    console.log("[MAIN] CcrConfigService initialized");
+  } catch (err) {
+    console.warn("[MAIN] CcrConfigService init failed (non-fatal):", err);
+  }
+
+  // ── Deferred global service starts ──
+  // These were previously run on the same tick as loadRenderer(), contending
+  // with the renderer for event-loop time while React hydrated and painted.
+  // They now drain sequentially after the renderer signals first-interactive
+  // (or after a fallback timeout), with `setImmediate` interleaved between
+  // tasks so IPC from the renderer stays responsive during drain.
+
+  registerDeferredTask({
+    name: "crash-recovery-backup-timer",
+    run: () => {
+      getCrashRecoveryService().startBackupTimer();
+    },
+  });
+
+  registerDeferredTask({
+    name: "hibernation-service",
+    run: () => {
+      initializeHibernationService();
+    },
+  });
+
+  registerDeferredTask({
+    name: "idle-terminal-notification-service",
+    run: async () => {
+      const { initializeIdleTerminalNotificationService } =
+        await import("../services/IdleTerminalNotificationService.js");
+      initializeIdleTerminalNotificationService();
+    },
+  });
+
+  registerDeferredTask({
+    name: "system-sleep-service",
+    run: () => {
+      initializeSystemSleepService();
+    },
+  });
+
+  registerDeferredTask({
+    name: "disk-space-monitor",
+    run: () => {
+      if (getStopDiskSpaceMonitor()) return;
+      setStopDiskSpaceMonitor(
+        startDiskSpaceMonitor({
+          sendStatus: (payload) => {
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (!wCtx.browserWindow.isDestroyed()) {
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                    name: "window:disk-space-status",
+                    payload,
+                  });
+                }
+              }
+            }
+          },
+          onCriticalChange: (isCritical) => {
+            const ptyClient = getPtyClient();
+            if (isCritical) {
+              getCrashRecoveryService().stopBackupTimer();
+              ptyClient?.suppressSessionPersistence(true);
+            } else {
+              getCrashRecoveryService().startBackupTimer();
+              ptyClient?.suppressSessionPersistence(false);
+            }
+          },
+          showNativeNotification: (title, body) => {
+            notificationService.showNativeNotification(title, body);
+          },
+          isWindowFocused: () => notificationService.isWindowFocused(),
+        })
+      );
+    },
+  });
+
+  registerDeferredTask({
+    name: "event-loop-lag-monitor",
+    run: () => {
+      if (!getStopEventLoopLagMonitor()) {
+        setStopEventLoopLagMonitor(startEventLoopLagMonitor());
+      }
+      if (process.env.DAINTREE_PERF_CAPTURE === "1" && !getStopProcessMemoryMonitor()) {
+        setStopProcessMemoryMonitor(startProcessMemoryMonitor());
+      }
+    },
+  });
+
+  registerDeferredTask({
+    name: "app-metrics-monitor",
+    run: () => {
+      if (getStopAppMetricsMonitor()) return;
+      setStopAppMetricsMonitor(
+        startAppMetricsMonitor({
+          clearCaches: async () => {
+            try {
+              await session.defaultSession.clearCache();
+            } catch {
+              /* non-critical */
+            }
+            try {
+              await session.defaultSession.clearStorageData({
+                storages: ["shadercache", "cachestorage"],
+              });
+            } catch {
+              /* non-critical */
+            }
+            try {
+              exposeGc?.();
+            } catch {
+              /* non-critical */
+            }
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (!wCtx.browserWindow.isDestroyed()) {
+                  try {
+                    sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                      name: "window:reclaim-memory",
+                      payload: { reason: "memory-pressure" },
+                    });
+                  } catch {
+                    /* non-critical */
+                  }
+                }
+              }
+            }
+          },
+          destroyHiddenWebviews: async (tier) => {
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (wCtx.browserWindow.isDestroyed()) continue;
+                try {
+                  if (wCtx.services.portalManager) {
+                    const evictedTabIds = await wCtx.services.portalManager.destroyHiddenTabs();
+                    if (evictedTabIds.length > 0) {
+                      sendToRenderer(wCtx.browserWindow, CHANNELS.PORTAL_TABS_EVICTED, {
+                        tabIds: evictedTabIds,
+                      });
+                    }
+                  }
+                } catch {
+                  /* non-critical */
+                }
+                try {
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
+                    name: "window:destroy-hidden-webviews",
+                    payload: { tier },
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
+          hibernateIdleProjects: async () => {
+            await getHibernationService().hibernateUnderMemoryPressure();
+          },
+          trimPtyHostState: () => {
+            getPtyClient()?.trimState(SCROLLBACK_BACKGROUND);
+          },
+          sampleBlinkMemory: () => {
+            if (!windowRegistry) return;
+            const requestId = `blink-${Date.now().toString(36)}`;
+            for (const wCtx of windowRegistry.all()) {
+              const w = wCtx.browserWindow;
+              if (w.isDestroyed()) continue;
+              // Per-window PVM tracks every cached project renderer; falling
+              // back to the app webContents covers windows still on the
+              // bootstrap shell (no PVM yet).
+              const pvm = wCtx.services.projectViewManager;
+              const targets = pvm
+                ? pvm.getAllViews().map((v) => v.view.webContents)
+                : [getAppWebContents(w)];
+              for (const wc of targets) {
+                if (!wc || wc.isDestroyed()) continue;
+                try {
+                  wc.send(CHANNELS.EVENTS_PUSH, {
+                    name: "window:sample-blink-memory",
+                    payload: { requestId },
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
+          sampleRendererElu: () => {
+            if (!windowRegistry) return;
+            const requestId = `elu-${Date.now().toString(36)}`;
+            for (const wCtx of windowRegistry.all()) {
+              const w = wCtx.browserWindow;
+              if (w.isDestroyed()) continue;
+              // Cached/loading views have setBackgroundThrottling(true) which
+              // throttles JS timers and the LoAF observer, producing burst
+              // signal that doesn't reflect user-visible lag. Only sample
+              // active views; fall back to the app webContents for windows
+              // still on the bootstrap shell (no PVM yet).
+              const pvm = wCtx.services.projectViewManager;
+              const targets = pvm
+                ? pvm
+                    .getAllViews()
+                    .filter((v) => v.state === "active")
+                    .map((v) => v.view.webContents)
+                : [getAppWebContents(w)];
+              for (const wc of targets) {
+                if (!wc || wc.isDestroyed()) continue;
+                try {
+                  wc.send(CHANNELS.EVENTS_PUSH, {
+                    name: "window:sample-renderer-elu",
+                    payload: { requestId },
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
+        })
+      );
+    },
+  });
+
+  // Must register AFTER event-loop-lag and app-metrics monitors so it can
+  // read their data once its own start() fires.
+  registerDeferredTask({
+    name: "resource-profile-service",
+    run: () => {
+      if (getResourceProfileService()) return;
+      const svc = new ResourceProfileService({
+        getPtyClient: () => getPtyClient(),
+        getWorkspaceClient: () => getWorkspaceClientRef(),
+        getHibernationService: () => getHibernationService(),
+        getProjectViewManager: () => getProjectViewManager(),
+        getProjectStatsService: () => getProjectStatsService(),
+        getUserCachedViewLimit: () =>
+          store.get("terminalConfig")?.cachedProjectViews ??
+          (process.env.DAINTREE_E2E_MODE ? 4 : 1),
+      });
+      setResourceProfileService(svc);
+      svc.start();
+    },
+  });
+
+  // Background token-health polling (30-minute interval + focus/wake
+  // re-checks). The service guards itself with the GitHubAuth.tokenVersion
+  // so a stale probe cannot clobber a freshly-set token.
+  registerDeferredTask({
+    name: "github-token-health",
+    run: () => {
+      gitHubTokenHealthService.start();
+    },
+  });
+
+  // Background agent provider reachability probes (Claude, Gemini, Codex)
+  // and the registry that aggregates GitHub, agents, and MCP into a single
+  // per-service connectivity snapshot for renderers. Registry must register
+  // before mcp-server so it wires onStatusChange before MCP's first event.
+  registerDeferredTask({
+    name: "agent-connectivity",
+    run: () => {
+      agentConnectivityService.start();
+    },
+  });
+
+  registerDeferredTask({
+    name: "service-connectivity-registry",
+    run: () => {
+      getServiceConnectivityRegistry().start();
+    },
+  });
+
+  if (windowRegistry) {
+    const registryRef = windowRegistry;
+    // Wire `helpSessionService.mcpRegistry` synchronously, BEFORE the
+    // deferred queue drains. The renderer can call `help:provision-session`
+    // as soon as IPC handlers are registered (a few hundred ms before the
+    // first deferred task runs); without this synchronous wire-up,
+    // `ensureMcpServerReady()` would no-op on the null registry and the
+    // assistant would launch with a stub `.mcp.json` missing the daintree
+    // entry. The setter is just a reference store — no MCP SDK loaded.
+    try {
+      const { helpSessionService } = await import("../services/HelpSessionService.js");
+      helpSessionService.setMcpRegistry(registryRef);
+    } catch (err) {
+      console.error("[MAIN] Failed to wire HelpSessionService MCP registry:", err);
+    }
+
+    registerDeferredTask({
+      name: "mcp-server",
+      run: async () => {
+        try {
+          const { mcpServerService } = await import("../services/McpServerService.js");
+          const { helpSessionService } = await import("../services/HelpSessionService.js");
+          // Register the help-token validator before start() so the very first
+          // request can authenticate against a help session if the renderer
+          // races ahead of us. (Also wired in HelpSessionService.ensureMcpServerReady
+          // — this deferred wiring covers the no-assistant warm-start path.)
+          mcpServerService.setHelpTokenValidator((token) =>
+            helpSessionService.validateToken(token)
+          );
+          await mcpServerService.start(registryRef);
+        } catch (err) {
+          console.error("[MAIN] MCP server failed to start:", err);
+        }
+      },
+    });
+
+    registerDeferredTask({
+      name: "help-session-gc",
+      run: async () => {
+        try {
+          const { helpSessionService } = await import("../services/HelpSessionService.js");
+          await helpSessionService.gcStaleSessions();
+        } catch (err) {
+          console.warn("[MAIN] Help session GC failed:", err);
+        }
+      },
+    });
+  }
+
+  registerDeferredTask({
+    name: "session-eviction",
+    run: () => evictStaleSessionFiles(),
+  });
+
+  return "ok";
+}
+
+/**
+ * Exported only for unit tests so they can verify session eviction logic
+ * without driving the full deferred queue. Not part of the public surface.
+ */
+export const __test__ = { evictStaleSessionFiles };

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -1,0 +1,286 @@
+import { session, type BrowserWindow } from "electron";
+import type { HandlerDependencies } from "../ipc/types.js";
+import { sendToRenderer } from "../ipc/handlers.js";
+import { getAppWebContents } from "./webContentsRegistry.js";
+import { distributePortsToView } from "./portDistribution.js";
+import { PtyClient } from "../services/PtyClient.js";
+import { getMainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
+import { CliAvailabilityService } from "../services/CliAvailabilityService.js";
+import { AgentVersionService } from "../services/AgentVersionService.js";
+import { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
+import { PortalManager } from "../services/PortalManager.js";
+import { EventBuffer } from "../services/EventBuffer.js";
+import { CHANNELS } from "../ipc/channels.js";
+import { createApplicationMenu } from "../menu.js";
+import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
+import { notificationService } from "../services/NotificationService.js";
+import { logInfo } from "../utils/logger.js";
+import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
+import { isDemoMode } from "../setup/environment.js";
+import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
+import { registerDeferredTask, finalizeDeferredRegistration } from "./deferredInitQueue.js";
+import { toDisposable } from "../utils/lifecycle.js";
+import {
+  getCliAvailabilityServiceRef,
+  setCliAvailabilityServiceRef,
+  getPtyClient,
+  setPtyClientRef,
+  getMainProcessWatchdogClientRef,
+  setMainProcessWatchdogClientRef,
+  getAgentVersionService,
+  setAgentVersionService,
+  getAgentUpdateHandler,
+  setAgentUpdateHandler,
+  getWorkspaceClientRef,
+} from "./serviceRefs.js";
+
+/**
+ * Run the per-window initialization steps that happen on every
+ * `setupWindowServices` call: menu creation, the per-window CLI deferred task,
+ * deferred-queue arming, NotificationService wire-up, first-window-only
+ * critical-services boot (PtyClient + watchdog), and per-window service
+ * objects (EventBuffer, PortalManager, ProjectSwitchService, ctx.cleanup).
+ *
+ * Returns a partially-populated `HandlerDependencies` for the caller to extend
+ * with `worktreeService`, `worktreePortBroker`, and `projectViewManager` once
+ * the workspace client and ProjectViewManager are wired in the orchestrator.
+ */
+export function initPerWindowServices(
+  win: BrowserWindow,
+  ctx: WindowContext,
+  windowRegistry: WindowRegistry | undefined
+): HandlerDependencies {
+  // Menu & Notifications (per-window: menu references this window)
+  console.log("[MAIN] Creating application menu (initial, no agent availability yet)...");
+  let cliAvailabilityService = getCliAvailabilityServiceRef();
+  if (!cliAvailabilityService) {
+    cliAvailabilityService = new CliAvailabilityService();
+    setCliAvailabilityServiceRef(cliAvailabilityService);
+  }
+  createApplicationMenu(win, cliAvailabilityService);
+
+  // Per-window deferred work. Menu is window-specific, so each window queues
+  // its own CLI check + menu rebuild. Registered here (before any awaits that
+  // could hang) so finalize below is guaranteed to run.
+  const cliService = cliAvailabilityService;
+  registerDeferredTask({
+    name: `cli-availability-check:${win.id}`,
+    run: async () => {
+      try {
+        const availability = await cliService.checkAvailability();
+        console.log("[MAIN] CLI availability checked:", availability);
+        if (!win.isDestroyed()) {
+          createApplicationMenu(win, cliService);
+        }
+      } catch (err) {
+        console.error("[MAIN] CliAvailabilityService initialization failed:", err);
+      }
+    },
+  });
+
+  // Arm the drain trigger immediately. All tasks for this window are now
+  // registered; any subsequent `await` in setupWindowServices could hang
+  // (PTY host, workspace loadProject, plugin init) and must not block the
+  // deferred queue from becoming drainable. The renderer's first-interactive
+  // IPC fires on the happy path; the 10s fallback drains on hang.
+  finalizeDeferredRegistration();
+
+  if (windowRegistry) {
+    notificationService.initialize(windowRegistry);
+    ctx.cleanup.add(toDisposable(() => notificationService.detachWindowListeners(win.id)));
+  }
+  console.log("[MAIN] NotificationService initialized");
+
+  // Critical services (global, first window only)
+  let ptyClient = getPtyClient();
+  if (!ptyClient) {
+    console.log("[MAIN] Starting critical services...");
+
+    // Start the external main-process watchdog before PtyClient so a deadlock
+    // during PTY host fork (worst case: a synchronous spawn that hangs) is
+    // still recoverable. The watchdog is fail-open: if its own fork throws,
+    // PtyClient still starts normally.
+    if (!getMainProcessWatchdogClientRef()) {
+      try {
+        // Use the singleton accessor so `disposeMainProcessWatchdog()` in
+        // shutdown.ts reaches the running instance instead of a no-op.
+        setMainProcessWatchdogClientRef(getMainProcessWatchdogClient());
+      } catch (err) {
+        console.error("[MAIN] Failed to start main-process watchdog:", err);
+        setMainProcessWatchdogClientRef(null);
+      }
+    }
+
+    ptyClient = new PtyClient({
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+      showCrashDialog: false,
+    });
+    setPtyClientRef(ptyClient);
+
+    const versionSvc = new AgentVersionService(cliAvailabilityService);
+    setAgentVersionService(versionSvc);
+    setAgentUpdateHandler(new AgentUpdateHandler(ptyClient, versionSvc, cliAvailabilityService));
+
+    ptyClient.on("host-crash-details", (details) => {
+      console.error(`[MAIN] Pty Host crashed:`, details);
+      // Broadcast to all windows
+      if (windowRegistry) {
+        for (const wCtx of windowRegistry.all()) {
+          const w = wCtx.browserWindow;
+          if (!w.isDestroyed()) {
+            const wc = getAppWebContents(w);
+            if (!wc.isDestroyed()) {
+              try {
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "terminal:backend-crashed",
+                  payload: {
+                    crashType: details.crashType,
+                    code: details.code,
+                    signal: details.signal,
+                    timestamp: details.timestamp,
+                  },
+                });
+              } catch {
+                // Silently ignore send failures during window disposal.
+              }
+            }
+          }
+        }
+      }
+    });
+    ptyClient.on("host-crash", (code) => {
+      console.error(`[MAIN] Pty Host crashed with code ${code} (max restarts exceeded)`);
+    });
+    ptyClient.on("host-throttled", (payload) => {
+      if (!payload.isThrottled) {
+        logInfo("pty-host-resumed", { duration: payload.duration });
+        return;
+      }
+      logInfo("pty-host-throttled", { reason: payload.reason });
+      try {
+        session.defaultSession.clearCache().catch(() => {});
+      } catch {
+        /* non-critical */
+      }
+      // Broadcast to all windows
+      if (windowRegistry) {
+        for (const wCtx of windowRegistry.all()) {
+          const w = wCtx.browserWindow;
+          if (!w.isDestroyed()) {
+            try {
+              sendToRenderer(w, CHANNELS.EVENTS_PUSH, {
+                name: "window:reclaim-memory",
+                payload: { reason: "pty-host-pressure" },
+              });
+            } catch {
+              /* non-critical */
+            }
+          }
+        }
+      }
+      try {
+        ptyClient!.trimState(SCROLLBACK_BACKGROUND);
+      } catch {
+        /* non-critical */
+      }
+    });
+    ptyClient.setPortRefreshCallback(() => {
+      console.log("[MAIN] Pty Host restarted, refreshing ports...");
+      // Refresh ports for ALL registered windows — target the active view
+      if (windowRegistry) {
+        for (const wCtx of windowRegistry.all()) {
+          if (!wCtx.browserWindow.isDestroyed()) {
+            const wc = getAppWebContents(wCtx.browserWindow);
+            if (!wc.isDestroyed()) {
+              distributePortsToView(wCtx.browserWindow, wCtx, wc, ptyClient);
+              try {
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "terminal:backend-ready",
+                  payload: undefined,
+                });
+              } catch {
+                // Silently ignore send failures during window disposal.
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  // Per-window services
+  ctx.services.eventBuffer = new EventBuffer(1000);
+  // EventBuffer.start() must run eagerly — it subscribes to the internal event
+  // bus so early-boot events (migrations, PTY init, hydration) reach the
+  // inspector. Deferring would drop those events.
+  ctx.services.eventBuffer.start();
+  ctx.services.portalManager = new PortalManager(win);
+  ctx.services.projectSwitchService = new ProjectSwitchService({
+    mainWindow: win,
+    ptyClient: ptyClient ?? undefined,
+    eventBuffer: ctx.services.eventBuffer,
+    portalManager: ctx.services.portalManager,
+    cliAvailabilityService,
+    agentVersionService: getAgentVersionService() ?? undefined,
+    agentUpdateHandler: getAgentUpdateHandler() ?? undefined,
+    isDemoMode,
+    windowRegistry,
+  } as HandlerDependencies);
+
+  // Per-window cleanup: ports, portalManager, eventBuffer
+  ctx.cleanup.add(
+    toDisposable(() => {
+      // Notify PTY host to disconnect this window's port before closing it
+      const pty = getPtyClient();
+      if (pty) {
+        pty.disconnectMessagePort(ctx.windowId);
+      }
+      if (ctx.services.activeRendererPort) {
+        try {
+          ctx.services.activeRendererPort.close();
+        } catch {
+          /* ignore */
+        }
+        ctx.services.activeRendererPort = undefined;
+      }
+      if (ctx.services.activePtyHostPort) {
+        try {
+          ctx.services.activePtyHostPort.close();
+        } catch {
+          /* ignore */
+        }
+        ctx.services.activePtyHostPort = undefined;
+      }
+      if (ctx.services.portalManager) {
+        ctx.services.portalManager.destroy();
+        ctx.services.portalManager = undefined;
+      }
+      if (ctx.services.eventBuffer) {
+        ctx.services.eventBuffer.stop();
+        ctx.services.eventBuffer = undefined;
+      }
+      ctx.services.projectSwitchService = undefined;
+      const ws = getWorkspaceClientRef();
+      if (ws) {
+        ws.unregisterWindow(win.id);
+      }
+    })
+  );
+
+  const handlerDeps: HandlerDependencies = {
+    mainWindow: win,
+    ptyClient: ptyClient ?? undefined,
+    eventBuffer: ctx.services.eventBuffer,
+    portalManager: ctx.services.portalManager,
+    cliAvailabilityService,
+    agentVersionService: getAgentVersionService() ?? undefined,
+    agentUpdateHandler: getAgentUpdateHandler() ?? undefined,
+    isDemoMode,
+    windowRegistry,
+  };
+
+  handlerDeps.projectSwitchService = ctx.services.projectSwitchService;
+
+  return handlerDeps;
+}

--- a/electron/window/serviceRefs.ts
+++ b/electron/window/serviceRefs.ts
@@ -1,0 +1,175 @@
+// Leaf module: zero runtime imports so every consumer can safely import
+// from it without risking ESM TDZ during cold startup. Holds the global
+// (cross-window) singleton refs that windowServices.ts and its extracted
+// helpers (globalServicesInit, perWindowInit) read and mutate. Type-only
+// imports are erased at compile time and cannot create circular runtime
+// edges.
+import type { PtyClient } from "../services/PtyClient.js";
+import type { MainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
+import type { WorkspaceClient } from "../services/WorkspaceClient.js";
+import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
+import type { AgentVersionService } from "../services/AgentVersionService.js";
+import type { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
+import type { ResourceProfileService } from "../services/ResourceProfileService.js";
+import type { WorktreePortBroker } from "../services/WorktreePortBroker.js";
+import type { CcrConfigService } from "../services/CcrConfigService.js";
+import type { autoUpdaterService as AutoUpdaterServiceType } from "../services/AutoUpdaterService.js";
+import type { agentNotificationService as AgentNotificationServiceType } from "../services/AgentNotificationService.js";
+
+// Guard: process.argv CLI path should only be consumed by the first window
+let processArgvCliHandled = false;
+
+// Guard: IPC handlers are globally scoped (ipcMain.handle throws on re-registration)
+let ipcHandlersRegistered = false;
+
+// Guard: one-time global initialization (migrations, GitHubAuth, etc.)
+let globalServicesInitialized = false;
+
+// ── Global service refs (shared across all windows) ──
+let ptyClient: PtyClient | null = null;
+let mainProcessWatchdogClient: MainProcessWatchdogClient | null = null;
+let workspaceClient: WorkspaceClient | null = null;
+let cliAvailabilityService: CliAvailabilityService | null = null;
+let agentVersionService: AgentVersionService | null = null;
+let agentUpdateHandler: AgentUpdateHandler | null = null;
+let cleanupIpcHandlers: (() => void) | null = null;
+let cleanupErrorHandlers: (() => void) | null = null;
+let stopEventLoopLagMonitor: (() => void) | null = null;
+let stopProcessMemoryMonitor: (() => void) | null = null;
+let stopAppMetricsMonitor: (() => void) | null = null;
+let stopDiskSpaceMonitor: (() => void) | null = null;
+let resourceProfileService: ResourceProfileService | null = null;
+let worktreePortBroker: WorktreePortBroker | null = null;
+let ccrConfigService: CcrConfigService | null = null;
+
+// Singletons resolved by deferred tasks. Held here so dispose paths can clean
+// them up safely if the task ran. If the window closes before the task runs
+// (early shutdown), these stay null and the dispose path no-ops.
+let autoUpdaterServiceRef: typeof AutoUpdaterServiceType | null = null;
+let agentNotificationServiceRef: typeof AgentNotificationServiceType | null = null;
+
+// ── Public getters/setters (consumed by main.ts, menu.ts, shutdown.ts) ──
+export function getPtyClient(): PtyClient | null {
+  return ptyClient;
+}
+export function setPtyClientRef(v: PtyClient | null): void {
+  ptyClient = v;
+}
+export function getMainProcessWatchdogClientRef(): MainProcessWatchdogClient | null {
+  return mainProcessWatchdogClient;
+}
+export function setMainProcessWatchdogClientRef(v: MainProcessWatchdogClient | null): void {
+  mainProcessWatchdogClient = v;
+}
+export function getWorkspaceClientRef(): WorkspaceClient | null {
+  return workspaceClient;
+}
+export function setWorkspaceClientRef(v: WorkspaceClient | null): void {
+  workspaceClient = v;
+}
+export function getWorktreePortBrokerRef(): WorktreePortBroker | null {
+  return worktreePortBroker;
+}
+export function setWorktreePortBrokerRef(v: WorktreePortBroker | null): void {
+  worktreePortBroker = v;
+}
+export function getCliAvailabilityServiceRef(): CliAvailabilityService | null {
+  return cliAvailabilityService;
+}
+export function setCliAvailabilityServiceRef(v: CliAvailabilityService | null): void {
+  cliAvailabilityService = v;
+}
+export function getCleanupIpcHandlers(): (() => void) | null {
+  return cleanupIpcHandlers;
+}
+export function setCleanupIpcHandlers(v: (() => void) | null): void {
+  cleanupIpcHandlers = v;
+}
+export function getCleanupErrorHandlers(): (() => void) | null {
+  return cleanupErrorHandlers;
+}
+export function setCleanupErrorHandlers(v: (() => void) | null): void {
+  cleanupErrorHandlers = v;
+}
+export function getStopEventLoopLagMonitor(): (() => void) | null {
+  return stopEventLoopLagMonitor;
+}
+export function setStopEventLoopLagMonitor(v: (() => void) | null): void {
+  stopEventLoopLagMonitor = v;
+}
+export function getStopProcessMemoryMonitor(): (() => void) | null {
+  return stopProcessMemoryMonitor;
+}
+export function setStopProcessMemoryMonitor(v: (() => void) | null): void {
+  stopProcessMemoryMonitor = v;
+}
+export function getStopAppMetricsMonitor(): (() => void) | null {
+  return stopAppMetricsMonitor;
+}
+export function setStopAppMetricsMonitor(v: (() => void) | null): void {
+  stopAppMetricsMonitor = v;
+}
+export function getStopDiskSpaceMonitor(): (() => void) | null {
+  return stopDiskSpaceMonitor;
+}
+export function setStopDiskSpaceMonitor(v: (() => void) | null): void {
+  stopDiskSpaceMonitor = v;
+}
+
+// ── Internal getters/setters (used across split modules) ──
+export function getProcessArgvCliHandled(): boolean {
+  return processArgvCliHandled;
+}
+export function setProcessArgvCliHandled(v: boolean): void {
+  processArgvCliHandled = v;
+}
+export function getIpcHandlersRegistered(): boolean {
+  return ipcHandlersRegistered;
+}
+export function setIpcHandlersRegistered(v: boolean): void {
+  ipcHandlersRegistered = v;
+}
+export function getGlobalServicesInitialized(): boolean {
+  return globalServicesInitialized;
+}
+export function setGlobalServicesInitialized(v: boolean): void {
+  globalServicesInitialized = v;
+}
+export function getAgentVersionService(): AgentVersionService | null {
+  return agentVersionService;
+}
+export function setAgentVersionService(v: AgentVersionService | null): void {
+  agentVersionService = v;
+}
+export function getAgentUpdateHandler(): AgentUpdateHandler | null {
+  return agentUpdateHandler;
+}
+export function setAgentUpdateHandler(v: AgentUpdateHandler | null): void {
+  agentUpdateHandler = v;
+}
+export function getResourceProfileService(): ResourceProfileService | null {
+  return resourceProfileService;
+}
+export function setResourceProfileService(v: ResourceProfileService | null): void {
+  resourceProfileService = v;
+}
+export function getCcrConfigService(): CcrConfigService | null {
+  return ccrConfigService;
+}
+export function setCcrConfigService(v: CcrConfigService | null): void {
+  ccrConfigService = v;
+}
+export function getAutoUpdaterServiceRef(): typeof AutoUpdaterServiceType | null {
+  return autoUpdaterServiceRef;
+}
+export function setAutoUpdaterServiceRef(v: typeof AutoUpdaterServiceType | null): void {
+  autoUpdaterServiceRef = v;
+}
+export function getAgentNotificationServiceRef(): typeof AgentNotificationServiceType | null {
+  return agentNotificationServiceRef;
+}
+export function setAgentNotificationServiceRef(
+  v: typeof AgentNotificationServiceType | null
+): void {
+  agentNotificationServiceRef = v;
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -293,11 +293,6 @@ export async function setupWindowServices(
         }
       }
     );
-  } else {
-    // Workspace already initialized by an earlier window — wire its refs into
-    // this window's handler deps so per-window IPC handlers can reach them.
-    handlerDeps.worktreeService = getWorkspaceClientRef() ?? undefined;
-    handlerDeps.worktreePortBroker = getWorktreePortBrokerRef() ?? undefined;
   }
 
   const { armRestoreQuota } = await import("../ipc/utils.js");

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -1,49 +1,23 @@
-import { app, BrowserWindow, dialog, session, webContents } from "electron";
+import { app, BrowserWindow, dialog, webContents } from "electron";
 import os from "os";
-import type { HandlerDependencies } from "../ipc/types.js";
 import { registerIpcHandlers, sendToRenderer } from "../ipc/handlers.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { distributePortsToView } from "./portDistribution.js";
 import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.js";
-import { PtyClient, disposePtyClient } from "../services/PtyClient.js";
-import {
-  MainProcessWatchdogClient,
-  getMainProcessWatchdogClient,
-  disposeMainProcessWatchdog,
-} from "../services/MainProcessWatchdogClient.js";
-import {
-  getWorkspaceClient,
-  disposeWorkspaceClient,
-  WorkspaceClient,
-} from "../services/WorkspaceClient.js";
-import { CliAvailabilityService } from "../services/CliAvailabilityService.js";
-import { AgentVersionService } from "../services/AgentVersionService.js";
-import { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
-import { PortalManager } from "../services/PortalManager.js";
-import { EventBuffer } from "../services/EventBuffer.js";
+import { disposePtyClient } from "../services/PtyClient.js";
+import { disposeMainProcessWatchdog } from "../services/MainProcessWatchdogClient.js";
+import { getWorkspaceClient, disposeWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
-import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
-import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
+import { handleDirectoryOpen } from "../menu.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { taskQueueService } from "../services/TaskQueueService.js";
-import { store } from "../store.js";
-import {
-  LATEST_SCHEMA_VERSION,
-  MigrationRunner,
-  isStoreMigrationError,
-} from "../services/StoreMigrations.js";
-import { initializeTelemetry, setOnboardingCompleteTag } from "../services/TelemetryService.js";
-import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
 import {
   agentConnectivityService,
   getServiceConnectivityRegistry,
 } from "../services/connectivity/index.js";
-import { secureStorage } from "../services/SecureStorage.js";
 import { notificationService } from "../services/NotificationService.js";
-import type { agentNotificationService as AgentNotificationServiceType } from "../services/AgentNotificationService.js";
 import { preAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
-import { getActionBreadcrumbService } from "../services/ActionBreadcrumbService.js";
 import {
   initializeAgentAvailabilityStore,
   disposeAgentAvailabilityStore,
@@ -53,186 +27,92 @@ import {
   disposePowerSaveBlockerService,
 } from "../services/PowerSaveBlockerService.js";
 import { initializeAgentRouter, disposeAgentRouter } from "../services/AgentRouter.js";
-
 import {
   initializeTaskOrchestrator,
   disposeTaskOrchestrator,
 } from "../services/TaskOrchestrator.js";
-import type { autoUpdaterService as AutoUpdaterServiceType } from "../services/AutoUpdaterService.js";
 import { runSmokeFunctionalChecks } from "../services/smokeTest.js";
-import {
-  initializeHibernationService,
-  getHibernationService,
-} from "../services/HibernationService.js";
-import {
-  evictSessionFiles,
-  SESSION_EVICTION_TTL_MS,
-  SESSION_EVICTION_MAX_BYTES,
-} from "../services/pty/terminalSessionPersistence.js";
-import {
-  initializeSystemSleepService,
-  getSystemSleepService,
-} from "../services/SystemSleepService.js";
+import { getHibernationService } from "../services/HibernationService.js";
+import { getSystemSleepService } from "../services/SystemSleepService.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getIdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
-import {
-  markPerformance,
-  startEventLoopLagMonitor,
-  startProcessMemoryMonitor,
-} from "../utils/performance.js";
-import { startAppMetricsMonitor } from "../services/ProcessMemoryMonitor.js";
-import { ResourceProfileService } from "../services/ResourceProfileService.js";
-import { startDiskSpaceMonitor, getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
-import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
-import { logInfo } from "../utils/logger.js";
+import { markPerformance } from "../utils/performance.js";
+import { getCurrentDiskSpaceStatus } from "../services/DiskSpaceMonitor.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
-import { isSmokeTest, isDemoMode, smokeTestStart, exposeGc } from "../setup/environment.js";
+import { isSmokeTest, smokeTestStart } from "../setup/environment.js";
 import { shouldEnableEarlyRenderer } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
-import { getProjectViewManager } from "./windowRef.js";
-import { getProjectStatsService } from "../ipc/handlers/projectCrud/index.js";
+import { resetDeferredQueue } from "./deferredInitQueue.js";
+import { initGlobalServices } from "./globalServicesInit.js";
+import { initPerWindowServices } from "./perWindowInit.js";
 import {
-  registerDeferredTask,
-  finalizeDeferredRegistration,
-  resetDeferredQueue,
-} from "./deferredInitQueue.js";
-import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { toDisposable } from "../utils/lifecycle.js";
+  getPtyClient,
+  setPtyClientRef,
+  getMainProcessWatchdogClientRef,
+  setMainProcessWatchdogClientRef,
+  getWorkspaceClientRef,
+  setWorkspaceClientRef,
+  getWorktreePortBrokerRef,
+  setWorktreePortBrokerRef,
+  getCliAvailabilityServiceRef,
+  getCleanupIpcHandlers,
+  setCleanupIpcHandlers,
+  getCleanupErrorHandlers,
+  setCleanupErrorHandlers,
+  getStopEventLoopLagMonitor,
+  setStopEventLoopLagMonitor,
+  getStopProcessMemoryMonitor,
+  setStopProcessMemoryMonitor,
+  getStopAppMetricsMonitor,
+  setStopAppMetricsMonitor,
+  getStopDiskSpaceMonitor,
+  setStopDiskSpaceMonitor,
+  getResourceProfileService,
+  setResourceProfileService,
+  getCcrConfigService,
+  setCcrConfigService,
+  getAutoUpdaterServiceRef,
+  setAutoUpdaterServiceRef,
+  getAgentNotificationServiceRef,
+  setAgentNotificationServiceRef,
+  getProcessArgvCliHandled,
+  setProcessArgvCliHandled,
+  getIpcHandlersRegistered,
+  setIpcHandlersRegistered,
+  getGlobalServicesInitialized,
+  setGlobalServicesInitialized,
+} from "./serviceRefs.js";
+
+// Re-export the public getters/setters so existing import paths in main.ts,
+// menu.ts, and shutdown.ts (via main.ts wiring) continue to resolve through
+// `./window/windowServices.js`. The underlying state lives in serviceRefs.ts.
+export {
+  getPtyClient,
+  setPtyClientRef,
+  getMainProcessWatchdogClientRef,
+  getWorkspaceClientRef,
+  getWorktreePortBrokerRef,
+  getCliAvailabilityServiceRef,
+  getCleanupIpcHandlers,
+  setCleanupIpcHandlers,
+  getCleanupErrorHandlers,
+  setCleanupErrorHandlers,
+  getStopEventLoopLagMonitor,
+  setStopEventLoopLagMonitor,
+  getStopProcessMemoryMonitor,
+  setStopProcessMemoryMonitor,
+  getStopAppMetricsMonitor,
+  setStopAppMetricsMonitor,
+  getStopDiskSpaceMonitor,
+  setStopDiskSpaceMonitor,
+} from "./serviceRefs.js";
 
 const DEFAULT_TERMINAL_ID = "default";
 
-// Guard: process.argv CLI path should only be consumed by the first window
-let processArgvCliHandled = false;
-
-// ── Global service refs (shared across all windows) ──
-let ptyClient: PtyClient | null = null;
-let mainProcessWatchdogClient: MainProcessWatchdogClient | null = null;
-let workspaceClient: WorkspaceClient | null = null;
-let cliAvailabilityService: CliAvailabilityService | null = null;
-let agentVersionService: AgentVersionService | null = null;
-let agentUpdateHandler: AgentUpdateHandler | null = null;
-let cleanupIpcHandlers: (() => void) | null = null;
-let cleanupErrorHandlers: (() => void) | null = null;
-let stopEventLoopLagMonitor: (() => void) | null = null;
-let stopProcessMemoryMonitor: (() => void) | null = null;
-let stopAppMetricsMonitor: (() => void) | null = null;
-let stopDiskSpaceMonitor: (() => void) | null = null;
-let resourceProfileService: ResourceProfileService | null = null;
-let worktreePortBroker: import("../services/WorktreePortBroker.js").WorktreePortBroker | null =
-  null;
-let ccrConfigService: import("../services/CcrConfigService.js").CcrConfigService | null = null;
-
-// Singletons resolved by deferred tasks. Held here so dispose paths can clean
-// them up safely if the task ran. If the window closes before the task runs
-// (early shutdown), these stay null and the dispose path no-ops.
-let autoUpdaterServiceRef: typeof AutoUpdaterServiceType | null = null;
-let agentNotificationServiceRef: typeof AgentNotificationServiceType | null = null;
-
-// Guard: IPC handlers are globally scoped (ipcMain.handle throws on re-registration)
-let ipcHandlersRegistered = false;
-
-// Guard: one-time global initialization (migrations, GitHubAuth, etc.)
-let globalServicesInitialized = false;
-
-// Expose getters for shutdown handler
-export function getPtyClient(): PtyClient | null {
-  return ptyClient;
-}
-export function setPtyClientRef(v: PtyClient | null): void {
-  ptyClient = v;
-}
-export function getMainProcessWatchdogClientRef(): MainProcessWatchdogClient | null {
-  return mainProcessWatchdogClient;
-}
-export function getWorkspaceClientRef(): WorkspaceClient | null {
-  return workspaceClient;
-}
-export function getWorktreePortBrokerRef():
-  | import("../services/WorktreePortBroker.js").WorktreePortBroker
-  | null {
-  return worktreePortBroker;
-}
-export function getCliAvailabilityServiceRef(): CliAvailabilityService | null {
-  return cliAvailabilityService;
-}
-export function getCleanupIpcHandlers(): (() => void) | null {
-  return cleanupIpcHandlers;
-}
-export function setCleanupIpcHandlers(v: (() => void) | null): void {
-  cleanupIpcHandlers = v;
-}
-export function getCleanupErrorHandlers(): (() => void) | null {
-  return cleanupErrorHandlers;
-}
-export function setCleanupErrorHandlers(v: (() => void) | null): void {
-  cleanupErrorHandlers = v;
-}
-export function getStopEventLoopLagMonitor(): (() => void) | null {
-  return stopEventLoopLagMonitor;
-}
-export function setStopEventLoopLagMonitor(v: (() => void) | null): void {
-  stopEventLoopLagMonitor = v;
-}
-export function getStopProcessMemoryMonitor(): (() => void) | null {
-  return stopProcessMemoryMonitor;
-}
-export function setStopProcessMemoryMonitor(v: (() => void) | null): void {
-  stopProcessMemoryMonitor = v;
-}
-export function getStopAppMetricsMonitor(): (() => void) | null {
-  return stopAppMetricsMonitor;
-}
-export function setStopAppMetricsMonitor(v: (() => void) | null): void {
-  stopAppMetricsMonitor = v;
-}
-export function getStopDiskSpaceMonitor(): (() => void) | null {
-  return stopDiskSpaceMonitor;
-}
-export function setStopDiskSpaceMonitor(v: (() => void) | null): void {
-  stopDiskSpaceMonitor = v;
-}
-
 function createAndDistributePorts(win: BrowserWindow, ctx: WindowContext): void {
   const wc = getAppWebContents(win);
-  distributePortsToView(win, ctx, wc, ptyClient);
-}
-
-async function evictStaleSessionFiles(): Promise<void> {
-  try {
-    const allProjects = projectStore.getAllProjects();
-    const knownIds = new Set<string>();
-
-    const states = await Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id)));
-    for (const state of states) {
-      if (state?.terminals) {
-        for (const t of state.terminals) {
-          knownIds.add(t.id);
-        }
-      }
-    }
-
-    const appTerminals = store.get("appState")?.terminals;
-    if (Array.isArray(appTerminals)) {
-      for (const t of appTerminals) {
-        knownIds.add(t.id);
-      }
-    }
-
-    const result = await evictSessionFiles({
-      ttlMs: SESSION_EVICTION_TTL_MS,
-      maxBytes: SESSION_EVICTION_MAX_BYTES,
-      knownIds,
-    });
-
-    if (result.deleted > 0) {
-      console.log(
-        `[MAIN] Session eviction: deleted ${result.deleted} file(s), freed ${(result.bytesFreed / 1024 / 1024).toFixed(1)} MB`
-      );
-    }
-  } catch (err) {
-    console.warn("[MAIN] Session eviction failed:", err);
-  }
+  distributePortsToView(win, ctx, wc, getPtyClient());
 }
 
 export interface SetupWindowServicesOptions {
@@ -261,702 +141,21 @@ export async function setupWindowServices(
   markPerformance(PERF_MARKS.WINDOW_SERVICES_START);
 
   // ── One-time global initialization (first window only) ──
-  if (!globalServicesInitialized) {
-    globalServicesInitialized = true;
-    markPerformance(PERF_MARKS.SERVICE_INIT_START);
-
-    // Store migrations — lazy-load the migrations barrel only when the store is
-    // out of sync with the latest schema version. In the common case (already up
-    // to date), this skips parsing ~15KB of migration modules on startup.
-    try {
-      const migrationRunner = new MigrationRunner(store);
-      const currentVersion = migrationRunner.getCurrentVersion();
-      if (currentVersion !== LATEST_SCHEMA_VERSION) {
-        console.log(
-          `[MAIN] Running store migrations (v${currentVersion} -> v${LATEST_SCHEMA_VERSION})...`
-        );
-        const { migrations } = await import("../services/migrations/index.js");
-        await migrationRunner.runMigrations(migrations);
-        console.log("[MAIN] Store migrations completed");
-      }
-      markPerformance(PERF_MARKS.SERVICE_INIT_MIGRATIONS_DONE);
-    } catch (error) {
-      console.error("[MAIN] Store migration failed:", error);
-      const message = formatErrorMessage(error, "Store migration failed");
-      const lines = [`Couldn't migrate application data: ${message}`];
-      if (isStoreMigrationError(error)) {
-        if (error.restored) {
-          // After a successful restore, backupPath has been renamed over
-          // storePath and no longer exists on disk — don't print it.
-          lines.push("", "Your pre-migration data has been restored.");
-        } else if (error.backupPath) {
-          lines.push("", `Pre-migration backup is preserved at:\n${error.backupPath}`);
-        }
-        if (error.failedStatePath) {
-          lines.push("", `Failed migration state preserved at:\n${error.failedStatePath}`);
-        }
-      }
-      lines.push("", "The application will exit.");
-      dialog.showErrorBox("Migration failed", lines.join("\n"));
-      app.exit(1);
-      return;
-    }
-
-    // Sentry and GitHub token validation are deferred to after the renderer
-    // reports first-interactive to avoid contending for the event loop while
-    // React hydrates. GitHubAuth.initializeStorage must stay eager because
-    // other services read tokens synchronously during startup.
-    registerDeferredTask({
-      name: "telemetry",
-      run: async () => {
-        await initializeTelemetry();
-        setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
-      },
-    });
-
-    // Initialize GitHubAuth storage (must stay eager — synchronous reads)
-    GitHubAuth.initializeStorage({
-      get: () => secureStorage.get("userConfig.githubToken"),
-      set: (token) => secureStorage.set("userConfig.githubToken", token),
-      delete: () => secureStorage.delete("userConfig.githubToken"),
-    });
-    console.log("[MAIN] GitHubAuth initialized with storage");
-
-    if (GitHubAuth.hasToken()) {
-      const token = GitHubAuth.getToken();
-      if (token) {
-        const versionAtStart = GitHubAuth.getTokenVersion();
-        registerDeferredTask({
-          name: "github-auth-validate",
-          run: async () => {
-            try {
-              const validation = await GitHubAuth.validate(token);
-              if (validation.valid && validation.username) {
-                GitHubAuth.setValidatedUserInfo(
-                  validation.username,
-                  validation.avatarUrl,
-                  validation.scopes,
-                  versionAtStart
-                );
-                console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
-              }
-            } catch (err) {
-              console.warn("[MAIN] Failed to validate stored GitHub token:", err);
-            }
-          },
-        });
-      }
-    }
-
-    // E2E hook: seed/clear an in-memory GitHub token so fault-mode tests can
-    // reach IPC paths gated on `hasToken: true` without hitting the network.
-    // Skips token validation by pre-seeding cached user info, mirroring the
-    // post-validate state. Mirrors the __daintreeFaultRegistry / __daintreeResetRateLimits
-    // pattern — gated on DAINTREE_E2E_FAULT_MODE, never present in production.
-    if (process.env.DAINTREE_E2E_FAULT_MODE === "1") {
-      (globalThis as Record<string, unknown>).__daintreeSeedGitHubToken = (token: string) => {
-        GitHubAuth.setMemoryToken(token);
-        const version = GitHubAuth.getTokenVersion();
-        GitHubAuth.setValidatedUserInfo("e2e-user", undefined, ["repo"], version);
-      };
-      (globalThis as Record<string, unknown>).__daintreeClearGitHubToken = () => {
-        GitHubAuth.setMemoryToken(null);
-      };
-    }
-
-    // Notifications (global singletons)
-    // AgentNotificationService is deferred — agents can't emit state events
-    // before the renderer is interactive, and its boot grace period now starts
-    // from the deferred initialize() so the suppression window still covers
-    // the actual agent startup interval.
-    preAgentSnapshotService.initialize();
-    getActionBreadcrumbService().initialize();
-
-    registerDeferredTask({
-      name: "agent-notification-service",
-      run: async () => {
-        const { agentNotificationService } =
-          await import("../services/AgentNotificationService.js");
-        agentNotificationServiceRef = agentNotificationService;
-        agentNotificationService.initialize();
-      },
-    });
-
-    // Auto-updater
-    registerDeferredTask({
-      name: "auto-updater",
-      run: async () => {
-        const { autoUpdaterService } = await import("../services/AutoUpdaterService.js");
-        autoUpdaterServiceRef = autoUpdaterService;
-        autoUpdaterService.initialize();
-      },
-    });
-
-    // CCR config — discover Claude Code Router models as agent presets
-    try {
-      const { CcrConfigService } = await import("../services/CcrConfigService.js");
-      ccrConfigService = CcrConfigService.getInstance();
-      await ccrConfigService.loadAndApply();
-      ccrConfigService.startWatching();
-      console.log("[MAIN] CcrConfigService initialized");
-    } catch (err) {
-      console.warn("[MAIN] CcrConfigService init failed (non-fatal):", err);
-    }
-
-    // ── Deferred global service starts ──
-    // These were previously run on the same tick as loadRenderer(), contending
-    // with the renderer for event-loop time while React hydrated and painted.
-    // They now drain sequentially after the renderer signals first-interactive
-    // (or after a fallback timeout), with `setImmediate` interleaved between
-    // tasks so IPC from the renderer stays responsive during drain.
-
-    registerDeferredTask({
-      name: "crash-recovery-backup-timer",
-      run: () => {
-        getCrashRecoveryService().startBackupTimer();
-      },
-    });
-
-    registerDeferredTask({
-      name: "hibernation-service",
-      run: () => {
-        initializeHibernationService();
-      },
-    });
-
-    registerDeferredTask({
-      name: "idle-terminal-notification-service",
-      run: async () => {
-        const { initializeIdleTerminalNotificationService } =
-          await import("../services/IdleTerminalNotificationService.js");
-        initializeIdleTerminalNotificationService();
-      },
-    });
-
-    registerDeferredTask({
-      name: "system-sleep-service",
-      run: () => {
-        initializeSystemSleepService();
-      },
-    });
-
-    registerDeferredTask({
-      name: "disk-space-monitor",
-      run: () => {
-        if (stopDiskSpaceMonitor) return;
-        stopDiskSpaceMonitor = startDiskSpaceMonitor({
-          sendStatus: (payload) => {
-            if (windowRegistry) {
-              for (const wCtx of windowRegistry.all()) {
-                if (!wCtx.browserWindow.isDestroyed()) {
-                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
-                    name: "window:disk-space-status",
-                    payload,
-                  });
-                }
-              }
-            }
-          },
-          onCriticalChange: (isCritical) => {
-            if (isCritical) {
-              getCrashRecoveryService().stopBackupTimer();
-              ptyClient?.suppressSessionPersistence(true);
-            } else {
-              getCrashRecoveryService().startBackupTimer();
-              ptyClient?.suppressSessionPersistence(false);
-            }
-          },
-          showNativeNotification: (title, body) => {
-            notificationService.showNativeNotification(title, body);
-          },
-          isWindowFocused: () => notificationService.isWindowFocused(),
-        });
-      },
-    });
-
-    registerDeferredTask({
-      name: "event-loop-lag-monitor",
-      run: () => {
-        if (!stopEventLoopLagMonitor) {
-          stopEventLoopLagMonitor = startEventLoopLagMonitor();
-        }
-        if (process.env.DAINTREE_PERF_CAPTURE === "1" && !stopProcessMemoryMonitor) {
-          stopProcessMemoryMonitor = startProcessMemoryMonitor();
-        }
-      },
-    });
-
-    registerDeferredTask({
-      name: "app-metrics-monitor",
-      run: () => {
-        if (stopAppMetricsMonitor) return;
-        stopAppMetricsMonitor = startAppMetricsMonitor({
-          clearCaches: async () => {
-            try {
-              await session.defaultSession.clearCache();
-            } catch {
-              /* non-critical */
-            }
-            try {
-              await session.defaultSession.clearStorageData({
-                storages: ["shadercache", "cachestorage"],
-              });
-            } catch {
-              /* non-critical */
-            }
-            try {
-              exposeGc?.();
-            } catch {
-              /* non-critical */
-            }
-            if (windowRegistry) {
-              for (const wCtx of windowRegistry.all()) {
-                if (!wCtx.browserWindow.isDestroyed()) {
-                  try {
-                    sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
-                      name: "window:reclaim-memory",
-                      payload: { reason: "memory-pressure" },
-                    });
-                  } catch {
-                    /* non-critical */
-                  }
-                }
-              }
-            }
-          },
-          destroyHiddenWebviews: async (tier) => {
-            if (windowRegistry) {
-              for (const wCtx of windowRegistry.all()) {
-                if (wCtx.browserWindow.isDestroyed()) continue;
-                try {
-                  if (wCtx.services.portalManager) {
-                    const evictedTabIds = await wCtx.services.portalManager.destroyHiddenTabs();
-                    if (evictedTabIds.length > 0) {
-                      sendToRenderer(wCtx.browserWindow, CHANNELS.PORTAL_TABS_EVICTED, {
-                        tabIds: evictedTabIds,
-                      });
-                    }
-                  }
-                } catch {
-                  /* non-critical */
-                }
-                try {
-                  sendToRenderer(wCtx.browserWindow, CHANNELS.EVENTS_PUSH, {
-                    name: "window:destroy-hidden-webviews",
-                    payload: { tier },
-                  });
-                } catch {
-                  /* non-critical */
-                }
-              }
-            }
-          },
-          hibernateIdleProjects: async () => {
-            await getHibernationService().hibernateUnderMemoryPressure();
-          },
-          trimPtyHostState: () => {
-            ptyClient?.trimState(SCROLLBACK_BACKGROUND);
-          },
-          sampleBlinkMemory: () => {
-            if (!windowRegistry) return;
-            const requestId = `blink-${Date.now().toString(36)}`;
-            for (const wCtx of windowRegistry.all()) {
-              const w = wCtx.browserWindow;
-              if (w.isDestroyed()) continue;
-              // Per-window PVM tracks every cached project renderer; falling
-              // back to the app webContents covers windows still on the
-              // bootstrap shell (no PVM yet).
-              const pvm = wCtx.services.projectViewManager;
-              const targets = pvm
-                ? pvm.getAllViews().map((v) => v.view.webContents)
-                : [getAppWebContents(w)];
-              for (const wc of targets) {
-                if (!wc || wc.isDestroyed()) continue;
-                try {
-                  wc.send(CHANNELS.EVENTS_PUSH, {
-                    name: "window:sample-blink-memory",
-                    payload: { requestId },
-                  });
-                } catch {
-                  /* non-critical */
-                }
-              }
-            }
-          },
-          sampleRendererElu: () => {
-            if (!windowRegistry) return;
-            const requestId = `elu-${Date.now().toString(36)}`;
-            for (const wCtx of windowRegistry.all()) {
-              const w = wCtx.browserWindow;
-              if (w.isDestroyed()) continue;
-              // Cached/loading views have setBackgroundThrottling(true) which
-              // throttles JS timers and the LoAF observer, producing burst
-              // signal that doesn't reflect user-visible lag. Only sample
-              // active views; fall back to the app webContents for windows
-              // still on the bootstrap shell (no PVM yet).
-              const pvm = wCtx.services.projectViewManager;
-              const targets = pvm
-                ? pvm
-                    .getAllViews()
-                    .filter((v) => v.state === "active")
-                    .map((v) => v.view.webContents)
-                : [getAppWebContents(w)];
-              for (const wc of targets) {
-                if (!wc || wc.isDestroyed()) continue;
-                try {
-                  wc.send(CHANNELS.EVENTS_PUSH, {
-                    name: "window:sample-renderer-elu",
-                    payload: { requestId },
-                  });
-                } catch {
-                  /* non-critical */
-                }
-              }
-            }
-          },
-        });
-      },
-    });
-
-    // Must register AFTER event-loop-lag and app-metrics monitors so it can
-    // read their data once its own start() fires.
-    registerDeferredTask({
-      name: "resource-profile-service",
-      run: () => {
-        if (resourceProfileService) return;
-        resourceProfileService = new ResourceProfileService({
-          getPtyClient: () => ptyClient,
-          getWorkspaceClient: () => workspaceClient,
-          getHibernationService: () => getHibernationService(),
-          getProjectViewManager: () => getProjectViewManager(),
-          getProjectStatsService: () => getProjectStatsService(),
-          getUserCachedViewLimit: () =>
-            store.get("terminalConfig")?.cachedProjectViews ??
-            (process.env.DAINTREE_E2E_MODE ? 4 : 1),
-        });
-        resourceProfileService.start();
-      },
-    });
-
-    // Background token-health polling (30-minute interval + focus/wake
-    // re-checks). The service guards itself with the GitHubAuth.tokenVersion
-    // so a stale probe cannot clobber a freshly-set token.
-    registerDeferredTask({
-      name: "github-token-health",
-      run: () => {
-        gitHubTokenHealthService.start();
-      },
-    });
-
-    // Background agent provider reachability probes (Claude, Gemini, Codex)
-    // and the registry that aggregates GitHub, agents, and MCP into a single
-    // per-service connectivity snapshot for renderers. Registry must register
-    // before mcp-server so it wires onStatusChange before MCP's first event.
-    registerDeferredTask({
-      name: "agent-connectivity",
-      run: () => {
-        agentConnectivityService.start();
-      },
-    });
-
-    registerDeferredTask({
-      name: "service-connectivity-registry",
-      run: () => {
-        getServiceConnectivityRegistry().start();
-      },
-    });
-
-    if (windowRegistry) {
-      const registryRef = windowRegistry;
-      // Wire `helpSessionService.mcpRegistry` synchronously, BEFORE the
-      // deferred queue drains. The renderer can call `help:provision-session`
-      // as soon as IPC handlers are registered (a few hundred ms before the
-      // first deferred task runs); without this synchronous wire-up,
-      // `ensureMcpServerReady()` would no-op on the null registry and the
-      // assistant would launch with a stub `.mcp.json` missing the daintree
-      // entry. The setter is just a reference store — no MCP SDK loaded.
-      try {
-        const { helpSessionService } = await import("../services/HelpSessionService.js");
-        helpSessionService.setMcpRegistry(registryRef);
-      } catch (err) {
-        console.error("[MAIN] Failed to wire HelpSessionService MCP registry:", err);
-      }
-
-      registerDeferredTask({
-        name: "mcp-server",
-        run: async () => {
-          try {
-            const { mcpServerService } = await import("../services/McpServerService.js");
-            const { helpSessionService } = await import("../services/HelpSessionService.js");
-            // Register the help-token validator before start() so the very first
-            // request can authenticate against a help session if the renderer
-            // races ahead of us. (Also wired in HelpSessionService.ensureMcpServerReady
-            // — this deferred wiring covers the no-assistant warm-start path.)
-            mcpServerService.setHelpTokenValidator((token) =>
-              helpSessionService.validateToken(token)
-            );
-            await mcpServerService.start(registryRef);
-          } catch (err) {
-            console.error("[MAIN] MCP server failed to start:", err);
-          }
-        },
-      });
-
-      registerDeferredTask({
-        name: "help-session-gc",
-        run: async () => {
-          try {
-            const { helpSessionService } = await import("../services/HelpSessionService.js");
-            await helpSessionService.gcStaleSessions();
-          } catch (err) {
-            console.warn("[MAIN] Help session GC failed:", err);
-          }
-        },
-      });
-    }
-
-    registerDeferredTask({
-      name: "session-eviction",
-      run: () => evictStaleSessionFiles(),
-    });
+  if (!getGlobalServicesInitialized()) {
+    const result = await initGlobalServices(windowRegistry);
+    if (result === "exit-requested") return;
   }
 
   // ── Per-window initialization ──
-
-  // Menu & Notifications (per-window: menu references this window)
-  console.log("[MAIN] Creating application menu (initial, no agent availability yet)...");
-  if (!cliAvailabilityService) {
-    cliAvailabilityService = new CliAvailabilityService();
-  }
-  createApplicationMenu(win, cliAvailabilityService);
-
-  // Per-window deferred work. Menu is window-specific, so each window queues
-  // its own CLI check + menu rebuild. Registered here (before any awaits that
-  // could hang) so finalize below is guaranteed to run.
-  const cliService = cliAvailabilityService;
-  registerDeferredTask({
-    name: `cli-availability-check:${win.id}`,
-    run: async () => {
-      try {
-        const availability = await cliService.checkAvailability();
-        console.log("[MAIN] CLI availability checked:", availability);
-        if (!win.isDestroyed()) {
-          createApplicationMenu(win, cliService);
-        }
-      } catch (err) {
-        console.error("[MAIN] CliAvailabilityService initialization failed:", err);
-      }
-    },
-  });
-
-  // Arm the drain trigger immediately. All tasks for this window are now
-  // registered; any subsequent `await` in setupWindowServices could hang
-  // (PTY host, workspace loadProject, plugin init) and must not block the
-  // deferred queue from becoming drainable. The renderer's first-interactive
-  // IPC fires on the happy path; the 10s fallback drains on hang.
-  finalizeDeferredRegistration();
-
-  if (windowRegistry) {
-    notificationService.initialize(windowRegistry);
-    ctx.cleanup.add(toDisposable(() => notificationService.detachWindowListeners(win.id)));
-  }
-  console.log("[MAIN] NotificationService initialized");
-
-  // Critical services (global, first window only)
-  if (!ptyClient) {
-    console.log("[MAIN] Starting critical services...");
-
-    // Start the external main-process watchdog before PtyClient so a deadlock
-    // during PTY host fork (worst case: a synchronous spawn that hangs) is
-    // still recoverable. The watchdog is fail-open: if its own fork throws,
-    // PtyClient still starts normally.
-    if (!mainProcessWatchdogClient) {
-      try {
-        // Use the singleton accessor so `disposeMainProcessWatchdog()` in
-        // shutdown.ts reaches the running instance instead of a no-op.
-        mainProcessWatchdogClient = getMainProcessWatchdogClient();
-      } catch (err) {
-        console.error("[MAIN] Failed to start main-process watchdog:", err);
-        mainProcessWatchdogClient = null;
-      }
-    }
-
-    ptyClient = new PtyClient({
-      maxRestartAttempts: 3,
-      healthCheckIntervalMs: 30000,
-      showCrashDialog: false,
-    });
-
-    agentVersionService = new AgentVersionService(cliAvailabilityService);
-    agentUpdateHandler = new AgentUpdateHandler(
-      ptyClient,
-      agentVersionService,
-      cliAvailabilityService
-    );
-
-    ptyClient.on("host-crash-details", (details) => {
-      console.error(`[MAIN] Pty Host crashed:`, details);
-      // Broadcast to all windows
-      if (windowRegistry) {
-        for (const wCtx of windowRegistry.all()) {
-          const w = wCtx.browserWindow;
-          if (!w.isDestroyed()) {
-            const wc = getAppWebContents(w);
-            if (!wc.isDestroyed()) {
-              try {
-                wc.send(CHANNELS.EVENTS_PUSH, {
-                  name: "terminal:backend-crashed",
-                  payload: {
-                    crashType: details.crashType,
-                    code: details.code,
-                    signal: details.signal,
-                    timestamp: details.timestamp,
-                  },
-                });
-              } catch {
-                // Silently ignore send failures during window disposal.
-              }
-            }
-          }
-        }
-      }
-    });
-    ptyClient.on("host-crash", (code) => {
-      console.error(`[MAIN] Pty Host crashed with code ${code} (max restarts exceeded)`);
-    });
-    ptyClient.on("host-throttled", (payload) => {
-      if (!payload.isThrottled) {
-        logInfo("pty-host-resumed", { duration: payload.duration });
-        return;
-      }
-      logInfo("pty-host-throttled", { reason: payload.reason });
-      try {
-        session.defaultSession.clearCache().catch(() => {});
-      } catch {
-        /* non-critical */
-      }
-      // Broadcast to all windows
-      if (windowRegistry) {
-        for (const wCtx of windowRegistry.all()) {
-          const w = wCtx.browserWindow;
-          if (!w.isDestroyed()) {
-            try {
-              sendToRenderer(w, CHANNELS.EVENTS_PUSH, {
-                name: "window:reclaim-memory",
-                payload: { reason: "pty-host-pressure" },
-              });
-            } catch {
-              /* non-critical */
-            }
-          }
-        }
-      }
-      try {
-        ptyClient!.trimState(SCROLLBACK_BACKGROUND);
-      } catch {
-        /* non-critical */
-      }
-    });
-    ptyClient.setPortRefreshCallback(() => {
-      console.log("[MAIN] Pty Host restarted, refreshing ports...");
-      // Refresh ports for ALL registered windows — target the active view
-      if (windowRegistry) {
-        for (const wCtx of windowRegistry.all()) {
-          if (!wCtx.browserWindow.isDestroyed()) {
-            const wc = getAppWebContents(wCtx.browserWindow);
-            if (!wc.isDestroyed()) {
-              distributePortsToView(wCtx.browserWindow, wCtx, wc, ptyClient);
-              try {
-                wc.send(CHANNELS.EVENTS_PUSH, {
-                  name: "terminal:backend-ready",
-                  payload: undefined,
-                });
-              } catch {
-                // Silently ignore send failures during window disposal.
-              }
-            }
-          }
-        }
-      }
-    });
-  }
-
-  // Per-window services
-  ctx.services.eventBuffer = new EventBuffer(1000);
-  // EventBuffer.start() must run eagerly — it subscribes to the internal event
-  // bus so early-boot events (migrations, PTY init, hydration) reach the
-  // inspector. Deferring would drop those events.
-  ctx.services.eventBuffer.start();
-  ctx.services.portalManager = new PortalManager(win);
-  ctx.services.projectSwitchService = new ProjectSwitchService({
-    mainWindow: win,
-    ptyClient: ptyClient ?? undefined,
-    eventBuffer: ctx.services.eventBuffer,
-    portalManager: ctx.services.portalManager,
-    cliAvailabilityService,
-    agentVersionService,
-    agentUpdateHandler,
-    isDemoMode,
-    windowRegistry,
-  } as HandlerDependencies);
-
-  // Per-window cleanup: ports, portalManager, eventBuffer
-  ctx.cleanup.add(
-    toDisposable(() => {
-      // Notify PTY host to disconnect this window's port before closing it
-      if (ptyClient) {
-        ptyClient.disconnectMessagePort(ctx.windowId);
-      }
-      if (ctx.services.activeRendererPort) {
-        try {
-          ctx.services.activeRendererPort.close();
-        } catch {
-          /* ignore */
-        }
-        ctx.services.activeRendererPort = undefined;
-      }
-      if (ctx.services.activePtyHostPort) {
-        try {
-          ctx.services.activePtyHostPort.close();
-        } catch {
-          /* ignore */
-        }
-        ctx.services.activePtyHostPort = undefined;
-      }
-      if (ctx.services.portalManager) {
-        ctx.services.portalManager.destroy();
-        ctx.services.portalManager = undefined;
-      }
-      if (ctx.services.eventBuffer) {
-        ctx.services.eventBuffer.stop();
-        ctx.services.eventBuffer = undefined;
-      }
-      ctx.services.projectSwitchService = undefined;
-      if (workspaceClient) {
-        workspaceClient.unregisterWindow(win.id);
-      }
-    })
-  );
+  const handlerDeps = initPerWindowServices(win, ctx, windowRegistry);
+  const cliAvailabilityService = getCliAvailabilityServiceRef();
 
   console.log("[MAIN] Registering IPC handlers...");
-  const handlerDeps: HandlerDependencies = {
-    mainWindow: win,
-    ptyClient: ptyClient ?? undefined,
-    eventBuffer: ctx.services.eventBuffer,
-    portalManager: ctx.services.portalManager,
-    cliAvailabilityService,
-    agentVersionService: agentVersionService ?? undefined,
-    agentUpdateHandler: agentUpdateHandler ?? undefined,
-    isDemoMode,
-    windowRegistry,
-  };
-
-  handlerDeps.projectSwitchService = ctx.services.projectSwitchService;
 
   // IPC handlers are globally scoped — register only once
-  if (!ipcHandlersRegistered) {
-    ipcHandlersRegistered = true;
-    cleanupIpcHandlers = registerIpcHandlers(handlerDeps);
+  if (!getIpcHandlersRegistered()) {
+    setIpcHandlersRegistered(true);
+    setCleanupIpcHandlers(registerIpcHandlers(handlerDeps));
     markPerformance(PERF_MARKS.SERVICE_INIT_IPC_READY);
 
     try {
@@ -996,10 +195,12 @@ export async function setupWindowServices(
       // Under DAINTREE_EARLY_RENDERER, workspaceClient may still be null on the
       // first did-finish-load — the initial direct-port attach is performed by
       // the loadProject() path below once the workspace host is ready.
+      const workspaceClient = getWorkspaceClientRef();
       if (workspaceClient) {
         workspaceClient.attachDirectPort(win.id, appWc);
 
         // Re-broker worktree port for initial view reload
+        const worktreePortBroker = getWorktreePortBrokerRef();
         if (worktreePortBroker) {
           const host = workspaceClient.getHostForWindow(win.id);
           if (host) {
@@ -1027,7 +228,8 @@ export async function setupWindowServices(
 
   // Initialize workspace client (first window only) — per-project hosts
   // are started on-demand when loadProject() is called, not at init time.
-  if (!workspaceClient) {
+  const ptyClient = getPtyClient();
+  if (!getWorkspaceClientRef()) {
     console.log("[MAIN] Waiting for Pty Host to be ready before initializing Workspace Client...");
     try {
       await ptyClient!.waitForReady();
@@ -1037,11 +239,12 @@ export async function setupWindowServices(
       console.error("[MAIN] Pty Host failed to start:", error);
     }
 
-    workspaceClient = getWorkspaceClient({
+    const workspaceClient = getWorkspaceClient({
       maxRestartAttempts: 3,
       healthCheckIntervalMs: 60000,
       showCrashDialog: false,
     });
+    setWorkspaceClientRef(workspaceClient);
 
     // Give PluginService the WorkspaceClient reference now that it's ready —
     // PluginService.initialize() ran earlier before workspaceClient existed.
@@ -1055,13 +258,13 @@ export async function setupWindowServices(
     markPerformance(PERF_MARKS.SERVICE_INIT_WORKSPACE_READY);
 
     // Create WorktreePortBroker alongside WorkspaceClient
-    if (!worktreePortBroker) {
+    if (!getWorktreePortBrokerRef()) {
       const { WorktreePortBroker } = await import("../services/WorktreePortBroker.js");
-      worktreePortBroker = new WorktreePortBroker();
+      setWorktreePortBrokerRef(new WorktreePortBroker());
     }
 
     handlerDeps.worktreeService = workspaceClient;
-    handlerDeps.worktreePortBroker = worktreePortBroker ?? undefined;
+    handlerDeps.worktreePortBroker = getWorktreePortBrokerRef() ?? undefined;
 
     workspaceClient.on("host-crash", (code: number) => {
       console.error(`[MAIN] Workspace Host crashed with code ${code}`);
@@ -1077,6 +280,7 @@ export async function setupWindowServices(
         projectPath: string;
         host: import("../services/WorkspaceHostProcess.js").WorkspaceHostProcess;
       }) => {
+        const worktreePortBroker = getWorktreePortBrokerRef();
         if (!worktreePortBroker) return;
         const wcIds = worktreePortBroker.closePortsForHost(projectPath);
         if (wcIds.length > 0) {
@@ -1089,6 +293,11 @@ export async function setupWindowServices(
         }
       }
     );
+  } else {
+    // Workspace already initialized by an earlier window — wire its refs into
+    // this window's handler deps so per-window IPC handlers can reach them.
+    handlerDeps.worktreeService = getWorkspaceClientRef() ?? undefined;
+    handlerDeps.worktreePortBroker = getWorktreePortBrokerRef() ?? undefined;
   }
 
   const { armRestoreQuota } = await import("../ipc/utils.js");
@@ -1102,8 +311,8 @@ export async function setupWindowServices(
   startRendererLoad("after-services-ready");
 
   // Error handlers also use ipcMain.handle — register once
-  if (!cleanupErrorHandlers) {
-    cleanupErrorHandlers = registerErrorHandlers(workspaceClient, ptyClient);
+  if (!getCleanupErrorHandlers()) {
+    setCleanupErrorHandlers(registerErrorHandlers(getWorkspaceClientRef(), getPtyClient()));
   }
 
   console.log("[MAIN] All critical services ready");
@@ -1116,7 +325,7 @@ export async function setupWindowServices(
 
   try {
     const results = await Promise.allSettled([
-      ptyClient!.waitForReady(),
+      getPtyClient()!.waitForReady(),
       projectStore.initialize(),
     ]);
 
@@ -1159,12 +368,13 @@ export async function setupWindowServices(
 
   // PTY-related features
   if (ptyReady) {
+    const pty = getPtyClient()!;
     createAndDistributePorts(win, ctx);
 
     if (restoreProject) {
-      ptyClient!.setActiveProject(win.id, restoreProject.id, restoreProject.path);
+      pty.setActiveProject(win.id, restoreProject.id, restoreProject.path);
     } else {
-      ptyClient!.setActiveProject(win.id, null);
+      pty.setActiveProject(win.id, null);
     }
 
     const availabilityStore = initializeAgentAvailabilityStore();
@@ -1172,10 +382,10 @@ export async function setupWindowServices(
     initializePowerSaveBlockerService();
     console.log("[MAIN] AgentAvailabilityStore, AgentRouter, and PowerSaveBlocker initialized");
 
-    initializeTaskOrchestrator(ptyClient!, agentRouter);
+    initializeTaskOrchestrator(pty, agentRouter);
     console.log("[MAIN] TaskOrchestrator initialized");
 
-    const processArgvCli = !processArgvCliHandled ? extractCliPath(process.argv) : null;
+    const processArgvCli = !getProcessArgvCliHandled() ? extractCliPath(process.argv) : null;
     const skipDefaultSpawn =
       opts.initialProjectPath || processArgvCli || getPendingCliPath() || restoreProject;
     if (skipDefaultSpawn) {
@@ -1186,7 +396,7 @@ export async function setupWindowServices(
       const terminalId = `${DEFAULT_TERMINAL_ID}-${win.id}`;
       console.log("[MAIN] Spawning default terminal:", terminalId);
       try {
-        ptyClient!.spawn(terminalId, {
+        pty.spawn(terminalId, {
           cwd: os.homedir(),
           cols: 80,
           rows: 30,
@@ -1219,6 +429,7 @@ export async function setupWindowServices(
   // Load worktrees — prefer initialProjectPath, else restoreProject for
   // startup windows. Unbound windows (no project) skip worktree loading.
   const projectPathForWorktrees = opts.initialProjectPath ?? restoreProject?.path;
+  const workspaceClient = getWorkspaceClientRef();
   if (projectPathForWorktrees && workspaceClient && workspaceReady) {
     console.log("[MAIN] Loading worktrees for project path:", projectPathForWorktrees);
     try {
@@ -1233,6 +444,7 @@ export async function setupWindowServices(
 
         // Broker new worktree port (Phase 1)
         const host = workspaceClient.getHostForProject(projectPathForWorktrees);
+        const worktreePortBroker = getWorktreePortBrokerRef();
         if (host && worktreePortBroker) {
           worktreePortBroker.brokerPort(host, directPortTarget);
           console.log("[MAIN] Worktree port brokered");
@@ -1270,13 +482,13 @@ export async function setupWindowServices(
     if (!ptyReady || !workspaceReady) {
       console.error("[SMOKE] FAILED — one or more services did not start");
       if (win && !win.isDestroyed()) win.destroy();
-      workspaceClient!.dispose();
-      ptyClient!.dispose();
+      getWorkspaceClientRef()?.dispose();
+      getPtyClient()?.dispose();
       app.exit(1);
       return;
     }
 
-    const smokeClient = ptyClient!;
+    const smokeClient = getPtyClient()!;
     const allPassed = await runSmokeFunctionalChecks(
       win,
       smokeClient,
@@ -1285,12 +497,12 @@ export async function setupWindowServices(
 
     if (win && !win.isDestroyed()) win.destroy();
     try {
-      workspaceClient!.dispose();
+      getWorkspaceClientRef()?.dispose();
     } catch {
       /* ignore */
     }
     try {
-      ptyClient!.dispose();
+      getPtyClient()?.dispose();
     } catch {
       /* ignore */
     }
@@ -1300,8 +512,8 @@ export async function setupWindowServices(
 
   // CLI path handling — skip if this window was opened with an explicit initialProjectPath
   if (!opts.initialProjectPath) {
-    const firstLaunchCliPath = !processArgvCliHandled ? extractCliPath(process.argv) : null;
-    if (firstLaunchCliPath) processArgvCliHandled = true;
+    const firstLaunchCliPath = !getProcessArgvCliHandled() ? extractCliPath(process.argv) : null;
+    if (firstLaunchCliPath) setProcessArgvCliHandled(true);
     const cliPath = firstLaunchCliPath ?? getPendingCliPath();
     if (cliPath) {
       setPendingCliPath(null);
@@ -1330,36 +542,44 @@ export async function setupWindowServices(
     // Stop the CCR config watcher first, before any guard resets or IPC teardown.
     // Awaiting here blocks a new window from racing into the init block (which would
     // restart the singleton watcher) and finding this handler about to null the ref.
+    const ccrConfigService = getCcrConfigService();
     if (ccrConfigService) {
       await ccrConfigService.stopWatching();
-      ccrConfigService = null;
+      setCcrConfigService(null);
     }
 
-    if (stopEventLoopLagMonitor) {
-      stopEventLoopLagMonitor();
-      stopEventLoopLagMonitor = null;
+    const stopELL = getStopEventLoopLagMonitor();
+    if (stopELL) {
+      stopELL();
+      setStopEventLoopLagMonitor(null);
     }
-    if (stopProcessMemoryMonitor) {
-      stopProcessMemoryMonitor();
-      stopProcessMemoryMonitor = null;
+    const stopPM = getStopProcessMemoryMonitor();
+    if (stopPM) {
+      stopPM();
+      setStopProcessMemoryMonitor(null);
     }
-    if (stopAppMetricsMonitor) {
-      stopAppMetricsMonitor();
-      stopAppMetricsMonitor = null;
+    const stopAM = getStopAppMetricsMonitor();
+    if (stopAM) {
+      stopAM();
+      setStopAppMetricsMonitor(null);
     }
-    if (stopDiskSpaceMonitor) {
-      stopDiskSpaceMonitor();
-      stopDiskSpaceMonitor = null;
+    const stopDS = getStopDiskSpaceMonitor();
+    if (stopDS) {
+      stopDS();
+      setStopDiskSpaceMonitor(null);
     }
-    if (resourceProfileService) {
-      resourceProfileService.stop();
-      resourceProfileService = null;
+    const rps = getResourceProfileService();
+    if (rps) {
+      rps.stop();
+      setResourceProfileService(null);
     }
 
-    if (worktreePortBroker) worktreePortBroker.dispose();
-    worktreePortBroker = null;
-    if (workspaceClient) workspaceClient.dispose();
-    workspaceClient = null;
+    const wpb = getWorktreePortBrokerRef();
+    if (wpb) wpb.dispose();
+    setWorktreePortBrokerRef(null);
+    const ws = getWorkspaceClientRef();
+    if (ws) ws.dispose();
+    setWorkspaceClientRef(null);
     disposeWorkspaceClient();
 
     // Drop PluginService's WorkspaceClient reference so plugin event handlers
@@ -1376,25 +596,31 @@ export async function setupWindowServices(
     disposePowerSaveBlockerService();
     disposeAgentAvailabilityStore();
 
-    if (ptyClient) ptyClient.dispose();
-    ptyClient = null;
+    const pty = getPtyClient();
+    if (pty) pty.dispose();
+    setPtyClientRef(null);
     disposePtyClient();
 
-    if (mainProcessWatchdogClient) mainProcessWatchdogClient.dispose();
-    mainProcessWatchdogClient = null;
+    const watchdog = getMainProcessWatchdogClientRef();
+    if (watchdog) watchdog.dispose();
+    setMainProcessWatchdogClientRef(null);
     disposeMainProcessWatchdog();
 
     // Clean up IPC handlers and reset guards so next window re-registers fresh
-    if (cleanupIpcHandlers) {
-      cleanupIpcHandlers();
-      cleanupIpcHandlers = null;
+    const cleanupIpc = getCleanupIpcHandlers();
+    if (cleanupIpc) {
+      cleanupIpc();
+      setCleanupIpcHandlers(null);
     }
-    if (cleanupErrorHandlers) {
-      cleanupErrorHandlers();
-      cleanupErrorHandlers = null;
+    const cleanupErr = getCleanupErrorHandlers();
+    if (cleanupErr) {
+      cleanupErr();
+      setCleanupErrorHandlers(null);
     }
-    ipcHandlersRegistered = false;
-    globalServicesInitialized = false;
+    setIpcHandlersRegistered(false);
+    // Reset the global init guard so the next window re-runs
+    // initGlobalServices() from a clean slate.
+    setGlobalServicesInitialized(false);
     resetDeferredQueue();
 
     getHibernationService().stop();
@@ -1405,14 +631,16 @@ export async function setupWindowServices(
     agentConnectivityService.dispose();
     getServiceConnectivityRegistry().dispose();
     notificationService.dispose();
-    if (agentNotificationServiceRef) {
-      agentNotificationServiceRef.dispose();
-      agentNotificationServiceRef = null;
+    const ans = getAgentNotificationServiceRef();
+    if (ans) {
+      ans.dispose();
+      setAgentNotificationServiceRef(null);
     }
     preAgentSnapshotService.dispose();
-    if (autoUpdaterServiceRef) {
-      autoUpdaterServiceRef.dispose();
-      autoUpdaterServiceRef = null;
+    const aus = getAutoUpdaterServiceRef();
+    if (aus) {
+      aus.dispose();
+      setAutoUpdaterServiceRef(null);
     }
   });
 }


### PR DESCRIPTION
## Summary

- `windowServices.ts` was 1418 lines — split into a leaf state module (`serviceRefs.ts`), two phase helpers (`globalServicesInit.ts`, `perWindowInit.ts`), and a slimmed orchestrator (643 lines, 54% reduction)
- `serviceRefs.ts` has zero runtime imports (`import type` only), so it always evaluates first and eliminates any ESM Temporal Dead Zone risk during cold startup; `globalServicesInit.ts` and `perWindowInit.ts` import from it, not the other way around
- The orchestrator re-exports all 16 public getter/setter symbols from `serviceRefs.ts`, keeping every existing import path in `main.ts`, `menu.ts`, and `shutdown.ts` unchanged

Resolves #6700

## Changes

- **New:** `electron/window/serviceRefs.ts` — 30 singleton refs, 3 guard flags, getters/setters; leaf node with no runtime deps
- **New:** `electron/window/globalServicesInit.ts` — async `initGlobalServices()` covering migrations, GitHubAuth storage, ~18 deferred-task registrations, `helpSessionService.setMcpRegistry`; returns `"ok" | "exit-requested"`
- **New:** `electron/window/perWindowInit.ts` — `initPerWindowServices()` covering menu, PtyClient + watchdog boot (first window only), EventBuffer/PortalManager/ProjectSwitchService, `ctx.cleanup`; returns partial `HandlerDependencies`
- **New tests:** `serviceRefs.test.ts` (6 tests: defaults, round-trips, isolation) and `globalServicesInit.order.test.ts` (6 tests: ordering invariants, no-registry skip path, migration-failure regression)
- **Modified:** `windowServices.ts` — retains IPC registration, renderer load, workspace init, project binding, smoke-test, CLI path, and closed-handler blocks inline; everything else delegated

## Testing

- `npx tsc --noEmit` passes
- `npx vitest run electron/window/__tests__/` passes (260 tests across 22 files)
- ESLint at 2502 warnings, down 2 from baseline
- All 19 pre-existing window tests pass without modification
- Key ordering constraints enforced by tests: `helpSessionService.setMcpRegistry` called before the mcp-server deferred task registers; `finalizeDeferredRegistration()` called before any hanging awaits; `eventLoopLagMonitor`/`appMetricsMonitor` start before `ResourceProfileService`