### PR TITLE
feat(power-monitor): extend window-blur throttle to 4 background pollers

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,6 +64,8 @@ import {
   registerWindowForFocusThrottle,
 } from "./window/powerMonitor.js";
 import { getProjectStatsService } from "./ipc/handlers/projectCrud/index.js";
+import { getIdleTerminalNotificationService } from "./services/IdleTerminalNotificationService.js";
+import { preAgentSnapshotService } from "./services/PreAgentSnapshotService.js";
 import { isSmokeTest } from "./setup/environment.js";
 import { store } from "./store.js";
 import {
@@ -325,6 +327,8 @@ if (!gotTheLock) {
         getPtyClient,
         getWorkspaceClient: getWorkspaceClientRef,
         getProjectStatsService,
+        getIdleTerminalNotificationService: () => getIdleTerminalNotificationService(),
+        getPreAgentSnapshotService: () => preAgentSnapshotService,
       });
     }
 

--- a/electron/services/DiskSpaceMonitor.ts
+++ b/electron/services/DiskSpaceMonitor.ts
@@ -34,6 +34,20 @@ export function getCurrentDiskSpaceStatus(): DiskSpacePayload {
   return currentStatus;
 }
 
+let currentDiskSpacePollIntervalMs = POLL_INTERVAL_MS;
+let rearmDiskSpaceTimer: (() => void) | null = null;
+let diskSpacePollFn: (() => Promise<void>) | null = null;
+
+export function setDiskSpaceMonitorPollInterval(ms: number): void {
+  if (ms === currentDiskSpacePollIntervalMs) return;
+  currentDiskSpacePollIntervalMs = ms;
+  rearmDiskSpaceTimer?.();
+}
+
+export function refreshDiskSpaceMonitor(): void {
+  diskSpacePollFn?.();
+}
+
 export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => void {
   let lastStatus: DiskSpaceStatus = "normal";
   let lastNotificationAt = 0;
@@ -111,14 +125,25 @@ export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => v
     }
   }
 
-  void poll();
+  diskSpacePollFn = poll;
 
-  const clear = setAlignedInterval(() => {
-    void poll();
-  }, POLL_INTERVAL_MS);
+  let clearAlignedInterval: (() => void) | null = null;
+  const armTimer = () => {
+    clearAlignedInterval?.();
+    clearAlignedInterval = setAlignedInterval(() => {
+      void poll();
+    }, currentDiskSpacePollIntervalMs);
+  };
+  rearmDiskSpaceTimer = armTimer;
+
+  void poll();
+  armTimer();
 
   return () => {
     disposed = true;
-    clear();
+    clearAlignedInterval?.();
+    clearAlignedInterval = null;
+    diskSpacePollFn = null;
+    rearmDiskSpaceTimer = null;
   };
 }

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -57,6 +57,7 @@ export class IdleTerminalNotificationService {
   private readonly CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
   private readonly STARTUP_QUIET_MS = 2 * 60 * 1000; // 2 minutes
   private readonly INITIAL_CHECK_DELAY_MS = 5_000;
+  private currentCheckIntervalMs = this.CHECK_INTERVAL_MS;
 
   private normalizeThreshold(value: unknown, fallback: number): number {
     if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -129,7 +130,7 @@ export class IdleTerminalNotificationService {
       void this.checkAndNotify().catch((error) => {
         logError("idle-terminal-notify-check-failed", error);
       });
-    }, this.CHECK_INTERVAL_MS);
+    }, this.currentCheckIntervalMs);
 
     if (this.initialCheckTimer) {
       clearTimeout(this.initialCheckTimer);
@@ -151,6 +152,19 @@ export class IdleTerminalNotificationService {
     if (this.initialCheckTimer) {
       clearTimeout(this.initialCheckTimer);
       this.initialCheckTimer = null;
+    }
+  }
+
+  updatePollInterval(ms: number): void {
+    if (ms === this.currentCheckIntervalMs) return;
+    this.currentCheckIntervalMs = ms;
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = setInterval(() => {
+        void this.checkAndNotify().catch((error) => {
+          logError("idle-terminal-notify-check-failed", error);
+        });
+      }, this.currentCheckIntervalMs);
     }
   }
 

