### PR TITLE
feat(toolbar): replace empty-state brand pill with action-verb label

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -979,6 +979,7 @@ export function Toolbar({
               data-toolbar-item=""
               className="toolbar-project-pill app-no-drag pointer-events-auto flex h-9 min-w-0 max-w-full items-center justify-center gap-2 overflow-hidden border px-3 outline-hidden"
               data-testid="project-switcher-trigger"
+              aria-label={currentProject ? undefined : "Open project"}
               onClick={() => projectSwitcher.open("dropdown")}
             >
               {currentProject ? (
@@ -1003,10 +1004,7 @@ export function Toolbar({
               ) : (
                 <>
                   <span className="text-xs font-medium text-daintree-text tracking-wide truncate min-w-0">
-                    Daintree
-                  </span>
-                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-status-info/15 text-status-info shrink-0">
-                    Beta
+                    Open project
                   </span>
                   <ChevronsUpDown className="toolbar-project-meta ml-0.5 h-3 w-3 shrink-0" />
                 </>

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -139,5 +139,18 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       const chevronMatches = source.match(/ml-0\.5 h-3 w-3 shrink-0/g);
       expect(chevronMatches).not.toBeNull();
     });
+
+    it("empty-state pill displays action-verb label, not brand text", () => {
+      expect(source).toContain("Open project");
+      expect(source).not.toContain("Daintree");
+    });
+
+    it("empty-state pill has no Beta badge", () => {
+      expect(source).not.toMatch(/>Beta</);
+    });
+
+    it("empty-state button has conditional aria-label for accessibility", () => {
+      expect(source).toContain('aria-label={currentProject ? undefined : "Open project"}');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- On first launch, the toolbar center pill showed "Daintree" and a Beta badge, which reads as branding and doesn't communicate that the pill is the project switcher.
- Replaces the empty-state copy with "Open project" so the affordance is unambiguous.
- Adds a conditional `aria-label` on the pill button for screen readers.

Resolves #6751

## Changes
- `Toolbar.tsx`: empty-state pill text changed from "Daintree" + Beta badge to "Open project"; conditional `aria-label` added to the button
- `Toolbar.layout.test.ts`: 3 new test assertions covering the new copy, absence of the Beta badge, and the aria-label expression

## Testing
- Layout tests pass locally
- Verified the empty-state and loaded-state pill renders correctly