### PR TITLE
refactor(pty): split PtyClient into focused modules

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1,16 +1,28 @@
 /**
- * PtyClient - Main process stub for terminal management.
+ * PtyClient - Main process orchestrator for terminal management.
  *
  * @pattern Dependency Injection via main.ts (Pattern B)
  *
- * This class provides a drop-in replacement for PtyManager in the Main process.
- * It forwards all operations to the Pty Host (UtilityProcess) via IPC,
- * keeping the Main thread responsive.
+ * Acts as a drop-in replacement for PtyManager in the Main process. Forwards
+ * all operations to the Pty Host (UtilityProcess) via IPC, keeping the Main
+ * thread responsive.
  *
- * Architecture:
- * - Uses RequestResponseBroker for unified request/response correlation
- * - Uses PtyEventsBridge for domain event routing to internal event bus
- * - Keeps this class focused on transport and lifecycle management
+ * Architecture (post-#6690 split):
+ * - {@link PtyHostLifecycle} (`pty/PtyHostLifecycle.ts`) — UtilityProcess fork,
+ *   exit handling, restart backoff, child-process-gone race, host log
+ *   forwarding, and `readyPromise` lifecycle.
+ * - {@link PtyHealthWatchdog} (`pty/PtyHealthWatchdog.ts`) — heartbeat watchdog,
+ *   sleep/wake handshake, RTT observability.
+ * - {@link routeHostEvent} (`pty/PtyEventRouter.ts`) — pure-function router for
+ *   transport-level host events. Eliminates `event as any` casts via the
+ *   {@link PtyHostResponseEvent} sub-union.
+ * - {@link bridgePtyEvent} (`pty/PtyEventsBridge.ts`) — domain event bridge to
+ *   the internal event bus. Called first by the router.
+ * - {@link RequestResponseBroker} — request/response correlation.
+ *
+ * PtyClient itself owns the cross-cutting business state (broker, pending
+ * spawns/kills, MessagePort plumbing, project context, log-level overrides)
+ * and the public API.
  *
  * Why this pattern:
  * - Manages critical child process (UtilityProcess) requiring explicit lifecycle control
@@ -25,13 +37,11 @@
  * - Multiple services need to interact (composition root in main.ts)
  */
 
-import { utilityProcess, UtilityProcess, app, MessagePortMain } from "electron";
+import { MessagePortMain } from "electron";
 import { EventEmitter } from "events";
 import path from "path";
-import os from "os";
 import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
-import { performance } from "node:perf_hooks";
 import { createLogger, isValidLogOverrideLevel } from "../utils/logger.js";
 import { store } from "../store.js";
 
@@ -42,18 +52,16 @@ const logWarn = (msg: string, ctx?: Record<string, unknown>) =>
   ctx ? logger.warn(msg, ctx) : logger.warn(msg);
 import { getTrashedPidTracker } from "./TrashedPidTracker.js";
 import { RequestResponseBroker, BrokerError } from "./rpc/index.js";
-import { bridgePtyEvent } from "./pty/PtyEventsBridge.js";
+import { routeHostEvent, type PtyEventRouterDeps } from "./pty/PtyEventRouter.js";
+import { PtyHealthWatchdog } from "./pty/PtyHealthWatchdog.js";
+import { PtyHostLifecycle } from "./pty/PtyHostLifecycle.js";
 import type {
   PtyHostRequest,
   PtyHostEvent,
   PtyHostSpawnOptions,
-  TerminalStatusPayload,
   PtyHostActivityTier,
   CrashType,
-  HostCrashPayload,
   SpawnResult,
-  TerminalResourceBatchPayload,
-  BroadcastWriteResultPayload,
 } from "../../shared/types/pty-host.js";
 import type { TerminalSnapshot } from "./PtyManager.js";
 import type { AgentStateChangeTrigger } from "../types/index.js";
@@ -116,6 +124,8 @@ const DEFAULT_CONFIG: Required<PtyClientConfig> = {
   memoryLimitMb: 512,
 };
 
+const MAX_MISSED_HEARTBEATS = 3;
+
 /**
  * Centralized per-operation timeout policy for PTY host RPC calls.
  * Keys are logical method labels forwarded to the broker's onTimeout hook
@@ -130,57 +140,6 @@ const PTY_TIMEOUTS = {
   "get-all-snapshots": 5000,
   "transition-state": 5000,
 } as const satisfies Record<string, number>;
-
-/**
- * Map an authoritative `child-process-gone` reason (Electron 37+) to our CrashType.
- * Used when `app.on("child-process-gone")` fires for the PTY host — the reason
- * string is more reliable than the exit code heuristic in `classifyCrash()`.
- */
-function mapGoneReasonToCrashType(reason: string): CrashType {
-  switch (reason) {
-    case "oom":
-    case "memory-eviction":
-      return "OUT_OF_MEMORY";
-    case "killed":
-      return "SIGNAL_TERMINATED";
-    case "clean-exit":
-      return "CLEAN_EXIT";
-    case "crashed":
-    case "abnormal-exit":
-    case "launch-failed":
-    case "integrity-failure":
-    default:
-      return "UNKNOWN_CRASH";
-  }
-}
-
-/**
- * Classify crash type based on exit code and signal.
- * Exit codes 137 (128+9=SIGKILL) and 134 (128+6=SIGABRT) often indicate OOM.
- */
-function classifyCrash(code: number | null, signal: string | null): CrashType {
-  if (code === null) {
-    return "SIGNAL_TERMINATED";
-  }
-  if (code === 0) {
-    return "CLEAN_EXIT";
-  }
-  // OOM detection - SIGKILL (exit 137) or SIGABRT (exit 134)
-  if (code === 137 || signal === "SIGKILL") {
-    return "OUT_OF_MEMORY";
-  }
-  if (code === 134 || signal === "SIGABRT") {
-    return "ASSERTION_FAILURE";
-  }
-  // Signal-terminated (exit code > 128 typically means 128 + signal number)
-  if (code > 128) {
-    return "SIGNAL_TERMINATED";
-  }
-  if (code !== 0) {
-    return "UNKNOWN_CRASH";
-  }
-  return "CLEAN_EXIT";
-}
 
 /**
  * Read and sanitize the persisted log-level override map. Invalid values are
@@ -203,34 +162,13 @@ function readPersistedOverrides(): Record<string, string> {
   }
 }
 
-const RTT_BUFFER_SIZE = 20;
-const RTT_LOG_EVERY_N_SAMPLES = 10;
-const RTT_LOG_INTERVAL_MS = 5 * 60 * 1000;
-const RTT_WARN_THRESHOLD_MS = 5000;
-
-function rttPercentile(sorted: number[], p: number): number {
-  if (sorted.length === 0) return 0;
-  if (p <= 0) return sorted[0];
-  if (p >= 1) return sorted[sorted.length - 1];
-  const idx = p * (sorted.length - 1);
-  const low = Math.floor(idx);
-  const high = Math.ceil(idx);
-  if (low === high) return sorted[low];
-  const frac = idx - low;
-  return sorted[low] * (1 - frac) + sorted[high] * frac;
-}
-
 export class PtyClient extends EventEmitter {
-  private child: UtilityProcess | null = null;
   private config: Required<PtyClientConfig>;
-  private isInitialized = false;
   private isDisposed = false;
-  private healthCheckInterval: NodeJS.Timeout | null = null;
-  private restartTimer: NodeJS.Timeout | null = null;
-  private restartAttempts = 0;
-  private isHealthCheckPaused = false;
-  private isWaitingForHandshake = false;
-  private handshakeTimeout: NodeJS.Timeout | null = null;
+  private readonly lifecycle: PtyHostLifecycle;
+  private readonly healthWatchdog: PtyHealthWatchdog;
+  private readonly routerDeps: PtyEventRouterDeps;
+
   private pendingSpawns: Map<string, PtyHostSpawnOptions> = new Map();
   private ipcDataMirrorIds = new Set<string>();
   private pendingKillCount: Map<string, number> = new Map();
@@ -245,10 +183,6 @@ export class PtyClient extends EventEmitter {
   private terminalPids: Map<string, number> = new Map();
   private resourceMonitoringEnabled = false;
   private sessionPersistSuppressed = false;
-
-  /** Watchdog: Track missed heartbeat responses to detect deadlocks */
-  private missedHeartbeats = 0;
-  private readonly MAX_MISSED_HEARTBEATS = 3;
 
   /**
    * Cap on pendingSpawns to prevent restart-storm amplification. If the host
@@ -266,12 +200,6 @@ export class PtyClient extends EventEmitter {
    */
   private readonly MAX_PENDING_KILLS = 500;
 
-  /** RTT observability: timestamp of the in-flight health-check ping, or null if none. */
-  private lastPingTime: number | null = null;
-  private rttSamples: number[] = [];
-  private rttSamplesSinceLastLog = 0;
-  private lastRttLogTime = 0;
-
   /** Unified request/response broker for all async operations */
   private broker = new RequestResponseBroker({
     defaultTimeoutMs: 5000,
@@ -281,15 +209,8 @@ export class PtyClient extends EventEmitter {
     },
   });
 
-  private readyPromise: Promise<void>;
-  private readyResolve: (() => void) | null = null;
-  private readyReject: ((error: Error) => void) | null = null;
-
   /** Callback to notify renderer when MessagePort needs to be refreshed */
   private onPortRefresh: (() => void) | null = null;
-
-  private hostStdoutBuffer = "";
-  private hostStderrBuffer = "";
 
   /** Cached log-level overrides. Replayed on every host spawn/restart via the
    * `ready` event, which is the first moment the child's message listener is
@@ -298,629 +219,127 @@ export class PtyClient extends EventEmitter {
    * user's saved configuration without waiting for renderer IPC. */
   private logLevelOverridesCache: Record<string, string> = readPersistedOverrides();
 
-  /**
-   * Authoritative crash reason captured from `app.on("child-process-gone")`.
-   * Consumed by the next `exit` handler via `setImmediate` deferral, since
-   * Electron 37-41 has a documented race where `exit` often fires before
-   * `child-process-gone` for utility-process crashes.
-   */
-  private pendingChildProcessGoneReason: { reason: string; exitCode: number } | null = null;
-  /** Stored handler reference so dispose() can deregister via app.off(). */
-  private childProcessGoneHandler:
-    | ((event: Electron.Event, details: Electron.Details) => void)
-    | null = null;
-
   constructor(config: PtyClientConfig = {}) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config };
-
-    // Create ready promise that resolves when host is ready or rejects on failure
-    this.readyPromise = new Promise((resolve, reject) => {
-      this.readyResolve = resolve;
-      this.readyReject = reject;
-    });
 
     // SharedArrayBuffer cannot be sent to Electron UtilityProcess via postMessage
     // ("An object could not be cloned"). This is a Chromium structured clone limitation
     // that affects all platforms. Use IPC fallback for terminal I/O.
     console.log("[PtyClient] Using IPC mode (SharedArrayBuffer not supported in UtilityProcess)");
 
