### PR TITLE
fix(panel): polish TabButton interactions — close fade, pixel-shift, error asymmetry

### DIFF
--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -117,6 +117,9 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
       const detail = e.detail as unknown;
       if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
       if ((detail as { id: string }).id === id) {
+        clearErrorTimers();
+        setShowRenameError(false);
+        setShowRenameErrorTint(false);
         setEditValue(title);
         setIsEditing(true);
         didCommitOrCancelRef.current = false;
@@ -128,7 +131,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
       signal: controller.signal,
     });
     return () => controller.abort();
-  }, [id, title, onRename]);
+  }, [id, title, onRename, clearErrorTimers]);
 
   const handleClose = useCallback(
     (e: React.MouseEvent) => {

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -14,6 +14,8 @@ import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
 import { UI_ANIMATION_DURATION } from "@/lib/animationUtils";
 
+const RENAME_ERROR_TINT_HOLD_MS = 300;
+
 export interface TabInfo {
   id: string;
   title: string;
@@ -68,22 +70,28 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(title);
   const [showRenameError, setShowRenameError] = useState(false);
+  const [showRenameErrorTint, setShowRenameErrorTint] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const didCommitOrCancelRef = useRef(false);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorTintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearErrorTimer = useCallback(() => {
+  const clearErrorTimers = useCallback(() => {
     if (errorTimerRef.current !== null) {
       clearTimeout(errorTimerRef.current);
       errorTimerRef.current = null;
+    }
+    if (errorTintTimerRef.current !== null) {
+      clearTimeout(errorTintTimerRef.current);
+      errorTintTimerRef.current = null;
     }
   }, []);
 
   useEffect(() => {
     return () => {
-      clearErrorTimer();
+      clearErrorTimers();
     };
-  }, [clearErrorTimer]);
+  }, [clearErrorTimers]);
 
   // Focus input when entering edit mode
   useEffect(() => {
@@ -175,30 +183,36 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
         e.preventDefault();
         const trimmed = editValue.trim();
         if (!trimmed || trimmed === title) {
-          // Reject empty/unchanged: keep edit mode open and flash the border red.
-          clearErrorTimer();
+          clearErrorTimers();
           setShowRenameError(true);
+          setShowRenameErrorTint(true);
           errorTimerRef.current = setTimeout(() => {
             setShowRenameError(false);
             errorTimerRef.current = null;
           }, UI_ANIMATION_DURATION);
+          errorTintTimerRef.current = setTimeout(() => {
+            setShowRenameErrorTint(false);
+            errorTintTimerRef.current = null;
+          }, RENAME_ERROR_TINT_HOLD_MS);
           return;
         }
         onRename?.(trimmed);
-        clearErrorTimer();
+        clearErrorTimers();
         setShowRenameError(false);
+        setShowRenameErrorTint(false);
         didCommitOrCancelRef.current = true;
         setIsEditing(false);
       } else if (e.key === "Escape") {
         e.preventDefault();
         setEditValue(title);
-        clearErrorTimer();
+        clearErrorTimers();
         setShowRenameError(false);
+        setShowRenameErrorTint(false);
         didCommitOrCancelRef.current = true;
         setIsEditing(false);
       }
     },
-    [editValue, title, onRename, clearErrorTimer]
+    [editValue, title, onRename, clearErrorTimers]
   );
 
   const handleInputBlur = useCallback(() => {
@@ -209,10 +223,11 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
         onRename?.(trimmed);
       }
     }
-    clearErrorTimer();
+    clearErrorTimers();
     setShowRenameError(false);
+    setShowRenameErrorTint(false);
     setIsEditing(false);
-  }, [editValue, title, onRename, clearErrorTimer]);
+  }, [editValue, title, onRename, clearErrorTimers]);
 
   const handleInputClick = useCallback((e: React.MouseEvent) => {
     // Prevent click from bubbling to tab click handler
@@ -304,15 +319,21 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               animate={{ opacity: 1 }}
               transition={{ duration: 0.1 }}
               className={cn(
-                "text-xs bg-daintree-bg/80 border px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text transition-colors duration-150 focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent",
-                showRenameError ? "border-status-error" : "border-border-strong"
+                "text-xs bg-daintree-bg/80 border px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent",
+                showRenameError
+                  ? "border-status-error duration-150"
+                  : "border-border-strong duration-250",
+                showRenameErrorTint && "bg-status-error/5"
               )}
               aria-label={`Rename tab ${title}`}
               aria-invalid={showRenameError || undefined}
             />
           ) : (
             <span
-              className={cn("truncate max-w-[100px]", onRename && "cursor-text")}
+              className={cn(
+                "truncate max-w-[100px] inline-block border border-transparent px-1",
+                onRename && "cursor-text"
+              )}
               onDoubleClick={handleDoubleClick}
             >
               {title}
@@ -366,7 +387,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
                 onClick={handleClose}
                 onKeyDown={handleCloseKeyDown}
                 className={cn(
-                  "shrink-0 p-0.5 -mr-1 rounded transition-colors",
+                  "shrink-0 p-0.5 -mr-1 rounded transition-[opacity,color,background-color,border-color]",
                   "opacity-0 group-hover/tab:opacity-100 group-focus-visible/tab:opacity-100 focus-visible:opacity-100",
                   "hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)]",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -220,6 +220,14 @@ describe("TabButton", () => {
       expect(closeButton.className).toContain("group-hover/tab:opacity-100");
       expect(closeButton.className).toContain("focus-visible:opacity-100");
     });
+
+    it("uses scoped transition so opacity fades instead of hard-hopping", () => {
+      render(<TabButton {...defaultProps} />);
+      const closeButton = screen.getByLabelText("Close Test Agent");
+      expect(closeButton.className).toContain(
+        "transition-[opacity,color,background-color,border-color]"
+      );
+    });
   });
 
   describe("rename validation feedback", () => {
@@ -330,6 +338,109 @@ describe("TabButton", () => {
         vi.advanceTimersByTime(150);
       });
     });
+
+    it("shows tint background immediately on error and holds it past border recovery", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(input.className).toContain("bg-status-error/5");
+
+      // Border clears at 150ms but tint persists
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(input.className).not.toContain("border-status-error");
+      expect(input.className).toContain("bg-status-error/5");
+
+      // Tint clears at 300ms
+      act(() => {
+        vi.advanceTimersByTime(150);
+      });
+
+      expect(input.className).not.toContain("bg-status-error/5");
+    });
+
+    it("clears both border and tint immediately on Escape", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.className).toContain("bg-status-error/5");
+
+      fireEvent.keyDown(input, { key: "Escape" });
+      // Edit mode exited — input unmounted
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+
+      // Re-enter edit mode: error states must be clean
+      enterEditMode(screen.getByText("Test Agent"));
+      const freshInput = screen.getByTestId("motion-input") as HTMLInputElement;
+      expect(freshInput.className).not.toContain("bg-status-error/5");
+      expect(freshInput.className).not.toContain("border-status-error");
+    });
+
+    it("clears both border and tint on blur", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.className).toContain("bg-status-error/5");
+
+      fireEvent.blur(input);
+      // Edit mode exited — input unmounted
+      expect(screen.queryByTestId("motion-input")).toBeNull();
+
+      // Re-enter edit mode: error states must be clean
+      enterEditMode(screen.getByText("Test Agent"));
+      const freshInput = screen.getByTestId("motion-input") as HTMLInputElement;
+      expect(freshInput.className).not.toContain("bg-status-error/5");
+      expect(freshInput.className).not.toContain("border-status-error");
+    });
+
+    it("resets both timers on repeated invalid Enter", () => {
+      vi.useFakeTimers();
+      const onRename = vi.fn();
+      render(<TabButton {...defaultProps} onRename={onRename} />);
+
+      enterEditMode(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.className).toContain("bg-status-error/5");
+
+      // Advance partially then trigger error again
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      // Old tint timer should be reset — tint shouldn't clear at old 300ms mark
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(input.className).toContain("bg-status-error/5");
+
+      // Should still clear at 300ms from second press (100 + 200 = 300ms from start = 200ms from second press)
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(input.className).not.toContain("bg-status-error/5");
+    });
   });
 
   describe("context-menu rename path", () => {
@@ -369,6 +480,25 @@ describe("TabButton", () => {
       const input = screen.getByTestId("motion-input");
       expect(input).not.toBeNull();
       expect(input.tagName).toBe("INPUT");
+    });
+  });
+
+  describe("span layout stability", () => {
+    it("has matching box-model classes to prevent pixel shift on rename swap", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      const span = screen.getByText("Test Agent");
+      expect(span.className).toContain("inline-block");
+      expect(span.className).toContain("border");
+      expect(span.className).toContain("border-transparent");
+      expect(span.className).toContain("px-1");
+    });
+
+    it("input has matching box-model foundation", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+      expect(input.className).toContain("border");
+      expect(input.className).toContain("px-1");
     });
   });
 


