### PR TITLE
feat(e2e): add list-mount perf budget to core suite

### DIFF
--- a/e2e/core/core-perf-list-mount-budget.spec.ts
+++ b/e2e/core/core-perf-list-mount-budget.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Core: List Mount Perf Budget
+ *
+ * Mounts ReviewHub with 1000 unstaged files and asserts two count-based ceilings:
+ * - DOM node count delta (before → after mount) ≤ MAX_DOM_DELTA
+ * - Long-animation-frame occurrence count ≤ MAX_LONG_TASKS
+ *
+ * Count metrics are used deliberately over millisecond-based INP/LCP because
+ * lab/CI shared-runner CPU variance makes timing thresholds unreliable.
+ * These complement the existing static baselines (bundle-size,
+ * compiler-bailout, eager-import) — they don't replace them.
+ *
+ * @see https://github.com/GoogleChrome/web-vitals/issues/180
+ */
+
+import { test, expect } from "@playwright/test";
+import { rmSync } from "fs";
+import { launchApp, closeApp, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { openAndOnboardProject } from "../helpers/project";
+import { SEL } from "../helpers/selectors";
+import { T_LONG, T_SETTLE } from "../helpers/timeouts";
+
+const FILE_COUNT = 1000;
+const MAX_DOM_DELTA = 25_000;
+const MAX_LONG_TASKS = 10;
+
+let ctx: AppContext;
+let fixtureDir: string;
+
+test.describe.serial("Core: List Mount Perf Budget", () => {
+  test.beforeAll(async () => {
+    fixtureDir = createFixtureRepo({
+      name: "perf-budget",
+      unstagedFileCount: FILE_COUNT,
+    });
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Perf Budget Test");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    try {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  });
+
+  test("ReviewHub working-tree mode stays within node count and longtask budgets", async () => {
+    const { window } = ctx;
+
+    const lastFileName = `bulk-unstaged/file-${FILE_COUNT}.txt`;
+
+    // Snapshot baseline DOM node count before opening the hub
+    const beforeNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
+
+    // Install a PerformanceObserver for long-animation-frames before triggering
+    // the mount, so buffered entries and new entries during render are captured.
+    const observerInstalled = await window.evaluate(() => {
+      if (!("PerformanceObserver" in window)) return false;
+      const supported = PerformanceObserver.supportedEntryTypes ?? [];
+      if (!supported.includes("long-animation-frame")) return false;
+
+      (window as any).__daintreeE2ePerfEntries = [];
+      const obs = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          (window as any).__daintreeE2ePerfEntries.push(entry.toJSON());
+        }
+      });
+      obs.observe({ type: "long-animation-frame", buffered: true });
+      (window as any).__daintreeE2ePerfObserver = obs;
+      return true;
+    });
+
+    // Open the ReviewHub
+    const reviewBtn = window.locator(SEL.worktree.reviewHubButton);
+    await reviewBtn.first().click();
+
+    const hub = window.locator(SEL.reviewHub.container);
+    await expect(hub).toBeVisible({ timeout: T_LONG });
+
+    // Wait for the last file row to render — confirms full data load completed
+    const lastStageBtn = hub.locator(SEL.reviewHub.stageButton(lastFileName));
+    await expect(lastStageBtn).toBeVisible({ timeout: T_LONG });
+
+    // Allow a brief settle for final paints and observer callbacks
+    await window.waitForTimeout(T_SETTLE);
+
+    // Snapshot post-mount DOM node count
+    const afterNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
+
+    // Collect longtask entries
+    const longTaskEntries: Array<{ duration: number; startTime: number }> = await window.evaluate(
+      () => {
+        const obs = (window as any).__daintreeE2ePerfObserver as PerformanceObserver | undefined;
+        obs?.disconnect();
+        const entries = (window as any).__daintreeE2ePerfEntries ?? [];
+        delete (window as any).__daintreeE2ePerfObserver;
+        delete (window as any).__daintreeE2ePerfEntries;
+        return entries;
+      }
+    );
+
+    // Assert DOM delta
+    const domDelta = afterNodeCount - beforeNodeCount;
+    console.log(
+      `[perf-budget] DOM delta: ${domDelta} (before=${beforeNodeCount}, after=${afterNodeCount})`
+    );
+    expect(domDelta).toBeLessThanOrEqual(MAX_DOM_DELTA);
+
+    // Assert longtask count (skip if the API is unsupported in this runtime)
+    if (observerInstalled) {
+      const longTaskCount = longTaskEntries.length;
+      console.log(`[perf-budget] Long-animation-frames: ${longTaskCount}`);
+      expect(longTaskCount).toBeLessThanOrEqual(MAX_LONG_TASKS);
+    } else {
+      console.warn(
+        "[perf-budget] long-animation-frame not supported in this runtime; skipping longtask budget assertion"
+      );
+    }
+  });
+});