--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -8,19 +8,31 @@ const STASH_PREFIX = "daintree:pre-agent:";
 const DEFAULT_TTL_MS = 48 * 60 * 60 * 1000; // 48 hours
 const PRUNE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
-class PreAgentSnapshotService {
+export class PreAgentSnapshotService {
   private snapshots = new Map<string, SnapshotInfo>();
   private unsubscribers: Array<() => void> = [];
   private pruneTimer: NodeJS.Timeout | null = null;
+  private pruneIntervalMs = PRUNE_INTERVAL_MS;
 
   initialize(): void {
+    if (this.pruneTimer) return;
+
     const unsub = events.on("agent:state-changed", (payload) => {
       this.handleStateChanged(payload);
     });
     this.unsubscribers.push(unsub);
 
     this.pruneAllWorktrees();
-    this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), PRUNE_INTERVAL_MS);
+    this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
+  }
+
+  updatePollInterval(ms: number): void {
+    if (ms === this.pruneIntervalMs) return;
+    this.pruneIntervalMs = ms;
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
+    }
   }
 
   private handleStateChanged(payload: {

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -201,6 +201,20 @@ function getProcessMemoryMb(proc: Electron.ProcessMetric): number {
   return (proc.memory.privateBytes ?? proc.memory.workingSetSize) / 1024;
 }
 
+let currentAppMetricsPollIntervalMs = POLL_INTERVAL_MS;
+let rearmAppMetricsTimer: (() => void) | null = null;
+let appMetricsPollFn: (() => void) | null = null;
+
+export function setAppMetricsMonitorPollInterval(ms: number): void {
+  if (ms === currentAppMetricsPollIntervalMs) return;
+  currentAppMetricsPollIntervalMs = ms;
+  rearmAppMetricsTimer?.();
+}
+
+export function refreshAppMetricsMonitor(): void {
+  appMetricsPollFn?.();
+}
+
 export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => void {
   const snapshotCooldowns = new Map<number, number>();
   const trendState = new Map<number, PidTrendState>();
@@ -209,7 +223,7 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   let lastTier2At = 0;
   let mitigationInFlight = false;
 
-  const clear = setAlignedInterval(() => {
+  const poll = () => {
     try {
       pollCount++;
       // Kick off a Blink-memory sample fan-out for this tick. Renderer replies
@@ -371,7 +385,23 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
     } catch (err) {
       logWarn("process-memory-poll-failed", { error: String(err) });
     }
-  }, POLL_INTERVAL_MS);
+  };
 
-  return clear;
+  appMetricsPollFn = poll;
+
+  let clearAlignedInterval: (() => void) | null = null;
+  const armTimer = () => {
+    clearAlignedInterval?.();
+    clearAlignedInterval = setAlignedInterval(poll, currentAppMetricsPollIntervalMs);
+  };
+  rearmAppMetricsTimer = armTimer;
+
+  armTimer();
+
+  return () => {
+    clearAlignedInterval?.();
+    clearAlignedInterval = null;
+    appMetricsPollFn = null;
+    rearmAppMetricsTimer = null;
+  };
 }

--- a/electron/window/__tests__/windowFocusThrottle.test.ts
+++ b/electron/window/__tests__/windowFocusThrottle.test.ts
@@ -20,10 +20,27 @@ vi.mock("../webContentsRegistry.js", () => ({
   getAppWebContents: vi.fn(),
 }));
 
+const mockSetDiskSpaceInterval = vi.fn();
+const mockRefreshDiskSpace = vi.fn();
+const mockSetAppMetricsInterval = vi.fn();
+const mockRefreshAppMetrics = vi.fn();
+
+vi.mock("../../services/DiskSpaceMonitor.js", () => ({
+  setDiskSpaceMonitorPollInterval: mockSetDiskSpaceInterval,
+  refreshDiskSpaceMonitor: mockRefreshDiskSpace,
+}));
+
+vi.mock("../../services/ProcessMemoryMonitor.js", () => ({
+  setAppMetricsMonitorPollInterval: mockSetAppMetricsInterval,
+  refreshAppMetricsMonitor: mockRefreshAppMetrics,
+}));
+
 import { app } from "electron";
 import type { PtyClient } from "../../services/PtyClient.js";
 import type { WorkspaceClient } from "../../services/WorkspaceClient.js";
 import type { ProjectStatsService } from "../../services/ProjectStatsService.js";
+import type { IdleTerminalNotificationService } from "../../services/IdleTerminalNotificationService.js";
+import type { PreAgentSnapshotService } from "../../services/PreAgentSnapshotService.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Electron's app.on() signature uses any
 type AppEventHandler = (...args: any[]) => void;
@@ -52,15 +69,27 @@ function createMockDeps() {
     refresh: vi.fn(),
   } as unknown as ProjectStatsService;
 
+  const idleTerminalService = {
+    updatePollInterval: vi.fn(),
+  } as unknown as IdleTerminalNotificationService;
+
+  const preAgentSnapshotService = {
+    updatePollInterval: vi.fn(),
+  } as unknown as PreAgentSnapshotService;
+
   return {
     deps: {
       getPtyClient: () => ptyClient,
       getWorkspaceClient: () => workspaceClient,
       getProjectStatsService: () => statsService,
+      getIdleTerminalNotificationService: () => idleTerminalService,
+      getPreAgentSnapshotService: () => preAgentSnapshotService,
     },
     ptyClient,
     workspaceClient,
     statsService,
+    idleTerminalService,
+    preAgentSnapshotService,
   };
 }
 
@@ -72,6 +101,10 @@ describe("WindowFocusThrottle", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     appHandlers.clear();
+    mockSetDiskSpaceInterval.mockClear();
+    mockRefreshDiskSpace.mockClear();
+    mockSetAppMetricsInterval.mockClear();
+    mockRefreshAppMetrics.mockClear();
     // Re-import to get fresh module state
     vi.resetModules();
 
@@ -100,6 +133,16 @@ describe("WindowFocusThrottle", () => {
       getAppWebContents: vi.fn(),
     }));
 
+    vi.doMock("../../services/DiskSpaceMonitor.js", () => ({
+      setDiskSpaceMonitorPollInterval: mockSetDiskSpaceInterval,
+      refreshDiskSpaceMonitor: mockRefreshDiskSpace,
+    }));
+
+    vi.doMock("../../services/ProcessMemoryMonitor.js", () => ({
+      setAppMetricsMonitorPollInterval: mockSetAppMetricsInterval,
+      refreshAppMetricsMonitor: mockRefreshAppMetrics,
+    }));
+
     const mod = await import("../powerMonitor.js");
     setupWindowFocusThrottle = mod.setupWindowFocusThrottle;
     registerWindowForFocusThrottle = mod.registerWindowForFocusThrottle;
@@ -110,7 +153,14 @@ describe("WindowFocusThrottle", () => {
   });
 
   it("throttles all services on blur when no window is focused", async () => {
-    const { deps, workspaceClient, statsService, ptyClient } = createMockDeps();
+    const {
+      deps,
+      workspaceClient,
+      statsService,
+      ptyClient,
+      idleTerminalService,
+      preAgentSnapshotService,
+    } = createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const blurHandler = appHandlers.get("browser-window-blur")!;
@@ -133,10 +183,17 @@ describe("WindowFocusThrottle", () => {
       vi.mocked(ptyClient as unknown as { setProcessTreePollInterval: () => void })
         .setProcessTreePollInterval
     ).toHaveBeenCalledWith(12_500);
+
+    // New services
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledWith(1_500_000);
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledWith(150_000);
+    expect(idleTerminalService.updatePollInterval).toHaveBeenCalledWith(1_500_000);
+    expect(preAgentSnapshotService.updatePollInterval).toHaveBeenCalledWith(18_000_000);
   });
 
   it("does not throttle on blur when another window is focused", async () => {
-    const { deps, workspaceClient } = createMockDeps();
+    const { deps, workspaceClient, idleTerminalService, preAgentSnapshotService } =
+      createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const blurHandler = appHandlers.get("browser-window-blur")!;
@@ -147,10 +204,15 @@ describe("WindowFocusThrottle", () => {
     vi.advanceTimersByTime(100);
 
     expect(workspaceClient.updateMonitorConfig).not.toHaveBeenCalled();
+    expect(mockSetDiskSpaceInterval).not.toHaveBeenCalled();
+    expect(mockSetAppMetricsInterval).not.toHaveBeenCalled();
+    expect(idleTerminalService.updatePollInterval).not.toHaveBeenCalled();
+    expect(preAgentSnapshotService.updatePollInterval).not.toHaveBeenCalled();
   });
 
   it("cancels throttle when focus arrives within debounce window", async () => {
-    const { deps, workspaceClient } = createMockDeps();
+    const { deps, workspaceClient, idleTerminalService, preAgentSnapshotService } =
+      createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const blurHandler = appHandlers.get("browser-window-blur")!;
@@ -162,10 +224,21 @@ describe("WindowFocusThrottle", () => {
     vi.advanceTimersByTime(100);
 
     expect(workspaceClient.updateMonitorConfig).not.toHaveBeenCalled();
+    expect(mockSetDiskSpaceInterval).not.toHaveBeenCalled();
+    expect(mockSetAppMetricsInterval).not.toHaveBeenCalled();
+    expect(idleTerminalService.updatePollInterval).not.toHaveBeenCalled();
+    expect(preAgentSnapshotService.updatePollInterval).not.toHaveBeenCalled();
   });
 
   it("unthrottles and refreshes on focus", async () => {
-    const { deps, workspaceClient, statsService, ptyClient } = createMockDeps();
+    const {
+      deps,
+      workspaceClient,
+      statsService,
+      ptyClient,
+      idleTerminalService,
+      preAgentSnapshotService,
+    } = createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const blurHandler = appHandlers.get("browser-window-blur")!;
@@ -182,6 +255,10 @@ describe("WindowFocusThrottle", () => {
     vi.mocked(workspaceClient.setPollingEnabled).mockClear();
     vi.mocked(workspaceClient.setPRPollCadence).mockClear();
     vi.mocked(statsService.updatePollInterval).mockClear();
+    mockSetDiskSpaceInterval.mockClear();
+    mockRefreshDiskSpace.mockClear();
+    mockSetAppMetricsInterval.mockClear();
+    mockRefreshAppMetrics.mockClear();
 
     // Then unthrottle
     focusHandler();
@@ -206,10 +283,25 @@ describe("WindowFocusThrottle", () => {
       vi.mocked(ptyClient as unknown as { setProcessTreePollInterval: () => void })
         .setProcessTreePollInterval
     ).toHaveBeenCalledWith(2_500);
+
+    // New services: restore normal intervals
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledWith(300_000);
+    expect(mockRefreshDiskSpace).toHaveBeenCalled();
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledWith(30_000);
+    expect(mockRefreshAppMetrics).toHaveBeenCalled();
+    expect(idleTerminalService.updatePollInterval).toHaveBeenCalledWith(300_000);
+    expect(preAgentSnapshotService.updatePollInterval).toHaveBeenCalledWith(3_600_000);
   });
 
   it("is idempotent — double throttle only calls services once", async () => {
-    const { deps, workspaceClient } = createMockDeps();
+    const {
+      deps,
+      workspaceClient,
+      statsService,
+      ptyClient,
+      idleTerminalService,
+      preAgentSnapshotService,
+    } = createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const blurHandler = appHandlers.get("browser-window-blur")!;
@@ -223,10 +315,20 @@ describe("WindowFocusThrottle", () => {
 
     expect(workspaceClient.updateMonitorConfig).toHaveBeenCalledTimes(1);
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledTimes(1);
+    expect(statsService.updatePollInterval).toHaveBeenCalledTimes(1);
+    expect(
+      vi.mocked(ptyClient as unknown as { setProcessTreePollInterval: () => void })
+        .setProcessTreePollInterval
+    ).toHaveBeenCalledTimes(1);
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledTimes(1);
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledTimes(1);
+    expect(idleTerminalService.updatePollInterval).toHaveBeenCalledTimes(1);
+    expect(preAgentSnapshotService.updatePollInterval).toHaveBeenCalledTimes(1);
   });
 
   it("handles minimize → throttle and restore → unthrottle via per-window events", async () => {
-    const { deps, workspaceClient, statsService } = createMockDeps();
+    const { deps, workspaceClient, statsService, idleTerminalService, preAgentSnapshotService } =
+      createMockDeps();
     setupWindowFocusThrottle(deps);
 
     const { BrowserWindow: BW } = await import("electron");
@@ -248,9 +350,15 @@ describe("WindowFocusThrottle", () => {
       pollIntervalBackground: 50_000,
     });
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledWith(1_500_000);
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledWith(150_000);
+    expect(idleTerminalService.updatePollInterval).toHaveBeenCalledWith(1_500_000);
+    expect(preAgentSnapshotService.updatePollInterval).toHaveBeenCalledWith(18_000_000);
 
     vi.mocked(workspaceClient.updateMonitorConfig).mockClear();
     vi.mocked(workspaceClient.setPollingEnabled).mockClear();
+    mockSetDiskSpaceInterval.mockClear();
+    mockSetAppMetricsInterval.mockClear();
 
     // Restore triggers unthrottle
     windowHandlers.get("restore")!();
@@ -260,5 +368,31 @@ describe("WindowFocusThrottle", () => {
     });
     expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
     expect(statsService.refresh).toHaveBeenCalled();
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledWith(300_000);
+    expect(mockRefreshDiskSpace).toHaveBeenCalled();
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledWith(30_000);
+    expect(mockRefreshAppMetrics).toHaveBeenCalled();
+  });
+
+  it("skips deps-based services gracefully when getters return null", async () => {
+    const deps = {
+      getPtyClient: () => null,
+      getWorkspaceClient: () => null,
+      getProjectStatsService: () => null,
+      getIdleTerminalNotificationService: () => null,
+      getPreAgentSnapshotService: () => null,
+    };
+    setupWindowFocusThrottle(deps);
+
+    const blurHandler = appHandlers.get("browser-window-blur")!;
+    const { BrowserWindow: BW } = await import("electron");
+    (BW.getFocusedWindow as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    blurHandler();
+    vi.advanceTimersByTime(100);
+
+    // Module-level setters are always called (they no-op internally via idempotency guard)
+    expect(mockSetDiskSpaceInterval).toHaveBeenCalledWith(1_500_000);
+    expect(mockSetAppMetricsInterval).toHaveBeenCalledWith(150_000);
   });
 });

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -3,10 +3,20 @@ import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import type { MainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import type { ProjectStatsService } from "../services/ProjectStatsService.js";
+import type { IdleTerminalNotificationService } from "../services/IdleTerminalNotificationService.js";
+import type { PreAgentSnapshotService } from "../services/PreAgentSnapshotService.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
 import { agentConnectivityService } from "../services/connectivity/AgentConnectivityService.js";
+import {
+  setDiskSpaceMonitorPollInterval,
+  refreshDiskSpaceMonitor,
+} from "../services/DiskSpaceMonitor.js";
+import {
+  setAppMetricsMonitorPollInterval,
+  refreshAppMetricsMonitor,
+} from "../services/ProcessMemoryMonitor.js";
 
 let resumeTimeout: NodeJS.Timeout | null = null;
 
@@ -123,11 +133,17 @@ const WORKSPACE_ACTIVE_NORMAL = 2_000;
 const WORKSPACE_BACKGROUND_NORMAL = 10_000;
 const STATS_NORMAL = 5_000;
 const PROCESS_TREE_NORMAL = 2_500;
+const DISK_SPACE_NORMAL = 5 * 60 * 1000;
+const APP_METRICS_NORMAL = 30_000;
+const IDLE_TERMINAL_NORMAL = 5 * 60 * 1000;
+const PRE_AGENT_PRUNE_NORMAL = 60 * 60 * 1000;
 
 export interface WindowFocusThrottleDeps {
   getPtyClient: () => PtyClient | null;
   getWorkspaceClient: () => WorkspaceClient | null;
   getProjectStatsService: () => ProjectStatsService | null;
+  getIdleTerminalNotificationService?: () => IdleTerminalNotificationService | null;
+  getPreAgentSnapshotService?: () => PreAgentSnapshotService | null;
 }
 
 const focusThrottleState = {
@@ -160,6 +176,19 @@ function applyThrottle(): void {
   if (ptyClient) {
     ptyClient.setProcessTreePollInterval(PROCESS_TREE_NORMAL * THROTTLE_MULTIPLIER);
   }
+
+  setDiskSpaceMonitorPollInterval(DISK_SPACE_NORMAL * THROTTLE_MULTIPLIER);
+  setAppMetricsMonitorPollInterval(APP_METRICS_NORMAL * THROTTLE_MULTIPLIER);
+
+  const idleTerminalService = focusThrottleDeps.getIdleTerminalNotificationService?.() ?? null;
+  if (idleTerminalService) {
+    idleTerminalService.updatePollInterval(IDLE_TERMINAL_NORMAL * THROTTLE_MULTIPLIER);
+  }
+
+  const preAgentSnapshotService = focusThrottleDeps.getPreAgentSnapshotService?.() ?? null;
+  if (preAgentSnapshotService) {
+    preAgentSnapshotService.updatePollInterval(PRE_AGENT_PRUNE_NORMAL * THROTTLE_MULTIPLIER);
+  }
 }
 
 function removeThrottle(): void {
@@ -186,6 +215,21 @@ function removeThrottle(): void {
   const ptyClient = focusThrottleDeps.getPtyClient();
   if (ptyClient) {
     ptyClient.setProcessTreePollInterval(PROCESS_TREE_NORMAL);
+  }
+
+  setDiskSpaceMonitorPollInterval(DISK_SPACE_NORMAL);
+  setAppMetricsMonitorPollInterval(APP_METRICS_NORMAL);
+  refreshDiskSpaceMonitor();
+  refreshAppMetricsMonitor();
+
+  const idleTerminalService = focusThrottleDeps.getIdleTerminalNotificationService?.() ?? null;
+  if (idleTerminalService) {
+    idleTerminalService.updatePollInterval(IDLE_TERMINAL_NORMAL);
+  }
+
+  const preAgentSnapshotService = focusThrottleDeps.getPreAgentSnapshotService?.() ?? null;
+  if (preAgentSnapshotService) {
+    preAgentSnapshotService.updatePollInterval(PRE_AGENT_PRUNE_NORMAL);
   }
 
   // Opportunistic token-health re-check on focus regain, gated by the


### PR DESCRIPTION
## Summary
- Extends the window-blur throttle from the 3 existing pollers to 4 additional ones: `DiskSpaceMonitor`, `ProcessMemoryMonitor`, `IdleTerminalNotificationService`, and `PreAgentSnapshotService`
- Each service gets a runtime interval setter so the 5x multiplier kicks in on window blur and restores the normal cadence on focus
- `DiskSpaceMonitor` and `ProcessMemoryMonitor` also trigger an immediate poll refresh on unthrottle so data is current when the window comes back

Resolves #6783

## Changes
- Added `setDiskSpaceMonitorPollInterval` / `refreshDiskSpaceMonitor` to `DiskSpaceMonitor` and `setAppMetricsMonitorPollInterval` / `refreshAppMetricsMonitor` to `ProcessMemoryMonitor` -- module-level functions wired directly in `powerMonitor.ts`
- Added `updatePollInterval` method to `IdleTerminalNotificationService` and `PreAgentSnapshotService` -- class-based services wired through optional getters on `WindowFocusThrottleDeps`
- Extended `WindowFocusThrottleDeps` with `getIdleTerminalNotificationService` and `getPreAgentSnapshotService` optional getters
- Wired the two class-based services into `main.ts` the same way `getProjectStatsService` is already passed

## Testing
- 7 tests covering: blur throttle with no focused windows, skip on blur when another window is focused, cancel throttle on rapid focus regain, unthrottle on focus (with refresh for disk/app-metrics), idempotency of double throttle, minimize/restore cycle, and null-graceful getters