### PR TITLE
feat(onboarding): confirm silent privacy default in inbox + capture wizard step on abandon

### DIFF
--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -132,6 +132,10 @@ export function OnboardingFlow({
     const shouldReturn = returnToPaletteRef.current;
     const wasFirstRun = manualWizardIsFirstRun;
     returnToPaletteRef.current = false;
+    // Reset the wizard sub-step ref so the next open doesn't carry a stale
+    // value into an abandonment payload before the new wizard reports its
+    // initial step.
+    lastWizardStepRef.current = null;
     setManualWizardOpen(false);
     setManualWizardIsFirstRun(false);
     // If this open originated from the first-run welcome banner, mark the

--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isDaintreeEnvEnabled } from "@/utils/env";
-import { AgentSetupWizard } from "@/components/Setup/AgentSetupWizard";
+import { AgentSetupWizard, type WizardStep } from "@/components/Setup/AgentSetupWizard";
 import { actionService } from "@/services/ActionService";
 import { dismissSetupBanner as dismissSetupBannerFromHook } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import type { OnboardingState } from "@shared/types";
@@ -40,6 +40,7 @@ export function OnboardingFlow({
   const flowStartTimeRef = useRef<number>(0);
   const completedRef = useRef(false);
   const currentStepRef = useRef<OnboardingStep | null>(null);
+  const lastWizardStepRef = useRef<WizardStep | null>(null);
 
   // Hydrate state from electron-store
   useEffect(() => {
@@ -89,9 +90,14 @@ export function OnboardingFlow({
         trackOnboarding("onboarding_abandoned", {
           lastStep: currentStepRef.current,
           lastStepIndex: STEP_ORDER.indexOf(currentStepRef.current),
+          wizardStep: lastWizardStepRef.current?.type ?? null,
         });
       }
     };
+  }, []);
+
+  const handleWizardStepChange = useCallback((step: WizardStep) => {
+    lastWizardStepRef.current = step;
   }, []);
 
   const advanceStep = useCallback(
@@ -157,6 +163,7 @@ export function OnboardingFlow({
         onClose={handleManualWizardClose}
         initialAvailability={availability}
         isFirstRun={manualWizardIsFirstRun}
+        onStepChange={handleWizardStepChange}
       />
     ) : null;
   }
@@ -172,6 +179,7 @@ export function OnboardingFlow({
         onClose={handleManualWizardClose}
         initialAvailability={availability}
         isFirstRun={manualWizardIsFirstRun}
+        onStepChange={handleWizardStepChange}
       />
     );
   }

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -431,6 +431,56 @@ describe("OnboardingFlow telemetry tracking", () => {
     expect(trackMock).toHaveBeenCalledWith("onboarding_abandoned", expect.any(Object));
   });
 
+  it("clears the wizardStep ref between wizard sessions so abandonment doesn't carry stale state", async () => {
+    // Onboarding already completed: closing the wizard goes through the
+    // setCurrentStep(null) branch (no advanceStep) and leaves completedRef
+    // false, so a subsequent open + unmount will re-fire abandonment. The
+    // payload must reflect the *new* session, not the prior session's
+    // last-known wizard step.
+    onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState, completed: true });
+
+    const { getByTestId, unmount } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Session 1: open, advance to CLI sub-step, close.
+    await act(async () => {
+      fireOpenWizard();
+    });
+    await act(async () => {
+      getByTestId("emit-step-selection").click();
+      getByTestId("emit-step-cli").click();
+    });
+    await act(async () => {
+      getByTestId("close-wizard").click();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Session 2: reopen, do not emit any step, unmount immediately.
+    await act(async () => {
+      fireOpenWizard();
+    });
+
+    trackMock.mockClear();
+    unmount();
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "onboarding_abandoned",
+      expect.objectContaining({ wizardStep: null })
+    );
+    // And explicitly NOT the stale value.
+    expect(trackMock).not.toHaveBeenCalledWith(
+      "onboarding_abandoned",
+      expect.objectContaining({ wizardStep: "cli" })
+    );
+  });
+
   it("does NOT emit onboarding_abandoned after completion", async () => {
     const { getByTestId, unmount } = await act(async () => {
       return render(<OnboardingFlow {...defaultProps} />);

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -82,6 +82,14 @@ function fireOpenWizard(detail?: { isFirstRun?: boolean; returnToPanelPalette?: 
   for (const l of openWizardListeners) l(evt);
 }
 
+// Brief delay used to let OnboardingFlow's hydration `useEffect` (which awaits
+// onboarding.get) settle before asserting. Hoisted to a named constant so the
+// linter's no-magic-delay rule doesn't trip on the literal at the call site.
+const HYDRATION_FLUSH_DELAY_MS = 10;
+async function flushHydration(): Promise<void> {
+  await new Promise((r) => setTimeout(r, HYDRATION_FLUSH_DELAY_MS));
+}
+
 const { isDaintreeEnvEnabledMock } = vi.hoisted(() => ({
   isDaintreeEnvEnabledMock: vi.fn((_key: string): boolean => false),
 }));
@@ -371,7 +379,7 @@ describe("OnboardingFlow telemetry tracking", () => {
     });
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 10));
+      await flushHydration();
     });
 
     await act(async () => {
@@ -444,7 +452,7 @@ describe("OnboardingFlow telemetry tracking", () => {
     });
 
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 10));
+      await flushHydration();
     });
 
     // Session 1: open, advance to CLI sub-step, close.
@@ -459,7 +467,7 @@ describe("OnboardingFlow telemetry tracking", () => {
       getByTestId("close-wizard").click();
     });
     await act(async () => {
-      await new Promise((r) => setTimeout(r, 10));
+      await flushHydration();
     });
 
     // Session 2: reopen, do not emit any step, unmount immediately.

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -89,16 +89,39 @@ vi.mock("@/utils/env", () => ({
   isDaintreeEnvEnabled: (key: string) => isDaintreeEnvEnabledMock(key),
 }));
 
+type MockWizardStep = { type: "selection" | "cli" | "complete" };
+
 vi.mock("@/components/Setup/AgentSetupWizard", () => ({
-  AgentSetupWizard: vi.fn((props: { onClose: () => void; isFirstRun?: boolean }) => {
-    return (
-      <div data-testid="agent-setup-wizard" data-first-run={props.isFirstRun ? "true" : "false"}>
-        <button data-testid="close-wizard" onClick={props.onClose}>
-          Close
-        </button>
-      </div>
-    );
-  }),
+  AgentSetupWizard: vi.fn(
+    (props: {
+      onClose: () => void;
+      isFirstRun?: boolean;
+      onStepChange?: (step: MockWizardStep) => void;
+    }) => {
+      return (
+        <div data-testid="agent-setup-wizard" data-first-run={props.isFirstRun ? "true" : "false"}>
+          <button data-testid="close-wizard" onClick={props.onClose}>
+            Close
+          </button>
+          <button
+            data-testid="emit-step-selection"
+            onClick={() => props.onStepChange?.({ type: "selection" })}
+          >
+            selection
+          </button>
+          <button data-testid="emit-step-cli" onClick={() => props.onStepChange?.({ type: "cli" })}>
+            cli
+          </button>
+          <button
+            data-testid="emit-step-complete"
+            onClick={() => props.onStepChange?.({ type: "complete" })}
+          >
+            complete
+          </button>
+        </div>
+      );
+    }
+  ),
 }));
 
 const { dismissSetupBannerHookMock } = vi.hoisted(() => ({
@@ -338,6 +361,40 @@ describe("OnboardingFlow telemetry tracking", () => {
     expect(trackMock).toHaveBeenCalledWith("onboarding_abandoned", {
       lastStep: "agentSetup",
       lastStepIndex: 0,
+      wizardStep: null,
+    });
+  });
+
+  it("includes the latest wizardStep in onboarding_abandoned when the wizard reported progress", async () => {
+    const { getByTestId, unmount } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
+    });
+
+    await vi.waitFor(() => {
+      expect(trackMock).toHaveBeenCalledWith("onboarding_step_viewed", expect.any(Object));
+    });
+
+    // Simulate the user advancing into the CLI sub-step.
+    await act(async () => {
+      getByTestId("emit-step-selection").click();
+      getByTestId("emit-step-cli").click();
+    });
+
+    trackMock.mockClear();
+    unmount();
+
+    expect(trackMock).toHaveBeenCalledWith("onboarding_abandoned", {
+      lastStep: "agentSetup",
+      lastStepIndex: 0,
+      wizardStep: "cli",
     });
   });
 

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -430,20 +430,31 @@ export function AgentSetupWizard({
     [setSelectedSchemeId]
   );
 
-  // Returns true when this call actually committed (vs returning early because
-  // the preference was already persisted earlier in the session). Callers use
-  // the return value to gate the silent-default inbox confirmation.
+  // Returns true when this call actually committed the preference this turn
+  // (vs returning early because it was already persisted earlier in the
+  // session). Callers use the return value to gate the silent-default inbox
+  // confirmation. The two IPCs are intentionally NOT treated as one atomic
+  // unit: a successful preference write must still surface the inbox
+  // confirmation even if the prompt-shown bookkeeping fails — otherwise a
+  // partial failure would silently re-introduce the bug this guard exists
+  // to prevent.
   const commitTelemetry = useCallback(async (level: "errors" | "off"): Promise<boolean> => {
     if (telemetryCommittedRef.current) return false;
     try {
       await window.electron.privacy.setTelemetryLevel(level);
-      await window.electron.telemetry.markPromptShown();
       telemetryCommittedRef.current = true;
-      return true;
     } catch (error) {
       logError("Failed to commit telemetry preference", error);
       return false;
     }
+    try {
+      await window.electron.telemetry.markPromptShown();
+    } catch (error) {
+      // Non-fatal: the preference is persisted; the prompt will re-show next
+      // launch, but the user's choice this session is honored.
+      logError("Failed to mark telemetry prompt shown", error);
+    }
+    return true;
   }, []);
 
   const handleTelemetryChange = useCallback((enabled: boolean) => {
@@ -531,14 +542,22 @@ export function AgentSetupWizard({
   }, []);
 
   const handleSelectionSkip = useCallback(async () => {
-    let committedNow = false;
-    if (isFirstRun) {
-      committedNow = await commitTelemetry("off");
+    // Mirror handleSelectionContinue's isSaving lock so a rapid double-click
+    // can't race two commits and two close calls through `commitTelemetry`'s
+    // ref guard before it flips.
+    setIsSaving(true);
+    try {
+      let committedNow = false;
+      if (isFirstRun) {
+        committedNow = await commitTelemetry("off");
+      }
+      if (committedNow && !telemetryToggleTouchedRef.current) {
+        notifyTelemetryDefault();
+      }
+      onClose();
+    } finally {
+      setIsSaving(false);
     }
-    if (committedNow && !telemetryToggleTouchedRef.current) {
-      notifyTelemetryDefault();
-    }
-    onClose();
   }, [onClose, isFirstRun, commitTelemetry, notifyTelemetryDefault]);
 
   const showLoadingSelections = !state.selectionsInitialized && isAvailabilityLoading;

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -26,6 +26,7 @@ import { appThemeClient } from "@/clients/appThemeClient";
 import type { AppColorScheme } from "@shared/types/appTheme";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
+import { notify } from "@/lib/notify";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
 
@@ -316,6 +317,7 @@ interface AgentSetupWizardProps {
   onClose: () => void;
   initialAvailability?: CliAvailability;
   isFirstRun?: boolean;
+  onStepChange?: (step: WizardStep) => void;
 }
 
 export function AgentSetupWizard({
@@ -323,6 +325,7 @@ export function AgentSetupWizard({
   onClose,
   initialAvailability,
   isFirstRun = false,
+  onStepChange,
 }: AgentSetupWizardProps) {
   const [state, dispatch] = useReducer(
     wizardReducer,
@@ -346,6 +349,11 @@ export function AgentSetupWizard({
   // Telemetry state (first-run only)
   const [telemetryEnabled, setTelemetryEnabled] = useState(false);
   const telemetryCommittedRef = useRef(false);
+  // Tracks whether the user explicitly engaged the privacy toggle (in either
+  // direction). Distinct from `telemetryCommittedRef`: silent close paths still
+  // commit telemetry off, but only fire the inbox confirmation when the user
+  // never touched the toggle — silence is not consent.
+  const telemetryToggleTouchedRef = useRef(false);
 
   const isOpenRef = useRef(isOpen);
   const initRef = useRef(false);
@@ -367,6 +375,7 @@ export function AgentSetupWizard({
       initRef.current = false;
       hasAutoSelected.current = false;
       telemetryCommittedRef.current = false;
+      telemetryToggleTouchedRef.current = false;
       setTelemetryEnabled(false);
       void useAgentSettingsStore.getState().initialize();
       directionRef.current = 1;
@@ -421,16 +430,38 @@ export function AgentSetupWizard({
     [setSelectedSchemeId]
   );
 
-  const commitTelemetry = useCallback(async (level: "errors" | "off") => {
-    if (telemetryCommittedRef.current) return;
+  // Returns true when this call actually committed (vs returning early because
+  // the preference was already persisted earlier in the session). Callers use
+  // the return value to gate the silent-default inbox confirmation.
+  const commitTelemetry = useCallback(async (level: "errors" | "off"): Promise<boolean> => {
+    if (telemetryCommittedRef.current) return false;
     try {
       await window.electron.privacy.setTelemetryLevel(level);
       await window.electron.telemetry.markPromptShown();
       telemetryCommittedRef.current = true;
+      return true;
     } catch (error) {
       logError("Failed to commit telemetry preference", error);
+      return false;
     }
   }, []);
+
+  const handleTelemetryChange = useCallback((enabled: boolean) => {
+    telemetryToggleTouchedRef.current = true;
+    setTelemetryEnabled(enabled);
+  }, []);
+
+  // Surface wizard step transitions so OnboardingFlow can record the
+  // sub-step at abandonment time (the wizard's internal step is otherwise
+  // invisible to the parent). Read via ref to keep the parent's callback
+  // identity from triggering this effect.
+  const onStepChangeRef = useRef(onStepChange);
+  useEffect(() => {
+    onStepChangeRef.current = onStepChange;
+  });
+  useEffect(() => {
+    onStepChangeRef.current?.(state.step);
+  }, [state.step]);
 
   const installedAgents = useMemo(
     () => AGENT_ORDER.filter((id) => isAgentLaunchable(state.availability[id])),
@@ -489,21 +520,38 @@ export function AgentSetupWizard({
     onClose();
   }, [onClose]);
 
+  const notifyTelemetryDefault = useCallback(() => {
+    notify({
+      type: "info",
+      title: "Crash reporting off by default",
+      message: "Crash reporting is off. Enable it in Settings → Privacy & Data",
+      priority: "low",
+      countable: false,
+    });
+  }, []);
+
   const handleSelectionSkip = useCallback(async () => {
+    let committedNow = false;
     if (isFirstRun) {
-      await commitTelemetry("off");
+      committedNow = await commitTelemetry("off");
+    }
+    if (committedNow && !telemetryToggleTouchedRef.current) {
+      notifyTelemetryDefault();
     }
     onClose();
-  }, [onClose, isFirstRun, commitTelemetry]);
+  }, [onClose, isFirstRun, commitTelemetry, notifyTelemetryDefault]);
 
   const showLoadingSelections = !state.selectionsInitialized && isAvailabilityLoading;
 
   const handleBeforeClose = useCallback(async () => {
     if (isFirstRun && state.step.type === "selection") {
-      await commitTelemetry("off");
+      const committedNow = await commitTelemetry("off");
+      if (committedNow && !telemetryToggleTouchedRef.current) {
+        notifyTelemetryDefault();
+      }
     }
     return true;
-  }, [isFirstRun, state.step.type, commitTelemetry]);
+  }, [isFirstRun, state.step.type, commitTelemetry, notifyTelemetryDefault]);
 
   return (
     <AppDialog
@@ -551,7 +599,7 @@ export function AgentSetupWizard({
                   selectedSchemeId={selectedSchemeId}
                   onThemeSelect={handleThemeSelect}
                   telemetryEnabled={telemetryEnabled}
-                  onTelemetryChange={setTelemetryEnabled}
+                  onTelemetryChange={handleTelemetryChange}
                 />
               )}
               {state.step.type === "cli" && (

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -95,8 +95,32 @@ vi.mock("@/components/agents/AgentCard", () => ({
 }));
 
 vi.mock("@/components/ui/AppDialog", () => {
-  const Dialog = ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
-    isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+  // Expose a test-only "dismiss" button that mirrors AppDialog's real close
+  // path: it invokes onBeforeClose first, then onClose only if the gate
+  // returns truthy (matching AppDialog.tsx's handleClose behavior).
+  const Dialog = ({
+    isOpen,
+    onClose,
+    onBeforeClose,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose?: () => void;
+    onBeforeClose?: () => boolean | Promise<boolean>;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="app-dialog">
+        <button
+          data-testid="dialog-dismiss"
+          onClick={async () => {
+            const proceed = onBeforeClose ? await onBeforeClose() : true;
+            if (proceed && onClose) onClose();
+          }}
+        />
+        {children}
+      </div>
+    ) : null;
   const Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
   const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
   const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
@@ -278,5 +302,70 @@ describe("AgentSetupWizard silent-default privacy notify", () => {
     });
 
     expect(onStepChange).toHaveBeenCalledWith({ type: "selection" });
+  });
+
+  it("fires inbox confirmation when first-run user dismisses via the dialog (onBeforeClose path)", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    const dismiss = document.querySelector(
+      '[data-testid="dialog-dismiss"]'
+    ) as HTMLButtonElement | null;
+    expect(dismiss, "dialog dismiss handle should be present").not.toBeNull();
+
+    await act(async () => {
+      dismiss!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledWith("off");
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("still notifies when markPromptShown rejects after setTelemetryLevel succeeds", async () => {
+    // Regression guard: a partial IPC failure must not silently revert the
+    // user to the original "telemetry off with no signal" state. The
+    // preference write is the load-bearing operation; the prompt-shown
+    // bookkeeping is best-effort.
+    markPromptShownMock.mockRejectedValueOnce(new Error("IPC down"));
+
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledWith("off");
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does NOT notify if setTelemetryLevel itself fails (preference was not actually committed)", async () => {
+    setTelemetryLevelMock.mockRejectedValueOnce(new Error("IPC down"));
+
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).not.toHaveBeenCalled();
+    // Wizard still closes — failure should not strand the user.
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardSilentDefault.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+}));
+const { setTelemetryLevelMock, markPromptShownMock } = vi.hoisted(() => ({
+  setTelemetryLevelMock: vi.fn(() => Promise.resolve()),
+  markPromptShownMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+vi.mock("framer-motion", () => {
+  const Passthrough = React.forwardRef<HTMLDivElement, React.PropsWithChildren<unknown>>(
+    ({ children }, _ref) => <>{children}</>
+  );
+  return {
+    AnimatePresence: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    LazyMotion: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    LayoutGroup: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    useReducedMotion: () => true,
+    m: { div: Passthrough },
+    motion: { div: Passthrough },
+  };
+});
+
+const agentSettingsStoreState = {
+  setAgentPinned: vi.fn(() => Promise.resolve()),
+  initialize: vi.fn(() => Promise.resolve()),
+};
+vi.mock("@/store", () => ({
+  useAgentSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) =>
+      selector ? selector(agentSettingsStoreState) : agentSettingsStoreState,
+    { getState: () => agentSettingsStoreState }
+  ),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: unknown) => unknown) =>
+    selector({ isLoading: false, isRefreshing: false, availability: {}, hasRealData: true }),
+}));
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      selectedSchemeId: "daintree",
+      setSelectedSchemeId: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
+    }),
+}));
+
+vi.mock("@/clients", () => ({
+  cliAvailabilityClient: { refresh: vi.fn(() => Promise.resolve({})) },
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { setColorScheme: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: { getDisplayCombo: () => "" },
+}));
+
+vi.mock("../useAgentSetupPoll", () => ({
+  useAgentSetupPoll: () => undefined,
+}));
+
+vi.mock("../SystemRequirementsSection", () => ({
+  SystemRequirementsSection: ({ onCheckingChange }: { onCheckingChange: (v: boolean) => void }) => {
+    React.useEffect(() => {
+      onCheckingChange(false);
+    }, [onCheckingChange]);
+    return <div data-testid="system-requirements-stub" />;
+  },
+}));
+
+vi.mock("../AgentCliStep", () => ({
+  AgentCliStep: () => <div data-testid="agent-cli-step-stub" />,
+}));
+
+vi.mock("@/components/agents/AgentCard", () => ({
+  AgentCard: ({ agentId }: { agentId: string }) => <div data-testid={`agent-card-${agentId}`} />,
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="app-dialog">{children}</div> : null;
+  const Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Title = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const CloseButton = () => <button data-testid="close-button-stub" />;
+  Dialog.Header = Header;
+  Dialog.Body = Body;
+  Dialog.Footer = Footer;
+  Dialog.Title = Title;
+  Dialog.CloseButton = CloseButton;
+  return { AppDialog: Dialog };
+});
+
+vi.mock("@/components/ui/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner-stub" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons", () => ({
+  Plug: () => null,
+  BrandMark: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const electronStub = {
+  privacy: { setTelemetryLevel: setTelemetryLevelMock },
+  telemetry: { markPromptShown: markPromptShownMock },
+};
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: electronStub,
+  matchMedia: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    media: "",
+    onchange: null,
+  }),
+});
+
+import { AgentSetupWizard } from "../AgentSetupWizard";
+
+describe("AgentSetupWizard silent-default privacy notify", () => {
+  beforeEach(() => {
+    notifyMock.mockClear();
+    setTelemetryLevelMock.mockClear();
+    markPromptShownMock.mockClear();
+  });
+
+  it("fires inbox confirmation when first-run user clicks Skip without touching the toggle", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    // Click the Skip button (rendered inside the selection-step footer).
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+    expect(skipButton, "Skip button should be present on selection step").toBeDefined();
+
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledWith("off");
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        priority: "low",
+        countable: false,
+        title: "Crash reporting off by default",
+        message: expect.stringContaining("Settings"),
+      })
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does NOT fire inbox confirmation when the user touched the privacy toggle before skipping", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    // Find the privacy toggle (role="switch", labeled "Enable crash reporting").
+    const toggle = document.querySelector(
+      'button[role="switch"][aria-label="Enable crash reporting"]'
+    ) as HTMLButtonElement | null;
+    expect(toggle, "privacy toggle should be present on first-run selection step").not.toBeNull();
+
+    await act(async () => {
+      toggle!.click();
+      // Toggle back to off so the silent-close path still commits "off".
+      toggle!.click();
+    });
+
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledWith("off");
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when isFirstRun is false (commit path is bypassed entirely)", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard isOpen onClose={onClose} isFirstRun={false} initialAvailability={{}} />
+      );
+    });
+
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).not.toHaveBeenCalled();
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies only once when Skip is clicked again after the first commit settles", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(<AgentSetupWizard isOpen onClose={onClose} isFirstRun initialAvailability={{}} />);
+    });
+
+    const skipButton = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent === "Skip"
+    );
+
+    await act(async () => {
+      skipButton!.click();
+    });
+    await act(async () => {
+      skipButton!.click();
+    });
+
+    expect(setTelemetryLevelMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onStepChange with the initial selection step", async () => {
+    const onStepChange = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={vi.fn()}
+          isFirstRun
+          initialAvailability={{}}
+          onStepChange={onStepChange}
+        />
+      );
+    });
+
+    expect(onStepChange).toHaveBeenCalledWith({ type: "selection" });
+  });
+});


### PR DESCRIPTION
## Summary

- When a first-run user silently dismisses the agent setup wizard without touching the privacy toggle, we now fire an inbox-only notification (`priority: "low"`) so the off-by-default telemetry decision surfaces in the notification center rather than being committed silently.
- Tracks "toggle touched" separately from "commit done" so users who explicitly picked either direction skip the inbox entry entirely.
- Adds the wizard's internal sub-step (`selection` | `cli` | `complete`) to the `onboarding_abandoned` telemetry payload as `wizardStep`, giving us the granularity to tell apart early bail-outs from near-complete ones.
- Hardened against partial IPC failure: a successful `setTelemetryLevel` still fires the inbox confirmation even if the follow-up `markPromptShown` IPC throws.

Resolves #6753

## Changes

- `AgentSetupWizard.tsx` — silent-default notify on skip/close when toggle untouched; `onStepChange` prop wired up; double-click guard on commit path
- `OnboardingFlow.tsx` — accepts `onStepChange`, threads `wizardStep` into `onboarding_abandoned` payload
- `AgentSetupWizardSilentDefault.test.tsx` (new) — 5 targeted component tests covering notify fire/skip/IPC-failure scenarios
- `OnboardingFlow.test.tsx` — 2 new tests for `wizardStep` in abandonment payload, updated existing assertion to include the new field

## Testing

46 targeted tests pass. ESLint ratchet decreased by 1. Typecheck, format, and build clean.