### PR TITLE
feat(notifications): pinned severity section, group-by-context, and new-since-last-looked divider

### DIFF
--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -120,6 +120,9 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
         .sort((a, b) => a - b);
       allowed.quietHoursWeekdays = Array.from(new Set(days));
     }
+    if (typeof s.groupByContext === "boolean") {
+      allowed.groupByContext = s.groupByContext;
+    }
 
     for (const [field, value] of Object.entries(allowed)) {
       store.set(`notificationSettings.${field}`, value);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -142,6 +142,7 @@ export interface StoreSchema {
     quietHoursStartMin: number;
     quietHoursEndMin: number;
     quietHoursWeekdays: number[];
+    groupByContext?: boolean;
   };
   userAgentRegistry: UserAgentRegistry;
   agentUpdateSettings: AgentUpdateSettings;
@@ -307,6 +308,7 @@ const storeOptions = {
       quietHoursStartMin: 22 * 60,
       quietHoursEndMin: 8 * 60,
       quietHoursWeekdays: [],
+      groupByContext: false,
     },
     userAgentRegistry: {},
     agentUpdateSettings: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -180,6 +180,8 @@ export interface NotificationSettings {
   quietHoursEndMin: number;
   /** Days the schedule applies to, 0 (Sun) - 6 (Sat). Empty array means every day. */
   quietHoursWeekdays: number[];
+  /** When true, the bell drawer groups entries by worktree/project context. */
+  groupByContext?: boolean;
 }
 
 // ElectronAPI Type (exposed via preload)

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Bell, CheckCheck, Ellipsis, Moon, Trash2, X } from "lucide-react";
+import { Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2, X } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,
@@ -18,6 +18,8 @@ import {
 import { actionService } from "@/services/ActionService";
 import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } from "@/lib/notify";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { useUIStore } from "@/store/uiStore";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
 import type { NotificationType } from "@/store/notificationStore";
 
@@ -27,6 +29,9 @@ const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
   info: 1,
   success: 0,
 } as const;
+
+const NEEDS_ATTENTION_CAP = 5;
+const CONTEXT_NONE_KEY = "__none__";
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
@@ -40,6 +45,20 @@ function getWorstSeverity(entries: NotificationHistoryEntry[]): NotificationType
   ).type;
 }
 
+function isUnreadGroup(group: ThreadGroup): boolean {
+  return group.entries.some((e) => !e.seenAsToast);
+}
+
+function getGroupContextKey(group: ThreadGroup): string {
+  for (const e of group.entries) {
+    const wt = e.context?.worktreeId;
+    if (wt) return `wt:${wt}`;
+    const proj = e.context?.projectId;
+    if (proj) return `proj:${proj}`;
+  }
+  return CONTEXT_NONE_KEY;
+}
+
 interface NotificationCenterProps {
   open: boolean;
   onClose: () => void;
@@ -49,6 +68,13 @@ interface ThreadGroup {
   correlationId: string | undefined;
   entries: NotificationHistoryEntry[];
   latestTimestamp: number;
+}
+
+interface ContextSection {
+  key: string;
+  worktreeId?: string;
+  projectId?: string;
+  groups: ThreadGroup[];
 }
 
 function groupByCorrelationId(entries: NotificationHistoryEntry[]): ThreadGroup[] {
@@ -78,6 +104,28 @@ function groupByCorrelationId(entries: NotificationHistoryEntry[]): ThreadGroup[
   });
 }
 
+function partitionByContext(groups: ThreadGroup[]): ContextSection[] {
+  const sections = new Map<string, ContextSection>();
+  const order: string[] = [];
+
+  for (const g of groups) {
+    const key = getGroupContextKey(g);
+    if (!sections.has(key)) {
+      const first = g.entries.find((e) => e.context?.worktreeId || e.context?.projectId);
+      sections.set(key, {
+        key,
+        worktreeId: first?.context?.worktreeId,
+        projectId: first?.context?.projectId,
+        groups: [],
+      });
+      order.push(key);
+    }
+    sections.get(key)!.groups.push(g);
+  }
+
+  return order.map((k) => sections.get(k)!);
+}
+
 export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const entries = useNotificationHistoryStore((s) => s.entries);
   const unreadCount = useNotificationHistoryStore((s) => s.unreadCount);
