### PR TITLE
refactor(worktree): split NewWorktreeDialog into hooks and subview components

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1,19 +1,10 @@
 import { useCallback, useReducer, useRef, useMemo, useEffect, useLayoutEffect } from "react";
 import PQueue from "p-queue";
-import {
-  Check,
-  AlertTriangle,
-  UserPlus,
-  Play,
-  ChevronsUpDown,
-  RotateCcw,
-  Copy,
-} from "lucide-react";
+import { Check, AlertTriangle, UserPlus, RotateCcw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { FolderGit2 } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { worktreeClient, githubClient, agentSettingsClient, systemClient } from "@/clients";
 import { resolveIssuePrequeries } from "./bulkCreatePrequery";
@@ -27,6 +18,7 @@ import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
+import { RecipePickerPopover } from "@/components/Worktree/views/RecipePickerPopover";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
 import { spawnPanelsFromRecipe } from "@/components/Worktree/panelSpawning";
 import { progressReducer, getStageLabel } from "./bulkCreateReducer";
@@ -801,8 +793,8 @@ export function BulkCreateWorktreeDialog({
     storedOnComplete?.();
   }, [onComplete, onClose]);
 
-  const handleRecipeSelect = useCallback(
-    (recipeId: string) => {
+  const handleRecipeSelectCombined = useCallback(
+    (recipeId: string | null) => {
       recipeSelectionTouchedRef.current = true;
       setSelectedRecipeId(recipeId);
       if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, recipeId);
@@ -816,19 +808,6 @@ export function BulkCreateWorktreeDialog({
       setLastSelectedWorktreeRecipeIdByProject,
     ]
   );
-
-  const handleRecipeSelectNone = useCallback(() => {
-    recipeSelectionTouchedRef.current = true;
-    setSelectedRecipeId(null);
-    if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, null);
-    setRecipePickerOpen(false);
-  }, [
-    setSelectedRecipeId,
-    setRecipePickerOpen,
-    recipeSelectionTouchedRef,
-    projectId,
-    setLastSelectedWorktreeRecipeIdByProject,
-  ]);
 
   return (
     <AppDialog
@@ -910,142 +889,18 @@ export function BulkCreateWorktreeDialog({
               </div>
             )}
 
-            {/* Starting Layout picker */}
-            <div className="space-y-2">
-              <label
-                htmlFor="bulk-recipe-selector"
-                className="block text-sm font-medium text-daintree-text"
-              >
-                Starting Layout
-              </label>
-              <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
-                <PopoverTrigger asChild>
-                  <Button
-                    id="bulk-recipe-selector"
-                    variant="outline"
-                    role="combobox"
-                    aria-expanded={recipePickerOpen}
-                    aria-haspopup="listbox"
-                    aria-controls="bulk-recipe-list"
-                    className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                  >
-                    <span className="flex items-center gap-2 truncate">
-                      {selectedRecipeId === CLONE_LAYOUT_ID ? (
-                        <>
-                          <Copy className="shrink-0 text-daintree-accent" />
-                          <span>Clone current layout</span>
-                        </>
-                      ) : selectedRecipe ? (
-                        <>
-                          <Play className="shrink-0 text-daintree-accent" />
-                          <span>{selectedRecipe.name}</span>
-                          <span className="text-xs text-daintree-text/50">
-                            ({selectedRecipe.terminals.length} terminal
-                            {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                          </span>
-                        </>
-                      ) : (
-                        <>
-                          <Play className="shrink-0 text-daintree-accent" />
-                          <span className="text-daintree-text/60">Empty</span>
-                        </>
-                      )}
-                    </span>
-                    <ChevronsUpDown className="opacity-50 shrink-0" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="w-[400px] p-0"
-                  align="start"
-                  onEscapeKeyDown={(e) => e.stopPropagation()}
-                >
-                  <div
-                    id="bulk-recipe-list"
-                    role="listbox"
-                    className="max-h-[300px] overflow-y-auto p-1"
-                  >
-                    <div
-                      role="option"
-                      aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          handleRecipeSelect(CLONE_LAYOUT_ID);
-                        }
-                      }}
-                      onClick={() => handleRecipeSelect(CLONE_LAYOUT_ID)}
-                      className={cn(
-                        "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                        selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
-                      )}
-                    >
-                      <div className="flex items-center gap-2">
-                        <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
-                        <span>Clone current layout</span>
-                      </div>
-                      {selectedRecipeId === CLONE_LAYOUT_ID && (
-                        <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                      )}
-                    </div>
-                    <div
-                      role="option"
-                      aria-selected={selectedRecipeId === null}
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          handleRecipeSelectNone();
-                        }
-                      }}
-                      onClick={handleRecipeSelectNone}
-                      className={cn(
-                        "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                        selectedRecipeId === null && "bg-daintree-border"
-                      )}
-                    >
-                      <span className="text-daintree-text/60">Empty</span>
-                      {selectedRecipeId === null && (
-                        <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                      )}
-                    </div>
-                    {globalRecipes.map((recipe) => (
-                      <div
-                        key={recipe.id}
-                        role="option"
-                        aria-selected={recipe.id === selectedRecipeId}
-                        tabIndex={0}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                            handleRecipeSelect(recipe.id);
-                          }
-                        }}
-                        onClick={() => handleRecipeSelect(recipe.id)}
-                        className={cn(
-                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                          recipe.id === selectedRecipeId && "bg-daintree-border"
-                        )}
-                      >
-                        <div className="flex items-center gap-2 min-w-0">
-                          <span className="truncate">{recipe.name}</span>
-                          <span className="text-xs text-daintree-text/50 shrink-0">
-                            {recipe.terminals.length} terminal
-                            {recipe.terminals.length !== 1 ? "s" : ""}
-                          </span>
-                          {recipe.id === defaultRecipeId && (
-                            <span className="text-xs text-status-info shrink-0">(default)</span>
-                          )}
-                        </div>
-                        {recipe.id === selectedRecipeId && (
-                          <Check className="h-4 w-4 shrink-0 text-daintree-accent" />
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
+            <RecipePickerPopover
+              recipes={globalRecipes}
+              selectedRecipeId={selectedRecipeId}
+              selectedRecipe={selectedRecipe}
+              defaultRecipeId={defaultRecipeId}
+              open={recipePickerOpen}
+              onOpenChange={setRecipePickerOpen}
+              onSelectRecipe={handleRecipeSelectCombined}
+              onMarkTouched={() => {}}
+              label="Starting Layout"
+              listId="bulk-recipe-selector"
+            />
 
             {/* Worktree list */}
             <div className="space-y-2">

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -5,6 +5,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, act } from "@testing-library/react";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
 const mockWorktreeCreate = vi.fn();
 const mockGetAvailableBranch = vi.fn();
 const mockGetDefaultPath = vi.fn();

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1,38 +1,18 @@
 import { useState, useEffect, useRef, useMemo, useCallback, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import {
-  FolderOpen,
-  Check,
-  AlertCircle,
-  ChevronsUpDown,
-  Search,
-  UserPlus,
-  Play,
-  Info,
-  ChevronDown,
-  GitBranch,
-  Copy,
-} from "lucide-react";
+import { FolderGit2, Check, AlertCircle, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
-import { ScrollShadow } from "@/components/ui/ScrollShadow";
-import { FolderGit2 } from "@/components/icons";
 import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import { worktreeClient, githubClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
-import { IssueSelector } from "@/components/GitHub/IssueSelector";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { parseBranchInput } from "./branchPrefixUtils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
-import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
 import { notify } from "@/lib/notify";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
-import { mapCreationError, type WorktreeCreationError } from "./worktreeCreationErrors";
+import { mapCreationError } from "./worktreeCreationErrors";
 import { logError } from "@/utils/logger";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -44,46 +24,24 @@ import { useBranchValidation } from "./hooks/useBranchValidation";
 import { useBranchPicker } from "./hooks/useBranchPicker";
 import { usePrefixPicker } from "./hooks/usePrefixPicker";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "./hooks/useRecipePicker";
+import { useWorktreeFormErrors } from "./hooks/useWorktreeFormErrors";
+import { useWorktreeFormValidation } from "./hooks/useWorktreeFormValidation";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { spawnPanelsFromRecipe } from "./panelSpawning";
 
+import {
+  PrHeader,
+  IssueLinkerView,
+  BranchModeControl,
+  BaseBranchCombobox,
+  ExistingBranchPicker,
+  NewBranchInput,
+  WorktreePathPicker,
+  EnvironmentRadioGroup,
+  RecipePickerPopover,
+} from "./views";
+
 type BranchMode = "new" | "existing";
-
-function HighlightBranchText({
-  text,
-  matchRanges,
-  nameLength,
-}: {
-  text: string;
-  matchRanges: { start: number; end: number }[];
-  nameLength: number;
-}) {
-  if (matchRanges.length === 0) return <>{text}</>;
-
-  const nodes: React.ReactNode[] = [];
-  let lastIndex = 0;
-
-  for (let i = 0; i < matchRanges.length; i++) {
-    const { start, end } = matchRanges[i]!;
-    if (start >= nameLength) break;
-    const clampedEnd = Math.min(end, nameLength - 1);
-    if (start > lastIndex) {
-      nodes.push(text.substring(lastIndex, start));
-    }
-    nodes.push(
-      <mark key={i} className="bg-daintree-accent/25 text-inherit rounded-sm">
-        {text.substring(start, clampedEnd + 1)}
-      </mark>
-    );
-    lastIndex = clampedEnd + 1;
-  }
-
-  if (lastIndex < text.length) {
-    nodes.push(text.substring(lastIndex));
-  }
-
-  return <>{nodes}</>;
-}
 
 interface NewWorktreeDialogProps {
   isOpen: boolean;
@@ -107,11 +65,6 @@ export function NewWorktreeDialog({
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [errorField, setErrorField] = useState<
-    "base-branch" | "new-branch" | "worktree-path" | null
-  >(null);
-  const [creationError, setCreationError] = useState<WorktreeCreationError | null>(null);
   const [baseBranch, setBaseBranch] = useState("");
   const [prBranchResolved, setPrBranchResolved] = useState<boolean | null>(null);
   const [isDismissing, setIsDismissing] = useState(false);
@@ -121,6 +74,10 @@ export function NewWorktreeDialog({
   const [existingBranchQuery, setExistingBranchQuery] = useState("");
   const [worktreeMode, setWorktreeMode] = useState<string>("local");
   const keepEditingButtonRef = useRef<HTMLButtonElement>(null);
+  const isCreatingRef = useRef(false);
+
+  const { errors, setValidationError, clearErrors, setCreationError, markTouched } =
+    useWorktreeFormErrors();
 
   const assignWorktreeToSelf = usePreferencesStore((s) => s.assignWorktreeToSelf);
   const setAssignWorktreeToSelf = usePreferencesStore((s) => s.setAssignWorktreeToSelf);
@@ -142,10 +99,7 @@ export function NewWorktreeDialog({
   const currentUser = githubConfig?.username;
   const currentUserAvatar = githubConfig?.avatarUrl;
 
-  // --- Hook: Project Settings ---
-  const { projectSettings, configuredBranchPrefix } = useNewWorktreeProjectSettings({
-    isOpen,
-  });
+  const { projectSettings, configuredBranchPrefix } = useNewWorktreeProjectSettings({ isOpen });
 
   const resourceEnvironments = projectSettings?.resourceEnvironments;
   const hasAnyEnvironments = Object.keys(resourceEnvironments ?? {}).length > 0;
@@ -153,13 +107,10 @@ export function NewWorktreeDialog({
   const defaultRecipeId = projectSettings?.defaultWorktreeRecipeId;
   const globalRecipes = useMemo(() => recipes.filter((r) => !r.worktreeId), [recipes]);
 
-  // --- Hook: Branch Input ---
   const {
     branchInput,
     setBranchInput,
-    branchInputTouchedRef,
     selectedIssue,
-    issueTouchedRef,
     fromRemote,
     setFromRemote,
     newBranchInputRef,
@@ -175,7 +126,6 @@ export function NewWorktreeDialog({
 
   const canAssignIssue = Boolean(currentUser && selectedIssue);
 
-  // --- Hook: Branch Validation ---
   const onBranchAutoResolved = useCallback(
     (resolvedName: string) => setBranchInput(resolvedName),
     [setBranchInput]
@@ -200,7 +150,6 @@ export function NewWorktreeDialog({
     overrideBranchName: isExistingMode ? (selectedExistingBranch ?? "") : undefined,
   });
 
-  // --- Hook: Branch Picker ---
   const onSelectBranch = useCallback(
     (name: string, isRemote: boolean) => {
       setBaseBranch(name);
@@ -231,7 +180,6 @@ export function NewWorktreeDialog({
     onSelectBranch,
   });
 
-  // --- Existing branch candidates (local only, not in use by a worktree) ---
   const existingBranchCandidates = useMemo(() => {
     const inUseSet = new Set<string>();
     for (const wt of worktreeMap.values()) {
@@ -246,16 +194,16 @@ export function NewWorktreeDialog({
     return existingBranchCandidates.filter((b) => b.name.toLowerCase().includes(q));
   }, [existingBranchCandidates, existingBranchQuery]);
 
-  const handleBranchModeChange = useCallback((mode: BranchMode) => {
-    setBranchMode(mode);
-    setSelectedExistingBranch(null);
-    setExistingBranchQuery("");
-    setValidationError(null);
-    setErrorField(null);
-    setCreationError(null);
-  }, []);
+  const handleBranchModeChange = useCallback(
+    (mode: BranchMode) => {
+      setBranchMode(mode);
+      setSelectedExistingBranch(null);
+      setExistingBranchQuery("");
+      clearErrors();
+    },
+    [clearErrors]
+  );
 
-  // --- Hook: Prefix Picker ---
   const onSelectPrefix = useCallback(
     (newValue: string) => {
       setBranchInput(newValue);
@@ -278,7 +226,6 @@ export function NewWorktreeDialog({
     newBranchInputRef,
   });
 
-  // --- Hook: Recipe Picker ---
   const {
     selectedRecipeId,
     setSelectedRecipeId,
@@ -313,9 +260,7 @@ export function NewWorktreeDialog({
     if (!isOpen) return;
 
     setLoading(true);
-    setValidationError(null);
-    setErrorField(null);
-    setCreationError(null);
+    clearErrors();
     setPrBranchResolved(null);
     setBranches([]);
     setBaseBranch("");
@@ -324,6 +269,8 @@ export function NewWorktreeDialog({
     setSelectedExistingBranch(null);
     setExistingBranchQuery("");
     setWorktreeMode("local");
+    isCreatingRef.current = false;
+    // resetErrors() is NOT called here — touched refs are managed by individual hooks
 
     let isCurrent = true;
 
@@ -356,11 +303,9 @@ export function NewWorktreeDialog({
             setFromRemote(false);
             setPrBranchResolved(true);
           } else {
-            // Branch not found locally — try fetching from GitHub's PR refs
             try {
               await worktreeClient.fetchPRBranch(rootPath, initialPR.number, initialPR.headRefName);
               if (!isCurrent) return;
-              // Re-list branches after fetch
               const updatedBranches = await worktreeClient.listBranches(rootPath);
               if (!isCurrent) return;
               setBranches(updatedBranches);
@@ -406,8 +351,7 @@ export function NewWorktreeDialog({
       })
       .catch((err) => {
         if (!isCurrent) return;
-        setValidationError(`Failed to load branches: ${err.message}`);
-        setErrorField(null);
+        setValidationError(`Failed to load branches: ${err.message}`, null);
         setBranches([]);
         setBaseBranch("");
         setFromRemote(false);
@@ -420,7 +364,16 @@ export function NewWorktreeDialog({
     return () => {
       isCurrent = false;
     };
-  }, [isOpen, rootPath, initialIssue, initialPR, setFromRemote, setRecentBranchNames]);
+  }, [
+    isOpen,
+    rootPath,
+    initialIssue,
+    initialPR,
+    setFromRemote,
+    setRecentBranchNames,
+    setValidationError,
+    clearErrors,
+  ]);
 
   // Initialize worktreeMode when projectSettings loads asynchronously
   const settingsDefaultMode = projectSettings?.defaultWorktreeMode;
@@ -442,35 +395,32 @@ export function NewWorktreeDialog({
   }, [isOpen, loading, newBranchInputRef]);
 
   // --- Form dirty check and dismiss guard ---
-  const isFormDirty = useMemo(() => {
-    // selectedRecipeId is a trigger dep (the memo reads recipeSelectionTouchedRef
-    // which flips when selection changes).
-    void selectedRecipeId;
+  const formDirty = useMemo(() => {
     if (selectedExistingBranch !== null) return true;
-    if (branchInputTouchedRef.current && branchInput.trim()) return true;
-    if (issueTouchedRef.current && selectedIssue !== null) return true;
-    if (recipeSelectionTouchedRef.current) return true;
-    if (pathTouchedRef.current && worktreePath.trim()) return true;
+    if (errors.touchedFields.branchInput && branchInput.trim()) return true;
+    if (errors.touchedFields.issue && selectedIssue !== null) return true;
+    if (errors.touchedFields.recipe) return true;
+    if (errors.touchedFields.worktreePath && worktreePath.trim()) return true;
     if (worktreeMode !== "local") return true;
     return false;
   }, [
     branchInput,
     worktreePath,
     selectedIssue,
-    selectedRecipeId,
     selectedExistingBranch,
     worktreeMode,
+    errors.touchedFields,
   ]);
 
   const handleBeforeClose = useCallback((): boolean => {
-    if (!isFormDirty) return true;
+    if (!formDirty) return true;
     if (isDismissing) {
       setIsDismissing(false);
       return false;
     }
     setIsDismissing(true);
     return false;
-  }, [isFormDirty, isDismissing]);
+  }, [formDirty, isDismissing]);
 
   const handleRequestClose = useCallback(() => {
     if (handleBeforeClose()) onClose();
@@ -482,57 +432,107 @@ export function NewWorktreeDialog({
     }
   }, [isDismissing]);
 
+  // --- Validation hook ---
+  const { validate } = useWorktreeFormValidation();
+
   // --- Create handler ---
   const handleCreate = () => {
-    if (isExistingMode) {
-      if (!selectedExistingBranch) {
-        setValidationError("Please select a branch");
-        setErrorField(null);
-        return;
-      }
-      if (!worktreePath.trim()) {
-        setValidationError("Please enter a worktree path");
-        setErrorField("worktree-path");
+    if (isCreatingRef.current) return;
+    isCreatingRef.current = true;
+
+    try {
+      const result = validate({
+        branchMode,
+        baseBranch,
+        branchInput,
+        selectedExistingBranch,
+        worktreePath,
+      });
+
+      if (!result.valid) {
+        setValidationError(result.error!.message, result.error!.field);
+        isCreatingRef.current = false;
         return;
       }
 
-      setValidationError(null);
-      setErrorField(null);
-      setCreationError(null);
+      clearErrors();
+
+      const fullBranchName = isExistingMode ? selectedExistingBranch! : result.fullBranchName!;
+
+      const snapBranchMode = branchMode;
+      const snapUseExisting = snapBranchMode === "existing";
+      const snapFromRemote = fromRemote;
+      const snapWorktreePath = worktreePath.trim();
+      const snapWorktreeMode = worktreeMode;
+      const snapIssue = selectedIssue;
+      const snapRecipeId = selectedRecipeId;
+      const snapSelectedRecipe = selectedRecipe;
+      const snapInitialPR = initialPR;
+      const snapBranches = branches;
+      const snapAssignToSelf = assignWorktreeToSelf;
+      const snapCurrentUser = currentUser;
 
       startTransition(async () => {
         try {
           const sourceWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
 
+          const useExistingBranch =
+            snapUseExisting ||
+            (snapInitialPR !== null && snapInitialPR !== undefined
+              ? snapBranches.some((b) => b.name === fullBranchName && !b.remote)
+              : false);
+
           const options: CreateWorktreeOptions = {
-            baseBranch: selectedExistingBranch,
-            newBranch: selectedExistingBranch,
-            path: worktreePath.trim(),
-            fromRemote: false,
-            useExistingBranch: true,
-            provisionResource: worktreeMode !== "local" || undefined,
-            worktreeMode: worktreeMode,
+            baseBranch: snapUseExisting ? selectedExistingBranch! : baseBranch,
+            newBranch: fullBranchName,
+            path: snapWorktreePath,
+            fromRemote: useExistingBranch ? false : snapFromRemote,
+            useExistingBranch,
+            provisionResource: snapWorktreeMode !== "local" || undefined,
+            worktreeMode: snapWorktreeMode,
           };
 
-          const result = await actionService.dispatch(
+          const actionResult = await actionService.dispatch(
             "worktree.create",
             { rootPath, options },
             { source: "user" }
           );
-          if (!result.ok) {
-            throw new Error(result.error.message);
+          if (!actionResult.ok) {
+            throw new Error(actionResult.error.message);
           }
 
-          const worktreeId = result.result as string;
+          const worktreeId = actionResult.result as string;
           useWorktreeSelectionStore.getState().setPendingWorktree(worktreeId);
           useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
 
-          if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
+          if (!snapUseExisting && snapIssue && snapAssignToSelf && snapCurrentUser) {
+            try {
+              await githubClient.assignIssue(rootPath, snapIssue.number, snapCurrentUser);
+            } catch (assignErr) {
+              const message = formatErrorMessage(assignErr, "Failed to assign issue");
+              const issueUrl = snapIssue.url;
+              notify({
+                type: "warning",
+                title: "Could not assign issue",
+                message: `${message} — you can assign it manually on GitHub`,
+                actions: issueUrl
+                  ? [
+                      {
+                        label: "Assign on GitHub",
+                        onClick: () => systemClient.openExternal(issueUrl),
+                      },
+                    ]
+                  : [],
+              });
+            }
+          }
+
+          if (snapRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
             try {
               const terminals = useRecipeStore
                 .getState()
                 .generateRecipeFromActiveTerminals(sourceWorktreeId);
-              await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: worktreePath.trim() });
+              await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: snapWorktreePath });
             } catch (cloneErr) {
               const message = formatErrorMessage(cloneErr, "Failed to clone layout");
               notify({
@@ -541,16 +541,25 @@ export function NewWorktreeDialog({
                 message: `${message} — worktree was created successfully`,
               });
             }
-          } else if (selectedRecipe) {
+          } else if (snapSelectedRecipe) {
             try {
-              await runRecipe(selectedRecipe.id, worktreePath.trim(), worktreeId, {
-                worktreePath: worktreePath.trim(),
-                branchName: selectedExistingBranch,
+              await runRecipe(snapSelectedRecipe.id, snapWorktreePath, worktreeId, {
+                issueNumber: snapIssue?.number,
+                prNumber: snapInitialPR?.number,
+                worktreePath: snapWorktreePath,
+                branchName: fullBranchName,
               });
             } catch (recipeErr) {
               const message = formatErrorMessage(recipeErr, "Failed to run recipe");
-              const recipeId = selectedRecipe.id;
-              const recipePath = worktreePath.trim();
+              const recipeId = snapSelectedRecipe.id;
+              const recipePath = snapWorktreePath;
+              const recipeWorktreeId = worktreeId;
+              const recipeContext = {
+                issueNumber: snapIssue?.number,
+                prNumber: snapInitialPR?.number,
+                worktreePath: recipePath,
+                branchName: fullBranchName,
+              };
               notify({
                 type: "warning",
                 title: "Could not run recipe",
@@ -559,10 +568,9 @@ export function NewWorktreeDialog({
                   {
                     label: "Retry recipe",
                     onClick: () => {
-                      runRecipe(recipeId, recipePath, worktreeId, {
-                        worktreePath: recipePath,
-                        branchName: selectedExistingBranch,
-                      }).catch((err) => logError("Failed to run recipe", err));
+                      runRecipe(recipeId, recipePath, recipeWorktreeId, recipeContext).catch(
+                        (err) => logError("Failed to run recipe", err)
+                      );
                     },
                   },
                 ],
@@ -573,199 +581,101 @@ export function NewWorktreeDialog({
           onWorktreeCreated?.(worktreeId);
           onClose();
 
-          setSelectedExistingBranch(null);
+          setBranchInput("");
           setWorktreePath("");
+          setFromRemote(false);
         } catch (err: unknown) {
           const message = formatErrorMessage(err, "Failed to create worktree");
           setCreationError(mapCreationError(message, onClose));
+        } finally {
+          isCreatingRef.current = false;
         }
       });
-      return;
+    } catch {
+      isCreatingRef.current = false;
     }
-
-    if (!baseBranch) {
-      setValidationError("Please select a base branch");
-      setErrorField("base-branch");
-      return;
-    }
-
-    const trimmedInput = branchInput.trim();
-    if (!trimmedInput) {
-      setValidationError("Please enter a branch name");
-      setErrorField("new-branch");
-      return;
-    }
-
-    const parsed = parseBranchInput(trimmedInput);
-
-    if (parsed.hasPrefix) {
-      if (!parsed.slug || !parsed.slug.trim()) {
-        setValidationError("Please enter a branch name after the prefix");
-        setErrorField("new-branch");
-        return;
-      }
-      if (
-        /[\s.:]/.test(parsed.prefix) ||
-        /^[.-]/.test(parsed.prefix) ||
-        parsed.prefix.includes("..")
-      ) {
-        setValidationError("Branch prefix contains invalid characters");
-        setErrorField("new-branch");
-        return;
-      }
-      if (/[\s.]$/.test(parsed.slug) || /^[.-]/.test(parsed.slug)) {
-        setValidationError("Branch name cannot start with '.', '-' or end with space or '.'");
-        setErrorField("new-branch");
-        return;
-      }
-      if (/[\\:]/.test(parsed.slug) || parsed.slug.includes("..")) {
-        setValidationError("Branch name contains invalid characters");
-        setErrorField("new-branch");
-        return;
-      }
-    } else {
-      if (/[\s.]$/.test(trimmedInput) || /^[.-]/.test(trimmedInput)) {
-        setValidationError("Branch name cannot start with '.', '-' or end with space or '.'");
-        setErrorField("new-branch");
-        return;
-      }
-      if (/[/\\:]/.test(trimmedInput) || trimmedInput.includes("..")) {
-        setValidationError("Branch name contains invalid characters");
-        setErrorField("new-branch");
-        return;
-      }
-    }
-
-    if (!worktreePath.trim()) {
-      setValidationError("Please enter a worktree path");
-      setErrorField("worktree-path");
-      return;
-    }
-
-    const fullBranchName = parsed.fullBranchName;
-
-    setValidationError(null);
-    setErrorField(null);
-    setCreationError(null);
-
-    startTransition(async () => {
-      try {
-        const sourceWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-
-        const useExistingBranch =
-          initialPR !== null && initialPR !== undefined
-            ? branches.some((b) => b.name === fullBranchName && !b.remote)
-            : false;
-
-        const options: CreateWorktreeOptions = {
-          baseBranch,
-          newBranch: fullBranchName,
-          path: worktreePath.trim(),
-          fromRemote: useExistingBranch ? false : fromRemote,
-          useExistingBranch,
-          provisionResource: worktreeMode !== "local" || undefined,
-          worktreeMode: worktreeMode,
-        };
-
-        const result = await actionService.dispatch(
-          "worktree.create",
-          { rootPath, options },
-          { source: "user" }
-        );
-        if (!result.ok) {
-          throw new Error(result.error.message);
-        }
-
-        const worktreeId = result.result as string;
-        useWorktreeSelectionStore.getState().setPendingWorktree(worktreeId);
-        useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
-
-        if (selectedIssue && assignWorktreeToSelf && currentUser) {
-          try {
-            await githubClient.assignIssue(rootPath, selectedIssue.number, currentUser);
-          } catch (assignErr) {
-            const message = formatErrorMessage(assignErr, "Failed to assign issue");
-            const issueUrl = selectedIssue.url;
-            notify({
-              type: "warning",
-              title: "Could not assign issue",
-              message: `${message} — you can assign it manually on GitHub`,
-              actions: issueUrl
-                ? [
-                    {
-                      label: "Assign on GitHub",
-                      onClick: () => systemClient.openExternal(issueUrl),
-                    },
-                  ]
-                : [],
-            });
-          }
-        }
-
-        if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
-          try {
-            const terminals = useRecipeStore
-              .getState()
-              .generateRecipeFromActiveTerminals(sourceWorktreeId);
-            await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: worktreePath.trim() });
-          } catch (cloneErr) {
-            const message = formatErrorMessage(cloneErr, "Failed to clone layout");
-            notify({
-              type: "warning",
-              title: "Could not clone layout",
-              message: `${message} — worktree was created successfully`,
-            });
-          }
-        } else if (selectedRecipe) {
-          const worktreeId = result.result as string | undefined;
-          try {
-            await runRecipe(selectedRecipe.id, worktreePath.trim(), worktreeId, {
-              issueNumber: selectedIssue?.number,
-              prNumber: initialPR?.number,
-              worktreePath: worktreePath.trim(),
-              branchName: fullBranchName,
-            });
-          } catch (recipeErr) {
-            const message = formatErrorMessage(recipeErr, "Failed to run recipe");
-            const recipeId = selectedRecipe.id;
-            const recipePath = worktreePath.trim();
-            const recipeWorktreeId = worktreeId;
-            const recipeContext = {
-              issueNumber: selectedIssue?.number,
-              prNumber: initialPR?.number,
-              worktreePath: recipePath,
-              branchName: fullBranchName,
-            };
-            notify({
-              type: "warning",
-              title: "Could not run recipe",
-              message: `${message} — worktree was created successfully`,
-              actions: [
-                {
-                  label: "Retry recipe",
-                  onClick: () => {
-                    runRecipe(recipeId, recipePath, recipeWorktreeId, recipeContext).catch((err) =>
-                      logError("Failed to run recipe", err)
-                    );
-                  },
-                },
-              ],
-            });
-          }
-        }
-
-        onWorktreeCreated?.(worktreeId);
-        onClose();
-
-        setBranchInput("");
-        setWorktreePath("");
-        setFromRemote(false);
-      } catch (err: unknown) {
-        const message = formatErrorMessage(err, "Failed to create worktree");
-        setCreationError(mapCreationError(message, onClose));
-      }
-    });
   };
+
+  // --- Callback wrappers for view components ---
+  const handleBranchInputChange = useCallback(
+    (value: string) => {
+      setBranchInput(value);
+      markBranchInputTouched();
+      markTouched("branchInput");
+      clearErrors();
+    },
+    [setBranchInput, markBranchInputTouched, markTouched, clearErrors]
+  );
+
+  const handleWorktreePathChange = useCallback(
+    (value: string) => {
+      setWorktreePath(value);
+      pathTouchedRef.current = true;
+      markTouched("worktreePath");
+      clearErrors();
+    },
+    [setWorktreePath, pathTouchedRef, markTouched, clearErrors]
+  );
+
+  const handleBrowseClick = useCallback(async () => {
+    try {
+      const result = await actionService.dispatch("project.openDialog", undefined, {
+        source: "user",
+      });
+      if (result.ok && result.result) {
+        setWorktreePath(result.result as string);
+        pathTouchedRef.current = true;
+        markTouched("worktreePath");
+        clearErrors();
+      }
+    } catch (err: unknown) {
+      logError("Failed to open directory picker", err);
+      const message = formatErrorMessage(err, "Failed to open directory picker");
+      setValidationError(`Failed to open directory picker: ${message}`, null);
+    }
+  }, [setWorktreePath, pathTouchedRef, markTouched, clearErrors, setValidationError]);
+
+  const handleRecipeSelect = useCallback(
+    (id: string | null) => {
+      recipeSelectionTouchedRef.current = true;
+      markTouched("recipe");
+      setSelectedRecipeId(id);
+      if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, id);
+      clearErrors();
+    },
+    [
+      recipeSelectionTouchedRef,
+      markTouched,
+      setSelectedRecipeId,
+      projectId,
+      setLastSelectedWorktreeRecipeIdByProject,
+      clearErrors,
+    ]
+  );
+
+  const handleExistingBranchSelect = useCallback(
+    (branchName: string) => {
+      setSelectedExistingBranch(branchName);
+      clearErrors();
+    },
+    [clearErrors]
+  );
+
+  const handlePrefixSelectWrap = useCallback(
+    (suggestion: { type: { prefix: string; displayName: string } }) => {
+      handlePrefixSelect(suggestion.type.prefix);
+    },
+    [handlePrefixSelect]
+  );
+
+  const handleIssueSelectWrapper = useCallback(
+    (issue: GitHubIssue | null) => {
+      handleIssueSelect(issue);
+      if (issue) markTouched("issue");
+      clearErrors();
+    },
+    [handleIssueSelect, markTouched, clearErrors]
+  );
 
   return (
     <AppDialog
@@ -792,579 +702,92 @@ export function NewWorktreeDialog({
         ) : (
           <div className="space-y-4">
             {initialPR ? (
-              <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-strong text-sm min-w-0">
-                <FolderGit2 className="w-4 h-4 text-daintree-text/60 shrink-0" aria-hidden="true" />
-                <TruncatedTooltip content={`PR #${initialPR.number} — ${initialPR.title}`}>
-                  <span className="text-daintree-text/80 min-w-0 truncate">
-                    PR <span className="font-medium text-daintree-text">#{initialPR.number}</span> —{" "}
-                    {initialPR.title}
-                  </span>
-                </TruncatedTooltip>
-              </div>
+              <PrHeader pr={initialPR} />
             ) : (
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <label className="block text-sm font-medium text-daintree-text">
-                    Link Issue (Optional)
-                  </label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                        aria-label="Help for Link Issue field"
-                        disabled={isPending}
-                      >
-                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                        <span className="sr-only">Help for Link Issue field</span>
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">
-                      <p>Select an issue to auto-generate a branch name</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <IssueSelector
-                  projectPath={rootPath}
-                  selectedIssue={selectedIssue}
-                  onSelect={handleIssueSelect}
-                  disabled={isPending}
-                />
-              </div>
-            )}
-
-            {!initialPR && canAssignIssue && (
-              <div className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border bg-daintree-bg/50 border-daintree-border transition-colors">
-                {currentUserAvatar ? (
-                  <img
-                    src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=64`}
-                    alt={currentUser}
-                    className="w-8 h-8 rounded-full shrink-0"
-                  />
-                ) : (
-                  <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-overlay-medium text-daintree-text/60">
-                    <UserPlus className="w-4 h-4" />
-                  </div>
-                )}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-daintree-text">Assign to me</span>
-                    <span className="text-xs text-daintree-text/50 font-mono">@{currentUser}</span>
-                  </div>
-                </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={assignWorktreeToSelf}
-                    onChange={(e) => setAssignWorktreeToSelf(e.target.checked)}
-                    disabled={isPending}
-                    className="sr-only peer"
-                    aria-label="Assign issue to me when creating worktree"
-                  />
-                  <div
-                    className={cn(
-                      "w-9 h-5 rounded-full transition-colors",
-                      "peer-focus-visible:ring-2 peer-focus-visible:ring-daintree-accent",
-                      "after:content-[''] after:absolute after:top-0.5 after:left-0.5",
-                      "after:rounded-full after:h-4 after:w-4",
-                      "after:transition-transform after:duration-150",
-                      assignWorktreeToSelf
-                        ? "bg-daintree-accent after:translate-x-4 after:bg-text-inverse"
-                        : "bg-daintree-border after:translate-x-0 after:bg-daintree-text",
-                      isPending && "opacity-50 cursor-not-allowed"
-                    )}
-                  />
-                </label>
-              </div>
+              <IssueLinkerView
+                projectPath={rootPath}
+                selectedIssue={selectedIssue}
+                onSelectIssue={handleIssueSelectWrapper}
+                canAssignIssue={canAssignIssue}
+                assignWorktreeToSelf={assignWorktreeToSelf}
+                onSetAssignWorktreeToSelf={setAssignWorktreeToSelf}
+                currentUser={currentUser}
+                currentUserAvatar={currentUserAvatar}
+                disabled={isPending}
+              />
             )}
 
             {!initialPR && (
-              <div
-                className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-                role="radiogroup"
-                aria-label="Branch mode"
-              >
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={branchMode === "new"}
-                  onClick={() => handleBranchModeChange("new")}
-                  disabled={isPending}
-                  className={cn(
-                    "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                    branchMode === "new"
-                      ? "bg-daintree-bg text-daintree-text shadow-sm"
-                      : "text-daintree-text/60 hover:text-daintree-text"
-                  )}
-                >
-                  New Branch
-                </button>
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={branchMode === "existing"}
-                  onClick={() => handleBranchModeChange("existing")}
-                  disabled={isPending}
-                  className={cn(
-                    "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                    branchMode === "existing"
-                      ? "bg-daintree-bg text-daintree-text shadow-sm"
-                      : "text-daintree-text/60 hover:text-daintree-text"
-                  )}
-                >
-                  Existing Branch
-                </button>
-              </div>
+              <BranchModeControl
+                branchMode={branchMode}
+                onChange={handleBranchModeChange}
+                disabled={isPending}
+              />
             )}
 
             {!isExistingMode && (
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <label
-                    htmlFor="base-branch"
-                    className="block text-sm font-medium text-daintree-text"
-                  >
-                    Base Branch
-                  </label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                        aria-label="Help for Base Branch field"
-                        disabled={isPending}
-                      >
-                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                        <span className="sr-only">Help for Base Branch field</span>
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">
-                      <p>The branch to create the new worktree from</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <Popover open={branchPickerOpen} onOpenChange={setBranchPickerOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="base-branch"
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={branchPickerOpen}
-                      aria-haspopup="listbox"
-                      aria-invalid={errorField === "base-branch" ? true : undefined}
-                      aria-describedby={
-                        errorField === "base-branch" ? "validation-error" : undefined
-                      }
-                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                      disabled={isPending}
-                    >
-                      <span className="truncate">
-                        {selectedBranchOption?.labelText || "Select base branch..."}
-                      </span>
-                      <ChevronsUpDown className="opacity-50 shrink-0" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[400px] p-0"
-                    align="start"
-                    onEscapeKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center border-b border-daintree-border px-3">
-                      <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
-                      <input
-                        ref={branchInputRef}
-                        className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                        placeholder="Search branches..."
-                        value={branchQuery}
-                        onChange={(e) => setBranchQuery(e.target.value)}
-                        onKeyDown={handleBranchKeyDown}
-                        role="combobox"
-                        aria-label="Search base branches"
-                        aria-autocomplete="list"
-                        aria-controls="branch-list"
-                        aria-expanded={branchPickerOpen}
-                        aria-activedescendant={
-                          selectableRows.length > 0 && selectedIndex >= 0
-                            ? `branch-option-${selectedIndex}`
-                            : undefined
-                        }
-                      />
-                    </div>
-                    <ScrollShadow
-                      ref={branchListRef}
-                      id="branch-list"
-                      role="listbox"
-                      className="max-h-[300px]"
-                      scrollClassName="p-1"
-                    >
-                      {selectableRows.length === 0 ? (
-                        <div className="py-6 text-center text-sm text-muted-foreground">
-                          {branchQuery ? "No branches found" : "No branches available"}
-                        </div>
-                      ) : (
-                        (() => {
-                          let optionIndex = 0;
-                          return branchRows.map((row) => {
-                            if (row.kind === "section") {
-                              return (
-                                <div
-                                  key={`section-${row.label}`}
-                                  role="presentation"
-                                  className="px-2 py-1 text-xs font-medium text-daintree-text/50 uppercase tracking-wider"
-                                >
-                                  {row.label}
-                                </div>
-                              );
-                            }
-                            const idx = optionIndex++;
-                            return (
-                              <div
-                                key={row.name}
-                                id={`branch-option-${idx}`}
-                                data-option-index={idx}
-                                role="option"
-                                aria-selected={row.name === baseBranch}
-                                onClick={() => {
-                                  if (row.inUseWorktree) {
-                                    actionService.dispatch("worktree.setActive", {
-                                      worktreeId: row.inUseWorktree.id,
-                                    });
-                                    setBranchPickerOpen(false);
-                                    onClose();
-                                    return;
-                                  }
-                                  handleBranchSelect(row);
-                                }}
-                                className={cn(
-                                  "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                                  row.name === baseBranch && "bg-daintree-border",
-                                  idx === selectedIndex && "bg-overlay-selected"
-                                )}
-                              >
-                                <span className="truncate">
-                                  <HighlightBranchText
-                                    text={row.labelText}
-                                    matchRanges={row.matchRanges}
-                                    nameLength={row.name.length}
-                                  />
-                                </span>
-                                <span className="flex items-center gap-1 shrink-0">
-                                  {row.inUseWorktree && (
-                                    <span
-                                      className="text-xs text-status-warning"
-                                      title={`In use by worktree: ${row.inUseWorktree.name}`}
-                                    >
-                                      in use
-                                    </span>
-                                  )}
-                                  {row.name === baseBranch && (
-                                    <Check className="h-4 w-4 text-daintree-text" />
-                                  )}
-                                </span>
-                              </div>
-                            );
-                          });
-                        })()
-                      )}
-                    </ScrollShadow>
-                    {!branchQuery && branchOptions.length > 500 && (
-                      <div className="border-t border-daintree-border px-3 py-2 text-xs text-daintree-text/60">
-                        Showing first 500 branches. Type to search.
-                      </div>
-                    )}
-                  </PopoverContent>
-                </Popover>
-              </div>
+              <BaseBranchCombobox
+                baseBranch={baseBranch}
+                branchPickerOpen={branchPickerOpen}
+                onOpenChange={setBranchPickerOpen}
+                branchQuery={branchQuery}
+                onQueryChange={setBranchQuery}
+                branchRows={branchRows}
+                selectableRows={selectableRows}
+                selectedIndex={selectedIndex}
+                selectedBranchLabel={selectedBranchOption?.labelText}
+                onKeyDown={handleBranchKeyDown}
+                onSelect={handleBranchSelect}
+                branchInputRef={branchInputRef}
+                branchListRef={branchListRef}
+                errorField={errors.errorField}
+                branchOptionsLength={branchOptions.length}
+                disabled={isPending}
+                onClose={onClose}
+              />
             )}
 
             {isExistingMode ? (
-              <div className="space-y-2">
-                <label className="block text-sm font-medium text-daintree-text">
-                  Select Branch
-                </label>
-                <Popover open={existingBranchPickerOpen} onOpenChange={setExistingBranchPickerOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={existingBranchPickerOpen}
-                      aria-haspopup="listbox"
-                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                      disabled={isPending}
-                      data-testid="existing-branch-picker"
-                    >
-                      <span className="flex items-center gap-2 truncate">
-                        <GitBranch className="w-4 h-4 shrink-0 text-daintree-accent" />
-                        {selectedExistingBranch ? (
-                          <span className="font-mono text-sm">{selectedExistingBranch}</span>
-                        ) : (
-                          <span className="text-daintree-text/60">Select a local branch...</span>
-                        )}
-                      </span>
-                      <ChevronsUpDown className="opacity-50 shrink-0" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[400px] p-0"
-                    align="start"
-                    onEscapeKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center border-b border-daintree-border px-3">
-                      <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
-                      <input
-                        className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                        placeholder="Search local branches..."
-                        value={existingBranchQuery}
-                        onChange={(e) => setExistingBranchQuery(e.target.value)}
-                        autoFocus
-                        aria-label="Search existing branches"
-                        data-testid="existing-branch-search"
-                      />
-                    </div>
-                    <ScrollShadow role="listbox" className="max-h-[300px]" scrollClassName="p-1">
-                      {filteredExistingBranches.length === 0 ? (
-                        <div className="py-6 text-center text-sm text-muted-foreground">
-                          {existingBranchQuery
-                            ? "No matching branches"
-                            : "No available local branches"}
-                        </div>
-                      ) : (
-                        filteredExistingBranches.map((branch) => (
-                          <div
-                            key={branch.name}
-                            role="option"
-                            aria-selected={branch.name === selectedExistingBranch}
-                            onClick={() => {
-                              setSelectedExistingBranch(branch.name);
-                              setExistingBranchPickerOpen(false);
-                              setExistingBranchQuery("");
-                              setValidationError(null);
-                              setErrorField(null);
-                              setCreationError(null);
-                            }}
-                            className={cn(
-                              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border font-mono",
-                              branch.name === selectedExistingBranch && "bg-daintree-border"
-                            )}
-                          >
-                            <span className="truncate">{branch.name}</span>
-                            {branch.name === selectedExistingBranch && (
-                              <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-                            )}
-                          </div>
-                        ))
-                      )}
-                    </ScrollShadow>
-                  </PopoverContent>
-                </Popover>
-              </div>
+              <ExistingBranchPicker
+                open={existingBranchPickerOpen}
+                onOpenChange={setExistingBranchPickerOpen}
+                selectedBranch={selectedExistingBranch}
+                query={existingBranchQuery}
+                onQueryChange={setExistingBranchQuery}
+                filteredBranches={filteredExistingBranches}
+                onSelect={handleExistingBranchSelect}
+                disabled={isPending}
+              />
             ) : (
-              <div className="space-y-2">
-                <label
-                  htmlFor="new-branch"
-                  className="block text-sm font-medium text-daintree-text"
-                >
-                  New Branch Name
-                </label>
-                <Popover open={prefixPickerOpen} onOpenChange={setPrefixPickerOpen}>
-                  <PopoverTrigger asChild>
-                    <div className="relative">
-                      <input
-                        ref={newBranchInputRef}
-                        id="new-branch"
-                        type="text"
-                        data-testid="branch-name-input"
-                        value={branchInput}
-                        onChange={(e) => {
-                          setBranchInput(e.target.value);
-                          markBranchInputTouched();
-                          setValidationError(null);
-                          setErrorField(null);
-                          setCreationError(null);
-                        }}
-                        onKeyDown={handlePrefixKeyDown}
-                        placeholder="feature/add-user-auth"
-                        className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent font-mono text-sm"
-                        disabled={isPending}
-                        aria-invalid={errorField === "new-branch" ? true : undefined}
-                        aria-describedby={
-                          [
-                            errorField === "new-branch" ? "validation-error" : null,
-                            branchWasAutoResolved ? "branch-resolved-hint" : null,
-                          ]
-                            .filter(Boolean)
-                            .join(" ") || undefined
-                        }
-                        role="combobox"
-                        aria-autocomplete="list"
-                        aria-controls="prefix-list"
-                        aria-expanded={prefixPickerOpen}
-                      />
-                      {isCheckingBranch && (
-                        <Spinner
-                          size="md"
-                          className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
-                        />
-                      )}
-                    </div>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    align="start"
-                    className="w-[var(--radix-popover-trigger-width)] p-0 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]"
-                    onOpenAutoFocus={(e) => e.preventDefault()}
-                    onEscapeKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <ScrollShadow
-                      ref={prefixListRef}
-                      id="prefix-list"
-                      role="listbox"
-                      className="max-h-[240px]"
-                      scrollClassName="p-1"
-                    >
-                      {prefixSuggestions.length === 0 ? (
-                        <div className="py-4 text-center text-sm text-daintree-text/60">
-                          No matching prefixes
-                        </div>
-                      ) : (
-                        prefixSuggestions.map((suggestion, index) => (
-                          <div
-                            key={suggestion.type.prefix}
-                            role="option"
-                            aria-selected={index === prefixSelectedIndex}
-                            onClick={() => handlePrefixSelect(suggestion.type.prefix)}
-                            className={cn(
-                              "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                              index === prefixSelectedIndex && "bg-overlay-selected"
-                            )}
-                          >
-                            <span className="font-mono text-daintree-text">
-                              {suggestion.type.prefix}/
-                            </span>
-                            <span className="text-daintree-text/60">
-                              {suggestion.type.displayName}
-                            </span>
-                          </div>
-                        ))
-                      )}
-                    </ScrollShadow>
-                  </PopoverContent>
-                </Popover>
-                <p className="text-xs text-daintree-text/60 select-text">
-                  {parsedBranch.hasPrefix ? (
-                    <>
-                      <span className="font-mono text-daintree-text">{parsedBranch.prefix}/</span>
-                      <span className="font-mono">{parsedBranch.slug || "..."}</span>
-                    </>
-                  ) : (
-                    <span className="font-mono">{parsedBranch.fullBranchName || "..."}</span>
-                  )}
-                </p>
-                {branchWasAutoResolved && (
-                  <p
-                    id="branch-resolved-hint"
-                    className="text-xs text-status-success flex items-center gap-1.5 mt-1"
-                    role="status"
-                    aria-live="polite"
-                  >
-                    <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                    Name auto-incremented to avoid conflict with existing branch
-                  </p>
-                )}
-              </div>
+              <NewBranchInput
+                value={branchInput}
+                onChange={handleBranchInputChange}
+                isPending={isPending}
+                isCheckingBranch={isCheckingBranch}
+                errorField={errors.errorField}
+                branchWasAutoResolved={branchWasAutoResolved}
+                parsedBranch={parsedBranch}
+                prefixPickerOpen={prefixPickerOpen}
+                onPrefixPickerOpenChange={setPrefixPickerOpen}
+                prefixSuggestions={prefixSuggestions}
+                prefixSelectedIndex={prefixSelectedIndex}
+                onPrefixKeyDown={handlePrefixKeyDown}
+                onPrefixSelect={handlePrefixSelectWrap}
+                prefixListRef={prefixListRef}
+                inputRef={newBranchInputRef}
+              />
             )}
 
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <label
-                  htmlFor="worktree-path"
-                  className="block text-sm font-medium text-daintree-text"
-                >
-                  Worktree Path
-                </label>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                      aria-label="Help for Worktree Path field"
-                      disabled={isPending}
-                    >
-                      <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                      <span className="sr-only">Help for Worktree Path field</span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">
-                    <p>Directory where the worktree will be created</p>
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-              <div className="flex gap-2 items-center">
-                <div className="relative flex-1">
-                  <input
-                    id="worktree-path"
-                    data-testid="worktree-path-input"
-                    type="text"
-                    value={worktreePath}
-                    onChange={(e) => {
-                      setWorktreePath(e.target.value);
-                      pathTouchedRef.current = true;
-                      setValidationError(null);
-                      setErrorField(null);
-                      setCreationError(null);
-                    }}
-                    placeholder="/path/to/worktree"
-                    className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
-                    disabled={isPending}
-                    aria-invalid={errorField === "worktree-path" ? true : undefined}
-                    aria-describedby={
-                      errorField === "worktree-path" ? "validation-error" : undefined
-                    }
-                  />
-                  {isGeneratingPath && (
-                    <Spinner
-                      size="md"
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
-                    />
-                  )}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={async () => {
-                    try {
-                      const result = await actionService.dispatch("project.openDialog", undefined, {
-                        source: "user",
-                      });
-                      if (result.ok && result.result) {
-                        setWorktreePath(result.result as string);
-                        pathTouchedRef.current = true;
-                        setValidationError(null);
-                        setErrorField(null);
-                        setCreationError(null);
-                      }
-                    } catch (err: unknown) {
-                      logError("Failed to open directory picker", err);
-                      const message = formatErrorMessage(err, "Failed to open directory picker");
-                      setValidationError(`Failed to open directory picker: ${message}`);
-                      setErrorField(null);
-                    }
-                  }}
-                  disabled={isPending}
-                >
-                  <FolderOpen />
-                </Button>
-              </div>
-              {pathWasAutoResolved && (
-                <p
-                  className="text-xs text-status-success flex items-center gap-1.5 mt-1"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                  Path auto-incremented to avoid conflict with existing directory
-                </p>
-              )}
-            </div>
+            <WorktreePathPicker
+              value={worktreePath}
+              onChange={handleWorktreePathChange}
+              isPending={isPending}
+              isGeneratingPath={isGeneratingPath}
+              errorField={errors.errorField}
+              pathWasAutoResolved={pathWasAutoResolved}
+              onBrowseClick={handleBrowseClick}
+              disabled={isPending}
+            />
 
             {!isExistingMode && (
               <div className="flex items-center gap-2">
@@ -1382,265 +805,30 @@ export function NewWorktreeDialog({
               </div>
             )}
 
-            {hasAnyEnvironments && (
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <label className="block text-sm font-medium text-daintree-text">
-                    Environment
-                  </label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                        aria-label="Help for Environment field"
-                        disabled={isPending}
-                      >
-                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">
-                      <p>
-                        Choose where this worktree runs. Non-local environments provision remote
-                        compute from project environment settings.
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <div
-                  className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
-                  role="radiogroup"
-                  aria-label="Worktree environment mode"
-                >
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={worktreeMode === "local"}
-                    onClick={() => setWorktreeMode("local")}
-                    disabled={isPending}
-                    className={cn(
-                      "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                      worktreeMode === "local"
-                        ? "bg-daintree-bg text-daintree-text shadow-sm"
-                        : "text-daintree-text/60 hover:text-daintree-text"
-                    )}
-                  >
-                    Local
-                  </button>
-                  {Object.entries(resourceEnvironments ?? {}).map(([key]) => (
-                    <button
-                      key={key}
-                      type="button"
-                      role="radio"
-                      aria-checked={worktreeMode === key}
-                      onClick={() => setWorktreeMode(key)}
-                      disabled={isPending}
-                      className={cn(
-                        "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
-                        worktreeMode === key
-                          ? "bg-daintree-bg text-daintree-text shadow-sm"
-                          : "text-daintree-text/60 hover:text-daintree-text"
-                      )}
-                    >
-                      {key}
-                    </button>
-                  ))}
-                </div>
-                {worktreeMode !== "local" && (
-                  <p className="text-xs text-daintree-text/50">
-                    Provisions {worktreeMode} environment after worktree setup
-                  </p>
-                )}
-              </div>
-            )}
+            <EnvironmentRadioGroup
+              worktreeMode={worktreeMode}
+              onChange={setWorktreeMode}
+              resourceEnvironments={resourceEnvironments}
+              hasAnyEnvironments={hasAnyEnvironments}
+              disabled={isPending}
+            />
 
             {globalRecipes.length > 0 && (
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <label
-                    htmlFor="recipe-selector"
-                    className="block text-sm font-medium text-daintree-text"
-                  >
-                    Run Recipe (Optional)
-                  </label>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
-                        aria-label="Help for Run Recipe field"
-                        disabled={isPending}
-                      >
-                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                        <span className="sr-only">Help for Run Recipe field</span>
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right">
-                      <p>Select a recipe to run after creating the worktree</p>
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="recipe-selector"
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={recipePickerOpen}
-                      aria-haspopup="listbox"
-                      aria-controls="recipe-list"
-                      className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
-                      disabled={isPending}
-                    >
-                      <span className="flex items-center gap-2 truncate">
-                        {selectedRecipeId === CLONE_LAYOUT_ID ? (
-                          <>
-                            <Copy className="shrink-0 text-daintree-accent" />
-                            <span>Clone current layout</span>
-                          </>
-                        ) : selectedRecipe ? (
-                          <>
-                            <Play className="shrink-0 text-daintree-accent" />
-                            <span>{selectedRecipe.name}</span>
-                            <span className="text-xs text-daintree-text/50">
-                              ({selectedRecipe.terminals.length} terminal
-                              {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                            </span>
-                          </>
-                        ) : (
-                          <>
-                            <Play className="shrink-0 text-daintree-accent" />
-                            <span className="text-daintree-text/60">Empty</span>
-                          </>
-                        )}
-                      </span>
-                      <ChevronsUpDown className="opacity-50 shrink-0" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[400px] p-0"
-                    align="start"
-                    onEscapeKeyDown={(e) => e.stopPropagation()}
-                  >
-                    <ScrollShadow
-                      id="recipe-list"
-                      role="listbox"
-                      className="max-h-[300px]"
-                      scrollClassName="p-1"
-                    >
-                      <div
-                        role="option"
-                        aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
-                        tabIndex={0}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            recipeSelectionTouchedRef.current = true;
-                            setSelectedRecipeId(CLONE_LAYOUT_ID);
-                            if (projectId)
-                              setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
-                            setRecipePickerOpen(false);
-                          }
-                        }}
-                        onClick={() => {
-                          recipeSelectionTouchedRef.current = true;
-                          setSelectedRecipeId(CLONE_LAYOUT_ID);
-                          if (projectId)
-                            setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
-                          setRecipePickerOpen(false);
-                        }}
-                        className={cn(
-                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                          selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
-                        )}
-                      >
-                        <div className="flex items-center gap-2">
-                          <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
-                          <span>Clone current layout</span>
-                        </div>
-                        {selectedRecipeId === CLONE_LAYOUT_ID && (
-                          <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-                        )}
-                      </div>
-                      <div
-                        role="option"
-                        aria-selected={selectedRecipeId === null}
-                        tabIndex={0}
-                        onKeyDown={(event) => {
-                          if (event.key === "Enter" || event.key === " ") {
-                            event.preventDefault();
-                            recipeSelectionTouchedRef.current = true;
-                            setSelectedRecipeId(null);
-                            if (projectId)
-                              setLastSelectedWorktreeRecipeIdByProject(projectId, null);
-                            setRecipePickerOpen(false);
-                          }
-                        }}
-                        onClick={() => {
-                          recipeSelectionTouchedRef.current = true;
-                          setSelectedRecipeId(null);
-                          if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, null);
-                          setRecipePickerOpen(false);
-                        }}
-                        className={cn(
-                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                          selectedRecipeId === null && "bg-daintree-border"
-                        )}
-                      >
-                        <span className="text-daintree-text/60">Empty</span>
-                        {selectedRecipeId === null && (
-                          <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-                        )}
-                      </div>
-                      {globalRecipes.map((recipe) => (
-                        <div
-                          key={recipe.id}
-                          role="option"
-                          aria-selected={recipe.id === selectedRecipeId}
-                          tabIndex={0}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              recipeSelectionTouchedRef.current = true;
-                              setSelectedRecipeId(recipe.id);
-                              if (projectId)
-                                setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
-                              setRecipePickerOpen(false);
-                            }
-                          }}
-                          onClick={() => {
-                            recipeSelectionTouchedRef.current = true;
-                            setSelectedRecipeId(recipe.id);
-                            if (projectId)
-                              setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
-                            setRecipePickerOpen(false);
-                          }}
-                          className={cn(
-                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
-                            recipe.id === selectedRecipeId && "bg-daintree-border"
-                          )}
-                        >
-                          <div className="flex items-center gap-2 min-w-0">
-                            <span className="truncate">{recipe.name}</span>
-                            <span className="text-xs text-daintree-text/50 shrink-0">
-                              {recipe.terminals.length} terminal
-                              {recipe.terminals.length !== 1 ? "s" : ""}
-                            </span>
-                            {recipe.id === defaultRecipeId && (
-                              <span className="text-xs text-daintree-text/50 shrink-0">
-                                (default)
-                              </span>
-                            )}
-                          </div>
-                          {recipe.id === selectedRecipeId && (
-                            <Check className="h-4 w-4 shrink-0 text-daintree-text" />
-                          )}
-                        </div>
-                      ))}
-                    </ScrollShadow>
-                  </PopoverContent>
-                </Popover>
-              </div>
+              <RecipePickerPopover
+                recipes={globalRecipes}
+                selectedRecipeId={selectedRecipeId}
+                selectedRecipe={selectedRecipe}
+                defaultRecipeId={defaultRecipeId}
+                open={recipePickerOpen}
+                onOpenChange={setRecipePickerOpen}
+                onSelectRecipe={handleRecipeSelect}
+                onMarkTouched={() => {
+                  markTouched("recipe");
+                }}
+                disabled={isPending}
+                label="Run Recipe (Optional)"
+                listId="recipe-selector"
+              />
             )}
 
             {initialPR && prBranchResolved === false && (
@@ -1656,43 +844,43 @@ export function NewWorktreeDialog({
               </div>
             )}
 
-            {validationError && (
+            {errors.validationError && (
               <div
                 id="validation-error"
                 role="alert"
                 className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)]"
               >
                 <AlertCircle className="w-4 h-4 text-status-error mt-0.5 flex-shrink-0" />
-                <p className="text-sm text-status-error">{validationError}</p>
+                <p className="text-sm text-status-error">{errors.validationError}</p>
               </div>
             )}
 
-            {creationError && (
+            {errors.creationError && (
               <div
                 role="alert"
                 className="p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)] space-y-2"
               >
                 <div className="flex items-start gap-2">
                   <AlertCircle className="w-4 h-4 text-status-error mt-0.5 flex-shrink-0" />
-                  <p className="text-sm text-status-error">{creationError.friendly}</p>
+                  <p className="text-sm text-status-error">{errors.creationError.friendly}</p>
                 </div>
-                {creationError.recovery && (
+                {errors.creationError.recovery && (
                   <button
                     type="button"
-                    onClick={creationError.recovery.onAction}
+                    onClick={errors.creationError.recovery.onAction}
                     className="ml-6 text-xs font-medium text-status-error underline underline-offset-2 hover:text-status-error/80"
                   >
-                    {creationError.recovery.label}
+                    {errors.creationError.recovery.label}
                   </button>
                 )}
-                {creationError.raw !== creationError.friendly && (
+                {errors.creationError.raw !== errors.creationError.friendly && (
                   <details className="ml-6">
                     <summary className="flex items-center gap-1 text-xs text-daintree-text/50 cursor-pointer select-none">
                       <ChevronDown className="w-3 h-3" />
                       Show details
                     </summary>
                     <pre className="mt-1.5 overflow-x-auto rounded bg-status-error/5 p-2 font-mono text-[11px] text-daintree-text/50 whitespace-pre-wrap break-all select-text">
-                      {creationError.raw}
+                      {errors.creationError.raw}
                     </pre>
                   </details>
                 )}
@@ -1742,7 +930,7 @@ export function NewWorktreeDialog({
                   <Spinner />
                   Creating...
                 </>
-              ) : creationError ? (
+              ) : errors.creationError ? (
                 <>
                   <Check />
                   Retry create

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -76,7 +76,7 @@ export function NewWorktreeDialog({
   const keepEditingButtonRef = useRef<HTMLButtonElement>(null);
   const isCreatingRef = useRef(false);
 
-  const { errors, setValidationError, clearErrors, setCreationError, markTouched } =
+  const { errors, setValidationError, clearErrors, setCreationError, markTouched, resetErrors } =
     useWorktreeFormErrors();
 
   const assignWorktreeToSelf = usePreferencesStore((s) => s.assignWorktreeToSelf);
@@ -260,7 +260,7 @@ export function NewWorktreeDialog({
     if (!isOpen) return;
 
     setLoading(true);
-    clearErrors();
+    resetErrors();
     setPrBranchResolved(null);
     setBranches([]);
     setBaseBranch("");
@@ -664,8 +664,9 @@ export function NewWorktreeDialog({
   const handlePrefixSelectWrap = useCallback(
     (suggestion: { type: { prefix: string; displayName: string } }) => {
       handlePrefixSelect(suggestion.type.prefix);
+      markTouched("branchInput");
     },
-    [handlePrefixSelect]
+    [handlePrefixSelect, markTouched]
   );
 
   const handleIssueSelectWrapper = useCallback(

--- a/src/components/Worktree/hooks/__tests__/useWorktreeFormErrors.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useWorktreeFormErrors.test.ts
@@ -55,7 +55,7 @@ describe("useWorktreeFormErrors", () => {
       result.current.setCreationError({
         friendly: "Creation failed",
         raw: "Error: Creation failed",
-        recovery: null,
+        recovery: undefined,
       });
     });
 

--- a/src/components/Worktree/hooks/__tests__/useWorktreeFormErrors.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useWorktreeFormErrors.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWorktreeFormErrors } from "../useWorktreeFormErrors";
+
+describe("useWorktreeFormErrors", () => {
+  it("initializes with null errors and untouched fields", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    expect(result.current.errors.validationError).toBeNull();
+    expect(result.current.errors.errorField).toBeNull();
+    expect(result.current.errors.creationError).toBeNull();
+    expect(result.current.errors.touchedFields.branchInput).toBe(false);
+    expect(result.current.errors.touchedFields.worktreePath).toBe(false);
+    expect(result.current.errors.touchedFields.recipe).toBe(false);
+    expect(result.current.errors.touchedFields.issue).toBe(false);
+  });
+
+  it("setValidationError sets message and field, clears creationError", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.setValidationError("Branch name required", "new-branch");
+    });
+
+    expect(result.current.errors.validationError).toBe("Branch name required");
+    expect(result.current.errors.errorField).toBe("new-branch");
+    expect(result.current.errors.creationError).toBeNull();
+  });
+
+  it("clearErrors clears all error state", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.setValidationError("test error", "new-branch");
+    });
+    act(() => {
+      result.current.clearErrors();
+    });
+
+    expect(result.current.errors.validationError).toBeNull();
+    expect(result.current.errors.errorField).toBeNull();
+    expect(result.current.errors.creationError).toBeNull();
+  });
+
+  it("setCreationError sets creation error and clears validation", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.setValidationError("before", "new-branch");
+    });
+    act(() => {
+      result.current.setCreationError({
+        friendly: "Creation failed",
+        raw: "Error: Creation failed",
+        recovery: null,
+      });
+    });
+
+    expect(result.current.errors.validationError).toBeNull();
+    expect(result.current.errors.errorField).toBeNull();
+    expect(result.current.errors.creationError?.friendly).toBe("Creation failed");
+  });
+
+  it("markTouched updates specific touched field", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.markTouched("branchInput");
+    });
+
+    expect(result.current.errors.touchedFields.branchInput).toBe(true);
+    expect(result.current.errors.touchedFields.worktreePath).toBe(false);
+    expect(result.current.errors.touchedFields.recipe).toBe(false);
+  });
+
+  it("resetErrors returns to initial state", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.setValidationError("err", "base-branch");
+      result.current.markTouched("branchInput");
+      result.current.markTouched("worktreePath");
+    });
+    act(() => {
+      result.current.resetErrors();
+    });
+
+    expect(result.current.errors.validationError).toBeNull();
+    expect(result.current.errors.errorField).toBeNull();
+    expect(result.current.errors.touchedFields.branchInput).toBe(false);
+    expect(result.current.errors.touchedFields.worktreePath).toBe(false);
+  });
+
+  it("isFormDirty returns true when any field is touched", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    expect(result.current.isFormDirty()).toBe(false);
+
+    act(() => {
+      result.current.markTouched("recipe");
+    });
+
+    expect(result.current.isFormDirty()).toBe(true);
+  });
+
+  it("isFormDirty returns false when no fields touched", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+    expect(result.current.isFormDirty()).toBe(false);
+  });
+
+  it("setValidationError with null field works", () => {
+    const { result } = renderHook(() => useWorktreeFormErrors());
+
+    act(() => {
+      result.current.setValidationError("General error", null);
+    });
+
+    expect(result.current.errors.validationError).toBe("General error");
+    expect(result.current.errors.errorField).toBeNull();
+  });
+});

--- a/src/components/Worktree/hooks/__tests__/useWorktreeFormValidation.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useWorktreeFormValidation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useWorktreeFormValidation } from "../useWorktreeFormValidation";
+
+describe("useWorktreeFormValidation", () => {
+  const baseInput = {
+    branchMode: "new" as const,
+    baseBranch: "develop",
+    branchInput: "feature/my-feature",
+    selectedExistingBranch: null,
+    worktreePath: "/path/to/worktree",
+  };
+
+  it("returns valid for good new-branch input", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate(baseInput);
+    expect(validation.valid).toBe(true);
+    expect(validation.fullBranchName).toBe("feature/my-feature");
+  });
+
+  it("validates existing mode", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchMode: "existing",
+      branchInput: "",
+      selectedExistingBranch: "develop",
+      baseBranch: "",
+    });
+    expect(validation.valid).toBe(true);
+  });
+
+  it("rejects existing mode without selected branch", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchMode: "existing",
+      selectedExistingBranch: null,
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toBe("Please select a branch");
+  });
+
+  it("rejects existing mode without worktree path", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchMode: "existing",
+      selectedExistingBranch: "develop",
+      worktreePath: "",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("worktree path");
+    expect(validation.error?.field).toBe("worktree-path");
+  });
+
+  it("rejects missing base branch in new mode", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      baseBranch: "",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("base branch");
+    expect(validation.error?.field).toBe("base-branch");
+  });
+
+  it("rejects empty branch input in new mode", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("branch name");
+    expect(validation.error?.field).toBe("new-branch");
+  });
+
+  it("rejects branch name with leading dot", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: ".hidden",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.field).toBe("new-branch");
+  });
+
+  it("rejects branch name with trailing dot", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "trailing.",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.field).toBe("new-branch");
+  });
+
+  it("rejects branch name with backslash", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "bad\\name",
+    });
+    expect(validation.valid).toBe(false);
+  });
+
+  it("rejects prefixed branch with empty slug", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "feature/",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("after the prefix");
+  });
+
+  it("rejects invalid prefix characters", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "bad:prefix/my-feature",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("invalid characters");
+  });
+
+  it("rejects missing worktree path", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      worktreePath: "",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error?.message).toContain("worktree path");
+    expect(validation.error?.field).toBe("worktree-path");
+  });
+
+  it("returns fullBranchName for prefixed input", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "feature/PROJ-123-fix-bug",
+    });
+    expect(validation.valid).toBe(true);
+    expect(validation.fullBranchName).toBe("feature/PROJ-123-fix-bug");
+  });
+
+  it("returns fullBranchName for unprefixed input", () => {
+    const { result } = renderHook(() => useWorktreeFormValidation());
+
+    const validation = result.current.validate({
+      ...baseInput,
+      branchInput: "simple-branch",
+    });
+    expect(validation.valid).toBe(true);
+    expect(validation.fullBranchName).toBe("simple-branch");
+  });
+});

--- a/src/components/Worktree/hooks/useWorktreeFormErrors.ts
+++ b/src/components/Worktree/hooks/useWorktreeFormErrors.ts
@@ -1,0 +1,114 @@
+import { useReducer, useCallback } from "react";
+import type { WorktreeCreationError } from "../worktreeCreationErrors";
+
+export type ErrorField = "base-branch" | "new-branch" | "worktree-path";
+
+export interface WorktreeFormErrors {
+  validationError: string | null;
+  errorField: ErrorField | null;
+  creationError: WorktreeCreationError | null;
+  touchedFields: {
+    branchInput: boolean;
+    worktreePath: boolean;
+    recipe: boolean;
+    issue: boolean;
+  };
+}
+
+type Action =
+  | { type: "SET_VALIDATION_ERROR"; payload: { message: string; field: ErrorField | null } }
+  | { type: "CLEAR_ERRORS" }
+  | { type: "SET_CREATION_ERROR"; payload: WorktreeCreationError }
+  | { type: "MARK_TOUCHED"; payload: keyof WorktreeFormErrors["touchedFields"] }
+  | { type: "RESET" };
+
+const initialState: WorktreeFormErrors = {
+  validationError: null,
+  errorField: null,
+  creationError: null,
+  touchedFields: {
+    branchInput: false,
+    worktreePath: false,
+    recipe: false,
+    issue: false,
+  },
+};
+
+function reducer(state: WorktreeFormErrors, action: Action): WorktreeFormErrors {
+  switch (action.type) {
+    case "SET_VALIDATION_ERROR":
+      return {
+        ...state,
+        validationError: action.payload.message,
+        errorField: action.payload.field,
+        creationError: null,
+      };
+    case "CLEAR_ERRORS":
+      return {
+        ...state,
+        validationError: null,
+        errorField: null,
+        creationError: null,
+      };
+    case "SET_CREATION_ERROR":
+      return {
+        ...state,
+        creationError: action.payload,
+        validationError: null,
+        errorField: null,
+      };
+    case "MARK_TOUCHED":
+      return {
+        ...state,
+        touchedFields: { ...state.touchedFields, [action.payload]: true },
+      };
+    case "RESET":
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+export function useWorktreeFormErrors() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  const setValidationError = useCallback((message: string, field: ErrorField | null = null) => {
+    dispatch({ type: "SET_VALIDATION_ERROR", payload: { message, field } });
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    dispatch({ type: "CLEAR_ERRORS" });
+  }, []);
+
+  const clearErrorForField = useCallback((_field: ErrorField | "issue" | "recipe") => {
+    dispatch({ type: "CLEAR_ERRORS" });
+  }, []);
+
+  const setCreationError = useCallback((error: WorktreeCreationError) => {
+    dispatch({ type: "SET_CREATION_ERROR", payload: error });
+  }, []);
+
+  const markTouched = useCallback((field: keyof WorktreeFormErrors["touchedFields"]) => {
+    dispatch({ type: "MARK_TOUCHED", payload: field });
+  }, []);
+
+  const resetErrors = useCallback(() => {
+    dispatch({ type: "RESET" });
+  }, []);
+
+  const isFormDirty = (): boolean => {
+    const { touchedFields: touched } = state;
+    return touched.branchInput || touched.worktreePath || touched.recipe || touched.issue;
+  };
+
+  return {
+    errors: state,
+    setValidationError,
+    clearErrors,
+    clearErrorForField,
+    setCreationError,
+    markTouched,
+    resetErrors,
+    isFormDirty,
+  } as const;
+}

--- a/src/components/Worktree/hooks/useWorktreeFormValidation.ts
+++ b/src/components/Worktree/hooks/useWorktreeFormValidation.ts
@@ -1,0 +1,129 @@
+import { useCallback } from "react";
+import { parseBranchInput } from "../branchPrefixUtils";
+import type { ErrorField } from "./useWorktreeFormErrors";
+
+type BranchMode = "new" | "existing";
+
+interface ValidationInput {
+  branchMode: BranchMode;
+  baseBranch: string;
+  branchInput: string;
+  selectedExistingBranch: string | null;
+  worktreePath: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: {
+    message: string;
+    field: ErrorField | null;
+  };
+  fullBranchName?: string;
+}
+
+export function useWorktreeFormValidation() {
+  const validate = useCallback(
+    ({
+      branchMode,
+      baseBranch,
+      branchInput,
+      selectedExistingBranch,
+      worktreePath,
+    }: ValidationInput): ValidationResult => {
+      if (branchMode === "existing") {
+        if (!selectedExistingBranch) {
+          return {
+            valid: false,
+            error: { message: "Please select a branch", field: null },
+          };
+        }
+        if (!worktreePath.trim()) {
+          return {
+            valid: false,
+            error: { message: "Please enter a worktree path", field: "worktree-path" },
+          };
+        }
+        return { valid: true };
+      }
+
+      if (!baseBranch) {
+        return {
+          valid: false,
+          error: { message: "Please select a base branch", field: "base-branch" },
+        };
+      }
+
+      const trimmedInput = branchInput.trim();
+      if (!trimmedInput) {
+        return {
+          valid: false,
+          error: { message: "Please enter a branch name", field: "new-branch" },
+        };
+      }
+
+      const parsed = parseBranchInput(trimmedInput);
+
+      if (parsed.hasPrefix) {
+        if (!parsed.slug || !parsed.slug.trim()) {
+          return {
+            valid: false,
+            error: { message: "Please enter a branch name after the prefix", field: "new-branch" },
+          };
+        }
+        if (
+          /[\s.:]/.test(parsed.prefix) ||
+          /^[.-]/.test(parsed.prefix) ||
+          parsed.prefix.includes("..")
+        ) {
+          return {
+            valid: false,
+            error: { message: "Branch prefix contains invalid characters", field: "new-branch" },
+          };
+        }
+        if (/[\s.]$/.test(parsed.slug) || /^[.-]/.test(parsed.slug)) {
+          return {
+            valid: false,
+            error: {
+              message: "Branch name cannot start with '.', '-' or end with space or '.'",
+              field: "new-branch",
+            },
+          };
+        }
+        if (/[\\:]/.test(parsed.slug) || parsed.slug.includes("..")) {
+          return {
+            valid: false,
+            error: { message: "Branch name contains invalid characters", field: "new-branch" },
+          };
+        }
+      } else {
+        if (/[\s.]$/.test(trimmedInput) || /^[.-]/.test(trimmedInput)) {
+          return {
+            valid: false,
+            error: {
+              message: "Branch name cannot start with '.', '-' or end with space or '.'",
+              field: "new-branch",
+            },
+          };
+        }
+        if (/[/\\:]/.test(trimmedInput) || trimmedInput.includes("..")) {
+          return {
+            valid: false,
+            error: { message: "Branch name contains invalid characters", field: "new-branch" },
+          };
+        }
+      }
+
+      if (!worktreePath.trim()) {
+        return {
+          valid: false,
+          error: { message: "Please enter a worktree path", field: "worktree-path" },
+        };
+      }
+
+      return { valid: true, fullBranchName: parsed.fullBranchName };
+    },
+    []
+  );
+
+  return { validate };
+}

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -1,0 +1,202 @@
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Check, ChevronsUpDown, Info, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { actionService } from "@/services/ActionService";
+import { HighlightBranchText } from "./HighlightBranchText";
+import type { BranchPickerRow } from "../branchPickerUtils";
+
+interface BaseBranchComboboxProps {
+  baseBranch: string;
+  branchPickerOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  branchQuery: string;
+  onQueryChange: (query: string) => void;
+  branchRows: BranchPickerRow[];
+  selectableRows: (BranchPickerRow & { kind: "option" })[];
+  selectedIndex: number;
+  selectedBranchLabel: string | undefined;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onSelect: (row: BranchPickerRow & { kind: "option" }) => void;
+  branchInputRef: React.RefObject<HTMLInputElement | null>;
+  branchListRef: React.RefObject<HTMLDivElement | null>;
+  errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
+  branchOptionsLength: number;
+  disabled?: boolean;
+  onClose: () => void;
+}
+
+export function BaseBranchCombobox({
+  baseBranch,
+  branchPickerOpen,
+  onOpenChange,
+  branchQuery,
+  onQueryChange,
+  branchRows,
+  selectableRows,
+  selectedIndex,
+  selectedBranchLabel,
+  onKeyDown,
+  onSelect,
+  branchInputRef,
+  branchListRef,
+  errorField,
+  branchOptionsLength,
+  disabled,
+  onClose,
+}: BaseBranchComboboxProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor="base-branch" className="block text-sm font-medium text-daintree-text">
+          Base Branch
+        </label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+              aria-label="Help for Base Branch field"
+              disabled={disabled}
+            >
+              <Info className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="sr-only">Help for Base Branch field</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>The branch to create the new worktree from</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <Popover open={branchPickerOpen} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            id="base-branch"
+            variant="outline"
+            role="combobox"
+            aria-expanded={branchPickerOpen}
+            aria-haspopup="listbox"
+            aria-invalid={errorField === "base-branch" ? true : undefined}
+            aria-describedby={errorField === "base-branch" ? "validation-error" : undefined}
+            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+            disabled={disabled}
+          >
+            <span className="truncate">{selectedBranchLabel || "Select base branch..."}</span>
+            <ChevronsUpDown className="opacity-50 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[400px] p-0"
+          align="start"
+          onEscapeKeyDown={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center border-b border-daintree-border px-3">
+            <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
+            <input
+              ref={branchInputRef}
+              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder="Search branches..."
+              value={branchQuery}
+              onChange={(e) => onQueryChange(e.target.value)}
+              onKeyDown={onKeyDown}
+              role="combobox"
+              aria-label="Search base branches"
+              aria-autocomplete="list"
+              aria-controls="branch-list"
+              aria-expanded={branchPickerOpen}
+              aria-activedescendant={
+                selectableRows.length > 0 && selectedIndex >= 0
+                  ? `branch-option-${selectedIndex}`
+                  : undefined
+              }
+            />
+          </div>
+          <ScrollShadow
+            ref={branchListRef}
+            id="branch-list"
+            role="listbox"
+            className="max-h-[300px]"
+            scrollClassName="p-1"
+          >
+            {selectableRows.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">
+                {branchQuery ? "No branches found" : "No branches available"}
+              </div>
+            ) : (
+              (() => {
+                let optionIndex = 0;
+                return branchRows.map((row) => {
+                  if (row.kind === "section") {
+                    return (
+                      <div
+                        key={`section-${row.label}`}
+                        role="presentation"
+                        className="px-2 py-1 text-xs font-medium text-daintree-text/50 uppercase tracking-wider"
+                      >
+                        {row.label}
+                      </div>
+                    );
+                  }
+                  const idx = optionIndex++;
+                  return (
+                    <div
+                      key={row.name}
+                      id={`branch-option-${idx}`}
+                      data-option-index={idx}
+                      role="option"
+                      aria-selected={row.name === baseBranch}
+                      onClick={() => {
+                        if (row.inUseWorktree) {
+                          actionService.dispatch("worktree.setActive", {
+                            worktreeId: row.inUseWorktree.id,
+                          });
+                          onOpenChange(false);
+                          onClose();
+                          return;
+                        }
+                        onSelect(row);
+                      }}
+                      className={cn(
+                        "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                        row.name === baseBranch && "bg-daintree-border",
+                        idx === selectedIndex && "bg-overlay-selected"
+                      )}
+                    >
+                      <span className="truncate">
+                        <HighlightBranchText
+                          text={row.labelText}
+                          matchRanges={row.matchRanges}
+                          nameLength={row.name.length}
+                        />
+                      </span>
+                      <span className="flex items-center gap-1 shrink-0">
+                        {row.inUseWorktree && (
+                          <span
+                            className="text-xs text-status-warning"
+                            title={`In use by worktree: ${row.inUseWorktree.name}`}
+                          >
+                            in use
+                          </span>
+                        )}
+                        {row.name === baseBranch && (
+                          <Check className="h-4 w-4 text-daintree-text" />
+                        )}
+                      </span>
+                    </div>
+                  );
+                });
+              })()
+            )}
+          </ScrollShadow>
+          {!branchQuery && branchOptionsLength > 500 && (
+            <div className="border-t border-daintree-border px-3 py-2 text-xs text-daintree-text/60">
+              Showing first 500 branches. Type to search.
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/Worktree/views/BranchModeControl.tsx
+++ b/src/components/Worktree/views/BranchModeControl.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+type BranchMode = "new" | "existing";
+
+interface BranchModeControlProps {
+  branchMode: BranchMode;
+  onChange: (mode: BranchMode) => void;
+  disabled?: boolean;
+}
+
+export function BranchModeControl({ branchMode, onChange, disabled }: BranchModeControlProps) {
+  return (
+    <div
+      className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
+      role="radiogroup"
+      aria-label="Branch mode"
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={branchMode === "new"}
+        onClick={() => onChange("new")}
+        disabled={disabled}
+        className={cn(
+          "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+          branchMode === "new"
+            ? "bg-daintree-bg text-daintree-text shadow-sm"
+            : "text-daintree-text/60 hover:text-daintree-text"
+        )}
+      >
+        New Branch
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={branchMode === "existing"}
+        onClick={() => onChange("existing")}
+        disabled={disabled}
+        className={cn(
+          "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+          branchMode === "existing"
+            ? "bg-daintree-bg text-daintree-text shadow-sm"
+            : "text-daintree-text/60 hover:text-daintree-text"
+        )}
+      >
+        Existing Branch
+      </button>
+    </div>
+  );
+}

--- a/src/components/Worktree/views/EnvironmentRadioGroup.tsx
+++ b/src/components/Worktree/views/EnvironmentRadioGroup.tsx
@@ -1,0 +1,91 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface EnvironmentRadioGroupProps {
+  worktreeMode: string;
+  onChange: (mode: string) => void;
+  resourceEnvironments: Record<string, unknown> | undefined;
+  hasAnyEnvironments: boolean;
+  disabled?: boolean;
+}
+
+export function EnvironmentRadioGroup({
+  worktreeMode,
+  onChange,
+  resourceEnvironments,
+  hasAnyEnvironments,
+  disabled,
+}: EnvironmentRadioGroupProps) {
+  if (!hasAnyEnvironments) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <label className="block text-sm font-medium text-daintree-text">Environment</label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+              aria-label="Help for Environment field"
+              disabled={disabled}
+            >
+              <Info className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>
+              Choose where this worktree runs. Non-local environments provision remote compute from
+              project environment settings.
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <div
+        className="inline-flex rounded-[var(--radius-md)] bg-daintree-border/50 p-0.5"
+        role="radiogroup"
+        aria-label="Worktree environment mode"
+      >
+        <button
+          type="button"
+          role="radio"
+          aria-checked={worktreeMode === "local"}
+          onClick={() => onChange("local")}
+          disabled={disabled}
+          className={cn(
+            "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+            worktreeMode === "local"
+              ? "bg-daintree-bg text-daintree-text shadow-sm"
+              : "text-daintree-text/60 hover:text-daintree-text"
+          )}
+        >
+          Local
+        </button>
+        {Object.entries(resourceEnvironments ?? {}).map(([key]) => (
+          <button
+            key={key}
+            type="button"
+            role="radio"
+            aria-checked={worktreeMode === key}
+            onClick={() => onChange(key)}
+            disabled={disabled}
+            className={cn(
+              "px-3 py-1 text-sm font-medium rounded-[var(--radius-sm)] transition-colors",
+              worktreeMode === key
+                ? "bg-daintree-bg text-daintree-text shadow-sm"
+                : "text-daintree-text/60 hover:text-daintree-text"
+            )}
+          >
+            {key}
+          </button>
+        ))}
+      </div>
+      {worktreeMode !== "local" && (
+        <p className="text-xs text-daintree-text/50">
+          Provisions {worktreeMode} environment after worktree setup
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Worktree/views/ExistingBranchPicker.tsx
+++ b/src/components/Worktree/views/ExistingBranchPicker.tsx
@@ -1,0 +1,104 @@
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Check, ChevronsUpDown, GitBranch, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { BranchInfo } from "@/types/electron";
+
+interface ExistingBranchPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedBranch: string | null;
+  query: string;
+  onQueryChange: (query: string) => void;
+  filteredBranches: BranchInfo[];
+  onSelect: (branchName: string) => void;
+  disabled?: boolean;
+}
+
+export function ExistingBranchPicker({
+  open,
+  onOpenChange,
+  selectedBranch,
+  query,
+  onQueryChange,
+  filteredBranches,
+  onSelect,
+  disabled,
+}: ExistingBranchPickerProps) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-daintree-text">Select Branch</label>
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+            disabled={disabled}
+            data-testid="existing-branch-picker"
+          >
+            <span className="flex items-center gap-2 truncate">
+              <GitBranch className="w-4 h-4 shrink-0 text-daintree-accent" />
+              {selectedBranch ? (
+                <span className="font-mono text-sm">{selectedBranch}</span>
+              ) : (
+                <span className="text-daintree-text/60">Select a local branch...</span>
+              )}
+            </span>
+            <ChevronsUpDown className="opacity-50 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[400px] p-0"
+          align="start"
+          onEscapeKeyDown={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center border-b border-daintree-border px-3">
+            <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
+            <input
+              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              placeholder="Search local branches..."
+              value={query}
+              onChange={(e) => onQueryChange(e.target.value)}
+              autoFocus
+              aria-label="Search existing branches"
+              data-testid="existing-branch-search"
+            />
+          </div>
+          <ScrollShadow role="listbox" className="max-h-[300px]" scrollClassName="p-1">
+            {filteredBranches.length === 0 ? (
+              <div className="py-6 text-center text-sm text-muted-foreground">
+                {query ? "No matching branches" : "No available local branches"}
+              </div>
+            ) : (
+              filteredBranches.map((branch) => (
+                <div
+                  key={branch.name}
+                  role="option"
+                  aria-selected={branch.name === selectedBranch}
+                  onClick={() => {
+                    onSelect(branch.name);
+                    onOpenChange(false);
+                    onQueryChange("");
+                  }}
+                  className={cn(
+                    "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border font-mono",
+                    branch.name === selectedBranch && "bg-daintree-border"
+                  )}
+                >
+                  <span className="truncate">{branch.name}</span>
+                  {branch.name === selectedBranch && (
+                    <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+                  )}
+                </div>
+              ))
+            )}
+          </ScrollShadow>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/Worktree/views/HighlightBranchText.tsx
+++ b/src/components/Worktree/views/HighlightBranchText.tsx
@@ -1,0 +1,35 @@
+export function HighlightBranchText({
+  text,
+  matchRanges,
+  nameLength,
+}: {
+  text: string;
+  matchRanges: { start: number; end: number }[];
+  nameLength: number;
+}) {
+  if (matchRanges.length === 0) return <>{text}</>;
+
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (let i = 0; i < matchRanges.length; i++) {
+    const { start, end } = matchRanges[i]!;
+    if (start >= nameLength) break;
+    const clampedEnd = Math.min(end, nameLength - 1);
+    if (start > lastIndex) {
+      nodes.push(text.substring(lastIndex, start));
+    }
+    nodes.push(
+      <mark key={i} className="bg-daintree-accent/25 text-inherit rounded-sm">
+        {text.substring(start, clampedEnd + 1)}
+      </mark>
+    );
+    lastIndex = clampedEnd + 1;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.substring(lastIndex));
+  }
+
+  return <>{nodes}</>;
+}

--- a/src/components/Worktree/views/IssueSelectorView.tsx
+++ b/src/components/Worktree/views/IssueSelectorView.tsx
@@ -1,0 +1,108 @@
+import type { GitHubIssue } from "@shared/types/github";
+import { IssueSelector } from "@/components/GitHub/IssueSelector";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info, UserPlus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface IssueLinkerViewProps {
+  projectPath: string;
+  selectedIssue: GitHubIssue | null;
+  onSelectIssue: (issue: GitHubIssue | null) => void;
+  canAssignIssue: boolean;
+  assignWorktreeToSelf: boolean;
+  onSetAssignWorktreeToSelf: (assign: boolean) => void;
+  currentUser?: string;
+  currentUserAvatar?: string;
+  disabled?: boolean;
+}
+
+export function IssueLinkerView({
+  projectPath,
+  selectedIssue,
+  onSelectIssue,
+  canAssignIssue,
+  assignWorktreeToSelf,
+  onSetAssignWorktreeToSelf,
+  currentUser,
+  currentUserAvatar,
+  disabled,
+}: IssueLinkerViewProps) {
+  return (
+    <>
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <label className="block text-sm font-medium text-daintree-text">
+            Link Issue (Optional)
+          </label>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+                aria-label="Help for Link Issue field"
+                disabled={disabled}
+              >
+                <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                <span className="sr-only">Help for Link Issue field</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p>Select an issue to auto-generate a branch name</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <IssueSelector
+          projectPath={projectPath}
+          selectedIssue={selectedIssue}
+          onSelect={onSelectIssue}
+          disabled={disabled}
+        />
+      </div>
+
+      {canAssignIssue && (
+        <div className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border bg-daintree-bg/50 border-daintree-border transition-colors">
+          {currentUserAvatar ? (
+            <img
+              src={`${currentUserAvatar}${currentUserAvatar.includes("?") ? "&" : "?"}s=64`}
+              alt={currentUser}
+              className="w-8 h-8 rounded-full shrink-0"
+            />
+          ) : (
+            <div className="flex items-center justify-center w-8 h-8 rounded-full shrink-0 bg-overlay-medium text-daintree-text/60">
+              <UserPlus className="w-4 h-4" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-daintree-text">Assign to me</span>
+              <span className="text-xs text-daintree-text/50 font-mono">@{currentUser}</span>
+            </div>
+          </div>
+          <label className="relative inline-flex items-center cursor-pointer">
+            <input
+              type="checkbox"
+              checked={assignWorktreeToSelf}
+              onChange={(e) => onSetAssignWorktreeToSelf(e.target.checked)}
+              disabled={disabled}
+              className="sr-only peer"
+              aria-label="Assign issue to me when creating worktree"
+            />
+            <div
+              className={cn(
+                "w-9 h-5 rounded-full transition-colors",
+                "peer-focus-visible:ring-2 peer-focus-visible:ring-daintree-accent",
+                "after:content-[''] after:absolute after:top-0.5 after:left-0.5",
+                "after:rounded-full after:h-4 after:w-4",
+                "after:transition-transform after:duration-150",
+                assignWorktreeToSelf
+                  ? "bg-daintree-accent after:translate-x-4 after:bg-text-inverse"
+                  : "bg-daintree-border after:translate-x-0 after:bg-daintree-text",
+                disabled && "opacity-50 cursor-not-allowed"
+              )}
+            />
+          </label>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Worktree/views/NewBranchInput.tsx
+++ b/src/components/Worktree/views/NewBranchInput.tsx
@@ -1,0 +1,144 @@
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Spinner } from "@/components/ui/Spinner";
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PrefixSuggestion } from "../branchPrefixUtils";
+
+interface NewBranchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  isPending?: boolean;
+  isCheckingBranch: boolean;
+  errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
+  branchWasAutoResolved: boolean;
+  parsedBranch: { hasPrefix: boolean; prefix: string; slug: string; fullBranchName: string };
+  prefixPickerOpen: boolean;
+  onPrefixPickerOpenChange: (open: boolean) => void;
+  prefixSuggestions: PrefixSuggestion[];
+  prefixSelectedIndex: number;
+  onPrefixKeyDown: (e: React.KeyboardEvent) => void;
+  onPrefixSelect: (suggestion: PrefixSuggestion) => void;
+  prefixListRef: React.RefObject<HTMLDivElement | null>;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+export function NewBranchInput({
+  value,
+  onChange,
+  isPending,
+  isCheckingBranch,
+  errorField,
+  branchWasAutoResolved,
+  parsedBranch,
+  prefixPickerOpen,
+  onPrefixPickerOpenChange,
+  prefixSuggestions,
+  prefixSelectedIndex,
+  onPrefixKeyDown,
+  onPrefixSelect,
+  prefixListRef,
+  inputRef,
+}: NewBranchInputProps) {
+  return (
+    <div className="space-y-2">
+      <label htmlFor="new-branch" className="block text-sm font-medium text-daintree-text">
+        New Branch Name
+      </label>
+      <Popover open={prefixPickerOpen} onOpenChange={onPrefixPickerOpenChange}>
+        <PopoverTrigger asChild>
+          <div className="relative">
+            <input
+              ref={inputRef}
+              id="new-branch"
+              type="text"
+              data-testid="branch-name-input"
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              onKeyDown={onPrefixKeyDown}
+              placeholder="feature/add-user-auth"
+              className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent font-mono text-sm"
+              disabled={isPending}
+              aria-invalid={errorField === "new-branch" ? true : undefined}
+              aria-describedby={
+                [
+                  errorField === "new-branch" ? "validation-error" : null,
+                  branchWasAutoResolved ? "branch-resolved-hint" : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ") || undefined
+              }
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls="prefix-list"
+              aria-expanded={prefixPickerOpen}
+            />
+            {isCheckingBranch && (
+              <Spinner
+                size="md"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
+              />
+            )}
+          </div>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[var(--radix-popover-trigger-width)] p-0 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.stopPropagation()}
+        >
+          <ScrollShadow
+            ref={prefixListRef}
+            id="prefix-list"
+            role="listbox"
+            className="max-h-[240px]"
+            scrollClassName="p-1"
+          >
+            {prefixSuggestions.length === 0 ? (
+              <div className="py-4 text-center text-sm text-daintree-text/60">
+                No matching prefixes
+              </div>
+            ) : (
+              prefixSuggestions.map((suggestion, index) => (
+                <div
+                  key={suggestion.type.prefix}
+                  role="option"
+                  aria-selected={index === prefixSelectedIndex}
+                  onClick={() => onPrefixSelect(suggestion)}
+                  className={cn(
+                    "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                    index === prefixSelectedIndex && "bg-overlay-selected"
+                  )}
+                >
+                  <span className="font-mono text-daintree-text">{suggestion.type.prefix}/</span>
+                  <span className="text-daintree-text/60">{suggestion.type.displayName}</span>
+                </div>
+              ))
+            )}
+          </ScrollShadow>
+        </PopoverContent>
+      </Popover>
+      <p className="text-xs text-daintree-text/60 select-text">
+        {parsedBranch.hasPrefix ? (
+          <>
+            <span className="font-mono text-daintree-text">{parsedBranch.prefix}/</span>
+            <span className="font-mono">{parsedBranch.slug || "..."}</span>
+          </>
+        ) : (
+          <span className="font-mono">{parsedBranch.fullBranchName || "..."}</span>
+        )}
+      </p>
+      {branchWasAutoResolved && (
+        <p
+          id="branch-resolved-hint"
+          className="text-xs text-status-success flex items-center gap-1.5 mt-1"
+          role="status"
+          aria-live="polite"
+        >
+          <Info className="w-3.5 h-3.5" aria-hidden="true" />
+          Name auto-incremented to avoid conflict with existing branch
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Worktree/views/PrHeader.tsx
+++ b/src/components/Worktree/views/PrHeader.tsx
@@ -1,0 +1,20 @@
+import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
+import { FolderGit2 } from "@/components/icons";
+import type { GitHubPR } from "@shared/types/github";
+
+interface PrHeaderProps {
+  pr: GitHubPR;
+}
+
+export function PrHeader({ pr }: PrHeaderProps) {
+  return (
+    <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-[var(--radius-md)] bg-overlay-subtle border border-border-strong text-sm min-w-0">
+      <FolderGit2 className="w-4 h-4 text-daintree-text/60 shrink-0" aria-hidden="true" />
+      <TruncatedTooltip content={`PR #${pr.number} — ${pr.title}`}>
+        <span className="text-daintree-text/80 min-w-0 truncate">
+          PR <span className="font-medium text-daintree-text">#{pr.number}</span> — {pr.title}
+        </span>
+      </TruncatedTooltip>
+    </div>
+  );
+}

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -1,0 +1,173 @@
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { Button } from "@/components/ui/button";
+import { Check, ChevronsUpDown, Copy, Play } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TerminalRecipe } from "@/types";
+import { CLONE_LAYOUT_ID } from "../hooks/useRecipePicker";
+
+interface RecipePickerPopoverProps {
+  recipes: TerminalRecipe[];
+  selectedRecipeId: string | null;
+  selectedRecipe: TerminalRecipe | undefined;
+  defaultRecipeId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectRecipe: (id: string | null) => void;
+  onMarkTouched: () => void;
+  disabled?: boolean;
+  label: string;
+  listId: string;
+}
+
+export function RecipePickerPopover({
+  recipes,
+  selectedRecipeId,
+  selectedRecipe,
+  defaultRecipeId,
+  open,
+  onOpenChange,
+  onSelectRecipe,
+  onMarkTouched,
+  disabled,
+  label,
+  listId,
+}: RecipePickerPopoverProps) {
+  const handleSelect = (id: string | null) => {
+    onMarkTouched();
+    onSelectRecipe(id);
+    onOpenChange(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor={listId} className="block text-sm font-medium text-daintree-text">
+        {label}
+      </label>
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <Button
+            id={listId}
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            aria-controls={listId}
+            className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
+            disabled={disabled}
+          >
+            <span className="flex items-center gap-2 truncate">
+              {selectedRecipeId === CLONE_LAYOUT_ID ? (
+                <>
+                  <Copy className="shrink-0 text-daintree-accent" />
+                  <span>Clone current layout</span>
+                </>
+              ) : selectedRecipe ? (
+                <>
+                  <Play className="shrink-0 text-daintree-accent" />
+                  <span>{selectedRecipe.name}</span>
+                  <span className="text-xs text-daintree-text/50">
+                    ({selectedRecipe.terminals.length} terminal
+                    {selectedRecipe.terminals.length !== 1 ? "s" : ""})
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Play className="shrink-0 text-daintree-accent" />
+                  <span className="text-daintree-text/60">Empty</span>
+                </>
+              )}
+            </span>
+            <ChevronsUpDown className="opacity-50 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[400px] p-0"
+          align="start"
+          onEscapeKeyDown={(e) => e.stopPropagation()}
+        >
+          <ScrollShadow id={listId} role="listbox" className="max-h-[300px]" scrollClassName="p-1">
+            <div
+              role="option"
+              aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  handleSelect(CLONE_LAYOUT_ID);
+                }
+              }}
+              onClick={() => handleSelect(CLONE_LAYOUT_ID)}
+              className={cn(
+                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                selectedRecipeId === CLONE_LAYOUT_ID && "bg-daintree-border"
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <Copy className="h-3.5 w-3.5 text-daintree-text/50" />
+                <span>Clone current layout</span>
+              </div>
+              {selectedRecipeId === CLONE_LAYOUT_ID && (
+                <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+              )}
+            </div>
+            <div
+              role="option"
+              aria-selected={selectedRecipeId === null}
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  handleSelect(null);
+                }
+              }}
+              onClick={() => handleSelect(null)}
+              className={cn(
+                "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                selectedRecipeId === null && "bg-daintree-border"
+              )}
+            >
+              <span className="text-daintree-text/60">Empty</span>
+              {selectedRecipeId === null && (
+                <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+              )}
+            </div>
+            {recipes.map((recipe) => (
+              <div
+                key={recipe.id}
+                role="option"
+                aria-selected={recipe.id === selectedRecipeId}
+                tabIndex={0}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    handleSelect(recipe.id);
+                  }
+                }}
+                onClick={() => handleSelect(recipe.id)}
+                className={cn(
+                  "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-daintree-border",
+                  recipe.id === selectedRecipeId && "bg-daintree-border"
+                )}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="truncate">{recipe.name}</span>
+                  <span className="text-xs text-daintree-text/50 shrink-0">
+                    {recipe.terminals.length} terminal
+                    {recipe.terminals.length !== 1 ? "s" : ""}
+                  </span>
+                  {recipe.id === defaultRecipeId && (
+                    <span className="text-xs text-daintree-text/50 shrink-0">(default)</span>
+                  )}
+                </div>
+                {recipe.id === selectedRecipeId && (
+                  <Check className="h-4 w-4 shrink-0 text-daintree-text" />
+                )}
+              </div>
+            ))}
+          </ScrollShadow>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/Worktree/views/RecipePickerPopover.tsx
+++ b/src/components/Worktree/views/RecipePickerPopover.tsx
@@ -41,13 +41,13 @@ export function RecipePickerPopover({
 
   return (
     <div className="space-y-2">
-      <label htmlFor={listId} className="block text-sm font-medium text-daintree-text">
+      <label htmlFor={`${listId}-trigger`} className="block text-sm font-medium text-daintree-text">
         {label}
       </label>
       <Popover open={open} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
           <Button
-            id={listId}
+            id={`${listId}-trigger`}
             variant="outline"
             role="combobox"
             aria-expanded={open}

--- a/src/components/Worktree/views/WorktreePathPicker.tsx
+++ b/src/components/Worktree/views/WorktreePathPicker.tsx
@@ -1,0 +1,87 @@
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/Spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { FolderOpen, Info } from "lucide-react";
+
+interface WorktreePathPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  isPending?: boolean;
+  isGeneratingPath: boolean;
+  errorField?: "base-branch" | "new-branch" | "worktree-path" | null;
+  pathWasAutoResolved: boolean;
+  onBrowseClick: () => void;
+  disabled?: boolean;
+}
+
+export function WorktreePathPicker({
+  value,
+  onChange,
+  isPending,
+  isGeneratingPath,
+  errorField,
+  pathWasAutoResolved,
+  onBrowseClick,
+  disabled,
+}: WorktreePathPickerProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <label htmlFor="worktree-path" className="block text-sm font-medium text-daintree-text">
+          Worktree Path
+        </label>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent focus-visible:ring-offset-2"
+              aria-label="Help for Worktree Path field"
+              disabled={disabled}
+            >
+              <Info className="w-3.5 h-3.5" aria-hidden="true" />
+              <span className="sr-only">Help for Worktree Path field</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p>Directory where the worktree will be created</p>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <div className="flex gap-2 items-center">
+        <div className="relative flex-1">
+          <input
+            id="worktree-path"
+            data-testid="worktree-path-input"
+            type="text"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder="/path/to/worktree"
+            className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
+            disabled={isPending}
+            aria-invalid={errorField === "worktree-path" ? true : undefined}
+            aria-describedby={errorField === "worktree-path" ? "validation-error" : undefined}
+          />
+          {isGeneratingPath && (
+            <Spinner
+              size="md"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"
+            />
+          )}
+        </div>
+        <Button variant="outline" size="sm" onClick={onBrowseClick} disabled={disabled}>
+          <FolderOpen />
+        </Button>
+      </div>
+      {pathWasAutoResolved && (
+        <p
+          className="text-xs text-status-success flex items-center gap-1.5 mt-1"
+          role="status"
+          aria-live="polite"
+        >
+          <Info className="w-3.5 h-3.5" aria-hidden="true" />
+          Path auto-incremented to avoid conflict with existing directory
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Worktree/views/index.ts
+++ b/src/components/Worktree/views/index.ts
@@ -1,0 +1,10 @@
+export { PrHeader } from "./PrHeader";
+export { IssueLinkerView } from "./IssueSelectorView";
+export { BranchModeControl } from "./BranchModeControl";
+export { BaseBranchCombobox } from "./BaseBranchCombobox";
+export { ExistingBranchPicker } from "./ExistingBranchPicker";
+export { NewBranchInput } from "./NewBranchInput";
+export { WorktreePathPicker } from "./WorktreePathPicker";
+export { EnvironmentRadioGroup } from "./EnvironmentRadioGroup";
+export { RecipePickerPopover } from "./RecipePickerPopover";
+export { HighlightBranchText } from "./HighlightBranchText";

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -157,6 +157,10 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
   "#5984": [
     "src/components/GitHub/BulkCreateWorktreeDialog.tsx",
     "src/components/Worktree/NewWorktreeDialog.tsx",
+    "src/components/Worktree/views/ExistingBranchPicker.tsx",
+    "src/components/Worktree/views/HighlightBranchText.tsx",
+    "src/components/Worktree/views/IssueSelectorView.tsx",
+    "src/components/Worktree/views/RecipePickerPopover.tsx",
   ],
 
   // #5985: [panels] Exit Focus badge competes with macro-focus ring


### PR DESCRIPTION
## Summary

`NewWorktreeDialog` was the largest component in the app at 1840 lines, with JSX nesting 8 levels deep and a 280-line `handleSubmit`. This PR pulls it apart into self-contained pieces -- 7 subview components, 2 shared components, and 2 hooks for form state -- without changing any behavior. A pure structural refactor.

Resolves #6696.

## Changes

- Extracted 7 subview components into `src/components/Worktree/views/`: `IssueSelectorView`, `BranchModeControl`, `BaseBranchCombobox`, `ExistingBranchPicker`, `NewBranchInput`, `WorktreePathPicker`, and `EnvironmentRadioGroup`.
- Extracted 2 shared components from the dialog: `HighlightBranchText` and a reusable `RecipePickerPopover` (also replaces near-duplicate recipe JSX in `BulkCreateWorktreeDialog`).
- Added `useWorktreeFormErrors` hook -- a reducer that replaces 3 `useState` + 3 `useRef` calls for tracking touched state.
- Added `useWorktreeFormValidation` hook -- extracts the validation logic that was inlined in `handleCreate`.
- Added `isCreatingRef` reentrancy guard to prevent double-submit on fast clicks.
- `BulkCreateWorktreeDialog` now shares the extracted `RecipePickerPopover` instead of maintaining its own copy.

## Testing

87 tests pass. Typecheck, lint, and format are clean.