### PR TITLE
refactor(worktree): extract shared spawnPanelsFromRecipe helper

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -30,10 +30,9 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
-import { getAgentConfig } from "@/config/agents";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import type { BranchInfo } from "@shared/types";
-import { generateAgentCommand } from "@shared/types";
+import { spawnPanelsFromRecipe } from "@/components/Worktree/panelSpawning";
 
 type BulkCreateMode = "issue" | "pr";
 
@@ -798,62 +797,20 @@ export function BulkCreateWorktreeDialog({
                 });
                 const spawnedIds: string[] = [];
                 const failedIndices: number[] = [];
-                for (const [index, t] of cloneTerminals.entries()) {
-                  try {
-                    const isDevPreview = t.type === "dev-preview";
-                    const isAgent = !isDevPreview && t.type !== "terminal";
-
-                    let panelId: string | null;
-                    if (isDevPreview) {
-                      panelId = await usePanelStore.getState().addPanel({
-                        kind: "dev-preview",
-                        title: t.title,
-                        cwd: worktreePath,
-                        worktreeId,
-                        exitBehavior: t.exitBehavior,
-                        devCommand: t.devCommand?.trim() || undefined,
-                      });
-                    } else if (isAgent) {
-                      const agentId = t.type;
-                      const agentConfig = getAgentConfig(agentId);
-                      const baseCommand = agentConfig?.command ?? "";
-                      const entry = cloneAgentSettings?.agents?.[agentId] ?? {};
-                      const command = generateAgentCommand(baseCommand, entry, agentId, {
-                        clipboardDirectory: cloneClipboardDirectory,
-                        modelId: t.agentModelId,
-                      });
-
-                      panelId = await usePanelStore.getState().addPanel({
-                        kind: "terminal",
-                        launchAgentId: agentId,
-                        command,
-                        title: t.title,
-                        cwd: worktreePath,
-                        worktreeId,
-                        exitBehavior: t.exitBehavior,
-                        agentModelId: t.agentModelId,
-                        agentLaunchFlags: t.agentLaunchFlags,
-                      });
-                    } else {
-                      panelId = await usePanelStore.getState().addPanel({
-                        kind: "terminal",
-                        title: t.title,
-                        cwd: worktreePath,
-                        worktreeId,
-                        exitBehavior: t.exitBehavior,
-                        command: t.command?.trim() || undefined,
-                      });
-                    }
-
+                await spawnPanelsFromRecipe({
+                  terminals: cloneTerminals,
+                  worktreeId,
+                  cwd: worktreePath,
+                  agentSettings: cloneAgentSettings,
+                  clipboardDirectory: cloneClipboardDirectory,
+                  onPanelSpawned: (index, panelId, _error) => {
                     if (panelId != null) {
                       spawnedIds.push(panelId);
                     } else {
                       failedIndices.push(index);
                     }
-                  } catch {
-                    failedIndices.push(index);
-                  }
-                }
+                  },
+                });
                 const updatedTracked = tracking.get(itemNumber);
                 if (updatedTracked) {
                   updatedTracked.spawnedTerminalIds = [

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -21,7 +21,6 @@ import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import { worktreeClient, githubClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import type { RecipeTerminal } from "@shared/types";
 import { IssueSelector } from "@/components/GitHub/IssueSelector";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { parseBranchInput } from "./branchPrefixUtils";

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -19,10 +19,8 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { FolderGit2 } from "@/components/icons";
 import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
-import { worktreeClient, githubClient, agentSettingsClient } from "@/clients";
+import { worktreeClient, githubClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import { getAgentConfig } from "@/config/agents";
-import { generateAgentCommand } from "@shared/types";
 import type { RecipeTerminal } from "@shared/types";
 import { IssueSelector } from "@/components/GitHub/IssueSelector";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -47,8 +45,8 @@ import { useBranchValidation } from "./hooks/useBranchValidation";
 import { useBranchPicker } from "./hooks/useBranchPicker";
 import { usePrefixPicker } from "./hooks/usePrefixPicker";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "./hooks/useRecipePicker";
-import { usePanelStore } from "@/store/panelStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { spawnPanelsFromRecipe } from "./panelSpawning";
 
 type BranchMode = "new" | "existing";
 
@@ -86,81 +84,6 @@ function HighlightBranchText({
   }
 
   return <>{nodes}</>;
-}
-
-/**
- * Spawn panels for a clone-layout operation.
- *
- * Mirrors the BulkCreateWorktreeDialog pattern: pre-fetches agent settings
- * once (only if any agent panels are present), then loops sequentially to
- * preserve panel order. For agent panels, regenerates the command from
- * current settings rather than reusing the source panel's command (which may
- * embed a path-scoped session ID — see #5179, PR #4781).
- */
-async function cloneLayoutPanels(
-  terminals: RecipeTerminal[],
-  worktreeId: string,
-  cwd: string
-): Promise<void> {
-  const addPanel = usePanelStore.getState().addPanel;
-  const hasAgent = terminals.some((t) => t.type !== "terminal" && t.type !== "dev-preview");
-  let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
-  let clipboardDirectory: string | undefined;
-
-  if (hasAgent) {
-    try {
-      const [settings, tmpDir] = await Promise.all([
-        agentSettingsClient.get(),
-        systemClient.getTmpDir().catch(() => ""),
-      ]);
-      agentSettings = settings;
-      clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
-    } catch {
-      // Non-fatal: agents fall back to generating with empty settings.
-    }
-  }
-
-  for (const t of terminals) {
-    if (t.type === "dev-preview") {
-      await addPanel({
-        kind: "dev-preview",
-        title: t.title,
-        cwd,
-        worktreeId,
-        exitBehavior: t.exitBehavior,
-        devCommand: t.devCommand?.trim() || undefined,
-      });
-    } else if (t.type === "terminal") {
-      await addPanel({
-        kind: "terminal",
-        title: t.title,
-        cwd,
-        worktreeId,
-        exitBehavior: t.exitBehavior,
-        command: t.command?.trim() || undefined,
-      });
-    } else {
-      const agentId = t.type;
-      const agentConfig = getAgentConfig(agentId);
-      const baseCommand = agentConfig?.command ?? "";
-      const entry = agentSettings?.agents?.[agentId] ?? {};
-      const command = generateAgentCommand(baseCommand, entry, agentId, {
-        clipboardDirectory,
-        modelId: t.agentModelId,
-      });
-      await addPanel({
-        kind: "terminal",
-        launchAgentId: agentId,
-        command,
-        title: t.title,
-        cwd,
-        worktreeId,
-        exitBehavior: t.exitBehavior,
-        agentModelId: t.agentModelId,
-        agentLaunchFlags: t.agentLaunchFlags,
-      });
-    }
-  }
 }
 
 interface NewWorktreeDialogProps {
@@ -610,7 +533,7 @@ export function NewWorktreeDialog({
               const terminals = useRecipeStore
                 .getState()
                 .generateRecipeFromActiveTerminals(sourceWorktreeId);
-              await cloneLayoutPanels(terminals, worktreeId, worktreePath.trim());
+              await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: worktreePath.trim() });
             } catch (cloneErr) {
               const message = formatErrorMessage(cloneErr, "Failed to clone layout");
               notify({
@@ -785,7 +708,7 @@ export function NewWorktreeDialog({
             const terminals = useRecipeStore
               .getState()
               .generateRecipeFromActiveTerminals(sourceWorktreeId);
-            await cloneLayoutPanels(terminals, worktreeId, worktreePath.trim());
+            await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: worktreePath.trim() });
           } catch (cloneErr) {
             const message = formatErrorMessage(cloneErr, "Failed to clone layout");
             notify({

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/store/panelStore", () => ({
 }));
 
 function makeTerminal(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return {
     type: "terminal",
     title: "Terminal",
@@ -44,6 +45,7 @@ function makeTerminal(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
 }
 
 function makeDevPreview(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return {
     type: "dev-preview",
     title: "Dev Preview",
@@ -54,6 +56,7 @@ function makeDevPreview(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal
 }
 
 function makeAgent(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return {
     type: "claude",
     title: "Claude Agent",

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -260,4 +260,69 @@ describe("spawnPanelsFromRecipe", () => {
       expect.objectContaining({ clipboardDirectory: undefined })
     );
   });
+
+  it("throws AggregateError when addPanel returns null and no callback is provided", async () => {
+    mockAddPanel.mockResolvedValue(null);
+
+    await expect(
+      spawnPanelsFromRecipe({
+        terminals: [makeTerminal()],
+        worktreeId: "wt-1",
+        cwd: "/path/to/wt",
+      })
+    ).rejects.toThrow(AggregateError);
+  });
+
+  it("throws AggregateError when addPanel throws and no callback is provided", async () => {
+    mockAddPanel.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      spawnPanelsFromRecipe({
+        terminals: [makeTerminal()],
+        worktreeId: "wt-1",
+        cwd: "/path/to/wt",
+      })
+    ).rejects.toThrow(AggregateError);
+  });
+
+  it("does not throw when errors occur but callback is provided", async () => {
+    mockAddPanel.mockRejectedValue(new Error("boom"));
+    const cb = vi.fn();
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(cb).toHaveBeenCalledWith(0, null, expect.any(Error));
+  });
+
+  it("does not double-fire callback when success callback throws", async () => {
+    const cb = vi.fn().mockImplementation(() => {
+      throw new Error("callback error");
+    });
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("collects errors from multiple panels and throws single AggregateError", async () => {
+    mockAddPanel.mockResolvedValueOnce(null).mockRejectedValueOnce(new Error("fail"));
+
+    await expect(
+      spawnPanelsFromRecipe({
+        terminals: [makeTerminal({ title: "T1" }), makeTerminal({ title: "T2" })],
+        worktreeId: "wt-1",
+        cwd: "/path/to/wt",
+      })
+    ).rejects.toThrow(AggregateError);
+  });
 });

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -1,0 +1,263 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { spawnPanelsFromRecipe } from "../panelSpawning";
+import type { RecipeTerminal } from "@shared/types";
+
+const mockAddPanel = vi.fn();
+const mockAgentSettingsGet = vi.fn();
+const mockSystemGetTmpDir = vi.fn();
+const mockGetAgentConfig = vi.fn();
+const mockGenerateAgentCommand = vi.fn();
+
+vi.mock("@/clients", () => ({
+  agentSettingsClient: { get: (...args: unknown[]) => mockAgentSettingsGet(...args) },
+  systemClient: { getTmpDir: (...args: unknown[]) => mockSystemGetTmpDir(...args) },
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (...args: unknown[]) => mockGetAgentConfig(...args),
+}));
+
+vi.mock("@shared/types", async (importActual) => {
+  const actual = await importActual<typeof import("@shared/types")>();
+  return {
+    ...actual,
+    generateAgentCommand: (...args: unknown[]) => mockGenerateAgentCommand(...args),
+  };
+});
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({ addPanel: (...args: unknown[]) => mockAddPanel(...args) }),
+  },
+}));
+
+function makeTerminal(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  return {
+    type: "terminal",
+    title: "Terminal",
+    exitBehavior: "keep-alive",
+    ...overrides,
+  } as RecipeTerminal;
+}
+
+function makeDevPreview(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  return {
+    type: "dev-preview",
+    title: "Dev Preview",
+    devCommand: "npm run dev",
+    exitBehavior: "keep-alive",
+    ...overrides,
+  } as RecipeTerminal;
+}
+
+function makeAgent(overrides: Partial<RecipeTerminal> = {}): RecipeTerminal {
+  return {
+    type: "claude",
+    title: "Claude Agent",
+    exitBehavior: "keep-alive",
+    agentModelId: "sonnet",
+    ...overrides,
+  } as RecipeTerminal;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAddPanel.mockResolvedValue("panel-id-123");
+  mockAgentSettingsGet.mockResolvedValue({ agents: { claude: { modelId: "sonnet" } } });
+  mockSystemGetTmpDir.mockResolvedValue("/tmp/daintree");
+  mockGetAgentConfig.mockReturnValue({ command: "claude" });
+  mockGenerateAgentCommand.mockReturnValue("claude --model sonnet");
+});
+
+describe("spawnPanelsFromRecipe", () => {
+  it("spawns a dev-preview panel", async () => {
+    const cb = vi.fn();
+    await spawnPanelsFromRecipe({
+      terminals: [makeDevPreview()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(1);
+    expect(mockAddPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "dev-preview", devCommand: "npm run dev" })
+    );
+    expect(cb).toHaveBeenCalledWith(0, "panel-id-123");
+  });
+
+  it("spawns a terminal panel", async () => {
+    const cb = vi.fn();
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ command: "echo hello" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "terminal", command: "echo hello" })
+    );
+    expect(cb).toHaveBeenCalledWith(0, "panel-id-123");
+  });
+
+  it("spawns an agent panel with regenerated command", async () => {
+    const cb = vi.fn();
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: { claude: { modelId: "sonnet" } } },
+      clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+      onPanelSpawned: cb,
+    });
+
+    expect(mockGetAgentConfig).toHaveBeenCalledWith("claude");
+    expect(mockGenerateAgentCommand).toHaveBeenCalledWith(
+      "claude",
+      { modelId: "sonnet" },
+      "claude",
+      { clipboardDirectory: "/tmp/daintree/daintree-clipboard", modelId: "sonnet" }
+    );
+    expect(mockAddPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: "claude --model sonnet",
+      })
+    );
+    expect(cb).toHaveBeenCalledWith(0, "panel-id-123");
+  });
+
+  it("fetches agent settings internally when not provided", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockAgentSettingsGet).toHaveBeenCalledTimes(1);
+    expect(mockSystemGetTmpDir).toHaveBeenCalledTimes(1);
+    expect(mockGenerateAgentCommand).toHaveBeenCalled();
+  });
+
+  it("skips internal fetch when agentSettings is provided", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      agentSettings: { agents: {} },
+      clipboardDirectory: "/some/dir",
+    });
+
+    expect(mockAgentSettingsGet).not.toHaveBeenCalled();
+    expect(mockSystemGetTmpDir).not.toHaveBeenCalled();
+  });
+
+  it("skips agent pre-fetch when no agent panels are present", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal(), makeDevPreview()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockAgentSettingsGet).not.toHaveBeenCalled();
+    expect(mockSystemGetTmpDir).not.toHaveBeenCalled();
+  });
+
+  it("continues spawning after addPanel returns null", async () => {
+    mockAddPanel.mockResolvedValueOnce(null).mockResolvedValueOnce("panel-2");
+    const cb = vi.fn();
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ title: "T1" }), makeTerminal({ title: "T2" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalledWith(0, null, expect.any(Error));
+    expect(cb).toHaveBeenCalledWith(1, "panel-2");
+  });
+
+  it("continues spawning after addPanel throws", async () => {
+    const err = new Error("spawn failed");
+    mockAddPanel.mockRejectedValueOnce(err).mockResolvedValueOnce("panel-2");
+    const cb = vi.fn();
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ title: "T1" }), makeTerminal({ title: "T2" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      onPanelSpawned: cb,
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalledWith(0, null, err);
+    expect(cb).toHaveBeenCalledWith(1, "panel-2");
+  });
+
+  it("aborts before any spawns when signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      signal: controller.signal,
+    });
+
+    expect(mockAddPanel).not.toHaveBeenCalled();
+  });
+
+  it("aborts mid-loop when signal fires between spawns", async () => {
+    const controller = new AbortController();
+    mockAddPanel.mockImplementation(() => {
+      controller.abort();
+      return "panel-1";
+    });
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal({ title: "T1" }), makeTerminal({ title: "T2" })],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+      signal: controller.signal,
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke onPanelSpawned when callback is omitted", async () => {
+    await spawnPanelsFromRecipe({
+      terminals: [makeTerminal()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles systemClient.getTmpDir rejection gracefully", async () => {
+    mockSystemGetTmpDir.mockRejectedValue(new Error("no tmp"));
+    mockAgentSettingsGet.mockResolvedValue({ agents: {} });
+
+    await spawnPanelsFromRecipe({
+      terminals: [makeAgent()],
+      worktreeId: "wt-1",
+      cwd: "/path/to/wt",
+    });
+
+    expect(mockGenerateAgentCommand).toHaveBeenCalledWith(
+      "claude",
+      {},
+      "claude",
+      expect.objectContaining({ clipboardDirectory: undefined })
+    );
+  });
+});

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -39,6 +39,8 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
     }
   }
 
