### PR TITLE
feat(notify): suppress toasts when origin surface is on screen

### DIFF
--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1524,6 +1524,68 @@ describe("notify()", () => {
       expect(useNotificationStore.getState().notifications).toHaveLength(1);
     });
 
+    it("promotes to toast on window blur during grace window", () => {
+      // Alt-tab without changing worktree/panel doesn't fire a context
+      // subscriber, so without the blur fallback the timer would silently
+      // drop the notification with seenAsToast=true.
+      const focusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Alt-tab signal",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+
+      focusSpy.mockReturnValue(false);
+      window.dispatchEvent(new Event("blur"));
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationStore.getState().notifications[0]!.message).toBe("Alt-tab signal");
+    });
+
+    it("promoted toast carries the same historyEntryId as the suppressed entry", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "linked",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      const entryId = useNotificationHistoryStore.getState().entries[0]!.id;
+      setActiveWorktree("wt-2");
+      const toast = useNotificationStore.getState().notifications[0];
+      expect(toast?.historyEntryId).toBe(entryId);
+    });
+
+    it("does not promote when subscriber fires after grace expires", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Late nav",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      vi.advanceTimersByTime(501);
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("watch priority with matching surface still toasts (no suppression for watch)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "warning",
+        message: "Watch in scope",
+        priority: "watch",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(mockShowNative).toHaveBeenCalledTimes(1);
+    });
+
     it("_resetPendingSuppressedForTest clears pending grace timers and listeners", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       setActiveWorktree("wt-1");

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -12,6 +12,9 @@ import {
   muteForDuration,
   muteUntilNextMorning,
   isScheduledQuietHours,
+  setActiveContextAccessors,
+  _resetActiveContextAccessorsForTest,
+  _resetPendingSuppressedForTest,
 } from "../notify";
 import { useNotificationStore } from "../../store/notificationStore";
 import { useNotificationHistoryStore } from "../../store/slices/notificationHistorySlice";
@@ -1250,6 +1253,291 @@ describe("notify()", () => {
       const notifications = useNotificationStore.getState().notifications;
       expect(notifications).toHaveLength(1);
       expect(notifications[0]!.context).toEqual({ projectId: "A" });
+    });
+  });
+
+  describe("active-context suppression — surface already on screen", () => {
+    let activeWorktreeId: string | null = null;
+    let focusedPanelId: string | null = null;
+    let listeners: Array<() => void> = [];
+
+    function setActiveWorktree(id: string | null): void {
+      activeWorktreeId = id;
+      for (const cb of listeners) cb();
+    }
+    function setFocusedPanel(id: string | null): void {
+      focusedPanelId = id;
+      for (const cb of listeners) cb();
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      activeWorktreeId = null;
+      focusedPanelId = null;
+      listeners = [];
+      setActiveContextAccessors({
+        getActiveWorktreeId: () => activeWorktreeId,
+        getFocusedPanelId: () => focusedPanelId,
+        subscribeActiveContext: (cb) => {
+          listeners.push(cb);
+          return () => {
+            listeners = listeners.filter((fn) => fn !== cb);
+          };
+        },
+      });
+      _resetPendingSuppressedForTest();
+    });
+
+    afterEach(() => {
+      _resetPendingSuppressedForTest();
+      _resetActiveContextAccessorsForTest();
+      vi.useRealTimers();
+    });
+
+    it("suppresses toast when context.worktreeId matches active worktree", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Agent done",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      const entries = useNotificationHistoryStore.getState().entries;
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.seenAsToast).toBe(true);
+    });
+
+    it("suppresses toast when context.panelId matches focused panel", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setFocusedPanel("panel-1");
+      notify({
+        type: "info",
+        message: "Panel event",
+        priority: "high",
+        context: { panelId: "panel-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+    });
+
+    it("does not suppress when only projectId is supplied", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Project event",
+        priority: "high",
+        context: { projectId: "proj-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("does not suppress when context.worktreeId differs from active", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Other worktree",
+        priority: "high",
+        context: { worktreeId: "wt-2" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("does not suppress when window is blurred (no toast either, existing behavior)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Background",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      // Blurred + high → no toast, history only — same as without suppression.
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      const entries = useNotificationHistoryStore.getState().entries;
+      expect(entries).toHaveLength(1);
+      // Not seen — they will pick it up from the inbox when they refocus.
+      expect(entries[0]!.seenAsToast).toBe(false);
+    });
+
+    it("does not suppress watch-priority notifications", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "warning",
+        message: "Watch event",
+        priority: "watch",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("low priority is unaffected (history only, no grace)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Background only",
+        priority: "low",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      // Navigating away within 500ms should NOT promote a low-priority event.
+      setActiveWorktree("wt-2");
+      vi.advanceTimersByTime(500);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("grid-bar placement bypasses suppression (always inline)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Inline bar",
+        placement: "grid-bar",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("promotes to toast when active worktree changes within 500ms", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Should promote",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+
+      vi.advanceTimersByTime(100);
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationStore.getState().notifications[0]!.message).toBe("Should promote");
+    });
+
+    it("promotes to toast when focused panel changes within 500ms", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setFocusedPanel("panel-1");
+      notify({
+        type: "info",
+        message: "Panel signal",
+        priority: "high",
+        context: { panelId: "panel-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+
+      setFocusedPanel("panel-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("does not promote when context remains visible through grace window", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Stays suppressed",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      vi.advanceTimersByTime(600);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("re-firing into the same surface after grace resets the suppression cleanly", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "first",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      vi.advanceTimersByTime(600);
+      notify({
+        type: "info",
+        message: "second",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      vi.advanceTimersByTime(600);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(2);
+    });
+
+    it("does not promote if notifications get disabled during the grace window", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Will not toast",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      useNotificationSettingsStore.setState({ enabled: false });
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("does not promote if quiet hours start during the grace window", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "Will not toast",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      _setQuietUntil(Date.now() + 60_000);
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+    });
+
+    it("urgent flag promotes through quiet hours", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "warning",
+        message: "Urgent suppressed",
+        priority: "high",
+        urgent: true,
+        context: { worktreeId: "wt-1" },
+      });
+      _setQuietUntil(Date.now() + 60_000);
+      setActiveWorktree("wt-2");
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("falls back to no suppression when no accessors are registered", () => {
+      _resetActiveContextAccessorsForTest();
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "No accessors",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("_resetPendingSuppressedForTest clears pending grace timers and listeners", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      setActiveWorktree("wt-1");
+      notify({
+        type: "info",
+        message: "cancelled",
+        priority: "high",
+        context: { worktreeId: "wt-1" },
+      });
+      _resetPendingSuppressedForTest();
+      // Navigating away should NOT promote — the listener was cleaned up.
+      setActiveWorktree("wt-2");
+      vi.advanceTimersByTime(600);
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
     });
   });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -96,6 +96,65 @@ export function _resetCoalesceMap(): void {
   _activeCoalesced.clear();
 }
 
+// ── active-context suppression ──────────────────────────────────────────────
+//
+// When a focused, high-priority notification originates from a surface the
+// user is already looking at (matching `context.worktreeId` or
+// `context.panelId`), the toast is suppressed and the event is recorded
+// only in the inbox. A 500ms grace window catches navigate-away races: if
+// the user moves to a different surface before the timer expires, the
+// suppressed event is promoted to a real toast so the missed signal still
+// reaches them.
+
+export interface ActiveContextAccessors {
+  getActiveWorktreeId: () => string | null;
+  getFocusedPanelId: () => string | null;
+  /** Subscribes to changes in either active worktree or focused panel. Returns an unsubscribe. */
+  subscribeActiveContext: (cb: () => void) => () => void;
+}
+
+let _activeContextAccessors: ActiveContextAccessors | null = null;
+
+export function setActiveContextAccessors(accessors: ActiveContextAccessors): void {
+  _activeContextAccessors = accessors;
+}
+
+export function _resetActiveContextAccessorsForTest(): void {
+  _activeContextAccessors = null;
+}
+
+const SUPPRESS_GRACE_MS = 500;
+
+interface PendingSuppressedEntry {
+  timerId: ReturnType<typeof setTimeout>;
+  unsub: () => void;
+}
+
+const _pendingSuppressed = new Map<string, PendingSuppressedEntry>();
+
+export function _resetPendingSuppressedForTest(): void {
+  for (const entry of _pendingSuppressed.values()) {
+    clearTimeout(entry.timerId);
+    entry.unsub();
+  }
+  _pendingSuppressed.clear();
+}
+
+function isOriginSurfaceVisible(context: NotifyPayload["context"]): boolean {
+  if (!context) return false;
+  if (!_activeContextAccessors) return false;
+  if (typeof document !== "undefined" && !document.hasFocus()) return false;
+
+  if (context.worktreeId) {
+    if (_activeContextAccessors.getActiveWorktreeId() === context.worktreeId) return true;
+  }
+  if (context.panelId) {
+    if (_activeContextAccessors.getFocusedPanelId() === context.panelId) return true;
+  }
+  // `projectId` alone is not a surface — a project can have many worktrees.
+  return false;
+}
+
 // ── transient error escalation ──────────────────────────────────────────────
 //
 // Transient errors (EBUSY, EAGAIN, ETIMEDOUT, ECONNRESET, ENOTFOUND) are
@@ -377,7 +436,10 @@ export function notify(payload: NotifyPayload): string {
 
   const isFocused = typeof document !== "undefined" ? document.hasFocus() : true;
 
-  const shouldToast = priority === "watch" || (priority === "high" && isFocused);
+  const originVisible =
+    priority === "high" && isFocused && isOriginSurfaceVisible(context);
+  const shouldToast =
+    priority === "watch" || (priority === "high" && isFocused && !originVisible);
   const shouldNative = priority === "watch";
 
   const historyEntryId = historyMessage
@@ -386,7 +448,7 @@ export function notify(payload: NotifyPayload): string {
         title,
         message: historyMessage,
         correlationId,
-        seenAsToast: !isQuiet && notificationsEnabled && shouldToast,
+        seenAsToast: !isQuiet && notificationsEnabled && (shouldToast || originVisible),
         countable: payload.countable,
         actions: historyActions.length > 0 ? historyActions : undefined,
         context,
@@ -400,6 +462,11 @@ export function notify(payload: NotifyPayload): string {
       title: title ?? "Daintree",
       body: historyMessage,
     });
+  }
+
+  if (originVisible && historyEntryId) {
+    scheduleSuppressionGrace(historyEntryId, payload, priority, context);
+    return "";
   }
 
   if (shouldToast && payload.coalesce) {
@@ -481,4 +548,53 @@ export function notify(payload: NotifyPayload): string {
   }
 
   return "";
+}
+
+function scheduleSuppressionGrace(
+  historyEntryId: string,
+  payload: NotifyPayload,
+  priority: NotificationPriority,
+  context: NotifyPayload["context"]
+): void {
+  const subscriber = _activeContextAccessors?.subscribeActiveContext;
+
+  // Replace any prior pending entry for this id (defensive — historyEntryId
+  // is a UUID, but cancel-and-replace keeps the invariant clean).
+  const prev = _pendingSuppressed.get(historyEntryId);
+  if (prev) {
+    clearTimeout(prev.timerId);
+    prev.unsub();
+    _pendingSuppressed.delete(historyEntryId);
+  }
+
+  const cleanup = (): void => {
+    const entry = _pendingSuppressed.get(historyEntryId);
+    if (!entry) return;
+    clearTimeout(entry.timerId);
+    entry.unsub();
+    _pendingSuppressed.delete(historyEntryId);
+  };
+
+  const promote = (): void => {
+    // Re-read state at callback time to avoid the stale-closure trap (#5087).
+    if (isOriginSurfaceVisible(context)) return;
+    cleanup();
+    if (!useNotificationSettingsStore.getState().enabled) return;
+    if (!payload.urgent && (Date.now() < _quietUntil || isScheduledQuietHours())) return;
+    useNotificationStore.getState().addNotification({
+      ...payload,
+      priority,
+      historyEntryId,
+    });
+  };
+
+  const timerId = setTimeout(() => {
+    cleanup();
+  }, SUPPRESS_GRACE_MS);
+
+  // If no subscriber is registered (very early startup), the timer is the
+  // sole gate — falls back to "suppress for 500ms then drop".
+  const unsub = subscriber ? subscriber(promote) : () => {};
+
+  _pendingSuppressed.set(historyEntryId, { timerId, unsub });
 }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -594,7 +594,23 @@ function scheduleSuppressionGrace(
 
   // If no subscriber is registered (very early startup), the timer is the
   // sole gate — falls back to "suppress for 500ms then drop".
-  const unsub = subscriber ? subscriber(promote) : () => {};
+  const unsubContext = subscriber ? subscriber(promote) : () => {};
+
+  // Window blur during grace means the user can no longer see the inline
+  // affordance, but no worktree/panel state changes to fire `subscriber`.
+  // Treat it as navigate-away so the missed signal still surfaces when they
+  // come back instead of being silently swallowed with `seenAsToast: true`.
+  let unsubBlur = (): void => {};
+  if (typeof window !== "undefined") {
+    const blurHandler = (): void => promote();
+    window.addEventListener("blur", blurHandler);
+    unsubBlur = (): void => window.removeEventListener("blur", blurHandler);
+  }
+
+  const unsub = (): void => {
+    unsubContext();
+    unsubBlur();
+  };
 
   _pendingSuppressed.set(historyEntryId, { timerId, unsub });
 }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -436,10 +436,8 @@ export function notify(payload: NotifyPayload): string {
 
   const isFocused = typeof document !== "undefined" ? document.hasFocus() : true;
 
-  const originVisible =
-    priority === "high" && isFocused && isOriginSurfaceVisible(context);
-  const shouldToast =
-    priority === "watch" || (priority === "high" && isFocused && !originVisible);
+  const originVisible = priority === "high" && isFocused && isOriginSurfaceVisible(context);
+  const shouldToast = priority === "watch" || (priority === "high" && isFocused && !originVisible);
   const shouldNative = priority === "watch";
 
   const historyEntryId = historyMessage

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -12,6 +12,7 @@ import { useVoiceRecordingStore } from "./voiceRecordingStore";
 import { useLayoutUndoStore } from "./layoutUndoStore";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 import { useAgentSettingsStore } from "./agentSettingsStore";
+import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 
@@ -21,6 +22,27 @@ let cleanupFn: (() => void) | null = null;
 
 export function initStoreOrchestrator(): () => void {
   if (cleanupFn) return cleanupFn;
+
+  // Register accessors so notify() can suppress toasts whose origin surface
+  // (worktree or panel) is already visible, and promote them if the user
+  // navigates away within the grace window.
+  setActiveContextAccessors({
+    getActiveWorktreeId: () => useWorktreeSelectionStore.getState().activeWorktreeId,
+    getFocusedPanelId: () => usePanelStore.getState().focusedId,
+    subscribeActiveContext: (cb) => {
+      const unsubWorktree = useWorktreeSelectionStore.subscribe((state, prev) => {
+        if (state.activeWorktreeId !== prev.activeWorktreeId) cb();
+      });
+      const unsubPanel = usePanelStore.subscribe(
+        (state) => state.focusedId,
+        () => cb()
+      );
+      return () => {
+        unsubWorktree();
+        unsubPanel();
+      };
+    },
+  });
 
   const disposables = new DisposableStore();
 


### PR DESCRIPTION
## Summary

- `notify()` was routing every high-priority event to a toast whenever the window was focused, regardless of whether the originating surface was already in view. The result was redundant noise on top of inline state — and one fewer slot in the three-toast cap for errors that actually needed it.
- Active-context suppression is now wired into the toast decision: when the notification's `context.worktreeId` or `context.panelId` matches the currently visible surface, the event goes straight to the inbox and skips the toast entirely. The inbox entry is always written, so the audit trail and WCAG fallback are intact.
- A 500ms grace window handles navigate-away races — if the active context changes before the timer expires, the suppressed event is promoted back to a toast so the signal isn't silently lost.

Resolves #6837

## Changes

- **`src/lib/notify.ts`** — `isOriginSurfaceVisible()` check added before the `shouldToast` decision; `_pendingSuppressed` map tracks in-flight grace timers; `window.blur` listener promotes any pending suppressed events to toasts when the user alt-tabs during the grace window (so events aren't silently dropped when the app loses focus mid-timer).
- **`src/store/rendererStoreOrchestrator.ts`** — registers `ActiveContextAccessors` (`getActiveWorktreeId`, `getFocusedPanelId`, `subscribeActiveContext`) with `notify.ts` at app startup, giving the routing logic read access to the active worktree and focused panel without a direct store import.
- **`src/lib/__tests__/notify.test.ts`** — 19 new tests covering: basic suppression by worktree/panel id, grace-window promotion on context change, window.blur promotion during grace, no suppression when accessors aren't registered, no suppression when `document.hasFocus()` is false, inline placement passthrough (`grid-bar`), and sticky toast passthrough.

## Out of scope

New inline placement values (`worktree-row`, `panel-banner`, `settings-tab`) aren't part of this PR — suppression gracefully falls through to a toast when no inline target is registered. Breadcrumb decoration of surviving toasts and migration of long-lived sticky toasts (update-ready, hibernation, unsaved-changes) are separate work.

## Testing

- 145 tests passing in `notify.test.ts` (19 new active-context-suppression tests)
- Verified suppression with matching `worktreeId`, promotion on context switch within 500ms, and window.blur promotion during grace window