### PR TITLE
fix(terminal): keep WebGL while visible on tier transitions

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -231,7 +231,8 @@ class TerminalInstanceService {
         if (managed.runtimeAgentId) {
           if (isWebGLEligibleTier(tier)) {
             this.webGLManager.ensureContext(id, managed);
-          } else {
+          } else if (!managed.isVisible) {
+            // Keep WebGL while visible — releasing here causes a one-frame renderer gap.
             const hadWebGL = this.webGLManager.isActive(id);
             this.webGLManager.releaseContext(id);
             if (hadWebGL && managed.terminal.rows > 0) {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -208,16 +208,17 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   let managed: ManagedTerminal;
 
   function makeManagedTerminal(agentId?: string | null): ManagedTerminal {
-    // After the #5777 kind collapse, agent identity lives on `agentId`, not
-    // `kind`. WebGL reservation gates on `managed.agentId`. Tests that want
-    // a plain (non-agent) terminal pass `null` (or omit — but `null` is more
-    // explicit and avoids the default-param trap when callers pass `undefined`).
+    // Agent identity lives on `runtimeAgentId`. WebGL reservation gates on it.
+    // Tests that want a plain (non-agent) terminal pass `null` (or omit — but
+    // `null` is more explicit and avoids the default-param trap when callers
+    // pass `undefined`).
     return {
       terminal: { loadAddon: vi.fn(), refresh: vi.fn(), rows: 24 },
       isOpened: true,
+      isVisible: true,
       lastActiveTime: Date.now(),
       kind: "terminal",
-      agentId: agentId === null ? undefined : (agentId ?? "claude"),
+      runtimeAgentId: agentId === null ? undefined : (agentId ?? "claude"),
     } as unknown as ManagedTerminal;
   }
 
@@ -231,7 +232,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   });
 
   function simulateOnTierApplied(id: string, tier: TerminalRefreshTier, m: ManagedTerminal) {
-    if (!(m as unknown as { agentId?: string }).agentId) return;
+    if (!m.runtimeAgentId) return;
 
     if (
       tier === TerminalRefreshTier.FOCUSED ||
@@ -239,7 +240,7 @@ describe("onTierApplied handler — WebGL manager integration", () => {
       tier === TerminalRefreshTier.VISIBLE
     ) {
       webGLManager.ensureContext(id, m);
-    } else {
+    } else if (!m.isVisible) {
       const hadWebGL = webGLManager.isActive(id);
       webGLManager.releaseContext(id);
       if (hadWebGL && m.terminal.rows > 0) {
@@ -274,11 +275,24 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     expect(webGLManager.isActive("t2")).toBe(true);
   });
 
-  it("BACKGROUND releases context for that terminal only", () => {
+  it("BACKGROUND retains context while terminal is visible", () => {
     const managed2 = makeManagedTerminal();
     simulateOnTierApplied("t1", TerminalRefreshTier.FOCUSED, managed);
     simulateOnTierApplied("t2", TerminalRefreshTier.VISIBLE, managed2);
 
+    // Visible agent terminal: tier alone must not release WebGL — that would
+    // cause a one-frame flicker on click while the terminal stays on screen.
+    simulateOnTierApplied("t1", TerminalRefreshTier.BACKGROUND, managed);
+    expect(webGLManager.isActive("t1")).toBe(true);
+    expect(webGLManager.isActive("t2")).toBe(true);
+  });
+
+  it("BACKGROUND releases context when terminal is hidden", () => {
+    const managed2 = makeManagedTerminal();
+    simulateOnTierApplied("t1", TerminalRefreshTier.FOCUSED, managed);
+    simulateOnTierApplied("t2", TerminalRefreshTier.VISIBLE, managed2);
+
+    managed.isVisible = false;
     simulateOnTierApplied("t1", TerminalRefreshTier.BACKGROUND, managed);
     expect(webGLManager.isActive("t1")).toBe(false);
     expect(webGLManager.isActive("t2")).toBe(true);
@@ -357,13 +371,15 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     simulateOnTierApplied("t1", TerminalRefreshTier.FOCUSED, managed);
     expect(webGLManager.isActive("t1")).toBe(true);
 
+    managed.isVisible = false;
     simulateOnTierApplied("t1", TerminalRefreshTier.BACKGROUND, managed);
     expect(webGLManager.isActive("t1")).toBe(false);
     expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
   });
 
   it("agent terminal refresh is NOT called when no WebGL was active", () => {
-    // Never acquired WebGL, go to BACKGROUND
+    // Never acquired WebGL, go to BACKGROUND while hidden
+    managed.isVisible = false;
     simulateOnTierApplied("t1", TerminalRefreshTier.BACKGROUND, managed);
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

- Agent terminals were flickering on click because `onTierApplied` released the WebGL context whenever the resolved refresh tier dropped to `BACKGROUND` — even if the terminal was still on screen. The one-frame gap between `WebglAddon.dispose()` removing the canvas and the DOM renderer painting via rAF is the visible flash.
- Added a one-line visibility guard in `onTierApplied`: `else if (!managed.isVisible)`. Context is now only released on tier transitions when the terminal is not visible. All existing release paths (`setVisible(false)`, `clearAgentPromotion`, hibernation, LRU pool eviction) remain unchanged and continue to fire as before.
- Backend tier tracking (`setBackendTier`) is unaffected — it still follows the resolved refresh tier exactly as it did before.

Resolves #6801

## Changes

- `src/services/terminal/TerminalInstanceService.ts` — added `!managed.isVisible` guard in `onTierApplied` with a short inline comment
- `src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts` — corrected `runtimeAgentId` field, added `isVisible: true` default, mirrored the guard in `simulateOnTierApplied`, split the BACKGROUND test into visible-retain and hidden-release cases, set `isVisible: false` on the refresh-call tests

## Testing

- 20 webglLease tests + 13 webglVisibility tests pass green
- Typecheck (renderer + electron + preload), channel drift check, lint, and format all pass