### PR TITLE
perf(store): drop redundant useShallow on single-field Zustand selectors

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -131,6 +131,12 @@
     "error": 2,
     "pipeline": 0
   },
+  "src/components/DevPreview/useDevPreviewLoadLifecycle.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
   "src/components/Diagnostics/DiagnosticsActions.tsx": {
     "success": 4,
     "skip": 0,
@@ -294,9 +300,15 @@
     "pipeline": 0
   },
   "src/components/Fleet/FleetArmingRibbon.tsx": {
-    "success": 6,
+    "success": 0,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Fleet/FleetCountChip.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Fleet/FleetDraftingPill.tsx": {
@@ -312,6 +324,48 @@
     "pipeline": 0
   },
   "src/components/Fleet/FleetPickerPalette.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/FleetWorktreeDots.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/SaveFleetForm.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/SavedFleetRow.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/SavedFleetsSection.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/useFleetEscapeChords.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/useFleetRibbonFlashes.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/useFleetWorktreeScope.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -354,9 +408,9 @@
     "pipeline": 0
   },
   "src/components/GitHub/GitHubResourceList.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
-    "error": 2,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/GitHub/IssueSelector.tsx": {
@@ -365,7 +419,13 @@
     "error": 0,
     "pipeline": 0
   },
-  "src/components/HelpPanel/HelpAgentPicker.tsx": {
+  "src/components/GitHub/useGitHubResourceListSWR.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 2,
+    "pipeline": 0
+  },
+  "src/components/HelpPanel/HelpIntroBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -455,6 +515,18 @@
     "error": 1,
     "pipeline": 0
   },
+  "src/components/Layout/FreshnessUtils.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Layout/GitHubStatPill.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Layout/GitHubStatsToolbarButton.tsx": {
     "success": 0,
     "skip": 0,
@@ -467,14 +539,14 @@
     "error": 0,
     "pipeline": 0
   },
-  "src/components/Layout/HelpAgentDockButton.tsx": {
+  "src/components/Layout/NotificationCenterToolbarButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0
   },
