### PR TITLE
feat(toolbar): co-locate Assistant and Portal toggles

### DIFF
--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -26,13 +26,14 @@ export type ToolbarButtonId =
   | "settings"
   | "problems"
   | "notification-center"
+  | "assistant-toggle"
   | "portal-toggle";
 
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {
   /** Ordered list of button IDs to show on the left side (excluding sidebar-toggle which is always first) */
   leftButtons: AnyToolbarButtonId[];
-  /** Ordered list of button IDs to show on the right side (excluding portal-toggle which is always last) */
+  /** Ordered list of button IDs to show on the right side (excluding assistant-toggle and portal-toggle which are always last) */
   rightButtons: AnyToolbarButtonId[];
   /** Button IDs that are hidden from the toolbar. Ordering is preserved in leftButtons/rightButtons. */
   hiddenButtons: AnyToolbarButtonId[];
@@ -53,6 +54,7 @@ export type ToolbarButtonPriority = 1 | 2 | 3 | 4 | 5;
 
 export const TOOLBAR_BUTTON_PRIORITIES: Record<ToolbarButtonId, ToolbarButtonPriority> = {
   "sidebar-toggle": 1,
+  "assistant-toggle": 1,
   "portal-toggle": 1,
   "github-stats": 1,
   "voice-recording": 1,

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -16,7 +16,6 @@ import { DockedTabGroup } from "./DockedTabGroup";
 import { TrashContainer } from "./TrashContainer";
 import { WaitingContainer } from "./WaitingContainer";
 import { BackgroundContainer } from "./BackgroundContainer";
-import { HelpAgentDockButton } from "./HelpAgentDockButton";
 import { DockLaunchButton } from "./DockLaunchButton";
 import {
   DockLaunchMenuItems,
@@ -342,11 +341,6 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <BackgroundContainer compact={isCompact} />
             <WaitingContainer compact={isCompact} />
             <TrashContainer trashedTerminals={trashedItems} compact={isCompact} />
-          </div>
-
-          {/* Right-aligned cluster: help */}
-          <div className="ml-auto shrink-0 flex items-center gap-2">
-            <HelpAgentDockButton />
           </div>
         </div>
       </ContextMenuTrigger>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -63,6 +63,7 @@ import { ToolbarLauncherButton } from "./ToolbarLauncherButton";
 import { ToolbarSettingsButton } from "./ToolbarSettingsButton";
 import { ToolbarProblemsButton } from "./ToolbarProblemsButton";
 import { ToolbarPortalButton } from "./ToolbarPortalButton";
+import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
 import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
 
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
@@ -570,6 +571,10 @@ export function Toolbar({
         ),
         isAvailable: showDeveloperTools,
       },
+      "assistant-toggle": {
+        render: () => <ToolbarAssistantButton key="assistant-toggle" data-toolbar-item="" />,
+        isAvailable: true,
+      },
       "portal-toggle": {
         render: () => <ToolbarPortalButton key="portal-toggle" data-toolbar-item="" />,
         isAvailable: true,
@@ -1031,7 +1036,10 @@ export function Toolbar({
 
           <div className={toolbarDividerClass} />
 
-          <div className="app-no-drag">{buttonRegistry["portal-toggle"]!.render()}</div>
+          <div className="app-no-drag flex items-center gap-0.5">
+            {buttonRegistry["assistant-toggle"]!.render()}
+            {buttonRegistry["portal-toggle"]!.render()}
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -601,7 +601,9 @@ export function Toolbar({
       effectiveAgentSettings,
       onLaunchAgent,
       sidebarShortcut,
+      sidebarHintHover,
       copyTreeShortcut,
+      copyTreeHintHover,
       hasActiveVoiceRecording,
       currentProject,
       handleCopyTreeClick,
@@ -618,6 +620,7 @@ export function Toolbar({
       pluginButtonIds,
       pluginConfigs,
       devServerShortcut,
+      devServerHintHover,
     ]
   );
 

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -76,7 +76,7 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
           aria-label={ariaLabel}
           aria-pressed={isOpen}
         >
-          <DaintreeIcon aria-hidden="true" />
+          <DaintreeIcon />
           {pip && (
             <span
               aria-hidden="true"

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -1,6 +1,9 @@
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
+import { createTooltipContent } from "@/lib/tooltipShortcut";
+import { useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useFocusStore } from "@/store/focusStore";
@@ -9,10 +12,10 @@ import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import type { McpRuntimeSnapshot } from "@shared/types";
 
+const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text transition-colors relative";
+
 interface PipDescriptor {
   className: string;
-  // Whether to gate the pip behind the 400ms Doherty anti-flicker (transient
-  // states only — failures should appear immediately).
   delayed: boolean;
   tooltip: string;
 }
@@ -34,65 +37,62 @@ function describePip(snapshot: McpRuntimeSnapshot): PipDescriptor | null {
     case "ready":
     case "disabled":
     default:
-      // Healthy state: no pip. Per the design rules we never render an
-      // "all clear" indicator — it's just visual noise when MCP is fine
-      // 99.9% of the time. Disabled state likewise has no pip; a user who
-      // turned daintreeControl off doesn't need a status marker.
       return null;
   }
 }
 
-export function HelpAgentDockButton() {
+export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
+  "data-toolbar-item": dataToolbarItem,
+}: {
+  "data-toolbar-item"?: string;
+}) {
   const isOpen = useHelpPanelStore((s) => s.isOpen);
   const toggle = useHelpPanelStore((s) => s.toggle);
   const mcp = useMcpReadiness();
+  const shortcut = useKeybindingDisplay("help.togglePanel");
+  const hintHover = useShortcutHintHover("help.togglePanel");
 
   const handleClick = useCallback(() => {
     suppressSidebarResizes();
-    // Explicit toggle takes ownership of the assistant's visibility — clear
-    // any lingering gesture suppression so the next visible state matches
-    // the toggle's intent rather than staying width=0 behind the gesture.
     useFocusStore.getState().clearAssistantGesture();
     toggle();
   }, [toggle]);
 
   const pip = describePip(mcp);
   const baseTooltip = isOpen ? "Close Daintree Assistant" : "Open Daintree Assistant";
-  // Fold pip state into the accessible name so screen-reader users hear the
-  // status change. The visible tooltip mirrors this; the pip itself is
-  // aria-hidden to avoid a duplicate announcement.
   const ariaLabel = pip ? `Daintree Assistant — ${pip.tooltip}` : "Daintree Assistant";
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <Button
+          {...hintHover}
           type="button"
-          variant="pill"
-          size="sm"
-          className={cn("relative px-2", isOpen && "bg-overlay-emphasis border-border-default")}
+          variant="ghost"
+          size="icon"
+          data-toolbar-item={dataToolbarItem}
           onClick={handleClick}
+          className={toolbarIconButtonClass}
           aria-label={ariaLabel}
-          aria-expanded={isOpen}
+          aria-pressed={isOpen}
         >
-          <DaintreeIcon className="w-3.5 h-3.5 text-daintree-text/50" />
+          <DaintreeIcon aria-hidden="true" />
           {pip && (
             <span
               aria-hidden="true"
               className={cn(
                 "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full ring-2 ring-daintree-bg",
                 pip.className,
-                // Anti-flicker only for transient states — failures must be
-                // visible immediately. CSS handles the 400ms delay.
                 pip.delayed && "animate-pulse-delayed"
               )}
             />
           )}
+          <ShortcutRevealChip actionId="help.togglePanel" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent side="top">
-        {pip ? `${baseTooltip} — ${pip.tooltip}` : baseTooltip}
+      <TooltipContent side="bottom">
+        {createTooltipContent(pip ? `${baseTooltip} — ${pip.tooltip}` : baseTooltip, shortcut)}
       </TooltipContent>
     </Tooltip>
   );
-}
+});

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -40,12 +40,10 @@ describe("ContentDock regression test", () => {
     const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
     const launchIdx = content.indexOf("<DockLaunchButton");
-    const helpIdx = content.indexOf("<HelpAgentDockButton");
     const trashIdx = content.indexOf("<TrashContainer");
 
     expect(launchIdx).toBeGreaterThan(0);
     expect(launchIdx).toBeLessThan(trashIdx);
-    expect(launchIdx).toBeLessThan(helpIdx);
   });
 
   // Issue #6428 — accent ring on isOver was a restraint violation; replace with neutral.

--- a/src/components/Layout/__tests__/dockPopoverShadow.test.tsx
+++ b/src/components/Layout/__tests__/dockPopoverShadow.test.tsx
@@ -111,7 +111,6 @@ describe("Dock Popover Visual Layer - Issue #2316", () => {
       "../StatusContainer.tsx",
       "../BackgroundContainer.tsx",
       "../TrashContainer.tsx",
-      "../HelpAgentDockButton.tsx",
     ];
 
     for (const relativePath of dockButtonFiles) {

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -500,6 +500,64 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.hiddenButtons).not.toContain("notes");
     });
 
+    it("v6→v7 strips 'assistant-toggle' from all button arrays", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "assistant-toggle", "browser"],
+              rightButtons: ["assistant-toggle", "settings"],
+              hiddenButtons: ["assistant-toggle"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 6,
+        })
+      );
+
+      const store = await loadStore();
+      const { layout } = store.getState();
+      expect(layout.leftButtons).not.toContain("assistant-toggle");
+      expect(layout.rightButtons).not.toContain("assistant-toggle");
+      expect(layout.hiddenButtons).not.toContain("assistant-toggle");
+    });
+
+    it("v6→v7 is idempotent on state already lacking assistant-toggle", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["terminal", "browser"],
+              rightButtons: ["settings"],
+              hiddenButtons: [],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 6,
+        })
+      );
+
+      const store = await loadStore();
+      const { layout } = store.getState();
+      expect(layout.leftButtons).toContain("terminal");
+      expect(layout.leftButtons).toContain("browser");
+      expect(layout.rightButtons).toContain("settings");
+      expect(layout.hiddenButtons).toEqual([]);
+    });
+
+    it("sanitizeButtonList strips assistant-toggle when set via setRightButtons", async () => {
+      const store = await loadStore();
+
+      store.getState().setRightButtons(["settings", "assistant-toggle" as never, "copy-tree"]);
+
+      const { layout } = store.getState();
+      expect(layout.rightButtons).not.toContain("assistant-toggle");
+      expect(layout.rightButtons).toContain("settings");
+      expect(layout.rightButtons).toContain("copy-tree");
+    });
+
     it("v4→v5 handles missing layout without throwing", async () => {
       storageMock.setItem(
         STORAGE_KEY,

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -38,7 +38,7 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
   },
 };
 
-const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "portal-toggle"];
+const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "assistant-toggle", "portal-toggle"];
 
 function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[] {
   return buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id as ToolbarButtonId));
