### PR TITLE
fix(skeleton): add font-family to skeleton tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,6 +420,15 @@
         margin-top: 12px;
         font-size: 13px;
         font-weight: 500;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
         line-height: 1.5;
         color: color-mix(
           in oklch,


### PR DESCRIPTION
## Summary
- The skeleton tagline in the cold-start HTML was missing a `font-family` declaration, so it rendered in the browser's default serif font, then snapped to sans-serif once React hydrated.
- Added a `system-ui` font stack to `.skeleton-tagline` in `index.html` so it paints in sans-serif from the very first frame.

Resolves #6772.

## Changes
- `index.html` — 9 lines of CSS: `font-family` with a system sans-serif stack on `.skeleton-tagline`.

## Testing
- Visual: cold-start load verified the tagline renders in sans-serif immediately, with no font shift on hydration.