-    this.registerChildProcessGoneListener();
-    this.startHost();
-  }
-
-  /**
-   * Register a single app-level listener for `child-process-gone`, scoped to
-   * our PTY host by `type === "Utility"` and `name === "daintree-pty-host"`.
-   * The handler only records the authoritative reason; the `exit` handler
-   * consumes it via `setImmediate` deferral to handle the Electron 37-41 race
-   * where `exit` can fire before `child-process-gone`.
-   */
-  private registerChildProcessGoneListener(): void {
-    if (this.childProcessGoneHandler) return;
-    const handler = (_event: Electron.Event, details: Electron.Details): void => {
-      if (this.isDisposed) return;
-      if (details.type !== "Utility") return;
-      // Electron 41 populates `name` from `serviceName` at runtime, but both
-      // fields are typed as optional. Accept either to stay resilient to
-      // future runtime changes or edge cases where only one is set.
-      const matchesHost =
-        details.name === "daintree-pty-host" || details.serviceName === "daintree-pty-host";
-      if (!matchesHost) return;
-      this.pendingChildProcessGoneReason = {
-        reason: details.reason,
-        exitCode: details.exitCode,
-      };
-    };
-    this.childProcessGoneHandler = handler;
-    app.on("child-process-gone", handler);
-  }
-
-  private forwardHostOutput(kind: "stdout" | "stderr", chunk: Buffer): void {
-    const text = chunk.toString("utf8");
-    if (kind === "stdout") {
-      this.hostStdoutBuffer += text;
-    } else {
-      this.hostStderrBuffer += text;
-    }
-
-    const MAX_BUFFER = 64 * 1024;
-    if (this.hostStdoutBuffer.length > MAX_BUFFER)
-      this.hostStdoutBuffer = this.hostStdoutBuffer.slice(-MAX_BUFFER);
-    if (this.hostStderrBuffer.length > MAX_BUFFER)
-      this.hostStderrBuffer = this.hostStderrBuffer.slice(-MAX_BUFFER);
-
-    const current = kind === "stdout" ? this.hostStdoutBuffer : this.hostStderrBuffer;
-    const lines = current.split(/\r?\n/);
-    const remainder = lines.pop() ?? "";
-    if (kind === "stdout") {
-      this.hostStdoutBuffer = remainder;
-    } else {
-      this.hostStderrBuffer = remainder;
-    }
-
-    for (const line of lines) {
-      const trimmed = line.trimEnd();
-      if (!trimmed) continue;
-      const message = `[PtyHost] ${trimmed.length > 4000 ? `${trimmed.slice(0, 4000)}…` : trimmed}`;
-      if (kind === "stderr") {
-        logWarn(message);
-      } else {
-        logInfo(message);
-      }
-    }
-  }
-
-  private installHostLogForwarding(): void {
-    if (!this.child) return;
-    this.hostStdoutBuffer = "";
-    this.hostStderrBuffer = "";
-
-    const stdout = (this.child as unknown as { stdout?: NodeJS.ReadableStream }).stdout;
-    const stderr = (this.child as unknown as { stderr?: NodeJS.ReadableStream }).stderr;
-
-    stdout?.on("data", (chunk: Buffer) => this.forwardHostOutput("stdout", chunk));
-    stderr?.on("data", (chunk: Buffer) => this.forwardHostOutput("stderr", chunk));
-  }
-
-  private flushHostOutputBuffers(): void {
-    const stdoutRemainder = this.hostStdoutBuffer.trim();
-    if (stdoutRemainder) {
-      logInfo(
-        `[PtyHost] ${stdoutRemainder.length > 4000 ? `${stdoutRemainder.slice(0, 4000)}…` : stdoutRemainder}`
-      );
-    }
-    const stderrRemainder = this.hostStderrBuffer.trim();
-    if (stderrRemainder) {
-      logWarn(
-        `[PtyHost] ${stderrRemainder.length > 4000 ? `${stderrRemainder.slice(0, 4000)}…` : stderrRemainder}`
-      );
-    }
-    this.hostStdoutBuffer = "";
-    this.hostStderrBuffer = "";
-  }
-
-  /** Wait for the host to be ready */
-  async waitForReady(): Promise<void> {
-    return this.readyPromise;
-  }
-
-  private startHost(): void {
-    if (this.isDisposed) {
-      console.warn("[PtyClient] Cannot start host - already disposed");
-      return;
-    }
-
-    if (this.restartTimer) {
-      clearTimeout(this.restartTimer);
-      this.restartTimer = null;
-    }
-
-    // Defensive: clear any stale crash reason from a prior host cycle. Under
-    // normal flow the `exit` handler's setImmediate consumes this, but a missed
-    // exit event (or out-of-band listener fire) would otherwise leak into the
-    // next crash.
-    this.pendingChildProcessGoneReason = null;
-
-    // Reset initialization state for restart
-    this.isInitialized = false;
-    this.readyPromise = new Promise((resolve, reject) => {
-      this.readyResolve = resolve;
-      this.readyReject = reject;
-    });
-
     const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
-    const hostPath = path.join(electronDir, "pty-host-bootstrap.js");
 
-    console.log(`[PtyClient] Starting Pty Host from: ${hostPath}`);
-
-    try {
-      this.child = utilityProcess.fork(hostPath, [], {
-        serviceName: "daintree-pty-host",
-        stdio: "pipe",
-        cwd: os.homedir(),
-        // `--diagnostic-dir` redirects v8.setHeapSnapshotNearHeapLimit dumps
-        // (set in pty-host.ts) into the app's logs directory instead of the
-        // utility process CWD (homedir).
-        execArgv: [
-          `--max-old-space-size=${this.config.memoryLimitMb}`,
-          `--diagnostic-dir=${app.getPath("logs")}`,
-          "--report-exclude-env",
-        ],
-        env: {
-          ...(process.env as Record<string, string>),
-          DAINTREE_USER_DATA: app.getPath("userData"),
-          DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
-          // node-pty 1.x hangs intermittently on Linux kernels with io_uring
-          // enabled (microsoft/node-pty#630, closed as not planned). The fix
-          // is permanent and must be set inside the explicit env object — a
-          // mutation on process.env wouldn't survive utilityProcess.fork's
-          // env override.
-          ...(process.platform === "linux" ? { UV_USE_IO_URING: "0" } : {}),
-        },
-      });
-      console.log(`[PtyClient] Pty Host started with ${this.config.memoryLimitMb}MB memory limit`);
-    } catch (error) {
-      console.error("[PtyClient] Failed to fork Pty Host:", error);
-      if (this.readyReject) {
-        this.readyReject(new Error("PTY host failed to start"));
-        this.readyResolve = null;
-        this.readyReject = null;
-      }
-      this.emit("host-crash", -1);
-      return;
-    }
-
-    this.installHostLogForwarding();
-
-    this.child.on("message", (msg: PtyHostEvent) => {
-      this.handleHostEvent(msg);
+    this.healthWatchdog = new PtyHealthWatchdog({
+      intervalMs: this.config.healthCheckIntervalMs,
+      maxMissedHeartbeats: MAX_MISSED_HEARTBEATS,
+      getChild: () => this.lifecycle.child,
+      isHostInitialized: () => this.lifecycle.isInitialized,
+      send: (request) => this.send(request),
+      emitCrashDetails: (payload) => {
+        this.emit("host-crash-details", payload);
+      },
     });
 
-    this.child.on("exit", (code) => {
-      this.flushHostOutputBuffers();
-      // Note: UtilityProcess exit event doesn't provide signal, but we can infer from code
-      const signal = code !== null && code > 128 ? `SIG${code - 128}` : null;
-      const fallbackCrashType = classifyCrash(code, signal);
-
-      // Clear health check
-      if (this.healthCheckInterval) {
-        clearInterval(this.healthCheckInterval);
-        this.healthCheckInterval = null;
-      }
-      this.lastPingTime = null;
-      this.rttSamples = [];
-      this.rttSamplesSinceLastLog = 0;
-      this.lastRttLogTime = 0;
-
-      // Reject ready promise if host exited before becoming ready
-      const wasReady = this.isInitialized;
-      this.isInitialized = false;
-      this.child = null; // Prevent posting to dead process
-
-      if (this.isDisposed) {
-        // Expected shutdown - drop any buffered reason so it can't leak.
-        this.pendingChildProcessGoneReason = null;
-        return;
-      }
-
-      // If host crashed before ready, reject the promise so startup doesn't hang
-      if (!wasReady && this.readyReject) {
-        this.readyReject(new Error("PTY host exited before ready"));
-        this.readyResolve = null;
-        this.readyReject = null;
-      }
-
-      this.cleanupOrphanedPtys(fallbackCrashType);
-
-      this.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
-      this.shouldResyncProjectContext = true;
-
-      // Electron 37-41 race: `exit` often fires before `child-process-gone`
-      // for utility-process crashes. Defer crash classification by one event
-      // loop tick so the authoritative reason can arrive; fall back to the
-      // exit-code heuristic when no reason was captured in time.
-      setImmediate(() => {
-        if (this.isDisposed) {
-          this.pendingChildProcessGoneReason = null;
-          return;
-        }
-
-        const gone = this.pendingChildProcessGoneReason;
-        this.pendingChildProcessGoneReason = null;
-        const crashType: CrashType = gone
-          ? mapGoneReasonToCrashType(gone.reason)
-          : fallbackCrashType;
-        // Prefer the authoritative exit code from `child-process-gone` over the
-        // (sometimes unreliable) one from `exit` — Electron 40-41 has a known
-        // signed/unsigned mangling bug on Windows for the exit event.
-        const reportedCode = gone ? gone.exitCode : code;
-
-        console.error(
-          `[PtyClient] Pty Host exited with code ${reportedCode}` +
-            (crashType !== "CLEAN_EXIT" ? ` (${crashType})` : "")
-        );
-
-        this.cleanupOrphanedPtys(crashType);
-
-        // Emit crash payload with classification for downstream consumers
-        if (crashType !== "CLEAN_EXIT") {
-          const crashPayload: HostCrashPayload = {
-            code: reportedCode,
-            // When we have an authoritative reason, trust it and clear the
-            // derived-from-exit-code signal string.
-            signal: gone ? null : signal,
-            crashType,
-            timestamp: Date.now(),
-          };
-          this.emit("host-crash-details", crashPayload);
-        }
-
-        // If `manualRestart()` already spawned a new host during the defer
-        // window (possible via the renderer TERMINAL_RESTART_SERVICE IPC call),
-        // don't schedule a second auto-restart — it would orphan that host.
-        if (this.child !== null) return;
-
-        // Try to restart
-        if (this.restartAttempts < this.config.maxRestartAttempts) {
-          this.restartAttempts++;
-          // Full jitter with floor: break deterministic retry lockstep while
-          // keeping a minimum wait so instant-fail crashes don't spin the CPU.
-          const cap = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
-          const floor = 100;
-          const delay = floor + Math.floor(Math.random() * Math.max(0, cap - floor));
-          console.log(
-            `[PtyClient] Restarting Host in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
-          );
-
-          if (this.restartTimer) {
-            clearTimeout(this.restartTimer);
+    this.lifecycle = new PtyHostLifecycle(
+      {
+        maxRestartAttempts: this.config.maxRestartAttempts,
+        memoryLimitMb: this.config.memoryLimitMb,
+        electronDir,
+      },
+      {
+        onMessage: (event) => this.handleHostEvent(event),
+        onExitSync: ({ wasReady: _wasReady, fallbackCrashType }) => {
+          this.healthWatchdog.stop();
+          if (this.isDisposed) {
+            return;
           }
-          this.restartTimer = setTimeout(() => {
-            this.restartTimer = null;
-            if (this.isDisposed || this.child !== null) return;
-            this.needsRespawn = true;
-            this.startHost();
-          }, delay);
-        } else {
-          console.error("[PtyClient] Max restart attempts reached, giving up");
-          this.emit("host-crash", reportedCode);
-        }
-      });
-    });
+          this.cleanupOrphanedPtys(fallbackCrashType);
+          this.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
+          this.shouldResyncProjectContext = true;
+        },
+        onCrashClassified: ({ crashType, payload }) => {
+          this.cleanupOrphanedPtys(crashType);
+          if (payload) {
+            this.emit("host-crash-details", payload);
+          }
+        },
+        onMaxRestartsReached: (code) => {
+          this.emit("host-crash", code);
+        },
+        onForkFailed: () => {
+          this.emit("host-crash", -1);
+        },
+        onBeforeRestart: () => {
+          this.needsRespawn = true;
+        },
+        isDisposed: () => this.isDisposed,
+        logInfo: (message) => logInfo(message),
+        logWarn: (message) => logWarn(message),
+      }
+    );
 
-    // Start health check with watchdog (only if not paused by system sleep)
-    if (!this.isHealthCheckPaused) {
-      this.startHealthCheckInterval();
-    }
+    this.routerDeps = {
+      isDisposed: () => this.isDisposed,
+      broker: this.broker,
+      emitter: this,
+      state: {
+        pendingSpawns: this.pendingSpawns,
+        pendingKillCount: this.pendingKillCount,
+        terminalPids: this.terminalPids,
+      },
+      callbacks: {
+        onReady: () => this.handleReady(),
+        onPong: () => this.healthWatchdog.recordPong(),
+        onTerminalRemovedFromTrash: (id) => getTrashedPidTracker().removeTrashed(id),
+      },
+      logWarn: (message) => console.warn(message),
+    };
+
+    this.lifecycle.start();
+
+    // Start health check (only if not already paused — initial start is never paused)
+    this.healthWatchdog.start();
 
     console.log("[PtyClient] Pty Host started");
   }
 
-  private handleHostEvent(event: PtyHostEvent): void {
-    // Skip processing if disposed to avoid sending to destroyed renderer frames
-    if (this.isDisposed) {
-      return;
-    }
-
-    // First, try to handle as a domain event via the bridge
-    const bridged = bridgePtyEvent(event, {
-      onTerminalStatus: (payload) => {
-        const statusPayload: TerminalStatusPayload = {
-          id: payload.id,
-          status: payload.status,
-          bufferUtilization: payload.bufferUtilization,
-          pauseDuration: payload.pauseDuration,
-          reason: payload.reason,
-          timestamp: payload.timestamp,
-        };
-        this.emit("terminal-status", statusPayload);
-      },
-      onHostThrottled: (payload) => {
-        this.emit("host-throttled", payload);
-      },
-    });
-
-    if (bridged) {
-      return;
-    }
-
-    // Handle transport-level events and request/response correlation
-    switch (event.type) {
-      case "ready": {
-        // Ignore late ready events if host is already dead
-        if (!this.child) {
-          console.warn("[PtyClient] Ignoring late ready event - host is dead");
-          break;
-        }
-        this.isInitialized = true;
-        this.restartAttempts = 0;
-        if (this.readyResolve) {
-          this.readyResolve();
-          this.readyResolve = null;
-          this.readyReject = null;
-        }
-        console.log("[PtyClient] Pty Host is ready");
-        // Replay log-level overrides on every ready (initial spawn + restarts).
-        // The child's message listener isn't attached until after it receives
-        // "ready", so pushing on spawn would race.
-        this.send({
-          type: "set-log-level-overrides",
-          overrides: this.logLevelOverridesCache,
-        });
-        if (this.needsRespawn) {
-          this.needsRespawn = false;
-          this.respawnPending();
-        }
-        const pendingPortWindowIds = new Set(this.pendingMessagePorts.keys());
-        this.flushPendingMessagePorts();
-        if (this.shouldResyncProjectContext) {
-          this.shouldResyncProjectContext = false;
-          this.syncProjectContext(pendingPortWindowIds);
-        }
-        break;
-      }
-
-      case "data":
-        this.emit("data", event.id, event.data);
-        break;
-
-      case "exit": {
-        getTrashedPidTracker().removeTrashed(event.id);
-        const killCount = this.pendingKillCount.get(event.id) ?? 0;
-        if (killCount > 0) {
-          // Exit from a kill() call — a new spawn() may have already
-          // re-registered this id; don't clear pendingSpawns.
-          const remaining = killCount - 1;
-          if (remaining > 0) {
-            this.pendingKillCount.set(event.id, remaining);
-          } else {
-            this.pendingKillCount.delete(event.id);
-          }
-        } else {
-          // Normal exit (process ended on its own)
-          this.pendingSpawns.delete(event.id);
-        }
-        this.terminalPids.delete(event.id);
-        this.emit("exit", event.id, event.exitCode);
-        break;
-      }
-
-      case "error":
-        this.emit("error", event.id, event.error);
-        break;
-
-      case "snapshot":
-        this.broker.resolve(event.requestId, (event.snapshot ?? null) as TerminalSnapshot | null);
-        break;
-
-      case "all-snapshots":
-        this.broker.resolve(event.requestId, (event.snapshots ?? []) as TerminalSnapshot[]);
-        break;
-
-      case "transition-result":
-        this.broker.resolve(event.requestId, event.success);
-        break;
-
-      case "pong":
-        this.missedHeartbeats = 0;
-        if (this.lastPingTime !== null) {
-          const now = performance.now();
-          const rtt = now - this.lastPingTime;
-          this.lastPingTime = null;
-          this.recordRtt(rtt, now);
-        }
-        if (this.isWaitingForHandshake) {
-          this.isWaitingForHandshake = false;
-          if (this.handshakeTimeout) {
-            clearTimeout(this.handshakeTimeout);
-            this.handshakeTimeout = null;
-          }
-          console.log("[PtyClient] Handshake successful - resuming health checks");
-          this.startHealthCheckInterval();
-        }
-        break;
-
-      // Request/response events handled via broker
-      case "terminals-for-project":
-        this.broker.resolve((event as any).requestId, (event as any).terminalIds ?? []);
-        break;
-
-      case "terminal-info":
-        this.broker.resolve((event as any).requestId, (event as any).terminal ?? null);
-        break;
-
-      case "replay-history-result":
-        this.broker.resolve((event as any).requestId, (event as any).replayed ?? 0);
-        break;
-
-      case "available-terminals": {
-        const availableEvent = event as {
-          type: "available-terminals";
-          requestId: string;
-          terminals: TerminalInfoResponse[];
-        };
-        this.broker.resolve(availableEvent.requestId, availableEvent.terminals ?? []);
-        break;
-      }
-
-      case "terminals-by-state": {
-        const byStateEvent = event as {
-          type: "terminals-by-state";
-          requestId: string;
-          terminals: TerminalInfoResponse[];
-        };
-        this.broker.resolve(byStateEvent.requestId, byStateEvent.terminals ?? []);
-        break;
-      }
-
-      case "all-terminals": {
-        const allEvent = event as {
-          type: "all-terminals";
-          requestId: string;
-          terminals: TerminalInfoResponse[];
-        };
-        this.broker.resolve(allEvent.requestId, allEvent.terminals ?? []);
-        break;
-      }
-
-      case "semantic-search-result": {
-        const semEvent = event as {
-          type: "semantic-search-result";
-          requestId: string;
-          matches: import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[];
-        };
-        this.broker.resolve(semEvent.requestId, semEvent.matches ?? []);
-        break;
-      }
-
-      case "serialized-state":
-        this.broker.resolve((event as any).requestId, (event as any).state ?? null);
-        break;
-
-      case "wake-result":
-        this.broker.resolve((event as any).requestId, {
-          state: (event as any).state ?? null,
-          warnings: (event as any).warnings,
-        });
-        break;
-
-      case "kill-by-project-result":
-        this.broker.resolve((event as any).requestId, (event as any).killed ?? 0);
-        break;
-
-      case "graceful-kill-result": {
-        const gkEvent = event as {
-          type: "graceful-kill-result";
-          requestId: string;
-          id: string;
-          agentSessionId: string | null;
-        };
-        this.broker.resolve(gkEvent.requestId, gkEvent.agentSessionId ?? null);
-        break;
-      }
-
-      case "graceful-kill-by-project-result": {
-        const gkpEvent = event as {
-          type: "graceful-kill-by-project-result";
-          requestId: string;
-          results: Array<{ id: string; agentSessionId: string | null }>;
-        };
-        this.broker.resolve(gkpEvent.requestId, gkpEvent.results ?? []);
-        break;
-      }
-
-      case "project-stats":
-        this.broker.resolve(
-          (event as any).requestId,
-          (event as any).stats ?? { terminalCount: 0, processIds: [], terminalTypes: {} }
-        );
-        break;
-
-      case "terminal-diagnostic-info":
-        this.broker.resolve(event.requestId, event.info);
-        break;
-
-      case "terminal-pid":
-        this.terminalPids.set(event.id, event.pid);
-        break;
-
-      case "spawn-result": {
-        const spawnResultEvent = event as { type: "spawn-result"; id: string; result: SpawnResult };
-        if (!spawnResultEvent.result.success) {
-          // Remove from pending spawns since spawn failed
-          this.pendingSpawns.delete(spawnResultEvent.id);
-        }
-        this.emit("spawn-result", spawnResultEvent.id, spawnResultEvent.result);
-        break;
-      }
-
-      case "resource-metrics": {
-        const rmEvent = event as {
-          type: "resource-metrics";
-          metrics: TerminalResourceBatchPayload;
-          timestamp: number;
-        };
-        this.emit("resource-metrics", rmEvent.metrics, rmEvent.timestamp);
-        break;
-      }
-
-      case "broadcast-write-result": {
-        const brEvent = event as {
-          type: "broadcast-write-result";
-        } & BroadcastWriteResultPayload;
-        this.emit("broadcast-write-result", { results: brEvent.results });
-        break;
-      }
-
-      default:
-        console.warn("[PtyClient] Unknown event type:", (event as { type: string }).type);
-    }
+  /** Wait for the host to be ready */
+  async waitForReady(): Promise<void> {
+    return this.lifecycle.waitForReady();
   }
 
-  private recordRtt(rtt: number, now: number): void {
-    this.rttSamples.push(rtt);
-    if (this.rttSamples.length > RTT_BUFFER_SIZE) {
-      this.rttSamples.shift();
+  private handleHostEvent(event: PtyHostEvent): void {
+    routeHostEvent(event, this.routerDeps);
+  }
+
+  private handleReady(): void {
+    if (!this.lifecycle.markReady()) {
+      console.warn("[PtyClient] Ignoring late ready event - host is dead");
+      return;
     }
-    this.rttSamplesSinceLastLog++;
-
-    if (rtt > RTT_WARN_THRESHOLD_MS) {
-      console.warn(
-        `[PtyClient] Heartbeat RTT spike: ${rtt.toFixed(1)}ms (> ${RTT_WARN_THRESHOLD_MS}ms)`
-      );
+    console.log("[PtyClient] Pty Host is ready");
+    // Replay log-level overrides on every ready (initial spawn + restarts).
+    // The child's message listener isn't attached until after it receives
+    // "ready", so pushing on spawn would race.
+    this.send({
+      type: "set-log-level-overrides",
+      overrides: this.logLevelOverridesCache,
+    });
+    if (this.needsRespawn) {
+      this.needsRespawn = false;
+      this.respawnPending();
     }
-
-    const countTrigger = this.rttSamplesSinceLastLog >= RTT_LOG_EVERY_N_SAMPLES;
-    const timeTrigger = now - this.lastRttLogTime >= RTT_LOG_INTERVAL_MS;
-    if (!countTrigger && !timeTrigger) return;
-
-    const sorted = [...this.rttSamples].sort((a, b) => a - b);
-    const p50 = rttPercentile(sorted, 0.5);
-    const p95 = rttPercentile(sorted, 0.95);
-    const p99 = rttPercentile(sorted, 0.99);
-    const max = sorted[sorted.length - 1] ?? 0;
-    console.log(
-      `[PtyClient] Heartbeat RTT (last ${sorted.length}): p50=${p50.toFixed(1)}ms p95=${p95.toFixed(1)}ms p99=${p99.toFixed(1)}ms max=${max.toFixed(1)}ms samples=${this.rttSamplesSinceLastLog}`
-    );
-    this.rttSamplesSinceLastLog = 0;
-    this.lastRttLogTime = now;
+    const pendingPortWindowIds = new Set(this.pendingMessagePorts.keys());
+    this.flushPendingMessagePorts();
+    if (this.shouldResyncProjectContext) {
+      this.shouldResyncProjectContext = false;
+      this.syncProjectContext(pendingPortWindowIds);
+    }
   }
 
   private send(request: PtyHostRequest): void {
-    if (!this.child) {
-      console.warn("[PtyClient] Cannot send - host not running");
-      return;
-    }
-    try {
-      this.child.postMessage(request);
-    } catch (error) {
-      console.error("[PtyClient] postMessage failed:", error);
-      // Treat as host crash - triggers restart path
-      if (this.child) {
-        this.child.kill();
-      }
-    }
+    this.lifecycle.postMessage(request);
   }
 
   private respawnPending(): void {
@@ -1027,13 +446,13 @@ export class PtyClient extends EventEmitter {
    */
   setLogLevelOverrides(overrides: Record<string, string>): void {
     this.logLevelOverridesCache = { ...overrides };
-    if (this.isInitialized && this.child) {
+    if (this.lifecycle.isInitialized && this.lifecycle.child) {
       this.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
     }
   }
 
   private flushPendingMessagePorts(): void {
-    if (!this.child || this.pendingMessagePorts.size === 0) {
+    if (!this.lifecycle.child || this.pendingMessagePorts.size === 0) {
       return;
     }
 
@@ -1056,14 +475,14 @@ export class PtyClient extends EventEmitter {
       this.pendingMessagePorts.delete(windowId);
     }
 
-    if (!this.child) {
+    if (!this.lifecycle.child) {
       console.warn("[PtyClient] Cannot connect MessagePort - host not running, will retry");
       this.pendingMessagePorts.set(windowId, port);
       return;
     }
 
     try {
-      this.child.postMessage({ type: "connect-port", windowId }, [port]);
+      this.lifecycle.child.postMessage({ type: "connect-port", windowId }, [port]);
       if (process.env.DAINTREE_VERBOSE) {
         console.log(`[PtyClient] MessagePort forwarded to Pty Host for window ${windowId}`);
       }
@@ -1109,20 +528,20 @@ export class PtyClient extends EventEmitter {
       enter: "\r",
       return: "\r",
       tab: "\t",
-      "shift+tab": "\u001b[Z",
-      esc: "\u001b",
-      escape: "\u001b",
-      backspace: "\u007f",
-      delete: "\u001b[3~",
-      insert: "\u001b[2~",
-      home: "\u001b[H",
-      end: "\u001b[F",
-      pageup: "\u001b[5~",
-      pagedown: "\u001b[6~",
-      up: "\u001b[A",
-      down: "\u001b[B",
-      right: "\u001b[C",
-      left: "\u001b[D",
+      "shift+tab": "[Z",
+      esc: "",
+      escape: "",
+      backspace: "",
+      delete: "[3~",
+      insert: "[2~",
+      home: "[H",
+      end: "[F",
+      pageup: "[5~",
+      pagedown: "[6~",
+      up: "[A",
+      down: "[B",
+      right: "[C",
+      left: "[D",
     };
 
     if (simpleMap[normalizedKey]) return simpleMap[normalizedKey];
@@ -1137,7 +556,7 @@ export class PtyClient extends EventEmitter {
     if (altMatch) {
       const rest = this.resolveKeySequence(altMatch[1]);
       if (!rest) return null;
-      return `\u001b${rest}`;
+      return `${rest}`;
     }
 
     if (normalizedKey.length === 1) return normalizedKey;
@@ -1314,7 +733,7 @@ export class PtyClient extends EventEmitter {
   }
 
   private syncProjectContext(skipWindowIds?: ReadonlySet<number>): void {
-    if (!this.child) {
+    if (!this.lifecycle.child) {
       this.shouldResyncProjectContext = true;
       return;
     }
@@ -1345,7 +764,7 @@ export class PtyClient extends EventEmitter {
     this.activeProjectId = projectId;
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "active" });
 
-    if (!this.child) {
+    if (!this.lifecycle.child) {
       this.shouldResyncProjectContext = true;
       return;
     }
@@ -1362,7 +781,7 @@ export class PtyClient extends EventEmitter {
     this.activeProjectId = projectId;
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "switch" });
 
-    if (!this.child) {
+    if (!this.lifecycle.child) {
       this.shouldResyncProjectContext = true;
       return;
     }
@@ -1388,7 +807,7 @@ export class PtyClient extends EventEmitter {
       // clear told us (typed BrokerError), or because we notice it ourselves
       // (null child or disposed client, e.g. restart pending, max restarts
       // exhausted, or app quit arriving during the 5s timeout window).
-      if (error instanceof BrokerError || !this.child || this.isDisposed) {
+      if (error instanceof BrokerError || !this.lifecycle.child || this.isDisposed) {
         return null;
       }
       this.kill(id, "graceful-kill-timeout");
@@ -1632,137 +1051,16 @@ export class PtyClient extends EventEmitter {
 
   /** Pause health check during system sleep to prevent time-drift false positives */
   pauseHealthCheck(): void {
-    if (this.isHealthCheckPaused) return;
-    this.isHealthCheckPaused = true;
-    if (this.healthCheckInterval) {
-      clearInterval(this.healthCheckInterval);
-      this.healthCheckInterval = null;
-    }
-    // Clear any pending handshake from rapid suspend/resume cycles
-    if (this.handshakeTimeout) {
-      clearTimeout(this.handshakeTimeout);
-      this.handshakeTimeout = null;
-    }
-    this.isWaitingForHandshake = false;
-    this.lastPingTime = null;
-    console.log("[PtyClient] Health check paused");
+    this.healthWatchdog.pause();
   }
 
   /** Resume health check after system wake with handshake verification */
   resumeHealthCheck(): void {
-    if (!this.isHealthCheckPaused) return;
-    if (!this.isInitialized || !this.child) {
-      console.warn("[PtyClient] Cannot resume health check - host not ready");
-      this.isHealthCheckPaused = false;
-      return;
-    }
-
-    this.isHealthCheckPaused = false;
-
-    // Clear any existing interval before starting handshake
-    if (this.healthCheckInterval) {
-      clearInterval(this.healthCheckInterval);
-      this.healthCheckInterval = null;
-    }
-
-    // Clear any existing handshake timeout from rapid suspend/resume
-    if (this.handshakeTimeout) {
-      clearTimeout(this.handshakeTimeout);
-      this.handshakeTimeout = null;
-    }
-
-    // Send handshake ping before resuming normal health checks
-    console.log("[PtyClient] System resumed. Initiating handshake...");
-    this.isWaitingForHandshake = true;
-    this.lastPingTime = performance.now();
-    this.send({ type: "health-check" });
-
-    // Timeout if no response within 5 seconds - fall back to immediate start
-    this.handshakeTimeout = setTimeout(() => {
-      if (this.isWaitingForHandshake) {
-        console.warn("[PtyClient] Handshake timeout - forcing health check resume");
-        this.isWaitingForHandshake = false;
-        this.handshakeTimeout = null;
-        this.lastPingTime = null;
-        this.startHealthCheckInterval();
-      }
-    }, 5000);
+    this.healthWatchdog.resume();
   }
-
-  /** Start the health check interval with watchdog (called after handshake or timeout) */
-  private startHealthCheckInterval(): void {
-    // Clear any existing interval
-    if (this.healthCheckInterval) {
-      clearInterval(this.healthCheckInterval);
-      this.healthCheckInterval = null;
-    }
-
-    // Reset watchdog counter when starting
-    this.missedHeartbeats = 0;
-    this.lastRttLogTime = performance.now();
-
-    this.healthCheckInterval = setInterval(() => {
-      if (!this.isInitialized || !this.child || this.isHealthCheckPaused) return;
-
-      // WATCHDOG CHECK: Force-kill if host is unresponsive
-      if (this.missedHeartbeats >= this.MAX_MISSED_HEARTBEATS) {
-        const missedMs = this.missedHeartbeats * this.config.healthCheckIntervalMs;
-        console.error(
-          `[PtyClient] Watchdog: Host unresponsive for ${this.missedHeartbeats} checks (${missedMs}ms). Force killing.`
-        );
-
-        // Emit crash details before force-killing
-        const crashPayload: HostCrashPayload = {
-          code: null,
-          signal: "SIGKILL",
-          crashType: "SIGNAL_TERMINATED",
-          timestamp: Date.now(),
-        };
-        this.emit("host-crash-details", crashPayload);
-
-        // Force kill with SIGKILL (UtilityProcess.kill() only sends SIGTERM)
-        if (this.child.pid) {
-          process.kill(this.child.pid, "SIGKILL");
-        }
-        this.missedHeartbeats = 0;
-        this.lastPingTime = null;
-        return;
-      }
-
-      // Increment counter - will be reset by 'pong' response
-      this.missedHeartbeats++;
-      this.lastPingTime = performance.now();
-      this.send({ type: "health-check" });
-    }, this.config.healthCheckIntervalMs);
-
-    console.log("[PtyClient] Health check interval started (watchdog enabled)");
-  }
-
-  /** Handle project switch - forward to host */
-  // Note: Project switching is now handled via onProjectSwitch(projectId) which
-  // preserves the host and active terminals while changing filtering/backgrounding.
 
   manualRestart(): void {
-    if (this.isDisposed) {
-      console.warn("[PtyClient] Cannot manual restart - already disposed");
-      return;
-    }
-
-    if (this.child !== null) {
-      console.warn("[PtyClient] Cannot manual restart - host process already exists");
-      return;
-    }
-
-    if (this.restartTimer) {
-      clearTimeout(this.restartTimer);
-      this.restartTimer = null;
-    }
-
-    this.restartAttempts = 0;
-    this.needsRespawn = true;
-
-    console.log("[PtyClient] Manual restart initiated");
-    this.startHost();
+    this.lifecycle.manualRestart();
   }
 
   dispose(): void {
@@ -1774,22 +1072,8 @@ export class PtyClient extends EventEmitter {
     getTrashedPidTracker().clearAll();
     console.log("[PtyClient] Disposing...");
 
-    if (this.healthCheckInterval) {
-      clearInterval(this.healthCheckInterval);
-      this.healthCheckInterval = null;
-    }
-    this.lastPingTime = null;
-
-    if (this.restartTimer) {
-      clearTimeout(this.restartTimer);
-      this.restartTimer = null;
-    }
-
-    if (this.handshakeTimeout) {
-      clearTimeout(this.handshakeTimeout);
-      this.handshakeTimeout = null;
-    }
-    this.isWaitingForHandshake = false;
+    this.healthWatchdog.dispose();
+    this.lifecycle.dispose();
 
     for (const port of this.pendingMessagePorts.values()) {
       try {
@@ -1799,23 +1083,6 @@ export class PtyClient extends EventEmitter {
       }
     }
     this.pendingMessagePorts.clear();
-
-    if (this.child) {
-      this.send({ type: "dispose" });
-      // Give it a moment to clean up, then force kill
-      setTimeout(() => {
-        if (this.child) {
-          this.child.kill();
-          this.child = null;
-        }
-      }, 1000);
-    }
-
-    if (this.childProcessGoneHandler) {
-      app.off("child-process-gone", this.childProcessGoneHandler);
-      this.childProcessGoneHandler = null;
-    }
-    this.pendingChildProcessGoneReason = null;
 
     // Clean up all pending requests via broker (rejects pending promises with
     // "Broker disposed"; callers convert to sentinel values via .catch()).
@@ -1833,7 +1100,7 @@ export class PtyClient extends EventEmitter {
 
   /** Check if host is running and initialized */
   isReady(): boolean {
-    return this.isInitialized && this.child !== null;
+    return this.lifecycle.isRunning();
   }
 
   /**

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -298,9 +298,6 @@ export class PtyClient extends EventEmitter {
 
     this.lifecycle.start();
 
-    // Start health check (only if not already paused — initial start is never paused)
-    this.healthWatchdog.start();
-
     console.log("[PtyClient] Pty Host started");
   }
 
@@ -326,6 +323,14 @@ export class PtyClient extends EventEmitter {
       type: "set-log-level-overrides",
       overrides: this.logLevelOverridesCache,
     });
+    // Re-arm the watchdog on every successful ready — covers both the initial
+    // boot and every auto-restart cycle. The original code armed it inside
+    // startHost() before ready arrived, but the tick was a no-op until
+    // isInitialized=true anyway, so deferring to ready is equivalent and
+    // avoids a leaked timer when fork itself fails.
+    if (!this.healthWatchdog.isHealthCheckPaused) {
+      this.healthWatchdog.start();
+    }
     if (this.needsRespawn) {
       this.needsRespawn = false;
       this.respawnPending();

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -175,7 +175,7 @@ describe("PtyClient adversarial", () => {
     const newPort = createMockPort();
     const restartedChild = createMockChild();
 
-    privateAccess.child = null;
+    privateAccess.lifecycle.child = null;
     client.connectMessagePort(7, oldPort as unknown as import("electron").MessagePortMain);
     client.connectMessagePort(7, newPort as unknown as import("electron").MessagePortMain);
     shared.forkMock.mockReturnValue(restartedChild);
@@ -199,7 +199,7 @@ describe("PtyClient adversarial", () => {
     const port = createMockPort();
     const restartedChild = createMockChild();
 
-    privateAccess.child = null;
+    privateAccess.lifecycle.child = null;
     client.connectMessagePort(4, port as unknown as import("electron").MessagePortMain);
     client.setActiveProject(4, "project-a", "/projects/a");
     shared.forkMock.mockReturnValue(restartedChild);
@@ -364,7 +364,7 @@ describe("PtyClient adversarial", () => {
     const privateAccess = client as unknown as PtyClientPrivateAccess;
 
     mockChild.emit("exit", 1);
-    expect(privateAccess.child).toBeNull();
+    expect(privateAccess.lifecycle.child).toBeNull();
 
     shared.tracker.removeTrashed.mockClear();
     const latePromise = client.gracefulKill("t1");
@@ -672,12 +672,16 @@ describe("PtyClient adversarial", () => {
 
   it("HOST_EXIT_RESETS_RTT_STATE_ACROSS_RESTART", () => {
     const client = createReadyClient({ healthCheckIntervalMs: 1000 });
-    const privateRtt = client as unknown as {
-      rttSamples: number[];
-      lastPingTime: number | null;
-      rttSamplesSinceLastLog: number;
-      lastRttLogTime: number;
-    };
+    const privateRtt = (
+      client as unknown as {
+        healthWatchdog: {
+          rttSamples: number[];
+          lastPingTime: number | null;
+          rttSamplesSinceLastLog: number;
+          lastRttLogTime: number;
+        };
+      }
+    ).healthWatchdog;
 
     // Seed rolling-window state so a stale carry-over would be observable.
     privateRtt.rttSamples = [10, 20, 30];
@@ -739,9 +743,9 @@ describe("PtyClient adversarial", () => {
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const pendingPort = createMockPort();
 
-    privateAccess.child = null;
+    privateAccess.lifecycle.child = null;
     client.connectMessagePort(9, pendingPort as unknown as import("electron").MessagePortMain);
-    privateAccess.child = mockChild;
+    privateAccess.lifecycle.child = mockChild;
 
     const terminalPromise = client.getTerminalAsync("t1");
     const snapshotPromise = client.getTerminalSnapshot("t1");

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -68,7 +68,9 @@ interface MockMessagePortMain {
 }
 
 interface PtyClientPrivateAccess {
-  child: MockUtilityProcess | null;
+  lifecycle: {
+    child: MockUtilityProcess | null;
+  };
   pendingMessagePorts: Map<number, MockMessagePortMain>;
   pendingKillCount: Map<string, number>;
   ipcDataMirrorIds: Set<string>;

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -400,10 +400,12 @@ describe("PtyClient Handshake Protocol", () => {
 
   describe("RTT measurement", () => {
     interface RttPrivate {
-      lastPingTime: number | null;
-      rttSamples: number[];
-      rttSamplesSinceLastLog: number;
-      lastRttLogTime: number;
+      healthWatchdog: {
+        lastPingTime: number | null;
+        rttSamples: number[];
+        rttSamplesSinceLastLog: number;
+        lastRttLogTime: number;
+      };
     }
 
     let fakeNow: number;
@@ -431,13 +433,13 @@ describe("PtyClient Handshake Protocol", () => {
       client.pauseHealthCheck();
       fakeNow = 2_000;
       client.resumeHealthCheck();
-      expect(priv.lastPingTime).toBe(2_000);
+      expect(priv.healthWatchdog.lastPingTime).toBe(2_000);
 
       fakeNow = 2_050;
       mockChild.emit("message", { type: "pong" });
 
-      expect(priv.rttSamples).toEqual([50]);
-      expect(priv.lastPingTime).toBeNull();
+      expect(priv.healthWatchdog.rttSamples).toEqual([50]);
+      expect(priv.healthWatchdog.lastPingTime).toBeNull();
     });
 
     it("does not record RTT when lastPingTime is null", () => {
@@ -447,8 +449,8 @@ describe("PtyClient Handshake Protocol", () => {
       // Pong arrives without an outstanding ping timestamp
       mockChild.emit("message", { type: "pong" });
 
-      expect(priv.rttSamples).toEqual([]);
-      expect(priv.lastPingTime).toBeNull();
+      expect(priv.healthWatchdog.rttSamples).toEqual([]);
+      expect(priv.healthWatchdog.lastPingTime).toBeNull();
     });
 
     it("does not record a sample for a late pong after handshake timeout", () => {
@@ -457,14 +459,14 @@ describe("PtyClient Handshake Protocol", () => {
 
       client.pauseHealthCheck();
       client.resumeHealthCheck();
-      expect(priv.lastPingTime).not.toBeNull();
+      expect(priv.healthWatchdog.lastPingTime).not.toBeNull();
 
       // Handshake timeout fires at 5s — clears lastPingTime
       vi.advanceTimersByTime(5000);
-      expect(priv.lastPingTime).toBeNull();
+      expect(priv.healthWatchdog.lastPingTime).toBeNull();
 
       mockChild.emit("message", { type: "pong" });
-      expect(priv.rttSamples).toEqual([]);
+      expect(priv.healthWatchdog.rttSamples).toEqual([]);
     });
 
     it("logs a summary after 10 samples and resets the counter", () => {
@@ -487,7 +489,7 @@ describe("PtyClient Handshake Protocol", () => {
       );
       expect(summaryCalls).toHaveLength(1);
       expect(summaryCalls[0][0]).toContain("samples=10");
-      expect(priv.rttSamplesSinceLastLog).toBe(0);
+      expect(priv.healthWatchdog.rttSamplesSinceLastLog).toBe(0);
     });
 
     it("emits a spike warning when RTT exceeds the threshold", () => {
@@ -521,10 +523,10 @@ describe("PtyClient Handshake Protocol", () => {
         mockChild.emit("message", { type: "pong" });
       }
 
-      expect(priv.rttSamples).toHaveLength(20);
+      expect(priv.healthWatchdog.rttSamples).toHaveLength(20);
       // Oldest 5 samples were dropped; first kept sample has RTT = 6
-      expect(priv.rttSamples[0]).toBe(6);
-      expect(priv.rttSamples[priv.rttSamples.length - 1]).toBe(25);
+      expect(priv.healthWatchdog.rttSamples[0]).toBe(6);
+      expect(priv.healthWatchdog.rttSamples[priv.healthWatchdog.rttSamples.length - 1]).toBe(25);
     });
 
     it("clears lastPingTime when health check is paused", () => {
@@ -534,10 +536,10 @@ describe("PtyClient Handshake Protocol", () => {
 
       fakeNow = 5_000;
       vi.advanceTimersByTime(1000);
-      expect(priv.lastPingTime).not.toBeNull();
+      expect(priv.healthWatchdog.lastPingTime).not.toBeNull();
 
       client.pauseHealthCheck();
-      expect(priv.lastPingTime).toBeNull();
+      expect(priv.healthWatchdog.lastPingTime).toBeNull();
     });
 
     it("clears lastPingTime when the watchdog force-kills the host", () => {
@@ -554,7 +556,7 @@ describe("PtyClient Handshake Protocol", () => {
         vi.advanceTimersByTime(1000);
       }
 
-      expect(priv.lastPingTime).toBeNull();
+      expect(priv.healthWatchdog.lastPingTime).toBeNull();
       void client;
     });
   });

--- a/electron/services/__tests__/PtyClient.watchdog.test.ts
+++ b/electron/services/__tests__/PtyClient.watchdog.test.ts
@@ -43,12 +43,16 @@ interface MockUtilityProcess extends EventEmitter {
 }
 
 interface WatchdogPrivate {
-  child: MockUtilityProcess | null;
-  missedHeartbeats: number;
-  isHealthCheckPaused: boolean;
-  healthCheckInterval: NodeJS.Timeout | null;
-  isInitialized: boolean;
-  isWaitingForHandshake: boolean;
+  lifecycle: {
+    child: MockUtilityProcess | null;
+    isInitialized: boolean;
+  };
+  healthWatchdog: {
+    missedHeartbeats: number;
+    isHealthCheckPaused: boolean;
+    healthCheckInterval: NodeJS.Timeout | null;
+    isWaitingForHandshake: boolean;
+  };
 }
 
 function createMockChild(): MockUtilityProcess {
@@ -104,7 +108,7 @@ describe("PtyClient watchdog", () => {
     expect(killSpy).toHaveBeenCalledWith(321, "SIGKILL");
     expect(crashListener).toHaveBeenCalledTimes(1);
     // Watchdog resets the counter to 0 after firing so the next tick starts fresh.
-    expect((client as unknown as WatchdogPrivate).missedHeartbeats).toBe(0);
+    expect((client as unknown as WatchdogPrivate).healthWatchdog.missedHeartbeats).toBe(0);
   });
 
   it("CRASH_DETAILS_EMITTED_BEFORE_KILL_WITH_SIGNAL_PAYLOAD", () => {
@@ -136,14 +140,14 @@ describe("PtyClient watchdog", () => {
     const priv = client as unknown as WatchdogPrivate;
 
     vi.advanceTimersByTime(200);
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
 
     mockChild.emit("message", { type: "pong" });
-    expect(priv.missedHeartbeats).toBe(0);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(0);
 
     // Three more ticks bring the counter back to 3 without triggering the kill.
     vi.advanceTimersByTime(300);
-    expect(priv.missedHeartbeats).toBe(3);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(3);
     expect(killSpy).not.toHaveBeenCalled();
 
     // The fourth tick is the one that fires the watchdog guard.
@@ -156,15 +160,15 @@ describe("PtyClient watchdog", () => {
     const priv = client as unknown as WatchdogPrivate;
 
     vi.advanceTimersByTime(200);
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
 
     client.pauseHealthCheck();
-    expect(priv.isHealthCheckPaused).toBe(true);
-    expect(priv.healthCheckInterval).toBeNull();
+    expect(priv.healthWatchdog.isHealthCheckPaused).toBe(true);
+    expect(priv.healthWatchdog.healthCheckInterval).toBeNull();
 
     // With the interval cleared, advancing time has no effect on the counter.
     vi.advanceTimersByTime(10_000);
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
     expect(killSpy).not.toHaveBeenCalled();
   });
 
@@ -177,9 +181,9 @@ describe("PtyClient watchdog", () => {
     // Drive the counter up to the threshold, then simulate the exit-event race:
     // the host is gone (child = null) when the 4th tick tries to fire the watchdog.
     vi.advanceTimersByTime(300);
-    expect(priv.missedHeartbeats).toBe(3);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(3);
 
-    priv.child = null;
+    priv.lifecycle.child = null;
 
     expect(() => vi.advanceTimersByTime(100)).not.toThrow();
     expect(killSpy).not.toHaveBeenCalled();
@@ -191,21 +195,21 @@ describe("PtyClient watchdog", () => {
     const priv = client as unknown as WatchdogPrivate;
 
     vi.advanceTimersByTime(200);
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
 
     // pauseHealthCheck clears the interval but leaves the counter untouched.
     client.pauseHealthCheck();
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
 
     // resumeHealthCheck sends a handshake ping and arms a 5s fallback timeout.
     client.resumeHealthCheck();
-    expect(priv.isWaitingForHandshake).toBe(true);
+    expect(priv.healthWatchdog.isWaitingForHandshake).toBe(true);
 
     // A pong during the handshake window clears the counter and re-enters
     // startHealthCheckInterval(), which itself resets missedHeartbeats to 0.
     mockChild.emit("message", { type: "pong" });
-    expect(priv.isWaitingForHandshake).toBe(false);
-    expect(priv.missedHeartbeats).toBe(0);
+    expect(priv.healthWatchdog.isWaitingForHandshake).toBe(false);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(0);
 
     // Re-armed interval takes 4 fresh ticks to reach the kill threshold.
     vi.advanceTimersByTime(300);
@@ -263,7 +267,7 @@ describe("PtyClient watchdog", () => {
 
     expect(killSpy).not.toHaveBeenCalled();
     expect(crashListener).not.toHaveBeenCalled();
-    expect(priv.missedHeartbeats).toBe(0);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(0);
     const healthChecks = mockChild.postMessage.mock.calls.filter(
       (call: unknown[]) => (call[0] as { type?: string })?.type === "health-check"
     );
@@ -279,17 +283,17 @@ describe("PtyClient watchdog", () => {
     const priv = client as unknown as WatchdogPrivate;
 
     vi.advanceTimersByTime(200);
-    expect(priv.missedHeartbeats).toBe(2);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(2);
 
     client.pauseHealthCheck();
     client.resumeHealthCheck();
-    expect(priv.isWaitingForHandshake).toBe(true);
+    expect(priv.healthWatchdog.isWaitingForHandshake).toBe(true);
 
     // No pong: handshake timeout (5000ms) fires and falls back to
     // startHealthCheckInterval() which resets the counter.
     vi.advanceTimersByTime(5000);
-    expect(priv.isWaitingForHandshake).toBe(false);
-    expect(priv.missedHeartbeats).toBe(0);
+    expect(priv.healthWatchdog.isWaitingForHandshake).toBe(false);
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(0);
 
     vi.advanceTimersByTime(300);
     expect(killSpy).not.toHaveBeenCalled();

--- a/electron/services/__tests__/PtyClient.watchdog.test.ts
+++ b/electron/services/__tests__/PtyClient.watchdog.test.ts
@@ -300,4 +300,39 @@ describe("PtyClient watchdog", () => {
     vi.advanceTimersByTime(100);
     expect(killSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("WATCHDOG_RE_ARMED_AFTER_AUTO_RESTART", () => {
+    // Regression for #6690: when the host crashes and is auto-restarted, the
+    // watchdog must restart with the new child. Previously a one-shot
+    // start-in-constructor left the watchdog dead after the first crash.
+    const client = createReadyClient({ healthCheckIntervalMs: 100 });
+    const priv = client as unknown as WatchdogPrivate;
+
+    // First host crashes — onExitSync stops the watchdog, restart timer is
+    // scheduled inside the lifecycle's setImmediate.
+    mockChild.emit("exit", 1);
+
+    // The next fork (during the restart timer) returns a fresh mock child.
+    const restartedChild = Object.assign(new EventEmitter(), {
+      postMessage: vi.fn(),
+      kill: vi.fn(),
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      pid: 654,
+    }) as MockUtilityProcess;
+    shared.forkMock.mockReturnValue(restartedChild);
+
+    // Drain the setImmediate + the random-jittered restart delay (max 2000ms
+    // for attempt 1: floor(100) + random*Math.min(2^1*1000, 10000)-100).
+    vi.advanceTimersByTime(2_001);
+    // New host emits ready
+    restartedChild.emit("message", { type: "ready" });
+
+    // Counter resets to 0 on each start; ticks 1-3 increment it; tick 4 fires.
+    vi.advanceTimersByTime(400);
+
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith(654, "SIGKILL");
+    expect(priv.healthWatchdog.missedHeartbeats).toBe(0);
+  });
 });

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -1,0 +1,254 @@
+/**
+ * PtyEventRouter - Pure-function router for transport-level PTY host events.
+ *
+ * Mirrors the {@link bridgePtyEvent} pattern: the caller delegates first to the
+ * domain-event bridge; if that returns false, this router handles request/response
+ * correlation (broker resolves), transport events (`data` / `exit` / `error`),
+ * the ready/pong lifecycle, and the small set of unsolicited push events
+ * (`spawn-result`, `terminal-pid`, `resource-metrics`, `broadcast-write-result`).
+ *
+ * State stays in {@link PtyClient}; the router takes shared maps by reference
+ * (so the `exit` case mutates the same `pendingSpawns`/`pendingKillCount`/
+ * `terminalPids` that `spawn()`/`kill()` read) and reaches everything else
+ * through callbacks. The disposed check is delegated via {@link PtyEventRouterDeps.isDisposed}
+ * so the router never owns lifecycle state.
+ *
+ * The `event as any` casts that used to live in `PtyClient.handleHostEvent` are
+ * gone here: every broker case narrows via the discriminated union, and the
+ * shared {@link isPtyHostResponseEvent} predicate is available for exhaustive
+ * switches on `requestId`-bearing events.
+ */
+
+import type { EventEmitter } from "events";
+import type {
+  BroadcastWriteResultPayload,
+  PtyHostEvent,
+  PtyHostSpawnOptions,
+  SpawnResult,
+  TerminalResourceBatchPayload,
+  TerminalStatusPayload,
+} from "../../../shared/types/pty-host.js";
+import type { TerminalSnapshot } from "../PtyManager.js";
+import { bridgePtyEvent } from "./PtyEventsBridge.js";
+
+/** Minimal broker contract — matches RequestResponseBroker's public surface. */
+export interface PtyEventRouterBroker {
+  resolve<T>(requestId: string, result: T): boolean;
+}
+
+/** Maps shared by reference between PtyClient and the router. */
+export interface PtyEventRouterState {
+  pendingSpawns: Map<string, PtyHostSpawnOptions>;
+  pendingKillCount: Map<string, number>;
+  terminalPids: Map<string, number>;
+}
+
+/** Callbacks invoked by the router for side effects that span multiple concerns. */
+export interface PtyEventRouterCallbacks {
+  /**
+   * Invoked when the host emits `ready`. Concrete consumer is PtyClient, which
+   * resolves its readyPromise, replays log-level overrides, runs respawn /
+   * port-flush / project-resync, etc. Returning the set of pending port windowIds
+   * lets the router skip them in the project resync (matches the previous
+   * inline behavior).
+   */
+  onReady: () => void;
+  /** Invoked on every `pong` so the watchdog can reset its missed-heartbeat counter. */
+  onPong: () => void;
+  /** Invoked when the host removes a trashed terminal (delegated to the tracker). */
+  onTerminalRemovedFromTrash: (id: string) => void;
+}
+
+export interface PtyEventRouterDeps {
+  isDisposed: () => boolean;
+  broker: PtyEventRouterBroker;
+  emitter: EventEmitter;
+  state: PtyEventRouterState;
+  callbacks: PtyEventRouterCallbacks;
+  /** Logger for warnings — keeps the router free of console.* coupling. */
+  logWarn: (message: string) => void;
+}
+
+/**
+ * Route one host event. Returns true if the event was handled (either by the
+ * domain bridge or this router); false for unknown event types so the caller
+ * can decide whether to log.
+ */
+export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): boolean {
+  if (deps.isDisposed()) {
+    return true;
+  }
+
+  const bridged = bridgePtyEvent(event, {
+    onTerminalStatus: (payload) => {
+      const statusPayload: TerminalStatusPayload = {
+        id: payload.id,
+        status: payload.status,
+        bufferUtilization: payload.bufferUtilization,
+        pauseDuration: payload.pauseDuration,
+        reason: payload.reason,
+        timestamp: payload.timestamp,
+      };
+      deps.emitter.emit("terminal-status", statusPayload);
+    },
+    onHostThrottled: (payload) => {
+      deps.emitter.emit("host-throttled", payload);
+    },
+  });
+
+  if (bridged) {
+    return true;
+  }
+
+  const { broker, emitter, state, callbacks } = deps;
+
+  switch (event.type) {
+    case "ready": {
+      callbacks.onReady();
+      return true;
+    }
+
+    case "data":
+      emitter.emit("data", event.id, event.data);
+      return true;
+
+    case "exit": {
+      callbacks.onTerminalRemovedFromTrash(event.id);
+      const killCount = state.pendingKillCount.get(event.id) ?? 0;
+      if (killCount > 0) {
+        // Exit from a kill() call — a new spawn() may have already
+        // re-registered this id; don't clear pendingSpawns.
+        const remaining = killCount - 1;
+        if (remaining > 0) {
+          state.pendingKillCount.set(event.id, remaining);
+        } else {
+          state.pendingKillCount.delete(event.id);
+        }
+      } else {
+        // Normal exit (process ended on its own)
+        state.pendingSpawns.delete(event.id);
+      }
+      state.terminalPids.delete(event.id);
+      emitter.emit("exit", event.id, event.exitCode);
+      return true;
+    }
+
+    case "error":
+      emitter.emit("error", event.id, event.error);
+      return true;
+
+    case "snapshot":
+      broker.resolve<TerminalSnapshot | null>(event.requestId, event.snapshot ?? null);
+      return true;
+
+    case "all-snapshots":
+      broker.resolve<TerminalSnapshot[]>(event.requestId, event.snapshots ?? []);
+      return true;
+
+    case "transition-result":
+      broker.resolve(event.requestId, event.success);
+      return true;
+
+    case "pong":
+      callbacks.onPong();
+      return true;
+
+    case "terminals-for-project":
+      broker.resolve(event.requestId, event.terminalIds ?? []);
+      return true;
+
+    case "terminal-info":
+      broker.resolve(event.requestId, event.terminal ?? null);
+      return true;
+
+    case "replay-history-result":
+      broker.resolve(event.requestId, event.replayed ?? 0);
+      return true;
+
+    case "available-terminals":
+      broker.resolve(event.requestId, event.terminals ?? []);
+      return true;
+
+    case "terminals-by-state":
+      broker.resolve(event.requestId, event.terminals ?? []);
+      return true;
+
+    case "all-terminals":
+      broker.resolve(event.requestId, event.terminals ?? []);
+      return true;
+
+    case "semantic-search-result":
+      broker.resolve(event.requestId, event.matches ?? []);
+      return true;
+
+    case "serialized-state":
+      broker.resolve(event.requestId, event.state ?? null);
+      return true;
+
+    case "wake-result":
+      broker.resolve(event.requestId, {
+        state: event.state ?? null,
+        warnings: event.warnings,
+      });
+      return true;
+
+    case "kill-by-project-result":
+      broker.resolve(event.requestId, event.killed ?? 0);
+      return true;
+
+    case "graceful-kill-result":
+      broker.resolve(event.requestId, event.agentSessionId ?? null);
+      return true;
+
+    case "graceful-kill-by-project-result":
+      broker.resolve(event.requestId, event.results ?? []);
+      return true;
+
+    case "project-stats":
+      // Fallback shape preserves the legacy `terminalTypes` key — the
+      // PtyClient public type signature still uses it, even though the host
+      // actually sends `detectedAgents` on the stats payload. Don't tighten
+      // this in a pure refactor.
+      broker.resolve(
+        event.requestId,
+        event.stats ?? { terminalCount: 0, processIds: [], terminalTypes: {} }
+      );
+      return true;
+
+    case "terminal-diagnostic-info":
+      broker.resolve(event.requestId, event.info);
+      return true;
+
+    case "terminal-pid":
+      state.terminalPids.set(event.id, event.pid);
+      return true;
+
+    case "spawn-result": {
+      const spawnResultEvent: { id: string; result: SpawnResult } = event;
+      if (!spawnResultEvent.result.success) {
+        // Remove from pending spawns since spawn failed
+        state.pendingSpawns.delete(spawnResultEvent.id);
+      }
+      emitter.emit("spawn-result", spawnResultEvent.id, spawnResultEvent.result);
+      return true;
+    }
+
+    case "resource-metrics": {
+      const rmEvent: { metrics: TerminalResourceBatchPayload; timestamp: number } = event;
+      emitter.emit("resource-metrics", rmEvent.metrics, rmEvent.timestamp);
+      return true;
+    }
+
+    case "broadcast-write-result": {
+      const brEvent: BroadcastWriteResultPayload = event;
+      emitter.emit("broadcast-write-result", { results: brEvent.results });
+      return true;
+    }
+
+    default: {
+      const unknownType = (event as { type: string }).type;
+      deps.logWarn(`[PtyClient] Unknown event type: ${unknownType}`);
+      return false;
+    }
+  }
+}

--- a/electron/services/pty/PtyHealthWatchdog.ts
+++ b/electron/services/pty/PtyHealthWatchdog.ts
@@ -1,0 +1,278 @@
+/**
+ * PtyHealthWatchdog - Heartbeat watchdog and RTT observability for the PTY host.
+ *
+ * Owns the missed-heartbeat counter, the heartbeat interval timer, the
+ * sleep/wake handshake state, and the rolling RTT sample buffer. PtyClient
+ * delegates all of this here so the lifecycle of a single host run can be
+ * tested without spinning up a UtilityProcess.
+ *
+ * Behavior is preserved from the original inline implementation in PtyClient:
+ *   - On every interval tick, increment `missedHeartbeats` then send `health-check`.
+ *     The next `pong` resets the counter via {@link recordPong}.
+ *   - When `missedHeartbeats >= maxMissedHeartbeats`, force-kill the host via
+ *     `process.kill(child.pid, "SIGKILL")` and emit `host-crash-details`. The
+ *     UtilityProcess `kill()` method only sends SIGTERM, so SIGKILL must come
+ *     from the OS.
+ *   - The handshake state (`isWaitingForHandshake`, `handshakeTimeout`) gates
+ *     the resume-after-sleep dance: send one ping, wait up to 5s for the pong,
+ *     then start the normal interval (whether or not the pong arrived).
+ *
+ * Public state fields are exposed for backward-compatible test access; the
+ * existing PtyClient tests pre-extract reach into `priv.missedHeartbeats`
+ * etc., and continue to work via the proxy properties on PtyClient.
+ */
+
+import { performance } from "node:perf_hooks";
+import type { UtilityProcess } from "electron";
+import type { HostCrashPayload, PtyHostRequest } from "../../../shared/types/pty-host.js";
+
+const HANDSHAKE_TIMEOUT_MS = 5_000;
+const RTT_BUFFER_SIZE = 20;
+const RTT_LOG_EVERY_N_SAMPLES = 10;
+const RTT_LOG_INTERVAL_MS = 5 * 60 * 1000;
+const RTT_WARN_THRESHOLD_MS = 5_000;
+
+function rttPercentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (p <= 0) return sorted[0];
+  if (p >= 1) return sorted[sorted.length - 1];
+  const idx = p * (sorted.length - 1);
+  const low = Math.floor(idx);
+  const high = Math.ceil(idx);
+  if (low === high) return sorted[low];
+  const frac = idx - low;
+  return sorted[low] * (1 - frac) + sorted[high] * frac;
+}
+
+export interface PtyHealthWatchdogDeps {
+  intervalMs: number;
+  maxMissedHeartbeats: number;
+  /** Returns the current child reference; null when the host is dead. */
+  getChild: () => UtilityProcess | null;
+  /** Returns whether the host has emitted `ready`. The interval no-ops until then. */
+  isHostInitialized: () => boolean;
+  /** Send a `health-check` request to the host. */
+  send: (request: PtyHostRequest) => void;
+  /** Emit a host-crash-details event when the watchdog force-kills the host. */
+  emitCrashDetails: (payload: HostCrashPayload) => void;
+}
+
+export class PtyHealthWatchdog {
+  /** Number of consecutive ticks since the last `pong`. Public for test access. */
+  missedHeartbeats = 0;
+  /** Active interval timer, or null when paused / not started. */
+  healthCheckInterval: NodeJS.Timeout | null = null;
+  /** True between pauseHealthCheck() and resumeHealthCheck(). */
+  isHealthCheckPaused = false;
+  /** True between sending the wake handshake ping and the matching pong / fallback. */
+  isWaitingForHandshake = false;
+  /** Fallback timer for the wake handshake; cleared on pong or pause. */
+  handshakeTimeout: NodeJS.Timeout | null = null;
+  /** Timestamp of the in-flight ping, or null if none. */
+  lastPingTime: number | null = null;
+  /** Rolling buffer of recent RTT samples (capped at RTT_BUFFER_SIZE). */
+  rttSamples: number[] = [];
+  /** Counter for the periodic summary log; resets on each emit. */
+  rttSamplesSinceLastLog = 0;
+  /** Timestamp of the last summary emit. */
+  lastRttLogTime = 0;
+
+  constructor(private readonly deps: PtyHealthWatchdogDeps) {}
+
+  /**
+   * Start the heartbeat interval. Resets `missedHeartbeats` and clears any
+   * existing interval first so this is safe to call multiple times.
+   */
+  start(): void {
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+
+    this.missedHeartbeats = 0;
+    this.lastRttLogTime = performance.now();
+
+    this.healthCheckInterval = setInterval(() => {
+      const child = this.deps.getChild();
+      if (!this.deps.isHostInitialized() || !child || this.isHealthCheckPaused) return;
+
+      // WATCHDOG CHECK: Force-kill if host is unresponsive
+      if (this.missedHeartbeats >= this.deps.maxMissedHeartbeats) {
+        const missedMs = this.missedHeartbeats * this.deps.intervalMs;
+        console.error(
+          `[PtyClient] Watchdog: Host unresponsive for ${this.missedHeartbeats} checks (${missedMs}ms). Force killing.`
+        );
+
+        const crashPayload: HostCrashPayload = {
+          code: null,
+          signal: "SIGKILL",
+          crashType: "SIGNAL_TERMINATED",
+          timestamp: Date.now(),
+        };
+        this.deps.emitCrashDetails(crashPayload);
+
+        // Force kill with SIGKILL (UtilityProcess.kill() only sends SIGTERM)
+        if (child.pid) {
+          process.kill(child.pid, "SIGKILL");
+        }
+        this.missedHeartbeats = 0;
+        this.lastPingTime = null;
+        return;
+      }
+
+      this.missedHeartbeats++;
+      this.lastPingTime = performance.now();
+      this.deps.send({ type: "health-check" });
+    }, this.deps.intervalMs);
+
+    console.log("[PtyClient] Health check interval started (watchdog enabled)");
+  }
+
+  /**
+   * Stop the heartbeat interval and clear all RTT/ping state. Called from the
+   * exit handler so a fresh host run starts with empty buffers.
+   */
+  stop(): void {
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+    this.lastPingTime = null;
+    this.rttSamples = [];
+    this.rttSamplesSinceLastLog = 0;
+    this.lastRttLogTime = 0;
+  }
+
+  /**
+   * Pause the heartbeat for system sleep. Tears down both the interval and any
+   * in-flight handshake fallback so a rapid suspend/resume can't strand state.
+   */
+  pause(): void {
+    if (this.isHealthCheckPaused) return;
+    this.isHealthCheckPaused = true;
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+    this.isWaitingForHandshake = false;
+    this.lastPingTime = null;
+    console.log("[PtyClient] Health check paused");
+  }
+
+  /**
+   * Resume after system wake. Returns true if a handshake was initiated; false
+   * if it was rejected (already running, or host not ready). When false, the
+   * caller should not expect any subsequent state changes from the watchdog.
+   */
+  resume(): boolean {
+    if (!this.isHealthCheckPaused) return false;
+    if (!this.deps.isHostInitialized() || !this.deps.getChild()) {
+      console.warn("[PtyClient] Cannot resume health check - host not ready");
+      this.isHealthCheckPaused = false;
+      return false;
+    }
+
+    this.isHealthCheckPaused = false;
+
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+
+    console.log("[PtyClient] System resumed. Initiating handshake...");
+    this.isWaitingForHandshake = true;
+    this.lastPingTime = performance.now();
+    this.deps.send({ type: "health-check" });
+
+    this.handshakeTimeout = setTimeout(() => {
+      if (this.isWaitingForHandshake) {
+        console.warn("[PtyClient] Handshake timeout - forcing health check resume");
+        this.isWaitingForHandshake = false;
+        this.handshakeTimeout = null;
+        this.lastPingTime = null;
+        this.start();
+      }
+    }, HANDSHAKE_TIMEOUT_MS);
+    return true;
+  }
+
+  /**
+   * Process an incoming `pong`. Resets the missed-heartbeat counter, records
+   * the RTT sample, and — if a handshake was outstanding — clears it and
+   * starts the normal interval.
+   */
+  recordPong(): void {
+    this.missedHeartbeats = 0;
+    if (this.lastPingTime !== null) {
+      const now = performance.now();
+      const rtt = now - this.lastPingTime;
+      this.lastPingTime = null;
+      this.recordRtt(rtt, now);
+    }
+    if (this.isWaitingForHandshake) {
+      this.isWaitingForHandshake = false;
+      if (this.handshakeTimeout) {
+        clearTimeout(this.handshakeTimeout);
+        this.handshakeTimeout = null;
+      }
+      console.log("[PtyClient] Handshake successful - resuming health checks");
+      this.start();
+    }
+  }
+
+  /** Whether the watchdog is currently armed (interval running). */
+  isRunning(): boolean {
+    return this.healthCheckInterval !== null;
+  }
+
+  /** Stop everything; called from PtyClient.dispose(). */
+  dispose(): void {
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+    this.isWaitingForHandshake = false;
+    this.lastPingTime = null;
+  }
+
+  private recordRtt(rtt: number, now: number): void {
+    this.rttSamples.push(rtt);
+    if (this.rttSamples.length > RTT_BUFFER_SIZE) {
+      this.rttSamples.shift();
+    }
+    this.rttSamplesSinceLastLog++;
+
+    if (rtt > RTT_WARN_THRESHOLD_MS) {
+      console.warn(
+        `[PtyClient] Heartbeat RTT spike: ${rtt.toFixed(1)}ms (> ${RTT_WARN_THRESHOLD_MS}ms)`
+      );
+    }
+
+    const countTrigger = this.rttSamplesSinceLastLog >= RTT_LOG_EVERY_N_SAMPLES;
+    const timeTrigger = now - this.lastRttLogTime >= RTT_LOG_INTERVAL_MS;
+    if (!countTrigger && !timeTrigger) return;
+
+    const sorted = [...this.rttSamples].sort((a, b) => a - b);
+    const p50 = rttPercentile(sorted, 0.5);
+    const p95 = rttPercentile(sorted, 0.95);
+    const p99 = rttPercentile(sorted, 0.99);
+    const max = sorted[sorted.length - 1] ?? 0;
+    console.log(
+      `[PtyClient] Heartbeat RTT (last ${sorted.length}): p50=${p50.toFixed(1)}ms p95=${p95.toFixed(1)}ms p99=${p99.toFixed(1)}ms max=${max.toFixed(1)}ms samples=${this.rttSamplesSinceLastLog}`
+    );
+    this.rttSamplesSinceLastLog = 0;
+    this.lastRttLogTime = now;
+  }
+}

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -1,0 +1,553 @@
+/**
+ * PtyHostLifecycle - Owns the UtilityProcess fork/exit/restart loop for the PTY host.
+ *
+ * Encapsulates everything tied to a single host run: the `child` reference,
+ * the `child-process-gone` deferred-classification race (Electron 37-41), the
+ * full-jitter restart backoff, stdout/stderr log forwarding, and the
+ * `readyPromise` lifecycle. PtyClient holds business state (broker, pending
+ * spawns, watchdog) and reaches into the lifecycle through callbacks.
+ *
+ * Why this exists:
+ *   - The exit handler ran ~70 lines of intertwined concerns inside PtyClient,
+ *     mixing setImmediate deferral, restart scheduling, broker teardown, and
+ *     orphan cleanup. Splitting the host-managing parts here keeps PtyClient
+ *     focused on transport/correlation while still letting the existing
+ *     adversarial/handshake/watchdog tests poke `child` for race simulation.
+ *   - The `readyPromise` reassignment on each restart is a subtle invariant —
+ *     having it owned here next to the resolve/reject pair removes a class of
+ *     "wrong promise resolved" bugs.
+ *
+ * Behavior preserved:
+ *   - `pendingChildProcessGoneReason` is consumed via `setImmediate` to bridge
+ *     the Electron 37-41 race where `exit` often fires before
+ *     `child-process-gone`.
+ *   - On Windows, the `child-process-gone` exitCode is preferred over the
+ *     `exit` event's code (Electron 40-41 has a known signed/unsigned mangling
+ *     bug on the `exit` path).
+ *   - Restart attempts use full jitter with a 100ms floor and a cap of
+ *     `min(2^N * 1000ms, 10000ms)` per attempt N.
+ *   - If `manualRestart()` already spawned a host during the setImmediate
+ *     window, the deferred restart no-ops to avoid orphaning.
+ */
+
+import { app, utilityProcess, type UtilityProcess } from "electron";
+import os from "os";
+import path from "path";
+import type {
+  CrashType,
+  HostCrashPayload,
+  PtyHostEvent,
+  PtyHostRequest,
+} from "../../../shared/types/pty-host.js";
+
+/**
+ * Map an authoritative `child-process-gone` reason (Electron 37+) to our CrashType.
+ * Used when `app.on("child-process-gone")` fires for the PTY host — the reason
+ * string is more reliable than the exit-code heuristic in `classifyCrash()`.
+ */
+export function mapGoneReasonToCrashType(reason: string): CrashType {
+  switch (reason) {
+    case "oom":
+    case "memory-eviction":
+      return "OUT_OF_MEMORY";
+    case "killed":
+      return "SIGNAL_TERMINATED";
+    case "clean-exit":
+      return "CLEAN_EXIT";
+    case "crashed":
+    case "abnormal-exit":
+    case "launch-failed":
+    case "integrity-failure":
+    default:
+      return "UNKNOWN_CRASH";
+  }
+}
+
+/**
+ * Classify crash type based on exit code and signal.
+ * Exit codes 137 (128+9=SIGKILL) and 134 (128+6=SIGABRT) often indicate OOM.
+ */
+export function classifyCrash(code: number | null, signal: string | null): CrashType {
+  if (code === null) {
+    return "SIGNAL_TERMINATED";
+  }
+  if (code === 0) {
+    return "CLEAN_EXIT";
+  }
+  if (code === 137 || signal === "SIGKILL") {
+    return "OUT_OF_MEMORY";
+  }
+  if (code === 134 || signal === "SIGABRT") {
+    return "ASSERTION_FAILURE";
+  }
+  if (code > 128) {
+    return "SIGNAL_TERMINATED";
+  }
+  if (code !== 0) {
+    return "UNKNOWN_CRASH";
+  }
+  return "CLEAN_EXIT";
+}
+
+const HOST_LOG_BUFFER_LIMIT = 64 * 1024;
+const HOST_LOG_LINE_LIMIT = 4_000;
+const RESTART_FLOOR_MS = 100;
+const RESTART_CAP_BASE_MS = 1_000;
+const RESTART_CAP_MAX_MS = 10_000;
+
+export interface PtyHostLifecycleConfig {
+  maxRestartAttempts: number;
+  memoryLimitMb: number;
+  electronDir: string;
+}
+
+export interface PtyHostLifecycleCallbacks {
+  /** Forward each message from the child. PtyClient routes these via {@link routeHostEvent}. */
+  onMessage: (event: PtyHostEvent) => void;
+  /**
+   * Called synchronously inside the exit handler, before the setImmediate
+   * deferral. PtyClient uses this to: stop the watchdog, reject readyPromise
+   * if !wasReady, run a first-pass orphan cleanup with the heuristic crash
+   * type, clear the broker, and set shouldResyncProjectContext.
+   */
+  onExitSync: (info: {
+    code: number | null;
+    wasReady: boolean;
+    fallbackCrashType: CrashType;
+  }) => void;
+  /**
+   * Called inside the setImmediate deferral with the final crash classification.
+   * PtyClient uses this to run a second orphan cleanup with the authoritative
+   * crash type and to emit `host-crash-details` when crashType !== CLEAN_EXIT.
+   */
+  onCrashClassified: (info: {
+    reportedCode: number | null;
+    crashType: CrashType;
+    signal: string | null;
+    payload: HostCrashPayload | null;
+  }) => void;
+  /** Called when the restart cap is hit. PtyClient emits `host-crash`. */
+  onMaxRestartsReached: (code: number | null) => void;
+  /**
+   * Called when `utilityProcess.fork()` itself throws. PtyClient emits
+   * `host-crash` with code -1.
+   */
+  onForkFailed: (error: unknown) => void;
+  /**
+   * Called just before each *restart* fork (not the initial start). PtyClient
+   * sets `needsRespawn=true` so its `ready` handler will replay pending spawns.
+   */
+  onBeforeRestart: () => void;
+  /** Returns whether PtyClient.isDisposed is true. */
+  isDisposed: () => boolean;
+  /** Logger functions. Decoupled from any specific logger implementation. */
+  logInfo: (message: string) => void;
+  logWarn: (message: string) => void;
+}
+
+export class PtyHostLifecycle {
+  /** Active UtilityProcess; null between exit and the next fork. Public for test access. */
+  child: UtilityProcess | null = null;
+  /** Public for test access — read by `isReady()` on PtyClient and the watchdog tick. */
+  isInitialized = false;
+  /** Number of restart attempts since the last successful `ready`. */
+  restartAttempts = 0;
+  /** Active restart timer; cleared on dispose / start / manualRestart. */
+  restartTimer: NodeJS.Timeout | null = null;
+  /**
+   * Authoritative crash reason captured from `app.on("child-process-gone")`.
+   * Consumed by the next `exit` handler via `setImmediate` deferral, since
+   * Electron 37-41 has a documented race where `exit` often fires before
+   * `child-process-gone` for utility-process crashes.
+   */
+  pendingChildProcessGoneReason: { reason: string; exitCode: number } | null = null;
+
+  private childProcessGoneHandler:
+    | ((event: Electron.Event, details: Electron.Details) => void)
+    | null = null;
+
+  private hostStdoutBuffer = "";
+  private hostStderrBuffer = "";
+
+  private readyPromise: Promise<void>;
+  private readyResolve: (() => void) | null = null;
+  private readyReject: ((error: Error) => void) | null = null;
+
+  constructor(
+    private readonly config: PtyHostLifecycleConfig,
+    private readonly callbacks: PtyHostLifecycleCallbacks
+  ) {
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+    this.registerChildProcessGoneListener();
+  }
+
+  /** Wait for the host to emit `ready`. Re-creates per fork; safe across restarts. */
+  waitForReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  /**
+   * Mark the host as ready. Called by PtyClient's `onReady` callback from the
+   * event router. Returns false if the host is already dead (late ready event).
+   */
+  markReady(): boolean {
+    if (!this.child) return false;
+    this.isInitialized = true;
+    this.restartAttempts = 0;
+    if (this.readyResolve) {
+      this.readyResolve();
+      this.readyResolve = null;
+      this.readyReject = null;
+    }
+    return true;
+  }
+
+  /** Whether the lifecycle is currently running a host. */
+  isRunning(): boolean {
+    return this.isInitialized && this.child !== null;
+  }
+
+  /**
+   * User-initiated restart (e.g., from the renderer). Resets `restartAttempts`
+   * to 0 and immediately starts a fresh host. No-ops if already disposed or
+   * already running.
+   */
+  manualRestart(): void {
+    if (this.callbacks.isDisposed()) {
+      this.callbacks.logWarn("[PtyClient] Cannot manual restart - already disposed");
+      return;
+    }
+
+    if (this.child !== null) {
+      this.callbacks.logWarn("[PtyClient] Cannot manual restart - host process already exists");
+      return;
+    }
+
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    this.restartAttempts = 0;
+    this.callbacks.onBeforeRestart();
+    this.callbacks.logInfo("[PtyClient] Manual restart initiated");
+    this.start();
+  }
+
+  /** Start the host. Used both for the initial spawn and subsequent restarts. */
+  start(): void {
+    if (this.callbacks.isDisposed()) {
+      console.warn("[PtyClient] Cannot start host - already disposed");
+      return;
+    }
+
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    // Defensive: clear any stale crash reason from a prior host cycle. Under
+    // normal flow the `exit` handler's setImmediate consumes this, but a missed
+    // exit event (or out-of-band listener fire) would otherwise leak into the
+    // next crash.
+    this.pendingChildProcessGoneReason = null;
+
+    this.isInitialized = false;
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+
+    const hostPath = path.join(this.config.electronDir, "pty-host-bootstrap.js");
+    console.log(`[PtyClient] Starting Pty Host from: ${hostPath}`);
+
+    try {
+      this.child = utilityProcess.fork(hostPath, [], {
+        serviceName: "daintree-pty-host",
+        stdio: "pipe",
+        cwd: os.homedir(),
+        // `--diagnostic-dir` redirects v8.setHeapSnapshotNearHeapLimit dumps
+        // (set in pty-host.ts) into the app's logs directory instead of the
+        // utility process CWD (homedir).
+        execArgv: [
+          `--max-old-space-size=${this.config.memoryLimitMb}`,
+          `--diagnostic-dir=${app.getPath("logs")}`,
+          "--report-exclude-env",
+        ],
+        env: {
+          ...(process.env as Record<string, string>),
+          DAINTREE_USER_DATA: app.getPath("userData"),
+          DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
+          // node-pty 1.x hangs intermittently on Linux kernels with io_uring
+          // enabled (microsoft/node-pty#630, closed as not planned). The fix
+          // is permanent and must be set inside the explicit env object — a
+          // mutation on process.env wouldn't survive utilityProcess.fork's
+          // env override.
+          ...(process.platform === "linux" ? { UV_USE_IO_URING: "0" } : {}),
+        },
+      });
+      console.log(`[PtyClient] Pty Host started with ${this.config.memoryLimitMb}MB memory limit`);
+    } catch (error) {
+      console.error("[PtyClient] Failed to fork Pty Host:", error);
+      if (this.readyReject) {
+        this.readyReject(new Error("PTY host failed to start"));
+        this.readyResolve = null;
+        this.readyReject = null;
+      }
+      this.callbacks.onForkFailed(error);
+      return;
+    }
+
+    this.installHostLogForwarding();
+
+    this.child.on("message", (msg: PtyHostEvent) => {
+      this.callbacks.onMessage(msg);
+    });
+
+    this.child.on("exit", (code) => {
+      this.handleExit(code);
+    });
+
+    console.log("[PtyClient] Pty Host started");
+  }
+
+  /** Send one request to the host. Treats `postMessage` failure as a crash. */
+  postMessage(request: PtyHostRequest): void {
+    if (!this.child) {
+      console.warn("[PtyClient] Cannot send - host not running");
+      return;
+    }
+    try {
+      this.child.postMessage(request);
+    } catch (error) {
+      console.error("[PtyClient] postMessage failed:", error);
+      if (this.child) {
+        this.child.kill();
+      }
+    }
+  }
+
+  /**
+   * Tear down the lifecycle. Called from PtyClient.dispose() — clears timers,
+   * removes the child-process-gone listener, asks the host to dispose, then
+   * force-kills after 1s if it hasn't exited.
+   */
+  dispose(): void {
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    if (this.child) {
+      this.postMessage({ type: "dispose" });
+      // Give the host a moment to clean up, then force kill
+      setTimeout(() => {
+        if (this.child) {
+          this.child.kill();
+          this.child = null;
+        }
+      }, 1000);
+    }
+
+    if (this.childProcessGoneHandler) {
+      app.off("child-process-gone", this.childProcessGoneHandler);
+      this.childProcessGoneHandler = null;
+    }
+    this.pendingChildProcessGoneReason = null;
+  }
+
+  /**
+   * Register the `child-process-gone` listener once. Filtered to our PTY host
+   * by `type === "Utility"` and `name === "daintree-pty-host"`. The handler
+   * only records the reason; the `exit` handler consumes it via setImmediate.
+   */
+  private registerChildProcessGoneListener(): void {
+    if (this.childProcessGoneHandler) return;
+    const handler = (_event: Electron.Event, details: Electron.Details): void => {
+      if (this.callbacks.isDisposed()) return;
+      if (details.type !== "Utility") return;
+      // Electron 41 populates `name` from `serviceName` at runtime, but both
+      // fields are typed as optional. Accept either to stay resilient to
+      // future runtime changes or edge cases where only one is set.
+      const matchesHost =
+        details.name === "daintree-pty-host" || details.serviceName === "daintree-pty-host";
+      if (!matchesHost) return;
+      this.pendingChildProcessGoneReason = {
+        reason: details.reason,
+        exitCode: details.exitCode,
+      };
+    };
+    this.childProcessGoneHandler = handler;
+    app.on("child-process-gone", handler);
+  }
+
+  private handleExit(code: number | null): void {
+    this.flushHostOutputBuffers();
+    // UtilityProcess exit event doesn't provide signal, but we can infer from code
+    const signal = code !== null && code > 128 ? `SIG${code - 128}` : null;
+    const fallbackCrashType = classifyCrash(code, signal);
+
+    const wasReady = this.isInitialized;
+    this.isInitialized = false;
+    this.child = null; // Prevent posting to dead process
+
+    if (this.callbacks.isDisposed()) {
+      // Expected shutdown - drop any buffered reason so it can't leak.
+      this.pendingChildProcessGoneReason = null;
+      this.callbacks.onExitSync({ code, wasReady, fallbackCrashType });
+      return;
+    }
+
+    // If host crashed before ready, reject the promise so startup doesn't hang
+    if (!wasReady && this.readyReject) {
+      this.readyReject(new Error("PTY host exited before ready"));
+      this.readyResolve = null;
+      this.readyReject = null;
+    }
+
+    this.callbacks.onExitSync({ code, wasReady, fallbackCrashType });
+
+    // Electron 37-41 race: `exit` often fires before `child-process-gone`
+    // for utility-process crashes. Defer crash classification by one event
+    // loop tick so the authoritative reason can arrive; fall back to the
+    // exit-code heuristic when no reason was captured in time.
+    setImmediate(() => {
+      if (this.callbacks.isDisposed()) {
+        this.pendingChildProcessGoneReason = null;
+        return;
+      }
+
+      const gone = this.pendingChildProcessGoneReason;
+      this.pendingChildProcessGoneReason = null;
+      const crashType: CrashType = gone ? mapGoneReasonToCrashType(gone.reason) : fallbackCrashType;
+      // Prefer the authoritative exit code from `child-process-gone` over the
+      // (sometimes unreliable) one from `exit` — Electron 40-41 has a known
+      // signed/unsigned mangling bug on Windows for the exit event.
+      const reportedCode = gone ? gone.exitCode : code;
+
+      console.error(
+        `[PtyClient] Pty Host exited with code ${reportedCode}` +
+          (crashType !== "CLEAN_EXIT" ? ` (${crashType})` : "")
+      );
+
+      const payload: HostCrashPayload | null =
+        crashType !== "CLEAN_EXIT"
+          ? {
+              code: reportedCode,
+              // When we have an authoritative reason, trust it and clear the
+              // derived-from-exit-code signal string.
+              signal: gone ? null : signal,
+              crashType,
+              timestamp: Date.now(),
+            }
+          : null;
+
+      this.callbacks.onCrashClassified({
+        reportedCode,
+        crashType,
+        signal: gone ? null : signal,
+        payload,
+      });
+
+      // If `manualRestart()` already spawned a new host during the defer
+      // window, don't schedule a second auto-restart — it would orphan that host.
+      if (this.child !== null) return;
+
+      if (this.restartAttempts < this.config.maxRestartAttempts) {
+        this.restartAttempts++;
+        // Full jitter with floor: break deterministic retry lockstep while
+        // keeping a minimum wait so instant-fail crashes don't spin the CPU.
+        const cap = Math.min(
+          RESTART_CAP_BASE_MS * Math.pow(2, this.restartAttempts),
+          RESTART_CAP_MAX_MS
+        );
+        const delay =
+          RESTART_FLOOR_MS + Math.floor(Math.random() * Math.max(0, cap - RESTART_FLOOR_MS));
+        console.log(
+          `[PtyClient] Restarting Host in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+        );
+
+        if (this.restartTimer) {
+          clearTimeout(this.restartTimer);
+        }
+        this.restartTimer = setTimeout(() => {
+          this.restartTimer = null;
+          if (this.callbacks.isDisposed() || this.child !== null) return;
+          this.callbacks.onBeforeRestart();
+          this.start();
+        }, delay);
+      } else {
+        console.error("[PtyClient] Max restart attempts reached, giving up");
+        this.callbacks.onMaxRestartsReached(reportedCode);
+      }
+    });
+  }
+
+  private installHostLogForwarding(): void {
+    if (!this.child) return;
+    this.hostStdoutBuffer = "";
+    this.hostStderrBuffer = "";
+
+    const stdout = (this.child as unknown as { stdout?: NodeJS.ReadableStream }).stdout;
+    const stderr = (this.child as unknown as { stderr?: NodeJS.ReadableStream }).stderr;
+
+    stdout?.on("data", (chunk: Buffer) => this.forwardHostOutput("stdout", chunk));
+    stderr?.on("data", (chunk: Buffer) => this.forwardHostOutput("stderr", chunk));
+  }
+
+  private forwardHostOutput(kind: "stdout" | "stderr", chunk: Buffer): void {
+    const text = chunk.toString("utf8");
+    if (kind === "stdout") {
+      this.hostStdoutBuffer += text;
+    } else {
+      this.hostStderrBuffer += text;
+    }
+
+    if (this.hostStdoutBuffer.length > HOST_LOG_BUFFER_LIMIT) {
+      this.hostStdoutBuffer = this.hostStdoutBuffer.slice(-HOST_LOG_BUFFER_LIMIT);
+    }
+    if (this.hostStderrBuffer.length > HOST_LOG_BUFFER_LIMIT) {
+      this.hostStderrBuffer = this.hostStderrBuffer.slice(-HOST_LOG_BUFFER_LIMIT);
+    }
+
+    const current = kind === "stdout" ? this.hostStdoutBuffer : this.hostStderrBuffer;
+    const lines = current.split(/\r?\n/);
+    const remainder = lines.pop() ?? "";
+    if (kind === "stdout") {
+      this.hostStdoutBuffer = remainder;
+    } else {
+      this.hostStderrBuffer = remainder;
+    }
+
+    for (const line of lines) {
+      const trimmed = line.trimEnd();
+      if (!trimmed) continue;
+      const message = `[PtyHost] ${trimmed.length > HOST_LOG_LINE_LIMIT ? `${trimmed.slice(0, HOST_LOG_LINE_LIMIT)}…` : trimmed}`;
+      if (kind === "stderr") {
+        this.callbacks.logWarn(message);
+      } else {
+        this.callbacks.logInfo(message);
+      }
+    }
+  }
+
+  private flushHostOutputBuffers(): void {
+    const stdoutRemainder = this.hostStdoutBuffer.trim();
+    if (stdoutRemainder) {
+      this.callbacks.logInfo(
+        `[PtyHost] ${stdoutRemainder.length > HOST_LOG_LINE_LIMIT ? `${stdoutRemainder.slice(0, HOST_LOG_LINE_LIMIT)}…` : stdoutRemainder}`
+      );
+    }
+    const stderrRemainder = this.hostStderrBuffer.trim();
+    if (stderrRemainder) {
+      this.callbacks.logWarn(
+        `[PtyHost] ${stderrRemainder.length > HOST_LOG_LINE_LIMIT ? `${stderrRemainder.slice(0, HOST_LOG_LINE_LIMIT)}…` : stderrRemainder}`
+      );
+    }
+    this.hostStdoutBuffer = "";
+    this.hostStderrBuffer = "";
+  }
+}

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import { routeHostEvent, type PtyEventRouterDeps } from "../PtyEventRouter.js";
+import { events } from "../../events.js";
+import type {
+  PtyHostEvent,
+  PtyHostSpawnOptions,
+  SpawnResult,
+} from "../../../../shared/types/pty-host.js";
+
+interface BrokerCall {
+  requestId: string;
+  result: unknown;
+}
+
+function makeDeps(overrides: Partial<PtyEventRouterDeps> = {}): {
+  deps: PtyEventRouterDeps;
+  emitter: EventEmitter;
+  brokerCalls: BrokerCall[];
+  state: PtyEventRouterDeps["state"];
+  callbacks: { onReadyCount: number; onPongCount: number; trashIdsRemoved: string[] };
+} {
+  const emitter = new EventEmitter();
+  const brokerCalls: BrokerCall[] = [];
+  const state: PtyEventRouterDeps["state"] = {
+    pendingSpawns: new Map(),
+    pendingKillCount: new Map(),
+    terminalPids: new Map(),
+  };
+  const callbacks = {
+    onReadyCount: 0,
+    onPongCount: 0,
+    trashIdsRemoved: [] as string[],
+  };
+  const deps: PtyEventRouterDeps = {
+    isDisposed: () => false,
+    broker: {
+      resolve: <T>(requestId: string, result: T) => {
+        brokerCalls.push({ requestId, result });
+        return true;
+      },
+    },
+    emitter,
+    state,
+    callbacks: {
+      onReady: () => {
+        callbacks.onReadyCount++;
+      },
+      onPong: () => {
+        callbacks.onPongCount++;
+      },
+      onTerminalRemovedFromTrash: (id) => {
+        callbacks.trashIdsRemoved.push(id);
+      },
+    },
+    logWarn: vi.fn(),
+    ...overrides,
+  };
+  return { deps, emitter, brokerCalls, state, callbacks };
+}
+
+describe("routeHostEvent", () => {
+  afterEach(() => {
+    events.removeAllListeners();
+  });
+
+  it("returns true and skips routing when disposed", () => {
+    const { deps, emitter } = makeDeps({ isDisposed: () => true });
+    const dataListener = vi.fn();
+    emitter.on("data", dataListener);
+
+    const handled = routeHostEvent({ type: "data", id: "t1", data: "hello" }, deps);
+
+    expect(handled).toBe(true);
+    expect(dataListener).not.toHaveBeenCalled();
+  });
+
+  it("delegates domain events to bridgePtyEvent first", () => {
+    const { deps } = makeDeps();
+    const agentStateEvents: unknown[] = [];
+    events.on("agent:state-changed", (payload) => {
+      agentStateEvents.push(payload);
+    });
+
+    const handled = routeHostEvent(
+      {
+        type: "agent-state",
+        id: "t1",
+        state: "working",
+        previousState: "idle",
+        timestamp: 1000,
+        trigger: "activity",
+        confidence: 1,
+      } as PtyHostEvent,
+      deps
+    );
+
+    expect(handled).toBe(true);
+    expect(agentStateEvents).toHaveLength(1);
+  });
+
+  it("emits transport-level data/exit/error events on the emitter", () => {
+    const { deps, emitter } = makeDeps();
+    const dataListener = vi.fn();
+    const exitListener = vi.fn();
+    const errorListener = vi.fn();
+    emitter.on("data", dataListener);
+    emitter.on("exit", exitListener);
+    emitter.on("error", errorListener);
+
+    routeHostEvent({ type: "data", id: "t1", data: "x" }, deps);
+    routeHostEvent({ type: "exit", id: "t1", exitCode: 0 }, deps);
+    routeHostEvent({ type: "error", id: "t1", error: "boom" }, deps);
+
+    expect(dataListener).toHaveBeenCalledWith("t1", "x");
+    expect(exitListener).toHaveBeenCalledWith("t1", 0);
+    expect(errorListener).toHaveBeenCalledWith("t1", "boom");
+  });
+
+  it("calls onReady when the host emits ready", () => {
+    const { deps, callbacks } = makeDeps();
+    routeHostEvent({ type: "ready" }, deps);
+    expect(callbacks.onReadyCount).toBe(1);
+  });
+
+  it("calls onPong when the host emits pong", () => {
+    const { deps, callbacks } = makeDeps();
+    routeHostEvent({ type: "pong" }, deps);
+    expect(callbacks.onPongCount).toBe(1);
+  });
+
+  it("decrements pendingKillCount on exit when a kill was queued", () => {
+    const { deps, state } = makeDeps();
+    state.pendingSpawns.set("t1", { cwd: "/", cols: 80, rows: 24 } as PtyHostSpawnOptions);
+    state.pendingKillCount.set("t1", 2);
+    state.terminalPids.set("t1", 999);
+
+    routeHostEvent({ type: "exit", id: "t1", exitCode: 0 }, deps);
+
+    expect(state.pendingKillCount.get("t1")).toBe(1);
+    // pendingSpawns NOT cleared — kill was queued
+    expect(state.pendingSpawns.has("t1")).toBe(true);
+    expect(state.terminalPids.has("t1")).toBe(false);
+  });
+
+  it("clears pendingSpawns on exit when no kill was queued", () => {
+    const { deps, state } = makeDeps();
+    state.pendingSpawns.set("t1", { cwd: "/", cols: 80, rows: 24 } as PtyHostSpawnOptions);
+
+    routeHostEvent({ type: "exit", id: "t1", exitCode: 0 }, deps);
+
+    expect(state.pendingSpawns.has("t1")).toBe(false);
+  });
+
+  it("removes the pendingKillCount entry once it reaches zero", () => {
+    const { deps, state } = makeDeps();
+    state.pendingKillCount.set("t1", 1);
+
+    routeHostEvent({ type: "exit", id: "t1", exitCode: 0 }, deps);
+
+    expect(state.pendingKillCount.has("t1")).toBe(false);
+  });
+
+  it("notifies the trash tracker on exit via callback", () => {
+    const { deps, callbacks } = makeDeps();
+    routeHostEvent({ type: "exit", id: "t1", exitCode: 0 }, deps);
+    expect(callbacks.trashIdsRemoved).toEqual(["t1"]);
+  });
+
+  it("resolves broker for snapshot events", () => {
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent({ type: "snapshot", id: "t1", requestId: "req-1", snapshot: null }, deps);
+    expect(brokerCalls).toEqual([{ requestId: "req-1", result: null }]);
+  });
+
+  it("resolves broker with terminalIds default for terminals-for-project", () => {
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent(
+      { type: "terminals-for-project", requestId: "req-2", terminalIds: ["a", "b"] },
+      deps
+    );
+    expect(brokerCalls).toEqual([{ requestId: "req-2", result: ["a", "b"] }]);
+  });
+
+  it("resolves broker with default snapshots empty array when missing", () => {
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent({ type: "all-snapshots", requestId: "req-3", snapshots: [] }, deps);
+    expect(brokerCalls).toEqual([{ requestId: "req-3", result: [] }]);
+  });
+
+  it("resolves broker for wake-result with state and warnings", () => {
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent(
+      {
+        type: "wake-result",
+        id: "t1",
+        requestId: "req-w",
+        state: "working",
+        warnings: ["slow"],
+      },
+      deps
+    );
+    expect(brokerCalls).toEqual([
+      { requestId: "req-w", result: { state: "working", warnings: ["slow"] } },
+    ]);
+  });
+
+  it("preserves the legacy terminalTypes fallback shape on missing project-stats", () => {
+    const { deps, brokerCalls } = makeDeps();
+    routeHostEvent(
+      // Force a missing-stats path by spreading a partial shape — the runtime can
+      // observe `event.stats === undefined` even though the type forbids it.
+      {
+        type: "project-stats",
+        requestId: "req-ps",
+        stats: undefined as unknown as {
+          terminalCount: number;
+          processIds: number[];
+          detectedAgents: Record<string, number>;
+        },
+      },
+      deps
+    );
+    expect(brokerCalls[0]?.result).toEqual({
+      terminalCount: 0,
+      processIds: [],
+      terminalTypes: {},
+    });
+  });
+
+  it("records terminal-pid on the shared state map", () => {
+    const { deps, state } = makeDeps();
+    routeHostEvent({ type: "terminal-pid", id: "t1", pid: 12345 }, deps);
+    expect(state.terminalPids.get("t1")).toBe(12345);
+  });
+
+  it("emits spawn-result and clears pendingSpawns on failed spawn", () => {
+    const { deps, emitter, state } = makeDeps();
+    state.pendingSpawns.set("t1", { cwd: "/", cols: 80, rows: 24 } as PtyHostSpawnOptions);
+    const spawnListener = vi.fn();
+    emitter.on("spawn-result", spawnListener);
+
+    const failedResult: SpawnResult = {
+      success: false,
+      id: "t1",
+      error: { code: "ENOENT", message: "shell not found" },
+    };
+    routeHostEvent({ type: "spawn-result", id: "t1", result: failedResult }, deps);
+
+    expect(state.pendingSpawns.has("t1")).toBe(false);
+    expect(spawnListener).toHaveBeenCalledWith("t1", failedResult);
+  });
+
+  it("emits spawn-result and keeps pendingSpawns intact on successful spawn", () => {
+    const { deps, emitter, state } = makeDeps();
+    state.pendingSpawns.set("t1", { cwd: "/", cols: 80, rows: 24 } as PtyHostSpawnOptions);
+    const spawnListener = vi.fn();
+    emitter.on("spawn-result", spawnListener);
+
+    routeHostEvent(
+      {
+        type: "spawn-result",
+        id: "t1",
+        result: { success: true, id: "t1" },
+      },
+      deps
+    );
+
+    expect(state.pendingSpawns.has("t1")).toBe(true);
+    expect(spawnListener).toHaveBeenCalled();
+  });
+
+  it("emits resource-metrics with timestamp", () => {
+    const { deps, emitter } = makeDeps();
+    const listener = vi.fn();
+    emitter.on("resource-metrics", listener);
+
+    routeHostEvent(
+      {
+        type: "resource-metrics",
+        metrics: { t1: { cpuPercent: 5, memoryKb: 1000, breakdown: [] } },
+        timestamp: 12345,
+      },
+      deps
+    );
+
+    expect(listener).toHaveBeenCalledWith(
+      { t1: { cpuPercent: 5, memoryKb: 1000, breakdown: [] } },
+      12345
+    );
+  });
+
+  it("logs and returns false for unknown event types", () => {
+    const logWarn = vi.fn();
+    const { deps } = makeDeps({ logWarn });
+    const handled = routeHostEvent({ type: "totally-unknown" } as unknown as PtyHostEvent, deps);
+    expect(handled).toBe(false);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("totally-unknown"));
+  });
+});

--- a/electron/services/pty/__tests__/PtyHealthWatchdog.test.ts
+++ b/electron/services/pty/__tests__/PtyHealthWatchdog.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PtyHealthWatchdog } from "../PtyHealthWatchdog.js";
+import type { HostCrashPayload, PtyHostRequest } from "../../../../shared/types/pty-host.js";
+
+interface FakeChild {
+  pid?: number;
+}
+
+function createWatchdog(
+  opts: {
+    intervalMs?: number;
+    maxMissedHeartbeats?: number;
+    child?: FakeChild | null;
+    isInitialized?: boolean;
+  } = {}
+) {
+  const sentRequests: PtyHostRequest[] = [];
+  const crashPayloads: HostCrashPayload[] = [];
+  const childRef = { current: opts.child ?? ({ pid: 555 } as FakeChild as FakeChild | null) };
+  const initialized = { value: opts.isInitialized ?? true };
+
+  const watchdog = new PtyHealthWatchdog({
+    intervalMs: opts.intervalMs ?? 100,
+    maxMissedHeartbeats: opts.maxMissedHeartbeats ?? 3,
+    getChild: () => childRef.current as never,
+    isHostInitialized: () => initialized.value,
+    send: (req) => {
+      sentRequests.push(req);
+    },
+    emitCrashDetails: (payload) => {
+      crashPayloads.push(payload);
+    },
+  });
+
+  return { watchdog, sentRequests, crashPayloads, childRef, initialized };
+}
+
+describe("PtyHealthWatchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("sends a health-check on each tick and increments missedHeartbeats", () => {
+    const { watchdog, sentRequests } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+
+    vi.advanceTimersByTime(300);
+    expect(watchdog.missedHeartbeats).toBe(3);
+    expect(sentRequests.filter((r) => r.type === "health-check")).toHaveLength(3);
+  });
+
+  it("force-kills the host once missedHeartbeats reaches the threshold", () => {
+    const { watchdog, crashPayloads } = createWatchdog({
+      intervalMs: 100,
+      maxMissedHeartbeats: 3,
+    });
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((() => true) as typeof process.kill);
+    watchdog.start();
+
+    // Tick 1, 2, 3 increment to 3. Tick 4 fires the watchdog.
+    vi.advanceTimersByTime(400);
+
+    expect(crashPayloads).toHaveLength(1);
+    expect(crashPayloads[0]).toMatchObject({
+      code: null,
+      signal: "SIGKILL",
+      crashType: "SIGNAL_TERMINATED",
+    });
+    expect(killSpy).toHaveBeenCalledWith(555, "SIGKILL");
+    expect(watchdog.missedHeartbeats).toBe(0); // reset after firing
+  });
+
+  it("emits the crash event before invoking process.kill", () => {
+    const { watchdog, crashPayloads } = createWatchdog({ intervalMs: 100 });
+    const order: string[] = [];
+    const origPush = crashPayloads.push.bind(crashPayloads);
+    crashPayloads.push = ((...args: HostCrashPayload[]) => {
+      order.push("event");
+      return origPush(...args);
+    }) as typeof crashPayloads.push;
+    vi.spyOn(process, "kill").mockImplementation((() => {
+      order.push("kill");
+      return true;
+    }) as typeof process.kill);
+    watchdog.start();
+
+    vi.advanceTimersByTime(400);
+    expect(order).toEqual(["event", "kill"]);
+  });
+
+  it("recordPong resets missedHeartbeats and records an RTT sample", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+
+    vi.advanceTimersByTime(200);
+    expect(watchdog.missedHeartbeats).toBe(2);
+
+    // Use a known offset relative to performance.now() so the RTT calc is
+    // deterministic without having to fight vi.useFakeTimers() over the
+    // performance.now() backing function.
+    watchdog.lastPingTime = performance.now() - 50;
+    watchdog.recordPong();
+
+    expect(watchdog.missedHeartbeats).toBe(0);
+    expect(watchdog.rttSamples).toHaveLength(1);
+    expect(watchdog.rttSamples[0]).toBeGreaterThanOrEqual(0);
+    expect(watchdog.lastPingTime).toBeNull();
+  });
+
+  it("recordPong with no in-flight ping leaves rttSamples empty", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    watchdog.lastPingTime = null;
+
+    watchdog.recordPong();
+
+    expect(watchdog.rttSamples).toEqual([]);
+  });
+
+  it("pause clears the interval and freezes missedHeartbeats", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    vi.advanceTimersByTime(200);
+    expect(watchdog.missedHeartbeats).toBe(2);
+
+    watchdog.pause();
+    expect(watchdog.isHealthCheckPaused).toBe(true);
+    expect(watchdog.healthCheckInterval).toBeNull();
+
+    vi.advanceTimersByTime(10_000);
+    expect(watchdog.missedHeartbeats).toBe(2);
+  });
+
+  it("resume sends a handshake ping and arms a 5s fallback timeout", () => {
+    const { watchdog, sentRequests } = createWatchdog({ intervalMs: 1_000 });
+    watchdog.start();
+    watchdog.pause();
+
+    expect(watchdog.resume()).toBe(true);
+    expect(watchdog.isWaitingForHandshake).toBe(true);
+    expect(sentRequests.filter((r) => r.type === "health-check")).toHaveLength(1);
+
+    // Fallback fires after 5s and rearmed interval starts.
+    vi.advanceTimersByTime(5_000);
+    expect(watchdog.isWaitingForHandshake).toBe(false);
+    expect(watchdog.missedHeartbeats).toBe(0);
+  });
+
+  it("recordPong during handshake clears it and arms the normal interval", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    watchdog.pause();
+    watchdog.resume();
+    expect(watchdog.isWaitingForHandshake).toBe(true);
+
+    watchdog.recordPong();
+
+    expect(watchdog.isWaitingForHandshake).toBe(false);
+    expect(watchdog.missedHeartbeats).toBe(0);
+    expect(watchdog.healthCheckInterval).not.toBeNull();
+  });
+
+  it("resume returns false when host is not initialized", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100, isInitialized: false });
+    watchdog.pause();
+    expect(watchdog.resume()).toBe(false);
+    expect(watchdog.isHealthCheckPaused).toBe(false); // pause() set it; resume failure clears it
+  });
+
+  it("watchdog tick is a no-op when child is null", () => {
+    const { watchdog, childRef } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    childRef.current = null;
+    expect(() => vi.advanceTimersByTime(500)).not.toThrow();
+    expect(watchdog.missedHeartbeats).toBe(0);
+  });
+
+  it("missing pid skips the kill but still emits crash-details", () => {
+    const { watchdog, crashPayloads } = createWatchdog({
+      intervalMs: 100,
+      child: { pid: undefined },
+    });
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((() => true) as typeof process.kill);
+    watchdog.start();
+
+    vi.advanceTimersByTime(400);
+
+    expect(crashPayloads).toHaveLength(1);
+    expect(killSpy).not.toHaveBeenCalled();
+  });
+
+  it("stop clears interval and resets RTT/lastPingTime state", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    watchdog.lastPingTime = 9999;
+    watchdog.rttSamples = [10, 20];
+    watchdog.rttSamplesSinceLastLog = 2;
+    watchdog.lastRttLogTime = 12345;
+
+    watchdog.stop();
+
+    expect(watchdog.healthCheckInterval).toBeNull();
+    expect(watchdog.lastPingTime).toBeNull();
+    expect(watchdog.rttSamples).toEqual([]);
+    expect(watchdog.rttSamplesSinceLastLog).toBe(0);
+    expect(watchdog.lastRttLogTime).toBe(0);
+  });
+
+  it("dispose clears interval and handshake timeout", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+    watchdog.pause();
+    watchdog.resume();
+    expect(watchdog.handshakeTimeout).not.toBeNull();
+
+    watchdog.dispose();
+
+    expect(watchdog.healthCheckInterval).toBeNull();
+    expect(watchdog.handshakeTimeout).toBeNull();
+    expect(watchdog.isWaitingForHandshake).toBe(false);
+    expect(watchdog.lastPingTime).toBeNull();
+  });
+
+  it("rttSamples buffer is capped at 20 entries", () => {
+    const { watchdog } = createWatchdog({ intervalMs: 100 });
+    watchdog.start();
+
+    for (let i = 0; i < 30; i++) {
+      watchdog.lastPingTime = performance.now();
+      watchdog.recordPong();
+    }
+
+    expect(watchdog.rttSamples).toHaveLength(20);
+  });
+});

