### PR TITLE
fix(ui): scale Radix overlays from their trigger anchor instead of center

### DIFF
--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -28,6 +28,15 @@ const UI_DURATION_CLASSES = [
   "data-[state=closed]:duration-[120ms]",
 ];
 
+const TRANSFORM_ORIGIN_VARS: Record<string, string> = {
+  popover: "var(--radix-popover-content-transform-origin)",
+  dropdownContent: "var(--radix-dropdown-menu-content-transform-origin)",
+  dropdownSubContent: "var(--radix-dropdown-menu-content-transform-origin)",
+  contextContent: "var(--radix-context-menu-content-transform-origin)",
+  contextSubContent: "var(--radix-context-menu-content-transform-origin)",
+  select: "var(--radix-select-content-transform-origin)",
+};
+
 const TOOLTIP_CLASSES = [
   "animate-in",
   "fade-in-0",
@@ -74,6 +83,7 @@ describe("Radix overlay animation classes — runtime render", () => {
     );
     expectAllInString(el.className, ENTER_EXIT_CLASSES, "PopoverContent");
     expectAllInString(el.className, UI_DURATION_CLASSES, "PopoverContent");
+    expect(el.style.transformOrigin).toBe(TRANSFORM_ORIGIN_VARS.popover);
   });
 
   it("DropdownMenuContent renders with full enter/exit class set and UI durations", () => {
@@ -88,6 +98,7 @@ describe("Radix overlay animation classes — runtime render", () => {
     const el = assertHTMLElement(document.querySelector("[role='menu']"), "DropdownMenuContent");
     expectAllInString(el.className, ENTER_EXIT_CLASSES, "DropdownMenuContent");
     expectAllInString(el.className, UI_DURATION_CLASSES, "DropdownMenuContent");
+    expect(el.style.transformOrigin).toBe(TRANSFORM_ORIGIN_VARS.dropdownContent);
   });
 
   it("DropdownMenuSubContent renders with full enter/exit class set and UI durations", () => {
@@ -108,6 +119,23 @@ describe("Radix overlay animation classes — runtime render", () => {
     const sub = assertHTMLElement(menus[menus.length - 1], "DropdownMenuSubContent");
     expectAllInString(sub.className, ENTER_EXIT_CLASSES, "DropdownMenuSubContent");
     expectAllInString(sub.className, UI_DURATION_CLASSES, "DropdownMenuSubContent");
+    expect(sub.style.transformOrigin).toBe(TRANSFORM_ORIGIN_VARS.dropdownSubContent);
+  });
+
+  it("PopoverContent respects caller-provided transformOrigin override", () => {
+    render(
+      <PopoverPrimitive.Root open>
+        <PopoverPrimitive.Trigger>trigger</PopoverPrimitive.Trigger>
+        <PopoverContent forceMount style={{ transformOrigin: "center" } as React.CSSProperties}>
+          content
+        </PopoverContent>
+      </PopoverPrimitive.Root>
+    );
+    const el = assertHTMLElement(
+      document.querySelector("[data-radix-popper-content-wrapper] > *"),
+      "PopoverContent"
+    );
+    expect(el.style.transformOrigin).toBe("center");
   });
 });
 
@@ -116,6 +144,7 @@ describe("Radix overlay animation classes — wrapper source", () => {
     const src = readWrapperSource("popover.tsx");
     expectAllInString(src, ENTER_EXIT_CLASSES, "popover.tsx");
     expectAllInString(src, UI_DURATION_CLASSES, "popover.tsx");
+    expect(src).toContain("var(--radix-popover-content-transform-origin)");
   });
 
   it("dropdown-menu.tsx contains the full enter/exit set and UI durations on Content and SubContent", () => {
@@ -124,6 +153,9 @@ describe("Radix overlay animation classes — wrapper source", () => {
     expectAllInString(src, UI_DURATION_CLASSES, "dropdown-menu.tsx");
     const occurrences = src.split("data-[state=open]:duration-200").length - 1;
     expect(occurrences, "duration-200 must appear on both Content and SubContent").toBe(2);
+    const originOccurrences =
+      src.split("var(--radix-dropdown-menu-content-transform-origin)").length - 1;
+    expect(originOccurrences, "transformOrigin must appear on both Content and SubContent").toBe(2);
   });
 
   it("context-menu.tsx contains the full enter/exit set and UI durations on Content and SubContent", () => {
@@ -132,12 +164,16 @@ describe("Radix overlay animation classes — wrapper source", () => {
     expectAllInString(src, UI_DURATION_CLASSES, "context-menu.tsx");
     const occurrences = src.split("data-[state=open]:duration-200").length - 1;
     expect(occurrences, "duration-200 must appear on both Content and SubContent").toBe(2);
+    const originOccurrences =
+      src.split("var(--radix-context-menu-content-transform-origin)").length - 1;
+    expect(originOccurrences, "transformOrigin must appear on both Content and SubContent").toBe(2);
   });
 
   it("select.tsx contains the full enter/exit set and UI durations", () => {
     const src = readWrapperSource("select.tsx");
     expectAllInString(src, ENTER_EXIT_CLASSES, "select.tsx");
     expectAllInString(src, UI_DURATION_CLASSES, "select.tsx");
+    expect(src).toContain("var(--radix-select-content-transform-origin)");
   });
 
   it("tooltip.tsx contains palette enter/exit set with palette durations", () => {

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -38,7 +38,7 @@ ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, sideOffset = 4, collisionPadding = 8, children, ...props }, ref) => {
+>(({ className, sideOffset = 4, collisionPadding = 8, children, style, ...props }, ref) => {
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
   return (
     <ContextMenuPrimitive.Portal>
@@ -46,6 +46,7 @@ const ContextMenuSubContent = React.forwardRef<
         ref={shadowRef}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
+        style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -65,13 +66,14 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, collisionPadding = 8, children, ...props }, ref) => {
+>(({ className, collisionPadding = 8, children, style, ...props }, ref) => {
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
   return (
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         ref={shadowRef}
         collisionPadding={collisionPadding}
+        style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -38,7 +38,7 @@ DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayNam
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, sideOffset = 4, collisionPadding = 8, children, ...props }, ref) => {
+>(({ className, sideOffset = 4, collisionPadding = 8, children, style, ...props }, ref) => {
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
   return (
     <DropdownMenuPrimitive.Portal>
@@ -46,6 +46,7 @@ const DropdownMenuSubContent = React.forwardRef<
         ref={shadowRef}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
+        style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -65,13 +66,14 @@ DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayNam
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, children, ...props }, ref) => {
+>(({ className, sideOffset = 4, children, style, ...props }, ref) => {
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         ref={shadowRef}
         sideOffset={sideOffset}
+        style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -34,7 +34,7 @@ const PopoverAnchor = PopoverPrimitive.Anchor;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, collisionBoundary, ...props }, ref) => {
+>(({ className, align = "center", sideOffset = 4, collisionBoundary, style, ...props }, ref) => {
   const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
 
   React.useEffect(() => {
@@ -48,6 +48,7 @@ const PopoverContent = React.forwardRef<
         align={align}
         sideOffset={sideOffset}
         collisionBoundary={collisionBoundary ?? boundary ?? undefined}
+        style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
         className={cn(
           "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -64,7 +64,7 @@ const SelectContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(
   (
-    { className, children, position = "popper", sideOffset = 4, onEscapeKeyDown, ...props },
+    { className, children, position = "popper", sideOffset = 4, onEscapeKeyDown, style, ...props },
     ref
   ) => (
     <SelectPrimitive.Portal>
@@ -76,6 +76,7 @@ const SelectContent = React.forwardRef<
           event.stopPropagation();
           onEscapeKeyDown?.(event);
         }}
+        style={{ transformOrigin: "var(--radix-select-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",


### PR DESCRIPTION
## Summary
This adds `transformOrigin` to the Radix `Content` and `SubContent` wrappers so overlays scale from their trigger anchor rather than from the center. Uses Radix's built-in `--radix-<primitive>-content-transform-origin` CSS variable, which resolves automatically to the correct trigger-anchored origin.

Resolves #6830

## Changes
- Added inline `transformOrigin` consuming `--radix-*-content-transform-origin` to `Content`/`SubContent` wrappers in `dropdown-menu.tsx`, `popover.tsx`, `context-menu.tsx`, and `select.tsx`
- Consumer-supplied `style.transformOrigin` wins via spread-merge order

## Testing
9 assertions passing across runtime behavior, source-code structure, and override precedence checks.