### PR TITLE
fix(terminal): remove redundant refresh calls that flash empty frames

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -483,13 +483,6 @@ class TerminalInstanceService {
           forceXtermReflow(termEl);
         }
 
-        requestAnimationFrame(() => {
-          const current = this.instances.get(id);
-          if (current && current.isVisible) {
-            current.terminal.refresh(0, current.terminal.rows - 1);
-          }
-        });
-
         // Debounced WebGL restore for same-tier transitions. If
         // applyRendererPolicy above triggers a tier upgrade (e.g.
         // BACKGROUND→VISIBLE), onTierApplied loads the addon immediately
@@ -503,19 +496,12 @@ class TerminalInstanceService {
           current.webGLRestoreTimer = undefined;
           if (!this.shouldRestoreWebGL(current)) return;
           this.webGLManager.ensureContext(id, current);
-          if (current.terminal.rows > 0) {
-            current.terminal.refresh(0, current.terminal.rows - 1);
-          }
         }, WEBGL_RESTORE_DEBOUNCE_MS);
       } else {
         // Going offscreen. Release the WebGL context immediately to free a
         // pool slot — xterm falls back to the DOM renderer until the
         // terminal becomes visible again.
-        const hadWebGL = this.webGLManager.isActive(id);
         this.webGLManager.releaseContext(id);
-        if (hadWebGL && managed.terminal.rows > 0) {
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
-        }
 
         // If we're already in a hibernation-eligible tier, onTierApplied
         // won't fire to start the timer — do it here instead.

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -234,7 +234,9 @@ class TerminalInstanceService {
           } else {
             const hadWebGL = this.webGLManager.isActive(id);
             this.webGLManager.releaseContext(id);
-            if (hadWebGL && managed.terminal.rows > 0) {
+            // Only refresh for a visible terminal — repainting an offscreen
+            // DOM produces a stale frame that flashes on next show (#6802).
+            if (hadWebGL && managed.isVisible && managed.terminal.rows > 0) {
               managed.terminal.refresh(0, managed.terminal.rows - 1);
             }
           }

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -162,7 +162,10 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 
-  it("setVisible(false) calls terminal.refresh after WebGL release for DOM fallback", () => {
+  it("setVisible(false) does not call terminal.refresh after WebGL release", () => {
+    // Calling refresh on the hide path forces the DOM renderer to paint a
+    // freshly-empty frame for an offscreen terminal — the visible flash on
+    // next show. Removed in #6802.
     const managed = makeMockManaged();
     service.instances.set("t1", managed as unknown as Record<string, unknown>);
     service.webGLManager.ensureContext("t1", managed);
@@ -170,7 +173,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     service.setVisible("t1", false);
 
-    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
   it("setVisible(false) does not refresh when no WebGL was active", () => {
@@ -198,7 +201,11 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 
-  it("setVisible(true) calls terminal.refresh after re-acquiring WebGL", () => {
+  it("setVisible(true) does not call terminal.refresh on the show path", () => {
+    // The pre-debounce rAF + the post-ensureContext refresh both painted
+    // stale DOM rows during the WebGL transition, producing the flash.
+    // WebglAddon.onLoad self-schedules its first frame; forceXtermReflow
+    // covers IntersectionObserver recovery. Removed in #6802.
     const managed = makeMockManaged({ isVisible: false });
     service.instances.set("t1", managed as unknown as Record<string, unknown>);
     (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
@@ -206,7 +213,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.setVisible("t1", true);
     vi.advanceTimersByTime(100);
 
-    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
   it("rapid hide→show→hide before debounce expires keeps context released", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -51,6 +51,7 @@ type WebGLVisibilityService = {
   instances: Map<string, Record<string, unknown>>;
   setVisible: (id: string, visible: boolean, expectedGeneration?: number) => void;
   destroy: (id: string) => void;
+  applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
   webGLManager: {
     isActive: (id: string) => boolean;
     ensureContext: (id: string, managed: unknown) => void;
@@ -65,6 +66,9 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     refresh: vi.fn(),
     loadAddon: vi.fn(),
     dispose: vi.fn(),
+    hasSelection: vi.fn(() => false),
+    options: { scrollback: 1000 },
+    buffer: { active: { length: 24 } },
     element: document.createElement("div"),
   };
 
@@ -312,6 +316,46 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     // Matching generation — release proceeds
     service.setVisible("t1", false, 5);
     expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("tier demotion while hidden does not refresh (project-switch flash)", () => {
+    // Project switches simultaneously hide terminals and demote their tier.
+    // Refreshing an offscreen DOM produces a stale frame that flashes on
+    // next show — the same root cause as the setVisible() refresh removals.
+    const managed = makeMockManaged({
+      isVisible: false,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+    // Downgrades go through a hysteresis timer (TIER_DOWNGRADE_HYSTERESIS_MS).
+    vi.advanceTimersByTime(500);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("tier demotion while visible still refreshes (DOM fallback paint)", () => {
+    // A visible terminal whose tier demotes (e.g., resource pressure)
+    // needs the DOM repaint so it doesn't go blank on screen.
+    const managed = makeMockManaged({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    (managed.terminal.refresh as ReturnType<typeof vi.fn>).mockClear();
+
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+    vi.advanceTimersByTime(500);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
   });
 
   it("agent demotion during debounce window cancels WebGL restore", () => {


### PR DESCRIPTION
## Summary

- Agent terminals flashed empty for a frame on tab switch, project switch, and panel show/hide. The flash was caused by redundant `terminal.refresh()` calls during WebGL hide/show transitions, which triggered offscreen DOM repaints before the WebGL canvas had a chance to paint.
- Removed three `refresh()` call sites in `setVisible()` (hide-after-dispose, show-pre-debounce rAF, show-post-`ensureContext`) and the dead `hadWebGL` variable. Once `WebglAddon` is mounted, xterm's render service paints the next frame correctly without a manual nudge.
- Added a visibility guard to the `onTierApplied` tier-demote path so it doesn't trigger a refresh when the terminal is offscreen (covers the project-switch flash).

Resolves #6802

## Changes

- `src/services/terminal/TerminalInstanceService.ts` — remove three `refresh()` call sites and dead `hadWebGL` variable; add `isVisible` guard to `onTierApplied`
- `src/services/terminal/TerminalInstanceService.webglVisibility.test.ts` — invert two assertions that previously expected the now-removed refresh calls; add two regression tests covering the visibility-guarded tier-demote path

## Testing

15/15 passing in `TerminalInstanceService.webglVisibility.test.ts`. Manually verified tab switching, project switching, and panel show/hide no longer produce a visible empty frame on agent terminals.