--- a/e2e/core/core-perf-list-mount-budget.spec.ts
+++ b/e2e/core/core-perf-list-mount-budget.spec.ts
@@ -19,11 +19,12 @@ import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { SEL } from "../helpers/selectors";
-import { T_LONG, T_SETTLE } from "../helpers/timeouts";
+import { T_SHORT, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 interface E2EPerfWindow extends Window {
   __daintreeE2ePerfEntries?: Array<{ duration: number; startTime: number }>;
   __daintreeE2ePerfObserver?: PerformanceObserver;
+  __daintreeE2eMountStart?: number;
 }
 
 const FILE_COUNT = 1000;
@@ -56,12 +57,13 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     const { window } = ctx;
 
     const lastFileName = `bulk-unstaged/file-${FILE_COUNT}.txt`;
+    const midFileName = `bulk-unstaged/file-0500.txt`;
 
     // Snapshot baseline DOM node count before opening the hub
     const beforeNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
 
     // Install a PerformanceObserver for long-animation-frames before triggering
-    // the mount, so buffered entries and new entries during render are captured.
+    // the mount. Do NOT use buffered: true — it captures startup noise.
     const observerInstalled = await window.evaluate(() => {
       if (!("PerformanceObserver" in window)) return false;
       const supported = PerformanceObserver.supportedEntryTypes ?? [];
@@ -69,14 +71,23 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
 
       const win = window as unknown as E2EPerfWindow;
       win.__daintreeE2ePerfEntries = [];
-      const obs = new PerformanceObserver((list) => {
-        for (const entry of list.getEntries()) {
-          win.__daintreeE2ePerfEntries!.push(entry.toJSON());
-        }
-      });
-      obs.observe({ type: "long-animation-frame", buffered: true });
-      win.__daintreeE2ePerfObserver = obs;
+      try {
+        const obs = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            win.__daintreeE2ePerfEntries!.push(entry.toJSON());
+          }
+        });
+        obs.observe({ type: "long-animation-frame", durationThreshold: 100 });
+        win.__daintreeE2ePerfObserver = obs;
+      } catch {
+        return false;
+      }
       return true;
+    });
+
+    // Record mount start time for entry filtering
+    await window.evaluate(() => {
+      (window as unknown as E2EPerfWindow).__daintreeE2eMountStart = performance.now();
     });
 
     // Open the ReviewHub
@@ -86,9 +97,17 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     const hub = window.locator(SEL.reviewHub.container);
     await expect(hub).toBeVisible({ timeout: T_LONG });
 
-    // Wait for the last file row to render — confirms full data load completed
+    // Confirm the hub is showing file data, not an empty state
+    await expect(hub.locator(SEL.reviewHub.cleanState)).not.toBeVisible({ timeout: T_SHORT });
+    await expect(hub.locator(SEL.reviewHub.noUnstagedChanges)).not.toBeVisible({
+      timeout: T_SHORT,
+    });
+
+    // Wait for both last and mid-range rows — confirms full list span
     const lastStageBtn = hub.locator(SEL.reviewHub.stageButton(lastFileName));
