### PR TITLE
fix(help-panel): require close confirmation when assistant has conversation history

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -172,6 +172,8 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
     agentId,
     preferredAgentId,
     introDismissed,
+    conversationTouched,
+    markConversationStarted,
     setWidth,
     setOpen,
     clearTerminal,
@@ -285,6 +287,17 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
       document.removeEventListener("visibilitychange", handler);
     };
   }, [revokePendingSession]);
+
+  // Latch conversationTouched when the terminal's agent state first leaves idle,
+  // so the close-confirm guard protects accumulated chat history indefinitely.
+  useEffect(() => {
+    if (terminalId && terminal?.agentState !== undefined && terminal.agentState !== "idle") {
+      const store = useHelpPanelStore.getState();
+      if (store.terminalId === terminalId) {
+        markConversationStarted();
+      }
+    }
+  }, [terminalId, terminal?.agentState, markConversationStarted]);
 
   // Auto-launch preferred agent when panel opens without an active terminal.
   // Always starts a new conversation (never resumes).
@@ -562,14 +575,16 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
     setOpen(false);
   }, [terminalId, removePanel, clearTerminal, setOpen, revokePendingSession]);
 
-  // Confirm before discarding an in-flight assistant turn. Mirrors the
-  // CLOSE_CONFIRM_AGENT_STATES gate used by GridPanel/DockedPanel/*TabGroup
-  // and honours the same skipWorkingCloseConfirm preference, so the
-  // assistant chat behaves consistently with regular terminal close paths.
+  // Confirm before discarding an in-flight assistant turn or accumulated
+  // conversation. Mirrors the CLOSE_CONFIRM_AGENT_STATES gate used by
+  // GridPanel/DockedPanel/*TabGroup but additionally protects non-empty
+  // chat history even after the agent goes idle — the conversation itself
+  // is the artifact (issue #6809). The skipWorkingCloseConfirm preference
+  // bypasses all confirmation.
   const shouldConfirmClose =
     !skipWorkingCloseConfirm &&