-  "src/components/Layout/NotificationCenterToolbarButton.tsx": {
-    "success": 1,
+  "src/components/Layout/RateLimitDetails.tsx": {
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -501,6 +573,12 @@
     "success": 1,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Layout/ToolbarAssistantButton.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Layout/ToolbarLauncherButton.tsx": {
@@ -587,6 +665,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/McpConfirmDialog.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Notifications/NotificationCenter.tsx": {
     "success": 2,
     "skip": 0,
@@ -618,12 +702,18 @@
     "pipeline": 0
   },
   "src/components/Panel/ContentPanel.tsx": {
-    "success": 2,
+    "success": 1,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Panel/PanelHeader.tsx": {
+    "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0
   },
-  "src/components/Panel/PanelHeader.tsx": {
+  "src/components/Panel/PanelTabList.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -761,12 +851,6 @@
     "error": 0,
     "pipeline": 0
   },
-  "src/components/Project/ProjectOnboardingWizard.tsx": {
-    "success": 0,
-    "skip": 0,
-    "error": 1,
-    "pipeline": 0
-  },
   "src/components/Project/ProjectResourceBadge.tsx": {
     "success": 4,
     "skip": 0,
@@ -804,7 +888,7 @@
     "pipeline": 0
   },
   "src/components/Project/WelcomeScreen.tsx": {
-    "success": 4,
+    "success": 5,
     "skip": 0,
     "error": 1,
     "pipeline": 0
@@ -881,6 +965,54 @@
     "error": 1,
     "pipeline": 0
   },
+  "src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/BehavioralControls.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/CustomPresetChrome.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/EnvBlock.tsx": {
+    "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/ScopeBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Settings/AgentScopeEditor/useAgentScope.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
   "src/components/Settings/AgentSelectorDropdown.tsx": {
     "success": 1,
     "skip": 0,
@@ -915,6 +1047,12 @@
     "success": 1,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Settings/DaintreeAssistantSettingsTab.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Settings/DiagnosticsReviewDialog.tsx": {
@@ -1044,7 +1182,7 @@
     "pipeline": 0
   },
   "src/components/Settings/SettingsDialog.tsx": {
-    "success": 5,
+    "success": 6,
     "skip": 0,
     "error": 1,
     "pipeline": 0
@@ -1154,7 +1292,7 @@
   "src/components/Setup/AgentSetupWizard.tsx": {
     "success": 3,
     "skip": 0,
-    "error": 1,
+    "error": 2,
     "pipeline": 0
   },
   "src/components/Setup/InstallBlock.tsx": {
@@ -1175,6 +1313,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Setup/useAgentSetupPoll.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Setup/useSystemHealthCheck.ts": {
     "success": 0,
     "skip": 0,
@@ -1188,7 +1332,31 @@
     "pipeline": 0
   },
   "src/components/Sidebar/SidebarContent.tsx": {
-    "success": 3,
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Sidebar/SidebarWorktreeRow.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Sidebar/StaticWorktreeRow.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Sidebar/useRecipeDialogState.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Sidebar/useScrollIndicator.ts": {
+    "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -1212,9 +1380,45 @@
     "pipeline": 0
   },
   "src/components/Terminal/ContentGrid.tsx": {
-    "success": 2,
+    "success": 1,
     "skip": 0,
-    "error": 3,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridDefault.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridEmptyState.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridFleetScope.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridMaximizedGroup.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridMaximizedSingle.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/ContentGridTwoPaneSplit.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Terminal/DockedPanel.tsx": {
@@ -1236,6 +1440,12 @@
     "pipeline": 0
   },
   "src/components/Terminal/GridPanel.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/GridShell.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -1326,6 +1536,12 @@
     "pipeline": 0
   },
   "src/components/Terminal/SpawnErrorBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/TerminalCloseConfirmHost.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -1439,7 +1655,37 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Terminal/contentGridTips.tsx": {
+    "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useAutocompleteApply.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Terminal/hooks/useAutocompleteItems.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useAutocompletePositioning.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useAutocompleteState.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useCompartmentDriver.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -1463,7 +1709,37 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Terminal/hooks/useEditorDomHandlers.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useEditorFactory.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Terminal/hooks/useEditorKeymap.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useFleetMirror.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/useHostReparent.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Terminal/hooks/usePasteExtensions.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -1485,6 +1761,12 @@
     "success": 0,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Terminal/useContentGridContext.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 2,
     "pipeline": 0
   },
   "src/components/Terminal/useTerminalFileTransfer.ts": {
@@ -1578,9 +1860,9 @@
     "pipeline": 0
   },
   "src/components/Worktree/NewWorktreeDialog.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 3,
+    "error": 2,
     "pipeline": 0
   },
   "src/components/Worktree/QuickCreatePalette.tsx": {
@@ -1637,13 +1919,61 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Worktree/WorktreeCard/CollapsedSessionIndicators.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx": {
     "success": 5,
     "skip": 0,
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Worktree/WorktreeCard/IssueBadge.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/PRBadge.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -1662,7 +1992,7 @@
     "pipeline": 0
   },
   "src/components/Worktree/WorktreeCard/WorktreeHeader.tsx": {
-    "success": 3,
+    "success": 1,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -1677,6 +2007,18 @@
     "success": 0,
     "skip": 0,
     "error": 2,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts": {
@@ -1776,6 +2118,78 @@
     "pipeline": 0
   },
   "src/components/Worktree/hooks/useRecipePicker.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/hooks/useWorktreeFormErrors.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/hooks/useWorktreeFormValidation.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/BaseBranchCombobox.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/BranchModeControl.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/EnvironmentRadioGroup.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/ExistingBranchPicker.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/HighlightBranchText.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/IssueSelectorView.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/NewBranchInput.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/PrHeader.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/RecipePickerPopover.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Worktree/views/WorktreePathPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -2237,12 +2651,6 @@
     "error": 0,
     "pipeline": 0
   },
