### PR TITLE
refactor(panel): extract PanelTabList from PanelHeader tab-bar duplication

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -37,7 +37,7 @@ import {
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
-import { LayoutGroup } from "framer-motion";
+import { PanelTabList } from "./PanelTabList";
 import type { PanelKind } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { formatShortcutForTooltip } from "@/lib/platform";
@@ -256,6 +256,10 @@ function PanelHeaderComponent({
   const toggleDockShortcut = useKeybindingDisplay("terminal.toggleDock");
   const maximizeShortcut = useKeybindingDisplay("terminal.maximize");
   const closeShortcut = useKeybindingDisplay("terminal.close");
+  const addTabTooltipContent = createTooltipContent(
+    "Duplicate panel as new tab",
+    duplicateShortcut
+  );
 
   // Terminal record for overflow menu actions (single shallow selector, matching TerminalContextMenu pattern)
   const terminal = usePanelStore(useShallow((state) => state.panelsById[id]));
@@ -543,7 +547,7 @@ function PanelHeaderComponent({
       onDoubleClick={handleHeaderDoubleClick}
     >
       {/* Tab bar - shown when there are multiple tabs */}
-      {hasTabs ? (
+      {hasTabs && tabs ? (
         canReorderTabs ? (
           <DndContext
             sensors={tabSensors}
@@ -552,121 +556,63 @@ function PanelHeaderComponent({
             modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
           >
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-              <div className="relative min-w-0 flex-1 flex">
-                <div
-                  ref={setTabListEl}
-                  className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
-                  role="tablist"
-                  aria-label="Panel tabs"
-                  onKeyDown={handleTabListKeyDown}
-                >
-                  <LayoutGroup id={`panel-tabs-${id}`}>
-                    <div className="flex items-center">
-                      {tabs.map((tab) => (
-                        <SortableTabButton
-                          key={tab.id}
-                          id={tab.id}
-                          title={getBaseTitle(tab.title)}
-                          chrome={tab.chrome}
-                          kind={tab.kind}
-                          agentState={tab.agentState}
-                          isActive={tab.isActive}
-                          presetColor={tab.presetColor}
-                          isUsingFallback={tab.isUsingFallback}
-                          fallbackTooltip={tab.fallbackTooltip}
-                          hasDangerousFlags={tab.hasDangerousFlags}
-                          onClick={() => onTabClick?.(tab.id)}
-                          onClose={() => onTabClose?.(tab.id)}
-                          onRename={
-                            onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                          }
-                        />
-                      ))}
-                      {onAddTab && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onAddTab();
-                              }}
-                              onPointerDown={(e) => e.stopPropagation()}
-                              className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                              aria-label="Duplicate panel as new tab"
-                              type="button"
-                            >
-                              <Plus className="w-3 h-3" aria-hidden="true" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {createTooltipContent("Duplicate panel as new tab", duplicateShortcut)}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                  </LayoutGroup>
-                </div>
-                {overflowTrigger}
-              </div>
+              <PanelTabList
+                layoutGroupId={`panel-tabs-dnd-${id}`}
+                tabs={tabs}
+                tabListRef={setTabListEl}
+                onKeyDown={handleTabListKeyDown}
+                onAddTab={onAddTab}
+                addTabTooltipContent={addTabTooltipContent}
+                overflowTrigger={overflowTrigger}
+                renderTab={(tab) => (
+                  <SortableTabButton
+                    key={tab.id}
+                    id={tab.id}
+                    title={getBaseTitle(tab.title)}
+                    chrome={tab.chrome}
+                    kind={tab.kind}
+                    agentState={tab.agentState}
+                    isActive={tab.isActive}
+                    presetColor={tab.presetColor}
+                    isUsingFallback={tab.isUsingFallback}
+                    fallbackTooltip={tab.fallbackTooltip}
+                    hasDangerousFlags={tab.hasDangerousFlags}
+                    onClick={() => onTabClick?.(tab.id)}
+                    onClose={() => onTabClose?.(tab.id)}
+                    onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}
+                  />
+                )}
+              />
             </SortableContext>
           </DndContext>
         ) : (
-          <div className="relative min-w-0 flex-1 flex">
-            <div
-              ref={setTabListEl}
-              className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
-              role="tablist"
-              aria-label="Panel tabs"
-              onKeyDown={handleTabListKeyDown}
-            >
-              <LayoutGroup id={`panel-tabs-${id}`}>
-                <div className="flex items-center">
-                  {tabs.map((tab) => (
-                    <TabButton
-                      key={tab.id}
-                      id={tab.id}
-                      title={getBaseTitle(tab.title)}
-                      chrome={tab.chrome}
-                      kind={tab.kind}
-                      agentState={tab.agentState}
-                      isActive={tab.isActive}
-                      presetColor={tab.presetColor}
-                      isUsingFallback={tab.isUsingFallback}
-                      fallbackTooltip={tab.fallbackTooltip}
-                      hasDangerousFlags={tab.hasDangerousFlags}
-                      onClick={() => onTabClick?.(tab.id)}
-                      onClose={() => onTabClose?.(tab.id)}
-                      onRename={
-                        onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined
-                      }
-                    />
-                  ))}
-                  {onAddTab && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onAddTab();
-                          }}
-                          onPointerDown={(e) => e.stopPropagation()}
-                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                          aria-label="Duplicate panel as new tab"
-                          type="button"
-                        >
-                          <Plus className="w-3 h-3" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">
-                        {createTooltipContent("Duplicate panel as new tab", duplicateShortcut)}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              </LayoutGroup>
-            </div>
-            {overflowTrigger}
-          </div>
+          <PanelTabList
+            layoutGroupId={`panel-tabs-static-${id}`}
+            tabs={tabs}
+            tabListRef={setTabListEl}
+            onKeyDown={handleTabListKeyDown}
+            onAddTab={onAddTab}
+            addTabTooltipContent={addTabTooltipContent}
+            overflowTrigger={overflowTrigger}
+            renderTab={(tab) => (
+              <TabButton
+                key={tab.id}
+                id={tab.id}
+                title={getBaseTitle(tab.title)}
+                chrome={tab.chrome}
+                kind={tab.kind}
+                agentState={tab.agentState}
+                isActive={tab.isActive}
+                presetColor={tab.presetColor}
+                isUsingFallback={tab.isUsingFallback}
+                fallbackTooltip={tab.fallbackTooltip}
+                hasDangerousFlags={tab.hasDangerousFlags}
+                onClick={() => onTabClick?.(tab.id)}
+                onClose={() => onTabClose?.(tab.id)}
+                onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}
+              />
+            )}
+          />
         )
       ) : (
         <div className="flex items-center gap-2 min-w-0">

--- a/src/components/Panel/PanelTabList.tsx
+++ b/src/components/Panel/PanelTabList.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React from "react";
 import { LayoutGroup } from "framer-motion";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -17,7 +17,7 @@ export interface PanelTabListProps {
   className?: string;
 }
 
-export const PanelTabList = memo(function PanelTabList({
+export function PanelTabList({
   layoutGroupId,
   tabs,
   tabListRef,
@@ -65,4 +65,4 @@ export const PanelTabList = memo(function PanelTabList({
       {overflowTrigger}
     </div>
   );
-});
+}

--- a/src/components/Panel/PanelTabList.tsx
+++ b/src/components/Panel/PanelTabList.tsx
@@ -1,0 +1,68 @@
+import React, { memo } from "react";
+import { LayoutGroup } from "framer-motion";
+import { Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { TabInfo } from "./TabButton";
+
+export interface PanelTabListProps {
+  layoutGroupId: string;
+  tabs: TabInfo[];
+  tabListRef: (el: HTMLDivElement | null) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onAddTab?: () => void;
+  addTabTooltipContent: React.ReactNode;
+  overflowTrigger: React.ReactNode | null;
+  renderTab: (tab: TabInfo) => React.ReactNode;
+  className?: string;
+}
+
+export const PanelTabList = memo(function PanelTabList({
+  layoutGroupId,
+  tabs,
+  tabListRef,
+  onKeyDown,
+  onAddTab,
+  addTabTooltipContent,
+  overflowTrigger,
+  renderTab,
+  className,
+}: PanelTabListProps) {
+  return (
+    <div className={cn("relative min-w-0 flex-1 flex", className)}>
+      <div
+        ref={tabListRef}
+        className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
+        role="tablist"
+        aria-label="Panel tabs"
+        onKeyDown={onKeyDown}
+      >
+        <LayoutGroup id={layoutGroupId}>
+          <div className="flex items-center">
+            {tabs.map((tab) => renderTab(tab))}
+            {onAddTab && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onAddTab();
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                    aria-label="Duplicate panel as new tab"
+                    type="button"
+                  >
+                    <Plus className="w-3 h-3" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{addTabTooltipContent}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </LayoutGroup>
+      </div>
+      {overflowTrigger}
+    </div>
+  );
+});

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -6,6 +6,8 @@ export { TabButton } from "./TabButton";
 export type { TabInfo, TabButtonProps } from "./TabButton";
 export { SortableTabButton } from "./SortableTabButton";
 export type { SortableTabButtonProps } from "./SortableTabButton";
+export { PanelTabList } from "./PanelTabList";
+export type { PanelTabListProps } from "./PanelTabList";
 export {
   TitleEditingProvider,
   useTitleEditing,


### PR DESCRIPTION
## Summary
Pure refactor. `PanelHeader` had two nearly identical tab-bar render paths (sortable `DndContext` and static) sharing ~120 lines of duplicated JSX. This extracts a `PanelTabList` component to eliminate the duplication.

Resolves #6706.

## Changes
- New `PanelTabList` component (`src/components/Panel/PanelTabList.tsx`) — accepts a `renderTab` prop so both the sortable and static paths render through the same component
- `PanelHeader` delegates tab rendering to `PanelTabList`, dropping ~120 lines of duplicated JSX
- Exported from `src/components/Panel/index.ts`

## Testing
No behavior changes — verified the panel tabs render identically in focused, docked, maximized, and selected modes.