### PR TITLE
perf(workspace-host): adopt watcher-driven cadence in worktree status pipeline

### DIFF
--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -65,11 +65,13 @@ export class WatcherController {
   }
 
   /**
-   * Poll cadence is mode-aware. Recursive coverage keeps the heartbeat at
-   * 30s; git-only on the active worktree tightens to 10s so mid-edit
-   * changes that bypass .git/ are still picked up promptly; background
-   * git-only stays at 30s; no watcher falls back to the supplied adaptive
-   * interval.
+   * Poll cadence is mode-aware. Recursive coverage drops the heartbeat to
+   * 5min — the watcher catches every working-tree edit, so the timer is
+   * just a safety net for OS suspend/wake and rare watcher-ghost cases.
+   * Git-only on the active worktree tightens to 60s so mid-edit changes
+   * that bypass .git/ are still picked up reasonably; background git-only
+   * shares the 5min fallback. No watcher falls back to the supplied
+   * adaptive interval.
    */
   pollIntervalMs(adaptiveFallback: () => number): number {
     switch (this.gitWatcherMode) {

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -3,8 +3,8 @@ import { invalidateGitStatusCache } from "../utils/git.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
 
 const GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS = 1000;
-const WATCHER_FALLBACK_POLL_INTERVAL_MS = 30_000;
-const WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS = 10_000;
+const WATCHER_FALLBACK_POLL_INTERVAL_MS = 300_000;
+const WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS = 60_000;
 const WATCHER_RETRY_INTERVAL_MS = 30_000;
 const WATCHER_MAX_RETRIES = 5;
 const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 150;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -28,7 +28,13 @@ const RESOURCE_POLL_DEFAULT_ACTIVE_MS = 30_000;
 const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 300_000;
 const HEARTBEAT_GAP_MULTIPLIER = 3;
 const HEARTBEAT_GAP_FLOOR_MS = 30_000;
-const HEARTBEAT_GAP_CEILING_MS = 120_000;
+// Cap on the heartbeat-gap stale threshold. Keeps suspend/wake detection
+// bounded as the base poll interval grows: with the 300s watcher-fallback
+// cadence the raw 3x threshold would balloon to 900s. The ceiling must sit
+// above the largest base interval (300s) so a normal heartbeat fire on a
+// quiet repo doesn't false-positive — 360s leaves ~60s of headroom for
+// timer drift past the expected fire time.
+const HEARTBEAT_GAP_CEILING_MS = 360_000;
 
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
@@ -138,6 +144,10 @@ export class WorktreeMonitor {
   // Resource status auto-polling — owned by `resourcePollTimer`.
   private readonly resourcePollTimer: ResourcePollTimer;
   private resourcePollIntervalMs: number = 0; // 0 = disabled
+  // True when a recipe / config supplied an explicit `statusInterval`. Guards
+  // the focus-flip auto-adapt in the `isCurrent` setter so user values aren't
+  // silently overwritten when they happen to equal a default constant.
+  private resourcePollIntervalExplicit: boolean = false;
 
   // Background fetch scheduler — separate from the local-status poll so a
   // stuck remote can't poison local-status updates. Cadence flips based on
@@ -417,11 +427,11 @@ export class WorktreeMonitor {
     const changed = this._isCurrent !== value;
     this._isCurrent = value;
     if (changed && this._hasResourceConfig && this._hasStatusCommand && this._isRunning) {
-      // Only adapt if no explicit statusInterval was configured (i.e., using defaults)
-      const isUsingDefaultInterval =
-        this.resourcePollIntervalMs === RESOURCE_POLL_DEFAULT_ACTIVE_MS ||
-        this.resourcePollIntervalMs === RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
-      if (isUsingDefaultInterval) {
+      // Only adapt if no explicit statusInterval was configured. Pre-PR this
+      // was a value-equality check against the default constants; that
+      // collided with explicit user values that happened to match a default
+      // (e.g. `statusInterval: 300` matching the new 300s background default).
+      if (!this.resourcePollIntervalExplicit) {
         this.resourcePollIntervalMs = value
           ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
           : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
@@ -628,6 +638,7 @@ export class WorktreeMonitor {
    */
   setResourcePollInterval(ms: number): void {
     this.resourcePollIntervalMs = ms;
+    this.resourcePollIntervalExplicit = ms > 0;
     this.clearResourcePollTimer();
     if (ms > 0 && this._hasResourceConfig && this._isRunning) {
       this.scheduleResourcePoll();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -25,9 +25,10 @@ import { WatcherController, type WatcherControllerHost } from "./WatcherControll
 
 const PLAN_FILE_CANDIDATES = ["TODO.md", "PLAN.md", "plan.md", "TASKS.md"] as const;
 const RESOURCE_POLL_DEFAULT_ACTIVE_MS = 30_000;
-const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 120_000;
+const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 300_000;
 const HEARTBEAT_GAP_MULTIPLIER = 3;
 const HEARTBEAT_GAP_FLOOR_MS = 30_000;
+const HEARTBEAT_GAP_CEILING_MS = 120_000;
 
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
@@ -971,7 +972,10 @@ export class WorktreeMonitor {
       // longer than the floor (e.g., a slow git on a frozen filesystem).
       if (!this._isUpdating && this.lastGitStatusCompletedAt > 0) {
         const elapsedMs = Date.now() - this.lastGitStatusCompletedAt;
-        const threshold = Math.max(delayMs * HEARTBEAT_GAP_MULTIPLIER, HEARTBEAT_GAP_FLOOR_MS);
+        const threshold = Math.min(
+          Math.max(delayMs * HEARTBEAT_GAP_MULTIPLIER, HEARTBEAT_GAP_FLOOR_MS),
+          HEARTBEAT_GAP_CEILING_MS
+        );
         if (elapsedMs > threshold) {
           this.mood = "stale";
           this.emitUpdate();

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1134,6 +1134,37 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("explicit interval matching a default constant survives focus flip", async () => {
+      // Regression: the focus-flip auto-adapt previously checked whether the
+      // current interval equaled either default, which collided with explicit
+      // user values that happened to match. After the new background default
+      // landed at 300s, `statusInterval: 300` was a plausible production
+      // value that would silently flip to 30s on focus change.
+      const backgroundWorktree: Worktree = { ...TEST_WORKTREE, isCurrent: false };
+      const callbacks = makeCallbacks({ onResourceStatusPoll: vi.fn() });
+      const monitor = new WorktreeMonitor(backgroundWorktree, TEST_CONFIG, callbacks, "main");
+
+      monitor.startWithoutGitStatus();
+      monitor.setHasResourceConfig(true);
+      monitor.setHasStatusCommand(true);
+      // Explicit value that exactly matches RESOURCE_POLL_DEFAULT_BACKGROUND_MS.
+      monitor.setResourcePollInterval(300_000);
+
+      monitor.isCurrent = true;
+
+      // If the focus-flip incorrectly reverted to the active default (30s),
+      // the callback would fire after 30s. With the explicit-flag guard it
+      // must wait the full 300s.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(callbacks.onResourceStatusPoll).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(240_000);
+      expect(callbacks.onResourceStatusPoll).toHaveBeenCalledWith("/test/worktree");
+      expect(callbacks.onResourceStatusPoll).toHaveBeenCalledTimes(1);
+
+      monitor.stop();
+    });
   });
 
   describe("snapshot capability flags", () => {
@@ -1460,12 +1491,12 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("does not mark stale when elapsed exceeds 30s floor but is below 120s ceiling", async () => {
+    it("does not mark stale when elapsed exceeds 30s floor but is below 360s ceiling", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
 
       const callbacks = makeCallbacks();
       // Watcher fallback path: base interval = 300s, raw threshold = 900s,
-      // capped to 120s by HEARTBEAT_GAP_CEILING_MS.
+      // capped to 360s by HEARTBEAT_GAP_CEILING_MS.
       const watcherConfig: WorktreeMonitorConfig = {
         ...TEST_CONFIG,
         gitWatchEnabled: true,
@@ -1481,7 +1512,7 @@ describe("WorktreeMonitor", () => {
       (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
         Date.now();
       // Advance another 60s to fire the heartbeat at T+305s.
-      // elapsed at fire = 55s: above 30s floor, below 120s ceiling — must not mark stale.
+      // elapsed at fire = 55s: above 30s floor, below 360s ceiling — must not mark stale.
       await vi.advanceTimersByTimeAsync(60_000);
 
       const moods = getMoodSequence(callbacks);
@@ -1535,7 +1566,7 @@ describe("WorktreeMonitor", () => {
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
     });
 
-    it("watcher fallback interval (300s) triggers stale when gap exceeds 120s ceiling", async () => {
+    it("watcher fallback interval (300s) triggers stale when gap exceeds 360s ceiling", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
       mockWatcherStartResult = true;
 
@@ -1548,11 +1579,12 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
 
-      // 121s gap exceeds the 120s ceiling cap on the watcher fallback path:
-      // raw threshold (3 * 300s = 900s) is clamped to 120s so suspend/wake
-      // detection stays bounded regardless of base interval.
+      // 100s past offset on lastCompleted plus the 300s timer fire gives an
+      // elapsed of ~400s at fire — above the 360s ceiling. Raw threshold
+      // (3 * 300s = 900s) is clamped to 360s so suspend/wake detection stays
+      // bounded regardless of base interval.
       (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
-        Date.now() - 121_000;
+        Date.now() - 100_000;
 
       await vi.advanceTimersByTimeAsync(305_000);
 
@@ -1562,7 +1594,7 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("watcher fallback interval (300s) does not trigger stale when gap is below 120s ceiling", async () => {
+    it("watcher fallback interval (300s) does not trigger stale on a quiet repo", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
       mockWatcherStartResult = true;
 
@@ -1575,14 +1607,12 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
 
-      // Advance to T+200s, then mark a watcher update — gap at fire becomes ~100s,
-      // safely below the 120s ceiling. Heartbeat must not mark stale.
-      // (Using ~100s instead of 119s to absorb the up-to-2000ms jitter on the
-      // polling timer's delay.)
-      await vi.advanceTimersByTimeAsync(200_000);
-      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
-        Date.now();
-      await vi.advanceTimersByTimeAsync(105_000);
+      // After the initial poll, lastCompleted is set and the heartbeat timer
+      // is scheduled for +300s. Advance to fire it without mutating
+      // lastCompleted (no watcher events, no manual override). Elapsed at
+      // fire is the base interval (~300s) — below the 360s ceiling, so the
+      // safety net must NOT flicker stale on every cycle.
+      await vi.advanceTimersByTimeAsync(305_000);
 
       const moods = getMoodSequence(callbacks);
       expect(moods).not.toContain("stale");

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1023,7 +1023,7 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("defaults to 120s polling for background worktree", async () => {
+    it("defaults to 300s polling for background worktree", async () => {
       const backgroundWorktree: Worktree = { ...TEST_WORKTREE, isCurrent: false };
       const callbacks = makeCallbacks({ onResourceStatusPoll: vi.fn() });
       const monitor = new WorktreeMonitor(backgroundWorktree, TEST_CONFIG, callbacks, "main");
@@ -1032,17 +1032,17 @@ describe("WorktreeMonitor", () => {
       monitor.setHasResourceConfig(true);
       monitor.setHasStatusCommand(true);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(270_000);
       expect(callbacks.onResourceStatusPoll).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(90_000);
+      await vi.advanceTimersByTimeAsync(30_000);
       expect(callbacks.onResourceStatusPoll).toHaveBeenCalledWith("/test/worktree");
       expect(callbacks.onResourceStatusPoll).toHaveBeenCalledTimes(1);
 
       monitor.stop();
     });
 
-    it("switches from 120s to 30s when isCurrent becomes true", async () => {
+    it("switches from 300s to 30s when isCurrent becomes true", async () => {
       const backgroundWorktree: Worktree = { ...TEST_WORKTREE, isCurrent: false };
       const callbacks = makeCallbacks({ onResourceStatusPoll: vi.fn() });
       const monitor = new WorktreeMonitor(backgroundWorktree, TEST_CONFIG, callbacks, "main");
@@ -1460,11 +1460,12 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("does not mark stale when elapsed exceeds 30s floor but is below 3x interval", async () => {
+    it("does not mark stale when elapsed exceeds 30s floor but is below 120s ceiling", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
 
       const callbacks = makeCallbacks();
-      // Use the watcher fallback path: base interval = 30s, threshold = 90s.
+      // Watcher fallback path: base interval = 300s, raw threshold = 900s,
+      // capped to 120s by HEARTBEAT_GAP_CEILING_MS.
       const watcherConfig: WorktreeMonitorConfig = {
         ...TEST_CONFIG,
         gitWatchEnabled: true,
@@ -1474,11 +1475,14 @@ describe("WorktreeMonitor", () => {
       await monitor.start();
 
       mockGetWorktreeChangesWithStats.mockClear();
-      // 60s gap > 30s floor but < 3 * 30s base = 90s threshold.
+      // Advance most of the way to the heartbeat fire (timer is at +300s).
+      await vi.advanceTimersByTimeAsync(245_000);
+      // Simulate a watcher-driven update landing at T+245s — lastCompleted is now recent.
       (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
-        Date.now() - 60_000;
-
-      await vi.advanceTimersByTimeAsync(35_000);
+        Date.now();
+      // Advance another 60s to fire the heartbeat at T+305s.
+      // elapsed at fire = 55s: above 30s floor, below 120s ceiling — must not mark stale.
+      await vi.advanceTimersByTimeAsync(60_000);
 
       const moods = getMoodSequence(callbacks);
       expect(moods).not.toContain("stale");
@@ -1531,7 +1535,7 @@ describe("WorktreeMonitor", () => {
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
     });
 
-    it("watcher fallback interval (30s) requires 90s+ gap to trigger stale", async () => {
+    it("watcher fallback interval (300s) triggers stale when gap exceeds 120s ceiling", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
       mockWatcherStartResult = true;
 
@@ -1544,14 +1548,44 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
       await monitor.start();
 
-      // 100s gap exceeds the 90s threshold for the 30s watcher fallback interval.
+      // 121s gap exceeds the 120s ceiling cap on the watcher fallback path:
+      // raw threshold (3 * 300s = 900s) is clamped to 120s so suspend/wake
+      // detection stays bounded regardless of base interval.
       (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
-        Date.now() - 100_000;
+        Date.now() - 121_000;
 
-      await vi.advanceTimersByTimeAsync(35_000);
+      await vi.advanceTimersByTimeAsync(305_000);
 
       const moods = getMoodSequence(callbacks);
       expect(moods).toContain("stale");
+
+      monitor.stop();
+    });
+
+    it("watcher fallback interval (300s) does not trigger stale when gap is below 120s ceiling", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);
+      mockWatcherStartResult = true;
+
+      const watcherConfig: WorktreeMonitorConfig = {
+        ...TEST_CONFIG,
+        gitWatchEnabled: true,
+      };
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, watcherConfig, callbacks, "main");
+      await monitor.start();
+
+      // Advance to T+200s, then mark a watcher update — gap at fire becomes ~100s,
+      // safely below the 120s ceiling. Heartbeat must not mark stale.
+      // (Using ~100s instead of 119s to absorb the up-to-2000ms jitter on the
+      // polling timer's delay.)
+      await vi.advanceTimersByTimeAsync(200_000);
+      (monitor as unknown as { lastGitStatusCompletedAt: number }).lastGitStatusCompletedAt =
+        Date.now();
+      await vi.advanceTimersByTimeAsync(105_000);
+
+      const moods = getMoodSequence(callbacks);
+      expect(moods).not.toContain("stale");
 
       monitor.stop();
     });


### PR DESCRIPTION
## Summary

The recursive `gitFileWatcher` catches every working-tree edit and every HEAD/refs/index change before the next poll fires. The polling timers' only remaining job is OS-suspend recovery and rare watcher-ghost detection. This PR aligns the constants with that reality.

- `WATCHER_FALLBACK_POLL_INTERVAL_MS` 30s → 300s, `WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS` 10s → 60s, `RESOURCE_POLL_DEFAULT_BACKGROUND_MS` 120s → 300s. The watcher is the primary signal; the timer is now a belt-and-braces heartbeat.
- Adds `HEARTBEAT_GAP_CEILING_MS = 360s` with a `Math.min(Math.max(delay * MULTIPLIER, FLOOR), CEILING)` clamp on the heartbeat-gap stale threshold. Without the cap, the raw 3× threshold at the new 300s base would balloon to 900s, silently degrading suspend/wake detection from ~90s to ~15min. The 360s ceiling sits above the 300s base (no false flicker on quiet repos) while bounding detection latency to ~60s past expected fire time.
- Replaces the value-equality sentinel in the `resourcePollInterval` setter with an explicit `resourcePollIntervalExplicit` flag. Pre-fix, an explicit `statusInterval: 300` would silently flip to the 30s active default on focus change because it matched the new 300s background constant.

Resolves #6775

## Changes

- `WatcherController.ts` — relaxed `WATCHER_FALLBACK_POLL_INTERVAL_MS` and `WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS` with updated docstrings
- `WorktreeMonitor.ts` — `RESOURCE_POLL_DEFAULT_BACKGROUND_MS`, `HEARTBEAT_GAP_CEILING_MS`, ceiling clamp on gap threshold, `resourcePollIntervalExplicit` flag
- `WorktreeMonitor.test.ts` — new tests: quiet-repo heartbeat (no false stale at 300s base), 360s ceiling boundary (above/below), explicit-interval-vs-default-collision regression; 75 + 23 tests passing

## Testing

- Full `WorktreeMonitor` and `WatcherController` test suites pass (75 + 23 tests)
- New tests specifically cover the quiet-repo heartbeat path, the ceiling boundary at exactly 360s, and the explicit-interval regression that was introduced by the constant value collision