### PR TITLE
fix(layout): split portal-only and obstruction CSS vars

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -375,14 +375,24 @@ export function AppLayout({
 
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
-    // Portal overlays the Assistant when both are open, so the rightmost fixed
-    // obstruction is the wider of the two — not their sum. Toaster, popovers,
-    // dropdowns, ReEntrySummary, and GettingStartedChecklist all read this var.
-    const totalOffset = Math.max(portalOffset, effectiveAssistantWidth);
-    document.body.style.setProperty("--portal-right-offset", `${totalOffset}px`);
+    // Two separate vars because they encode different layout truths.
+    // --portal-right-offset: width of the body-portaled Portal (web chat) only.
+    //   Used by toolbar dropdowns, which sit above the main row and only need
+    //   to dodge body-portaled overlays — the Assistant is a flex sibling
+    //   below the toolbar, not an overlay (issue #6800).
+    // --right-obstruction-offset: max of Portal and Assistant width — the
+    //   total occupied right-edge viewport space. Used by fixed body-portaled
+    //   elements (toaster, popovers, ReEntrySummary, GettingStartedChecklist,
+    //   ThemeBrowser overlay) that would otherwise be hidden behind whichever
+    //   is wider. Portal overlays the Assistant when both are open, so the
+    //   rightmost obstruction is max, not sum (issue #6629).
+    const obstructionOffset = Math.max(portalOffset, effectiveAssistantWidth);
+    document.body.style.setProperty("--portal-right-offset", `${portalOffset}px`);
+    document.body.style.setProperty("--right-obstruction-offset", `${obstructionOffset}px`);
 
     return () => {
       document.body.style.removeProperty("--portal-right-offset");
+      document.body.style.removeProperty("--right-obstruction-offset");
     };
   }, [layout.portalOpen, layout.portalWidth, effectiveAssistantWidth]);
 
@@ -476,7 +486,7 @@ export function AppLayout({
               <div
                 className="fixed inset-y-0 z-40 pointer-events-auto"
                 style={{
-                  right: "var(--portal-right-offset, 0px)",
+                  right: "var(--right-obstruction-offset, 0px)",
                 }}
               >
                 <ThemeBrowser />

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -83,15 +83,36 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     expect(source).toContain("[showAssistant]");
   });
 
-  it("uses max of portal and assistant widths for --portal-right-offset (issue #6629)", () => {
+  it("publishes --portal-right-offset as portal-only (issue #6800)", () => {
+    // The Assistant is a flex sibling below the toolbar — it doesn't overlay
+    // the toolbar. Toolbar dropdowns must dodge the Portal (body-portaled web
+    // chat) but not the Assistant. The previous shared-max value pushed
+    // dropdowns left by Assistant width even when the Portal was closed.
+    expect(source).toMatch(
+      /document\.body\.style\.setProperty\("--portal-right-offset", `\$\{portalOffset\}px`\)/
+    );
+    // The portal-only var must not be re-conflated with Assistant width.
+    expect(source).not.toMatch(/setProperty\("--portal-right-offset",[^)]*Math\.max\(portalOffset/);
+  });
+
+  it("publishes --right-obstruction-offset as max(portal, assistant) (issue #6629)", () => {
     // Portal overlays Assistant when both are open, so the rightmost fixed
-    // obstruction is max(portal, assistant), not their sum. The previous sum
-    // logic over-displaced toasts/popovers when both panels were open.
+    // obstruction is max(portal, assistant), not their sum. Toaster, popovers,
+    // ReEntrySummary, GettingStartedChecklist, and the ThemeBrowser overlay
+    // all read this var — they're body-portaled fixed elements that would
+    // otherwise be hidden behind the wider of the two panels.
     expect(source).toContain("Math.max(portalOffset, effectiveAssistantWidth)");
-    expect(source).toContain("--portal-right-offset");
+    expect(source).toMatch(
+      /document\.body\.style\.setProperty\("--right-obstruction-offset", `\$\{obstructionOffset\}px`\)/
+    );
     expect(source).toMatch(/\[layout\.portalOpen, layout\.portalWidth, effectiveAssistantWidth\]/);
     // The old sum semantics must not be reintroduced.
     expect(source).not.toMatch(/portalOffset \+ effectiveAssistantWidth/);
+  });
+
+  it("removes both right-edge vars on cleanup", () => {
+    expect(source).toContain('document.body.style.removeProperty("--portal-right-offset")');
+    expect(source).toContain('document.body.style.removeProperty("--right-obstruction-offset")');
   });
 });
 

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -67,13 +67,16 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     expect(source).not.toMatch(/isThemeBrowserOpen && "bg-scrim-soft\/30 backdrop-blur-\[2px\]"/);
   });
 
