### PR TITLE
fix(toast): gate auto-dismiss cap on action presence, bump success dwell

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -482,6 +482,114 @@ describe("Toast accessibility", () => {
     expect(screen.queryByText(/msg-/)).toBeNull();
   });
 
+  it("cap does NOT apply when toast has `action` with explicit non-zero duration", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 20000,
+        message: "action-toast",
+        action: { label: "Retry", onClick: vi.fn() },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    // 16s in: a capped toast would have dismissed at 15s.
+    await act(async () => {
+      vi.advanceTimersByTime(16000);
+    });
+    expect(screen.getByText("action-toast")).toBeTruthy();
+
+    // Cross the uncapped deadline (20s * 3 = 60s is far out; but the per-update
+    // timer fires at 20s from firstShownAt).
+    await act(async () => {
+      vi.advanceTimersByTime(4500);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("action-toast")).toBeNull();
+  });
+
+  it("cap does NOT apply when toast has `actions: [...]` with explicit non-zero duration", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 20000,
+        message: "actions-toast",
+        actions: [{ label: "Undo", onClick: vi.fn() }],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(16000);
+    });
+    expect(screen.getByText("actions-toast")).toBeTruthy();
+  });
+
+  it("cap does NOT apply to action-bearing toast under coalesce pressure", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 3000,
+        message: "action-msg-0",
+        correlationId: "entity-b",
+        action: { label: "Retry", onClick: vi.fn() },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Drive four coalesces 2000ms apart. Without the cap exemption the toast
+    // would be capped at 15s from firstShownAt (~9000ms of coalesce window).
+    for (let i = 1; i <= 4; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      await act(async () => {
+        addToast({
+          duration: 3000,
+          message: `action-msg-${i}`,
+          correlationId: "entity-b",
+          action: { label: "Retry", onClick: vi.fn() },
+        });
+      });
+    }
+
+    // After ~8016ms: a capped toast would collapse delay to ~984ms and dismiss
+    // soon after. With the exemption the per-update timer resets each time.
+    expect(screen.getByText("action-msg-4")).toBeTruthy();
+
+    // Advance past the full uncapped duration from the last coalesce.
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText(/action-msg-/)).toBeNull();
+  });
+
+  it("empty actions array counts as no action, cap still applies", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 20000,
+        message: "empty-actions",
+        actions: [],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    // The cap should still apply since [] has no visible buttons.
+    await act(async () => {
+      vi.advanceTimersByTime(15100);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("empty-actions")).toBeNull();
+  });
+
   it("fires onDismiss when the user clicks the close button", async () => {
     const onDismiss = vi.fn();
     render(<Toaster />);
@@ -1197,5 +1305,134 @@ describe("Toast overflow pill (issue #6424)", () => {
     expect(screen.queryByRole("status")).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.getByTestId("toast-overflow-pill")).toBeTruthy();
+  });
+});
+
+describe("Toast success dwell — 2000ms (issue #6844)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().reset();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("success label dwells for ~2000ms before auto-dismissing (synchronous onClick)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        message: "Settings saved",
+        action: {
+          label: "Undo",
+          onClick: () => {},
+          successLabel: "Undone",
+        },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const actionButton = screen.getByText("Undo");
+    await act(async () => {
+      fireEvent.click(actionButton);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1900);
+    });
+    expect(screen.getByText("Undone")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("Undone")).toBeNull();
+  });
+
+  it("does NOT dismiss before the 2000ms dwell elapses (synchronous)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        message: "File copied",
+        action: {
+          label: "Open",
+          onClick: () => {},
+          successLabel: "Opened",
+        },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const actionButton = screen.getByText("Open");
+    await act(async () => {
+      fireEvent.click(actionButton);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.getByText("Opened")).toBeTruthy();
+  });
+
+  it("success label dwells for ~2000ms before auto-dismissing (async onClick)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        message: "Processing…",
+        action: {
+          label: "Retry",
+          onClick: () => Promise.resolve(),
+          successLabel: "Retried",
+        },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const actionButton = screen.getByText("Retry");
+    await act(async () => {
+      fireEvent.click(actionButton);
+      await Promise.resolve();
+      vi.advanceTimersByTime(16);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1900);
+    });
+    expect(screen.getByText("Retried")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("Retried")).toBeNull();
+  });
+
+  it("action without successLabel dismisses immediately on click (no dwell)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        duration: 0,
+        message: "Quick action",
+        action: { label: "Dismiss", onClick: () => {} },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const actionButton = screen.getByText("Dismiss");
+    await act(async () => {
+      fireEvent.click(actionButton);
+      vi.advanceTimersByTime(16);
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("Quick action")).toBeNull();
   });
 });

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -525,6 +525,15 @@ describe("Toast accessibility", () => {
       vi.advanceTimersByTime(16000);
     });
     expect(screen.getByText("actions-toast")).toBeTruthy();
