### PR TITLE
feat(devServer): suggest detected command in project Settings

### DIFF
--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -303,15 +303,18 @@ export class RunCommandDetector {
       } else if (typeof postStart === "object" && postStart !== null) {
         const keys = Object.keys(postStart as Record<string, unknown>);
         if (keys.length > 0) {
+          const isValidVal = (v: unknown): boolean =>
+            (typeof v === "string" && v.trim().length > 0) || Array.isArray(v);
+
           const keyPriority = ["server", "dev", "start", "app"];
           const bestKey =
             keyPriority.find((k) => {
               const v = (postStart as Record<string, unknown>)[k];
-              return typeof v === "string" || Array.isArray(v);
+              return isValidVal(v);
             }) ??
             keys.find((k) => {
               const v = (postStart as Record<string, unknown>)[k];
-              return typeof v === "string" || Array.isArray(v);
+              return isValidVal(v);
             });
           if (bestKey) {
             const val = (postStart as Record<string, unknown>)[bestKey];

--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -32,6 +32,7 @@ export class RunCommandDetector {
       this.detectTaskfile(projectPath),
       this.detectDjango(projectPath),
       this.detectComposer(projectPath),
+      this.detectDevContainer(projectPath),
     ]);
 
     const commands = results.flat();
@@ -279,6 +280,93 @@ export class RunCommandDetector {
       console.warn(`[RunCommandDetector] Failed to parse ${composerPath}:`, error);
       return [];
     }
+  }
+  private async detectDevContainer(root: string): Promise<RunCommand[]> {
+    const devcontainerPath = path.join(root, ".devcontainer", "devcontainer.json");
+    if (!existsSync(devcontainerPath)) return [];
+
+    try {
+      const content = await fs.readFile(devcontainerPath, "utf-8");
+      const config = JSON.parse(content);
+      const postStart = config.postStartCommand;
+      if (postStart === undefined || postStart === null) return [];
+
+      let command: string | undefined;
+
+      if (typeof postStart === "string") {
+        command = postStart.trim();
+      } else if (Array.isArray(postStart)) {
+        command = postStart
+          .filter((item): item is string => typeof item === "string")
+          .join(" ")
+          .trim();
+      } else if (typeof postStart === "object" && postStart !== null) {
+        const keys = Object.keys(postStart as Record<string, unknown>);
+        if (keys.length > 0) {
+          const keyPriority = ["server", "dev", "start", "app"];
+          const bestKey =
+            keyPriority.find((k) => {
+              const v = (postStart as Record<string, unknown>)[k];
+              return typeof v === "string" || Array.isArray(v);
+            }) ??
+            keys.find((k) => {
+              const v = (postStart as Record<string, unknown>)[k];
+              return typeof v === "string" || Array.isArray(v);
+            });
+          if (bestKey) {
+            const val = (postStart as Record<string, unknown>)[bestKey];
+            if (typeof val === "string") {
+              command = val.trim();
+            } else if (Array.isArray(val)) {
+              command = val
+                .filter((item): item is string => typeof item === "string")
+                .join(" ")
+                .trim();
+            }
+          }
+        }
+      }
+
+      if (!command || command.length === 0) return [];
+
+      command = this.stripShellWrappers(command);
+      if (!command || command.length === 0) return [];
+
+      return [
+        {
+          id: "devcontainer-poststart",
+          name: "postStartCommand",
+          command,
+          icon: "terminal",
+          description: "from .devcontainer/devcontainer.json",
+        },
+      ];
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${devcontainerPath}:`, error);
+      return [];
+    }
+  }
+
+  private stripShellWrappers(command: string): string {
+    let result = command.trim();
+
+    if (result.startsWith("nohup ")) {
+      result = result.slice(6).trim();
+    }
+
+    if (result.endsWith(" &")) {
+      result = result.slice(0, -2).trim();
+    }
+
+    const bashCMatch = result.match(/^(?:bash|sh)\s+-c\s+'([^']*)'$/);
+    if (bashCMatch) {
+      result = bashCMatch[1].trim();
+      if (result.endsWith(" &")) {
+        result = result.slice(0, -2).trim();
+      }
+    }
+
+    return result;
   }
 }
 

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -484,6 +484,26 @@ describe("RunCommandDetector", () => {
       expect(dc[0]?.command).toBe("npm run dev");
     });
 
+    it("skips empty-string priority key in object postStartCommand", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({
+          postStartCommand: {
+            server: "",
+            dev: "npm run dev",
+          },
+        }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("npm run dev");
+    });
+
     it("falls back to first valid key when no priority keys match", async () => {
       const devcontainerDir = path.join(tempDir, ".devcontainer");
       await fs.mkdir(devcontainerDir);

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -425,6 +425,183 @@ describe("RunCommandDetector", () => {
     });
   });
 
+  describe("devcontainer detection", () => {
+    it("detects string postStartCommand", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({ postStartCommand: "npm run dev" }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc).toEqual([
+        expect.objectContaining({
+          id: "devcontainer-poststart",
+          name: "postStartCommand",
+          command: "npm run dev",
+          description: "from .devcontainer/devcontainer.json",
+        }),
+      ]);
+    });
+
+    it("joins array postStartCommand with spaces", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({ postStartCommand: ["npm", "run", "dev"] }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("npm run dev");
+    });
+
+    it("picks highest-priority key from object postStartCommand", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({
+          postStartCommand: {
+            app: "npm start",
+            server: "npm run dev",
+            watcher: "npm run watch",
+          },
+        }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("npm run dev");
+    });
+
+    it("falls back to first valid key when no priority keys match", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({
+          postStartCommand: {
+            watcher: "npm run watch",
+            db: "docker-compose up",
+          },
+        }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("npm run watch");
+    });
+
+    it("strips nohup bash -c wrapper", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({
+          postStartCommand: "nohup bash -c 'npm run dev &'",
+        }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("npm run dev");
+    });
+
+    it("strips sh -c wrapper", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({
+          postStartCommand: "sh -c 'python manage.py runserver'",
+        }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+
+      expect(dc[0]?.command).toBe("python manage.py runserver");
+    });
+
+    it("returns empty for missing devcontainer.json", async () => {
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+      expect(dc).toEqual([]);
+    });
+
+    it("returns empty for devcontainer.json without postStartCommand", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({ image: "node:20" }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+      expect(dc).toEqual([]);
+    });
+
+    it("returns empty for malformed JSON", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(path.join(devcontainerDir, "devcontainer.json"), "{invalid json", "utf-8");
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+      expect(dc).toEqual([]);
+    });
+
+    it("returns empty for null postStartCommand", async () => {
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({ postStartCommand: null }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const dc = commands.filter((cmd) => cmd.id === "devcontainer-poststart");
+      expect(dc).toEqual([]);
+    });
+
+    it("does not outrank npm dev script in full detect", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({ name: "test", scripts: { dev: "vite" } }),
+        "utf-8"
+      );
+      const devcontainerDir = path.join(tempDir, ".devcontainer");
+      await fs.mkdir(devcontainerDir);
+      await fs.writeFile(
+        path.join(devcontainerDir, "devcontainer.json"),
+        JSON.stringify({ postStartCommand: "npm run start" }),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const npmIds = commands.filter((cmd) => cmd.id.startsWith("npm-")).map((cmd) => cmd.id);
+      expect(npmIds).toContain("npm-dev");
+    });
+  });
+
   describe("caching", () => {
     it("returns cached results on second call without re-reading files", async () => {
       await fs.writeFile(

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -147,19 +147,14 @@ export function GeneralTab({
     return allDetectedRunners?.find((r) => r.id === "devcontainer-poststart");
   }, [allDetectedRunners, turbopackEnabled]);
 
+  const detectedCandidateRef = useRef(detectedCandidate);
+  detectedCandidateRef.current = detectedCandidate;
+
   const handleApplyDetected = useCallback(() => {
-    const candidate =
-      findDevServerCandidate(
-        useProjectSettingsStore.getState().allDetectedRunners,
-        turbopackEnabled
-      ) ??
-      useProjectSettingsStore
-        .getState()
-        .allDetectedRunners.find((r) => r.id === "devcontainer-poststart");
-    if (candidate) {
-      onDevServerCommandChange(candidate.command);
+    if (detectedCandidateRef.current) {
+      onDevServerCommandChange(detectedCandidateRef.current.command);
     }
-  }, [turbopackEnabled, onDevServerCommandChange]);
+  }, [onDevServerCommandChange]);
 
   useEffect(() => {
     const raf = requestAnimationFrame(() => {

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import {
   Image,
   Upload,
@@ -9,6 +9,7 @@ import {
   Copy,
   Palette,
   AlertTriangle,
+  WandSparkles,
 } from "lucide-react";
 import { FolderGit2, McpServerIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,8 @@ import { sanitizeSvg, svgToDataUrl } from "@/lib/svg";
 import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { DaintreeMcpTier, Project } from "@shared/types/project";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { findDevServerCandidate } from "@/utils/devServerDetection";
 
 const DAINTREE_MCP_TIER_OPTIONS: readonly ChoiceboxOption<DaintreeMcpTier>[] = [
   {
@@ -135,6 +138,28 @@ export function GeneralTab({
   const [inRepoError, setInRepoError] = useState<string | null>(null);
   const [gitignoreCopied, setGitignoreCopied] = useState(false);
   const gitignoreCopyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const allDetectedRunners = useProjectSettingsStore((s) => s.allDetectedRunners);
+
+  const detectedCandidate = useMemo(() => {
+    const candidate = findDevServerCandidate(allDetectedRunners, turbopackEnabled);
+    if (candidate) return candidate;
+    return allDetectedRunners?.find((r) => r.id === "devcontainer-poststart");
+  }, [allDetectedRunners, turbopackEnabled]);
+
+  const handleApplyDetected = useCallback(() => {
+    const candidate =
+      findDevServerCandidate(
+        useProjectSettingsStore.getState().allDetectedRunners,
+        turbopackEnabled
+      ) ??
+      useProjectSettingsStore
+        .getState()
+        .allDetectedRunners.find((r) => r.id === "devcontainer-poststart");
+    if (candidate) {
+      onDevServerCommandChange(candidate.command);
+    }
+  }, [turbopackEnabled, onDevServerCommandChange]);
 
   useEffect(() => {
     const raf = requestAnimationFrame(() => {
@@ -430,6 +455,29 @@ export function GeneralTab({
           Command to start the development server (e.g., npm run dev). When configured, a button
           will appear in the toolbar to start the dev server.
         </p>
+
+        {devServerCommand === "" && detectedCandidate && (
+          <div
+            className={cn(
+              "flex items-center gap-2 mb-3 px-3 py-2 rounded-[var(--radius-md)]",
+              "bg-overlay-subtle border border-daintree-border"
+            )}
+          >
+            <span className="text-xs text-daintree-text/60">
+              Detected:{" "}
+              <code className="font-mono text-daintree-text/80">{detectedCandidate.command}</code>
+            </span>
+            <Button
+              onClick={handleApplyDetected}
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 px-2.5 py-1 h-auto text-daintree-accent"
+            >
+              <WandSparkles className="h-3.5 w-3.5" />
+              Use command
+            </Button>
+          </div>
+        )}
 
         <input
           id="dev-server-command"

--- a/src/components/Project/__tests__/GeneralTab.devServerSuggestion.test.tsx
+++ b/src/components/Project/__tests__/GeneralTab.devServerSuggestion.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RunCommand } from "@shared/types";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    variant,
+    size,
+    className,
+  }: React.ComponentProps<"button"> & {
+    variant?: string;
+    size?: string;
+  }) => (
+    <button onClick={onClick} data-variant={variant} data-size={size} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/emoji-picker", () => ({
+  EmojiPicker: () => null,
+}));
+
+vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
+  SettingsSwitchCard: () => null,
+}));
+
+vi.mock("@/components/Settings/SettingsChoicebox", () => ({
+  SettingsChoicebox: () => null,
+}));
+
+const storeAllDetectedRunners: RunCommand[] = [];
+
+vi.mock("@/store/projectSettingsStore", () => {
+  const useProjectSettingsStore = (
+    selector: (state: { allDetectedRunners: RunCommand[] }) => unknown
+  ) => selector({ allDetectedRunners: storeAllDetectedRunners });
+  useProjectSettingsStore.getState = () => ({ allDetectedRunners: storeAllDetectedRunners });
+  return { useProjectSettingsStore };
+});
+
+vi.mock("@/components/icons", () => ({
+  FolderGit2: () => null,
+  McpServerIcon: () => null,
+}));
+
+import { GeneralTab } from "../GeneralTab";
+
+function devRunner(): RunCommand {
+  return {
+    id: "npm-dev",
+    name: "dev",
+    command: "npm run dev",
+    icon: "npm",
+    description: "vite",
+  };
+}
+
+function devcontainerRunner(): RunCommand {
+  return {
+    id: "devcontainer-poststart",
+    name: "postStartCommand",
+    command: "npm run dev",
+    icon: "terminal",
+    description: "from .devcontainer/devcontainer.json",
+  };
+}
+
+function renderGeneralTab(overrides: { devServerCommand?: string } = {}) {
+  return render(
+    <GeneralTab
+      currentProject={undefined}
+      name=""
+      onNameChange={vi.fn()}
+      emoji=""
+      onEmojiChange={vi.fn()}
+      color={undefined}
+      onColorChange={vi.fn()}
+      devServerCommand={overrides.devServerCommand ?? ""}
+      onDevServerCommandChange={vi.fn()}
+      devServerLoadTimeout={undefined}
+      onDevServerLoadTimeoutChange={vi.fn()}
+      turbopackEnabled={true}
+      onTurbopackEnabledChange={vi.fn()}
+      daintreeMcpTier="off"
+      onDaintreeMcpTierChange={vi.fn()}
+      projectIconSvg={undefined}
+      onProjectIconSvgChange={vi.fn()}
+      enableInRepoSettings={vi.fn()}
+      disableInRepoSettings={vi.fn()}
+      projectId="test-project"
+      isOpen={true}
+    />
+  );
+}
+
+describe("GeneralTab dev server suggestion", () => {
+  it("shows detected suggestion when field is empty and candidate exists", () => {
+    storeAllDetectedRunners.length = 0;
+    storeAllDetectedRunners.push(devRunner());
+
+    renderGeneralTab({ devServerCommand: "" });
+
+    expect(screen.getByText(/Detected:/)).toBeDefined();
+    expect(screen.getByText("npm run dev")).toBeDefined();
+    expect(screen.getByText("Use command")).toBeDefined();
+  });
+
+  it("does not show suggestion when field is non-empty", () => {
+    storeAllDetectedRunners.length = 0;
+    storeAllDetectedRunners.push(devRunner());
+
+    renderGeneralTab({ devServerCommand: "npm run start" });
+
+    expect(screen.queryByText(/Detected:/)).toBeNull();
+    expect(screen.queryByText("Use command")).toBeNull();
+  });
+
+  it("does not show suggestion when no runner is detected", () => {
+    storeAllDetectedRunners.length = 0;
+
+    renderGeneralTab({ devServerCommand: "" });
+
+    expect(screen.queryByText(/Detected:/)).toBeNull();
+    expect(screen.queryByText("Use command")).toBeNull();
+  });
+
+  it("shows suggestion for devcontainer fallback", () => {
+    storeAllDetectedRunners.length = 0;
+    storeAllDetectedRunners.push(devcontainerRunner());
+
+    renderGeneralTab({ devServerCommand: "" });
+
+    expect(screen.getByText(/Detected:/)).toBeDefined();
+    expect(screen.getByText("npm run dev")).toBeDefined();
+  });
+
+  it("calls onDevServerCommandChange with candidate command on apply", () => {
+    storeAllDetectedRunners.length = 0;
+    storeAllDetectedRunners.push(devRunner());
+
+    const onDevServerCommandChange = vi.fn();
+    render(
+      <GeneralTab
+        currentProject={undefined}
+        name=""
+        onNameChange={vi.fn()}
+        emoji=""
+        onEmojiChange={vi.fn()}
+        color={undefined}
+        onColorChange={vi.fn()}
+        devServerCommand=""
+        onDevServerCommandChange={onDevServerCommandChange}
+        devServerLoadTimeout={undefined}
+        onDevServerLoadTimeoutChange={vi.fn()}
+        turbopackEnabled={true}
+        onTurbopackEnabledChange={vi.fn()}
+        daintreeMcpTier="off"
+        onDaintreeMcpTierChange={vi.fn()}
+        projectIconSvg={undefined}
+        onProjectIconSvgChange={vi.fn()}
+        enableInRepoSettings={vi.fn()}
+        disableInRepoSettings={vi.fn()}
+        projectId="test-project"
+        isOpen={true}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Use command"));
+    expect(onDevServerCommandChange).toHaveBeenCalledWith("npm run dev");
+  });
+
+  it("hides suggestion after input is populated (field becomes non-empty)", () => {
+    storeAllDetectedRunners.length = 0;
+    storeAllDetectedRunners.push(devRunner());
+
+    const { rerender } = renderGeneralTab({ devServerCommand: "" });
+    expect(screen.getByText(/Detected:/)).toBeDefined();
+
+    rerender(
+      <GeneralTab
+        currentProject={undefined}
+        name=""
+        onNameChange={vi.fn()}
+        emoji=""
+        onEmojiChange={vi.fn()}
+        color={undefined}
+        onColorChange={vi.fn()}
+        devServerCommand="npm run dev"
+        onDevServerCommandChange={vi.fn()}
+        devServerLoadTimeout={undefined}
+        onDevServerLoadTimeoutChange={vi.fn()}
+        turbopackEnabled={true}
+        onTurbopackEnabledChange={vi.fn()}
+        daintreeMcpTier="off"
+        onDaintreeMcpTierChange={vi.fn()}
+        projectIconSvg={undefined}
+        onProjectIconSvgChange={vi.fn()}
+        enableInRepoSettings={vi.fn()}
+        disableInRepoSettings={vi.fn()}
+        projectId="test-project"
+        isOpen={true}
+      />
+    );
+
+    expect(screen.queryByText(/Detected:/)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The Dev Server Command field in project Settings now surfaces a suggested command when empty and a candidate is detected, so users don't have to type commands from scratch.
- Adds devcontainer.json `postStartCommand` as a fallback detection source when no package.json scripts match. The existing `findDevServerCandidate` helper remains the primary signal.
- This is the same UX already shipped in `DevPreviewPane`'s empty state, surfaced at the canonical configuration entry-point.

Resolves #6755

## Changes
- Added `postStartCommand` extraction from `.devcontainer/devcontainer.json` to `RunCommandDetector`, with empty-string key filtering in the object-priority path.
- Added a neutral-surface suggestion row to `GeneralTab.tsx` that appears below the Dev Server Command input when the field is empty and a candidate is available.
- Added unit tests for the devcontainer detection path and component tests for the suggestion affordance.

## Testing
- Unit: `RunCommandDetector` handles postStartCommand (string, array, object with `runCommand`, priority with empty keys skipped).
- Component: `GeneralTab` renders suggestion row when a candidate is detected and field is empty, doesn't render when field already has a value.