-  it("anchors ThemeBrowser right edge via shared --portal-right-offset (issue #6629)", () => {
+  it("anchors ThemeBrowser right edge via shared --right-obstruction-offset (issue #6629, #6800)", () => {
     // Both the Portal and the Assistant occupy the right edge of the viewport.
     // ThemeBrowser must step left of whichever is wider — and previously, when
     // only the Assistant was open, ThemeBrowser used `right: "0px"` and
     // overlapped the panel. Routing through the shared CSS var fixes both
-    // cases with a single source of truth.
-    expect(source).toContain('right: "var(--portal-right-offset, 0px)"');
+    // cases with a single source of truth. The var was renamed from
+    // --portal-right-offset to --right-obstruction-offset in #6800 so that
+    // toolbar dropdowns can keep using --portal-right-offset (portal-only)
+    // without dodging the Assistant.
+    expect(source).toContain('right: "var(--right-obstruction-offset, 0px)"');
     // The old hand-computed ternary must not be reintroduced.
     expect(source).not.toMatch(/right: layout\.portalOpen \? `\$\{layout\.portalWidth\}px` :/);
   });

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -67,7 +67,7 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     expect(source).not.toMatch(/isThemeBrowserOpen && "bg-scrim-soft\/30 backdrop-blur-\[2px\]"/);
   });
 
-  it("anchors ThemeBrowser right edge via shared --right-obstruction-offset (issue #6629, #6800)", () => {
+  it("anchors ThemeBrowser right edge via shared --right-obstruction-offset (issues #6629, #6800)", () => {
     // Both the Portal and the Assistant occupy the right edge of the viewport.
     // ThemeBrowser must step left of whichever is wider — and previously, when
     // only the Assistant was open, ThemeBrowser used `right: "0px"` and
@@ -80,4 +80,34 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
     // The old hand-computed ternary must not be reintroduced.
     expect(source).not.toMatch(/right: layout\.portalOpen \? `\$\{layout\.portalWidth\}px` :/);
   });
+});
+
+describe("Right-obstruction CSS var consumers (issue #6800)", () => {
+  // Source-scan guard: every fixed body-portaled consumer that should dodge
+  // both Portal and Assistant must read --right-obstruction-offset, NOT
+  // --portal-right-offset. The latter is portal-only and reserved for
+  // toolbar dropdowns (FixedDropdown).
+  const consumers = [
+    {
+      name: "popover collision boundary",
+      file: path.resolve(__dirname, "../../ui/popover.tsx"),
+    },
+    { name: "toaster", file: path.resolve(__dirname, "../../ui/toaster.tsx") },
+    {
+      name: "ReEntrySummary",
+      file: path.resolve(__dirname, "../../ui/ReEntrySummary.tsx"),
+    },
+    {
+      name: "GettingStartedChecklist",
+      file: path.resolve(__dirname, "../../Onboarding/GettingStartedChecklist.tsx"),
+    },
+  ];
+
+  for (const { name, file } of consumers) {
+    it(`${name} reads --right-obstruction-offset, not --portal-right-offset`, async () => {
+      const source = await fs.readFile(file, "utf-8");
+      expect(source).toContain("--right-obstruction-offset");
+      expect(source).not.toContain("--portal-right-offset");
+    });
+  }
 });

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -37,7 +37,7 @@ export function GettingStartedChecklist({
         "fixed bottom-4 z-[var(--z-toast)] pointer-events-none p-4",
         "flex justify-end w-full max-w-[320px]"
       )}
