### PR TITLE
perf(terminal): disable cosmetic xterm options for agent panels

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -636,6 +636,11 @@ class TerminalInstanceService {
       if (options) {
         this.updateOptions(id, options);
       }
+      if (launchAgentId !== undefined && !existing.isHibernated) {
+        existing.terminal.options.cursorBlink = false;
+        existing.terminal.options.rescaleOverlappingGlyphs = false;
+        existing.terminal.options.customGlyphs = false;
+      }
       return existing;
     }
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -662,6 +662,12 @@ class TerminalInstanceService {
       },
     };
 
+    if (launchAgentId !== undefined) {
+      terminalOptions.cursorBlink = false;
+      terminalOptions.rescaleOverlappingGlyphs = false;
+      terminalOptions.customGlyphs = false;
+    }
+
     const terminal = new Terminal(terminalOptions);
     this.cwdProviders.set(id, getCwd ?? (() => ""));
     const addons = setupTerminalAddons(

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -155,4 +155,46 @@ describe("TerminalInstanceService - options", () => {
 
     terminalInstanceService.destroy("test-options");
   });
+
+  it("preserves agent cosmetic overrides when existing terminal is reused with fresh options", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    // First creation — agent terminal
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options",
+      "claude",
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    expect(managed.terminal.options.cursorBlink).toBe(false);
+
+    // Simulate XtermAdapter re-rendering with fresh options from getXtermOptions()
+    // which includes cursorBlink: true from BASE_TERMINAL_OPTIONS
+    terminalInstanceService.getOrCreate(
+      "test-options",
+      "claude",
+      { cursorBlink: true, fontSize: 14 },
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    expect(managed.terminal.options).toMatchObject({
+      cursorBlink: false,
+      rescaleOverlappingGlyphs: false,
+      customGlyphs: false,
+    });
+    expect(managed.terminal.options.fontSize).toBe(14);
+
+    terminalInstanceService.destroy("test-options");
+  });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -65,10 +65,9 @@ const mockDocument = {
 (global as any).document = mockDocument;
 
 describe("TerminalInstanceService - options", () => {
-  it("sets rescaleOverlappingGlyphs and reflowCursorLine on constructed Terminal", async () => {
+  it("uses current defaults for non-agent terminals", async () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
 
-    // Mock matchMedia for xterm's Terminal.open()
     window.matchMedia = vi.fn().mockReturnValue({
       matches: false,
       addEventListener: vi.fn(),
@@ -79,7 +78,7 @@ describe("TerminalInstanceService - options", () => {
 
     const managed = terminalInstanceService.getOrCreate(
       "test-options",
-      "terminal",
+      undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
@@ -88,9 +87,71 @@ describe("TerminalInstanceService - options", () => {
     expect(managed.terminal.options).toEqual(
       expect.objectContaining({
         rescaleOverlappingGlyphs: true,
+        customGlyphs: true,
         reflowCursorLine: true,
       })
     );
+
+    terminalInstanceService.destroy("test-options");
+  });
+
+  it("disables cosmetic options for agent terminals", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options",
+      "claude",
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    expect(managed.terminal.options).toEqual(
+      expect.objectContaining({
+        cursorBlink: false,
+        rescaleOverlappingGlyphs: false,
+        customGlyphs: false,
+        reflowCursorLine: true,
+      })
+    );
+
+    terminalInstanceService.destroy("test-options");
+  });
+
+  it("preserves agent cosmetic options on terminal.options for hibernation rebuilds", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options",
+      "claude",
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    // TerminalHibernationManager.unhibernate() calls new Terminal(managed.terminal.options)
+    // so these must be present on the stored options object
+    expect(managed.terminal.options).toMatchObject({
+      cursorBlink: false,
+      rescaleOverlappingGlyphs: false,
+      customGlyphs: false,
+    });
 
     terminalInstanceService.destroy("test-options");
   });


### PR DESCRIPTION
## Summary
This moves agent terminal panels off xterm options that add per-panel cost without delivering value. `cursorBlink`, `rescaleOverlappingGlyphs`, and `customGlyphs` are all disabled when the terminal hosts an AI coding agent rather than an interactive shell. Across many open agent panels these compound: setInterval timers, per-character glyph checks, synthetic atlas entries — none of it observable.

Non-agent terminals keep their current defaults.

Resolves #6774

## Changes
- `TerminalInstanceService.getOrCreate` sets `cursorBlink: false`, `rescaleOverlappingGlyphs: false`, and `customGlyphs: false` on agent panels (`launchAgentId !== undefined`) at both fresh construction and reuse paths
- The reuse path re-applies the overrides after `updateOptions` so they can't be leaked away by `XtermAdapter` re-rendering with `BASE_TERMINAL_OPTIONS`
- Because the overrides land on `terminal.options`, `TerminalHibernationManager.unhibernate` picks them up without any extra work
- 3 new test cases + 1 existing test renamed to cover all three paths (fresh construction, hibernation rebuild options survival, reuse-after-updateOptions override preservation)

## Testing
Unit tests pass for all four construction/reuse scenarios. Manual smoke: agent panel opens with no cursor blinking; non-agent terminal cursor blinks as normal.