+
+    // Past the 20s explicit duration + exit fade — dismisses on schedule.
+    await act(async () => {
+      vi.advanceTimersByTime(4200);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.queryByText("actions-toast")).toBeNull();
   });
 
   it("cap does NOT apply to action-bearing toast under coalesce pressure", async () => {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -19,6 +19,7 @@ import {
   UI_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
+  UI_ACTION_SUCCESS_DWELL_MS,
   getUiTransitionDuration,
 } from "@/lib/animationUtils";
 import {
@@ -64,11 +65,6 @@ const TYPE_ICON_CONFIG: Record<string, IconConfig> = {
  */
 const MAX_VISIBLE_DURATION_MS = 15000;
 const VISIBLE_DURATION_MULTIPLIER = 3;
-
-// How long the success state dwells visible before the toast auto-dismisses.
-// Long enough for sighted users to notice the swap; short enough not to feel
-// stuck. Mirrors the announcer's polite cadence.
-const ACTION_SUCCESS_DWELL_MS = 500;
 
 function Toast({ notification }: { notification: Notification }) {
   const { dismissNotification, removeNotification } = useNotificationStore(
@@ -196,7 +192,10 @@ function Toast({ notification }: { notification: Notification }) {
     // sticky rather than silently auto-dismissing at 0ms.
     if (!notification.duration || isPaused) return;
     const duration = notification.duration;
-    const cap = Math.min(duration * VISIBLE_DURATION_MULTIPLIER, MAX_VISIBLE_DURATION_MS);
+    const hasActions = !!(notification.action || (notification.actions?.length ?? 0) > 0);
+    const cap = hasActions
+      ? duration * VISIBLE_DURATION_MULTIPLIER
+      : Math.min(duration * VISIBLE_DURATION_MULTIPLIER, MAX_VISIBLE_DURATION_MS);
     const deadline = (notification.firstShownAt ?? Date.now()) + cap;
     const delay = Math.min(duration, Math.max(0, deadline - Date.now()));
     const timer = setTimeout(() => dismissRef.current(), delay);
@@ -325,7 +324,7 @@ function Toast({ notification }: { notification: Notification }) {
                   useAnnouncerStore.getState().announce(announcementText, "polite");
                   dwellTimerRef.current = setTimeout(() => {
                     if (mountedRef.current) dismissRef.current();
-                  }, 500);
+                  }, UI_ACTION_SUCCESS_DWELL_MS);
                 })
                 .catch(() => {
                   settled = true;
@@ -345,7 +344,7 @@ function Toast({ notification }: { notification: Notification }) {
               useAnnouncerStore.getState().announce(announcementText, "polite");
               dwellTimerRef.current = setTimeout(() => {
                 if (mountedRef.current) dismissRef.current();
-              }, ACTION_SUCCESS_DWELL_MS);
+              }, UI_ACTION_SUCCESS_DWELL_MS);
             }
           };
 

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -84,6 +84,7 @@ function Toast({ notification }: { notification: Notification }) {
   const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const busyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
 
   // While bursts of count-only updates arrive, set aria-busy on the live
@@ -100,6 +101,7 @@ function Toast({ notification }: { notification: Notification }) {
       if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current);
       if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
       if (busyTimerRef.current) clearTimeout(busyTimerRef.current);
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
     };
   }, []);
 
@@ -157,6 +159,10 @@ function Toast({ notification }: { notification: Notification }) {
       clearTimeout(spinnerTimerRef.current);
       spinnerTimerRef.current = null;
     }
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
     restoreFocus();
     // Fire onDismiss exactly once, before marking dismissed, so callers see
     // a clean user-driven signal distinct from MAX_VISIBLE_TOASTS eviction.
@@ -198,9 +204,21 @@ function Toast({ notification }: { notification: Notification }) {
       : Math.min(duration * VISIBLE_DURATION_MULTIPLIER, MAX_VISIBLE_DURATION_MS);
     const deadline = (notification.firstShownAt ?? Date.now()) + cap;
     const delay = Math.min(duration, Math.max(0, deadline - Date.now()));
-    const timer = setTimeout(() => dismissRef.current(), delay);
-    return () => clearTimeout(timer);
-  }, [notification.duration, notification.contentKey, notification.firstShownAt, isPaused]);
+    dismissTimerRef.current = setTimeout(() => dismissRef.current(), delay);
+    return () => {
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
+    };
+  }, [
+    notification.duration,
+    notification.contentKey,
+    notification.firstShownAt,
+    isPaused,
+    notification.action,
+    notification.actions,
+  ]);
 
   const accentClass = ACCENT_CLASS[notification.type] ?? "border-l-status-info";
   const { Icon, className: iconClassName } =