-      style={{ right: "calc(var(--portal-right-offset, 0px))" }}
+      style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
       <div
         className={cn(

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -87,7 +87,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
   return createPortal(
     <div
       className="fixed top-3 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
-      style={{ right: "calc(var(--portal-right-offset, 0px))" }}
+      style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
       <div
         className={cn(

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -567,6 +567,8 @@ describe("FixedDropdown right-edge anchor (issue #6800)", () => {
 
   afterEach(() => {
     _resetForTests();
+    document.body.style.removeProperty("--portal-right-offset");
+    document.body.style.removeProperty("--right-obstruction-offset");
   });
 
   it("anchors right edge to --portal-right-offset, not --right-obstruction-offset", () => {
@@ -586,5 +588,50 @@ describe("FixedDropdown right-edge anchor (issue #6800)", () => {
     const rightStyle = portal?.style.right ?? "";
     expect(rightStyle).toContain("var(--portal-right-offset");
     expect(rightStyle).not.toContain("--right-obstruction-offset");
+  });
+
+  it("ignores --right-obstruction-offset when only the Assistant is open", () => {
+    // The actual #6800 scenario: Portal closed (--portal-right-offset = 0),
+    // Assistant open (--right-obstruction-offset = 320). The toolbar dropdown
+    // must NOT pick up the 320px shift, because only the Portal body-portals
+    // over the toolbar.
+    document.body.style.setProperty("--portal-right-offset", "0px");
+    document.body.style.setProperty("--right-obstruction-offset", "320px");
+
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    const portal = document.querySelector('[data-testid="dropdown-body"]')?.parentElement;
+    const rightStyle = portal?.style.right ?? "";
+    expect(rightStyle).toContain("var(--portal-right-offset");
+    expect(rightStyle).not.toContain("--right-obstruction-offset");
+    expect(rightStyle).not.toContain("320");
+  });
+});
+
+describe("FixedDropdown source-level guards (issue #6800)", () => {
+  // Cheap permanent regression scan: the toolbar-dropdown component must
+  // never reach for the obstruction var, even via a nested helper, since
+  // that would silently revert the #6800 fix.
+  let source: string;
+
+  beforeEach(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    source = await fs.readFile(path.resolve(__dirname, "../fixed-dropdown.tsx"), "utf-8");
+  });
+
+  it("references --portal-right-offset", () => {
+    expect(source).toContain("--portal-right-offset");
+  });
+
+  it("does not reference --right-obstruction-offset", () => {
+    // If a future refactor wires the obstruction var into FixedDropdown,
+    // toolbar dropdowns will start dodging the Assistant again — exactly
+    // the #6800 regression.
+    expect(source).not.toContain("--right-obstruction-offset");
   });
 });

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -552,3 +552,39 @@ describe("FixedDropdown keepMounted behavior", () => {
     expect(document.querySelector('[data-testid="body"]')).toBeNull();
   });
 });
+
+describe("FixedDropdown right-edge anchor (issue #6800)", () => {
+  let onOpenChange: ReturnType<typeof vi.fn<(open: boolean) => void>>;
+  let anchorRef: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    _resetForTests();
+    setOverlayClaimsSize(0);
+    onOpenChange = vi.fn();
+    anchorRef = createAnchor();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("anchors right edge to --portal-right-offset, not --right-obstruction-offset", () => {
+    // Toolbar dropdowns sit above the main flex row. The Assistant is a flex
+    // sibling of <main>, not an overlay — it doesn't cover the toolbar. Only
+    // the body-portaled Portal (web chat) needs to push toolbar dropdowns
+    // left. Using --right-obstruction-offset would shift dropdowns left by
+    // Assistant width too, which is the bug from #6800.
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
+        <div data-testid="dropdown-body">Content</div>
+      </FixedDropdown>
+    );
+
+    const portal = document.querySelector('[data-testid="dropdown-body"]')?.parentElement;
+    expect(portal).not.toBeNull();
+    const rightStyle = portal?.style.right ?? "";
+    expect(rightStyle).toContain("var(--portal-right-offset");
+    expect(rightStyle).not.toContain("--right-obstruction-offset");
+  });
+});

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -15,7 +15,7 @@ function getPortalBoundary() {
     position: "fixed",
     top: "0",
     left: "0",
-    width: "calc(100vw - var(--portal-right-offset, 0px))",
+    width: "calc(100vw - var(--right-obstruction-offset, 0px))",
     height: "100vh",
     pointerEvents: "none",
     visibility: "hidden",

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -497,7 +497,7 @@ export function Toaster() {
   return createPortal(
     <div
       className="fixed top-14 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
-      style={{ right: "calc(var(--portal-right-offset, 0px))" }}
+      style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
       {[...toastNotifications].reverse().map((notification) => (
         <Toast key={notification.id} notification={notification} />


### PR DESCRIPTION
## Summary

- `--portal-right-offset` was set to the `max` of portal width and Assistant width, which caused toolbar dropdowns to shift left whenever the Assistant was open — even though the Assistant is a flex sibling below the toolbar, not an overlay
- Split into two variables: `--portal-right-offset` (portal width only) and `--right-obstruction-offset` (max of portal + Assistant), so each consumer gets the right thing
- `FixedDropdown` now reads `--portal-right-offset`; toaster, popover collision boundary, `ReEntrySummary`, and `GettingStartedChecklist` route through `--right-obstruction-offset`

Resolves #6800

## Changes

- `AppLayout.tsx`: introduce `--right-obstruction-offset`, keep `--portal-right-offset` as portal-only
- `FixedDropdown`, `popover.tsx`, `toaster.tsx`, `ReEntrySummary`, `GettingStartedChecklist`: point each consumer at the correct variable
- Regression-guard tests: mount-time test covering the #6800 scenario (portal=0, obstruction=320) and source-scan negative tests to catch future re-conflation

## Testing

- New unit tests in `FixedDropdown.test.tsx`, `AppLayout.sidebar.test.ts`, and `AppLayout.themeBrowser.test.ts` cover the split and guard against reverting
- Manually verified dropdown positioning with Assistant open and closed