-    terminal?.agentState !== undefined &&
-    CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState);
+    ((terminal?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState)) ||
+      conversationTouched);
 
   const handleClose = useCallback(() => {
     if (shouldConfirmClose) {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -58,6 +58,8 @@ const {
     preferredAgentId: null as string | null,
     sessionId: null as string | null,
     introDismissed: true,
+    conversationTouched: false,
+    markConversationStarted: vi.fn(),
     setWidth: vi.fn(),
     setOpen: vi.fn(),
     clearTerminal: vi.fn(),
@@ -255,6 +257,8 @@ function resetState() {
   helpPanelState.preferredAgentId = null;
   helpPanelState.sessionId = null;
   helpPanelState.introDismissed = true;
+  helpPanelState.conversationTouched = false;
+  helpPanelState.markConversationStarted = vi.fn();
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
   helpPanelState.setWidth = vi.fn();
@@ -1213,9 +1217,10 @@ describe("HelpPanel — customArgs threading", () => {
 });
 
 describe("HelpPanel — close confirmation guard (issue #6623)", () => {
-  it("closes immediately when the assistant is idle (no dialog)", () => {
+  it("closes immediately when the assistant is idle with no conversation (no dialog)", () => {
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
+    helpPanelState.conversationTouched = false;
     panelStoreState.panelsById = {
       "term-1": {
         id: "term-1",
@@ -1307,10 +1312,11 @@ describe("HelpPanel — close confirmation guard (issue #6623)", () => {
   });
 
   it.each(["waiting", "directing", "completed", "exited"] as const)(
-    "closes immediately for %s agent state (only 'working' triggers confirm)",
+    "closes immediately for %s agent state when conversation is untouched",
     (state) => {
       helpPanelState.terminalId = "term-1";
       helpPanelState.agentId = "claude";
+      helpPanelState.conversationTouched = false;
       panelStoreState.panelsById = {
         "term-1": {
           id: "term-1",
@@ -1383,6 +1389,131 @@ describe("HelpPanel — close confirmation guard (issue #6623)", () => {
     expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
     expect(panelStoreState.removePanel).not.toHaveBeenCalled();
     expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+  });
+
+  it("shows confirm dialog for idle agent when conversation has been touched", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.conversationTouched = true;
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "idle",
+      },
+    };
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.setOpen).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop and close");
+  });
+
+  it.each(["waiting", "directing", "completed"] as const)(
+    "shows confirm dialog for %s agent when conversation has been touched",
+    (state) => {
+      helpPanelState.terminalId = "term-1";
+      helpPanelState.agentId = "claude";
+      helpPanelState.conversationTouched = true;
+      panelStoreState.panelsById = {
+        "term-1": {
+          id: "term-1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: state,
+        },
+      };
+
+      const { container, getByTestId } = render(<HelpPanel width={380} />);
+      fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+      expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+      expect(getByTestId("dialog-title").textContent).toBe("Stop this agent?");
+    }
+  );
+
+  it("closes immediately when skipWorkingCloseConfirm is true even with touched conversation", () => {
+    preferencesState.skipWorkingCloseConfirm = true;
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.conversationTouched = true;
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "idle",
+      },
+    };
+
+    const { container, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Close help panel"]')!);
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("marks conversation started when agent state leaves idle on mount", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    render(<HelpPanel width={380} />);
+
+    expect(helpPanelState.markConversationStarted).toHaveBeenCalled();
+  });
+
+  it("does not mark conversation started when agent state is idle on mount", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "idle",
+      },
+    };
+
+    render(<HelpPanel width={380} />);
+
+    expect(helpPanelState.markConversationStarted).not.toHaveBeenCalled();
+  });
+
+  it("does not mark conversation started after clearTerminal (stale guard)", () => {
+    // Simulate: terminal was set but clearTerminal was called before render.
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "working",
+      },
+    };
+
+    render(<HelpPanel width={380} />);
+
+    expect(helpPanelState.markConversationStarted).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -271,4 +271,90 @@ describe("helpPanelStore persistence migration", () => {
 
     expect(store.getState().isOpen).toBe(false);
   });
+
+  it("starts with conversationTouched: false on a fresh install", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().conversationTouched).toBe(false);
+  });
+
+  it("markConversationStarted sets conversationTouched to true", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().markConversationStarted();
+
+    expect(store.getState().conversationTouched).toBe(true);
+  });
+
+  it("markConversationStarted is idempotent (calling twice still yields true)", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().markConversationStarted();
+    store.getState().markConversationStarted();
+
+    expect(store.getState().conversationTouched).toBe(true);
+  });
+
+  it("setTerminal resets conversationTouched to false", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().markConversationStarted();
+    expect(store.getState().conversationTouched).toBe(true);
+
+    store.getState().setTerminal("term-1", "claude", null);
+    expect(store.getState().conversationTouched).toBe(false);
+  });
+
+  it("clearTerminal resets conversationTouched to false", async () => {
+    installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().markConversationStarted();
+    expect(store.getState().conversationTouched).toBe(true);
+
+    store.getState().clearTerminal();
+    expect(store.getState().conversationTouched).toBe(false);
+  });
+
+  it("conversationTouched is NOT persisted", async () => {
+    const backing = installLocalStorage({});
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+    store.getState().markConversationStarted();
+
+    const written = backing.get(STORAGE_KEY);
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!) as {
+      version: number;
+      state: Record<string, unknown>;
+    };
+    // conversationTouched is excluded from the persisted blob
+    expect(parsed.state).not.toHaveProperty("conversationTouched");
+    // The field is still true in the store
+    expect(store.getState().conversationTouched).toBe(true);
+  });
+
+  it("conversationTouched defaults to false after rehydration regardless of persisted blob", async () => {
+    // Simulate a (hypothetical) blob that somehow got conversationTouched injected
+    const blob = JSON.stringify({
+      version: 2,
+      state: {
+        isOpen: false,
+        width: 400,
+        preferredAgentId: null,
+        introDismissed: false,
+        conversationTouched: true,
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: blob });
+
+    const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+    expect(store.getState().conversationTouched).toBe(false);
+  });
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -20,6 +20,7 @@ interface HelpPanelState {
   preferredAgentId: string | null;
   sessionId: string | null;
   introDismissed: boolean;
+  conversationTouched: boolean;
 }
 
 interface HelpPanelActions {
@@ -30,6 +31,7 @@ interface HelpPanelActions {
   clearTerminal: () => void;
   setPreferredAgent: (agentId: string | null) => void;
   dismissIntro: () => void;
+  markConversationStarted: () => void;
 }
 
 const initialState: HelpPanelState = {
@@ -40,6 +42,7 @@ const initialState: HelpPanelState = {
   preferredAgentId: null,
   sessionId: null,
   introDismissed: false,
+  conversationTouched: false,
 };
 
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
@@ -57,13 +60,22 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
         }),
 
       setTerminal: (terminalId, agentId, sessionId) =>
-        set({ terminalId, agentId, sessionId, preferredAgentId: agentId }),
+        set({
+          terminalId,
+          agentId,
+          sessionId,
+          preferredAgentId: agentId,
+          conversationTouched: false,
+        }),
 
-      clearTerminal: () => set({ terminalId: null, agentId: null, sessionId: null }),
+      clearTerminal: () =>
+        set({ terminalId: null, agentId: null, sessionId: null, conversationTouched: false }),
 
       setPreferredAgent: (agentId) => set({ preferredAgentId: agentId }),
 
       dismissIntro: () => set({ introDismissed: true }),
+
+      markConversationStarted: () => set({ conversationTouched: true }),
     }),
     {
       name: "help-panel-storage",


### PR DESCRIPTION
## Summary
- The assistant help panel was closing without confirmation once a chat session went idle, making it easy to lose accumulated conversation history by accident.
- Adds a `conversationTouched` flag to `helpPanelStore` that latches when the agent first leaves idle state, so the close-confirmation guard protects non-empty chat history even after the agent finishes responding.
- The `skipWorkingCloseConfirm` preference still bypasses the prompt, and `setTerminal` / `clearTerminal` reset the flag.

Resolves #6809

## Changes
- `helpPanelStore`: new `conversationTouched` boolean and `markConversationStarted` action, reset by `setTerminal` and `clearTerminal`; not persisted.
- `HelpPanel`: close-confirmation condition extended from agent-state-only to also check `conversationTouched`; `useEffect` hook latches the flag when `agentState` first leaves idle.
- Tests: store tests for the flag's lifecycle (default, latch, reset, non-persistence) and component tests for each close-confirmation scenario (touched + idle, touched + non-working, skipWorkingCloseConfirm override, stale guard).

## Testing
- 89 tests pass (24 store + 65 component).
- Typecheck, lint, and format all clean.