### PR TITLE
refactor(dnd): extract pure drop-resolution helpers from DndProvider

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -44,6 +44,16 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import type { WorktreeSnapshot } from "@shared/types";
+import {
+  resolveContainerId,
+  filterTerminalsByContainer,
+  detectTargetContainer,
+  resolveTargetIndex,
+  isGridFull,
+  resolveGroupPlacementIndex,
+  findGroupIndex,
+  type OverDropData,
+} from "./dropResolution";
 
 // Placeholder ID used when dragging from dock to grid
 export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
@@ -392,13 +402,8 @@ export function DndProvider({ children }: DndProviderProps) {
     if (overData?.container) {
       detectedContainer = overData.container;
     } else if (overData?.sortable?.containerId) {
-      const containerId = overData.sortable.containerId;
-      if (containerId === "grid-container") {
-        detectedContainer = "grid";
-      } else if (containerId === "dock-container") {
-        detectedContainer = "dock";
-      }
-      // Accordion containers (worktree-*-accordion) are ignored for grid/dock detection
+      const resolved = resolveContainerId(overData.sortable.containerId);
+      if (resolved) detectedContainer = resolved;
     } else {
       const overId = over.id as string;
       // Skip accordion drop targets for non-accordion drags
@@ -601,98 +606,39 @@ export function DndProvider({ children }: DndProviderProps) {
 
       // Only process grid/dock reorder logic if this is NOT a worktree drop
       if (!isWorktreeDrop) {
-        // Priority 1: Check if dropped on a container directly
-        if (overData?.container) {
-          targetContainer = overData.container;
-        }
-        // Priority 2: Check sortable containerId
-        else if (overData?.sortable?.containerId) {
-          const containerId = overData.sortable.containerId;
-          if (containerId === "grid-container") {
-            targetContainer = "grid";
-          } else if (containerId === "dock-container") {
-            targetContainer = "dock";
-          }
-        }
-        // Priority 3: Use tracked overContainer state
-        else if (dropContainer) {
-          targetContainer = dropContainer;
-        }
-        // Priority 4: Determine from terminal location (skip accordion targets)
-        else {
-          // Skip accordion drop targets for grid/dock drags
-          const isAccordionTarget = parseAccordionDragId(overId) !== null;
-          if (!isAccordionTarget) {
-            const overTerminal = freshTerminalsById[overId];
-            if (overTerminal) {
-              targetContainer = overTerminal.location === "dock" ? "dock" : "grid";
-            }
-          }
-        }
+        const isAccordionTarget = parseAccordionDragId(overId) !== null;
+        targetContainer =
+          detectTargetContainer(
+            overData as OverDropData | undefined,
+            dropContainer,
+            overId,
+            freshTerminalsById,
+            isAccordionTarget
+          ) ??
+          sourceLocation ??
+          "grid";
 
-        // Get target index
-        let targetIndex = 0;
-        const containerTerminals: TerminalInstance[] = [];
-        for (const tid of freshTerminalIds) {
-          const t = freshTerminalsById[tid];
-          if (!t || (t.worktreeId ?? undefined) !== (activeWorktreeId ?? undefined)) continue;
-          if (targetContainer === "dock") {
-            if (t.location === "dock") containerTerminals.push(t);
-          } else {
-            if (t.location === "grid" || t.location === undefined) containerTerminals.push(t);
-          }
-        }
-
-        // Find index of item we're dropping on (skip accordion IDs)
         const isAccordionOver = parseAccordionDragId(overId) !== null;
-        const overTerminalIndex = isAccordionOver
-          ? -1
-          : containerTerminals.findIndex((t) => t.id === overId);
-        if (overTerminalIndex !== -1) {
-          targetIndex = overTerminalIndex;
-        } else if (overData?.sortable?.index !== undefined) {
-          targetIndex = overData.sortable.index;
-        } else {
-          // Dropping on empty container - append to end
-          targetIndex = containerTerminals.length;
-        }
+        const targetIndex = resolveTargetIndex(
+          freshTerminalsById,
+          freshTerminalIds,
+          activeWorktreeId,
+          targetContainer,
+          overId,
+          overData?.sortable?.index,
+          isAccordionOver
+        );
 
         // Block cross-container move from dock to grid if grid is full
-        // Count unique groups (each tab group = 1 slot)
-        const gridTerminals: TerminalInstance[] = [];
-        for (const tid of freshTerminalIds) {
-          const t = freshTerminalsById[tid];
-          if (
-            t &&
-            (t.location === "grid" || t.location === undefined) &&
-            (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
-          ) {
-            gridTerminals.push(t);
-          }
-        }
-        // Count groups using TabGroup data from store
-        const tabGroups = usePanelStore.getState().tabGroups;
-        const panelsInGroups = new Set<string>();
-        let explicitGroupCount = 0;
-        for (const group of tabGroups.values()) {
-          if (
-            group.location === "grid" &&
-            (group.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
-          ) {
-            explicitGroupCount++;
-            group.panelIds.forEach((pid) => panelsInGroups.add(pid));
-          }
-        }
-        // Count ungrouped panels (each is its own virtual group)
-        let ungroupedCount = 0;
-        for (const t of gridTerminals) {
-          if (!panelsInGroups.has(t.id)) {
-            ungroupedCount++;
-          }
-        }
-        const isGridFull = explicitGroupCount + ungroupedCount >= getMaxGridCapacity();
+        const gridIsFull = isGridFull(
+          freshTerminalsById,
+          freshTerminalIds,
+          activeWorktreeId,
+          usePanelStore.getState().tabGroups,
+          getMaxGridCapacity()
+        );
 
-        if (sourceLocation === "dock" && targetContainer === "grid" && isGridFull) {
+        if (sourceLocation === "dock" && targetContainer === "grid" && gridIsFull) {
           // Grid is full, cancel the drop - still run stabilization below
         } else if (isGroupDrag) {
           // Group-aware drag: move the entire tab group
@@ -702,36 +648,18 @@ export function DndProvider({ children }: DndProviderProps) {
               .getState()
               .getTabGroups(targetContainer, activeWorktreeId ?? undefined);
 
-            // Derive fromGroupIndex from live tabGroups by finding the group containing
-            // the dragged terminal. activeData.sourceIndex is the panel index among all
-            // individual panels, not the group index, so it cannot be used here.
-            // Prefer groupId match (explicit groups); fall back to panel membership.
-            let fromGroupIndex = tabGroupsAtLocation.findIndex((g) => g.id === activeData.groupId);
-            if (fromGroupIndex === -1) {
-              fromGroupIndex = tabGroupsAtLocation.findIndex((g) =>
-                g.panelIds.includes(activeData.terminal.id)
-              );
-            }
+            const fromGroupIndex = findGroupIndex(
+              tabGroupsAtLocation,
+              activeData.groupId,
+              activeData.terminal.id
+            );
 
             if (fromGroupIndex !== -1) {
-              // Find target group index: match by group ID or panel membership, then
-              // fall back to sortable.index when overId is a synthetic placeholder.
-              let toGroupIndex = -1;
-              for (let i = 0; i < tabGroupsAtLocation.length; i++) {
-                if (
-                  tabGroupsAtLocation[i]!.id === overId ||
-                  tabGroupsAtLocation[i]!.panelIds.includes(overId)
-                ) {
-                  toGroupIndex = i;
-                  break;
-                }
-              }
-              if (toGroupIndex === -1) {
-                toGroupIndex =
-                  overData?.sortable?.index !== undefined
-                    ? Math.min(Math.max(0, overData.sortable.index), tabGroupsAtLocation.length - 1)
-                    : tabGroupsAtLocation.length - 1;
-              }
+              const toGroupIndex = resolveGroupPlacementIndex(
+                tabGroupsAtLocation,
+                overId,
+                overData?.sortable?.index
+              );
 
               if (fromGroupIndex !== toGroupIndex) {
                 reorderTabGroups(fromGroupIndex, toGroupIndex, targetContainer, activeWorktreeId);
@@ -754,29 +682,12 @@ export function DndProvider({ children }: DndProviderProps) {
               );
 
               if (movedGroupIndex !== -1) {
-                // Find target group index: match by group ID or panel membership, then
-                // fall back to sortable.index when overId is a synthetic placeholder.
-                let toGroupIndex = -1;
-                for (let i = 0; i < tabGroupsAtLocation.length; i++) {
-                  if (
-                    tabGroupsAtLocation[i]!.id === overId ||
-                    tabGroupsAtLocation[i]!.panelIds.includes(overId)
-                  ) {
-                    toGroupIndex = i;
-                    break;
-                  }
-                }
-                if (toGroupIndex === -1) {
-                  toGroupIndex =
-                    overData?.sortable?.index !== undefined
-                      ? Math.min(
-                          Math.max(0, overData.sortable.index),
-                          tabGroupsAtLocation.length - 1
-                        )
-                      : tabGroupsAtLocation.length - 1;
-                }
+                const toGroupIndex = resolveGroupPlacementIndex(
+                  tabGroupsAtLocation,
+                  overId,
+                  overData?.sortable?.index
+                );
 
-                // If we're not already at the target position, reorder
                 if (movedGroupIndex !== toGroupIndex) {
                   reorderTabGroups(
                     movedGroupIndex,
@@ -800,6 +711,12 @@ export function DndProvider({ children }: DndProviderProps) {
           // Same container reorder
           if (sourceLocation === targetContainer) {
             if (draggedId !== overId) {
+              const containerTerminals = filterTerminalsByContainer(
+                freshTerminalsById,
+                freshTerminalIds,
+                targetContainer,
+                activeWorktreeId
+              );
               const oldIndex = containerTerminals.findIndex((t) => t.id === draggedId);
 
               if (oldIndex !== -1 && targetIndex !== -1 && oldIndex !== targetIndex) {

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -73,12 +73,12 @@ describe("filterTerminalsByContainer", () => {
     (tE as unknown as Record<string, unknown>).location = undefined;
     const byId = { ...terminalsById, e: tE };
     const result = filterTerminalsByContainer(byId, [...panelIds, "e"], "grid", "wt1");
-    expect(result.map((t) => t.id)).toContain("e");
+    expect(result.map((t) => t.id)).toEqual(["a", "c", "e"]);
   });
 
   it("skips terminals with wrong worktreeId", () => {
     const result = filterTerminalsByContainer(terminalsById, panelIds, "dock", "wt1");
-    expect(result.map((t) => t.id)).not.toContain("d");
+    expect(result.map((t) => t.id)).toEqual(["b"]);
   });
 
   it("skips undefined terminals (stale ID in panelIds)", () => {
@@ -95,10 +95,8 @@ describe("filterTerminalsByContainer", () => {
     const tNull = makeTerminal("null", "grid", undefined);
     (tNull as unknown as Record<string, unknown>).worktreeId = null;
     const byId = { null: tNull };
-    // When worktreeId is null, ?? undefined converts to undefined, matching null→undefined
-    // So filtering with null worktreeId should match terminals with null worktreeId
     const result = filterTerminalsByContainer(byId, ["null"], "grid", null);
-    expect(result).toHaveLength(1);
+    expect(result.map((t) => t.id)).toEqual(["null"]);
   });
 });
 
@@ -143,7 +141,8 @@ describe("detectTargetContainer", () => {
     ).toBeNull();
   });
 
-  it("P3: falls back to dropContainer", () => {
+  it("P2: unknown sortable.containerId blocks cascade (does not fall to P3/P4)", () => {
+    // old else-if chain: entering P2 branch blocks P3/P4 even when containerId is unknown
     expect(
       detectTargetContainer(
         { sortable: { containerId: "accordion-x" } },
@@ -152,7 +151,23 @@ describe("detectTargetContainer", () => {
         terminalsById,
         false
       )
-    ).toBe("dock");
+    ).toBeNull();
+  });
+
+  it("P3: falls back to dropContainer", () => {
+    expect(detectTargetContainer(undefined, "dock", "t1", terminalsById, false)).toBe("dock");
+  });
+
+  it("P1 beats P2/P3/P4", () => {
+    expect(
+      detectTargetContainer(
+        { container: "grid", sortable: { containerId: "dock-container" } },
+        "dock",
+        "t1",
+        terminalsById,
+        false
+      )
+    ).toBe("grid");
   });
 
   it("P4: resolves from terminal location", () => {
@@ -235,7 +250,8 @@ describe("isGridFull", () => {
     const tA = makeTerminal("a", "grid", "wt1");
     const tB = makeTerminal("b", "grid", "wt1");
     const tabGroups = new Map([["g1", group]]);
-    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", tabGroups, 1)).toBe(true); // group counts as 1 slot
+    // 2-panel group counts as 1 slot; capacity=2 means NOT full (proves panels aren't double-counted)
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", tabGroups, 2)).toBe(false);
   });
 
   it("counts ungrouped panels separately from grouped panels", () => {
@@ -250,21 +266,21 @@ describe("isGridFull", () => {
   it("ignores dock-location groups in grid check", () => {
     const group = makeTabGroup("g1", "dock", ["a"], "wt1");
     const tA = makeTerminal("a", "grid", "wt1");
+    const tB = makeTerminal("b", "grid", "wt1");
     const tabGroups = new Map([["g1", group]]);
-    // group is dock, doesn't count; terminal is grid, counts as ungrouped
-    expect(isGridFull({ a: tA }, ["a"], "wt1", tabGroups, 1)).toBe(true);
+    // group is dock, doesn't count; 2 grid terminals = 2 slots, capacity=2 => full
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", tabGroups, 2)).toBe(true);
   });
 
   it("filters by worktreeId for groups", () => {
     const group = makeTabGroup("g1", "grid", ["a"], "wt2");
     const tA = makeTerminal("a", "grid", "wt1");
     const tabGroups = new Map([["g1", group]]);
-    expect(isGridFull({ a: tA }, ["a"], "wt1", tabGroups, 1)).toBe(true); // group is wt2, doesn't count; terminal counts
+    // wt2 group excluded; only 1 wt1 terminal counted; capacity=2 => not full
+    expect(isGridFull({ a: tA }, ["a"], "wt1", tabGroups, 2)).toBe(false);
   });
 
-  it("uses insert-order Map iteration", () => {
-    // TabGroups are a Map; iteration must be stable. The function
-    // iterates with values() which is insert-order guaranteed.
+  it("multiple groups fill independent slots", () => {
     const g1 = makeTabGroup("g1", "grid", ["a"], "wt1");
     const g2 = makeTabGroup("g2", "grid", ["b"], "wt1");
     const map = new Map([
@@ -273,7 +289,10 @@ describe("isGridFull", () => {
     ]);
     const tA = makeTerminal("a", "grid", "wt1");
     const tB = makeTerminal("b", "grid", "wt1");
+    // 2 groups = 2 slots; capacity=2 => full
     expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", map, 2)).toBe(true);
+    // capacity=3 => not full (proves each group counts as 1, not double-counted with terminals)
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", map, 3)).toBe(false);
   });
 });
 

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveContainerId,
+  filterTerminalsByContainer,
+  detectTargetContainer,
+  resolveTargetIndex,
+  isGridFull,
+  resolveGroupPlacementIndex,
+  findGroupIndex,
+} from "../dropResolution";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@shared/types";
+
+function makeTerminal(
+  id: string,
+  location: "grid" | "dock",
+  worktreeId?: string
+): TerminalInstance {
+  return { id, location, worktreeId, title: `Terminal ${id}` } as TerminalInstance;
+}
+
+function makeTabGroup(
+  id: string,
+  location: "grid" | "dock",
+  panelIds: string[],
+  worktreeId?: string
+): TabGroup {
+  return { id, location, panelIds, worktreeId, activeTabId: panelIds[0] ?? id } as TabGroup;
+}
+
+// ---------------------------------------------------------------------------
+// resolveContainerId
+// ---------------------------------------------------------------------------
+describe("resolveContainerId", () => {
+  it('maps "grid-container" to "grid"', () => {
+    expect(resolveContainerId("grid-container")).toBe("grid");
+  });
+
+  it('maps "dock-container" to "dock"', () => {
+    expect(resolveContainerId("dock-container")).toBe("dock");
+  });
+
+  it("returns null for unknown container IDs", () => {
+    expect(resolveContainerId("worktree-foo-accordion")).toBeNull();
+    expect(resolveContainerId("")).toBeNull();
+    expect(resolveContainerId("random")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterTerminalsByContainer
+// ---------------------------------------------------------------------------
+describe("filterTerminalsByContainer", () => {
+  const tA = makeTerminal("a", "grid", "wt1");
+  const tB = makeTerminal("b", "dock", "wt1");
+  const tC = makeTerminal("c", "grid", "wt1");
+  const tD = makeTerminal("d", "dock", "wt2");
+  const terminalsById = { a: tA, b: tB, c: tC, d: tD };
+  const panelIds = ["a", "b", "c", "d"];
+
+  it("filters grid terminals for a worktree", () => {
+    const result = filterTerminalsByContainer(terminalsById, panelIds, "grid", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["a", "c"]);
+  });
+
+  it("filters dock terminals for a worktree", () => {
+    const result = filterTerminalsByContainer(terminalsById, panelIds, "dock", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["b"]);
+  });
+
+  it("treats undefined location as grid", () => {
+    const tE = makeTerminal("e", "grid", "wt1");
+    (tE as unknown as Record<string, unknown>).location = undefined;
+    const byId = { ...terminalsById, e: tE };
+    const result = filterTerminalsByContainer(byId, [...panelIds, "e"], "grid", "wt1");
+    expect(result.map((t) => t.id)).toContain("e");
+  });
+
+  it("skips terminals with wrong worktreeId", () => {
+    const result = filterTerminalsByContainer(terminalsById, panelIds, "dock", "wt1");
+    expect(result.map((t) => t.id)).not.toContain("d");
+  });
+
+  it("skips undefined terminals (stale ID in panelIds)", () => {
+    const result = filterTerminalsByContainer(terminalsById, [...panelIds, "ghost"], "grid", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["a", "c"]);
+  });
+
+  it("preserves panelIds ordering", () => {
+    const result = filterTerminalsByContainer(terminalsById, ["c", "a"], "grid", "wt1");
+    expect(result.map((t) => t.id)).toEqual(["c", "a"]);
+  });
+
+  it("handles null worktreeId by converting to undefined", () => {
+    const tNull = makeTerminal("null", "grid", undefined);
+    (tNull as unknown as Record<string, unknown>).worktreeId = null;
+    const byId = { null: tNull };
+    // When worktreeId is null, ?? undefined converts to undefined, matching null→undefined
+    // So filtering with null worktreeId should match terminals with null worktreeId
+    const result = filterTerminalsByContainer(byId, ["null"], "grid", null);
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectTargetContainer
+// ---------------------------------------------------------------------------
+describe("detectTargetContainer", () => {
+  const overTerminal = makeTerminal("t1", "dock", "wt1");
+  const terminalsById = { t1: overTerminal };
+
+  it("P1: returns direct container from overData", () => {
+    expect(detectTargetContainer({ container: "dock" }, null, "t1", terminalsById, false)).toBe(
+      "dock"
+    );
+    expect(detectTargetContainer({ container: "grid" }, "dock", "t1", terminalsById, false)).toBe(
+      "grid"
+    );
+  });
+
+  it("P2: resolves sortable.containerId", () => {
+    expect(
+      detectTargetContainer(
+        { sortable: { containerId: "grid-container" } },
+        null,
+        "t1",
+        terminalsById,
+        false
+      )
+    ).toBe("grid");
+  });
+
+  it("P2: returns null for unknown containerId when P3/P4 also miss", () => {
+    // unknown containerId → falls through to P3 (null) → P4 (ghost not found) → null
+    expect(
+      detectTargetContainer(
+        { sortable: { containerId: "accordion-x" } },
+        null,
+        "ghost",
+        terminalsById,
+        false
+      )
+    ).toBeNull();
+  });
+
+  it("P3: falls back to dropContainer", () => {
+    expect(
+      detectTargetContainer(
+        { sortable: { containerId: "accordion-x" } },
+        "dock",
+        "t1",
+        terminalsById,
+        false
+      )
+    ).toBe("dock");
+  });
+
+  it("P4: resolves from terminal location", () => {
+    expect(detectTargetContainer(undefined, null, "t1", terminalsById, false)).toBe("dock");
+  });
+
+  it("P4: respects skipAccordionTarget", () => {
+    expect(detectTargetContainer(undefined, null, "t1", terminalsById, true)).toBeNull();
+  });
+
+  it("P4: returns null when overId terminal not found", () => {
+    expect(detectTargetContainer(undefined, null, "ghost", terminalsById, false)).toBeNull();
+  });
+
+  it("P4: maps non-dock location to grid", () => {
+    const t2 = makeTerminal("t2", "grid", "wt1");
+    expect(detectTargetContainer(undefined, null, "t2", { t2 }, false)).toBe("grid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTargetIndex
+// ---------------------------------------------------------------------------
+describe("resolveTargetIndex", () => {
+  const tA = makeTerminal("a", "grid", "wt1");
+  const tB = makeTerminal("b", "grid", "wt1");
+  const tC = makeTerminal("c", "grid", "wt1");
+  const terminalsById = { a: tA, b: tB, c: tC };
+  const panelIds = ["a", "b", "c"];
+
+  it("finds exact terminal match index", () => {
+    expect(resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false)).toBe(
+      1
+    );
+  });
+
+  it("falls back to sortableIndex when overId not found", () => {
+    expect(resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "ghost", 2, false)).toBe(2);
+  });
+
+  it("appends to end when no match and no sortableIndex", () => {
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "ghost", undefined, false)
+    ).toBe(3);
+  });
+
+  it("skips exact match for accordion over (skipAccordionOver)", () => {
+    expect(resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, true)).toBe(
+      3
+    );
+  });
+
+  it("filters by worktreeId", () => {
+    const tD = makeTerminal("d", "grid", "wt2");
+    const byId = { ...terminalsById, d: tD };
+    const ids = [...panelIds, "d"];
+    // "d" is wt2 and won't appear when filtering for wt1
+    expect(resolveTargetIndex(byId, ids, "wt1", "grid", "d", undefined, false)).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isGridFull
+// ---------------------------------------------------------------------------
+describe("isGridFull", () => {
+  it("returns true when count meets capacity", () => {
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tB = makeTerminal("b", "grid", "wt1");
+    const terminalsById = { a: tA, b: tB };
+    expect(isGridFull(terminalsById, ["a", "b"], "wt1", new Map(), 2)).toBe(true);
+  });
+
+  it("returns false when count is below capacity", () => {
+    const tA = makeTerminal("a", "grid", "wt1");
+    expect(isGridFull({ a: tA }, ["a"], "wt1", new Map(), 2)).toBe(false);
+  });
+
+  it("counts explicit tab groups", () => {
+    const group = makeTabGroup("g1", "grid", ["a", "b"], "wt1");
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tB = makeTerminal("b", "grid", "wt1");
+    const tabGroups = new Map([["g1", group]]);
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", tabGroups, 1)).toBe(true); // group counts as 1 slot
+  });
+
+  it("counts ungrouped panels separately from grouped panels", () => {
+    const group = makeTabGroup("g1", "grid", ["a"], "wt1");
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tB = makeTerminal("b", "grid", "wt1"); // ungrouped
+    const tabGroups = new Map([["g1", group]]);
+    // 1 group + 1 ungrouped = 2, capacity = 2 => full
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", tabGroups, 2)).toBe(true);
+  });
+
+  it("ignores dock-location groups in grid check", () => {
+    const group = makeTabGroup("g1", "dock", ["a"], "wt1");
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tabGroups = new Map([["g1", group]]);
+    // group is dock, doesn't count; terminal is grid, counts as ungrouped
+    expect(isGridFull({ a: tA }, ["a"], "wt1", tabGroups, 1)).toBe(true);
+  });
+
+  it("filters by worktreeId for groups", () => {
+    const group = makeTabGroup("g1", "grid", ["a"], "wt2");
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tabGroups = new Map([["g1", group]]);
+    expect(isGridFull({ a: tA }, ["a"], "wt1", tabGroups, 1)).toBe(true); // group is wt2, doesn't count; terminal counts
+  });
+
+  it("uses insert-order Map iteration", () => {
+    // TabGroups are a Map; iteration must be stable. The function
+    // iterates with values() which is insert-order guaranteed.
+    const g1 = makeTabGroup("g1", "grid", ["a"], "wt1");
+    const g2 = makeTabGroup("g2", "grid", ["b"], "wt1");
+    const map = new Map([
+      ["g1", g1],
+      ["g2", g2],
+    ]);
+    const tA = makeTerminal("a", "grid", "wt1");
+    const tB = makeTerminal("b", "grid", "wt1");
+    expect(isGridFull({ a: tA, b: tB }, ["a", "b"], "wt1", map, 2)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGroupPlacementIndex
+// ---------------------------------------------------------------------------
+describe("resolveGroupPlacementIndex", () => {
+  const groups: TabGroup[] = [
+    makeTabGroup("g1", "grid", ["a", "b"]),
+    makeTabGroup("g2", "grid", ["c"]),
+    makeTabGroup("g3", "grid", ["d"]),
+  ];
+
+  it("finds index by group ID match", () => {
+    expect(resolveGroupPlacementIndex(groups, "g2", undefined)).toBe(1);
+  });
+
+  it("finds index by panel ID membership", () => {
+    expect(resolveGroupPlacementIndex(groups, "d", undefined)).toBe(2);
+  });
+
+  it("falls back to clamped sortableIndex when no match", () => {
+    expect(resolveGroupPlacementIndex(groups, "ghost", 0)).toBe(0);
+    expect(resolveGroupPlacementIndex(groups, "ghost", 5)).toBe(2); // clamped to length-1
+  });
+
+  it("falls back to last position when no match and no sortableIndex", () => {
+    expect(resolveGroupPlacementIndex(groups, "ghost", undefined)).toBe(2);
+  });
+
+  it("handles empty groups", () => {
+    expect(resolveGroupPlacementIndex([], "x", undefined)).toBe(-1);
+  });
+
+  it("handles empty groups with sortableIndex", () => {
+    // tabGroups.length - 1 = -1, Math.max(0, 3) = 3, Math.min(3, -1) = -1
+    // This edge case shouldn't happen in practice but we preserve the math
+    const result = resolveGroupPlacementIndex([], "x", 3);
+    expect(result).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findGroupIndex
+// ---------------------------------------------------------------------------
+describe("findGroupIndex", () => {
+  const groups: TabGroup[] = [
+    makeTabGroup("g1", "grid", ["a", "b"]),
+    makeTabGroup("g2", "grid", ["c"]),
+  ];
+
+  it("finds by groupId match (priority)", () => {
+    expect(findGroupIndex(groups, "g2", "a")).toBe(1);
+  });
+
+  it("falls back to panel membership", () => {
+    expect(findGroupIndex(groups, undefined, "c")).toBe(1);
+    expect(findGroupIndex(groups, "nonexistent", "a")).toBe(0);
+  });
+
+  it("returns -1 when not found", () => {
+    expect(findGroupIndex(groups, undefined, "ghost")).toBe(-1);
+  });
+});

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -49,8 +49,9 @@ export function detectTargetContainer(
 ): "grid" | "dock" | null {
   if (overData?.container) return overData.container;
 
-  const resolved = resolveContainerId(overData?.sortable?.containerId ?? "");
-  if (resolved) return resolved;
+  if (overData?.sortable?.containerId) {
+    return resolveContainerId(overData.sortable.containerId);
+  }
 
   if (dropContainer) return dropContainer;
 

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -159,7 +159,7 @@ export function findGroupIndex(
   groupId: string | undefined,
   terminalId: string
 ): number {
-  let idx = tabGroups.findIndex((g) => g.id === groupId);
+  const idx = tabGroups.findIndex((g) => g.id === groupId);
   if (idx !== -1) return idx;
   return tabGroups.findIndex((g) => g.panelIds.includes(terminalId));
 }

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -1,0 +1,164 @@
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@shared/types";
+
+export interface OverDropData {
+  container?: "grid" | "dock";
+  sortable?: { containerId?: string; index?: number };
+  type?: string;
+  worktreeId?: string;
+}
+
+/** Map dnd-kit container ID strings ("grid-container", "dock-container") to containers. */
+export function resolveContainerId(containerId: string): "grid" | "dock" | null {
+  if (containerId === "grid-container") return "grid";
+  if (containerId === "dock-container") return "dock";
+  return null;
+}
+
+/** Filter terminals to those in a given container and worktree, preserving panelIds order. */
+export function filterTerminalsByContainer(
+  terminalsById: Record<string, TerminalInstance | undefined>,
+  panelIds: readonly string[],
+  container: "grid" | "dock",
+  worktreeId: string | null | undefined
+): TerminalInstance[] {
+  const result: TerminalInstance[] = [];
+  for (const tid of panelIds) {
+    const t = terminalsById[tid];
+    if (!t || (t.worktreeId ?? undefined) !== (worktreeId ?? undefined)) continue;
+    if (container === "dock") {
+      if (t.location === "dock") result.push(t);
+    } else {
+      if (t.location === "grid" || t.location === undefined) result.push(t);
+    }
+  }
+  return result;
+}
+
+/**
+ * 4-priority container detection for handleDragEnd.
+ * P1: direct container on overData; P2: sortable.containerId via resolveContainerId;
+ * P3: tracked dropContainer state; P4: terminal location lookup (unless skipAccordionTarget).
+ */
+export function detectTargetContainer(
+  overData: OverDropData | undefined,
+  dropContainer: "grid" | "dock" | null,
+  overId: string,
+  terminalsById: Record<string, TerminalInstance | undefined>,
+  skipAccordionTarget: boolean
+): "grid" | "dock" | null {
+  if (overData?.container) return overData.container;
+
+  const resolved = resolveContainerId(overData?.sortable?.containerId ?? "");
+  if (resolved) return resolved;
+
+  if (dropContainer) return dropContainer;
+
+  if (!skipAccordionTarget) {
+    const overTerminal = terminalsById[overId];
+    if (overTerminal) {
+      return overTerminal.location === "dock" ? "dock" : "grid";
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Compute target insertion index within a container.
+ * Falls back: exact terminal match → sortable.index → append-to-end.
+ */
+export function resolveTargetIndex(
+  terminalsById: Record<string, TerminalInstance | undefined>,
+  panelIds: readonly string[],
+  worktreeId: string | null | undefined,
+  targetContainer: "grid" | "dock",
+  overId: string,
+  sortableIndex: number | undefined,
+  skipAccordionOver: boolean
+): number {
+  const containerTerminals = filterTerminalsByContainer(
+    terminalsById,
+    panelIds,
+    targetContainer,
+    worktreeId
+  );
+
+  if (!skipAccordionOver) {
+    const idx = containerTerminals.findIndex((t) => t.id === overId);
+    if (idx !== -1) return idx;
+  }
+
+  if (sortableIndex !== undefined) return sortableIndex;
+
+  return containerTerminals.length;
+}
+
+/**
+ * Check whether the grid container is at capacity for a given worktree.
+ * Counts explicit TabGroups + ungrouped terminals against maxGridCapacity.
+ */
+export function isGridFull(
+  terminalsById: Record<string, TerminalInstance | undefined>,
+  panelIds: readonly string[],
+  worktreeId: string | null | undefined,
+  tabGroups: Map<string, TabGroup>,
+  maxGridCapacity: number
+): boolean {
+  const gridTerminals = filterTerminalsByContainer(terminalsById, panelIds, "grid", worktreeId);
+
+  const panelsInGroups = new Set<string>();
+  let explicitGroupCount = 0;
+  for (const group of tabGroups.values()) {
+    if (
+      group.location === "grid" &&
+      (group.worktreeId ?? undefined) === (worktreeId ?? undefined)
+    ) {
+      explicitGroupCount++;
+      for (const pid of group.panelIds) panelsInGroups.add(pid);
+    }
+  }
+
+  let ungroupedCount = 0;
+  for (const t of gridTerminals) {
+    if (!panelsInGroups.has(t.id)) ungroupedCount++;
+  }
+
+  return explicitGroupCount + ungroupedCount >= maxGridCapacity;
+}
+
+/**
+ * Find the insertion index for a group among tabGroups.
+ * Linear search for group ID or panel membership; falls back to clamped
+ * sortableIndex, then last position.
+ */
+export function resolveGroupPlacementIndex(
+  tabGroups: TabGroup[],
+  overId: string,
+  sortableIndex: number | undefined
+): number {
+  for (let i = 0; i < tabGroups.length; i++) {
+    if (tabGroups[i]!.id === overId || tabGroups[i]!.panelIds.includes(overId)) {
+      return i;
+    }
+  }
+
+  if (sortableIndex !== undefined) {
+    return Math.min(Math.max(0, sortableIndex), tabGroups.length - 1);
+  }
+
+  return tabGroups.length - 1;
+}
+
+/**
+ * Find the source (from) group index by matching groupId then panel membership.
+ */
+export function findGroupIndex(
+  tabGroups: TabGroup[],
+  groupId: string | undefined,
+  terminalId: string
+): number {
+  let idx = tabGroups.findIndex((g) => g.id === groupId);
+  if (idx !== -1) return idx;
+  return tabGroups.findIndex((g) => g.panelIds.includes(terminalId));
+}


### PR DESCRIPTION
## Summary

- Extracts pure drop-resolution helpers from `DndProvider` into a new `dropResolution.ts` module, with a comprehensive test file.
- Cuts `handleDragEnd` from ~600 lines to ~450 by pulling out `resolveTargetContainer`, `resolveTargetIndex`, `isGridFull`, and the group placement/index helpers.
- The pure helpers take store snapshots as arguments -- they never call `getState()` themselves. No behavior changes.

Resolves #6707

## Changes

- **`src/components/DragDrop/dropResolution.ts`** -- new module: `resolveContainerId`, `filterTerminalsByContainer`, `detectTargetContainer`, `resolveTargetIndex`, `isGridFull`, `resolveGroupPlacementIndex`, `findGroupIndex`
- **`src/components/DragDrop/__tests__/dropResolution.test.ts`** -- 359 lines covering all helpers with edge cases (undefined worktreeIds, empty containers, grid vs dock filtering, group membership fallback, capacity boundaries, accordion skip modes)
- **`src/components/DragDrop/DndProvider.tsx`** -- imports helpers from `dropResolution.ts`; `handleDragEnd` and `handleDragOver` call them inline, leaving only side-effecting store calls and renderer-reset orchestration

## Testing

All drop-resolution helpers are unit tested in isolation. Existing DnD behavior is unchanged -- the extraction is a pure refactor with no logic modifications.