+    const midStageBtn = hub.locator(SEL.reviewHub.stageButton(midFileName));
     await expect(lastStageBtn).toBeVisible({ timeout: T_LONG });
+    await expect(midStageBtn).toBeVisible({ timeout: T_SHORT });
 
     // Allow a brief settle for final paints and observer callbacks
     await window.waitForTimeout(T_SETTLE);
@@ -96,14 +115,18 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     // Snapshot post-mount DOM node count
     const afterNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
 
-    // Collect longtask entries
+    // Collect longtask entries, filtering to post-click timestamps
     const longTaskEntries: Array<{ duration: number; startTime: number }> = await window.evaluate(
       () => {
         const win = window as unknown as E2EPerfWindow;
         win.__daintreeE2ePerfObserver?.disconnect();
-        const entries = win.__daintreeE2ePerfEntries ?? [];
+        const mountStart = win.__daintreeE2eMountStart ?? 0;
+        const entries = (win.__daintreeE2ePerfEntries ?? []).filter(
+          (e) => e.startTime >= mountStart
+        );
         delete win.__daintreeE2ePerfObserver;
         delete win.__daintreeE2ePerfEntries;
+        delete win.__daintreeE2eMountStart;
         return entries;
       }
     );
@@ -115,15 +138,14 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     );
     expect(domDelta).toBeLessThanOrEqual(MAX_DOM_DELTA);
 
-    // Assert longtask count (skip if the API is unsupported in this runtime)
+    // Assert longtask count
     if (observerInstalled) {
       const longTaskCount = longTaskEntries.length;
       console.log(`[perf-budget] Long-animation-frames: ${longTaskCount}`);
       expect(longTaskCount).toBeLessThanOrEqual(MAX_LONG_TASKS);
     } else {
-      console.warn(
-        "[perf-budget] long-animation-frame not supported in this runtime; skipping longtask budget assertion"
-      );
+      // Fail rather than skip — a release gate must not silently drop coverage
+      throw new Error("long-animation-frame API must be supported for the perf budget gate");
     }
   });
 });

--- a/e2e/core/core-perf-list-mount-budget.spec.ts
+++ b/e2e/core/core-perf-list-mount-budget.spec.ts
@@ -21,6 +21,11 @@ import { openAndOnboardProject } from "../helpers/project";
 import { SEL } from "../helpers/selectors";
 import { T_LONG, T_SETTLE } from "../helpers/timeouts";
 
+interface E2EPerfWindow extends Window {
+  __daintreeE2ePerfEntries?: Array<{ duration: number; startTime: number }>;
+  __daintreeE2ePerfObserver?: PerformanceObserver;
+}
+
 const FILE_COUNT = 1000;
 const MAX_DOM_DELTA = 25_000;
 const MAX_LONG_TASKS = 10;
@@ -62,14 +67,15 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
       const supported = PerformanceObserver.supportedEntryTypes ?? [];
       if (!supported.includes("long-animation-frame")) return false;
 
-      (window as any).__daintreeE2ePerfEntries = [];
+      const win = window as unknown as E2EPerfWindow;
+      win.__daintreeE2ePerfEntries = [];
       const obs = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          (window as any).__daintreeE2ePerfEntries.push(entry.toJSON());
+          win.__daintreeE2ePerfEntries!.push(entry.toJSON());
         }
       });
       obs.observe({ type: "long-animation-frame", buffered: true });
-      (window as any).__daintreeE2ePerfObserver = obs;
+      win.__daintreeE2ePerfObserver = obs;
       return true;
     });
 
