### PR TITLE
fix(mcp): drop redundant priority:low notify() calls from MCP settings

### DIFF
--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -18,7 +18,6 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import {
   type McpAuditRecord,
@@ -77,7 +76,9 @@ export function McpServerSettingsTab() {
   const [portInput, setPortInput] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
+  const [copiedAudit, setCopiedAudit] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
   const [auditEnabled, setAuditEnabled] = useState(true);
@@ -102,12 +103,6 @@ export function McpServerSettingsTab() {
       settled = true;
       setError("Settings load timed out");
       setLoading(false);
-      notify({
-        type: "error",
-        title: "MCP status failed",
-        message: "Loading MCP server status timed out. The settings panel may be out of date.",
-        priority: "low",
-      });
       logError("MCP status load timed out");
     }, 10_000);
 
@@ -129,12 +124,6 @@ export function McpServerSettingsTab() {
       .catch((err) => {
         if (settled) return;
         setError(formatErrorMessage(err, "Failed to load MCP status"));
-        notify({
-          type: "error",
-          title: "MCP status failed",
-          message: "Couldn't load MCP server status. The settings panel may be out of date.",
-          priority: "low",
-        });
         logError("Failed to load MCP status", err);
       })
       .finally(() => {
@@ -147,6 +136,7 @@ export function McpServerSettingsTab() {
     return () => {
       clearTimeout(timer);
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
     };
   }, []);
 
@@ -157,12 +147,6 @@ export function McpServerSettingsTab() {
       setStatus(newStatus);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update MCP server"));
-      notify({
-        type: "error",
-        title: "MCP server update failed",
-        message: "Couldn't update the MCP server state. Try again.",
-        priority: "low",
-      });
       logError("Failed to update MCP server", err);
     }
   }, [status.enabled]);
@@ -175,12 +159,6 @@ export function McpServerSettingsTab() {
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to copy config"));
-      notify({
-        type: "error",
-        title: "Config copy failed",
-        message: "Couldn't copy the MCP config. The server may not be running.",
-        priority: "low",
-      });
       logError("Failed to copy MCP config", err);
     }
   }, []);
@@ -199,12 +177,6 @@ export function McpServerSettingsTab() {
       setPortInput(newStatus.configuredPort?.toString() ?? "");
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update port"));
-      notify({
-        type: "error",
-        title: "Port update failed",
-        message: "Couldn't save the port setting. Check the value and try again.",
-        priority: "low",
-      });
       logError("Failed to update MCP port", err);
     }
   }, [portInput]);
@@ -216,20 +188,8 @@ export function McpServerSettingsTab() {
       setStatus((prev) => ({ ...prev, apiKey: key }));
       setShowApiKey(true);
       setCopiedKey(false);
-      notify({
-        type: "success",
-        title: "API key rotated",
-        message: "Update any external MCP clients with the new key.",
-        priority: "low",
-      });
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to rotate API key"));
-      notify({
-        type: "error",
-        title: "API key rotation failed",
-        message: "Couldn't rotate the API key. Try again.",
-        priority: "low",
-      });
       logError("Failed to rotate MCP API key", err);
     }
   }, []);
@@ -252,13 +212,8 @@ export function McpServerSettingsTab() {
       setAuditEnabled(cfg.enabled);
       setAuditMaxRecords(cfg.maxRecords);
     } catch (err) {
+      setError(formatErrorMessage(err, "Failed to update audit logging"));
       logError("Failed to toggle MCP audit log", err);
-      notify({
-        type: "error",
-        title: "Audit log update failed",
-        message: "Couldn't update audit logging. Try again.",
-        priority: "low",
-      });
     }
   }, [auditEnabled]);
 
@@ -270,12 +225,7 @@ export function McpServerSettingsTab() {
       parsed < MCP_AUDIT_MIN_RECORDS ||
       parsed > MCP_AUDIT_MAX_RECORDS
     ) {
-      notify({
-        type: "error",
-        title: "Audit cap invalid",
-        message: `Enter a number between ${MCP_AUDIT_MIN_RECORDS} and ${MCP_AUDIT_MAX_RECORDS}.`,
-        priority: "low",
-      });
+      setError(`Enter a number between ${MCP_AUDIT_MIN_RECORDS} and ${MCP_AUDIT_MAX_RECORDS}.`);
       return;
     }
     try {
@@ -285,13 +235,8 @@ export function McpServerSettingsTab() {
       setMaxRecordsInput(cfg.maxRecords.toString());
       await refreshAuditRecords();
     } catch (err) {
+      setError(formatErrorMessage(err, "Failed to update audit cap"));
       logError("Failed to update audit cap", err);
-      notify({
-        type: "error",
-        title: "Audit cap update failed",
-        message: "Couldn't save the audit cap. Try again.",
-        priority: "low",
-      });
     }
   }, [maxRecordsInput, refreshAuditRecords]);
 
