### PR TITLE
fix(terminal): route fd-leak-warning through PtyEventRouter to renderer

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -61,6 +61,7 @@ export const CHANNELS = {
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
   TERMINAL_RESTORE_SCROLLBACK: "terminal:restore-scrollback",
   TERMINAL_RESTART_SERVICE: "terminal:restart-service",
+  TERMINAL_FD_LEAK_WARNING: "terminal:fd-leak-warning",
   TERMINAL_RESOURCE_METRICS: "terminal:resource-metrics",
 
   AGENT_SESSION_LIST: "agent-session:list",

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -106,16 +106,10 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   ptyClient.on("resource-metrics", handleResourceMetrics);
   handlers.push(() => ptyClient.off("resource-metrics", handleResourceMetrics));
 
-  // FD leak warning — rising-edge gating to suppress the 2s repeat cadence.
-  // Only forwards on state transitions (no-warning → warning). When the leak
-  // clears the ResourceGovernor stops emitting, so a fresh warning after a
-  // clear period re-arms naturally.
-  let lastFdLeakWarning: FdLeakWarningPayload | null = null;
+  // FD leak warning — forwarded to renderer for user-visible notification.
+  // Deduplication is handled renderer-side with a 5-min cooldown.
   const handleFdLeakWarning = (payload: FdLeakWarningPayload) => {
-    if (lastFdLeakWarning === null) {
-      lastFdLeakWarning = payload;
-      broadcastToRenderer(CHANNELS.TERMINAL_FD_LEAK_WARNING, payload);
-    }
+    broadcastToRenderer(CHANNELS.TERMINAL_FD_LEAK_WARNING, payload);
   };
   ptyClient.on("fd-leak-warning", handleFdLeakWarning);
   handlers.push(() => ptyClient.off("fd-leak-warning", handleFdLeakWarning));

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -9,6 +9,7 @@ import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js"
 import type {
   SpawnResult,
   BroadcastWriteResultPayload,
+  FdLeakWarningPayload,
 } from "../../../../shared/types/pty-host.js";
 import type { HandlerDependencies } from "../../types.js";
 
@@ -104,6 +105,20 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   };
   ptyClient.on("resource-metrics", handleResourceMetrics);
   handlers.push(() => ptyClient.off("resource-metrics", handleResourceMetrics));
