### PR TITLE
feat(scratch): auto-cleanup at 30d + save-as-project promotion

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -655,6 +655,7 @@ export const CHANNELS = {
   SCRATCH_UPDATE: "scratch:update",
   SCRATCH_REMOVE: "scratch:remove",
   SCRATCH_SWITCH: "scratch:switch",
+  SCRATCH_SAVE_AS_PROJECT: "scratch:save-as-project",
   SCRATCH_UPDATED: "scratch:updated",
   SCRATCH_REMOVED: "scratch:removed",
   SCRATCH_ON_SWITCH: "scratch:on-switch",

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -9,7 +9,26 @@ import type { Project } from "../../../types/index.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
 
+/**
+ * Validate, register, and broadcast a project for the given absolute path.
+ * Extracted from `handleProjectAdd` so other handlers (e.g. scratch
+ * Save-as-Project) can register a path as a project without going through IPC.
+ */
+export async function addProjectByPath(projectPath: string): Promise<Project> {
+  if (typeof projectPath !== "string" || !projectPath) {
+    throw new Error("Invalid project path");
+  }
+  if (!path.isAbsolute(projectPath)) {
+    throw new Error("Project path must be absolute");
+  }
+  const project = await projectStore.addProject(projectPath);
+  broadcastToRenderer(CHANNELS.PROJECT_UPDATED, project);
+  return project;
+}
+
 export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () => void {
+  const handleProjectAdd = async (projectPath: string) => addProjectByPath(projectPath);
+
   const handlers: Array<() => void> = [];
 
   const handleProjectGetAll = async () => {
@@ -55,17 +74,6 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_GET_CURRENT, handleProjectGetCurrent));
 
-  const handleProjectAdd = async (projectPath: string) => {
-    if (typeof projectPath !== "string" || !projectPath) {
-      throw new Error("Invalid project path");
-    }
-    if (!path.isAbsolute(projectPath)) {
-      throw new Error("Project path must be absolute");
-    }
-    const project = await projectStore.addProject(projectPath);
-    broadcastToRenderer(CHANNELS.PROJECT_UPDATED, project);
-    return project;
-  };
   handlers.push(typedHandle(CHANNELS.PROJECT_ADD, handleProjectAdd));
 
   const handleProjectRemove = async (projectId: string) => {

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -8,15 +8,20 @@
  * `ProjectSwitchService` (which validates against `projects`).
  */
 import { randomUUID } from "crypto";
-import type { WebContentsView } from "electron";
+import { dialog, type WebContentsView } from "electron";
+import fs from "fs/promises";
+import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import { addProjectByPath } from "../projectCrud/crud.js";
+import { logError } from "../../../utils/logger.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Scratch } from "../../../../shared/types/scratch.js";
+import type { ScratchSaveAsProjectResult } from "../../../../shared/types/ipc/scratch.js";
 
 export function registerScratchHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -128,6 +133,89 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
     return updated;
   };
   handlers.push(typedHandleWithContext(CHANNELS.SCRATCH_SWITCH, handleSwitch));
+
+  /**
+   * Save-as-Project — opens a directory picker, copies the scratch folder to
+   * the chosen destination, and registers the destination as a regular
+   * project. Copy (not move) so a failed registration leaves the scratch
+   * intact; the original scratch is NOT deleted by this handler. The renderer
+   * prompts the user separately and calls `scratch:remove` if they confirm.
+   */
+  const handleSaveAsProject = async (
+    ctx: import("../../types.js").IpcContext,
+    scratchId: string
+  ): Promise<ScratchSaveAsProjectResult> => {
+    if (typeof scratchId !== "string" || !scratchId) {
+      throw new Error("Invalid scratch ID");
+    }
+
+    const scratch = scratchStore.getScratchById(scratchId);
+    if (!scratch) {
+      throw new Error(`Scratch not found: ${scratchId}`);
+    }
+
+    const senderWindow = getWindowForWebContents(ctx.event.sender);
+    const dialogOpts: Electron.OpenDialogOptions = {
+      title: "Save scratch as project",
+      buttonLabel: "Save here",
+      properties: ["openDirectory", "createDirectory"],
+    };
+    const result = senderWindow
+      ? await dialog.showOpenDialog(senderWindow, dialogOpts)
+      : await dialog.showOpenDialog(dialogOpts);
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { status: "cancelled" };
+    }
+
+    const destinationPath = result.filePaths[0]!;
+    if (!path.isAbsolute(destinationPath)) {
+      throw new Error("Destination path must be absolute");
+    }
+
+    // Refuse if the user picked the scratch directory itself or a path inside
+    // the scratch — `fs.cp` would recurse into the destination it's writing.
+    const normalizedScratch = path.resolve(scratch.path);
+    const normalizedDest = path.resolve(destinationPath);
+    if (
+      normalizedDest === normalizedScratch ||
+      normalizedDest.startsWith(normalizedScratch + path.sep)
+    ) {
+      throw new Error("Destination cannot be inside the scratch folder");
+    }
+
+    // Reject pre-existing non-empty destinations so we never silently merge
+    // the scratch contents into another project. The dialog's `createDirectory`
+    // option lets users make a fresh folder right from the picker.
+    try {
+      const entries = await fs.readdir(destinationPath);
+      if (entries.length > 0) {
+        throw new Error("Destination folder is not empty. Choose an empty folder.");
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw error;
+      // ENOENT means the dir doesn't exist; fs.cp will create it.
+    }
+
+    try {
+      await fs.cp(scratch.path, destinationPath, {
+        recursive: true,
+        preserveTimestamps: true,
+        errorOnExist: false,
+      });
+    } catch (error) {
+      logError(
+        `[IPC] scratch:save-as-project: copy failed for ${scratchId} -> ${destinationPath}`,
+        error
+      );
+      throw error;
+    }
+
+    const project = await addProjectByPath(destinationPath);
+    return { status: "saved", project, destinationPath };
+  };
+  handlers.push(typedHandleWithContext(CHANNELS.SCRATCH_SAVE_AS_PROJECT, handleSaveAsProject));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -18,6 +18,7 @@ import { distributePortsToView } from "../../../window/portDistribution.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { addProjectByPath } from "../projectCrud/crud.js";
+import { createHardenedGit } from "../../../utils/hardenedGit.js";
 import { logError } from "../../../utils/logger.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Scratch } from "../../../../shared/types/scratch.js";
@@ -175,12 +176,15 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
 
     // Refuse if the user picked the scratch directory itself or a path inside
     // the scratch — `fs.cp` would recurse into the destination it's writing.
-    const normalizedScratch = path.resolve(scratch.path);
-    const normalizedDest = path.resolve(destinationPath);
-    if (
-      normalizedDest === normalizedScratch ||
-      normalizedDest.startsWith(normalizedScratch + path.sep)
-    ) {
+    // Use realpath so a symlink at the destination that resolves into the
+    // scratch dir cannot bypass the guard. `realpath` throws ENOENT for paths
+    // that don't yet exist (the dialog's `createDirectory` option produces
+    // these); fall back to lexical resolve in that case.
+    const normalizedScratch = await fs.realpath(scratch.path).catch(() => scratch.path);
+    const normalizedDest = await fs.realpath(destinationPath).catch(() => destinationPath);
+    const resolvedScratch = path.resolve(normalizedScratch);
+    const resolvedDest = path.resolve(normalizedDest);
+    if (resolvedDest === resolvedScratch || resolvedDest.startsWith(resolvedScratch + path.sep)) {
       throw new Error("Destination cannot be inside the scratch folder");
     }
 
@@ -209,6 +213,19 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
         `[IPC] scratch:save-as-project: copy failed for ${scratchId} -> ${destinationPath}`,
         error
       );
+      throw error;
+    }
+
+    // Scratch folders are not git repositories, but `projectStore.addProject`
+    // requires a git root. Initialize a fresh repo at the destination so the
+    // saved folder behaves like any other project (worktrees, status, etc.).
+    // If the user already chose a git-tracked destination, `git init` is a
+    // no-op — it reports the existing repo and exits 0.
+    try {
+      const git = createHardenedGit(destinationPath);
+      await git.init();
+    } catch (error) {
+      logError(`[IPC] scratch:save-as-project: git init failed for ${destinationPath}`, error);
       throw error;
     }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,6 +79,7 @@ import { registerCommands } from "./services/commands/index.js";
 import { initializeCrashRecoveryService } from "./services/CrashRecoveryService.js";
 import { initializeGpuCrashMonitor } from "./services/GpuCrashMonitorService.js";
 import { initializeTrashedPidCleanup } from "./services/TrashedPidTracker.js";