@@ -299,40 +244,21 @@ export function McpServerSettingsTab() {
     try {
       await window.electron.mcpServer.clearAuditLog();
       setAuditRecords([]);
-      notify({
-        type: "info",
-        title: "Audit log cleared",
-        message: "All recorded MCP tool dispatches were removed.",
-        priority: "low",
-      });
     } catch (err) {
+      setError(formatErrorMessage(err, "Failed to clear audit log"));
       logError("Failed to clear MCP audit log", err);
-      notify({
-        type: "error",
-        title: "Couldn't clear audit log",
-        message: "The audit log wasn't cleared. Try again.",
-        priority: "low",
-      });
     }
   }, []);
 
   const handleCopyAuditAsJson = useCallback(async (records: McpAuditRecord[]) => {
     try {
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
-      notify({
-        type: "info",
-        title: "Audit log copied",
-        message: `${records.length} record${records.length === 1 ? "" : "s"} copied as JSON.`,
-        priority: "low",
-      });
+      setCopiedAudit(true);
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+      auditCopyTimeoutRef.current = setTimeout(() => setCopiedAudit(false), 2000);
     } catch (err) {
+      setError(formatErrorMessage(err, "Failed to copy audit log"));
       logError("Failed to copy MCP audit log", err);
-      notify({
-        type: "error",
-        title: "Couldn't copy audit log",
-        message: "Clipboard access failed. Try again.",
-        priority: "low",
-      });
     }
   }, []);
 
@@ -695,12 +621,19 @@ export function McpServerSettingsTab() {
                     "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
                     filteredAuditRecords.length === 0
                       ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
-                      : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+                      : copiedAudit
+                        ? "text-status-success border-status-success/30"
+                        : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
                   )}
                 >