@@ -91,6 +139,8 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     quietHoursStartMin,
     quietHoursEndMin,
     quietHoursWeekdays,
+    groupByContext,
+    setGroupByContext,
   } = useNotificationSettingsStore(
     useShallow((s) => ({
       quietUntil: s.quietUntil,
@@ -98,8 +148,13 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       quietHoursStartMin: s.quietHoursStartMin,
       quietHoursEndMin: s.quietHoursEndMin,
       quietHoursWeekdays: s.quietHoursWeekdays,
+      groupByContext: s.groupByContext,
+      setGroupByContext: s.setGroupByContext,
     }))
   );
+
+  const lastClosedAt = useUIStore((s) => s.lastNotificationCenterClosedAt);
+  const resetLastClosedAt = useUIStore((s) => s.resetNotificationCenterLastClosedAt);
 
   const [filter, setFilter] = useState<"all" | "unread">("all");
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
@@ -159,13 +214,53 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     return entries.filter((e) => !e.seenAsToast);
   }, [entries, filter, frozenUnreadIds]);
 
-  const groups = useMemo(() => groupByCorrelationId(filteredEntries), [filteredEntries]);
+  const { needsAttentionGroups, chronoSections, dividerGroupId } = useMemo(() => {
+    const allGroups = groupByCorrelationId(filteredEntries);
+
+    const pinned = allGroups
+      .filter((g) => {
+        if (!isUnreadGroup(g)) return false;
+        const sev = getWorstSeverity(g.entries);
+        return sev === "error" || sev === "warning";
+      })
+      .sort((a, b) => {
+        const sevDiff =
+          SEVERITY_WEIGHTS[getWorstSeverity(b.entries)] -
+          SEVERITY_WEIGHTS[getWorstSeverity(a.entries)];
+        if (sevDiff !== 0) return sevDiff;
+        return b.latestTimestamp - a.latestTimestamp;
+      })
+      .slice(0, NEEDS_ATTENTION_CAP);
+
+    const sections: ContextSection[] = groupByContext
+      ? partitionByContext(allGroups)
+      : [{ key: "all", groups: allGroups }];
+
+    let divider: string | null = null;
+    if (lastClosedAt > 0) {
+      for (const g of allGroups) {
+        if (g.latestTimestamp > lastClosedAt) {
+          divider = g.correlationId ?? g.entries[0]?.id ?? null;
+          break;
+        }
+      }
+    }
+
+    return {
+      needsAttentionGroups: pinned,
+      chronoSections: sections,
+      dividerGroupId: divider,
+    };
+  }, [filteredEntries, groupByContext, lastClosedAt]);
+
+  const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
   const handleMarkAllRead = () => {
     if (filter === "unread") {
       setFrozenUnreadIds(new Set(entries.filter((e) => !e.seenAsToast).map((e) => e.id)));
     }
     markAllRead();
+    resetLastClosedAt();
   };
 
   const handleMuteFor = (durationMs: number, label: string) => {
@@ -209,6 +304,8 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     ? `Muted until ${timeFormatter.format(new Date(quietUntil))}`
     : "Quiet hours";
   const morningLabel = `Until ${timeFormatter.format(new Date(nextOccurrenceTimestamp(8 * 60)))}`;
+
+  const showGroupToggle = entries.length > 0;
 
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
@@ -270,6 +367,22 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          {showGroupToggle && (
+            <button
+              type="button"
+              aria-label="Group by project or worktree"
+              aria-pressed={groupByContext}
+              title="Group by project or worktree"
+              onClick={() => setGroupByContext(!groupByContext)}
+              className={`p-1 transition-colors rounded-[var(--radius-sm)] ${
+                groupByContext
+                  ? "bg-overlay-medium text-daintree-text/80"
+                  : "text-daintree-text/50 hover:bg-daintree-text/10 hover:text-daintree-text/80"
+              }`}
+            >
+              <Layers className="w-3 h-3" aria-hidden="true" />
+            </button>
+          )}
           {unreadCount > 0 && (
             <Button
               type="button"
@@ -340,7 +453,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         </div>
       </div>
       <div className="flex-1 overflow-y-auto">
-        {groups.length === 0 ? (
+        {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
           filter === "unread" && entries.length > 0 ? (
             <EmptyState
               variant="user-cleared"
@@ -370,26 +483,131 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             />
           )
         ) : (
-          <div className="divide-y divide-tint/[0.04]">
-            {groups.map((group) =>
-              group.correlationId && group.entries.length > 1 ? (
-                <NotificationThread
-                  key={group.correlationId}
-                  group={group}
-                  onDismiss={dismissEntry}
-                />
-              ) : (
-                <NotificationCenterEntry
-                  key={group.entries[0]!.id}
-                  entry={group.entries[0]!}
-                  isNew={!group.entries[0]!.seenAsToast}
-                  onDismiss={() => dismissEntry(group.entries[0]!.id)}
-                />
-              )
+          <>
+            {needsAttentionGroups.length > 0 && (
+              <NeedsAttentionSection groups={needsAttentionGroups} onDismiss={dismissEntry} />
             )}
-          </div>
+            {chronoSections.map((section) => (
+              <ChronoSection
+                key={section.key}
+                section={section}
+                groupByContext={groupByContext}
+                dividerGroupId={dividerGroupId}
+                onDismiss={dismissEntry}
+              />
+            ))}
+          </>
         )}
       </div>
+    </div>
+  );
+}
+
+function NeedsAttentionSection({
+  groups,
+  onDismiss,
+}: {
+  groups: ThreadGroup[];
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <div data-testid="needs-attention-section" className="border-b border-divider">
+      <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-daintree-text/50">
+        Needs attention
+      </div>
+      <div className="divide-y divide-tint/[0.04]">
+        {groups.map((group) => renderGroup(group, onDismiss))}
+      </div>
+    </div>
+  );
+}
+
+function ChronoSection({
+  section,
+  groupByContext,
+  dividerGroupId,
+  onDismiss,
+}: {
+  section: ContextSection;
+  groupByContext: boolean;
+  dividerGroupId: string | null;
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <div data-testid="chrono-section">
+      {groupByContext && (
+        <ContextSectionHeader
+          worktreeId={section.worktreeId}
+          projectId={section.projectId}
+          count={section.groups.length}
+        />
+      )}
+      <div className="divide-y divide-tint/[0.04]">
+        {section.groups.map((group) => {
+          const groupKey = group.correlationId ?? group.entries[0]!.id;
+          const isDivider = dividerGroupId !== null && groupKey === dividerGroupId;
+          return (
+            <div key={groupKey}>
+              {isDivider && <NewSinceLastLookedDivider />}
+              {renderGroup(group, onDismiss)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function renderGroup(group: ThreadGroup, onDismiss: (id: string) => void) {
+  if (group.correlationId && group.entries.length > 1) {
+    return <NotificationThread key={group.correlationId} group={group} onDismiss={onDismiss} />;
+  }
+  const entry = group.entries[0]!;
+  return (
+    <NotificationCenterEntry
+      key={entry.id}
+      entry={entry}
+      isNew={!entry.seenAsToast}
+      onDismiss={() => onDismiss(entry.id)}
+    />
+  );
+}
+
+function ContextSectionHeader({
+  worktreeId,
+  projectId,
+  count,
+}: {
+  worktreeId?: string;
+  projectId?: string;
+  count: number;
+}) {
+  const worktreeName = useWorktreeStore((s) =>
+    worktreeId ? s.worktrees.get(worktreeId)?.name : undefined
+  );
+  const label = worktreeName ?? projectId ?? "Other";
+  return (
+    <div
+      data-testid="context-section-header"
+      className="flex items-center justify-between px-3 py-1 bg-overlay-subtle text-[10px] font-medium uppercase tracking-wide text-daintree-text/60"
+    >
+      <span className="truncate">{label}</span>
+      <span aria-hidden="true" className="ml-2 shrink-0 text-daintree-text/40 tabular-nums">
+        {count}
+      </span>
+    </div>
+  );
+}
+
+function NewSinceLastLookedDivider() {
+  return (
+    <div
+      data-testid="new-since-last-looked"
+      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50"
+    >
+      <span className="h-px flex-1 bg-divider" aria-hidden="true" />
+      <span>New since you last looked</span>
+      <span className="h-px flex-1 bg-divider" aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -215,9 +215,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   }, [entries, filter, frozenUnreadIds]);
 
   const { needsAttentionGroups, chronoSections, dividerGroupId } = useMemo(() => {
-    const allGroups = groupByCorrelationId(filteredEntries);
-
-    const pinned = allGroups
+    // Pinned reflects the global unread severe-threads set so it stays the
+    // same in All and Unread filter views. Chrono respects the active filter.
+    const rawGroups = groupByCorrelationId(entries);
+    const pinned = rawGroups
       .filter((g) => {
         if (!isUnreadGroup(g)) return false;
         const sev = getWorstSeverity(g.entries);
@@ -232,13 +233,14 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       })
       .slice(0, NEEDS_ATTENTION_CAP);
 
+    const chronoGroups = groupByCorrelationId(filteredEntries);
     const sections: ContextSection[] = groupByContext
-      ? partitionByContext(allGroups)
-      : [{ key: "all", groups: allGroups }];
+      ? partitionByContext(chronoGroups)
+      : [{ key: "all", groups: chronoGroups }];
 
     let divider: string | null = null;
     if (lastClosedAt > 0) {
-      for (const g of allGroups) {
+      for (const g of chronoGroups) {
         if (g.latestTimestamp > lastClosedAt) {
           divider = g.correlationId ?? g.entries[0]?.id ?? null;
           break;
@@ -251,7 +253,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       chronoSections: sections,
       dividerGroupId: divider,
     };
-  }, [filteredEntries, groupByContext, lastClosedAt]);
+  }, [entries, filteredEntries, groupByContext, lastClosedAt]);
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
@@ -585,7 +587,7 @@ function ContextSectionHeader({
   const worktreeName = useWorktreeStore((s) =>
     worktreeId ? s.worktrees.get(worktreeId)?.name : undefined
   );
-  const label = worktreeName ?? projectId ?? "Other";
+  const label = worktreeName ?? worktreeId ?? projectId ?? "Other";
   return (
     <div
       data-testid="context-section-header"

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { useUIStore } from "@/store/uiStore";
 import * as notifyLib from "@/lib/notify";
 import { NotificationCenter } from "../NotificationCenter";
 
@@ -18,6 +19,14 @@ vi.mock("@/lib/notify", () => ({
   muteUntilNextMorning: vi.fn().mockReturnValue(Date.now() + 3600_000),
   notify: vi.fn(),
   setSessionQuietUntil: vi.fn(),
+}));
+
+const worktreeStoreMock = vi.hoisted(() => ({
+  worktrees: new Map<string, { worktreeId: string; name: string }>(),
+}));
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: <T,>(selector: (state: typeof worktreeStoreMock) => T) =>
+    selector(worktreeStoreMock),
 }));
 
 let entryCounter = 0;
@@ -48,7 +57,13 @@ beforeEach(() => {
     quietHoursStartMin: 22 * 60,
     quietHoursEndMin: 8 * 60,
     quietHoursWeekdays: [],
+    groupByContext: false,
   });
+  useUIStore.setState({
+    notificationCenterOpen: false,
+    lastNotificationCenterClosedAt: 0,
+  });
+  worktreeStoreMock.worktrees.clear();
   dispatchMock.mockClear();
   getMock.mockReturnValue(null);
   vi.mocked(notifyLib.muteForDuration).mockClear();
@@ -82,7 +97,7 @@ describe("NotificationThread worst severity", () => {
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryByText("Deploy successful")).toBeTruthy();
+      expect(screen.queryAllByText("Deploy successful").length).toBeGreaterThan(0);
     });
 
     const errorIcon = container.querySelector(".text-status-error");
@@ -122,7 +137,7 @@ describe("NotificationThread worst severity", () => {
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryByText("Build failed")).toBeTruthy();
+      expect(screen.queryAllByText("Build failed").length).toBeGreaterThan(0);
     });
 
     const errorIcon = container.querySelector(".text-status-error");
@@ -162,7 +177,7 @@ describe("NotificationThread worst severity", () => {
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryByText("Lint warnings found")).toBeTruthy();
+      expect(screen.queryAllByText("Lint warnings found").length).toBeGreaterThan(0);
     });
 
     const warningIcon = container.querySelector(".text-status-warning");
@@ -255,7 +270,7 @@ describe("NotificationThread with single entry", () => {
     render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryByText("Single error")).toBeTruthy();
+      expect(screen.queryAllByText("Single error").length).toBeGreaterThan(0);
     });
 
     expect(screen.queryByText(/events$/)).toBeNull();
@@ -287,7 +302,7 @@ describe("NotificationThread message content", () => {
     render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryByText("Build retried and succeeded")).toBeTruthy();
+      expect(screen.queryAllByText("Build retried and succeeded").length).toBeGreaterThan(0);
     });
   });
 });
@@ -661,5 +676,261 @@ describe("NotificationCenter overflow menu", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["clearAll", "onClose"]);
     expect(screen.queryByLabelText("More notification actions")).toBeNull();
+  });
+});
+
+describe("NotificationCenter — Needs attention pinned section", () => {
+  it("does not render the section when there are no unread error/warning entries", () => {
+    setEntries([
+      makeEntry({ type: "info", message: "An info", seenAsToast: false }),
+      makeEntry({ id: "entry-99", type: "success", message: "A success", seenAsToast: false }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByTestId("needs-attention-section")).toBeNull();
+  });
+
+  it("does not render the section when severe entries are already read", () => {
+    setEntries([
+      makeEntry({ type: "error", message: "Old failure", seenAsToast: true }),
+      makeEntry({ id: "entry-2", type: "warning", message: "Old warning", seenAsToast: true }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByTestId("needs-attention-section")).toBeNull();
+  });
+
+  it("renders the pinned section above chrono with one unread error", () => {
+    setEntries([makeEntry({ type: "error", message: "Build failed", seenAsToast: false })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const pinned = screen.getByTestId("needs-attention-section");
+    const chrono = screen.getByTestId("chrono-section");
+    expect(within(pinned).getByText("Needs attention")).toBeTruthy();
+    expect(within(pinned).queryAllByText("Build failed").length).toBe(1);
+    expect(within(chrono).queryAllByText("Build failed").length).toBe(1);
+    // Pinned section comes before chrono section in DOM order.
+    const position = pinned.compareDocumentPosition(chrono);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("caps the pinned section at 5 entries even when more unread severe entries exist", () => {
+    const baseT = Date.now();
+    const items = Array.from({ length: 7 }, (_, i) =>
+      makeEntry({
+        id: `failure-${i}`,
+        type: "error",
+        message: `Failure ${i}`,
+        timestamp: baseT - i,
+        seenAsToast: false,
+      })
+    );
+    setEntries(items);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const pinned = screen.getByTestId("needs-attention-section");
+    const messages = within(pinned).getAllByText(/^Failure \d$/);
+    expect(messages).toHaveLength(5);
+  });
+
+  it("sorts pinned entries by severity (error before warning) then by recency", () => {
+    const t = Date.now();
+    setEntries([
+      makeEntry({
+        id: "newer-warn",
+        type: "warning",
+        message: "Newer warning",
+        timestamp: t + 10,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "newer-err",
+        type: "error",
+        message: "Newer error",
+        timestamp: t + 5,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "older-warn",
+        type: "warning",
+        message: "Old warning",
+        timestamp: t,
+        seenAsToast: false,
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const pinned = screen.getByTestId("needs-attention-section");
+    const messages = within(pinned).getAllByText(/^(Newer|Old) (error|warning)$/);
+    // Error first (severity 3), then newer warning, then older warning (sev 2 by recency).
+    expect(messages.map((n) => n.textContent)).toEqual([
+      "Newer error",
+      "Newer warning",
+      "Old warning",
+    ]);
+  });
+});
+
+describe("NotificationCenter — Group by context toggle", () => {
+  it("does not render the toggle when there are no entries", () => {
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByLabelText("Group by project or worktree")).toBeNull();
+  });
+
+  it("renders the toggle when entries exist", () => {
+    setEntries([makeEntry()]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.getByLabelText("Group by project or worktree")).toBeTruthy();
+  });
+
+  it("clicking the toggle flips groupByContext optimistically", async () => {
+    setEntries([makeEntry()]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const toggle = screen.getByLabelText("Group by project or worktree");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
+
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    expect(useNotificationSettingsStore.getState().groupByContext).toBe(true);
+    expect(screen.getByLabelText("Group by project or worktree").getAttribute("aria-pressed")).toBe(
+      "true"
+    );
+  });
+
+  it("renders context section headers with worktree names when groupByContext is on", () => {
+    worktreeStoreMock.worktrees.set("wt-1", { worktreeId: "wt-1", name: "feature/login" });
+    worktreeStoreMock.worktrees.set("wt-2", { worktreeId: "wt-2", name: "feature/billing" });
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    setEntries([
+      makeEntry({ message: "Login msg", context: { worktreeId: "wt-1" } }),
+      makeEntry({ id: "entry-99", message: "Billing msg", context: { worktreeId: "wt-2" } }),
+      makeEntry({
+        id: "entry-100",
+        message: "Stray msg",
+        context: { projectId: "proj-x" },
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const headers = screen.getAllByTestId("context-section-header");
+    expect(headers.map((h) => h.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining("feature/login")])
+    );
+    expect(headers.map((h) => h.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining("feature/billing")])
+    );
+    // Falls back to projectId when worktreeId is absent.
+    expect(headers.map((h) => h.textContent)).toEqual(
+      expect.arrayContaining([expect.stringContaining("proj-x")])
+    );
+  });
+
+  it("falls back to raw worktreeId when no name is registered", () => {
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    setEntries([makeEntry({ message: "Stray", context: { worktreeId: "wt-unknown" } })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    // No worktree mock entry → falls through to projectId (none) → "Other".
+    const header = screen.getByTestId("context-section-header");
+    expect(header.textContent).toContain("Other");
+  });
+
+  it("does not render context headers when groupByContext is off", () => {
+    setEntries([
+      makeEntry({ message: "msg-1", context: { worktreeId: "wt-1" } }),
+      makeEntry({ id: "entry-99", message: "msg-2", context: { worktreeId: "wt-2" } }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("context-section-header")).toBeNull();
+  });
+});
+
+describe("NotificationCenter — New since you last looked divider", () => {
+  it("does not render when lastClosedAt is 0 (cold session)", () => {
+    setEntries([makeEntry({ message: "Recent msg" })]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByTestId("new-since-last-looked")).toBeNull();
+  });
+
+  it("does not render when no entry is newer than lastClosedAt", () => {
+    const olderTs = Date.now() - 10_000;
+    setEntries([makeEntry({ message: "Old msg", timestamp: olderTs })]);
+    useUIStore.setState({ lastNotificationCenterClosedAt: Date.now() });
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByTestId("new-since-last-looked")).toBeNull();
+  });
+
+  it("renders the divider above the first entry whose timestamp is newer than lastClosedAt", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([
+      makeEntry({ message: "Newer 1", timestamp: closedAt + 4000 }),
+      makeEntry({ id: "entry-99", message: "Newer 2", timestamp: closedAt + 3000 }),
+      makeEntry({ id: "entry-100", message: "Older", timestamp: closedAt - 1000 }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("new-since-last-looked")).toBeTruthy();
+  });
+
+  it("clears the divider when 'Mark all read' is clicked", async () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    useNotificationHistoryStore.getState().addEntry({
+      type: "info",
+      message: "Newer",
+    });
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("new-since-last-looked")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark all read"));
+    });
+
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(0);
+    expect(screen.queryByTestId("new-since-last-looked")).toBeNull();
+  });
+});
+
+describe("uiStore — closeNotificationCenter records timestamp", () => {
+  it("sets lastNotificationCenterClosedAt to Date.now() when closing", () => {
+    useUIStore.setState({ notificationCenterOpen: true, lastNotificationCenterClosedAt: 0 });
+    const before = Date.now();
+    useUIStore.getState().closeNotificationCenter();
+    const after = Date.now();
+    expect(useUIStore.getState().notificationCenterOpen).toBe(false);
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBeGreaterThanOrEqual(before);
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBeLessThanOrEqual(after);
+  });
+
+  it("does not change the timestamp when already closed", () => {
+    useUIStore.setState({
+      notificationCenterOpen: false,
+      lastNotificationCenterClosedAt: 12345,
+    });
+    useUIStore.getState().closeNotificationCenter();
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(12345);
+  });
+
+  it("toggleNotificationCenter records timestamp only on closing transition", () => {
+    useUIStore.setState({ notificationCenterOpen: false, lastNotificationCenterClosedAt: 0 });
+    useUIStore.getState().toggleNotificationCenter();
+    expect(useUIStore.getState().notificationCenterOpen).toBe(true);
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(0);
+
+    useUIStore.getState().toggleNotificationCenter();
+    expect(useUIStore.getState().notificationCenterOpen).toBe(false);
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBeGreaterThan(0);
   });
 });

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -733,6 +733,41 @@ describe("NotificationCenter — Needs attention pinned section", () => {
     expect(messages).toHaveLength(5);
   });
 
+  it("stays consistent across All and Unread filter views for mixed read/unread threads", async () => {
+    const correlationId = "thread-mixed";
+    const t = Date.now();
+    setEntries([
+      // Newest first per store convention.
+      makeEntry({
+        id: "info-followup",
+        type: "info",
+        message: "Followup info",
+        correlationId,
+        timestamp: t + 1000,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "old-error",
+        type: "error",
+        message: "Old failure",
+        correlationId,
+        timestamp: t,
+        seenAsToast: true,
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("needs-attention-section")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Unread"));
+    });
+
+    // Pinned section uses raw entries — same group qualifies in both views.
+    expect(screen.queryByTestId("needs-attention-section")).toBeTruthy();
+  });
+
   it("sorts pinned entries by severity (error before warning) then by recency", () => {
     const t = Date.now();
     setEntries([
@@ -836,9 +871,35 @@ describe("NotificationCenter — Group by context toggle", () => {
 
     render(<NotificationCenter open onClose={vi.fn()} />);
 
-    // No worktree mock entry → falls through to projectId (none) → "Other".
+    // No worktree mock entry → falls through to raw worktreeId for disambiguation.
+    const header = screen.getByTestId("context-section-header");
+    expect(header.textContent).toContain("wt-unknown");
+  });
+
+  it("falls back to 'Other' only when the entry has no worktreeId or projectId", () => {
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    setEntries([makeEntry({ message: "Contextless" })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
     const header = screen.getByTestId("context-section-header");
     expect(header.textContent).toContain("Other");
+  });
+
+  it("renders distinct context sections for two unknown worktrees (no merge into one 'Other')", () => {
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    setEntries([
+      makeEntry({ id: "e1", message: "msg-1", context: { worktreeId: "wt-aaa" } }),
+      makeEntry({ id: "e2", message: "msg-2", context: { worktreeId: "wt-bbb" } }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const headers = screen.getAllByTestId("context-section-header");
+    expect(headers).toHaveLength(2);
+    const labels = headers.map((h) => h.textContent ?? "");
+    expect(labels.some((l) => l.includes("wt-aaa"))).toBe(true);
+    expect(labels.some((l) => l.includes("wt-bbb"))).toBe(true);
   });
 
   it("does not render context headers when groupByContext is off", () => {

--- a/src/store/notificationSettingsStore.ts
+++ b/src/store/notificationSettingsStore.ts
@@ -7,6 +7,7 @@ interface NotificationSettingsState {
   quietHoursStartMin: number;
   quietHoursEndMin: number;
   quietHoursWeekdays: number[];
+  groupByContext: boolean;
   // Reactive mirror of session-mute timestamp (epoch ms). Drives toolbar
   // DND indicator. In-memory only — meaningless across restarts.
   quietUntil: number;
@@ -16,6 +17,7 @@ interface NotificationSettingsState {
   setQuietHoursStartMin(value: number): void;
   setQuietHoursEndMin(value: number): void;
   setQuietHoursWeekdays(value: number[]): void;
+  setGroupByContext(value: boolean): void;
   setQuietUntil(ts: number): void;
 }
 
@@ -26,6 +28,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
   quietHoursStartMin: 22 * 60,
   quietHoursEndMin: 8 * 60,
   quietHoursWeekdays: [],
+  groupByContext: false,
   quietUntil: 0,
 
   async hydrate() {
@@ -43,6 +46,7 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
           quietHoursWeekdays: Array.isArray(settings.quietHoursWeekdays)
             ? settings.quietHoursWeekdays
             : [],
+          groupByContext: settings.groupByContext === true,
         });
       }
     } catch {
@@ -94,6 +98,14 @@ export const useNotificationSettingsStore = create<NotificationSettingsState>((s
     set({ quietHoursWeekdays: cleaned });
     window.electron?.notification?.setSettings({ quietHoursWeekdays: cleaned }).catch(() => {
       set({ quietHoursWeekdays: prev });
+    });
+  },
+
+  setGroupByContext(value: boolean) {
+    const prev = get().groupByContext;
+    set({ groupByContext: value });
+    window.electron?.notification?.setSettings({ groupByContext: value }).catch(() => {
+      set({ groupByContext: prev });
     });
   },
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -10,6 +10,12 @@ interface UIState {
   openNotificationCenter: () => void;
   closeNotificationCenter: () => void;
   toggleNotificationCenter: () => void;
+  // Epoch ms recorded when the notification center was last closed. Used by
+  // the "New since you last looked" divider to mark entries arriving after
+  // the user's most recent visit. In-memory only — a fresh session starts
+  // at 0 (no divider until the first close).
+  lastNotificationCenterClosedAt: number;
+  resetNotificationCenterLastClosedAt: () => void;
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
@@ -37,11 +43,16 @@ export const useUIStore = create<UIState>((set, get) => ({
   hasOpenOverlays: () => get().overlayClaims.size > 0,
 
   notificationCenterOpen: false,
+  lastNotificationCenterClosedAt: 0,
   openNotificationCenter: () => {
     useNotificationHistoryStore.getState().resetEvictedCount();
     set({ notificationCenterOpen: true });
   },
-  closeNotificationCenter: () => set({ notificationCenterOpen: false }),
+  closeNotificationCenter: () =>
+    set((state) => {
+      if (!state.notificationCenterOpen) return state;
+      return { notificationCenterOpen: false, lastNotificationCenterClosedAt: Date.now() };
+    }),
   toggleNotificationCenter: () =>
     set((state) => {
       const next = !state.notificationCenterOpen;
@@ -49,7 +60,9 @@ export const useUIStore = create<UIState>((set, get) => ({
       // should not silently zero an unread arrival counter.
       if (next) {
         useNotificationHistoryStore.getState().resetEvictedCount();
+        return { notificationCenterOpen: next };
       }
-      return { notificationCenterOpen: next };
+      return { notificationCenterOpen: next, lastNotificationCenterClosedAt: Date.now() };
     }),
+  resetNotificationCenterLastClosedAt: () => set({ lastNotificationCenterClosedAt: 0 }),
 }));


### PR DESCRIPTION
## Summary

- Adds a **Needs attention** pinned section at the top of the bell drawer — unread thread groups whose worst severity is `error` or `warning`, capped at 5, sorted by severity then recency. Computed from raw entries so it stays consistent across All/Unread filter views and collapses to nothing when clear.
- Adds a **group-by-context toggle** (Layers icon in the header) that partitions the chrono stream by `worktreeId` / `projectId`. Worktree names resolved via `useWorktreeStore`, falls back to raw IDs. Persisted via the existing `notificationSettings` IPC.
- Adds a **"New since you last looked" divider** above the first entry newer than `uiStore.lastNotificationCenterClosedAt`, recorded on close. Zeroed by Mark all read.

Resolves #6840

## Changes

- `NotificationCenter.tsx` — pinned section, group headers, delta divider, toggle button
- `uiStore.ts` — `lastNotificationCenterClosedAt` field + update action
- `notificationSettingsStore.ts` — `groupByContext` boolean setting
- `electron/store.ts` + `notifications.ts` + `shared/types/ipc/api.ts` — setting persistence
- `NotificationCenter.test.tsx` — 29 new tests (48 total in the file), all passing

## Testing

- 48 `NotificationCenter` tests + 1583 across notification/store directories — all green
- Typecheck, lint, and format clean