### PR TITLE
fix(settings): drop redundant priority:low notify() calls across three tabs

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -5,7 +5,7 @@ import { cliAvailabilityClient } from "@/clients";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { logError } from "@/utils/logger";
-import { notify } from "@/lib/notify";
+
 import { Button } from "@/components/ui/button";
 import {
   DEFAULT_AGENT_SETTINGS,
@@ -96,12 +96,6 @@ export function AgentSettings({
       await fetchCliDetails();
     } catch (error) {
       logError("[AgentSettings] Failed to refresh CLI availability", error);
-      notify({
-        type: "error",
-        title: "CLI refresh failed",
-        message: "Couldn't refresh agent availability. Try again.",
-        priority: "low",
-      });
     }
   }, [isRefreshingCli, refreshCliAvailability, fetchCliDetails]);
 
@@ -136,12 +130,6 @@ export function AgentSettings({
       setAddDialogAgentId(null);
     } catch (error) {
       logError("[AgentSettings] Failed to create preset", error);
-      notify({
-        type: "error",
-        title: "Preset creation failed",
-        message: "Couldn't save the new preset. Try again.",
-        priority: "low",
-      });
     }
   };
 

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -18,7 +18,7 @@ import { SettingsInput } from "./SettingsInput";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { notify } from "@/lib/notify";
+
 import { logError } from "@/utils/logger";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
@@ -98,23 +98,11 @@ export function DaintreeAssistantSettingsTab() {
       .catch((err) => {
         if (cancelled) return;
         setError(formatErrorMessage(err, "Couldn't load assistant settings"));
-        notify({
-          type: "error",
-          title: "Settings load failed",
-          message: "Couldn't load Daintree Assistant settings. The panel may be out of date.",
-          priority: "low",
-        });
         logError("Failed to load Daintree Assistant settings", err);
       });
 
     const mcpLoad = refreshStatus().catch((err) => {
       if (cancelled) return;
-      notify({
-        type: "error",
-        title: "MCP status failed",
-        message: "Couldn't load the MCP server status. The connection panel may be out of date.",
-        priority: "low",
-      });
       logError("Failed initial MCP status load for assistant tab", err);
     });
 
@@ -145,12 +133,6 @@ export function DaintreeAssistantSettingsTab() {
         await window.electron.helpAssistant.setSettings(patch);
       } catch (err) {
         setError(formatErrorMessage(err, "Couldn't save assistant settings"));
-        notify({
-          type: "error",
-          title: "Settings save failed",
-          message: "Couldn't save the change. Try again.",
-          priority: "low",
-        });
         logError("Failed to save Daintree Assistant settings", err);
       }
       // settings is intentionally read at call time via the closure; no stale risk
@@ -198,20 +180,8 @@ export function DaintreeAssistantSettingsTab() {
     try {
       const key = await window.electron.mcpServer.rotateApiKey();
       setMcpStatus((prev) => (prev ? { ...prev, apiKey: key } : prev));
-      notify({
-        type: "success",
-        title: "Key rotated",
-        message: "A new MCP API key has been generated. Update your MCP clients.",
-        priority: "low",
-      });
     } catch (err) {
       setError(formatErrorMessage(err, "Couldn't rotate key"));
-      notify({
-        type: "error",
-        title: "Key rotation failed",
-        message: "Couldn't rotate the API key. Try again.",
-        priority: "low",
-      });
       logError("Failed to rotate MCP API key", err);
     }
   }, []);

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -7,7 +7,6 @@ import { actionService } from "@/services/ActionService";
 import type { GitHubTokenConfig, GitHubTokenValidation } from "@/types";
 import { SettingsSection } from "./SettingsSection";
 import { logError } from "@/utils/logger";
-import { notify } from "@/lib/notify";
 
 type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
 
@@ -80,12 +79,6 @@ export function GitHubSettingsTab() {
       }
     } catch (error) {
       logError("Failed to save GitHub token", error);
-      notify({
-        type: "error",
-        title: "GitHub token save failed",
-        message: "Couldn't save the GitHub token. Check that the token is valid and try again.",
-        priority: "low",
-      });
       setValidationResult("error");
       setErrorMessage("Failed to save token");
     } finally {
@@ -114,12 +107,6 @@ export function GitHubSettingsTab() {
       setErrorMessage(null);
     } catch (error) {
       logError("Failed to clear GitHub token", error);
-      notify({
-        type: "error",
-        title: "GitHub token removal failed",
-        message: "Couldn't remove the GitHub token. Try again.",
-        priority: "low",
-      });
       setValidationResult("error");
       setErrorMessage("Failed to clear token");
     }
@@ -148,12 +135,6 @@ export function GitHubSettingsTab() {
       }
     } catch (error) {
       logError("Failed to test GitHub token", error);
-      notify({
-        type: "error",
-        title: "GitHub token test failed",
-        message: "Couldn't test the token. Check your network connection and try again.",
-        priority: "low",
-      });
       setValidationResult("test-error");
       setErrorMessage("Failed to validate token");
     } finally {

--- a/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
@@ -119,7 +119,7 @@ describe("GitHubSettingsTab handleSaveToken", () => {
     );
   });
 
-  it("routes IPC failure to inbox via low-priority notify alongside inline error", async () => {
+  it("shows inline error on IPC failure without firing notify", async () => {
     mockedDispatch.mockImplementation(async (actionId: string) => {
       if (actionId === "github.setToken") {
         return { ok: false, error: { message: "IPC down" } } as never;
@@ -135,15 +135,9 @@ describe("GitHubSettingsTab handleSaveToken", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save token" }));
 
     await waitFor(() => {
-      expect(mockedNotify).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "error",
-          priority: "low",
-          title: "GitHub token save failed",
-        })
-      );
+      expect(screen.getByText(/failed to save token/i)).toBeTruthy();
     });
 
-    expect(screen.getByText(/failed to save token/i)).toBeTruthy();
+    expect(mockedNotify).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Removes 10 redundant `priority: "low"` `notify()` calls across three settings tabs. Each was duplicating an inline error state already visible in the same tab.
- Updates the GitHubSettingsTab token-save test to drop assertions about the removed calls.
- Part of a broader signal-deduplication cleanup across all settings tabs.

Resolves #6843

## Changes
- **DaintreeAssistantSettingsTab** — 5 calls removed. Four error paths already paired with `setError(...)`; one "Key rotated" success fires after the new key value populates the field.
- **GitHubSettingsTab** — 3 calls removed. Each error notify paired with `setErrorMessage(...)` and `setValidationResult(...)` driving inline display.
- **AgentSettings** — 2 calls removed. Handlers for `handleRefreshCliAvailability` and `handleCreatePreset` both had inline error states covering the same signal.
- **GitHubSettingsTab.tokenSave.test.tsx** — removed assertions checking for the dropped calls.

## Testing
- TypeScript typecheck passes with zero errors.
- Existing test suite for GitHubSettingsTab token save updated and passing.