-                  <Copy className="w-3.5 h-3.5" />
-                  Copy {filteredAuditRecords.length === auditRecords.length ? "all" : "filtered"} as
-                  JSON
+                  {copiedAudit ? (
+                    <Check className="w-3.5 h-3.5" />
+                  ) : (
+                    <Copy className="w-3.5 h-3.5" />
+                  )}
+                  {copiedAudit
+                    ? "Copied!"
+                    : `Copy ${filteredAuditRecords.length === auditRecords.length ? "all" : "filtered"} as JSON`}
                 </button>
                 <button
                   type="button"

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -36,6 +36,8 @@ interface McpServerStatus {
 
 type AuditResultFilter = "all" | McpAuditResult;
 
+const COPY_FEEDBACK_MS = 2000;
+
 const RESULT_LABEL: Record<McpAuditResult, string> = {
   success: "Success",
   error: "Error",
@@ -260,7 +262,7 @@ export function McpServerSettingsTab() {
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
       setCopiedAudit(true);
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
-      auditCopyTimeoutRef.current = setTimeout(() => setCopiedAudit(false), 2000);
+      auditCopyTimeoutRef.current = setTimeout(() => setCopiedAudit(false), COPY_FEEDBACK_MS);
     } catch (err) {
       setCopiedAudit(false);
       if (auditCopyTimeoutRef.current) {

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -156,7 +156,8 @@ export function McpServerSettingsTab() {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
       await navigator.clipboard.writeText(snippet);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to copy config"));
       logError("Failed to copy MCP config", err);
@@ -207,6 +208,7 @@ export function McpServerSettingsTab() {
 
   const handleAuditEnabledToggle = useCallback(async () => {
     try {
+      setError(null);
       const next = !auditEnabled;
       const cfg = await window.electron.mcpServer.setAuditEnabled(next);
       setAuditEnabled(cfg.enabled);
@@ -229,6 +231,7 @@ export function McpServerSettingsTab() {
       return;
     }
     try {
+      setError(null);
       const cfg = await window.electron.mcpServer.setAuditMaxRecords(parsed);
       setAuditEnabled(cfg.enabled);
       setAuditMaxRecords(cfg.maxRecords);
@@ -242,6 +245,7 @@ export function McpServerSettingsTab() {
 
   const handleClearAuditLog = useCallback(async () => {
     try {
+      setError(null);
       await window.electron.mcpServer.clearAuditLog();
       setAuditRecords([]);
     } catch (err) {
@@ -252,11 +256,17 @@ export function McpServerSettingsTab() {
 
   const handleCopyAuditAsJson = useCallback(async (records: McpAuditRecord[]) => {
     try {
+      setError(null);
       await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
       setCopiedAudit(true);
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
       auditCopyTimeoutRef.current = setTimeout(() => setCopiedAudit(false), 2000);
     } catch (err) {
+      setCopiedAudit(false);
+      if (auditCopyTimeoutRef.current) {
+        clearTimeout(auditCopyTimeoutRef.current);
+        auditCopyTimeoutRef.current = null;
+      }
       setError(formatErrorMessage(err, "Failed to copy audit log"));
       logError("Failed to copy MCP audit log", err);
     }

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -373,11 +373,11 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByText("Copied!")).toBeTruthy();
     });
     expect(writeText).toHaveBeenCalledTimes(1);
-    const jsonArg = writeText.mock.calls[0][0] as string;
+    const jsonArg = writeText.mock.calls[0]![0] as string;
     const parsed = JSON.parse(jsonArg) as Array<{ id: string; toolId: string }>;
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].id).toBe("1");
-    expect(parsed[0].toolId).toBe("files.read");
+    expect(parsed[0]!.id).toBe("1");
+    expect(parsed[0]!.toolId).toBe("files.read");
     expect(mockedNotify).not.toHaveBeenCalled();
   });
 

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -373,11 +373,15 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByText("Copied!")).toBeTruthy();
     });
     expect(writeText).toHaveBeenCalledTimes(1);
-    const jsonArg = writeText.mock.calls[0]![0] as string;
-    const parsed = JSON.parse(jsonArg) as Array<{ id: string; toolId: string }>;
-    expect(parsed).toHaveLength(1);
-    expect(parsed[0]!.id).toBe("1");
-    expect(parsed[0]!.toolId).toBe("files.read");
+    const jsonArg = String(writeText.mock.calls[0]![0]);
+    const parsed: unknown = JSON.parse(jsonArg);
+    expect(Array.isArray(parsed)).toBe(true);
+    if (!Array.isArray(parsed)) throw new Error("expected array");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed by Array.isArray guard above
+    const arr = parsed as Array<{ id: string; toolId: string }>;
+    expect(arr).toHaveLength(1);
+    expect(arr[0]!.id).toBe("1");
+    expect(arr[0]!.toolId).toBe("files.read");
     expect(mockedNotify).not.toHaveBeenCalled();
   });
 

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -143,7 +143,7 @@ describe("McpServerSettingsTab", () => {
     expect(screen.queryByRole("button", { name: /^remove$/i })).toBeNull();
   });
 
-  it("routes IPC failure to inbox via low-priority notify and inline error", async () => {
+  it("shows inline error and logs IPC failure without notifying", async () => {
     installMcpApi({
       getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
     });
@@ -152,13 +152,7 @@ describe("McpServerSettingsTab", () => {
 
     await waitForContent(container, "IPC down");
 
-    expect(mockedNotify).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        priority: "low",
-        title: "MCP status failed",
-      })
-    );
+    expect(mockedNotify).not.toHaveBeenCalled();
     expect(mockedLogError).toHaveBeenCalledWith("Failed to load MCP status", expect.any(Error));
   });
 
@@ -261,7 +255,7 @@ describe("McpServerSettingsTab", () => {
     });
   });
 
-  it("routes toggle IPC failure to inbox while keeping inline error", async () => {
+  it("shows inline error and logs toggle failure without notifying", async () => {
     installMcpApi({
       setEnabled: vi.fn().mockRejectedValue(new Error("toggle failed")),
     });
@@ -272,13 +266,148 @@ describe("McpServerSettingsTab", () => {
     fireEvent.click(screen.getByLabelText("Enable MCP server"));
 
     await waitForContent(container, "toggle failed");
-    expect(mockedNotify).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        priority: "low",
-        title: "MCP server update failed",
-      })
-    );
+    expect(mockedNotify).not.toHaveBeenCalled();
     expect(mockedLogError).toHaveBeenCalledWith("Failed to update MCP server", expect.any(Error));
+  });
+
+  it("shows inline error for invalid audit max records instead of notifying", async () => {
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    const maxRecordsInput = container.querySelector("#mcp-audit-max-records") as HTMLInputElement;
+    fireEvent.change(maxRecordsInput, { target: { value: "99999" } });
+    fireEvent.keyDown(maxRecordsInput, { key: "Enter" });
+
+    await waitForContent(container, "Enter a number between");
+    expect(window.electron.mcpServer.setAuditMaxRecords).not.toHaveBeenCalled();
+    expect(mockedNotify).not.toHaveBeenCalled();
+    expect(mockedLogError).not.toHaveBeenCalled();
+  });
+
+  it("shows inline error and logs audit toggle failure without notifying", async () => {
+    installMcpApi({
+      setAuditEnabled: vi.fn().mockRejectedValue(new Error("audit toggle failed")),
+    });
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByRole("button", { name: /capture on/i }));
+
+    await waitForContent(container, "audit toggle failed");
+    expect(mockedNotify).not.toHaveBeenCalled();
+    expect(mockedLogError).toHaveBeenCalledWith(
+      "Failed to toggle MCP audit log",
+      expect.any(Error)
+    );
+  });
+
+  it("clears audit log without notifying", async () => {
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+      ]),
+    });
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "files.read");
+
+    fireEvent.click(screen.getByRole("button", { name: /clear log/i }));
+
+    await waitForContent(container, "No tool dispatches recorded yet.");
+    expect(mockedNotify).not.toHaveBeenCalled();
+  });
+
+  it("shows inline error and logs audit clear failure without notifying", async () => {
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+      ]),
+      clearAuditLog: vi.fn().mockRejectedValue(new Error("clear failed")),
+    });
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "files.read");
+
+    fireEvent.click(screen.getByRole("button", { name: /clear log/i }));
+
+    await waitForContent(container, "clear failed");
+    expect(mockedNotify).not.toHaveBeenCalled();
+    expect(mockedLogError).toHaveBeenCalledWith("Failed to clear MCP audit log", expect.any(Error));
+  });
+
+  it("shows Copied! pill on audit copy instead of notifying", async () => {
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+      ]),
+    });
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "files.read");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy all as json/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeTruthy();
+    });
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const jsonArg = writeText.mock.calls[0][0] as string;
+    const parsed = JSON.parse(jsonArg) as Array<{ id: string; toolId: string }>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe("1");
+    expect(parsed[0].toolId).toBe("files.read");
+    expect(mockedNotify).not.toHaveBeenCalled();
+  });
+
+  it("shows inline error and logs audit copy failure without notifying", async () => {
+    const writeTextReject = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: writeTextReject },
+      writable: true,
+      configurable: true,
+    });
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+      ]),
+    });
+
+    const { container } = render(<McpServerSettingsTab />);
+    await waitForContent(container, "files.read");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy all as json/i }));
+
+    await waitForContent(container, "clipboard denied");
+    expect(mockedNotify).not.toHaveBeenCalled();
+    expect(mockedLogError).toHaveBeenCalledWith("Failed to copy MCP audit log", expect.any(Error));
   });
 });


### PR DESCRIPTION
## Summary
- Removes redundant `priority:low` `notify()` calls from `McpServerSettingsTab`. Every success and error path was firing a notify alongside an inline error banner, inline confirmation pill, or visible state change — the inbox was getting ~14 entries per tab session.
- Wires the audit-copy button to the same `Copied!` pill pattern the sibling copy-config and copy-api-key buttons already use, the only missing piece of inline feedback.
- Clears stale errors on handler success so the inline banner doesn't linger when the next action succeeds.

Resolves #6838

## Changes
- `src/components/Settings/McpServerSettingsTab.tsx` — removed `notify()` import, dropped 14 notify calls across load, enable, port, API key, audit toggle, audit cap, audit clear, audit copy, and config copy handlers; added `copiedAudit` state + `auditCopyTimeoutRef` for the new pill; added `setError(null)` clears on handler success.
- `__tests__/McpServerSettingsTab.test.tsx` — added coverage for validation-as-error (not inbox), copied-audit pill timing, stale-error clearing, and removed assertions against now-deleted notify calls.

## Testing
- Typecheck, lint, and format pass.
- All 9 MCP settings tab tests pass.