+import { initializeScratchCleanup } from "./services/ScratchCleanupService.js";
 import { initializeCrashLoopGuard, getCrashLoopGuard } from "./services/CrashLoopGuardService.js";
 import { initializeDatabaseMaintenance } from "./services/DatabaseMaintenanceService.js";
 import { readLastActiveProjectIdSync } from "./services/persistence/readLastProjectId.js";
@@ -164,6 +165,7 @@ if (!gotTheLock) {
   initializeCrashRecoveryService();
   initializeDatabaseMaintenance();
   initializeTrashedPidCleanup();
+  initializeScratchCleanup();
   initializeGpuCrashMonitor();
 
   const windowRegistry = new WindowRegistry();

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1386,6 +1386,11 @@ const api: ElectronAPI = {
     switch: (scratchId: string): Promise<import("../shared/types/scratch.js").Scratch> =>
       _unwrappingInvoke(CHANNELS.SCRATCH_SWITCH, scratchId),
 
+    saveAsProject: (
+      scratchId: string
+    ): Promise<import("../shared/types/ipc/scratch.js").ScratchSaveAsProjectResult> =>
+      _unwrappingInvoke(CHANNELS.SCRATCH_SAVE_AS_PROJECT, scratchId),
+
     onUpdated: (callback: (scratch: import("../shared/types/scratch.js").Scratch) => void) =>
       _typedOn(CHANNELS.SCRATCH_UPDATED, callback),
 

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -1,11 +1,18 @@
 /**
  * Startup auto-cleanup for stale scratch workspaces.
  *
- * A scratch whose `lastOpened` predates `now - SCRATCH_TTL_MS` has its
- * filesystem directory removed; the SQLite row is preserved as a tombstone
- * (`deleted_at` set) so a partial delete left by a crash can be retried
- * idempotently on the next boot. Tombstoned rows are filtered out of every
- * renderer-facing query in `ScratchStore`, so the renderer never sees them.
+ * A scratch whose `lastOpened` predates `now - SCRATCH_CLEANUP_TTL_MS` has
+ * its filesystem directory removed and its DB row tombstoned (`deleted_at`
+ * set). Tombstoned rows are filtered out of every renderer-facing query in
+ * `ScratchStore`, so the renderer never sees them again. The current scratch
+ * (per `app_state.currentScratchId`) is always excluded so an actively-open
+ * workspace can never disappear under the user.
+ *
+ * Tombstoning is one-way — orphaned directories left by a failed `fs.rm`
+ * stay on disk (logged, not retried). Accepting that orphan rate is
+ * deliberate: the alternative (re-sweeping tombstoned rows) would require a
+ * second query and could surprise users who manually re-create folders at
+ * the same path.
  *
  * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`:
  * called once at app boot, never awaited, never throws — a cleanup failure
@@ -15,9 +22,9 @@ import fs from "fs/promises";
 import { existsSync } from "fs";
 import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
 import { logError, logInfo } from "../utils/logger.js";
+import { SCRATCH_CLEANUP_TTL_MS } from "../../shared/config/scratchCleanup.js";
 
-export const SCRATCH_TTL_DAYS = 30;
-export const SCRATCH_TTL_MS = SCRATCH_TTL_DAYS * 24 * 60 * 60 * 1000;
+export { SCRATCH_CLEANUP_TTL_MS as SCRATCH_TTL_MS } from "../../shared/config/scratchCleanup.js";
 
 export interface ScratchCleanupResult {
   /** Total rows examined as candidates (predate cutoff, not yet tombstoned). */
@@ -46,8 +53,11 @@ export async function runScratchCleanup(
     directoriesFailed: 0,
   };
 
-  const cutoff = now - SCRATCH_TTL_MS;
-  const candidates = store.getStaleScratchCandidates(cutoff);
+  const cutoff = now - SCRATCH_CLEANUP_TTL_MS;
+  const currentScratchId = store.getCurrentScratchId();
+  const candidates = store
+    .getStaleScratchCandidates(cutoff)
+    .filter((row) => row.id !== currentScratchId);
   result.candidates = candidates.length;
 
   for (const row of candidates) {

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -1,0 +1,105 @@
+/**
+ * Startup auto-cleanup for stale scratch workspaces.
+ *
+ * A scratch whose `lastOpened` predates `now - SCRATCH_TTL_MS` has its
+ * filesystem directory removed; the SQLite row is preserved as a tombstone
+ * (`deleted_at` set) so a partial delete left by a crash can be retried
+ * idempotently on the next boot. Tombstoned rows are filtered out of every
+ * renderer-facing query in `ScratchStore`, so the renderer never sees them.
+ *
+ * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`:
+ * called once at app boot, never awaited, never throws — a cleanup failure
+ * must not block startup.
+ */
+import fs from "fs/promises";
+import { existsSync } from "fs";
+import { scratchStore as defaultScratchStore } from "./ScratchStore.js";
+import { logError, logInfo } from "../utils/logger.js";
+
+export const SCRATCH_TTL_DAYS = 30;
+export const SCRATCH_TTL_MS = SCRATCH_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+export interface ScratchCleanupResult {
+  /** Total rows examined as candidates (predate cutoff, not yet tombstoned). */
+  candidates: number;
+  /** Rows actually tombstoned during this sweep. */
+  tombstoned: number;
+  /** Directories successfully removed (or already absent). */
+  directoriesRemoved: number;
+  /** Directories that failed to remove (logged, not rethrown). */
+  directoriesFailed: number;
+}
+
+/**
+ * Stale-scratch sweep — runs synchronously against the DB then asynchronously
+ * for the filesystem deletes. Returns a summary for tests; production callers
+ * use {@link initializeScratchCleanup} which discards the result.
+ */
+export async function runScratchCleanup(
+  now: number = Date.now(),
+  store = defaultScratchStore
+): Promise<ScratchCleanupResult> {
+  const result: ScratchCleanupResult = {
+    candidates: 0,
+    tombstoned: 0,
+    directoriesRemoved: 0,
+    directoriesFailed: 0,
+  };
+
+  const cutoff = now - SCRATCH_TTL_MS;
+  const candidates = store.getStaleScratchCandidates(cutoff);
+  result.candidates = candidates.length;
+
+  for (const row of candidates) {
+    // Lesson #3721: never treat a falsy `lastOpened` as maximally stale —
+    // skip rather than tombstone. The schema declares NOT NULL, but a
+    // hand-edited DB or a future migration could relax that, and we'd rather
+    // skip a row than nuke it on bad data.
+    if (!row.lastOpened) continue;
+
+    try {
+      store.tombstoneScratch(row.id, now);
+      result.tombstoned += 1;
+    } catch (error) {
+      logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
+      continue;
+    }
+
+    if (!row.path) {
+      result.directoriesRemoved += 1;
+      continue;
+    }
+
+    if (!existsSync(row.path)) {
+      result.directoriesRemoved += 1;
+      continue;
+    }
+
+    try {
+      await fs.rm(row.path, { recursive: true, force: true });
+      result.directoriesRemoved += 1;
+    } catch (error) {
+      result.directoriesFailed += 1;
+      logError(`[ScratchCleanup] Failed to remove scratch directory ${row.path}`, error);
+    }
+  }
+
+  if (result.tombstoned > 0 || result.directoriesFailed > 0) {
+    logInfo(
+      `[ScratchCleanup] sweep complete: ${result.tombstoned} tombstoned, ` +
+        `${result.directoriesRemoved} directories removed, ${result.directoriesFailed} failed`
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Fire-and-forget entry point invoked from `electron/main.ts` at startup.
+ * Errors are caught and logged; never propagate to the boot path.
+ */
+export function initializeScratchCleanup(): void {
+  runScratchCleanup().catch((err) => {
+    logError("[ScratchCleanup] sweep threw", err);
+  });
+}

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import { randomUUID } from "crypto";
-import { eq, desc } from "drizzle-orm";
+import { eq, desc, and, isNull, lt } from "drizzle-orm";
 import type { Scratch } from "../../shared/types/scratch.js";
 import { getSharedDb } from "./persistence/db.js";
 import {
@@ -87,15 +87,50 @@ export class ScratchStore {
 
   getAllScratches(): Scratch[] {
     const db = getSharedDb();
-    const rows = db.select().from(scratchesTable).orderBy(desc(scratchesTable.lastOpened)).all();
+    const rows = db
+      .select()
+      .from(scratchesTable)
+      .where(isNull(scratchesTable.deletedAt))
+      .orderBy(desc(scratchesTable.lastOpened))
+      .all();
     return rows.map(rowToScratch);
   }
 
   getScratchById(scratchId: string): Scratch | null {
     if (!isValidScratchId(scratchId)) return null;
     const db = getSharedDb();
-    const row = db.select().from(scratchesTable).where(eq(scratchesTable.id, scratchId)).get();
+    const row = db
+      .select()
+      .from(scratchesTable)
+      .where(and(eq(scratchesTable.id, scratchId), isNull(scratchesTable.deletedAt)))
+      .get();
     return row ? rowToScratch(row) : null;
+  }
+
+  /**
+   * Returns raw rows of scratches whose `last_opened` predates the cutoff and
+   * which have not yet been tombstoned. Used by the startup cleanup sweep —
+   * exposes `path` directly so the sweep does not have to re-derive it.
+   */
+  getStaleScratchCandidates(cutoffMs: number): ScratchRow[] {
+    const db = getSharedDb();
+    return db
+      .select()
+      .from(scratchesTable)
+      .where(and(lt(scratchesTable.lastOpened, cutoffMs), isNull(scratchesTable.deletedAt)))
+      .all();
+  }
+
+  /**
+   * Marks a scratch as tombstoned (sets `deleted_at`). The DB row is preserved
+   * so a partial directory delete can be retried idempotently on next startup.
+   */
+  tombstoneScratch(scratchId: string, deletedAt: number): void {
+    if (!isValidScratchId(scratchId)) {
+      throw new Error(`Invalid scratch ID: ${scratchId}`);
+    }
+    const db = getSharedDb();
+    db.update(scratchesTable).set({ deletedAt }).where(eq(scratchesTable.id, scratchId)).run();
   }
 
   updateScratch(
@@ -114,9 +149,16 @@ export class ScratchStore {
       set.lastOpened = updates.lastOpened;
     }
     if (Object.keys(set).length > 0) {
-      db.update(scratchesTable).set(set).where(eq(scratchesTable.id, scratchId)).run();
+      db.update(scratchesTable)
+        .set(set)
+        .where(and(eq(scratchesTable.id, scratchId), isNull(scratchesTable.deletedAt)))
+        .run();
     }
-    const row = db.select().from(scratchesTable).where(eq(scratchesTable.id, scratchId)).get();
+    const row = db
+      .select()
+      .from(scratchesTable)
+      .where(and(eq(scratchesTable.id, scratchId), isNull(scratchesTable.deletedAt)))
+      .get();
     if (!row) throw new Error(`Scratch not found: ${scratchId}`);
     return rowToScratch(row);
   }

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -12,13 +12,16 @@ vi.mock("../../utils/logger.js", () => ({
 
 interface FakeStore {
   rows: ScratchRow[];
+  currentScratchId: string | null;
   getStaleScratchCandidates: (cutoffMs: number) => ScratchRow[];
   tombstoneScratch: (scratchId: string, deletedAt: number) => void;
+  getCurrentScratchId: () => string | null;
 }
 
-function makeStore(rows: ScratchRow[]): FakeStore {
+function makeStore(rows: ScratchRow[], currentScratchId: string | null = null): FakeStore {
   const store: FakeStore = {
     rows,
+    currentScratchId,
     getStaleScratchCandidates(cutoffMs: number) {
       return store.rows.filter((r) => r.lastOpened < cutoffMs && r.deletedAt == null);
     },
@@ -26,6 +29,9 @@ function makeStore(rows: ScratchRow[]): FakeStore {
       const r = store.rows.find((x) => x.id === scratchId);
       if (!r) throw new Error(`not found: ${scratchId}`);
       r.deletedAt = deletedAt;
+    },
+    getCurrentScratchId() {
+      return store.currentScratchId;
     },
   };
   return store;
@@ -156,5 +162,55 @@ describe("runScratchCleanup", () => {
 
     expect(result.candidates).toBe(0);
     expect(store.rows[0]!.deletedAt).toBeNull();
+  });
+
+  it("never deletes the active scratch even when stale", async () => {
+    const activeDir = path.join(tmpDir, "active");
+    await fs.mkdir(activeDir, { recursive: true });
+    const otherDir = path.join(tmpDir, "other");
+    await fs.mkdir(otherDir, { recursive: true });
+    const store = makeStore(
+      [
+        row({ id: "active", path: activeDir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+        row({ id: "other", path: otherDir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+      ],
+      "active"
+    );
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.tombstoned).toBe(1);
+    expect(store.rows.find((r) => r.id === "active")!.deletedAt).toBeNull();
+    expect(store.rows.find((r) => r.id === "other")!.deletedAt).toBe(NOW);
+    await expect(fs.access(activeDir)).resolves.toBeUndefined();
+    await expect(fs.access(otherDir)).rejects.toBeDefined();
+  });
+
+  it("does not retry tombstoned rows even when their directory still exists", async () => {
+    const ghost = path.join(tmpDir, "ghost-dir");
+    await fs.mkdir(ghost, { recursive: true });
+    // Simulate a previous sweep that tombstoned the row but failed to remove
+    // the directory. The current implementation accepts this orphan rather
+    // than re-trying — guard the contract so future changes are deliberate.
+    const store = makeStore([
+      row({
+        id: "ghost",
+        path: ghost,
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 86_400_000,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.candidates).toBe(0);
+    expect(result.tombstoned).toBe(0);
+    await expect(fs.access(ghost)).resolves.toBeUndefined();
   });
 });

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { runScratchCleanup, SCRATCH_TTL_MS } from "../ScratchCleanupService.js";
+import type { ScratchRow } from "../persistence/schema.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+interface FakeStore {
+  rows: ScratchRow[];
+  getStaleScratchCandidates: (cutoffMs: number) => ScratchRow[];
+  tombstoneScratch: (scratchId: string, deletedAt: number) => void;
+}
+
+function makeStore(rows: ScratchRow[]): FakeStore {
+  const store: FakeStore = {
+    rows,
+    getStaleScratchCandidates(cutoffMs: number) {
+      return store.rows.filter((r) => r.lastOpened < cutoffMs && r.deletedAt == null);
+    },
+    tombstoneScratch(scratchId: string, deletedAt: number) {
+      const r = store.rows.find((x) => x.id === scratchId);
+      if (!r) throw new Error(`not found: ${scratchId}`);
+      r.deletedAt = deletedAt;
+    },
+  };
+  return store;
+}
+
+function row(overrides: Partial<ScratchRow> & Pick<ScratchRow, "id" | "path">): ScratchRow {
+  return {
+    id: overrides.id,
+    path: overrides.path,
+    name: overrides.name ?? "test scratch",
+    createdAt: overrides.createdAt ?? 0,
+    lastOpened: overrides.lastOpened ?? 0,
+    deletedAt: overrides.deletedAt ?? null,
+  };
+}
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "scratch-cleanup-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+describe("runScratchCleanup", () => {
+  it("does not touch scratches younger than the TTL", async () => {
+    const dir = path.join(tmpDir, "fresh");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore([
+      row({ id: "fresh", path: dir, lastOpened: NOW - SCRATCH_TTL_MS / 2 }),
+    ]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+  });
+
+  it("tombstones and removes scratches older than the TTL", async () => {
+    const dir = path.join(tmpDir, "stale");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "a.txt"), "hello");
+    const store = makeStore([
+      row({ id: "stale", path: dir, lastOpened: NOW - (SCRATCH_TTL_MS + 86_400_000) }),
+    ]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
+  it("is idempotent — already-tombstoned rows are skipped", async () => {
+    const store = makeStore([
+      row({
+        id: "tombstoned",
+        path: path.join(tmpDir, "missing"),
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+        deletedAt: NOW - 1000,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.candidates).toBe(0);
+    expect(result.tombstoned).toBe(0);
+  });
+
+  it("treats a missing directory as removed (no failure)", async () => {
+    const store = makeStore([
+      row({
+        id: "ghost",
+        path: path.join(tmpDir, "does-not-exist"),
+        lastOpened: NOW - 2 * SCRATCH_TTL_MS,
+      }),
+    ]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.tombstoned).toBe(1);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(result.directoriesFailed).toBe(0);
+  });
+
+  it("skips rows with falsy lastOpened (PR #3721 lesson)", async () => {
+    const store = makeStore([row({ id: "zero", path: tmpDir, lastOpened: 0 })]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    // lastOpened 0 < cutoff so it surfaces as a candidate, but we skip it.
+    expect(result.candidates).toBe(1);
+    expect(result.tombstoned).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+  });
+
+  it("respects the 30-day boundary at exactly the cutoff", async () => {
+    // lastOpened == cutoff is NOT stale (sweep uses `<`).
+    const at = path.join(tmpDir, "boundary");
+    await fs.mkdir(at, { recursive: true });
+    const store = makeStore([row({ id: "boundary", path: at, lastOpened: NOW - SCRATCH_TTL_MS })]);
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.candidates).toBe(0);
+    expect(store.rows[0]!.deletedAt).toBeNull();
+  });
+});

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -17,6 +17,13 @@ import { openDb } from "../db.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(__dirname, "../migrations");
 
+// Derive the expected migration count from the journal so each new migration
+// added to the repo doesn't require touching every assertion in this file.
+const migrationsJournalEntries = JSON.parse(
+  fs.readFileSync(path.join(migrationsFolder, "meta", "_journal.json"), "utf8")
+).entries as Array<{ tag: string }>;
+const EXPECTED_MIGRATION_COUNT = migrationsJournalEntries.length;
+
 type ColInfo = { name: string; type: string };
 
 describe("openDb (integration)", () => {
@@ -49,7 +56,7 @@ describe("openDb (integration)", () => {
         id: number;
         hash: string;
       }[];
-      expect(migrations).toHaveLength(2);
+      expect(migrations).toHaveLength(EXPECTED_MIGRATION_COUNT);
       expect(migrations[0].hash).toBeTruthy();
     } finally {
       sqlite.close();
@@ -88,7 +95,7 @@ describe("openDb (integration)", () => {
       const migrations = second.sqlite.prepare("SELECT id FROM __drizzle_migrations").all() as {
         id: number;
       }[];
-      expect(migrations).toHaveLength(2);
+      expect(migrations).toHaveLength(EXPECTED_MIGRATION_COUNT);
     } finally {
       second.sqlite.close();
     }
@@ -169,7 +176,7 @@ describe("openDb (integration)", () => {
       const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all() as {
         id: number;
       }[];
-      expect(migrations).toHaveLength(2);
+      expect(migrations).toHaveLength(EXPECTED_MIGRATION_COUNT);
     } finally {
       sqlite.close();
     }
@@ -255,7 +262,7 @@ describe("openDb (integration)", () => {
       const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all() as {
         id: number;
       }[];
-      expect(migrations).toHaveLength(2);
+      expect(migrations).toHaveLength(EXPECTED_MIGRATION_COUNT);
     } finally {
       sqlite.close();
     }

--- a/electron/services/persistence/migrations/0002_add_scratch_deleted_at.sql
+++ b/electron/services/persistence/migrations/0002_add_scratch_deleted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scratches` ADD `deleted_at` integer;

--- a/electron/services/persistence/migrations/meta/0002_snapshot.json
+++ b/electron/services/persistence/migrations/meta/0002_snapshot.json
@@ -1,0 +1,340 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5123a52b-3ee8-48c9-bdb2-b2c54ff8b102",
+  "prevId": "1e620814-0a59-4028-b601-c1d58d831177",
+  "tables": {
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened": {
+          "name": "last_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daintree_config_present": {
+          "name": "daintree_config_present",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_repo_settings": {
+          "name": "in_repo_settings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "frecency_score": {
+          "name": "frecency_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scratches": {
+      "name": "scratches",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_opened": {
+          "name": "last_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "worktree_id": {
+          "name": "worktree_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assigned_agent_id": {
+          "name": "assigned_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routing_hints": {
+          "name": "routing_hints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_project_idx": {
+          "name": "tasks_project_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "tasks_project_status_idx": {
+          "name": "tasks_project_status_idx",
+          "columns": ["project_id", "status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777962339910,
       "tag": "0001_add_scratches",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777971986182,
+      "tag": "0002_add_scratch_deleted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -54,6 +54,11 @@ export const scratches = sqliteTable("scratches", {
   name: text("name").notNull(),
   createdAt: integer("created_at").notNull(),
   lastOpened: integer("last_opened").notNull(),
+  // Set when the auto-cleanup sweep tombstones a stale scratch. The DB row is
+  // retained as crash-safe state so a partially-deleted directory can be
+  // re-attempted on the next startup; rows with `deletedAt` set are filtered
+  // out of all renderer-facing queries.
+  deletedAt: integer("deleted_at"),
 });
 
 export type TaskRow = typeof tasks.$inferInsert;

--- a/shared/config/scratchCleanup.ts
+++ b/shared/config/scratchCleanup.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared TTL constants for scratch auto-cleanup. Imported by both the main
+ * process (`ScratchCleanupService`) and the renderer (`ProjectSwitcherPalette`
+ * countdown) so the user-visible countdown can never drift from the actual
+ * deletion threshold.
+ */
+
+/** A scratch is eligible for cleanup once `lastOpened` is older than this. */
+export const SCRATCH_CLEANUP_TTL_DAYS = 30;
+
+/** TTL expressed in milliseconds for direct comparison against timestamps. */
+export const SCRATCH_CLEANUP_TTL_MS = SCRATCH_CLEANUP_TTL_DAYS * 24 * 60 * 60 * 1000;
+
+/** Show the cleanup countdown in the UI when within this many days of expiry. */
+export const SCRATCH_CLEANUP_COUNTDOWN_VISIBLE_DAYS = 7;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -597,6 +597,7 @@ export interface ElectronAPI {
     ): Promise<import("../scratch.js").Scratch>;
     remove(scratchId: string): Promise<void>;
     switch(scratchId: string): Promise<import("../scratch.js").Scratch>;
+    saveAsProject(scratchId: string): Promise<import("./scratch.js").ScratchSaveAsProjectResult>;
     onUpdated(callback: (scratch: import("../scratch.js").Scratch) => void): () => void;
     onRemoved(callback: (scratchId: string) => void): () => void;
     onSwitch(callback: (payload: import("./scratch.js").ScratchSwitchPayload) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -182,7 +182,7 @@ import type {
 } from "./demo.js";
 import type { BulkProjectStats } from "./project.js";
 import type { Scratch } from "../scratch.js";
-import type { ScratchSwitchPayload } from "./scratch.js";
+import type { ScratchSwitchPayload, ScratchSaveAsProjectResult } from "./scratch.js";
 import type {
   PrerequisiteSpec,
   PrerequisiteCheckResult,
@@ -2074,6 +2074,10 @@ export interface IpcInvokeMap {
   "scratch:switch": {
     args: [scratchId: string];
     result: Scratch;
+  };
+  "scratch:save-as-project": {
+    args: [scratchId: string];
+    result: ScratchSaveAsProjectResult;
   };
 
   // Global env channels

--- a/shared/types/ipc/scratch.ts
+++ b/shared/types/ipc/scratch.ts
@@ -1,4 +1,5 @@
 import type { Scratch } from "../scratch.js";
+import type { Project } from "../project.js";
 
 /**
  * Push payload sent to renderers when the active scratch changes. `scratch`
@@ -14,3 +15,12 @@ export interface ScratchUpdateInput {
   name?: string;
   lastOpened?: number;
 }
+
+/**
+ * Result of `scratch:save-as-project`. Either the user picked a destination
+ * and the scratch was copied + registered as a project, or they cancelled the
+ * directory picker.
+ */
+export type ScratchSaveAsProjectResult =
+  | { status: "saved"; project: Project; destinationPath: string }
+  | { status: "cancelled" };

--- a/shared/types/scratch.ts
+++ b/shared/types/scratch.ts
@@ -3,9 +3,6 @@
  * Parallel to `Project` rather than a subtype: separate table, store, IPC
  * namespace, and lifecycle. Folders live in a UUID-named path under the app's
  * `userData` directory so they don't pollute the user's project folders.
- *
- * Out of scope for v1: auto-cleanup, "Save as Project…" promotion, visual
- * differentiation of the active scratch, first-run note. See issue #6778.
  */
 export interface Scratch {
   /** UUID v4 — both identifier and path component under userData/scratches/. */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -916,6 +916,15 @@ function App() {
                   onRemoveScratch={(scratchId) =>
                     void projectSwitcherPalette.removeScratchAction(scratchId)
                   }
+                  onSaveAsProject={(scratchId) =>
+                    void projectSwitcherPalette.saveAsProject(scratchId)
+                  }
+                  saveAsProjectConfirm={projectSwitcherPalette.saveAsProjectConfirm}
+                  onDismissSaveAsProjectConfirm={projectSwitcherPalette.dismissSaveAsProjectConfirm}
+                  onConfirmDeleteOriginalScratch={() =>
+                    void projectSwitcherPalette.confirmDeleteOriginalScratch()
+                  }
+                  isDeletingOriginalScratch={projectSwitcherPalette.isDeletingOriginalScratch}
                 />
               </Suspense>
             )}

--- a/src/clients/scratchClient.ts
+++ b/src/clients/scratchClient.ts
@@ -1,4 +1,5 @@
 import type { Scratch } from "@shared/types";
+import type { ScratchSaveAsProjectResult } from "@shared/types/ipc/scratch";
 
 /**
  * Thin renderer-side wrapper for `window.electron.scratch`. Mirrors the
@@ -45,6 +46,11 @@ export const scratchClient = {
     const a = api();
     if (!a) return Promise.reject(new Error("scratch IPC unavailable"));
     return a.switch(scratchId);
+  },
+  saveAsProject(scratchId: string): Promise<ScratchSaveAsProjectResult> {
+    const a = api();
+    if (!a) return Promise.reject(new Error("scratch IPC unavailable"));
+    return a.saveAsProject(scratchId);
   },
   onUpdated(callback: (scratch: Scratch) => void): () => void {
     return api()?.onUpdated(callback) ?? NOOP_CLEANUP;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -986,6 +986,13 @@ export function Toolbar({
             onCreateScratch={() => void projectSwitcher.createScratch()}
             onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
             onRemoveScratch={(scratchId) => void projectSwitcher.removeScratchAction(scratchId)}
+            onSaveAsProject={(scratchId) => void projectSwitcher.saveAsProject(scratchId)}
+            saveAsProjectConfirm={projectSwitcher.saveAsProjectConfirm}
+            onDismissSaveAsProjectConfirm={projectSwitcher.dismissSaveAsProjectConfirm}
+            onConfirmDeleteOriginalScratch={() =>
+              void projectSwitcher.confirmDeleteOriginalScratch()
+            }
+            isDeletingOriginalScratch={projectSwitcher.isDeletingOriginalScratch}
           >
             <button
               data-toolbar-item=""

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   FolderOpen,
   FolderPlus,
+  FolderUp,
   Pin,
   PinOff,
   Plus,
@@ -77,6 +78,19 @@ export interface ProjectSwitcherPaletteProps {
   onSelectScratch?: (scratch: SearchableScratch) => void;
   /** Callback to remove a scratch. */
   onRemoveScratch?: (scratchId: string) => void;
+  /** Callback to save a scratch as a regular project (copy + register). */
+  onSaveAsProject?: (scratchId: string) => void;
+  /**
+   * "Delete original?" follow-up after a successful Save-as-Project copy.
+   * Surfaced as a top-level ConfirmDialog above the palette.
+   */
+  saveAsProjectConfirm?: {
+    scratch: SearchableScratch;
+    project: { name: string; path: string };
+  } | null;
+  onDismissSaveAsProjectConfirm?: () => void;
+  onConfirmDeleteOriginalScratch?: () => void;
+  isDeletingOriginalScratch?: boolean;
 }
 
 interface ProjectListItemProps {
@@ -445,11 +459,37 @@ function ProjectListContent({
   );
 }
 
+/**
+ * 30 days mirrors the auto-cleanup TTL in `ScratchCleanupService`. Kept in
+ * sync by hand because the renderer/main split prevents importing the value
+ * from a main-only module without a shared module — and a single literal in
+ * two places is simpler than a new shared module.
+ */
+const SCRATCH_CLEANUP_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+/** Show the countdown only when within this many days of cleanup. */
+const SCRATCH_COUNTDOWN_VISIBLE_DAYS = 7;
+
+/**
+ * Returns the cleanup-countdown microcopy when a scratch is within the
+ * visibility window, otherwise null. Strings are hardcoded English (sentence
+ * case, no period) per the project microcopy convention.
+ */
+export function formatScratchCleanupCountdown(lastOpened: number, now: number): string | null {
+  if (!lastOpened) return null;
+  const expiresAt = lastOpened + SCRATCH_CLEANUP_TTL_MS;
+  const daysLeft = Math.ceil((expiresAt - now) / (24 * 60 * 60 * 1000));
+  if (daysLeft > SCRATCH_COUNTDOWN_VISIBLE_DAYS) return null;
+  if (daysLeft <= 0) return "Auto-cleanup today";
+  if (daysLeft === 1) return "Auto-cleanup tomorrow";
+  return `Auto-cleanup in ${daysLeft} days`;
+}
+
 interface ScratchSectionProps {
   scratches: SearchableScratch[];
   onCreate?: () => void;
   onSelect?: (scratch: SearchableScratch) => void;
   onRemove?: (scratchId: string) => void;
+  onSaveAsProject?: (scratchId: string) => void;
 }
 
 /**
@@ -460,8 +500,19 @@ interface ScratchSectionProps {
  * Sort order is purely by `lastOpened` desc (the hook already does this).
  * Scratches deliberately do NOT participate in the project frecency ranking.
  */
-function ScratchSection({ scratches, onCreate, onSelect, onRemove }: ScratchSectionProps) {
+function ScratchSection({
+  scratches,
+  onCreate,
+  onSelect,
+  onRemove,
+  onSaveAsProject,
+}: ScratchSectionProps) {
   const [collapsed, setCollapsed] = useState<boolean>(scratches.length === 0);
+  // `now` is captured per-render so the countdown updates whenever the
+  // surrounding component re-renders. Refresh is naturally driven by store
+  // updates (loadScratches on palette open, scratch:updated push events) —
+  // an interval here would be wasteful given the daily granularity.
+  const now = Date.now();
 
   // If a scratch was just created from the empty state, expand the section
   // so the new entry is visible.
@@ -501,40 +552,61 @@ function ScratchSection({ scratches, onCreate, onSelect, onRemove }: ScratchSect
             </div>
           ) : (
             <div role="listbox" aria-label="Scratch workspaces">
-              {scratches.map((scratch) => (
-                <ContextMenu key={scratch.id}>
-                  <ContextMenuTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => onSelect?.(scratch)}
-                      className={cn(
-                        "w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
-                        scratch.isActive ? "bg-overlay-subtle" : "hover:bg-overlay-subtle"
-                      )}
-                      role="option"
-                      aria-selected={scratch.isActive}
-                    >
-                      <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
-                        <FileText className="h-4 w-4" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="text-sm font-medium truncate">{scratch.name}</div>
-                        <div className="text-xs text-daintree-text/40 truncate">
-                          {formatTimeAgo(scratch.lastOpened)}
+              {scratches.map((scratch) => {
+                const countdown = formatScratchCleanupCountdown(scratch.lastOpened, now);
+                const hasContextActions = Boolean(onRemove || onSaveAsProject);
+                return (
+                  <ContextMenu key={scratch.id}>
+                    <ContextMenuTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => onSelect?.(scratch)}
+                        className={cn(
+                          "w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
+                          scratch.isActive ? "bg-overlay-subtle" : "hover:bg-overlay-subtle"
+                        )}
+                        role="option"
+                        aria-selected={scratch.isActive}
+                      >
+                        <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground shrink-0">
+                          <FileText className="h-4 w-4" />
                         </div>
-                      </div>
-                    </button>
-                  </ContextMenuTrigger>
-                  {onRemove && (
-                    <ContextMenuContent>
-                      <ContextMenuItem destructive onClick={() => onRemove(scratch.id)}>
-                        <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-                        Delete scratch
-                      </ContextMenuItem>
-                    </ContextMenuContent>
-                  )}
-                </ContextMenu>
-              ))}
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm font-medium truncate">{scratch.name}</div>
+                          <div className="text-xs text-daintree-text/40 truncate">
+                            {formatTimeAgo(scratch.lastOpened)}
+                          </div>
+                          {countdown && (
+                            <div
+                              className="text-[11px] leading-none text-daintree-text/40 mt-0.5 truncate"
+                              data-testid="scratch-cleanup-countdown"
+                            >
+                              {countdown}
+                            </div>
+                          )}
+                        </div>
+                      </button>
+                    </ContextMenuTrigger>
+                    {hasContextActions && (
+                      <ContextMenuContent>
+                        {onSaveAsProject && (
+                          <ContextMenuItem onClick={() => onSaveAsProject(scratch.id)}>
+                            <FolderUp className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                            Save as project...
+                          </ContextMenuItem>
+                        )}
+                        {onSaveAsProject && onRemove && <ContextMenuSeparator />}
+                        {onRemove && (
+                          <ContextMenuItem destructive onClick={() => onRemove(scratch.id)}>
+                            <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+                            Delete scratch
+                          </ContextMenuItem>
+                        )}
+                      </ContextMenuContent>
+                    )}
+                  </ContextMenu>
+                );
+              })}
             </div>
           )}
           {onCreate && (
@@ -623,6 +695,7 @@ interface ProjectPaletteInnerProps {
   onCreateScratch?: () => void;
   onSelectScratch?: (scratch: SearchableScratch) => void;
   onRemoveScratch?: (scratchId: string) => void;
+  onSaveAsProject?: (scratchId: string) => void;
 }
 
 function ProjectPaletteInner({
@@ -652,6 +725,7 @@ function ProjectPaletteInner({
   onCreateScratch,
   onSelectScratch,
   onRemoveScratch,
+  onSaveAsProject,
 }: ProjectPaletteInnerProps) {
   const projectSwitcherShortcut = useEffectiveCombo("project.switcherPalette");
 
@@ -778,6 +852,7 @@ function ProjectPaletteInner({
               onCreate={onCreateScratch}
               onSelect={onSelectScratch}
               onRemove={onRemoveScratch}
+              onSaveAsProject={onSaveAsProject}
             />
           </>
         )}
@@ -960,6 +1035,7 @@ function ModalContent({
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
           onRemoveScratch={innerProps.onRemoveScratch}
+          onSaveAsProject={innerProps.onSaveAsProject}
         />
       </div>
     </div>,
@@ -1042,6 +1118,7 @@ function DropdownContent({
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
           onRemoveScratch={innerProps.onRemoveScratch}
+          onSaveAsProject={innerProps.onSaveAsProject}
         />
       </PopoverContent>
     </Popover>
@@ -1080,6 +1157,11 @@ export function ProjectSwitcherPalette({
   onCreateScratch,
   onSelectScratch,
   onRemoveScratch,
+  onSaveAsProject,
+  saveAsProjectConfirm,
+  onDismissSaveAsProjectConfirm,
+  onConfirmDeleteOriginalScratch,
+  isDeletingOriginalScratch = false,
 }: ProjectSwitcherPaletteProps) {
   const hasRunningProcesses = removeConfirmProject
     ? removeConfirmProject.processCount > 0 ||
@@ -1116,6 +1198,7 @@ export function ProjectSwitcherPalette({
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}
         onRemoveScratch={onRemoveScratch}
+        onSaveAsProject={onSaveAsProject}
       >
         {children}
       </DropdownContent>
@@ -1146,6 +1229,7 @@ export function ProjectSwitcherPalette({
         onCreateScratch={onCreateScratch}
         onSelectScratch={onSelectScratch}
         onRemoveScratch={onRemoveScratch}
+        onSaveAsProject={onSaveAsProject}
       />
     );
 
@@ -1210,6 +1294,29 @@ export function ProjectSwitcherPalette({
               {removeConfirmProject.isActive
                 ? "The project will remain in your list and can be reopened at any time."
                 : "This project will be removed from your list. You can add it back later, but any running terminals or processes will need to be restarted."}
+            </div>
+          </div>
+        </ConfirmDialog>
+      )}
+      {saveAsProjectConfirm && onDismissSaveAsProjectConfirm && onConfirmDeleteOriginalScratch && (
+        <ConfirmDialog
+          isOpen={true}
+          onClose={isDeletingOriginalScratch ? undefined : onDismissSaveAsProjectConfirm}
+          title={`Delete '${saveAsProjectConfirm.scratch.name}'?`}
+          zIndex="nested"
+          confirmLabel="Delete scratch"
+          cancelLabel="Keep scratch"
+          onConfirm={onConfirmDeleteOriginalScratch}
+          isConfirmLoading={isDeletingOriginalScratch}
+          variant="destructive"
+        >
+          <div className="space-y-3">
+            <div className="text-sm">
+              Saved as <span className="font-medium">{saveAsProjectConfirm.project.name}</span>. The
+              original scratch folder is no longer needed.
+            </div>
+            <div className="text-xs text-daintree-text/50 font-mono break-all">
+              {saveAsProjectConfirm.scratch.path}
             </div>
           </div>
         </ConfirmDialog>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -41,6 +41,10 @@ import type {
   SearchableScratch,
 } from "@/hooks/useProjectSwitcherPalette";
 import { useUIStore } from "@/store/uiStore";
+import {
+  SCRATCH_CLEANUP_TTL_MS,
+  SCRATCH_CLEANUP_COUNTDOWN_VISIBLE_DAYS,
+} from "@shared/config/scratchCleanup";
 
 export interface ProjectSwitcherPaletteProps {
   isOpen: boolean;
@@ -460,25 +464,17 @@ function ProjectListContent({
 }
 
 /**
- * 30 days mirrors the auto-cleanup TTL in `ScratchCleanupService`. Kept in
- * sync by hand because the renderer/main split prevents importing the value
- * from a main-only module without a shared module — and a single literal in
- * two places is simpler than a new shared module.
- */
-const SCRATCH_CLEANUP_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-/** Show the countdown only when within this many days of cleanup. */
-const SCRATCH_COUNTDOWN_VISIBLE_DAYS = 7;
-
-/**
  * Returns the cleanup-countdown microcopy when a scratch is within the
  * visibility window, otherwise null. Strings are hardcoded English (sentence
- * case, no period) per the project microcopy convention.
+ * case, no period) per the project microcopy convention. The TTL constant is
+ * imported from `shared/config/scratchCleanup` so the user-visible countdown
+ * never drifts from the actual deletion threshold in `ScratchCleanupService`.
  */
 export function formatScratchCleanupCountdown(lastOpened: number, now: number): string | null {
   if (!lastOpened) return null;
   const expiresAt = lastOpened + SCRATCH_CLEANUP_TTL_MS;
   const daysLeft = Math.ceil((expiresAt - now) / (24 * 60 * 60 * 1000));
-  if (daysLeft > SCRATCH_COUNTDOWN_VISIBLE_DAYS) return null;
+  if (daysLeft > SCRATCH_CLEANUP_COUNTDOWN_VISIBLE_DAYS) return null;
   if (daysLeft <= 0) return "Auto-cleanup today";
   if (daysLeft === 1) return "Auto-cleanup tomorrow";
   return `Auto-cleanup in ${daysLeft} days`;

--- a/src/components/Project/__tests__/scratchCleanupCountdown.test.ts
+++ b/src/components/Project/__tests__/scratchCleanupCountdown.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { formatScratchCleanupCountdown } from "../ProjectSwitcherPalette";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+const TTL_DAYS = 30;
+
+describe("formatScratchCleanupCountdown", () => {
+  it("returns null for fresh scratches outside the visibility window", () => {
+    // 25 days left -> outside the 7-day window
+    const lastOpened = NOW - 5 * DAY;
+    expect(formatScratchCleanupCountdown(lastOpened, NOW)).toBeNull();
+  });
+
+  it("renders 'in N days' inside the visibility window", () => {
+    // 5 days left
+    const lastOpened = NOW - (TTL_DAYS - 5) * DAY;
+    expect(formatScratchCleanupCountdown(lastOpened, NOW)).toBe("Auto-cleanup in 5 days");
+  });
+
+  it("renders 'tomorrow' when 1 day left", () => {
+    const lastOpened = NOW - (TTL_DAYS - 1) * DAY;
+    expect(formatScratchCleanupCountdown(lastOpened, NOW)).toBe("Auto-cleanup tomorrow");
+  });
+
+  it("renders 'today' when 0 days left", () => {
+    const lastOpened = NOW - TTL_DAYS * DAY;
+    expect(formatScratchCleanupCountdown(lastOpened, NOW)).toBe("Auto-cleanup today");
+  });
+
+  it("clamps negative remaining time to 'today'", () => {
+    const lastOpened = NOW - (TTL_DAYS + 5) * DAY;
+    expect(formatScratchCleanupCountdown(lastOpened, NOW)).toBe("Auto-cleanup today");
+  });
+
+  it("returns null for falsy lastOpened (defensive against bad data)", () => {
+    expect(formatScratchCleanupCountdown(0, NOW)).toBeNull();
+  });
+});

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -6,7 +6,7 @@ import { useScratchStore } from "@/store/scratchStore";
 import { usePaletteStore } from "@/store/paletteStore";
 import { notify } from "@/lib/notify";
 import type { Project, Scratch } from "@shared/types";
-import { projectClient } from "@/clients";
+import { projectClient, scratchClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 export type ProjectSwitcherMode = "modal" | "dropdown";
@@ -77,6 +77,21 @@ export interface UseProjectSwitcherPaletteReturn {
   selectScratch: (scratch: SearchableScratch) => Promise<void>;
   /** Remove a scratch (deletes folder + DB row). Used by context menu. */
   removeScratchAction: (scratchId: string) => Promise<void>;
+  /**
+   * Open the directory picker and save the scratch as a project. On success
+   * exposes a follow-up confirmation via {@link saveAsProjectConfirm} so the
+   * user can optionally delete the original scratch.
+   */
+  saveAsProject: (scratchId: string) => Promise<void>;
+  /**
+   * Pending "Delete original?" confirmation surfaced after a successful
+   * Save-as-Project copy. Cleared by `confirmDeleteOriginalScratch` or
+   * `dismissSaveAsProjectConfirm`.
+   */
+  saveAsProjectConfirm: { scratch: SearchableScratch; project: Project } | null;
+  dismissSaveAsProjectConfirm: () => void;
+  confirmDeleteOriginalScratch: () => Promise<void>;
+  isDeletingOriginalScratch: boolean;
 }
 
 const MAX_RESULTS = 15;
@@ -92,6 +107,11 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const [isStoppingProject, setIsStoppingProject] = useState(false);
   const [removeConfirmProject, setRemoveConfirmProject] = useState<SearchableProject | null>(null);
   const [isRemovingProject, setIsRemovingProject] = useState(false);
+  const [saveAsProjectConfirm, setSaveAsProjectConfirm] = useState<{
+    scratch: SearchableScratch;
+    project: Project;
+  } | null>(null);
+  const [isDeletingOriginalScratch, setIsDeletingOriginalScratch] = useState(false);
   const selectedProjectIdRef = useRef<string | null>(null);
 
   const projects = useProjectStore((state) => state.projects);
@@ -466,6 +486,48 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     [removeScratchActionStore]
   );
 
+  const saveAsProject = useCallback(
+    async (scratchId: string) => {
+      const scratch = scratchResults.find((s) => s.id === scratchId);
+      if (!scratch) return;
+      try {
+        const result = await scratchClient.saveAsProject(scratchId);
+        if (result.status === "cancelled") return;
+        await loadProjects();
+        setSaveAsProjectConfirm({ scratch, project: result.project });
+      } catch (error) {
+        notify({
+          type: "error",
+          title: "Couldn't save scratch as project",
+          message: formatErrorMessage(error, "Couldn't save scratch as project"),
+        });
+      }
+    },
+    [scratchResults, loadProjects]
+  );
+
+  const dismissSaveAsProjectConfirm = useCallback(() => {
+    setSaveAsProjectConfirm(null);
+  }, []);
+
+  const confirmDeleteOriginalScratch = useCallback(async () => {
+    if (!saveAsProjectConfirm || isDeletingOriginalScratch) return;
+    setIsDeletingOriginalScratch(true);
+    const scratchId = saveAsProjectConfirm.scratch.id;
+    try {
+      await removeScratchActionStore(scratchId);
+      setSaveAsProjectConfirm(null);
+    } catch (error) {
+      notify({
+        type: "error",
+        title: "Couldn't remove original scratch",
+        message: formatErrorMessage(error, "Couldn't remove the original scratch workspace"),
+      });
+    } finally {
+      setIsDeletingOriginalScratch(false);
+    }
+  }, [saveAsProjectConfirm, isDeletingOriginalScratch, removeScratchActionStore]);
+
   const confirmRemoveProject = useCallback(async () => {
     if (!removeConfirmProject || isRemovingProject) return;
 
@@ -550,5 +612,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     createScratch,
     selectScratch,
     removeScratchAction,
+    saveAsProject,
+    saveAsProjectConfirm,
+    dismissSaveAsProjectConfirm,
+    confirmDeleteOriginalScratch,
+    isDeletingOriginalScratch,
   };
 }


### PR DESCRIPTION
## Summary

- 30-day auto-cleanup runs at app startup; scratches are tombstoned before deletion so a mid-sweep crash doesn't lose the row permanently
- Save as Project opens a directory picker, copies the scratch folder, runs `git init`, registers the destination as a project, then asks whether to delete the original scratch
- Countdown badge appears on scratch cards when 7 days or fewer remain (`Auto-cleanup in N days` / `tomorrow` / `today`); the active scratch is always excluded from cleanup
- `shared/config/scratchCleanup.ts` holds a single `SCRATCH_CLEANUP_TTL_MS` constant so the renderer countdown and the main-process sweep can't drift independently

Resolves #6780

## Changes

- `ScratchCleanupService` — startup sweep with tombstone column (`deleted_at`) for crash safety; skips the current active scratch
- `scratch/index.ts` IPC handler — `saveAsProject` action: copy, `git init`, `addProjectByPath`, optional scratch deletion via `ConfirmDialog`
- `ProjectSwitcherPalette` + `useProjectSwitcherPalette` — countdown badge and Save as Project entry per scratch card
- `Toolbar` — wires the Save as Project action into the scratch toolbar
- Migration `0002_add_scratch_deleted_at.sql` — adds the tombstone column
- `shared/config/scratchCleanup.ts` — shared TTL constant

## Testing

14 unit tests: `ScratchCleanupService.test.ts` covers the sweep logic, tombstone behaviour, and active-scratch guard; `scratchCleanupCountdown.test.ts` covers the badge label generation across all countdown states.