### PR TITLE
fix(portal): toolbar icon and label don't signal web AI chat

### DIFF
--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -7,7 +7,7 @@ export const SEL = {
     openDevPreview: '[aria-label="Open Dev Preview"]',
     copyContext: '[aria-label="Copy Context"]',
     projectSwitcherTrigger: '[data-testid="project-switcher-trigger"]',
-    portalToggle: '[aria-label*="context portal"]',
+    portalToggle: '[aria-label*="web chat"]',
   },
   portal: {
     region: 'aside[aria-label="Portal"]',

--- a/src/components/Layout/ToolbarPortalButton.tsx
+++ b/src/components/Layout/ToolbarPortalButton.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import { Button } from "@/components/ui/button";
-import { PanelRightOpen, PanelRightClose } from "lucide-react";
+import { BotMessageSquare } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
@@ -29,20 +29,16 @@ export const ToolbarPortalButton = memo(function ToolbarPortalButton({
           data-toolbar-item={dataToolbarItem}
           onClick={togglePortal}
           className={toolbarIconButtonClass}
-          aria-label={portalOpen ? "Close context portal" : "Open context portal"}
+          aria-label={portalOpen ? "Close web chat" : "Open web chat"}
           aria-pressed={portalOpen}
         >
-          {portalOpen ? (
-            <PanelRightClose aria-hidden="true" />
-          ) : (
-            <PanelRightOpen aria-hidden="true" />
-          )}
+          <BotMessageSquare aria-hidden="true" />
           <ShortcutRevealChip actionId="panel.togglePortal" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">
         {createTooltipContent(
-          portalOpen ? "Close Context Portal" : "Open Context Portal",
+          portalOpen ? "Close web chat" : "Web chat: Claude, ChatGPT, Gemini",
           portalShortcut
         )}
       </TooltipContent>

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -69,7 +69,16 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
                 <div className="font-medium text-foreground group-hover:text-daintree-text transition-colors">
                   {link.title}
                 </div>
-                <div className="text-xs text-daintree-text/70">Open web client</div>
+                <div className="text-xs text-daintree-text/70">
+                  {(() => {
+                    try {
+                      const host = new URL(link.url).hostname;
+                      return host || "Open web client";
+                    } catch {
+                      return "Open web client";
+                    }
+                  })()}
+                </div>
               </div>
             </button>
           ))}

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -65,11 +65,11 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
               <div className="w-8 h-8 flex items-center justify-center text-foreground group-hover:text-daintree-text transition-colors">
                 <PortalIcon icon={link.icon} size="launchpad" url={link.url} type={link.type} />
               </div>
-              <div className="text-left">
+              <div className="text-left min-w-0">
                 <div className="font-medium text-foreground group-hover:text-daintree-text transition-colors">
                   {link.title}
                 </div>
-                <div className="text-xs text-daintree-text/70">
+                <div className="text-xs text-daintree-text/70 truncate">
                   {(() => {
                     try {
                       const host = new URL(link.url).hostname;


### PR DESCRIPTION
## Summary
- The toolbar button that opens the Portal panel used a generic `PanelRightOpen`/`PanelRightClose` icon and the label "Context Portal" -- neither signaled that this is where users access external web AI chat.
- Swapped to `BotMessageSquare` (robot in chat bubble), updated the tooltip and aria-label to name the actual providers, and replaced the generic "Open web client" launchpad subtitle with the URL hostname.

Resolves #6773

## Changes
- `ToolbarPortalButton`: single static `BotMessageSquare` icon replaces the open/close icon pair; tooltip reads "Web chat: Claude, ChatGPT, Gemini" / "Close web chat"; aria-label reads "Open web chat" / "Close web chat"
- `PortalLaunchpad`: rows now show hostnames (`claude.ai`, `chatgpt.com`, `gemini.google.com`) extracted via `new URL()` with try/catch fallback to "Open web client"
- E2E selector in `selectors.ts` synced from "context portal" to "web chat"

## Testing
- Verified the toolbar button toggles the Portal panel and renders the new icon correctly
- Verified launchpad row hostnames are extracted and truncated for long hostnames
- E2E selector updated to match the new aria-label text