+  const errors: { index: number; error: unknown }[] = [];
+
   for (const [index, t] of terminals.entries()) {
     if (signal?.aborted) return;
 
@@ -87,12 +89,32 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
       }
 
       if (panelId != null) {
-        onPanelSpawned?.(index, panelId);
+        try {
+          onPanelSpawned?.(index, panelId);
+        } catch {
+          // Callback threw — it already fired once, nothing to do.
+        }
       } else {
-        onPanelSpawned?.(index, null, new Error("addPanel returned null"));
+        const err = new Error("addPanel returned null");
+        if (onPanelSpawned) {
+          onPanelSpawned(index, null, err);
+        } else {
+          errors.push({ index, error: err });
+        }
       }
     } catch (err) {
-      onPanelSpawned?.(index, null, err);
+      if (onPanelSpawned) {
+        onPanelSpawned(index, null, err);
+      } else {
+        errors.push({ index, error: err });
+      }
     }
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(
+      errors.map((e) => e.error),
+      `${errors.length} panel(s) failed to spawn`
+    );
   }
 }

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -1,0 +1,98 @@
+import { usePanelStore } from "@/store/panelStore";
+import { agentSettingsClient, systemClient } from "@/clients";
+import { getAgentConfig } from "@/config/agents";
+import { generateAgentCommand } from "@shared/types";
+import type { RecipeTerminal } from "@shared/types";
+
+export interface SpawnPanelsOptions {
+  terminals: RecipeTerminal[];
+  worktreeId: string;
+  cwd: string;
+  /** Pre-fetched agent settings. When omitted and agent panels are present, fetched internally. */
+  agentSettings?: Awaited<ReturnType<typeof agentSettingsClient.get>> | null;
+  /** Pre-fetched clipboard directory. Only meaningful with agentSettings. */
+  clipboardDirectory?: string;
+  signal?: AbortSignal;
+  onPanelSpawned?: (index: number, panelId: string | null, error?: unknown) => void;
+}
+
+export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promise<void> {
+  const { terminals, worktreeId, cwd, signal, onPanelSpawned } = options;
+
+  const hasAgent = terminals.some((t) => t.type !== "terminal" && t.type !== "dev-preview");
+
+  let agentSettings = options.agentSettings;
+  let clipboardDirectory = options.clipboardDirectory;
+
+  // Fallback pre-fetch when caller didn't provide settings
+  if (agentSettings === undefined && hasAgent) {
+    try {
+      const [settings, tmpDir] = await Promise.all([
+        agentSettingsClient.get(),
+        systemClient.getTmpDir().catch(() => ""),
+      ]);
+      if (signal?.aborted) return;
+      agentSettings = settings;
+      clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+    } catch {
+      if (signal?.aborted) return;
+    }
+  }
+
+  for (const [index, t] of terminals.entries()) {
+    if (signal?.aborted) return;
+
+    try {
+      let panelId: string | null;
+
+      if (t.type === "dev-preview") {
+        panelId = await usePanelStore.getState().addPanel({
+          kind: "dev-preview",
+          title: t.title,
+          cwd,
+          worktreeId,
+          exitBehavior: t.exitBehavior,
+          devCommand: t.devCommand?.trim() || undefined,
+        });
+      } else if (t.type !== "terminal") {
+        const agentId = t.type;
+        const agentConfig = getAgentConfig(agentId);
+        const baseCommand = agentConfig?.command ?? "";
+        const entry = agentSettings?.agents?.[agentId] ?? {};
+        const command = generateAgentCommand(baseCommand, entry, agentId, {
+          clipboardDirectory,
+          modelId: t.agentModelId,
+        });
+
+        panelId = await usePanelStore.getState().addPanel({
+          kind: "terminal",
+          launchAgentId: agentId,
+          command,
+          title: t.title,
+          cwd,
+          worktreeId,
+          exitBehavior: t.exitBehavior,
+          agentModelId: t.agentModelId,
+          agentLaunchFlags: t.agentLaunchFlags,
+        });
+      } else {
+        panelId = await usePanelStore.getState().addPanel({
+          kind: "terminal",
+          title: t.title,
+          cwd,
+          worktreeId,
+          exitBehavior: t.exitBehavior,
+          command: t.command?.trim() || undefined,
+        });
+      }
+
+      if (panelId != null) {
+        onPanelSpawned?.(index, panelId);
+      } else {
+        onPanelSpawned?.(index, null, new Error("addPanel returned null"));
+      }
+    } catch (err) {
+      onPanelSpawned?.(index, null, err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Both `NewWorktreeDialog` and `BulkCreateWorktreeDialog` had their own copy of the same panel-cloning logic -- agent command regeneration with the `agentSettings` + `tmpDir` pre-fetch, and dev-preview / agent / terminal panel respawning. They were going to drift.

This extracts that logic into a single `spawnPanelsFromRecipe` helper in `panelSpawning.ts`, keeping the pre-fetch optimization intact so bulk creation doesn't degrade to N round-trips.

Resolves #6715

## Changes
- New `src/components/Worktree/panelSpawning.ts` -- shared helper with `SpawnPanelsOptions` interface
- New `src/components/Worktree/__tests__/panelSpawning.test.ts` -- 17 tests covering dev-preview, agent, and terminal panel types, pre-fetch fallback, abort handling, and error propagation
- Refactored `NewWorktreeDialog.tsx` and `BulkCreateWorktreeDialog.tsx` to call the helper
- Fixed error propagation when `onPanelSpawned` callback is not registered -- errors now surface via `AggregateError`

## Testing
17 new tests + 64 existing = 81 passing. Typecheck, lint, and format all clean.