### PR TITLE
fix(github): reset copy checkmark state on dropdown reopen

### DIFF
--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -128,6 +128,7 @@ export function GitHubListItem({
   const copyTimeoutRef = useRef<number | undefined>(undefined);
 
   useEffect(() => {
+    setCopied(false);
     return () => {
       if (copyTimeoutRef.current) {
         clearTimeout(copyTimeoutRef.current);

--- a/src/components/GitHub/__tests__/GitHubListItem.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubListItem.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { Activity, type ReactNode } from "react";
 import { GitHubListItem } from "../GitHubListItem";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import { actionService } from "@/services/ActionService";
@@ -170,8 +170,16 @@ describe("GitHubListItem", () => {
     expect(checkIconAfter).toBeNull();
   });
 
-  it("resets copy state on unmount/remount so checkmark does not persist across reopen", async () => {
-    const { unmount } = render(<GitHubListItem item={baseIssue} type="issue" />);
+  it("resets copy state on Activity hide/reveal so checkmark does not persist across reopen", async () => {
+    function Harness({ mode }: { mode: "visible" | "hidden" }) {
+      return (
+        <Activity mode={mode}>
+          <GitHubListItem item={baseIssue} type="issue" />
+        </Activity>
+      );
+    }
+
+    const { rerender } = render(<Harness mode="visible" />);
     const copyButton = screen.getByLabelText("Copy number 42");
 
     await act(async () => {
@@ -181,11 +189,10 @@ describe("GitHubListItem", () => {
     const checkIcon = copyButton.querySelector(".text-status-success");
     expect(checkIcon).not.toBeNull();
 
-    unmount();
+    rerender(<Harness mode="hidden" />);
+    rerender(<Harness mode="visible" />);
 
-    render(<GitHubListItem item={baseIssue} type="issue" />);
     const copyButtonAfter = screen.getByLabelText("Copy number 42");
-
     const checkIconAfter = copyButtonAfter.querySelector(".text-status-success");
     expect(checkIconAfter).toBeNull();
   });

--- a/src/components/GitHub/__tests__/GitHubListItem.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubListItem.test.tsx
@@ -170,6 +170,26 @@ describe("GitHubListItem", () => {
     expect(checkIconAfter).toBeNull();
   });
 
+  it("resets copy state on unmount/remount so checkmark does not persist across reopen", async () => {
+    const { unmount } = render(<GitHubListItem item={baseIssue} type="issue" />);
+    const copyButton = screen.getByLabelText("Copy number 42");
+
+    await act(async () => {
+      fireEvent.click(copyButton);
+    });
+
+    const checkIcon = copyButton.querySelector(".text-status-success");
+    expect(checkIcon).not.toBeNull();
+
+    unmount();
+
+    render(<GitHubListItem item={baseIssue} type="issue" />);
+    const copyButtonAfter = screen.getByLabelText("Copy number 42");
+
+    const checkIconAfter = copyButtonAfter.querySelector(".text-status-success");
+    expect(checkIconAfter).toBeNull();
+  });
+
   it("renders ellipsis menu trigger button", () => {
     render(<GitHubListItem item={baseIssue} type="issue" />);
     expect(screen.getByLabelText("More actions")).toBeTruthy();


### PR DESCRIPTION
## Summary
- One-line fix in `GitHubListItem.tsx` — adds `setCopied(false)` to the `useEffect` setup so the copied checkmark resets each time the dropdown reopens.
- React 19.2 Activity keeps the component mounted when hidden, so state persisted across reopen.
- Added a regression test using the `Activity` component to model the `keepMounted` lifecycle.

Resolves #6771

## Changes
- `src/components/GitHub/GitHubListItem.tsx` — reset `copied` state in `useEffect` setup
- `src/components/GitHub/__tests__/GitHubListItem.test.tsx` — test that uses `Activity` hide/reveal to simulate dropdown reopen

## Testing
- New regression test passes, verifying the checkmark clears on hide/reveal.
- Existing GitHubListItem tests continue to pass.
- Typecheck and lint clean.