### PR TITLE
perf(sleep): pause idle service intervals on system suspend

### DIFF
--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -206,7 +206,7 @@ class AutoUpdaterService {
     autoUpdater.allowDowngrade = channel === "nightly";
   }
 
-  private runUpdateCheck(context: "Initial" | "Periodic" | "Retry"): void {
+  private runUpdateCheck(context: "Initial" | "Periodic" | "Retry" | "Resume"): void {
     try {
       const result = autoUpdater.checkForUpdatesAndNotify();
       Promise.resolve(result).catch((err) => {

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -7,6 +7,7 @@ import * as semver from "semver";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { getCrashRecoveryService } from "./CrashRecoveryService.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 import { store } from "../store.js";
 import { PRODUCT_NAME } from "../utils/productBranding.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
@@ -51,10 +52,15 @@ const STABLE_FEED_URL = "https://updates.daintree.org/releases/";
 const NIGHTLY_FEED_URL = "https://updates.daintree.org/nightly/";
 const { autoUpdater } = electronUpdater;
 
+const RESUME_CHECK_DELAY_MS = 7_000;
+
 class AutoUpdaterService {
   private checkInterval: NodeJS.Timeout | null = null;
   private startupJitterTimeout: NodeJS.Timeout | null = null;
   private retryTimeout: NodeJS.Timeout | null = null;
+  private resumeTimeout: NodeJS.Timeout | null = null;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
   private retryCount = 0;
   private initialized = false;
   private channelHandlersRegistered = false;
@@ -436,6 +442,40 @@ class AutoUpdaterService {
         this.runUpdateCheck("Periodic");
       }, CHECK_INTERVAL_MS);
 
+      try {
+        this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+          if (this.checkInterval) {
+            clearInterval(this.checkInterval);
+            this.checkInterval = null;
+          }
+          if (this.startupJitterTimeout) {
+            clearTimeout(this.startupJitterTimeout);
+            this.startupJitterTimeout = null;
+          }
+          if (this.resumeTimeout) {
+            clearTimeout(this.resumeTimeout);
+            this.resumeTimeout = null;
+          }
+          this.clearRetryTimeout();
+          this.resetRetryState();
+        });
+        this.removeWakeListener = getSystemSleepService().onWake(() => {
+          if (this.resumeTimeout || this.checkInterval) return;
+          this.resumeTimeout = setTimeout(() => {
+            this.resumeTimeout = null;
+            this.runUpdateCheck("Resume");
+            if (!this.checkInterval) {
+              this.checkInterval = setInterval(() => {
+                this.runUpdateCheck("Periodic");
+              }, CHECK_INTERVAL_MS);
+            }
+          }, RESUME_CHECK_DELAY_MS);
+        });
+      } catch {
+        // SystemSleepService may not be initialized yet at early startup.
+        // The suspend hook is best-effort — periodic timer covers the gap.
+      }
+
       this.initialized = true;
       console.log("[MAIN] Auto-updater initialized");
     } catch (err) {
@@ -454,7 +494,20 @@ class AutoUpdaterService {
       this.startupJitterTimeout = null;
     }
     this.clearRetryTimeout();
+    if (this.resumeTimeout) {
+      clearTimeout(this.resumeTimeout);
+      this.resumeTimeout = null;
+    }
     this.retryCount = 0;
+
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
+    }
 
     if (this.checkingHandler) {
       autoUpdater.off("checking-for-update", this.checkingHandler);

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -118,7 +118,14 @@ export class CrashRecoveryService {
   private registerSleepListeners(): void {
     try {
       this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
-        this.stopBackupTimer();
+        if (this.backupTimer) {
+          clearInterval(this.backupTimer);
+          this.backupTimer = null;
+        }
+        if (this.debounceTimer) {
+          clearTimeout(this.debounceTimer);
+          this.debounceTimer = null;
+        }
       });
       this.removeWakeListener = getSystemSleepService().onWake(() => {
         this.startBackupTimer();

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -116,6 +116,7 @@ export class CrashRecoveryService {
   }
 
   private registerSleepListeners(): void {
+    this.unregisterSleepListeners();
     try {
       this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
         if (this.backupTimer) {

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -11,6 +11,7 @@ import type {
 import { coerceAgentState } from "../../shared/types/agent.js";
 import { store, windowStatesStore } from "../store.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
 
 const MAX_CRASH_LOGS = 10;
@@ -31,6 +32,8 @@ export class CrashRecoveryService {
   private pendingCrash: PendingCrash | null = null;
   private backupTimer: ReturnType<typeof setInterval> | null = null;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
   private crashRecorded = false;
   private pendingPanelFilter: string[] | null = null;
   private cachedBackupSnapshot: SessionSnapshot | null = null;
@@ -97,6 +100,7 @@ export class CrashRecoveryService {
     this.backupTimer = setInterval(() => {
       this.takeBackup();
     }, BACKUP_INTERVAL_MS);
+    this.registerSleepListeners();
   }
 
   stopBackupTimer(): void {
@@ -107,6 +111,31 @@ export class CrashRecoveryService {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
+    }
+    this.unregisterSleepListeners();
+  }
+
+  private registerSleepListeners(): void {
+    try {
+      this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+        this.stopBackupTimer();
+      });
+      this.removeWakeListener = getSystemSleepService().onWake(() => {
+        this.startBackupTimer();
+      });
+    } catch {
+      // SystemSleepService may not be initialized yet at early startup.
+    }
+  }
+
+  private unregisterSleepListeners(): void {
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
     }
   }
 

--- a/electron/services/DiskSpaceMonitor.ts
+++ b/electron/services/DiskSpaceMonitor.ts
@@ -3,6 +3,7 @@ import { app } from "electron";
 import { logDebug, logInfo, logWarn } from "../utils/logger.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import { setWritesSuppressed } from "./diskPressureState.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 
 export type DiskSpaceStatus = "normal" | "warning" | "critical";
 
@@ -52,6 +53,8 @@ export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => v
   let lastStatus: DiskSpaceStatus = "normal";
   let lastNotificationAt = 0;
   let disposed = false;
+  let removeSuspendListener: (() => void) | null = null;
+  let removeWakeListener: (() => void) | null = null;
 
   async function poll(): Promise<void> {
     if (disposed) return;
@@ -139,11 +142,27 @@ export function startDiskSpaceMonitor(actions: DiskSpaceMonitorActions): () => v
   void poll();
   armTimer();
 
+  try {
+    removeSuspendListener = getSystemSleepService().onSuspend(() => {
+      clearAlignedInterval?.();
+      clearAlignedInterval = null;
+    });
+    removeWakeListener = getSystemSleepService().onWake(() => {
+      if (disposed || clearAlignedInterval !== null) return;
+      void poll();
+      armTimer();
+    });
+  } catch {
+    // SystemSleepService may not be initialized yet at early startup.
+  }
+
   return () => {
     disposed = true;
     clearAlignedInterval?.();
     clearAlignedInterval = null;
     diskSpacePollFn = null;
     rearmDiskSpaceTimer = null;
+    removeSuspendListener?.();
+    removeWakeListener?.();
   };
 }

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../shared/types/ipc/idleTerminals.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 import { logInfo, logError } from "../utils/logger.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -54,9 +55,13 @@ export class IdleTerminalNotificationService {
    * real check further out.
    */
   private quietUntil: number | null = null;
+  private wakeQuietUntil: number | null = null;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
   private readonly CHECK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
   private readonly STARTUP_QUIET_MS = 2 * 60 * 1000; // 2 minutes
   private readonly INITIAL_CHECK_DELAY_MS = 5_000;
+  private readonly WAKE_QUIET_MS = 30_000;
   private currentCheckIntervalMs = this.CHECK_INTERVAL_MS;
 
   private normalizeThreshold(value: unknown, fallback: number): number {
@@ -141,6 +146,31 @@ export class IdleTerminalNotificationService {
         logError("idle-terminal-notify-initial-check-failed", error);
       });
     }, this.INITIAL_CHECK_DELAY_MS);
+
+    try {
+      this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+        if (this.checkInterval) {
+          clearInterval(this.checkInterval);
+          this.checkInterval = null;
+        }
+        if (this.initialCheckTimer) {
+          clearTimeout(this.initialCheckTimer);
+          this.initialCheckTimer = null;
+        }
+      });
+      this.removeWakeListener = getSystemSleepService().onWake(() => {
+        this.wakeQuietUntil = Date.now() + this.WAKE_QUIET_MS;
+        if (!this.checkInterval) {
+          this.checkInterval = setInterval(() => {
+            void this.checkAndNotify().catch((error) => {
+              logError("idle-terminal-notify-check-failed", error);
+            });
+          }, this.currentCheckIntervalMs);
+        }
+      });
+    } catch {
+      // SystemSleepService may not be initialized yet at early startup.
+    }
   }
 
   stop(): void {
@@ -152,6 +182,14 @@ export class IdleTerminalNotificationService {
     if (this.initialCheckTimer) {
       clearTimeout(this.initialCheckTimer);
       this.initialCheckTimer = null;
+    }
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
     }
   }
 
@@ -238,6 +276,12 @@ export class IdleTerminalNotificationService {
     // immediately after the user opens the app. Gated on `quietUntil`, which
     // is seeded once on first start and never bumped thereafter.
     if (this.quietUntil !== null && Date.now() < this.quietUntil) {
+      return;
+    }
+
+    // Post-wake quiet period — prevent notification burst right after
+    // system resume while the OS is still stabilizing.
+    if (this.wakeQuietUntil !== null && Date.now() < this.wakeQuietUntil) {
       return;
     }
 

--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -1,5 +1,6 @@
 import { events } from "./events.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 import { logInfo, logWarn } from "../utils/logger.js";
 import type { SnapshotInfo } from "../../shared/types/ipc/git.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -13,6 +14,8 @@ export class PreAgentSnapshotService {
   private unsubscribers: Array<() => void> = [];
   private pruneTimer: NodeJS.Timeout | null = null;
   private pruneIntervalMs = PRUNE_INTERVAL_MS;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
 
   initialize(): void {
     if (this.pruneTimer) return;
@@ -24,6 +27,21 @@ export class PreAgentSnapshotService {
 
     this.pruneAllWorktrees();
     this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
+
+    try {
+      this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+        if (this.pruneTimer) {
+          clearInterval(this.pruneTimer);
+          this.pruneTimer = null;
+        }
+      });
+      this.removeWakeListener = getSystemSleepService().onWake(() => {
+        if (this.pruneTimer) return;
+        this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
+      });
+    } catch {
+      // SystemSleepService may not be initialized yet at early startup.
+    }
   }
 
   updatePollInterval(ms: number): void {
@@ -257,6 +275,15 @@ export class PreAgentSnapshotService {
     if (this.pruneTimer) {
       clearInterval(this.pruneTimer);
       this.pruneTimer = null;
+    }
+
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
     }
 
     this.snapshots.clear();

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -229,16 +229,11 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
   const poll = () => {
     try {
       pollCount++;
-      // Kick off a Blink-memory sample fan-out for this tick. Renderer replies
-      // arrive asynchronously via the SYSTEM_REPORT_BLINK_MEMORY handler and
-      // populate `blinkSamples` for the next poll's diagnostics.
       try {
         actions?.sampleBlinkMemory?.();
       } catch {
         /* non-critical */
       }
-      // Kick off a renderer-ELU sample fan-out alongside Blink-memory. Replies
-      // arrive via SYSTEM_REPORT_RENDERER_ELU and populate `eluSamples`.
       try {
         actions?.sampleRendererElu?.();
       } catch {
@@ -266,7 +261,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
           });
         }
 
-        // Trend detection: bucket-minimum + EMA
         let state = trendState.get(proc.pid);
         if (!state) {
           state = {
@@ -289,7 +283,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
             state.emaHistory.shift();
           }
 
-          // Evaluate trend with dual suppression
           if (
             Date.now() - state.startedAt >= STARTUP_SUPPRESSION_MS &&
             state.emaHistory.length === BUCKET_WINDOW
@@ -329,7 +322,6 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
         }
       }
 
-      // Prune stale PID state
       for (const pid of trendState.keys()) {
         if (!activePids.has(pid)) trendState.delete(pid);
       }
@@ -406,7 +398,9 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
       clearAlignedInterval?.();
       clearAlignedInterval = null;
       trendState.clear();
-      snapshotCooldowns.clear();
+      consecutivePressureCount = 0;
+      lastTier2At = 0;
+      mitigationInFlight = false;
     });
     removeWakeListener = getSystemSleepService().onWake(() => {
       if (clearAlignedInterval !== null) return;

--- a/electron/services/ProcessMemoryMonitor.ts
+++ b/electron/services/ProcessMemoryMonitor.ts
@@ -4,6 +4,7 @@ import { mkdirSync } from "node:fs";
 import { app } from "electron";
 import { logDebug, logInfo, logWarn } from "../utils/logger.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
 
 const POLL_INTERVAL_MS = 30_000;
 const SNAPSHOT_COOLDOWN_MS = 5 * 60 * 1000;
@@ -218,6 +219,8 @@ export function refreshAppMetricsMonitor(): void {
 export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => void {
   const snapshotCooldowns = new Map<number, number>();
   const trendState = new Map<number, PidTrendState>();
+  let removeSuspendListener: (() => void) | null = null;
+  let removeWakeListener: (() => void) | null = null;
   let pollCount = 0;
   let consecutivePressureCount = 0;
   let lastTier2At = 0;
@@ -398,10 +401,27 @@ export function startAppMetricsMonitor(actions?: MemoryPressureActions): () => v
 
   armTimer();
 
+  try {
+    removeSuspendListener = getSystemSleepService().onSuspend(() => {
+      clearAlignedInterval?.();
+      clearAlignedInterval = null;
+      trendState.clear();
+      snapshotCooldowns.clear();
+    });
+    removeWakeListener = getSystemSleepService().onWake(() => {
+      if (clearAlignedInterval !== null) return;
+      armTimer();
+    });
+  } catch {
+    // SystemSleepService may not be initialized yet at early startup.
+  }
+
   return () => {
     clearAlignedInterval?.();
     clearAlignedInterval = null;
     appMetricsPollFn = null;
     rearmAppMetricsTimer = null;
+    removeSuspendListener?.();
+    removeWakeListener?.();
   };
 }


### PR DESCRIPTION
## Summary

Wires six main-process services into `SystemSleepService` so their `setInterval` timers pause on system suspend and resume on wake. Before this, those services kept running through OS sleep and would fire a catch-up burst of polls, backups, prunes, update checks, and notifications all at once — right when the user is least patient.

Each service clears its timers on suspend and restores them on resume. The pattern mirrors the existing `DatabaseMaintenanceService` adoption of the sleep registry.

Resolves #6782.

## Changes

- `AutoUpdaterService` — clears check, jitter, and retry timers on suspend; resumes with a 7-second delay on wake
- `CrashRecoveryService` — clears backup and debounce timers on suspend; restarts the backup interval on wake
- `DiskSpaceMonitor` — clears the poll timer on suspend; resumes polling on wake
- `ProcessMemoryMonitor` — clears the poll timer and resets trend/mitigation state on suspend; resumes on wake
- `IdleTerminalNotificationService` — clears timers on suspend; resumes with a 30-second quiet window on wake to avoid a notification burst
- `PreAgentSnapshotService` — clears the prune timer on suspend; resumes on wake

## Testing

All six services were verified to clear timers on suspend and restore them on wake. TypeScript typecheck and ESLint pass cleanly.