### PR TITLE
fix(font): optimize JetBrains Mono cold-paint loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,14 +300,26 @@ function App() {
 
   useEffect(() => {
     if (!isStateLoaded) return;
-    const id = requestIdleCallback(
-      () => {
-        preloadSettingsDialog();
-        preloadNewWorktreeDialog();
-      },
-      { timeout: 5000 }
-    );
-    return () => cancelIdleCallback(id);
+
+    const controller = new AbortController();
+
+    const execute = () => {
+      if (controller.signal.aborted) return;
+      preloadSettingsDialog();
+      preloadNewWorktreeDialog();
+      void import("@fontsource/jetbrains-mono/latin-500.css");
+      void import("@fontsource/jetbrains-mono/latin-600.css");
+    };
+
+    if (typeof scheduler !== "undefined" && typeof scheduler.postTask === "function") {
+      void scheduler.postTask(execute, { priority: "background", signal: controller.signal });
+    } else {
+      const id = requestIdleCallback(execute, { timeout: 5000 });
+      const cancel = () => cancelIdleCallback(id);
+      controller.signal.addEventListener("abort", cancel, { once: true });
+    }
+
+    return () => controller.abort();
   }, [isStateLoaded]);
 
   const handlePreloadSettings = useCallback(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -307,12 +307,14 @@ function App() {
       if (controller.signal.aborted) return;
       preloadSettingsDialog();
       preloadNewWorktreeDialog();
-      void import("@fontsource/jetbrains-mono/latin-500.css");
-      void import("@fontsource/jetbrains-mono/latin-600.css");
+      import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
+      import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
     };
 
     if (typeof scheduler !== "undefined" && typeof scheduler.postTask === "function") {
-      void scheduler.postTask(execute, { priority: "background", signal: controller.signal });
+      void scheduler
+        .postTask(execute, { priority: "background", signal: controller.signal })
+        .catch(() => {});
     } else {
       const id = requestIdleCallback(execute, { timeout: 5000 });
       const cancel = () => cancelIdleCallback(id);

--- a/src/index.css
+++ b/src/index.css
@@ -406,6 +406,18 @@
     "Liberation Mono", "Courier New", monospace;
 }
 
+@font-face {
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-display: optional;
+  font-weight: 400;
+  src: url(../node_modules/@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2)
+    format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 /* Motion token scale — single source of truth for durations and easings.
  * Emitted to :root (plain @theme, not inline) so @keyframes rules can use var().
  * Also generates Tailwind utilities (duration-*, ease-*) via the Tailwind v4

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,10 +10,8 @@ initBuiltInPanelKinds();
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@fontsource/jetbrains-mono/400.css";
-import "@fontsource/jetbrains-mono/500.css";
-import "@fontsource/jetbrains-mono/600.css";
-import "@fontsource/jetbrains-mono/700.css";
+import latin400Woff2Url from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2?url";
+import "@fontsource/jetbrains-mono/latin-700.css";
 import "./index.css";
 import { applyDefaultAppTheme } from "./theme/applyAppTheme";
 // Importing this module has the side effect of starting the font load (via
@@ -35,6 +33,18 @@ import { WorktreeStoreProvider } from "./contexts/WorktreeStoreContext";
 
 let cleanupGlobalErrorHandlers: (() => void) | undefined;
 let cleanupOrchestrator: (() => void) | undefined;
+
+function ensureLatin400Preload(href: string) {
+  if (document.head.querySelector(`link[rel="preload"][href="${href}"]`)) return;
+  const link = document.createElement("link");
+  link.rel = "preload";
+  link.as = "font";
+  link.type = "font/woff2";
+  link.href = href;
+  document.head.appendChild(link);
+}
+
+ensureLatin400Preload(latin400Woff2Url);
 
 async function bootstrap() {
   await initRendererSentry();


### PR DESCRIPTION
## Summary
* Eliminates cumulative layout shift on cold paint by giving the browser an immediate Latin-400 `@font-face` with `font-display: optional` and a preload `<link>` injected before `bootstrap()`.
* Replaces four eager full-subset font imports with a single Latin-700 CSS import, keeping the critical weight unblocked while deferring Latin-500/600 to async chunks.
* Switches from starvation-prone `requestIdleCallback` to `scheduler.postTask` with background priority, fixing the pattern identified in #3591.

Resolves #6781

## Changes

`src/index.css` — Added `@font-face` for Latin-400 with `font-display: optional`. The 100ms block window plus a local `app://` bundle makes the font nearly always win the race without blocking paint.

`src/main.tsx` — Replaced four full multi-subset CSS imports with a single Latin-700 import and a Latin-400 woff2 `?url` import for preload `<link>` injection. The preload fires before `bootstrap()` so Chromium 146's preload scanner picks it up at the earliest opportunity.

`src/App.tsx` — Replaced `requestIdleCallback` with `scheduler.postTask` (`priority: "background"`) for the deferred font callback. Latin-500 and Latin-600 CSS imports fire-and-forget inside it, with explicit `.catch()` handlers per #4852. Falls back to `requestIdleCallback` when the scheduler API is absent.

## Testing

Production build verified: Latin-400 woff2 outputs once (no duplication), Latin-700 bundles eagerly in the main chunk, Latin-500/600 land in separate async JS chunks. Typecheck, lint, format, tests, and build all pass.