@@ -93,11 +99,11 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     // Collect longtask entries
     const longTaskEntries: Array<{ duration: number; startTime: number }> = await window.evaluate(
       () => {
-        const obs = (window as any).__daintreeE2ePerfObserver as PerformanceObserver | undefined;
-        obs?.disconnect();
-        const entries = (window as any).__daintreeE2ePerfEntries ?? [];
-        delete (window as any).__daintreeE2ePerfObserver;
-        delete (window as any).__daintreeE2ePerfEntries;
+        const win = window as unknown as E2EPerfWindow;
+        win.__daintreeE2ePerfObserver?.disconnect();
+        const entries = win.__daintreeE2ePerfEntries ?? [];
+        delete win.__daintreeE2ePerfObserver;
+        delete win.__daintreeE2ePerfEntries;
         return entries;
       }
     );

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -100,10 +100,10 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): string {
     writeFileSync(path.join(dir, "uncommitted.txt"), "This file is not committed.\n");
   }
 
+  if (!Number.isInteger(unstagedFileCount) || unstagedFileCount < 0) {
+    throw new Error(`unstagedFileCount must be a non-negative integer, got ${unstagedFileCount}`);
+  }
   if (unstagedFileCount > 0) {
-    if (!Number.isInteger(unstagedFileCount) || unstagedFileCount < 0) {
-      throw new Error(`unstagedFileCount must be a non-negative integer, got ${unstagedFileCount}`);
-    }
     const bulkDir = path.join(dir, "bulk-unstaged");
     mkdirSync(bulkDir, { recursive: true });
     const width = String(unstagedFileCount).length;

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -10,6 +10,7 @@ interface FixtureRepoOptions {
   withImageFile?: boolean;
   withUncommittedChanges?: boolean;
   withSpreadCommits?: boolean;
+  unstagedFileCount?: number;
 }
 
 function git(cmd: string, cwd: string) {
@@ -24,6 +25,7 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): string {
     withImageFile = false,
     withUncommittedChanges = false,
     withSpreadCommits = false,
+    unstagedFileCount = 0,
   } = options;
 
   const dir = mkdtempSync(path.join(tmpdir(), `daintree-e2e-${name}-`));
@@ -96,6 +98,19 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): string {
 
   if (withUncommittedChanges) {
     writeFileSync(path.join(dir, "uncommitted.txt"), "This file is not committed.\n");
+  }
+
+  if (unstagedFileCount > 0) {
+    if (!Number.isInteger(unstagedFileCount) || unstagedFileCount < 0) {
+      throw new Error(`unstagedFileCount must be a non-negative integer, got ${unstagedFileCount}`);
+    }
+    const bulkDir = path.join(dir, "bulk-unstaged");
+    mkdirSync(bulkDir, { recursive: true });
+    const width = String(unstagedFileCount).length;
+    for (let i = 1; i <= unstagedFileCount; i++) {
+      const filename = `file-${String(i).padStart(width, "0")}.txt`;
+      writeFileSync(path.join(bulkDir, filename), `# file ${i}\n`);
+    }
   }
 
   return dir;


### PR DESCRIPTION
## Summary
- Adds a core E2E spec that mounts ReviewHub with 1000 unstaged files and asserts DOM node delta ≤ 25,000 and long-animation-frame count ≤ 10
- Extends `createFixtureRepo` with an `unstagedFileCount` option so we can generate bulk test files cheaply
- Uses count-based rather than timing-based metrics to avoid shared-runner CPU variance in CI

Resolves #6812

## Changes
- `e2e/helpers/fixtures.ts` — new `unstagedFileCount` option on `createFixtureRepo`; writes numbered files under `bulk-unstaged/`
- `e2e/core/core-perf-list-mount-budget.spec.ts` — new core spec; installs a `PerformanceObserver` for long-animation-frames, opens ReviewHub, asserts node count and longtask ceilings

## Testing
- Ran the test locally against a fixture repo with 1000 unstaged files — both budget assertions pass on a dev build
- The spec fails hard (rather than skipping) when the long-animation-frame API is unavailable, since this is a release gate