### PR TITLE
fix(assistant): preserve session across system sleep/wake

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -251,11 +251,18 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
         .then((metrics) => {
           if (cancelled) return;
           if (metrics.isCurrentlySleeping) return;
+          // Re-check after the IPC round-trip: the user may have reopened the
+          // lid (hidden → visible) or onSuspend may have arrived while we
+          // were waiting. Either way, skip teardown.
+          if (!document.hidden) return;
+          if (isSystemSuspendedRef.current) return;
           tearDown();
         })
         .catch((err: unknown) => {
           if (cancelled) return;
           logError("HelpPanel: failed to read systemSleep metrics", err);
+          if (!document.hidden) return;
+          if (isSystemSuspendedRef.current) return;
           tearDown();
         });
     };

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -197,6 +197,12 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
   // cleanup paths revoke this ref so the token isn't leaked until 7-day GC.
   const pendingSessionIdRef = useRef<string | null>(null);
 
+  // Set true while the OS is suspended so the visibilitychange teardown below
+  // distinguishes "system slept" from "project switched / window unloaded".
+  // macOS flips document.hidden=true on display-off, which is indistinguishable
+  // from a project switch without this flag (issue #6758).
+  const isSystemSuspendedRef = useRef(false);
+
   const revokePendingSession = useCallback(() => {
     const pending = pendingSessionIdRef.current;
     if (pending) {
@@ -220,9 +226,12 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
   // Clean up help terminal when the view becomes hidden (project switch, window close).
   // In Electron 41, beforeunload does not fire on WebContentsView detach, but
   // visibilitychange does — this covers both project switches and window unload.
+  // Skip teardown when the OS is suspended (display-off / sleep) — otherwise
+  // the assistant restarts and loses its conversation on every wake (#6758).
   useEffect(() => {
-    const handler = () => {
-      if (!document.hidden) return;
+    let cancelled = false;
+
+    const tearDown = () => {
       const state = useHelpPanelStore.getState();
       if (state.terminalId) {
         usePanelStore.getState().removePanel(state.terminalId);
@@ -231,8 +240,39 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
       }
       revokePendingSession();
     };
+
+    const handler = () => {
+      if (!document.hidden) return;
+      if (isSystemSuspendedRef.current) return;
+      // Race: visibilitychange may fire before the suspend IPC reaches the
+      // renderer. Confirm with the main process before tearing down.
+      void window.electron.systemSleep
+        .getMetrics()
+        .then((metrics) => {
+          if (cancelled) return;
+          if (metrics.isCurrentlySleeping) return;
+          tearDown();
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          logError("HelpPanel: failed to read systemSleep metrics", err);
+          tearDown();
+        });
+    };
+
+    const offSuspend = window.electron.systemSleep.onSuspend(() => {
+      isSystemSuspendedRef.current = true;
+    });
+    const offWake = window.electron.systemSleep.onWake(() => {
+      isSystemSuspendedRef.current = false;
+    });
     document.addEventListener("visibilitychange", handler);
-    return () => document.removeEventListener("visibilitychange", handler);
+    return () => {
+      cancelled = true;
+      offSuspend();
+      offWake();
+      document.removeEventListener("visibilitychange", handler);
+    };
   }, [revokePendingSession]);
 
   // Auto-launch preferred agent when panel opens without an active terminal.

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1482,6 +1482,89 @@ describe("HelpPanel — visibilitychange teardown vs. system sleep (issue #6758)
     expect(mockRevokeSession).toHaveBeenCalledWith("session-sleep");
   });
 
+  it("skips teardown if the document becomes visible before getMetrics resolves", async () => {
+    let resolveMetrics:
+      | ((value: {
+          totalSleepMs: number;
+          sleepPeriods: never[];
+          isCurrentlySleeping: boolean;
+          currentSleepStart: number | null;
+        }) => void)
+      | null = null;
+    mockSystemSleepGetMetrics.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMetrics = resolve;
+        })
+    );
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    await act(async () => {
+      resolveMetrics?.({
+        totalSleepMs: 0,
+        sleepPeriods: [],
+        isCurrentlySleeping: false,
+        currentSleepStart: null,
+      });
+    });
+    await flushAsync();
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+  });
+
+  it("skips teardown if onSuspend arrives while getMetrics is in flight", async () => {
+    let resolveMetrics:
+      | ((value: {
+          totalSleepMs: number;
+          sleepPeriods: never[];
+          isCurrentlySleeping: boolean;
+          currentSleepStart: number | null;
+        }) => void)
+      | null = null;
+    mockSystemSleepGetMetrics.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMetrics = resolve;
+        })
+    );
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    act(() => {
+      systemSleepListeners.suspend.forEach((cb) => cb());
+    });
+
+    await act(async () => {
+      resolveMetrics?.({
+        totalSleepMs: 0,
+        sleepPeriods: [],
+        isCurrentlySleeping: false,
+        currentSleepStart: null,
+      });
+    });
+    await flushAsync();
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+  });
+
   it("clears the suspend guard on wake so subsequent visibilitychange tears down normally", async () => {
     await act(async () => {
       mountWithBoundTerminal();

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -12,6 +12,10 @@ const {
   mockRevokeSession,
   mockGetAssistantSupportedAgentIds,
   mockGetHelpAssistantSettings,
+  mockSystemSleepGetMetrics,
+  mockSystemSleepOnSuspend,
+  mockSystemSleepOnWake,
+  systemSleepListeners,
   helpPanelState,
   panelStoreState,
   cliAvailabilityState,
@@ -34,6 +38,18 @@ const {
     auditRetention: 7,
     customArgs: "",
   }),
+  mockSystemSleepGetMetrics: vi.fn().mockResolvedValue({
+    totalSleepMs: 0,
+    sleepPeriods: [],
+    isCurrentlySleeping: false,
+    currentSleepStart: null,
+  }),
+  mockSystemSleepOnSuspend: vi.fn(),
+  mockSystemSleepOnWake: vi.fn(),
+  systemSleepListeners: {
+    suspend: [] as Array<() => void>,
+    wake: [] as Array<(sleepDurationMs: number) => void>,
+  },
   helpPanelState: {
     isOpen: true,
     width: 380,
@@ -285,6 +301,32 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetState();
 
+  systemSleepListeners.suspend.length = 0;
+  systemSleepListeners.wake.length = 0;
+  mockSystemSleepGetMetrics.mockReset();
+  mockSystemSleepGetMetrics.mockResolvedValue({
+    totalSleepMs: 0,
+    sleepPeriods: [],
+    isCurrentlySleeping: false,
+    currentSleepStart: null,
+  });
+  mockSystemSleepOnSuspend.mockReset();
+  mockSystemSleepOnSuspend.mockImplementation((cb: () => void) => {
+    systemSleepListeners.suspend.push(cb);
+    return () => {
+      const idx = systemSleepListeners.suspend.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.suspend.splice(idx, 1);
+    };
+  });
+  mockSystemSleepOnWake.mockReset();
+  mockSystemSleepOnWake.mockImplementation((cb: (sleepDurationMs: number) => void) => {
+    systemSleepListeners.wake.push(cb);
+    return () => {
+      const idx = systemSleepListeners.wake.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.wake.splice(idx, 1);
+    };
+  });
+
   Object.defineProperty(globalThis, "window", {
     value: {
       electron: {
@@ -296,6 +338,11 @@ beforeEach(() => {
         },
         helpAssistant: {
           getSettings: mockGetHelpAssistantSettings,
+        },
+        systemSleep: {
+          getMetrics: mockSystemSleepGetMetrics,
+          onSuspend: mockSystemSleepOnSuspend,
+          onWake: mockSystemSleepOnWake,
         },
       },
     },
@@ -1336,5 +1383,125 @@ describe("HelpPanel — close confirmation guard (issue #6623)", () => {
     expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
     expect(panelStoreState.removePanel).not.toHaveBeenCalled();
     expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("HelpPanel — visibilitychange teardown vs. system sleep (issue #6758)", () => {
+  function mountWithBoundTerminal() {
+    helpPanelState.terminalId = "term-sleep";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "session-sleep";
+    panelStoreState.panelsById = { "term-sleep": { id: "term-sleep" } };
+    return render(<HelpPanel width={380} />);
+  }
+
+  async function flushAsync() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("skips teardown when document.hidden flips during system suspend", async () => {
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    act(() => {
+      systemSleepListeners.suspend.forEach((cb) => cb());
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+    expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+    expect(mockSystemSleepGetMetrics).not.toHaveBeenCalled();
+  });
+
+  it("skips teardown when getMetrics reports the system is currently sleeping (race fallback)", async () => {
+    mockSystemSleepGetMetrics.mockResolvedValueOnce({
+      totalSleepMs: 0,
+      sleepPeriods: [],
+      isCurrentlySleeping: true,
+      currentSleepStart: Date.now(),
+    });
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    expect(mockSystemSleepGetMetrics).toHaveBeenCalledTimes(1);
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+  });
+
+  it("tears down when getMetrics reports the system is awake (project switch / window close path)", async () => {
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    expect(mockSystemSleepGetMetrics).toHaveBeenCalledTimes(1);
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-sleep");
+    expect(mockRevokeSession).toHaveBeenCalledWith("session-sleep");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+  });
+
+  it("tears down (safe fallback) when getMetrics rejects", async () => {
+    mockSystemSleepGetMetrics.mockRejectedValueOnce(new Error("ipc broken"));
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    expect(mockSystemSleepGetMetrics).toHaveBeenCalledTimes(1);
+    expect(mockLogError).toHaveBeenCalled();
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-sleep");
+    expect(mockRevokeSession).toHaveBeenCalledWith("session-sleep");
+  });
+
+  it("clears the suspend guard on wake so subsequent visibilitychange tears down normally", async () => {
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    act(() => {
+      systemSleepListeners.suspend.forEach((cb) => cb());
+    });
+    act(() => {
+      systemSleepListeners.wake.forEach((cb) => cb(1000));
+    });
+
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    expect(mockSystemSleepGetMetrics).toHaveBeenCalledTimes(1);
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-sleep");
+    expect(mockRevokeSession).toHaveBeenCalledWith("session-sleep");
   });
 });


### PR DESCRIPTION
## Summary

- The Daintree assistant panel was restarting and losing conversation context after system sleep/wake. Regular agent terminals were unaffected because they go through `PtyClient.pauseAll()`/`resumeAll()` — the assistant panel had no equivalent guard.
- Added sleep guard logic to `HelpPanel.tsx` using `window.electron.systemSleep.onSuspend` and `onWake`. On `visibilitychange`, if `isSystemSuspendedRef` is set, teardown is skipped. A `getMetrics` IPC call serves as a race fallback for the lid-close timing window where `visibilitychange` fires before `onSuspend` arrives.
- Re-checks `document.hidden` and the suspend ref after the IPC resolves to handle quick lid-close/reopen and late `onSuspend` arrivals. Cancellation guard via a local `cancelled` flag in cleanup.

Resolves #6758

## Changes

- `src/components/HelpPanel/HelpPanel.tsx` — sleep guard on the `visibilitychange` teardown effect
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` — 7 new test cases covering suspend-before-hidden, `getMetrics` sleeping/awake paths, rejection fallback, wake clears ref, visibility change and `onSuspend` during in-flight `getMetrics`

## Testing

57 tests pass in `HelpPanel.helpLaunch.test.tsx`. Typecheck, lint, and format all clean.