### PR TITLE
feat(shortcuts): polish first-run pedagogy — 500ms hold, biased tip rotation

### DIFF
--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act, render, cleanup } from "@testing-library/react";
+import { act, render, fireEvent, cleanup } from "@testing-library/react";
 
 vi.mock("@/hooks/useKeybinding", () => ({
   useKeybindingDisplay: () => "",
@@ -9,6 +9,13 @@ vi.mock("@/hooks/useKeybinding", () => ({
 const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch },
+}));
+
+const { isAgentLaunchableMock } = vi.hoisted(() => ({
+  isAgentLaunchableMock: vi.fn(() => true),
+}));
+vi.mock("../../../../shared/utils/agentAvailability", () => ({
+  isAgentLaunchable: (...args: unknown[]) => isAgentLaunchableMock(...args),
 }));
 
 import { RotatingTip, TIPS } from "../contentGridTips";
@@ -45,11 +52,13 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     setUnhydrated();
     useCliAvailabilityStore.setState({ availability: makeAvailability("ready") });
     dispatch.mockClear();
+    isAgentLaunchableMock.mockReturnValue(true);
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    isAgentLaunchableMock.mockReturnValue(true);
   });
 
   it("renders nothing while shortcutHintStore is not hydrated", () => {
@@ -123,18 +132,71 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     expect(after).toBe(before);
   });
 
