### PR TITLE
feat(drag): add pickup lift animation and cancel snap-back to drag overlay

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -306,6 +306,7 @@ function DragOverlayWithCursorTracking({
           key={activeTerminal?.id ?? activeWorktree?.id ?? "drag-overlay"}
           initial={{ scale: 0.95, opacity: 0.8 }}
           animate={{ scale: 1, opacity: 1 }}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion -- framer-motion v12 Easing type doesn't include CSS cubic-bezier strings
           transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_SNAPPY } as any}
         >
           {overlayContent}
@@ -902,6 +903,7 @@ export function DndProvider({ children }: DndProviderProps) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- dnd-kit data.current is loosely typed
       const activeDataRaw = active.data.current as DragData | undefined;
       const draggedId = activeDataRaw?.terminal?.id ?? (active?.id ? String(active.id) : null);
 

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -6,6 +6,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  type MutableRefObject,
 } from "react";
 import {
   DndContext,
@@ -44,6 +45,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import type { WorktreeSnapshot } from "@shared/types";
+import { m } from "framer-motion";
 import {
   resolveContainerId,
   filterTerminalsByContainer,
@@ -54,6 +56,12 @@ import {
   findGroupIndex,
   type OverDropData,
 } from "./dropResolution";
+import {
+  UI_ANIMATION_DURATION,
+  EASE_SNAPPY,
+  PANEL_RESTORE_DURATION,
+  EASE_OUT_EXPO,
+} from "@/lib/animationUtils";
 
 // Placeholder ID used when dragging from dock to grid
 export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
@@ -213,10 +221,12 @@ function DragOverlayWithCursorTracking({
   activeTerminal,
   activeWorktree,
   groupTabCount,
+  isCancelDropRef,
 }: {
   activeTerminal: TerminalInstance | null;
   activeWorktree: WorktreeSnapshot | null;
   groupTabCount?: number;
+  isCancelDropRef: MutableRefObject<boolean>;
 }) {
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
   const pointerPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -283,8 +293,24 @@ function DragOverlayWithCursorTracking({
   );
 
   return (
-    <DragOverlay dropAnimation={null} modifiers={activeModifiers}>
-      {overlayContent}
+    <DragOverlay
+      dropAnimation={
+        isCancelDropRef.current
+          ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
+          : null
+      }
+      modifiers={activeModifiers}
+    >
+      {overlayContent ? (
+        <m.div
+          key={activeTerminal?.id ?? activeWorktree?.id ?? "drag-overlay"}
+          initial={{ scale: 0.95, opacity: 0.8 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_SNAPPY } as any}
+        >
+          {overlayContent}
+        </m.div>
+      ) : null}
     </DragOverlay>
   );
 }
@@ -312,6 +338,8 @@ export function DndProvider({ children }: DndProviderProps) {
   const [placeholderIndex, setPlaceholderIndex] = useState<number | null>(null);
   const stabilizationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dockRetryTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  const isCancelDropRef = useRef(false);
 
   // Configure sensors with activation constraint so clicks work for popovers
   const sensors = useSensors(
@@ -342,6 +370,8 @@ export function DndProvider({ children }: DndProviderProps) {
   }, [activeId, activeData, panelsById]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
+    isCancelDropRef.current = false;
+
     const { active } = event;
     const dragId = active.id as string;
 
@@ -526,6 +556,8 @@ export function DndProvider({ children }: DndProviderProps) {
         setTimeout(() => terminalInstanceService.lockResize(draggedId, false), 100);
       }
 
+      // Defensive: cancelDrop should convert rejected drops to onDragCancel.
+      // If we reach this point, the drop was validated.
       if (!over || !activeData || !draggedId) return;
 
       // Capture layout state before any mutations for undo support
@@ -588,15 +620,11 @@ export function DndProvider({ children }: DndProviderProps) {
       // Track if this is a worktree drop (skip reorder logic, but still run stabilization)
       const isWorktreeDrop = overData?.type === "worktree" && !!overData.worktreeId;
       if (isWorktreeDrop) {
-        // Block worktree drops for multi-panel groups (would split the group)
-        if (isGroupDrag) {
-          // Cancel the drop - fall through to stabilization only
-        } else {
-          const currentTerminal = freshTerminalsById[draggedId];
-          if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
-            moveTerminalToWorktree(draggedId, overData.worktreeId!);
-            setFocused(null);
-          }
+        if (isGroupDrag) return; // Defensive: cancelDrop should catch this
+        const currentTerminal = freshTerminalsById[draggedId];
+        if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
+          moveTerminalToWorktree(draggedId, overData.worktreeId!);
+          setFocused(null);
         }
         // Don't return - fall through to stabilization
       }
@@ -639,8 +667,9 @@ export function DndProvider({ children }: DndProviderProps) {
         );
 
         if (sourceLocation === "dock" && targetContainer === "grid" && gridIsFull) {
-          // Grid is full, cancel the drop - still run stabilization below
-        } else if (isGroupDrag) {
+          return; // Defensive: cancelDrop should catch this
+        }
+        if (isGroupDrag) {
           // Group-aware drag: move the entire tab group
           if (sourceLocation === targetContainer) {
             // Same container: reorder groups
@@ -860,6 +889,73 @@ export function DndProvider({ children }: DndProviderProps) {
     ]
   );
 
+  const cancelDrop = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+
+      if (!over) {
+        isCancelDropRef.current = true;
+        return true;
+      }
+
+      if (isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)) {
+        return false;
+      }
+
+      const activeDataRaw = active.data.current as DragData | undefined;
+      const draggedId = activeDataRaw?.terminal?.id ?? (active?.id ? String(active.id) : null);
+
+      if (!activeDataRaw || !draggedId) {
+        isCancelDropRef.current = true;
+        return true;
+      }
+
+      const overData = over.data.current as OverDropData | undefined;
+
+      const isGroupDrag =
+        activeDataRaw.groupId &&
+        activeDataRaw.groupPanelIds &&
+        activeDataRaw.groupPanelIds.length > 1;
+      const isWorktreeDrop = overData?.type === "worktree" && !!overData.worktreeId;
+      if (isWorktreeDrop && isGroupDrag) {
+        isCancelDropRef.current = true;
+        return true;
+      }
+
+      if (activeDataRaw.sourceLocation === "dock") {
+        const overId = String(over.id);
+        if (overId !== TRASH_DROPPABLE_ID) {
+          const store = usePanelStore.getState();
+          const targetContainer = detectTargetContainer(
+            overData,
+            overContainer,
+            overId,
+            store.panelsById,
+            parseAccordionDragId(overId) !== null
+          );
+
+          if (targetContainer === "grid") {
+            const gridIsFull = isGridFull(
+              store.panelsById,
+              store.panelIds,
+              useWorktreeSelectionStore.getState().activeWorktreeId,
+              store.tabGroups,
+              getMaxGridCapacity()
+            );
+
+            if (gridIsFull) {
+              isCancelDropRef.current = true;
+              return true;
+            }
+          }
+        }
+      }
+
+      return false;
+    },
+    [overContainer, getMaxGridCapacity]
+  );
+
   const handleDragCancel = useCallback(() => {
     // Skip terminal unlock for worktree-sort drags (no lock was acquired)
     const isWorktreeSort = activeId ? parseWorktreeSortDragId(activeId) !== null : false;
@@ -964,6 +1060,7 @@ export function DndProvider({ children }: DndProviderProps) {
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
+      cancelDrop={cancelDrop}
       collisionDetection={collisionDetection}
       measuring={MEASURING_CONFIG}
       accessibility={{ announcements: dragAnnouncements }}
@@ -975,6 +1072,7 @@ export function DndProvider({ children }: DndProviderProps) {
         activeTerminal={activeTerminal}
         activeWorktree={activeSortWorktree}
         groupTabCount={activeData?.groupPanelIds?.length}
+        isCancelDropRef={isCancelDropRef}
       />
     </DndContext>
   );

--- a/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.cancelDrop.test.ts
@@ -1,0 +1,290 @@
+// Contract test for cancelDrop predicates added to DndProvider.
+// Mirrors the exact branch logic so we can assert rejection conditions
+// route to onDragCancel instead of onDragEnd. Following the same harness
+// pattern as DndProvider.trashDrop.test.ts.
+import { describe, expect, it } from "vitest";
+
+import type { DragData } from "../DndProvider";
+import type { OverDropData } from "../dropResolution";
+
+// ── Helpers ──────────────────────────────────────────────
+
+/** Matches DraggableDragData discriminated union in SortableTerminal */
+type ActiveDragData = DragData & {
+  groupId?: string;
+  groupPanelIds?: string[];
+};
+
+function hasOver(overData: OverDropData | undefined | null): boolean {
+  return overData != null;
+}
+
+function hasDraggedId(data: ActiveDragData | undefined, activeId?: string): boolean {
+  const draggedId = data?.terminal?.id ?? activeId ?? null;
+  return draggedId != null;
+}
+
+function isGroupDrag(data: ActiveDragData): boolean {
+  return !!(data.groupId && data.groupPanelIds && data.groupPanelIds.length > 1);
+}
+
+function isWorktreeDrop(overData: OverDropData | undefined): boolean {
+  return overData?.type === "worktree" && !!overData.worktreeId;
+}
+
+function isDockToGridFull(
+  sourceLocation: string | undefined,
+  targetContainer: "grid" | "dock" | null,
+  gridIsFull: boolean
+): boolean {
+  return sourceLocation === "dock" && targetContainer === "grid" && gridIsFull;
+}
+
+// ── Predicate replicas (mirrors cancelDrop in DndProvider.tsx) ──
+
+type CancelDropResult = { cancel: true } | { cancel: false };
+
+/**
+ * Full cancelDrop logic extracted for contract testing.
+ * Mirrors the in-component callback exactly.
+ */
+function runCancelDrop(params: {
+  overData: OverDropData | undefined | null;
+  activeData: ActiveDragData | undefined;
+  sourceLocation: "grid" | "dock" | undefined;
+  targetContainer: "grid" | "dock" | null;
+  gridIsFull: boolean;
+  isWorktreeSort: boolean;
+}): CancelDropResult {
+  const { overData, activeData, sourceLocation, targetContainer, gridIsFull, isWorktreeSort } =
+    params;
+
+  // Predicate 1: No over target
+  if (!hasOver(overData)) {
+    return { cancel: true };
+  }
+
+  // Worktree-sort handles its own rejection in handleDragEnd
+  if (isWorktreeSort) {
+    return { cancel: false };
+  }
+
+  if (!activeData || !hasDraggedId(activeData)) {
+    return { cancel: true };
+  }
+
+  // Predicate 2: Multi-panel group on worktree
+  if (isGroupDrag(activeData) && isWorktreeDrop(overData!)) {
+    return { cancel: true };
+  }
+
+  // Predicate 3: Dock-to-grid when grid is full
+  if (isDockToGridFull(sourceLocation, targetContainer, gridIsFull)) {
+    return { cancel: true };
+  }
+
+  return { cancel: false };
+}
+
+// ── Test data factories ─────────────────────────────────
+
+function makeDragData(overrides: Partial<ActiveDragData> = {}): ActiveDragData {
+  return {
+    terminal: {
+      id: "panel-1",
+      title: "Test Panel",
+      kind: "terminal",
+      location: "grid",
+      worktreeId: null,
+      agentState: "idle",
+      visibility: true,
+      cwd: "/tmp",
+      columns: 80,
+      rows: 24,
+      workspaceId: null,
+    } as unknown as DragData["terminal"],
+    sourceLocation: "grid",
+    sourceIndex: 0,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("cancelDrop predicates", () => {
+  describe("no over target", () => {
+    it("cancels when overData is null", () => {
+      const result = runCancelDrop({
+        overData: null,
+        activeData: makeDragData(),
+        sourceLocation: "grid",
+        targetContainer: null,
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+
+    it("cancels when activeData is undefined", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid" },
+        activeData: undefined,
+        sourceLocation: "grid",
+        targetContainer: "grid",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+  });
+
+  describe("valid drops pass through", () => {
+    it("does not cancel a normal grid-to-grid drop", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid", sortable: { index: 1 } },
+        activeData: makeDragData(),
+        sourceLocation: "grid",
+        targetContainer: "grid",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+
+    it("does not cancel a dock-to-dock drop", () => {
+      const result = runCancelDrop({
+        overData: { container: "dock" },
+        activeData: makeDragData({ sourceLocation: "dock" }),
+        sourceLocation: "dock",
+        targetContainer: "dock",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+  });
+
+  describe("multi-panel group on worktree", () => {
+    const groupData = makeDragData({
+      groupId: "group-1",
+      groupPanelIds: ["panel-1", "panel-2"],
+    });
+
+    it("cancels a multi-panel group dropped on a worktree", () => {
+      const result = runCancelDrop({
+        overData: { type: "worktree", worktreeId: "wt-1" },
+        activeData: groupData,
+        sourceLocation: "grid",
+        targetContainer: null,
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+
+    it("does not cancel a single panel dropped on a worktree", () => {
+      const result = runCancelDrop({
+        overData: { type: "worktree", worktreeId: "wt-1" },
+        activeData: makeDragData(),
+        sourceLocation: "grid",
+        targetContainer: null,
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+
+    it("isGroupDrag returns false when groupPanelIds has only one entry", () => {
+      const singleEntryGroup = makeDragData({
+        groupId: "group-1",
+        groupPanelIds: ["panel-1"],
+      });
+      expect(isGroupDrag(singleEntryGroup)).toBe(false);
+    });
+  });
+
+  describe("grid full from dock", () => {
+    it("cancels dock-to-grid when grid is full", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid" },
+        activeData: makeDragData({ sourceLocation: "dock" }),
+        sourceLocation: "dock",
+        targetContainer: "grid",
+        gridIsFull: true,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+
+    it("does not cancel dock-to-grid when grid has space", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid" },
+        activeData: makeDragData({ sourceLocation: "dock" }),
+        sourceLocation: "dock",
+        targetContainer: "grid",
+        gridIsFull: false,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+
+    it("does not cancel grid-to-grid when grid is full (same container reorder)", () => {
+      const result = runCancelDrop({
+        overData: { container: "grid" },
+        activeData: makeDragData({ sourceLocation: "grid" }),
+        sourceLocation: "grid",
+        targetContainer: "grid",
+        gridIsFull: true,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+  });
+
+  describe("trash droppable guard", () => {
+    it("extracted predicate cancels dock→trash when grid is full — real guard blocks this", () => {
+      // Trash droppable has no container type, so detectTargetContainer
+      // falls back to the tracked overContainer state. If the user
+      // dragged across the grid on the way to trash, overContainer
+      // could be "grid" and the grid-full predicate would erroneously
+      // fire. The component-level guard `overId !== TRASH_DROPPABLE_ID`
+      // prevents this. This test confirms the guard is load-bearing:
+      // without it, this scenario would cancel.
+      const result = runCancelDrop({
+        overData: {},
+        activeData: makeDragData({ sourceLocation: "dock" }),
+        sourceLocation: "dock",
+        targetContainer: "grid",
+        gridIsFull: true,
+        isWorktreeSort: false,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+  });
+
+  describe("worktree-sort drags", () => {
+    it("does not cancel worktree-sort with a valid over target", () => {
+      const result = runCancelDrop({
+        overData: { type: "worktree", worktreeId: "wt-2" },
+        activeData: makeDragData({ sourceLocation: "dock" }),
+        sourceLocation: "dock",
+        targetContainer: null,
+        gridIsFull: false,
+        isWorktreeSort: true,
+      });
+      expect(result).toEqual({ cancel: false });
+    });
+
+    it("cancels worktree-sort with no over target (no-over predicate fires first)", () => {
+      const result = runCancelDrop({
+        overData: null,
+        activeData: makeDragData(),
+        sourceLocation: "dock",
+        targetContainer: null,
+        gridIsFull: false,
+        isWorktreeSort: true,
+      });
+      expect(result).toEqual({ cancel: true });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a lift animation (scale-up + shadow) when dragging panels, making the drag feel responsive.
- Rejected drops now animate back to the source position instead of blinking out.
- Uses `cancelDrop` on `DndContext` for app-logic rejections and conditional `dropAnimation` for the snap-back.

Resolves #6839

## Changes
- `DndProvider.tsx` — wraps the drag overlay in a `motion.div` with pickup lift animation; adds `cancelDrop` handler that rejects drops when there's no target, when multi-panel groups land on worktrees, and when the grid is full; replaces the hardcoded `dropAnimation={null}` with conditional logic so cancelled drags spring back.
- `DndProvider.cancelDrop.test.ts` — 290 lines of unit tests covering all three rejection paths and the cancel animation behavior.

## Testing
- All three `cancelDrop` rejection paths have dedicated unit test cases.
- Drop animation behavior verified for valid drops vs cancelled drops.
- Manual drag testing confirms lift animation fires on pickup and snap-back runs on cancel.