### PR TITLE
feat(skeleton): polish cold-start skeleton with Doherty gate and stuck-state cue

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,28 +30,20 @@
       }
 
       /*
-       * Container opacity timeline for #startup-skeleton (10.4s total):
-       *   0–400ms (0–3.85%):    invisible — Doherty anti-flicker gate
-       *   400ms–9.5s (4–91.35%): fully visible
-       *   9.5s–10.4s (91.35–100%): safety fade-out if React never hydrates
-       *
-       * One keyframe encodes both the gate and the safety-fade because two
-       * comma-separated animations on the same property would conflict via
-       * CSS animation composite order (later entry wins — the safety-fade
-       * would immediately override the gate).
+       * Doherty 400ms anti-flicker gate. `animation-fill-mode: backwards`
+       * holds the `from` keyframe (opacity: 0) during the 400ms delay so
+       * sub-threshold loads never flash a skeleton, then fades to opacity 1
+       * over 200ms. Base CSS `opacity: 1` is the post-animation resting
+       * state, which lets the JS-driven `.fade-out` transition take over
+       * cleanly when removeStartupSkeleton() runs. The previous 10s silent
+       * safety-fade is replaced by the visible stuck-state overlay at 6s.
        */
-      @keyframes skeleton-safety-fade {
-        0%,
-        3.85% {
+      @keyframes skeleton-doherty-gate {
+        from {
           opacity: 0;
         }
-        4%,
-        91.35% {
+        to {
           opacity: 1;
-        }
-        100% {
-          opacity: 0;
-          pointer-events: none;
         }
       }
 
@@ -86,8 +78,7 @@
         display: flex;
         flex-direction: column;
         background: var(--theme-surface-grid, #0e0e0d);
-        opacity: 0;
-        animation: skeleton-safety-fade 10.4s ease-out forwards;
+        animation: skeleton-doherty-gate 200ms ease-out 400ms backwards;
         transition: opacity 120ms ease-out;
       }
       #startup-skeleton.fade-out {
@@ -853,10 +844,7 @@
       /* ── Reduced motion ── */
       @media (prefers-reduced-motion: reduce) {
         #startup-skeleton {
-          /* opacity: 1 here pairs with base opacity: 0 — without animation,
-             we need an explicit visible state so the skeleton still shows. */
           animation: none;
-          opacity: 1;
         }
         .skel-shape::after,
         .skel-recipe::after,
@@ -877,8 +865,11 @@
           animation: none;
           opacity: 1;
         }
-        /* Stuck-state animation is a delay mechanism, not decoration — keep
-           the keyframe so the 6s safety threshold still gates visibility. */
+        /* Snap the stuck-state in without a fade. Duration 0ms preserves the
+           6s safety delay (the timing mechanism) while removing the motion. */
+        .skeleton-stuck {
+          animation-duration: 0ms;
+        }
       }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -29,9 +29,24 @@
         }
       }
 
+      /*
+       * Container opacity timeline for #startup-skeleton (10.4s total):
+       *   0–400ms (0–3.85%):    invisible — Doherty anti-flicker gate
+       *   400ms–9.5s (4–91.35%): fully visible
+       *   9.5s–10.4s (91.35–100%): safety fade-out if React never hydrates
+       *
+       * One keyframe encodes both the gate and the safety-fade because two
+       * comma-separated animations on the same property would conflict via
+       * CSS animation composite order (later entry wins — the safety-fade
+       * would immediately override the gate).
+       */
       @keyframes skeleton-safety-fade {
         0%,
-        99% {
+        3.85% {
+          opacity: 0;
+        }
+        4%,
+        91.35% {
           opacity: 1;
         }
         100% {
@@ -50,6 +65,19 @@
         }
       }
 
+      /* Stuck-state reveal — animates pointer-events as a discrete property
+         so the overlay can't intercept clicks during the 6s delay window. */
+      @keyframes skeleton-stuck-reveal {
+        from {
+          opacity: 0;
+          pointer-events: none;
+        }
+        to {
+          opacity: 1;
+          pointer-events: auto;
+        }
+      }
+
       /* ── Base skeleton container ── */
       #startup-skeleton {
         position: fixed;
@@ -58,7 +86,8 @@
         display: flex;
         flex-direction: column;
         background: var(--theme-surface-grid, #0e0e0d);
-        animation: skeleton-safety-fade 10s forwards;
+        opacity: 0;
+        animation: skeleton-safety-fade 10.4s ease-out forwards;
         transition: opacity 120ms ease-out;
       }
       #startup-skeleton.fade-out {
@@ -395,6 +424,79 @@
         animation: skeleton-shimmer 1.5s linear infinite;
       }
 
