### PR TITLE
fix(portal): start web chat panel below toolbar so close button is reachable

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -494,7 +494,7 @@ export function AppLayout({
                 WebContentsView is already hidden via PortalVisibilityController. */}
             <div
               {...(isThemeBrowserOpen ? { inert: true } : {})}
-              className="fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
+              className="fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"
             >
               <PortalDock />
             </div>

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -141,7 +141,7 @@ describe("AppLayout portal viewport coverage — issue #6629", () => {
     // fixed` lets the Portal escape <main>'s width and overlay the Assistant.
     expect(source).toMatch(/\{layout\.portalOpen &&\s*\n\s*createPortal\(/);
     expect(source).toContain(
-      '"fixed top-0 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
+      '"fixed top-12 right-0 bottom-0 z-50 shadow-2xl border-l border-daintree-border"'
     );
     // The portal target must be document.body to escape the inert subtrees and
     // the <main> width constraint. A different target would silently reintroduce


### PR DESCRIPTION
## Summary

- The web chat panel (Portal) was rendering behind the app toolbar, cutting off the top 48px — including the entire close button row.
- Fix changes `top-0` to `top-12` in `AppLayout.tsx` so the panel starts below the toolbar instead of behind it.
- Test assertion in `AppLayout.sidebar.test.ts` updated to match.

Resolves #6799

## Changes

- `src/components/Layout/AppLayout.tsx` — `top-0` → `top-12` on the Portal panel container
- `src/components/Layout/__tests__/AppLayout.sidebar.test.ts` — assertion updated to expect `top-12`

## Testing

- Vitest unit tests (15 tests, all passing)
- Typecheck, lint, and format all clean