### PR TITLE
fix(ui): eliminate content reflow when toggling the Daintree Assistant

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -148,9 +148,15 @@ interface HelpPanelProps {
    * events, no focusable children).
    */
   width: number;
+  /**
+   * Whether the panel is visible. When false, the panel slides off-screen
+   * via translateX without reflowing sibling content. Defaults to width > 0
+   * for backward compatibility.
+   */
+  isVisible?: boolean;
 }
 
-export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
+export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: HelpPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
@@ -158,7 +164,7 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const skipWorkingCloseConfirm = usePreferencesStore((s) => s.skipWorkingCloseConfirm);
   const animateWidth = !isResizing && !reduceAnimations;
-  const isVisible = effectiveWidth > 0;
+  const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
 
   const {
@@ -706,8 +712,8 @@ export function HelpPanel({ width: effectiveWidth }: HelpPanelProps) {
         "bg-daintree-bg border-l border-daintree-border",
         "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
         animateWidth &&
-          "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
-        !isVisible && "pointer-events-none"
+          "transition-transform duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+        !isVisible && "translate-x-full pointer-events-none"
       )}
       style={{ width: effectiveWidth }}
     >

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -142,16 +142,16 @@ function revokeHelpSession(sessionId: string | null): void {
 
 interface HelpPanelProps {
   /**
-   * Effective rendered width in pixels. Owned by `AppLayout` so focus mode
-   * and `helpPanelOpen` collapse the panel to 0 without unmounting the
-   * xterm PTY. Width 0 means hidden chrome (aria-hidden, no pointer
-   * events, no focusable children).
+   * Configured panel width in pixels (the stable stored size, never 0).
+   * Visibility is controlled by the `isVisible` prop; the panel always
+   * renders at this width and the parent positions it absolutely with a
+   * compositor-only translateX slide-over.
    */
   width: number;
   /**
-   * Whether the panel is visible. When false, the panel slides off-screen
-   * via translateX without reflowing sibling content. Defaults to width > 0
-   * for backward compatibility.
+   * Whether the panel is visible. When false, the parent slides the panel
+   * off-screen via translateX without reflowing sibling content. Defaults
+   * to width > 0 for backward compatibility.
    */
   isVisible?: boolean;
 }
@@ -161,9 +161,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
   const contentRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
-  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const skipWorkingCloseConfirm = usePreferencesStore((s) => s.skipWorkingCloseConfirm);
-  const animateWidth = !isResizing && !reduceAnimations;
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
 
@@ -711,9 +709,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
         "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
         "bg-daintree-bg border-l border-daintree-border",
         "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
-        animateWidth &&
-          "transition-transform duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
-        !isVisible && "translate-x-full pointer-events-none"
+        !isVisible && "pointer-events-none"
       )}
       style={{ width: effectiveWidth }}
     >

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { cn } from "@/lib/utils";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
 import { TerminalDockRegion } from "./TerminalDockRegion";
@@ -430,8 +431,8 @@ export function AppLayout({
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
       >
         <div
-          className="flex-1 flex overflow-hidden"
-          style={{ flex: 1, display: "flex", overflow: "hidden" }}
+          className="flex-1 flex overflow-hidden relative"
+          style={{ flex: 1, display: "flex", overflow: "hidden", position: "relative" }}
         >
           {currentProject != null && (
             <ErrorBoundary variant="section" componentName="Sidebar">
@@ -458,7 +459,17 @@ export function AppLayout({
             </main>
           </ErrorBoundary>
           <ErrorBoundary variant="section" componentName="HelpPanel">
-            <HelpPanel width={effectiveAssistantWidth} />
+            <div
+              className={cn(
+                "absolute top-0 right-0 bottom-0 z-30",
+                !reduceAnimations &&
+                  "transition-transform duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                !showAssistant && "pointer-events-none translate-x-full"
+              )}
+              style={{ width: layout.helpPanelWidth }}
+            >
+              <HelpPanel width={layout.helpPanelWidth} isVisible={showAssistant} />
+            </div>
           </ErrorBoundary>
         </div>
         {/* Unified diagnostics dock replaces LogsPanel, EventInspectorPanel, and ProblemsPanel */}

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -63,19 +63,26 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     );
   });
 
-  it("mounts HelpPanel unconditionally as a flex sibling so the xterm PTY survives close (issue #6619)", () => {
+  it("mounts HelpPanel unconditionally as an absolute overlay so the xterm PTY survives close (issue #6619, #6816)", () => {
     // The old conditional-render guard (which destroyed the PTY on every
     // toggle) must not be reintroduced.
     expect(source).not.toMatch(/\{layout\.helpPanelOpen && \(\s*\n\s*<ErrorBoundary[^>]*HelpPanel/);
     expect(source).toMatch(
-      /<ErrorBoundary[^>]*componentName="HelpPanel"[^>]*>\s*\n\s*<HelpPanel\s+width=\{effectiveAssistantWidth\}\s*\/>/
+      /<HelpPanel\s+width=\{layout\.helpPanelWidth\}\s+isVisible=\{showAssistant\}/
     );
+    // The wrapper must use absolute positioning to avoid reflowing sibling content.
+    expect(source).toMatch(/"absolute top-0 right-0 bottom-0 z-30"/);
   });
 
-  it("passes effectiveAssistantWidth to HelpPanel so focus mode collapses width to 0", () => {
-    // Without the prop, HelpPanel reads its own store and ignores focus mode,
-    // leaving the panel at full width when the user enters focus mode.
-    expect(source).toContain("<HelpPanel width={effectiveAssistantWidth} />");
+  it("passes stable helpPanelWidth to HelpPanel so content renders at full width without reflow (issue #6816)", () => {
+    // width is always the stored configured width; visibility is controlled
+    // by the isVisible prop + translateX transform, not by collapsing width to 0.
+    expect(source).toContain(
+      "<HelpPanel width={layout.helpPanelWidth} isVisible={showAssistant} />"
+    );
+    // The old effectiveAssistantWidth (collapsing to 0 on close) must not be
+    // passed as the width prop — that defeats the transform-based slide.
+    expect(source).not.toContain("<HelpPanel width={effectiveAssistantWidth}");
   });
 
   it("uses showAssistant for the macro-focus assistant visibility effect", () => {


### PR DESCRIPTION
## Summary
- The assistant panel was a flex sibling of the main content area, so animating its width on toggle forced the neighboring content to rewrap and jump each frame.
- Moved the panel to an absolute overlay in `AppLayout.tsx` with a compositor-only `translateX` slide that floats above the content without triggering layout.
- `HelpPanel.tsx` now receives a consistent `helpPanelWidth` (never collapsed to 0) and a separate `isVisible` prop that drives the translate transform.

Resolves #6816

## Changes
- `HelpPanel.tsx` — added `isVisible` prop, dropped the width collapse-to-0 visibility pattern and the width transition class
- `AppLayout.tsx` — wrapped `HelpPanel` in an absolutely-positioned container with `translate-x-full` for the hidden state and a `transition-transform` for the slide-over
- Test assertions updated to verify the new absolute-overlay pattern

## Testing
- Toggled the assistant open and closed via toolbar button, close button, and focus-mode gesture. Verified no content reflow or text rewrap during the slide animation.