--- a/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
+++ b/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
@@ -1,0 +1,438 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { EventEmitter } from "events";
+import {
+  classifyCrash,
+  mapGoneReasonToCrashType,
+  PtyHostLifecycle,
+  type PtyHostLifecycleCallbacks,
+} from "../PtyHostLifecycle.js";
+
+const shared = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  });
+  return {
+    forkMock: vi.fn(),
+    appMock,
+  };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: shared.forkMock,
+  },
+  app: shared.appMock,
+}));
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  pid?: number;
+}
+
+function createMockChild(): MockUtilityProcess {
+  return Object.assign(new EventEmitter(), {
+    postMessage: vi.fn(),
+    kill: vi.fn(),
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    pid: 321,
+  });
+}
+
+function createCallbacks(): {
+  callbacks: PtyHostLifecycleCallbacks;
+  log: {
+    onMessageCalls: unknown[];
+    onExitSyncCalls: Array<Parameters<PtyHostLifecycleCallbacks["onExitSync"]>[0]>;
+    onCrashClassifiedCalls: Array<Parameters<PtyHostLifecycleCallbacks["onCrashClassified"]>[0]>;
+    onMaxRestartsCalls: Array<number | null>;
+    onForkFailedCalls: unknown[];
+    onBeforeRestartCalls: number;
+    isDisposed: { current: boolean };
+  };
+} {
+  const onMessageCalls: unknown[] = [];
+  const onExitSyncCalls: Array<Parameters<PtyHostLifecycleCallbacks["onExitSync"]>[0]> = [];
+  const onCrashClassifiedCalls: Array<
+    Parameters<PtyHostLifecycleCallbacks["onCrashClassified"]>[0]
+  > = [];
+  const onMaxRestartsCalls: Array<number | null> = [];
+  const onForkFailedCalls: unknown[] = [];
+  let onBeforeRestartCalls = 0;
+  const isDisposed = { current: false };
+
+  const callbacks: PtyHostLifecycleCallbacks = {
+    onMessage: (e) => onMessageCalls.push(e),
+    onExitSync: (info) => onExitSyncCalls.push(info),
+    onCrashClassified: (info) => onCrashClassifiedCalls.push(info),
+    onMaxRestartsReached: (code) => onMaxRestartsCalls.push(code),
+    onForkFailed: (err) => onForkFailedCalls.push(err),
+    onBeforeRestart: () => {
+      onBeforeRestartCalls++;
+    },
+    isDisposed: () => isDisposed.current,
+    logInfo: vi.fn(),
+    logWarn: vi.fn(),
+  };
+
+  return {
+    callbacks,
+    log: {
+      onMessageCalls,
+      onExitSyncCalls,
+      onCrashClassifiedCalls,
+      onMaxRestartsCalls,
+      onForkFailedCalls,
+      get onBeforeRestartCalls() {
+        return onBeforeRestartCalls;
+      },
+      isDisposed,
+    },
+  };
+}
+
+describe("classifyCrash", () => {
+  it("returns CLEAN_EXIT for code 0", () => {
+    expect(classifyCrash(0, null)).toBe("CLEAN_EXIT");
+  });
+
+  it("returns SIGNAL_TERMINATED for null code", () => {
+    expect(classifyCrash(null, null)).toBe("SIGNAL_TERMINATED");
+  });
+
+  it("returns OUT_OF_MEMORY for SIGKILL exit code 137", () => {
+    expect(classifyCrash(137, null)).toBe("OUT_OF_MEMORY");
+    expect(classifyCrash(99, "SIGKILL")).toBe("OUT_OF_MEMORY");
+  });
+
+  it("returns ASSERTION_FAILURE for SIGABRT exit code 134", () => {
+    expect(classifyCrash(134, null)).toBe("ASSERTION_FAILURE");
+    expect(classifyCrash(50, "SIGABRT")).toBe("ASSERTION_FAILURE");
+  });
+
+  it("returns SIGNAL_TERMINATED for codes > 128 (other signals)", () => {
+    expect(classifyCrash(140, null)).toBe("SIGNAL_TERMINATED");
+  });
+
+  it("returns UNKNOWN_CRASH for non-zero codes ≤128 with no signal", () => {
+    expect(classifyCrash(1, null)).toBe("UNKNOWN_CRASH");
+    expect(classifyCrash(127, null)).toBe("UNKNOWN_CRASH");
+  });
+});
+
+describe("mapGoneReasonToCrashType", () => {
+  it.each([
+    ["oom", "OUT_OF_MEMORY"],
+    ["memory-eviction", "OUT_OF_MEMORY"],
+    ["killed", "SIGNAL_TERMINATED"],
+    ["clean-exit", "CLEAN_EXIT"],
+    ["crashed", "UNKNOWN_CRASH"],
+    ["abnormal-exit", "UNKNOWN_CRASH"],
+    ["launch-failed", "UNKNOWN_CRASH"],
+    ["integrity-failure", "UNKNOWN_CRASH"],
+    ["something-novel", "UNKNOWN_CRASH"],
+  ] as const)("maps %s to %s", (reason, expected) => {
+    expect(mapGoneReasonToCrashType(reason)).toBe(expected);
+  });
+});
+
+describe("PtyHostLifecycle", () => {
+  let mockChild: MockUtilityProcess;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    shared.appMock.removeAllListeners();
+    mockChild = createMockChild();
+    shared.forkMock.mockReturnValue(mockChild);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function makeLifecycle(maxRestarts = 3): {
+    lifecycle: PtyHostLifecycle;
+    callbacks: ReturnType<typeof createCallbacks>;
+  } {
+    const callbacks = createCallbacks();
+    const lifecycle = new PtyHostLifecycle(
+      { maxRestartAttempts: maxRestarts, memoryLimitMb: 256, electronDir: "/tmp/electron" },
+      callbacks.callbacks
+    );
+    return { lifecycle, callbacks };
+  }
+
+  it("forks the host with serviceName=daintree-pty-host", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+    expect(shared.forkMock.mock.calls[0][2]).toMatchObject({
+      serviceName: "daintree-pty-host",
+    });
+    expect(lifecycle.child).toBe(mockChild);
+  });
+
+  it("calls onForkFailed when utilityProcess.fork throws", async () => {
+    const error = new Error("fork failed");
+    shared.forkMock.mockImplementationOnce(() => {
+      throw error;
+    });
+    const { lifecycle, callbacks } = makeLifecycle();
+    // Attach a no-op rejection handler before start() so the failed
+    // readyPromise (created inside start()) doesn't surface as unhandled.
+    const origStart = lifecycle.start.bind(lifecycle);
+    lifecycle.start = () => {
+      origStart();
+      lifecycle.waitForReady().catch(() => undefined);
+    };
+    lifecycle.start();
+    await Promise.resolve();
+    expect(callbacks.log.onForkFailedCalls).toEqual([error]);
+  });
+
+  it("readyPromise rejects if exit fires before ready", async () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    const promise = lifecycle.waitForReady();
+    // Attach catch synchronously so the rejection from exit handler is
+    // observed immediately and never floats as unhandled.
+    const captured: { error: Error | null } = { error: null };
+    promise.catch((err: Error) => {
+      captured.error = err;
+    });
+    mockChild.emit("exit", 1);
+    await Promise.resolve();
+    expect(captured.error?.message).toBe("PTY host exited before ready");
+  });
+
+  it("forwards each child message to onMessage callback", () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    mockChild.emit("message", { type: "ready" });
+    mockChild.emit("message", { type: "pong" });
+    expect(callbacks.log.onMessageCalls).toEqual([{ type: "ready" }, { type: "pong" }]);
+  });
+
+  it("markReady transitions to initialized and resolves the promise", async () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    expect(lifecycle.isInitialized).toBe(false);
+
+    expect(lifecycle.markReady()).toBe(true);
+
+    expect(lifecycle.isInitialized).toBe(true);
+    expect(lifecycle.restartAttempts).toBe(0);
+    await expect(lifecycle.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it("markReady returns false when child is null", () => {
+    const { lifecycle } = makeLifecycle();
+    expect(lifecycle.child).toBeNull();
+    expect(lifecycle.markReady()).toBe(false);
+  });
+
+  it("isRunning reflects initialized + child state", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    expect(lifecycle.isRunning()).toBe(false); // not yet ready
+    lifecycle.markReady();
+    expect(lifecycle.isRunning()).toBe(true);
+  });
+
+  it("exit handler defers crash classification by setImmediate", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    mockChild.emit("exit", 1);
+
+    // Sync portion: onExitSync fires
+    expect(callbacks.log.onExitSyncCalls).toHaveLength(1);
+    expect(callbacks.log.onExitSyncCalls[0]).toMatchObject({
+      code: 1,
+      wasReady: true,
+      fallbackCrashType: "UNKNOWN_CRASH",
+    });
+    // Deferred portion not yet fired
+    expect(callbacks.log.onCrashClassifiedCalls).toHaveLength(0);
+
+    // Flush setImmediate
+    await vi.advanceTimersByTimeAsync(0);
+    expect(callbacks.log.onCrashClassifiedCalls).toHaveLength(1);
+    expect(callbacks.log.onCrashClassifiedCalls[0]).toMatchObject({
+      crashType: "UNKNOWN_CRASH",
+      reportedCode: 1,
+    });
+  });
+
+  it("uses child-process-gone reason over exit-code heuristic when both arrive", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Simulate the Electron 37-41 race: child-process-gone arrives BEFORE exit
+    shared.appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: "daintree-pty-host",
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    mockChild.emit("exit", 1);
+
+    // Flush setImmediate
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.log.onCrashClassifiedCalls[0]).toMatchObject({
+      crashType: "OUT_OF_MEMORY",
+      reportedCode: 137, // prefers gone.exitCode over exit's code
+    });
+    expect(callbacks.log.onCrashClassifiedCalls[0].payload).toMatchObject({
+      crashType: "OUT_OF_MEMORY",
+      code: 137,
+      signal: null, // cleared when authoritative reason is present
+    });
+  });
+
+  it("ignores child-process-gone for unrelated utility processes", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    shared.appMock.emit(
+      "child-process-gone",
+      {} as Electron.Event,
+      {
+        type: "Utility",
+        name: "some-other-host",
+        reason: "oom",
+        exitCode: 137,
+      } as Electron.Details
+    );
+
+    mockChild.emit("exit", 0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.log.onCrashClassifiedCalls[0]).toMatchObject({
+      crashType: "CLEAN_EXIT",
+      reportedCode: 0, // falls back to exit's code
+    });
+  });
+
+  it("schedules a restart with full-jitter backoff", async () => {
+    const { lifecycle, callbacks } = makeLifecycle(3);
+    lifecycle.start();
+    lifecycle.markReady();
+    expect(lifecycle.restartAttempts).toBe(0);
+
+    // First crash: schedules restart attempt 1
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.restartAttempts).toBe(1);
+
+    // Restart timer is scheduled
+    expect(lifecycle.restartTimer).not.toBeNull();
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+
+    // Fire the timer (max delay 4000ms for attempt 1: 2^1 * 1000)
+    const newChild = createMockChild();
+    shared.forkMock.mockReturnValueOnce(newChild);
+    // Pre-attach a rejection handler so the new child's readyPromise (recreated
+    // inside start()) doesn't surface as unhandled if the test ends quickly.
+    await vi.advanceTimersByTimeAsync(2_001);
+    lifecycle.waitForReady().catch(() => undefined);
+    expect(callbacks.log.onBeforeRestartCalls).toBe(1);
+    expect(lifecycle.child).toBe(newChild);
+  });
+
+  it("calls onMaxRestartsReached when restart cap is hit", async () => {
+    const { lifecycle, callbacks } = makeLifecycle(1); // only 1 restart allowed
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Crash 1 — restart scheduled
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.restartAttempts).toBe(1);
+
+    // Fire the restart timer
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    await vi.advanceTimersByTimeAsync(4_001);
+    lifecycle.waitForReady().catch(() => undefined);
+
+    // Crash 2 — max reached
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(callbacks.log.onMaxRestartsCalls).toEqual([1]);
+  });
+
+  it("manualRestart no-ops when child is still alive", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    expect(lifecycle.child).not.toBeNull();
+
+    const beforeRestartChild = lifecycle.child;
+    lifecycle.manualRestart();
+    expect(lifecycle.child).toBe(beforeRestartChild);
+    expect(shared.forkMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("manualRestart spawns a fresh host once the prior child has exited", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Crash
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.child).toBeNull();
+
+    // manualRestart now valid
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    lifecycle.manualRestart();
+    lifecycle.waitForReady().catch(() => undefined);
+
+    expect(lifecycle.child).toBe(child2);
+    expect(lifecycle.restartAttempts).toBe(0);
+    // Auto-restart's onBeforeRestart fired once when the timer was scheduled,
+    // and manualRestart fires it again — but the auto-restart timer is a
+    // pending setTimeout that hasn't fired yet, so only manualRestart
+    // contributes here.
+    expect(callbacks.log.onBeforeRestartCalls).toBe(1);
+  });
+
+  it("dispose removes the child-process-gone listener", () => {
+    const { lifecycle } = makeLifecycle();
+    expect(shared.appMock.listenerCount("child-process-gone")).toBe(1);
+    lifecycle.dispose();
+    expect(shared.appMock.listenerCount("child-process-gone")).toBe(0);
+  });
+
+  it("postMessage forwards to the child", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.postMessage({ type: "health-check" });
+    expect(mockChild.postMessage).toHaveBeenCalledWith({ type: "health-check" });
+  });
+
+  it("postMessage no-ops when child is null", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.postMessage({ type: "health-check" });
+    expect(mockChild.postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -297,6 +297,20 @@ export type PtyHostEvent =
       results: BroadcastWriteTargetResult[];
     };
 
+/**
+ * Sub-union of host-to-main events that carry a `requestId` field — i.e. broker
+ * responses correlated with a `register()` call on the main side. Use this with
+ * `isPtyHostResponseEvent()` to safely call `broker.resolve(event.requestId, …)`
+ * without `as any` casts: the discriminant union of `PtyHostEvent` already types
+ * `requestId` on every response member, but a switch case can't reach it without
+ * narrowing first.
+ */
+export type PtyHostResponseEvent = Extract<PtyHostEvent, { requestId: string }>;
+
+export function isPtyHostResponseEvent(event: PtyHostEvent): event is PtyHostResponseEvent {
+  return "requestId" in event && typeof (event as { requestId?: unknown }).requestId === "string";
+}
+
 /** Terminal info sent from Host → Main for getTerminal queries */
 export interface PtyHostTerminalInfo {
   id: string;


### PR DESCRIPTION
## Summary

- `PtyClient.ts` was 1881 lines mixing UtilityProcess lifecycle, health-check watchdog, event routing, and transport into one class -- this PR pulls those into three dedicated modules so each can be read, tested, and changed in isolation
- Introduces `PtyHostResponseEvent = Extract<PtyHostEvent, { requestId: string }>` in `shared/types/pty-host.ts` to eliminate the `event as any` casts that had accumulated in the event router, giving the compiler a proper view of the request/response split
- Caught and fixed a watchdog re-arming regression during review: the watchdog was only armed at construction, so a PTY host crash-and-restart would leave the watchdog permanently disarmed until the process exited again

Resolves #6690

## Changes

- `electron/services/pty/PtyEventRouter.ts` -- pure function that dispatches `PtyHostEvent` to the correct handler; no state, fully typed via `PtyHostResponseEvent`
- `electron/services/pty/PtyHealthWatchdog.ts` -- heartbeat interval, missed-heartbeat counting, RTT sample buffer, p50/p95/p99 logging; re-arms on every `ready` signal, not only at construction
- `electron/services/pty/PtyHostLifecycle.ts` -- UtilityProcess fork/exit/restart with full-jitter backoff, crash classification, Electron 37-41 child-process-gone deferral, manual restart, and dispose
- `electron/services/PtyClient.ts` reduced from 1881 to ~570 lines; now an orchestrator that wires the three modules together and exposes the existing public API unchanged
- 65 new focused unit tests across `PtyEventRouter.test.ts`, `PtyHealthWatchdog.test.ts`, and `PtyHostLifecycle.test.ts`
- Existing `PtyClient` tests updated to navigate through `priv.lifecycle` and `priv.healthWatchdog` where the behaviour now lives

## Testing

- 971 tests pass across 48 files
- Typecheck, lint, and format all clean
- EventEmitter contract, `getPtyClient`/`disposePtyClient` exports, and legacy `terminalTypes` fallback shape on project-stats preserved -- no behaviour changes