@@ -317,6 +335,10 @@ function Toast({ notification }: { notification: Notification }) {
                     spinnerTimerRef.current = null;
                   }
                   if (!mountedRef.current) return;
+                  if (dismissTimerRef.current) {
+                    clearTimeout(dismissTimerRef.current);
+                    dismissTimerRef.current = null;
+                  }
                   setActionStatus("success");
                   const announcementText = notification.title
                     ? `${notification.title}: ${action.successLabel}`
@@ -337,6 +359,10 @@ function Toast({ notification }: { notification: Notification }) {
                   setActiveActionIndex(null);
                 });
             } else {
+              if (dismissTimerRef.current) {
+                clearTimeout(dismissTimerRef.current);
+                dismissTimerRef.current = null;
+              }
               setActionStatus("success");
               const announcementText = notification.title
                 ? `${notification.title}: ${action.successLabel}`

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -50,6 +50,12 @@ export const UI_PALETTE_EXIT_DURATION = DURATION_100;
  *  Keep in sync with .palette-results-stale transition-delay in src/index.css. */
 export const UI_DOHERTY_THRESHOLD = 400;
 
+/** How long an action success-label swap dwells visible before the toast
+ *  auto-dismisses. Covers saccade (~200ms), lexical recognition (~300ms), and
+ *  a comprehension buffer so sighted and screen-reader users can process the
+ *  label change before the toast disappears. */
+export const UI_ACTION_SUCCESS_DWELL_MS = 2000;
+
 export const UI_TOOLTIP_DELAY_DURATION = 500;
 export const UI_TOOLTIP_SKIP_DELAY_DURATION = DURATION_150;
 


### PR DESCRIPTION
## Summary
- The 15-second auto-dismiss cap is now gated on whether the toast has an action button, so keyboard and assistive-technology users never lose access to action-bearing toasts before they can interact with them.
- The success-label dwell after clicking an action bumps from 500ms to 2000ms (`UI_ACTION_SUCCESS_DWELL_MS` in `animationUtils.ts`), giving users enough time to read the confirmation before the toast disappears.
- The auto-dismiss timer clears when an action button is clicked, so the success dwell replaces the original dismiss deadline instead of racing it.

Resolves #6844

## Changes
- New named constant `UI_ACTION_SUCCESS_DWELL_MS` (2000ms) in `src/lib/animationUtils.ts`
- Cap gate in `src/components/ui/toaster.tsx`: `MAX_VISIBLE_DURATION_MS` only applies to toasts without actions
- Timer-clear-on-click: `dismissTimerRef` cleared before starting the success dwell
- 246 lines of tests covering the cap gate, dwell timing, and timer-clear behavior

## Testing
- Unit tests in `toaster.test.tsx` verify: cap applied to non-action toasts, cap skipped for action-bearing toasts, success dwell uses 2000ms, dismiss timer cleared on action click
- Typecheck, lint, and format pass cleanly