@@ -152,7 +152,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 6,
+      version: 7,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -224,6 +224,20 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             | undefined;
           if (layout) {
             const drop = (buttons?: string[]) => buttons?.filter((id) => id !== "notes");
+            layout.leftButtons = drop(layout.leftButtons);
+            layout.rightButtons = drop(layout.rightButtons);
+            layout.hiddenButtons = drop(layout.hiddenButtons);
+          }
+        }
+        if (version < 7) {
+          // "assistant-toggle" became a fixed pinned button alongside
+          // "portal-toggle" (#6748). Strip any stray persisted entries so
+          // mid-rollout users don't end up with a ghost in a variable list.
+          const layout = state.layout as
+            | { leftButtons?: string[]; rightButtons?: string[]; hiddenButtons?: string[] }
+            | undefined;
+          if (layout) {
+            const drop = (buttons?: string[]) => buttons?.filter((id) => id !== "assistant-toggle");
             layout.leftButtons = drop(layout.leftButtons);
             layout.rightButtons = drop(layout.rightButtons);
             layout.hiddenButtons = drop(layout.hiddenButtons);


### PR DESCRIPTION
## Summary

- Moves the Assistant toggle out of the content dock and into the toolbar, where it sits beside the Portal toggle as a fixed trailing pair
- Removes `HelpAgentDockButton`, which existed solely to host the button in the dock
- Adds `assistant-toggle` to the toolbar type union, priority map, and `FIXED_BUTTON_IDS` so it can't be hidden; bumps store to v7 with a defensive migration that strips any persisted copies from `leftButtons`, `rightButtons`, and `hiddenButtons`

Resolves #6748

## Changes

- `ToolbarAssistantButton.tsx` — new memo component (ghost/icon variant) replacing `HelpAgentDockButton` in the toolbar
- `Toolbar.tsx` — registers `assistant-toggle` in `buttonRegistry`, wraps the fixed trailing pair in a `flex` container with `gap-0.5`, fixes missing `hint-hover` deps in `useMemo`
- `ContentDock.tsx` — drops the help cluster; dock items naturally right-align via `flex-1`
- `HelpAgentDockButton.tsx` — deleted (no remaining consumers)
- `shared/types/toolbar.ts` — adds `"assistant-toggle"` to `ToolbarButtonId` and `TOOLBAR_BUTTON_PRIORITIES`
- `toolbarPreferencesStore.ts` — adds `assistant-toggle` to `FIXED_BUTTON_IDS`, bumps to v7, adds migration
- Tests — updated `ContentDock.test.tsx` and `dockPopoverShadow.test.tsx` to drop `HelpAgentDockButton` refs; added 3 v7 migration / sanitize tests

All MCP readiness pip states preserved (`warning` + `danger` with `animate-pulse-delayed`), `aria-label`, and click handlers (`suppressSidebarResizes()` + `clearAssistantGesture()`).

## Testing

- 53 vitest tests pass
- Typecheck clean
- `lint:ratchet` clean — no new warnings