### PR DESCRIPTION
## Summary
Three micro-interaction fixes on `TabButton.tsx` that close out #6836. None of these are bugs — they're rough edges the earlier polish pass left behind, each visible as a micro-jolt in daily use.

## Changes
- **Zero-pixel-shift rename commit.** The inline rename `<input>` now matches the static `<span>` box model (`border`, `px-1`, `inline-block`), so pressing Enter to commit doesn't resize the tab by 2-3px.
- **Asymmetric error fade-back.** The rename error border still flashes on in 150ms, but it now fades back over 250ms with a subtle 300ms background tint so the recovery reads as "calming down" rather than snapping.
- **Smooth close-button reveal.** The close "X" now transitions opacity on hover/group-hover instead of a hard instant hop. Scoped to `transition-[opacity,color,background-color,border-color]`.
- **Stale error cleanup.** Context-menu rename triggers now clear any lingering rename error states and timers.
- **Test coverage** for rename error states, aria-invalid mirroring, tint timing, and timer cleanup.

Fixes #6836

## Testing
- Rename a tab, press Enter — verify no layout shift on commit.
- Trigger a rename error (empty input, Enter) — verify border flashes red then fades back with a held tint.
- Hover over a tab — verify close button fades in smoothly.
- Trigger a context-menu rename while a rename error is active — verify error state clears.