-  "src/hooks/app/useContextFilesOffer.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0
-  },
   "src/hooks/app/useCrashRecoveryGate.ts": {
     "success": 1,
     "skip": 0,
@@ -2364,6 +2772,12 @@
     "pipeline": 0
   },
   "src/hooks/useBranchForPath.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/hooks/useBrowserActionListeners.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -2562,6 +2976,12 @@
     "pipeline": 0
   },
   "src/hooks/useMcpBridge.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/hooks/useMcpReadiness.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
@@ -2835,6 +3255,12 @@
     "success": 1,
     "skip": 0,
     "error": 0,
+    "pipeline": 0
+  },
+  "src/hooks/useWebviewEvents.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
     "pipeline": 0
   },
   "src/hooks/useWebviewEviction.ts": {

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -33,7 +33,7 @@ import {
   useWorktreeSelectionStore,
   type TerminalInstance,
 } from "@/store";
-import { useShallow } from "zustand/react/shallow";
+
 import { TerminalDragPreview } from "./TerminalDragPreview";
 import { WorktreeDragPreview } from "./WorktreeDragPreview";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -323,7 +323,7 @@ export function DndProvider({ children }: DndProviderProps) {
     })
   );
 
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
+  const panelsById = usePanelStore((state) => state.panelsById);
   const reorderTerminals = usePanelStore((s) => s.reorderTerminals);
   const reorderTabGroups = usePanelStore((s) => s.reorderTabGroups);
   const moveTerminalToPosition = usePanelStore((s) => s.moveTerminalToPosition);

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -46,7 +46,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { useShallow } from "zustand/react/shallow";
+
 import { resolveEffectivePresetId } from "@shared/types";
 import {
   getDominantAgentState,
@@ -154,8 +154,8 @@ export function AgentButton({
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
-  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
-  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const panelIds = usePanelStore((s) => s.panelIds);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   // Radix Tooltip reopens on focus restoration. When the chevron's

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -41,7 +41,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { useShallow } from "zustand/react/shallow";
+
 import { useKeybindingDisplay } from "@/hooks";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
@@ -280,7 +280,7 @@ export function AgentTrayButton({
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const updateWorktreePreset = useAgentSettingsStore((s) => s.updateWorktreePreset);
 
-  const getSortedActionMruList = useActionMruStore(useShallow((s) => s.getSortedActionMruList));
+  const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
 
   const refreshAvailability = useCliAvailabilityStore((s) => s.refresh);
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
@@ -294,8 +294,8 @@ export function AgentTrayButton({
 
   const [open, setOpen] = useState(false);
 
-  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
-  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const panelIds = usePanelStore((s) => s.panelIds);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   // Before the first real availability result lands we can't distinguish

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useCallback } from "react";
-import { useShallow } from "zustand/react/shallow";
+
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { useDroppable } from "@dnd-kit/core";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -64,9 +64,9 @@ interface ContentDockProps {
 export function ContentDock({ density = "normal" }: ContentDockProps) {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
-  const trashedTerminals = usePanelStore(useShallow((state) => state.trashedTerminals));
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
-  const storeTerminalIds = usePanelStore(useShallow((state) => state.panelIds));
+  const trashedTerminals = usePanelStore((state) => state.trashedTerminals);
+  const panelsById = usePanelStore((state) => state.panelsById);
+  const storeTerminalIds = usePanelStore((state) => state.panelIds);
   const getTabGroups = usePanelStore((state) => state.getTabGroups);
   const getTabGroupPanels = usePanelStore((state) => state.getTabGroupPanels);
   const currentProject = useProjectStore((s) => s.currentProject);

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -58,7 +58,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { TabButton, type TabInfo } from "./TabButton";
 import { SortableTabButton } from "./SortableTabButton";
-import { useShallow } from "zustand/react/shallow";
+
 import { panelKindCanRestart, panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { actionService } from "@/services/ActionService";
 import { fireWatchNotification } from "@/lib/watchNotification";
@@ -261,8 +261,7 @@ function PanelHeaderComponent({
     duplicateShortcut
   );
 
-  // Terminal record for overflow menu actions (single shallow selector, matching TerminalContextMenu pattern)
-  const terminal = usePanelStore(useShallow((state) => state.panelsById[id]));
+  const terminal = usePanelStore((state) => state.panelsById[id]);
   const isInputLocked = terminal?.isInputLocked ?? false;
   const hasPty = panelKindHasPty(kind);
 

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -49,10 +49,6 @@ vi.mock("@/components/DragDrop/DragHandleContext", () => ({
   useDragHandle: () => null,
 }));
 
-vi.mock("zustand/react/shallow", () => ({
-  useShallow: (fn: (...args: unknown[]) => unknown) => fn,
-}));
-
 const mockWatchPanel = vi.fn();
 const mockUnwatchPanel = vi.fn();
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -150,8 +150,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const clearQuickStateFilter = useWorktreeFilterStore((state) => state.clearQuickStateFilter);
 
   // Terminal store for derived metadata
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
-  const panelIds = usePanelStore(useShallow((state) => state.panelIds));
+  const panelsById = usePanelStore((state) => state.panelsById);
+  const panelIds = usePanelStore((state) => state.panelIds);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -3,7 +3,7 @@ import { isMac } from "@/lib/platform";
 import type React from "react";
 import { type PanelLocation } from "@/types";
 import { usePanelStore } from "@/store";
-import { useShallow } from "zustand/react/shallow";
+
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
@@ -66,7 +66,7 @@ export function TerminalContextMenu({
   children,
   forceLocation,
 }: TerminalContextMenuProps) {
-  const terminal = usePanelStore(useShallow((state) => state.panelsById[terminalId]));
+  const terminal = usePanelStore((state) => state.panelsById[terminalId]);
   const maximizeTarget = usePanelStore((s) => s.maximizeTarget);
   const getPanelGroup = usePanelStore((s) => s.getPanelGroup);
 

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -206,8 +206,8 @@ export function WorktreeOverviewModal({
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
 
   // Terminal store for derived metadata
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
-  const panelIds = usePanelStore(useShallow((state) => state.panelIds));
+  const panelsById = usePanelStore((state) => state.panelsById);
+  const panelIds = usePanelStore((state) => state.panelIds);
 
   // Error store for derived metadata
   // Filter store: hide main worktree preference

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from "react";
 import { usePanelStore } from "@/store";
-import { useShallow } from "zustand/react/shallow";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import type { AgentState } from "@shared/types/agent";
 
@@ -31,8 +30,8 @@ export function useAccessibilityAnnouncements() {
   const debounceTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
   const focusedId = usePanelStore((s) => s.focusedId);
-  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
-  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const panelIds = usePanelStore((s) => s.panelIds);
 
   // Panel focus announcements
   useEffect(() => {

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { useShallow } from "zustand/react/shallow";
+
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 import { notify } from "@/lib/notify";
@@ -80,9 +80,7 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
 
 export function useActionPalette(): UseActionPaletteReturn {
   const isActionOpen = usePaletteStore((state) => state.activePaletteId === "action");
-  const getSortedActionMruList = useActionMruStore(
-    useShallow((state) => state.getSortedActionMruList)
-  );
+  const getSortedActionMruList = useActionMruStore((state) => state.getSortedActionMruList);
 
   const allActions = useMemo<ActionPaletteItem[]>(() => {
     if (!isActionOpen) return [];

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState, useEffect, useRef, useSyncExternalStore } from "react";
-import { useShallow } from "zustand/react/shallow";
+
 import { usePanelStore } from "@/store/panelStore";
 import { useErrorStore } from "@/store/errorStore";
 import type { AgentState, CopyTreeProgress } from "@/types";
@@ -88,7 +88,7 @@ const globalInjectionState = {
 export function useContextInjection(targetTerminalId?: string): UseContextInjectionReturn {
   const [error, setError] = useState<string | null>(null);
   const focusedId = usePanelStore((state) => state.focusedId);
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
+  const panelsById = usePanelStore((state) => state.panelsById);
   const addError = useErrorStore((state) => state.addError);
   const removeError = useErrorStore((state) => state.removeError);
 

--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -43,7 +43,7 @@ export function useDockRenderState(): DockRenderState & {
     )
   );
 
-  const trashedCount = usePanelStore(useShallow((state) => state.trashedTerminals.size));
+  const trashedCount = usePanelStore((state) => state.trashedTerminals.size);
 
   const { waitingCount } = useTerminalNotificationCounts();
 

--- a/src/hooks/useLayoutState.ts
+++ b/src/hooks/useLayoutState.ts
@@ -81,9 +81,7 @@ export function useLayoutState(): LayoutState {
 
   const performanceMode = usePerformanceModeStore((state) => state.performanceMode);
 
-  const errorCount = useErrorStore(
-    useShallow((state) => state.errors.filter((e) => !e.dismissed).length)
-  );
+  const errorCount = useErrorStore((state) => state.errors.filter((e) => !e.dismissed).length);
 
   return useMemo(
     () => ({

--- a/src/hooks/usePromptHistoryPalette.ts
+++ b/src/hooks/usePromptHistoryPalette.ts
@@ -1,7 +1,6 @@
 import { useState, useCallback, useMemo } from "react";
 import type { IFuseOptions } from "fuse.js";
 import { useCommandHistoryStore, type PromptHistoryEntry } from "@/store/commandHistoryStore";
-import { useShallow } from "zustand/react/shallow";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 import { useSearchablePalette } from "./useSearchablePalette";
 
@@ -23,7 +22,7 @@ export interface UsePromptHistoryPaletteOptions {
 export function usePromptHistoryPalette({ terminalId, projectId }: UsePromptHistoryPaletteOptions) {
   const [scope, setScope] = useState<HistoryScope>("project");
 
-  const history = useCommandHistoryStore(useShallow((s) => s.history));
+  const history = useCommandHistoryStore((s) => s.history);
 
   const items = useMemo(() => {
     if (scope === "project") {

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -52,10 +52,10 @@ const MAX_RESULTS = 20;
 const MRU_BOOST_FACTOR = 0.05;
 
 export function useQuickSwitcher(): UseQuickSwitcherReturn {
-  const panelIds = usePanelStore(useShallow((state) => state.panelIds));
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
+  const panelIds = usePanelStore((state) => state.panelIds);
+  const panelsById = usePanelStore((state) => state.panelsById);
   const setFocused = usePanelStore((state) => state.setFocused);
-  const mruList = usePanelStore(useShallow((state) => state.mruList));
+  const mruList = usePanelStore((state) => state.mruList);
   const pruneMru = usePanelStore((state) => state.pruneMru);
 
   const {

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
-import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { useSearchablePalette } from "./useSearchablePalette";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
@@ -79,8 +78,8 @@ function sendSelectionToTarget(targetId: string): void {
 const MAX_RESULTS = 20;
 
 export function useSendToAgentPalette() {
-  const panelIds = usePanelStore(useShallow((state) => state.panelIds));
-  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
+  const panelIds = usePanelStore((state) => state.panelIds);
+  const panelsById = usePanelStore((state) => state.panelsById);
   const isOpen = usePaletteStore((state) => state.activePaletteId === "send-to-agent");
 
   const items = useMemo<SendToAgentItem[]>(() => {


### PR DESCRIPTION
## Summary
- Removes 27 redundant `useShallow` wrappers across 17 files where selectors return a single stored field. For single-field access the shallow key-walk produces the same result that React's `Object.is` already checks before triggering a re-render — so `useShallow` was pure overhead on those call sites.
- Drops 11 `useShallow` imports entirely from files that no longer need the hook. Four files keep it for object-returning selectors that genuinely require shallow comparison.

Resolves #6776.

## Changes
- Unwrapped single-field selectors in components (Sidebar, PanelHeader, TerminalContextMenu, WorktreeOverviewModal, DragDrop, Layout) and hooks (useActionPalette, useContextInjection, useQuickSwitcher, etc.)
- Removed unused `useShallow` imports
- Cleaned up a test mock that referenced the old wrapping pattern
- Refreshed compiler bailout baseline

## Testing
- `npm run check` passes (typecheck, lint, format)
- `npm run compiler-budget:check` passes