+
+  // FD leak warning — rising-edge gating to suppress the 2s repeat cadence.
+  // Only forwards on state transitions (no-warning → warning). When the leak
+  // clears the ResourceGovernor stops emitting, so a fresh warning after a
+  // clear period re-arms naturally.
+  let lastFdLeakWarning: FdLeakWarningPayload | null = null;
+  const handleFdLeakWarning = (payload: FdLeakWarningPayload) => {
+    if (lastFdLeakWarning === null) {
+      lastFdLeakWarning = payload;
+      broadcastToRenderer(CHANNELS.TERMINAL_FD_LEAK_WARNING, payload);
+    }
+  };
+  ptyClient.on("fd-leak-warning", handleFdLeakWarning);
+  handlers.push(() => ptyClient.off("fd-leak-warning", handleFdLeakWarning));
 
   // Terminal activity
   const unsubTerminalActivity = events.on(

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -89,6 +89,7 @@ import type {
   SpawnResult,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
+  FdLeakWarningPayload,
 } from "../shared/types/pty-host.js";
 
 type SpawnResultPayload = SpawnResult;
@@ -818,6 +819,9 @@ const api: ElectronAPI = {
     onResourceMetrics: (
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void
     ) => _typedOn(CHANNELS.TERMINAL_RESOURCE_METRICS, callback),
+
+    onFdLeakWarning: (callback: (data: FdLeakWarningPayload) => void) =>
+      _typedOn(CHANNELS.TERMINAL_FD_LEAK_WARNING, callback),
 
     onBackendCrashed: (
       callback: (data: {

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -22,6 +22,7 @@
 import type { EventEmitter } from "events";
 import type {
   BroadcastWriteResultPayload,
+  FdLeakWarningPayload,
   PtyHostEvent,
   PtyHostSpawnOptions,
   SpawnResult,
@@ -236,6 +237,19 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
     case "resource-metrics": {
       const rmEvent: { metrics: TerminalResourceBatchPayload; timestamp: number } = event;
       emitter.emit("resource-metrics", rmEvent.metrics, rmEvent.timestamp);
+      return true;
+    }
+
+    case "fd-leak-warning": {
+      const flwEvent: FdLeakWarningPayload = {
+        fdCount: event.fdCount,
+        activeTerminals: event.activeTerminals,
+        estimatedLeaked: event.estimatedLeaked,
+        orphanedPids: event.orphanedPids,
+        ptmxLimit: event.ptmxLimit,
+        timestamp: event.timestamp,
+      };
+      emitter.emit("fd-leak-warning", flwEvent);
       return true;
     }
 

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -270,6 +270,35 @@ describe("routeHostEvent", () => {
     expect(spawnListener).toHaveBeenCalled();
   });
 
+  it("emits fd-leak-warning and returns true", () => {
+    const { deps, emitter } = makeDeps();
+    const listener = vi.fn();
+    emitter.on("fd-leak-warning", listener);
+
+    const handled = routeHostEvent(
+      {
+        type: "fd-leak-warning",
+        fdCount: 50,
+        activeTerminals: 5,
+        estimatedLeaked: 30,
+        orphanedPids: [],
+        ptmxLimit: 511,
+        timestamp: 1000,
+      },
+      deps
+    );
+
+    expect(handled).toBe(true);
+    expect(listener).toHaveBeenCalledWith({
+      fdCount: 50,
+      activeTerminals: 5,
+      estimatedLeaked: 30,
+      orphanedPids: [],
+      ptmxLimit: 511,
+      timestamp: 1000,
+    });
+  });
+
   it("emits resource-metrics with timestamp", () => {
     const { deps, emitter } = makeDeps();
     const listener = vi.fn();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -127,6 +127,7 @@ import type {
   SpawnResult,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
+  FdLeakWarningPayload,
 } from "../pty-host.js";
 import type { ShowContextMenuPayload } from "../menu.js";
 import type {
@@ -278,6 +279,7 @@ export interface ElectronAPI {
     onResourceMetrics(
       callback: (data: { metrics: TerminalResourceBatchPayload; timestamp: number }) => void
     ): () => void;
+    onFdLeakWarning(callback: (data: FdLeakWarningPayload) => void): () => void;
     onBackendCrashed(
       callback: (data: {
         crashType: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -155,6 +155,7 @@ import type {
   TerminalStatusPayload,
   TerminalResourceBatchPayload,
   BroadcastWriteResultPayload,
+  FdLeakWarningPayload,
 } from "../pty-host.js";
 import type { HibernationConfig, HibernationProjectHibernatedPayload } from "./hibernation.js";
 import type { IdleTerminalNotifyConfig, IdleTerminalNotifyPayload } from "./idleTerminals.js";
@@ -2320,6 +2321,7 @@ export interface IpcEventMap {
   "terminal:restored": { id: string };
   "terminal:status": TerminalStatusPayload;
   "terminal:reliability-metric": TerminalReliabilityMetricPayload;
+  "terminal:fd-leak-warning": FdLeakWarningPayload;
   "terminal:resource-metrics": { metrics: TerminalResourceBatchPayload; timestamp: number };
   "terminal:broadcast-write-result": BroadcastWriteResultPayload;
   "terminal:send-key": [id: string, key: string];

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -297,6 +297,15 @@ export type PtyHostEvent =
       results: BroadcastWriteTargetResult[];
     };
 
+export interface FdLeakWarningPayload {
+  fdCount: number;
+  activeTerminals: number;
+  estimatedLeaked: number;
+  orphanedPids: number[];
+  ptmxLimit: number | null;
+  timestamp: number;
+}
+
 /**
  * Sub-union of host-to-main events that carry a `requestId` field — i.e. broker
  * responses correlated with a `register()` call on the main side. Use this with

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -195,6 +195,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminal: {
     onResourceMetrics: vi.fn(() => vi.fn()),
     onReclaimMemory: vi.fn(() => vi.fn()),
+    onFdLeakWarning: vi.fn(() => vi.fn()),
   },
   terminalConfig: {
     get: vi.fn().mockResolvedValue({}),

--- a/src/store/listeners/panel/__tests__/fdLeakWarning.test.ts
+++ b/src/store/listeners/panel/__tests__/fdLeakWarning.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const notifyMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+import { setupFdLeakWarningListeners, _resetFdLeakWarningCooldown } from "../fdLeakWarning";
+import { notify } from "@/lib/notify";
+
+let onFdLeakWarningCb: ((data: unknown) => void) | null = null;
+
+beforeEach(() => {
+  onFdLeakWarningCb = null;
+  notifyMock.mockClear();
+  _resetFdLeakWarningCooldown();
+
+  vi.stubGlobal("electron", {
+    terminal: {
+      onFdLeakWarning: (cb: (data: unknown) => void) => {
+        onFdLeakWarningCb = cb;
+        return () => {
+          onFdLeakWarningCb = null;
+        };
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const makePayload = (overrides = {}) => ({
+  fdCount: 50,
+  activeTerminals: 5,
+  estimatedLeaked: 30,
+  orphanedPids: [] as number[],
+  ptmxLimit: 511,
+  timestamp: Date.now(),
+  ...overrides,
+});
+
+describe("setupFdLeakWarningListeners", () => {
+  it("calls notify on first warning", () => {
+    const d = setupFdLeakWarningListeners();
+    onFdLeakWarningCb!(makePayload());
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notifyMock.mock.lastCall?.[0]).toMatchObject({
+      type: "warning",
+      title: "FD leak detected",
+      correlationId: "terminal:fd-leak-warning",
+    });
+    d.dispose();
+  });
+
+  it("suppresses repeat notifications within cooldown period", () => {
+    const d = setupFdLeakWarningListeners();
+    onFdLeakWarningCb!(makePayload());
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    onFdLeakWarningCb!(makePayload());
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    d.dispose();
+  });
+
+  it("includes ptmxLimit percentage in message", () => {
+    const d = setupFdLeakWarningListeners();
+    onFdLeakWarningCb!(makePayload({ fdCount: 400, ptmxLimit: 511 }));
+    const message = notifyMock.mock.lastCall?.[0]?.message;
+    expect(message).toContain("78% of limit");
+    d.dispose();
+  });
+
+  it("omits percentage when ptmxLimit is null", () => {
+    const d = setupFdLeakWarningListeners();
+    onFdLeakWarningCb!(makePayload({ ptmxLimit: null }));
+    const message = notifyMock.mock.lastCall?.[0]?.message;
+    expect(message).not.toContain("of limit");
+    d.dispose();
+  });
+});

--- a/src/store/listeners/panel/fdLeakWarning.ts
+++ b/src/store/listeners/panel/fdLeakWarning.ts
@@ -1,0 +1,39 @@
+import type { FdLeakWarningPayload } from "@shared/types/pty-host";
+import { notify } from "@/lib/notify";
+import { DisposableStore, toDisposable } from "@/utils/disposable";
+
+let lastWarningTimestamp = 0;
+const REARM_MS = 5 * 60 * 1000; // 5 min cooldown before re-arming
+
+export function _resetFdLeakWarningCooldown() {
+  lastWarningTimestamp = 0;
+}
+
+export function setupFdLeakWarningListeners(): DisposableStore {
+  const d = new DisposableStore();
+
+  d.add(
+    toDisposable(
+      window.electron.terminal.onFdLeakWarning((data: FdLeakWarningPayload) => {
+        const now = Date.now();
+        if (now - lastWarningTimestamp < REARM_MS) return;
+        lastWarningTimestamp = now;
+
+        const fdPct =
+          data.ptmxLimit != null && data.ptmxLimit > 0
+            ? ` (${Math.round((data.fdCount / data.ptmxLimit) * 100)}% of limit)`
+            : "";
+
+        notify({
+          type: "warning",
+          title: "FD leak detected",
+          message: `${data.fdCount} open file descriptors, ${data.activeTerminals} active terminals, ~${data.estimatedLeaked} leaked${fdPct}.`,
+          priority: "high",
+          correlationId: "terminal:fd-leak-warning",
+        });
+      })
+    )
+  );
+
+  return d;
+}

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -5,6 +5,7 @@ import { setupLifecycleListeners } from "./listeners/panel/lifecycle";
 import { setupActivityListeners } from "./listeners/panel/activity";
 import { setupBackendHealthListeners } from "./listeners/panel/backendHealth";
 import { setupResourceListeners } from "./listeners/panel/resource";
+import { setupFdLeakWarningListeners } from "./listeners/panel/fdLeakWarning";
 
 let store: DisposableStore | null = null;
 
@@ -30,6 +31,7 @@ export function setupTerminalStoreListeners() {
   disposables.add(setupActivityListeners());
   disposables.add(setupBackendHealthListeners());
   disposables.add(setupResourceListeners());
+  disposables.add(setupFdLeakWarningListeners());
 
   return cleanupTerminalStoreListeners;
 }


### PR DESCRIPTION
## Summary
- The `PtyEventRouter` had no case for `fd-leak-warning` events, so every warning from the PTY host's `ResourceGovernor` hit the default branch and logged "Unknown event type" every two seconds.
- Real FD leak signals were silently dropped instead of reaching the renderer -- on macOS the ptmx pool caps at 511, so an unchecked leak eventually blocks new terminals.
- Added the missing case in the router, wired up IPC channels and preload exposure, and added a renderer-side store listener that surfaces warnings in the diagnostics dock.

Resolves #6815

## Changes
- `PtyEventRouter.ts` -- handle `fd-leak-warning` events instead of dropping them
- IPC channels + preload exposure so the event reaches the renderer
- `fdLeakWarning.ts` store listener -- routes warnings to the diagnostics dock
- Tests for the router and the store listener

## Testing
- Unit tests for the new PtyEventRouter case and the renderer-side listener