-  it("renders nothing when no tips pass agent availability", () => {
-    // Filter all tips out by claiming no agents are launchable AND mark every
-    // non-agent tip as having a `requiredAgents` constraint. Since we can't
-    // mutate TIPS, instead make all agents missing and verify a tip still
-    // renders (most tips have no requiredAgents). This validates the empty
-    // path indirectly via the unhydrated case above.
+  it("still renders non-agent tips when all agents are unavailable", () => {
+    // Confirms over-filtering doesn't strip the rotation entirely — most tips
+    // have no `requiredAgents`, so they survive even when every agent is missing.
     useCliAvailabilityStore.setState({ availability: makeAvailability("missing") });
     const { container } = render(<RotatingTip />);
     setHydrated();
-    // At least one non-agent-gated tip exists, so we still get a tip even with
-    // all agents missing — this confirms filtering doesn't over-exclude.
     expect(container.querySelector("p")?.textContent).toMatch(/^Tip:/);
+  });
+
+  it("renders null when filteredTips is empty (no tip survives filtering)", () => {
+    // Drive `filteredTips.length === 0` by treating every tip as agent-gated and
+    // marking every agent as unlaunchable. Exercises the empty-filter branch
+    // in the useEffect guard.
+    isAgentLaunchableMock.mockReturnValue(false);
+    useCliAvailabilityStore.setState({ availability: makeAvailability("missing") });
+    // Patch every TIPS entry to require an agent so none survive the filter.
+    const originalRequired = TIPS.map((t) => t.requiredAgents);
+    TIPS.forEach((t) => {
+      t.requiredAgents = ["claude"];
+    });
+    try {
+      const { container } = render(<RotatingTip />);
+      setHydrated();
+      expect(container.firstChild).toBeNull();
+    } finally {
+      TIPS.forEach((t, i) => {
+        t.requiredAgents = originalRequired[i];
+      });
+    }
+  });
+
+  it("uses shortcutActionId for the count lookup (worktree-overview path)", () => {
+    // The worktree-overview tip dispatches "worktree.overview" via keyboard but
+    // has actionId "worktree.overview.open" for label clicks. Counts from kbd
+    // usage land under "worktree.overview", and the bias must respect that.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const counts: Record<string, number> = {};
+    // Saturate every tip's lookup key (shortcutActionId ?? actionId) except
+    // quick-switcher so we can confirm the chosen tip is quick-switcher.
+    for (const tip of TIPS) {
+      const key = tip.shortcutActionId ?? tip.actionId;
+      if (key && key !== "nav.quickSwitcher") {
+        counts[key] = 999;
+      }
+    }
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    expect(container.querySelector("button")?.textContent).toBe("Open Quick Switcher");
+  });
+
+  it("clicking the action label dispatches the tip's actionId", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const counts: Record<string, number> = {};
+    for (const tip of TIPS) {
+      const key = tip.shortcutActionId ?? tip.actionId;
+      if (key && key !== "nav.quickSwitcher") {
+        counts[key] = 999;
+      }
+    }
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+    expect(dispatch).toHaveBeenCalledWith("nav.quickSwitcher", undefined, { source: "user" });
   });
 });
 

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -12,10 +12,10 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 const { isAgentLaunchableMock } = vi.hoisted(() => ({
-  isAgentLaunchableMock: vi.fn(() => true),
+  isAgentLaunchableMock: vi.fn((_arg: unknown) => true),
 }));
 vi.mock("../../../../shared/utils/agentAvailability", () => ({
-  isAgentLaunchable: (...args: unknown[]) => isAgentLaunchableMock(...args),
+  isAgentLaunchable: (arg: unknown) => isAgentLaunchableMock(arg),
 }));
 
 import { RotatingTip, TIPS } from "../contentGridTips";

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, cleanup } from "@testing-library/react";
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useKeybindingDisplay: () => "",
+}));
+
+const { dispatch } = vi.hoisted(() => ({ dispatch: vi.fn() }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch },
+}));
+
+import { RotatingTip, TIPS } from "../contentGridTips";
+import { shortcutHintStore } from "@/store/shortcutHintStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+
+function setHydrated(counts: Record<string, number> = {}) {
+  act(() => {
+    shortcutHintStore.setState({ counts, hydrated: true });
+  });
+}
+
+function setUnhydrated() {
+  shortcutHintStore.setState({
+    counts: {},
+    hydrated: false,
+    pointer: null,
+    activeHint: null,
+    hintedHover: new Set(),
+  });
+}
+
+function makeAvailability(state: "ready" | "missing") {
+  return {
+    claude: state,
+    gemini: state,
+    codex: state,
+    terminal: state,
+  } as never;
+}
+
+describe("RotatingTip — count-biased selection (#6756)", () => {
+  beforeEach(() => {
+    setUnhydrated();
+    useCliAvailabilityStore.setState({ availability: makeAvailability("ready") });
+    dispatch.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing while shortcutHintStore is not hydrated", () => {
+    const { container } = render(<RotatingTip />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a tip once hydrated", () => {
+    const { container } = render(<RotatingTip />);
+    expect(container.firstChild).toBeNull();
+    setHydrated();
+    expect(container.querySelector("p")?.textContent).toMatch(/^Tip:/);
+  });
+
+  it("biases toward an unused (zero-count) actionId over high-count ones", () => {
+    // Math.random=0 always picks the first item in the prioritized subset.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    // Saturate every shortcut except `terminal.inject` so it is the unique
+    // zero-count tip and must be at index 0 of the sorted prioritized subset.
+    const counts: Record<string, number> = {};
+    for (const tip of TIPS) {
+      if (tip.actionId && tip.actionId !== "terminal.inject") {
+        counts[tip.actionId] = 999;
+      }
+    }
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    expect(container.querySelector("button")?.textContent).toBe("Inject Context");
+  });
+
+  it("limits selection to the lowest-count subset (high-count tips never win)", () => {
+    // Math.random=0.999... → last index of the prioritized subset.
+    vi.spyOn(Math, "random").mockReturnValue(0.9999);
+    // Every tip has a count except quick-switcher; force quick-switcher's count
+    // to exceed all others so it should be excluded from the lowest-N subset.
+    // Build counts so the 4-tip subset is { actionA, actionB, actionC, actionD }
+    // and quick-switcher has the highest count.
+    const counts: Record<string, number> = {};
+    TIPS.forEach((tip, idx) => {
+      if (!tip.actionId) return;
+      // Stagger counts so subset boundary is well-defined.
+      counts[tip.actionId] = idx === 0 ? 9999 : idx;
+    });
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    // quick-switcher has by far the largest count; it must NOT be the chosen tip.
+    expect(container.querySelector("button")?.textContent).not.toBe("Open Quick Switcher");
+  });
+
+  it("freezes the chosen tip — count updates after mount do not swap it", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const counts: Record<string, number> = {};
+    for (const tip of TIPS) {
+      if (tip.actionId && tip.actionId !== "nav.quickSwitcher") {
+        counts[tip.actionId] = 999;
+      }
+    }
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    const before = container.querySelector("button")?.textContent;
+    expect(before).toBe("Open Quick Switcher");
+
+    // Simulate the user invoking some other shortcut after the tip mounted.
+    act(() => {
+      shortcutHintStore.setState({
+        counts: { ...counts, "terminal.inject": 5 },
+      });
+    });
+
+    const after = container.querySelector("button")?.textContent;
+    expect(after).toBe(before);
+  });
+
+  it("renders nothing when no tips pass agent availability", () => {
+    // Filter all tips out by claiming no agents are launchable AND mark every
+    // non-agent tip as having a `requiredAgents` constraint. Since we can't
+    // mutate TIPS, instead make all agents missing and verify a tip still
+    // renders (most tips have no requiredAgents). This validates the empty
+    // path indirectly via the unhydrated case above.
+    useCliAvailabilityStore.setState({ availability: makeAvailability("missing") });
+    const { container } = render(<RotatingTip />);
+    setHydrated();
+    // At least one non-agent-gated tip exists, so we still get a tip even with
+    // all agents missing — this confirms filtering doesn't over-exclude.
+    expect(container.querySelector("p")?.textContent).toMatch(/^Tip:/);
+  });
+});
+
+describe("contentGridTips module — no module-level mutable counter (#6756, #4754)", () => {
+  it("does not declare a module-level mount counter", async () => {
+    const { readFile } = await import("fs/promises");
+    const { resolve } = await import("path");
+    const source = await readFile(resolve(__dirname, "../contentGridTips.tsx"), "utf-8");
+    expect(source).not.toMatch(/let\s+tipMountCount\b/);
+  });
+});

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -227,8 +227,13 @@ export function RotatingTip() {
   useEffect(() => {
     if (tip || !hydrated || filteredTips.length === 0) return;
     const counts = shortcutHintStore.getState().counts;
+    // Use shortcutActionId when present (mirrors LiveTipMessage lookup) so a tip
+    // whose kbd shortcut dispatches a different action than its label-click
+    // (e.g. worktree-overview: ⌘⇧O → "worktree.overview", click → ".open") still
+    // counts toward "used" when the user invokes it via keyboard.
+    const lookupKey = (tipEntry: TipEntry) => tipEntry.shortcutActionId ?? tipEntry.actionId ?? "";
     const prioritized = [...filteredTips]
-      .sort((a, b) => (counts[a.actionId ?? ""] ?? 0) - (counts[b.actionId ?? ""] ?? 0))
+      .sort((a, b) => (counts[lookupKey(a)] ?? 0) - (counts[lookupKey(b)] ?? 0))
       .slice(0, ROTATING_TIP_SUBSET_SIZE);
     // Pick randomly within the unused-bias subset so per-mount variety doesn't
     // require a module-level counter (which leaks between tests, see #4754).

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -1,11 +1,16 @@
-import React, { useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { useStore } from "zustand";
 import { Kbd } from "@/components/ui/Kbd";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { actionService } from "@/services/ActionService";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import type { ActionId } from "@shared/types/actions";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
+
+// HCI: surface 3–5 unlearned tips at a time; 4 balances variety vs cognitive load.
+const ROTATING_TIP_SUBSET_SIZE = 4;
 
 export interface TipEntry {
   id: string;
@@ -201,12 +206,12 @@ export function LiveTipMessage({ tip }: { tip: TipEntry }) {
   return <>{tip.message}</>;
 }
 
-let tipMountCount = 0;
-
 export function RotatingTip() {
   "use memo";
-  const mountIndex = useRef(tipMountCount++);
   const availability = useCliAvailabilityStore((s) => s.availability);
+  // Subscribe to `hydrated` only — `counts` are read once via getState() when we
+  // pick the tip, so subsequent increments don't churn or swap the visible tip.
+  const hydrated = useStore(shortcutHintStore, (s) => s.hydrated);
 
   const filteredTips = useMemo(
     () =>
@@ -217,9 +222,22 @@ export function RotatingTip() {
     [availability]
   );
 
-  if (filteredTips.length === 0) return null;
+  const [tip, setTip] = useState<TipEntry | null>(null);
 
-  const tip = filteredTips[mountIndex.current % filteredTips.length]!;
+  useEffect(() => {
+    if (tip || !hydrated || filteredTips.length === 0) return;
+    const counts = shortcutHintStore.getState().counts;
+    const prioritized = [...filteredTips]
+      .sort((a, b) => (counts[a.actionId ?? ""] ?? 0) - (counts[b.actionId ?? ""] ?? 0))
+      .slice(0, ROTATING_TIP_SUBSET_SIZE);
+    // Pick randomly within the unused-bias subset so per-mount variety doesn't
+    // require a module-level counter (which leaks between tests, see #4754).
+    const index = Math.floor(Math.random() * prioritized.length);
+    const picked = prioritized[index] ?? null;
+    if (picked) setTip(picked);
+  }, [tip, hydrated, filteredTips]);
+
+  if (!tip) return null;
 
   return (
     <div className="flex flex-col items-center gap-2 animate-in fade-in duration-200">

--- a/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
+++ b/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
@@ -122,6 +122,21 @@ describe("useHeldShortcutReveal", () => {
     expect(isRevealed()).toBe(false);
   });
 
+  it("cancels pending reveal if keyup fires at exactly 499ms (boundary)", () => {
+    renderHook(() => useHeldShortcutReveal());
+
+    act(() => dispatchKey("keydown", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    act(() => dispatchKey("keyup", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(isRevealed()).toBe(false);
+  });
+
   it("clears reveal on window blur", () => {
     renderHook(() => useHeldShortcutReveal());
 

--- a/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
+++ b/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
@@ -32,7 +32,18 @@ describe("useHeldShortcutReveal", () => {
     delete document.documentElement.dataset[REVEAL_DATASET_KEY];
   });
 
-  it("does not reveal before 1s threshold", () => {
+  it("does not reveal before 500ms threshold", () => {
+    renderHook(() => useHeldShortcutReveal());
+
+    act(() => dispatchKey("keydown", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(isRevealed()).toBe(false);
+  });
+
+  it("reveals after 500ms hold of Meta on macOS", () => {
     renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Meta"));
@@ -40,26 +51,15 @@ describe("useHeldShortcutReveal", () => {
       vi.advanceTimersByTime(500);
     });
 
-    expect(isRevealed()).toBe(false);
-  });
-
-  it("reveals after 1s hold of Meta on macOS", () => {
-    renderHook(() => useHeldShortcutReveal());
-
-    act(() => dispatchKey("keydown", "Meta"));
-    act(() => {
-      vi.advanceTimersByTime(1000);
-    });
-
     expect(isRevealed()).toBe(true);
   });
 
-  it("does not reveal at 999ms but reveals on the next tick", () => {
+  it("does not reveal at 499ms but reveals on the next tick", () => {
     renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(999);
+      vi.advanceTimersByTime(499);
     });
     expect(isRevealed()).toBe(false);
 
@@ -69,13 +69,13 @@ describe("useHeldShortcutReveal", () => {
     expect(isRevealed()).toBe(true);
   });
 
-  it("reveals after 1s hold of Control on non-mac", () => {
+  it("reveals after 500ms hold of Control on non-mac", () => {
     isMacMock.mockReturnValue(false);
     renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Control"));
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(500);
     });
 
     expect(isRevealed()).toBe(true);
@@ -99,7 +99,7 @@ describe("useHeldShortcutReveal", () => {
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(500);
     });
     expect(isRevealed()).toBe(true);
 
@@ -112,7 +112,7 @@ describe("useHeldShortcutReveal", () => {
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(400);
     });
     act(() => dispatchKey("keyup", "Meta"));
     act(() => {
@@ -127,7 +127,7 @@ describe("useHeldShortcutReveal", () => {
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(500);
     });
     expect(isRevealed()).toBe(true);
 
@@ -143,7 +143,7 @@ describe("useHeldShortcutReveal", () => {
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(400);
     });
     act(() => {
       window.dispatchEvent(new Event("blur"));
@@ -160,7 +160,7 @@ describe("useHeldShortcutReveal", () => {
 
     act(() => dispatchKey("keydown", "Meta"));
     act(() => {
-      vi.advanceTimersByTime(900);
+      vi.advanceTimersByTime(400);
     });
     // Auto-repeat: should NOT restart the timer
     act(() => dispatchKey("keydown", "Meta", true));
@@ -168,7 +168,7 @@ describe("useHeldShortcutReveal", () => {
       vi.advanceTimersByTime(150);
     });
 
-    // Original timer at 900+150=1050ms should have fired
+    // Original timer at 400+150=550ms should have fired
     expect(isRevealed()).toBe(true);
   });
 
@@ -176,14 +176,14 @@ describe("useHeldShortcutReveal", () => {
     renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Meta"));
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(500));
     expect(isRevealed()).toBe(true);
 
     act(() => dispatchKey("keyup", "Meta"));
     expect(isRevealed()).toBe(false);
 
     act(() => dispatchKey("keydown", "Meta"));
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(500));
     expect(isRevealed()).toBe(true);
   });
 
@@ -191,7 +191,7 @@ describe("useHeldShortcutReveal", () => {
     const { unmount } = renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Meta"));
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(500));
     expect(isRevealed()).toBe(true);
 
     unmount();
@@ -199,7 +199,7 @@ describe("useHeldShortcutReveal", () => {
 
     // After unmount, further events should have no effect
     act(() => dispatchKey("keydown", "Meta"));
-    act(() => vi.advanceTimersByTime(1000));
+    act(() => vi.advanceTimersByTime(500));
     expect(isRevealed()).toBe(false);
   });
 
@@ -207,7 +207,7 @@ describe("useHeldShortcutReveal", () => {
     const { unmount } = renderHook(() => useHeldShortcutReveal());
 
     act(() => dispatchKey("keydown", "Meta"));
-    act(() => vi.advanceTimersByTime(500));
+    act(() => vi.advanceTimersByTime(400));
     unmount();
     act(() => vi.advanceTimersByTime(2000));
 

--- a/src/hooks/useHeldShortcutReveal.ts
+++ b/src/hooks/useHeldShortcutReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { isMac } from "@/lib/platform";
 
-const REVEAL_HOLD_MS = 1000;
+const REVEAL_HOLD_MS = 500;
 const REVEAL_ATTR = "shortcutReveal";
 
 function isPrimaryModifierKey(key: string): boolean {


### PR DESCRIPTION
## Summary

- Cuts `REVEAL_HOLD_MS` in `useHeldShortcutReveal` from 1000ms to 500ms — CHI 2013 (Malacria et al., "ExposeHK") puts the perceived-lag threshold at ~500ms, beyond which users read the delay as system lag rather than a deliberate gesture.
- Replaces the module-level `tipMountCount` in `RotatingTip` with persisted count-biased selection from `shortcutHintStore`: sorts tips by usage count ascending, takes the lowest-4 subset, picks randomly within it. The selected tip is frozen via `useState` so it doesn't swap mid-view when an unrelated count increments.
- Sort key uses `shortcutActionId ?? actionId` to mirror `LiveTipMessage` — so keyboard usage of worktree-overview (`⌘⇧O` dispatches `"worktree.overview"`, not `".open"`) counts toward the right tip.
- Renders `null` while `shortcutHintStore.hydrated` is false; the brief window is covered by `EmptyState`'s 500ms fade-in.

Resolves #6756

## Changes

- `src/hooks/useHeldShortcutReveal.ts` — `REVEAL_HOLD_MS` 1000 → 500
- `src/components/Terminal/contentGridTips.tsx` — `RotatingTip` rewired to `shortcutHintStore`, `tipMountCount` removed (lesson #4754: module-level mutable state leaks across tests)
- `src/store/shortcutHintStore.ts` — no change; existing `counts` map and `hydrated` flag used as-is

## Testing

59 tests pass across 4 files (`useHeldShortcutReveal`, `contentGridTips`, `contentGridEmptyState`, `shortcutHintStore`).

New tests added:
- 4 behavioral tests for `RotatingTip`: hydration gate, count bias, freeze on mount, `shortcutActionId` lookup, label-click dispatch, empty-filter null path
- 1 boundary test for `useHeldShortcutReveal`: cancellation at exactly 499ms

No new dependencies. No IPC changes.