### PR TITLE
fix(worktree): reveal sidebar drag handle on row hover and keyboard focus

### DIFF
--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -70,6 +70,31 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
   });
 
+  describe("WorktreeCard drag handle", () => {
+    const SIDEBAR_CSS_PATH = path.resolve(__dirname, "../../../styles/components/sidebar.css");
+
+    it("marks the drag handle with data-worktree-row-drag-handle so focus CSS can target it", async () => {
+      const cardSource = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+      expect(cardSource).toContain('data-worktree-row-drag-handle=""');
+    });
+
+    it("reveals drag handle on keyboard focus via [data-worktree-row-drag-handle] CSS selector", async () => {
+      const cssSource = await fs.readFile(SIDEBAR_CSS_PATH, "utf-8");
+      expect(cssSource).toContain("[data-worktree-row-drag-handle]");
+    });
+
+    it("uses group-hover/card for mouse row-level reveal (not self-scoped hover)", async () => {
+      const cardSource = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+      expect(cardSource).toContain("group-hover/card:text-text-primary/30");
+      expect(cardSource).toContain("group-hover/card:bg-overlay-soft");
+    });
+
+    it("keeps motion-reduce:transition-none on the drag handle for WCAG reduced-motion", async () => {
+      const cardSource = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+      expect(cardSource).toContain("motion-reduce:transition-none");
+    });
+  });
+
   describe("SidebarContent grid wiring", () => {
     let source: string;
     beforeEach(async () => {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -655,13 +655,14 @@ export function WorktreeCard({
             {dragHandleListeners && (
               <div
                 ref={dragHandleActivatorRef}
+                data-worktree-row-drag-handle=""
                 className={cn(
-                  "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors",
+                  "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors motion-reduce:transition-none",
                   isDraggingSort
                     ? "bg-overlay-emphasis text-text-primary"
                     : isWorktreeSortDragging
                       ? "text-text-primary/30 hover:text-text-primary/50 hover:bg-overlay-soft"
-                      : "text-transparent hover:text-text-primary/30 hover:bg-overlay-soft"
+                      : "text-transparent group-hover/card:text-text-primary/30 group-hover/card:bg-overlay-soft"
                 )}
                 aria-label="Drag to reorder"
                 {...dragHandleListeners}

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -56,6 +56,14 @@
   pointer-events: auto;
 }
 
+/* Reveal the drag handle whenever the row has keyboard focus, matching the
+   toolbar reveal pattern above. */
+[data-worktree-row]:focus [data-worktree-row-drag-handle],
+[data-worktree-row]:focus-within [data-worktree-row-drag-handle] {
+  color: color-mix(in srgb, var(--theme-text-primary) 30%, transparent);
+  background-color: var(--theme-overlay-soft);
+}
+
 @media (forced-colors: active) {
   [data-worktree-row]:focus-visible .sidebar-worktree-card {
     outline: 2px solid Highlight;


### PR DESCRIPTION
## Summary
The drag handle for sidebar worktree rows was only visible when the cursor was in the narrow column that holds the handle. This made it difficult to discover and impossible to reach via keyboard.

- Reveals the drag handle on full-row hover, matching the toolbar's reveal pattern
- Surfaces the handle when the row has keyboard focus, so arrow-key navigation works
- Preserves reduced-motion support for WCAG compliance

Resolves #6829

## Changes
- `src/components/Worktree/WorktreeCard.tsx` — Switched from self-scoped hover to group-hover/card for row-level reveal; added `motion-reduce:transition-none` and a data attribute for keyboard focus targeting
- `src/styles/components/sidebar.css` — Added `:focus` / `:focus-within` rules to reveal the handle when the row receives keyboard focus
- `src/components/Sidebar/__tests__/SidebarContent.grid.test.ts` — Four assertions covering the data attribute, CSS selector, group-hover class, and reduced-motion class

## Testing
Unit tests cover the markup and CSS selectors for both mouse and keyboard reveal paths, plus the motion-reduce guard. Manually verified row hover, keyboard navigation, and sort-drag state interactions in dev.