+      /* ── Tagline (real text — synced with WelcomeScreen.tsx) ── */
+      .skeleton-tagline {
+        margin-top: 12px;
+        font-size: 13px;
+        font-weight: 500;
+        line-height: 1.5;
+        color: color-mix(
+          in oklch,
+          var(--theme-surface-grid, #0e0e0d),
+          var(--theme-text-primary, #e4e4e7) 60%
+        );
+        opacity: 0;
+        animation: skeleton-reveal 400ms ease-out forwards;
+        animation-delay: 160ms;
+      }
+
+      /* ── Stuck-state overlay (fades in at 6s if React never hydrates) ── */
+      .skeleton-stuck {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 24px;
+        background: color-mix(in oklch, var(--theme-surface-grid, #0e0e0d) 88%, transparent);
+        opacity: 0;
+        pointer-events: none;
+        animation: skeleton-stuck-reveal 200ms ease-out forwards;
+        animation-delay: 6000ms;
+      }
+      .skeleton-stuck-title {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+        line-height: 1.5;
+        color: var(--theme-text-primary, #e4e4e7);
+        text-align: center;
+      }
+      .skeleton-stuck-btn {
+        padding: 7px 14px;
+        border-radius: 6px;
+        border: 1px solid
+          color-mix(
+            in oklch,
+            var(--theme-surface-grid, #0e0e0d),
+            var(--theme-text-primary, #e4e4e7) 18%
+          );
+        background: color-mix(
+          in oklch,
+          var(--theme-surface-grid, #0e0e0d),
+          var(--theme-text-primary, #e4e4e7) 6%
+        );
+        color: var(--theme-text-primary, #e4e4e7);
+        font: inherit;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background-color 150ms ease-out;
+      }
+      .skeleton-stuck-btn:hover {
+        background: color-mix(
+          in oklch,
+          var(--theme-surface-grid, #0e0e0d),
+          var(--theme-text-primary, #e4e4e7) 10%
+        );
+      }
+      .skeleton-stuck-btn:focus-visible {
+        outline: 2px solid var(--theme-text-primary, #e4e4e7);
+        outline-offset: 2px;
+      }
+
       /* ── Recipes skeleton ── */
       .skeleton-recipes {
         margin-bottom: 24px;
@@ -710,12 +812,51 @@
             var(--theme-text-primary, #1e252e) 5%
           );
         }
+        .skeleton-tagline {
+          color: color-mix(
+            in oklch,
+            var(--theme-surface-grid, #cdd3db),
+            var(--theme-text-primary, #1e252e) 60%
+          );
+        }
+        .skeleton-stuck {
+          background: color-mix(in oklch, var(--theme-surface-grid, #cdd3db) 88%, transparent);
+        }
+        .skeleton-stuck-title {
+          color: var(--theme-text-primary, #1e252e);
+        }
+        .skeleton-stuck-btn {
+          border-color: color-mix(
+            in oklch,
+            var(--theme-surface-grid, #cdd3db),
+            var(--theme-text-primary, #1e252e) 18%
+          );
+          background: color-mix(
+            in oklch,
+            var(--theme-surface-grid, #cdd3db),
+            var(--theme-text-primary, #1e252e) 6%
+          );
+          color: var(--theme-text-primary, #1e252e);
+        }
+        .skeleton-stuck-btn:hover {
+          background: color-mix(
+            in oklch,
+            var(--theme-surface-grid, #cdd3db),
+            var(--theme-text-primary, #1e252e) 10%
+          );
+        }
+        .skeleton-stuck-btn:focus-visible {
+          outline-color: var(--theme-text-primary, #1e252e);
+        }
       }
 
       /* ── Reduced motion ── */
       @media (prefers-reduced-motion: reduce) {
         #startup-skeleton {
+          /* opacity: 1 here pairs with base opacity: 0 — without animation,
+             we need an explicit visible state so the skeleton still shows. */
           animation: none;
+          opacity: 1;
         }
         .skel-shape::after,
         .skel-recipe::after,
@@ -732,6 +873,12 @@
           animation: none;
           opacity: 1;
         }
+        .skeleton-tagline {
+          animation: none;
+          opacity: 1;
+        }
+        /* Stuck-state animation is a delay mechanism, not decoration — keep
+           the keyframe so the 6s safety threshold still gates visibility. */
       }
     </style>
   </head>
@@ -880,6 +1027,8 @@
                   />
                 </svg>
                 <div class="skeleton-title"></div>
+                <!-- Source of truth: src/components/Project/WelcomeScreen.tsx line 83 -->
+                <p class="skeleton-tagline">A habitat for your AI agents.</p>
               </div>
 
               <!-- Recipes (reveals fourth) -->
@@ -978,8 +1127,15 @@
         </div>
         <!-- /skeleton-main-col -->
       </div>
+
+      <!-- Stuck-state recovery cue (CSS animation-delay reveals it at 6s) -->
+      <div class="skeleton-stuck" role="alert" aria-live="assertive">
+        <p class="skeleton-stuck-title">Daintree is taking longer than expected</p>
+        <button type="button" class="skeleton-stuck-btn" id="skeleton-stuck-btn">Reload app</button>
+      </div>
     </div>
     <script src="/skeleton-heatmap.js"></script>
+    <script src="/skeleton-stuck.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/skeleton-stuck.js
+++ b/public/skeleton-stuck.js
@@ -1,0 +1,10 @@
+/* global document, window */
+// Wires the stuck-state Reload button. Production CSP forbids inline
+// onclick handlers (script-src 'self' has no 'unsafe-inline').
+(function () {
+  var btn = document.getElementById("skeleton-stuck-btn");
+  if (!btn) return;
+  btn.addEventListener("click", function () {
+    window.location.reload();
+  });
+})();


### PR DESCRIPTION
## Summary

- Adds a 400ms Doherty anti-flicker gate to `#startup-skeleton` via `animation-fill-mode: backwards` — sub-threshold loads never flash the skeleton
- Embeds the "A habitat for your AI agents." tagline in the skeleton's logo section (synced with `WelcomeScreen.tsx` via comment)
- Replaces the silent 10s `skeleton-safety-fade` with a visible stuck-state overlay at 6s: title "Daintree is taking longer than expected" and a "Reload app" button as a real recovery affordance

Resolves #6754

## Changes

- `index.html` — new `skeleton-gate` keyframe for the container delay; `skeleton-stuck-reveal` keyframe that animates `pointer-events` as a discrete property so the overlay can't intercept clicks during the 6s window; tagline HTML; light-mode and `prefers-reduced-motion` overrides extended to cover all new elements; reduced-motion path snaps the stuck-state in at 0ms duration while preserving the 6s timing gate
- `public/skeleton-stuck.js` (new, 11 lines) — CSP-safe external script wiring the "Reload app" button click handler; production CSP forbids inline `onclick` handlers so this lives outside `index.html`

## Testing

- Warm cache launch (sub-400ms hydration): skeleton never becomes visible
- Slow launch (3–6s): skeleton fades in at 400ms, tagline visible, no stuck-state overlay
- Stuck launch (>6s): overlay appears with title and "Reload app" button; clicking reloads
- `prefers-reduced-motion`: skeleton and stuck-state appear immediately without animation; 6s timing gate still holds